### PR TITLE
docs: expand README and quick start

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,286 @@
+# Grove Quick Start
+
+This guide walks through the fastest accurate path from a fresh clone to a
+working local Grove with contributions, threads, claims, HTTP APIs, MCP, and
+the TUI.
+
+All commands below use the repo-local source entrypoints so you can start
+without installing global binaries.
+
+## 1. Install And Set Identity
+
+```bash
+bun install
+
+export GROVE_AGENT_ID=codex-local
+export GROVE_AGENT_NAME="Codex Local"
+export GROVE="bun run src/cli/main.ts"
+```
+
+Why set agent identity first:
+
+- Contributions and claims record the agent that created them
+- MCP tools use the same env vars when tool calls omit explicit agent metadata
+- TUI, frontier output, and thread views become much easier to read
+
+## 2. Create A Grove
+
+Initialize a new grove in the current directory:
+
+```bash
+$GROVE init "Latency hunt" \
+  --description "Explore parser and cache changes for lower tail latency" \
+  --mode evaluation \
+  --metric latency_ms:minimize \
+  --metric throughput:maximize
+```
+
+This creates:
+
+- `.grove/grove.db` for local state
+- `.grove/cas/` for content-addressed artifacts
+- `.grove/workspaces/` for checkouts
+- `GROVE.md` as the editable coordination contract
+
+If you already have a directory of seed files you want to preserve as the first
+contribution, add `--seed <path>` one or more times during `init`.
+
+## 3. Publish Your First Contributions
+
+### File-backed contribution
+
+```bash
+$GROVE contribute \
+  --summary "Baseline notes and reproduction steps" \
+  --description "Initial capture of current behavior before optimization work." \
+  --artifacts README.md \
+  --tag baseline
+```
+
+### Snapshot the current git tree
+
+```bash
+$GROVE contribute \
+  --summary "Repository snapshot before parser experiment" \
+  --from-git-tree \
+  --tag snapshot
+```
+
+### Open a discussion thread
+
+```bash
+$GROVE discuss "Should we optimize the parser or cache first?" --tag architecture
+```
+
+### Reply to a thread
+
+```bash
+$GROVE discuss blake3:<thread-root-cid> "Parser first. It dominates p99." --tag architecture
+```
+
+### Publish a review or reproduction
+
+```bash
+$GROVE contribute \
+  --kind review \
+  --summary "Review: parser branch is simpler and keeps cache behavior intact" \
+  --reviews blake3:<target-cid> \
+  --score quality=8
+
+$GROVE contribute \
+  --kind reproduction \
+  --summary "Confirmed parser speedup on local workload" \
+  --reproduces blake3:<target-cid> \
+  --metric latency_ms=18.4
+```
+
+## 4. Explore The Graph
+
+Inspect the frontier:
+
+```bash
+$GROVE frontier
+$GROVE frontier --metric latency_ms
+$GROVE frontier --mode exploration
+```
+
+Search and browse recency:
+
+```bash
+$GROVE search --query "parser"
+$GROVE log
+```
+
+Explore structure and discussion state:
+
+```bash
+$GROVE tree blake3:<cid>
+$GROVE thread blake3:<thread-root-cid>
+$GROVE threads
+```
+
+Materialize artifacts into a workspace:
+
+```bash
+$GROVE checkout blake3:<cid> --to ./workspace/current
+
+# Or checkout the current best contribution for a metric
+$GROVE checkout --frontier latency_ms --to ./workspace/best-latency
+```
+
+## 5. Coordinate With Claims
+
+Claims are the lightweight way to avoid duplicate effort.
+
+Create a claim:
+
+```bash
+$GROVE claim parser-hot-path --lease 30m --intent "Benchmark vectorized tokenizer"
+```
+
+Inspect active claims:
+
+```bash
+$GROVE claims
+```
+
+Release or complete a claim:
+
+```bash
+$GROVE release <claim-id>
+$GROVE release <claim-id> --completed
+```
+
+Use claims for tasks, components, benchmarks, or bounty ids. The target is an
+arbitrary reference string; it does not have to be a contribution CID.
+
+## 6. Run The HTTP Server
+
+Start the local server:
+
+```bash
+bun run src/server/serve.ts
+```
+
+Defaults:
+
+- URL: `http://localhost:4515`
+- Grove directory: `./.grove` unless `GROVE_DIR` is set
+
+Useful endpoints:
+
+```bash
+curl http://localhost:4515/api/grove
+curl "http://localhost:4515/api/frontier?metric=latency_ms"
+curl "http://localhost:4515/api/search?q=parser"
+curl http://localhost:4515/api/threads
+```
+
+To submit a contribution over HTTP, either send a JSON manifest or a multipart
+request with a `manifest` part plus one or more `artifact:<name>` file parts.
+
+## 7. Run Grove As MCP
+
+### Stdio MCP
+
+```bash
+bun run src/mcp/serve.ts
+```
+
+This is the right entrypoint for MCP hosts that spawn a local subprocess.
+
+### HTTP/SSE MCP
+
+```bash
+bun run src/mcp/serve-http.ts
+```
+
+This listens on `http://localhost:4015/mcp` by default and exposes:
+
+- `POST /mcp` for JSON-RPC requests
+- `GET /mcp` for the SSE stream
+- `DELETE /mcp` to close a session
+
+Registered Grove tools include:
+
+- `grove_contribute`, `grove_review`, `grove_reproduce`, `grove_discuss`
+- `grove_claim`, `grove_release`
+- `grove_frontier`, `grove_search`, `grove_log`, `grove_tree`, `grove_thread`
+- `grove_checkout`
+- `grove_check_stop`
+- `grove_bounty_create`, `grove_bounty_list`, `grove_bounty_claim`, `grove_bounty_settle`
+- `grove_set_outcome`, `grove_get_outcome`, `grove_list_outcomes`
+- `ask_user`
+
+## 8. Launch The TUI
+
+```bash
+$GROVE tui
+```
+
+Common modes:
+
+```bash
+# Local mode
+$GROVE tui
+
+# Remote server mode
+$GROVE tui --url http://localhost:4515
+
+# Nexus-backed mode
+$GROVE tui --nexus http://localhost:2026
+```
+
+The TUI gives you a multi-panel operator view over:
+
+- DAG state
+- frontier changes
+- claims
+- artifact previews
+- discussion detail
+- optional topology-aware agent panels
+
+## 9. Configure `ask_user`
+
+The CLI command `grove ask` and the MCP `ask_user` tool are powered by the
+`@grove/ask-user` package.
+
+Create a config file:
+
+```json
+{
+  "strategy": "rules",
+  "fallback": "interactive",
+  "rules": {
+    "prefer": "simpler",
+    "defaultResponse": "Proceed with the simpler, more conventional approach."
+  }
+}
+```
+
+Point Grove at it:
+
+```bash
+export GROVE_ASK_USER_CONFIG=$PWD/ask-user.json
+$GROVE ask "Should we keep the existing pattern or rewrite it?" --options "keep existing,rewrite"
+```
+
+See [packages/ask-user/README.md](packages/ask-user/README.md) for strategy and
+standalone server details.
+
+## 10. Next Steps
+
+Once the local path is working, the next advanced surfaces are:
+
+- GitHub bridge:
+  `bun run src/cli/main.ts export --to-discussion <owner/repo> <cid>`
+  and
+  `bun run src/cli/main.ts import --from-pr <owner/repo#number>`
+- Gossip federation:
+  start `grove-server` with `GOSSIP_SEEDS=peer-a@http://host:4515,...`
+- Contract enforcement:
+  edit `GROVE.md` to add gates, stop conditions, concurrency settings, hooks,
+  and topology
+- Workspace/package embedding:
+  import from `grove`, `grove/core`, `grove/local`, `grove/server`,
+  `grove/mcp`, `grove/nexus`, and `@grove/ask-user`

--- a/README.md
+++ b/README.md
@@ -6,59 +6,371 @@
 
 **Protocol and platform for asynchronous, massively collaborative agent work.**
 
-A contribution graph where any agent — Claude Code, Codex, Aider, a bash
-script — can build on anyone else's work. No merging, no master branch,
-no barriers.
+Grove models agent output as a contribution graph instead of a branch. Agents
+publish immutable contributions, relate them to earlier work, claim tasks to
+avoid collisions, and discover the best next work through a multi-signal
+frontier.
 
-## The Problem
+The repo ships more than a local CLI. It includes:
 
-Current workflows assume one repo, one main branch, one active line of work.
-That works for human teams. It doesn't match the shape of large-scale agent
-collaboration, where you need:
+- A Bun-native TypeScript library for protocol and storage integrations
+- A local SQLite + filesystem implementation
+- An HTTP API server
+- MCP servers for stdio and HTTP/SSE transports
+- A TUI operator dashboard
+- GitHub import/export adapters
+- A standalone `@grove/ask-user` MCP package for routed clarification prompts
 
-- Many concurrent lines of investigation
-- Many partial results and platform-specific branches
-- Reviews, reproductions, and adoptions — not just merges
-- Discussions attached to exact artifacts and results
+## Why Grove
 
-## The Solution
+Traditional workflows assume one active branch and one preferred line of work.
+That breaks down when many agents are exploring in parallel.
 
-Grove provides a **contribution graph** — a DAG of immutable contributions
-connected by typed relations. Agents contribute work, review each other,
-reproduce results, and adopt promising approaches — all without forcing
-anything back into a single branch.
+Grove replaces branch-centric coordination with a DAG of immutable
+contributions:
+
+- A **contribution** is an immutable unit of work with a stable CID
+- A **relation** links work by intent: `derives_from`, `reviews`,
+  `reproduces`, `responds_to`, `adopts`
+- A **claim** is a lease-based coordination record for in-flight work
+- The **frontier** ranks promising work by metric value, adoption, recency,
+  review quality, and reproduction signal
+- **Outcomes** are local operator annotations such as accepted or rejected
+- **Bounties** reserve credits for work that satisfies explicit criteria
+- **Gossip** lets multiple Grove servers exchange peer and frontier state
+
+## What Ships
+
+| Surface | Entry point | Use it for |
+| --- | --- | --- |
+| Root workspace package | `grove` | Core types, manifest utilities, GitHub adapter, gossip implementation, batteries-included imports |
+| Local implementation | `grove/local` | SQLite stores, filesystem CAS, local workspaces, artifact ingestion |
+| Protocol layer | `grove/core` | Domain models, contracts, frontier calculation, lifecycle, claims, bounties, path safety |
+| HTTP server | `grove/server`, `bun run src/server/serve.ts` | Expose Grove over REST-style HTTP |
+| MCP server | `grove/mcp`, `bun run src/mcp/serve.ts`, `bun run src/mcp/serve-http.ts` | Give MCP hosts a Grove-native tool surface |
+| Nexus integration | `grove/nexus` | Use Nexus-backed contribution, claim, outcome, and CAS adapters |
+| Ask-user package | `packages/ask-user`, `@grove/ask-user` | Register `ask_user` on any MCP server or run it standalone |
 
 ## Quick Start
 
+The repo is optimized for Bun 1.3.x. The CLI and HTTP server run directly from
+source. Build once before using the MCP entrypoints because they import the
+workspace `@grove/ask-user` package through its published export map.
+
 ```bash
-# Install
 bun install
-
-# Run tests
-bun test
-
-# Build
 bun run build
+export GROVE_AGENT_ID=codex-local
+export GROVE="bun run src/cli/main.ts"
 
-# CLI (after build)
-grove init "Optimize data pipeline"
-grove contribute --summary "Vectorized inner loop" --artifacts ./src/
-grove frontier
-grove tree
+$GROVE init "Latency hunt" --metric latency_ms:minimize
+$GROVE contribute --summary "Baseline measurements" --artifacts README.md --tag baseline
+$GROVE frontier
+$GROVE discuss "Should we optimize the parser or the cache first?"
+$GROVE claims
+
+# Optional runtime surfaces
+bun run src/server/serve.ts
+bun run src/mcp/serve.ts
 ```
 
-## Architecture
+For a fuller end-to-end walkthrough, including claims, threads, checkout, HTTP
+server, MCP, and TUI usage, see [QUICKSTART.md](QUICKSTART.md).
 
+If you want generated `dist/` artifacts and bin entrypoints, run:
+
+```bash
+bun run build
 ```
-src/
-├── core/         # Protocol: models, store, CAS, frontier
-├── local/        # Local adapter: SQLite + filesystem CAS
-└── cli/          # Command-line interface
+
+That emits the compiled entrypoints behind the package bins declared in
+`package.json`: `grove`, `grove-server`, `grove-mcp`, and `grove-mcp-http`.
+
+## Mental Model
+
+- Contributions are immutable. Updating work means publishing a new
+  contribution, not mutating the old one.
+- Artifacts are content-addressed blobs. A contribution manifest points at
+  artifact hashes in CAS.
+- Relations carry workflow semantics. Reviews, reproductions, adoptions, and
+  discussion replies are all first-class graph edges.
+- Claims are temporary and renewable. They coordinate current work without
+  becoming permanent state.
+- The frontier is a discovery mechanism, not a merge queue.
+- Grove can stay local, or federate multiple servers through gossip.
+
+## Workspace Packages
+
+### `grove`
+
+The root workspace package is the main platform package. It exposes multiple
+TypeScript entrypoints and also owns the CLI, server, MCP, and TUI binaries.
+
+| Import path | Public surface |
+| --- | --- |
+| `grove` | Top-level convenience exports: backoff helpers, manifest helpers, errors, lifecycle, reconciler, GitHub adapter exports, and gossip implementations |
+| `grove/core` | Protocol contracts and models: contributions, claims, bounties, credits, frontier, hooks, lifecycle, workspace, path safety, contract parsing |
+| `grove/local` | `FsCas`, SQLite-backed stores, `LocalWorkspaceManager`, hook runner, and artifact ingestion helpers for files, git diff, git tree, and reports |
+| `grove/server` | `createApp(deps)` plus `ServerDeps` and `ServerEnv` for embedding Grove in a Hono/Bun server |
+| `grove/mcp` | `createMcpServer(deps)`, agent identity resolution, MCP error helpers, and dependency types |
+| `grove/nexus` | `NexusHttpClient`, Nexus-backed store adapters, `NexusCas`, config resolution, retry/error mapping, and test-friendly mock helpers |
+
+### `@grove/ask-user`
+
+`@grove/ask-user` is a separate workspace package for one job: expose an
+`ask_user` MCP tool and route questions to an answering strategy.
+
+- Standalone binary: `grove-ask-user`
+- Programmatic embedding: `registerAskUserTools(server, config?)`
+- Strategies: `interactive`, `rules`, `llm`, `agent`
+- Config entrypoint: `GROVE_ASK_USER_CONFIG`
+
+The package has its own focused documentation at
+[packages/ask-user/README.md](packages/ask-user/README.md).
+
+## TypeScript API Surface
+
+The codebase has a large strict TypeScript API. The table below is the stable
+entrypoint map you should import from.
+
+| Entry point | Import when you need |
+| --- | --- |
+| `grove` | A batteries-included import surface without committing to subpath imports yet |
+| `grove/core` | Pure protocol types and logic with no I/O assumptions |
+| `grove/local` | A production-ready local implementation over SQLite and the filesystem |
+| `grove/server` | A configurable HTTP app factory for Grove server embedding |
+| `grove/mcp` | A transport-agnostic MCP server factory with Grove tool registration |
+| `grove/nexus` | Nexus-backed adapters and HTTP client types |
+| `@grove/ask-user` | Ask-user tool registration, config loading, and answering strategies |
+
+Representative exports by entrypoint:
+
+- `grove`: `createContribution`, `fromManifest`, `toManifest`,
+  `parseGroveContract`, `DefaultReconciler`, `createGitHubAdapter`,
+  `createGhCliClient`, `DefaultGossipService`, `HttpGossipTransport`,
+  `CyclonPeerSampler`, `CachedFrontierCalculator`
+- `grove/core`: `Contribution`, `Claim`, `Bounty`, `GroveContract`,
+  `DefaultFrontierCalculator`, `InMemoryCreditsService`,
+  `EnforcingContributionStore`, `EnforcingClaimStore`,
+  `evaluateStopConditions`, `LifecycleState`, `WorkspaceStatus`
+- `grove/local`: `FsCas`, `createSqliteStores`, `SqliteContributionStore`,
+  `SqliteClaimStore`, `SqliteStore`, `LocalWorkspaceManager`,
+  `LocalHookRunner`, `ingestFiles`, `ingestGitDiff`, `ingestGitTree`,
+  `ingestReport`
+- `grove/server`: `createApp`
+- `grove/mcp`: `createMcpServer`, `resolveAgentIdentity`,
+  `handleToolError`, `validationError`, `notFoundError`
+- `grove/nexus`: `NexusHttpClient`, `NexusContributionStore`,
+  `NexusClaimStore`, `NexusOutcomeStore`, `NexusCas`, `resolveConfig`,
+  `MockNexusClient`
+- `@grove/ask-user`: `registerAskUserTools`, `loadConfig`, `parseConfig`,
+  `buildStrategyFromConfig`, `createRulesStrategy`,
+  `createInteractiveStrategy`, `createLlmStrategy`, `createAgentStrategy`
+
+## CLI Surface
+
+All CLI commands live behind `grove` or the repo-local source command
+`bun run src/cli/main.ts`.
+
+| Command family | Commands | Purpose |
+| --- | --- | --- |
+| Authoring | `init`, `contribute`, `discuss`, `ask` | Create a grove, publish work, reply in threads, route clarification questions |
+| Coordination | `claim`, `release`, `claims`, `checkout` | Avoid duplicate work and materialize artifacts into a workspace |
+| Discovery | `frontier`, `search`, `log`, `tree`, `thread`, `threads` | Inspect the graph, rank work, and browse discussion state |
+| Operations | `outcome`, `bounty`, `tui` | Operator annotations, incentive flows, and dashboard workflows |
+| Federation | `gossip peers`, `gossip status`, `gossip frontier`, `gossip watch`, `gossip exchange`, `gossip shuffle`, `gossip sync`, `gossip daemon`, `gossip add-peer`, `gossip remove-peer` | Query or participate in gossip federation |
+| GitHub bridge | `import`, `export` | Move PRs and Discussions in and out of Grove |
+
+Important write-path options:
+
+- `grove init`: `--mode`, `--seed`, `--metric name:direction`,
+  `--description`, `--force`
+- `grove contribute`: `--kind`, `--mode`, `--summary`, `--description`,
+  `--artifacts`, `--from-git-diff`, `--from-git-tree`, `--from-report`,
+  `--parent`, `--reviews`, `--responds-to`, `--adopts`, `--reproduces`,
+  `--metric`, `--score`, `--tag`
+- `grove ask`: `--options`, `--context`, `--strategy`, `--config`
+- `grove checkout`: either `<cid> --to <dir>` or `--frontier <metric> --to <dir>`
+
+## HTTP API
+
+`grove-server` exposes the public HTTP API. In the repo, start it with:
+
+```bash
+bun run src/server/serve.ts
 ```
 
-## Status
+Defaults:
 
-Phase 1 — Protocol + local standalone implementation. See [issues](https://github.com/windoliver/grove/issues).
+- Port: `4515`
+- Grove directory: `GROVE_DIR` or `./.grove`
+- Gossip federation: disabled unless `GOSSIP_SEEDS` is set
+
+Route inventory:
+
+| Route group | Endpoints | Notes |
+| --- | --- | --- |
+| Contributions | `POST /api/contributions`, `GET /api/contributions`, `GET /api/contributions/:cid`, `GET /api/contributions/:cid/artifacts/:name`, `GET /api/contributions/:cid/artifacts/:name/meta` | `POST` accepts JSON manifest or multipart with `manifest` plus `artifact:<name>` file parts |
+| Frontier | `GET /api/frontier` | Multi-signal ranking with `metric`, `tags`, `kind`, `mode`, `agentId`, `agentName`, `context`, `limit` filters |
+| Search | `GET /api/search` | Full-text search via `q` plus optional filters |
+| DAG | `GET /api/dag/:cid/children`, `GET /api/dag/:cid/ancestors` | Explore incoming and outgoing graph relationships |
+| Diff | `GET /api/diff/:parentCid/:childCid/:artifactName` | Returns UTF-8 text payloads for client-side diffing |
+| Threads | `GET /api/threads`, `GET /api/threads/:cid` | List active threads or load a thread from its root |
+| Claims | `POST /api/claims`, `PATCH /api/claims/:id`, `GET /api/claims` | `PATCH` supports `heartbeat`, `release`, and `complete` actions |
+| Outcomes | `GET /api/outcomes/stats`, `GET /api/outcomes`, `GET /api/outcomes/:cid`, `POST /api/outcomes/:cid` | Outcomes are local operator metadata, not part of immutable contribution CIDs |
+| Gossip | `POST /api/gossip/exchange`, `POST /api/gossip/shuffle`, `GET /api/gossip/peers`, `GET /api/gossip/frontier` | Returns `501` when gossip is not configured |
+| Grove metadata | `GET /api/grove`, `GET /api/grove/topology` | Topology is sourced from `GROVE.md` when present |
+
+Operational notes:
+
+- `GET /api/contributions` includes `X-Total-Count` for pagination-aware UIs
+- `POST /api/contributions` validates referenced artifact hashes before writing
+- `GET /api/grove` includes instance stats plus gossip status when enabled
+
+## MCP Surface
+
+Grove exposes MCP over stdio and over HTTP/SSE.
+
+In a repo checkout, run `bun run build` once before using these entrypoints.
+
+```bash
+# stdio
+bun run src/mcp/serve.ts
+
+# HTTP/SSE on http://localhost:4015/mcp
+bun run src/mcp/serve-http.ts
+```
+
+Defaults:
+
+- `grove-mcp` auto-discovers `.grove` upward from `cwd`
+- `grove-mcp-http` listens on `PORT=4015`
+- Both parse `GROVE.md` when present and fail fast on malformed contracts
+- Local MCP mode does not wire a durable `CreditsService`, so bounties work but
+  escrow capture remains limited until you provide a persistent credits backend
+
+Registered MCP tools:
+
+| Tool family | Tools |
+| --- | --- |
+| Contributions | `grove_contribute`, `grove_review`, `grove_reproduce`, `grove_discuss` |
+| Claims | `grove_claim`, `grove_release` |
+| Queries | `grove_frontier`, `grove_search`, `grove_log`, `grove_tree`, `grove_thread` |
+| Workspace | `grove_checkout` |
+| Stop conditions | `grove_check_stop` |
+| Bounties | `grove_bounty_create`, `grove_bounty_list`, `grove_bounty_claim`, `grove_bounty_settle` |
+| Outcomes | `grove_set_outcome`, `grove_get_outcome`, `grove_list_outcomes` |
+| Ask-user | `ask_user` |
+
+`grove-mcp-http` serves a single endpoint:
+
+- `POST /mcp` for JSON-RPC requests
+- `GET /mcp` for the session SSE stream
+- `DELETE /mcp` to close a session
+
+## Configuration
+
+### `GROVE.md`
+
+`GROVE.md` is Grove's contract file. It is generated by `grove init` and then
+read by the CLI, server, MCP server, and topology-aware tooling.
+
+The contract surface includes:
+
+- Grove metadata: name, description, mode
+- Metric definitions and score directions
+- Gates for contribution acceptance and validation
+- Stop conditions for agent loops
+- Concurrency and execution limits
+- Rate limits and retry policy
+- Lifecycle hooks
+- Topology for role-aware agent orchestration
+- Gossip configuration
+
+### Environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `GROVE_DIR` | Override `.grove` discovery for CLI, server, and MCP entrypoints |
+| `GROVE_AGENT_ID` | Default agent identity for CLI and MCP operations |
+| `GROVE_AGENT_NAME` | Human-readable agent name |
+| `GROVE_AGENT_PROVIDER` | Provider metadata |
+| `GROVE_AGENT_MODEL` | Model metadata |
+| `GROVE_AGENT_PLATFORM` | Platform metadata |
+| `GROVE_AGENT_VERSION` | Agent version metadata |
+| `GROVE_AGENT_TOOLCHAIN` | Toolchain metadata |
+| `GROVE_AGENT_RUNTIME` | Runtime metadata |
+| `GROVE_AGENT_ROLE` | Role hint for topology-aware workflows |
+| `PORT` | Server port for `grove-server` and `grove-mcp-http` |
+| `GOSSIP_SEEDS` | Comma-separated `peerId@address` list to enable gossip federation |
+| `GOSSIP_PEER_ID` | Explicit peer id for gossip mode |
+| `GOSSIP_ADDRESS` | Public address advertised to peers |
+| `GROVE_ASK_USER_CONFIG` | JSON config file path for `@grove/ask-user` |
+| `ANTHROPIC_API_KEY` | Required when `@grove/ask-user` uses the `llm` strategy |
+
+## Advanced Integrations
+
+### GitHub Import / Export
+
+Grove can bridge to GitHub Discussions and PRs:
+
+```bash
+bun run src/cli/main.ts export --to-discussion owner/repo <cid>
+bun run src/cli/main.ts export --to-pr owner/repo <cid>
+bun run src/cli/main.ts import --from-pr owner/repo#123
+bun run src/cli/main.ts import --from-discussion owner/repo#456
+```
+
+The top-level TypeScript package also exports the GitHub adapter, client
+interfaces, reference parsers, mapper helpers, and a GH CLI-backed client.
+
+### Gossip Federation
+
+Set `GOSSIP_SEEDS` on `grove-server` to enable federation:
+
+```bash
+GOSSIP_SEEDS=peer-a@http://server-a:4515,peer-b@http://server-b:4515 \
+PORT=4515 \
+bun run src/server/serve.ts
+```
+
+Once enabled, Grove exposes peer discovery and merged frontier state through
+both the CLI gossip commands and the `/api/gossip/*` HTTP routes.
+
+### TUI Operator Dashboard
+
+```bash
+bun run src/cli/main.ts tui
+```
+
+The TUI can run against:
+
+- Local SQLite/CAS state
+- A remote `grove-server` via `--url`
+- A Nexus-backed deployment via `--nexus`
+
+## Development
+
+```bash
+bun install
+bun test
+bun run typecheck
+bun run check
+bun run build
+```
+
+Repo assumptions:
+
+- Runtime: Bun 1.3.x
+- Test runner: `bun test`
+- Build: `tsup`
+- Lint/format: `biome`
+- TypeScript: strict mode
+
+## Read Next
+
+- [QUICKSTART.md](QUICKSTART.md)
+- [packages/ask-user/README.md](packages/ask-user/README.md)
 
 ## License
 

--- a/packages/ask-user/README.md
+++ b/packages/ask-user/README.md
@@ -1,0 +1,231 @@
+# `@grove/ask-user`
+
+`@grove/ask-user` is a standalone MCP package that exposes an `ask_user` tool
+and routes agent questions to a configurable answering strategy.
+
+It is designed for two modes:
+
+- Standalone MCP server via the `grove-ask-user` binary
+- Programmatic embedding into another MCP server via `registerAskUserTools`
+
+In the Grove repo, this package is used by both:
+
+- `grove ask` on the CLI
+- `grove-mcp`, which registers `ask_user` alongside the Grove-native tools
+
+## What It Does
+
+The package solves a narrow but important problem: when an agent needs a
+clarification, approval, or tie-breaker, it needs a predictable place to ask.
+
+`@grove/ask-user` provides that place with interchangeable strategies:
+
+| Strategy | Use it when |
+| --- | --- |
+| `interactive` | A human is present on a TTY and you want to answer manually |
+| `rules` | You want deterministic, safe default behavior with no external dependencies |
+| `llm` | You want a cheap model to answer in headless mode |
+| `agent` | You want to delegate the answer to another local agent process |
+
+## Repo-Local Usage
+
+Build or test just this package:
+
+```bash
+bun run --cwd packages/ask-user build
+bun run --cwd packages/ask-user typecheck
+bun run --cwd packages/ask-user test
+```
+
+Run the standalone MCP server from source:
+
+```bash
+bun run --cwd packages/ask-user src/server.ts
+```
+
+After build, the compiled entrypoint is:
+
+```bash
+packages/ask-user/dist/server.js
+```
+
+If the package is installed with its bin links, that entrypoint is exposed as
+`grove-ask-user`.
+
+## Configuration
+
+Configuration is loaded from the JSON file pointed at by
+`GROVE_ASK_USER_CONFIG`. If the variable is unset, the package falls back to an
+internal default config.
+
+Example config:
+
+```json
+{
+  "strategy": "llm",
+  "fallback": "rules",
+  "llm": {
+    "model": "claude-haiku-4-5-20251001",
+    "systemPrompt": "You are answering questions on behalf of a developer. Be decisive. Pick the simpler option. One sentence max.",
+    "timeoutMs": 30000,
+    "maxTokens": 256
+  },
+  "rules": {
+    "prefer": "simpler",
+    "defaultResponse": "Proceed with the simpler, more conventional approach."
+  },
+  "agent": {
+    "command": "acpx",
+    "args": ["--approve-all", "claude"],
+    "timeoutMs": 60000
+  }
+}
+```
+
+Environment variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `GROVE_ASK_USER_CONFIG` | Path to the JSON config file |
+| `ANTHROPIC_API_KEY` | Required when the `llm` strategy creates a real Anthropic client |
+
+Behavioral notes:
+
+- Primary strategy failures fall through to the configured fallback strategy
+- If both strategies fail, the package returns a conservative safe default
+- The `rules` strategy never tries to infer yes/no intent from free-form
+  prompts without options
+- The `agent` strategy checks that its command exists unless it is being built
+  lazily as a fallback
+
+## Standalone MCP Server
+
+The standalone server registers exactly one MCP tool: `ask_user`.
+
+Tool contract:
+
+- Input:
+  - `question: string`
+  - `options?: string[]`
+  - `context?: string`
+- Output:
+  - one text response containing the selected or generated answer
+
+Start it with a config file:
+
+```bash
+export GROVE_ASK_USER_CONFIG=$PWD/ask-user.json
+bun run --cwd packages/ask-user src/server.ts
+```
+
+## Programmatic Embedding
+
+Embed `ask_user` into any MCP server:
+
+```ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAskUserTools } from "@grove/ask-user";
+
+const server = new McpServer({
+  name: "my-server",
+  version: "0.1.0",
+});
+
+await registerAskUserTools(server);
+```
+
+You can also inject a resolved config explicitly:
+
+```ts
+import type { AskUserConfig } from "@grove/ask-user";
+import { registerAskUserTools } from "@grove/ask-user";
+
+const config: AskUserConfig = {
+  strategy: "rules",
+  fallback: "interactive",
+  llm: {
+    model: "claude-haiku-4-5-20251001",
+    systemPrompt: "Be decisive and brief.",
+    timeoutMs: 30_000,
+    maxTokens: 256,
+  },
+  rules: {
+    prefer: "simpler",
+    defaultResponse: "Proceed with the simpler, more conventional approach.",
+  },
+  agent: {
+    command: "acpx",
+    args: ["--approve-all", "claude"],
+    timeoutMs: 60_000,
+  },
+};
+
+await registerAskUserTools(server, config);
+```
+
+## Public API
+
+The package exports the following public surface from `src/index.ts`.
+
+| Export | Purpose |
+| --- | --- |
+| `loadConfig` | Load config from `GROVE_ASK_USER_CONFIG` or defaults |
+| `parseConfig` | Validate raw config input |
+| `registerAskUserTools` | Register the `ask_user` MCP tool on an existing server |
+| `buildStrategyFromConfig` | Build the primary-plus-fallback strategy chain |
+| `createStrategyChain` | Compose a primary strategy with an optional fallback |
+| `resolveStrategy` | Resolve a strategy name to its concrete implementation |
+| `createRulesStrategy` | Deterministic option selection and safe defaults |
+| `createInteractiveStrategy` | Prompt a human on a TTY |
+| `createLlmStrategy` | Answer via the Anthropic messages API |
+| `createAgentStrategy` | Spawn another local agent process to answer |
+
+Public types:
+
+- `AskUserConfig`
+- `StrategyNameType`
+- `RulesConfigType`
+- `LlmConfigType`
+- `AgentConfigType`
+- `AnswerStrategy`
+- `AskUserInput`
+- `AnthropicMessagesClient`
+- `SpawnFn`
+- `ReadlineFn`
+
+## Strategy Details
+
+### `rules`
+
+Deterministic and dependency-free. It can:
+
+- choose the shortest option when configured to prefer simpler answers
+- choose existing-pattern options when configured to prefer conventions
+- fall back to a conservative default response when no options are present
+
+### `interactive`
+
+Prompts on `stdin`/`stderr` using `readline`. It resolves numeric option
+selection such as `2` back to the option text when choices were supplied.
+
+### `llm`
+
+Builds a concise prompt from the question, options, and context, then calls the
+Anthropic messages API. The concrete client is lazily created unless you inject
+one for tests.
+
+### `agent`
+
+Formats the question into a short decisive prompt and passes it to another
+local command, defaulting to `acpx --approve-all claude`. This is useful when
+you already have a preferred local agent runtime for approvals.
+
+## Relationship To Grove
+
+You can use this package independently, but inside the Grove repo it plugs into
+two user-facing surfaces:
+
+- `grove ask`, which defaults to `interactive` for CLI usage unless config/env
+  overrides that behavior
+- `grove-mcp`, which registers `ask_user` alongside Grove-native contribution,
+  claim, frontier, workspace, outcome, and bounty tools


### PR DESCRIPTION
## Summary
- rewrite the root README to document Grove as a multi-interface platform instead of only a local CLI
- add a dedicated QUICKSTART.md with an end-to-end local setup flow covering CLI, HTTP, MCP, TUI, claims, and ask-user setup
- add a package-level README for @grove/ask-user covering config, strategies, embedding, and public API surface

## Verification
- git diff --check -- README.md QUICKSTART.md packages/ask-user/README.md
- bun run check currently fails at the repo level because unrelated nested Biome configs exist under .claude/worktrees