### PR TITLE
docs: upgrade README to world-class quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,24 +67,30 @@ contributions:
 ## Architecture
 
 ```
-                          grove init --preset review-loop
-                                      |
-                                      v
-                    +----------------------------------+
-                    |          .grove/ directory        |
-                    |  grove.db | cas/ | GROVE.md | ... |
-                    +----------------------------------+
-                           |              |
-                    grove up              |
-                    (orchestrator)        |
-                      /    |    \         |
-                     v     v     v        v
-                 +------+ +---+ +---+  +-----+
-                 |Server| |MCP| |TUI|  | CLI |
-                 |:4515 | |   | |   |  |     |
-                 +------+ +---+ +---+  +-----+
-                     \      |     /       |
-                      v     v    v        v
+                              grove init --preset <name>
+                                        |
+                                        v
+                      +----------------------------------+
+                      |          .grove/ directory        |
+                      |  grove.db | cas/ | GROVE.md | ... |
+                      +----------------------------------+
+                             |              |
+                      grove up              |
+                      (orchestrator)        |
+                        /       \           |
+                       v         v          v
+                 +------+      +---+     +-----+
+                 |Server|      |TUI|     | CLI |
+                 |:4515 |      |   |     |     |
+                 +------+      +---+     +-----+
+                    |   \        /          |
+                    |  (optional)           |
+                    |   +-----+            |
+                    |   | MCP |            |
+                    |   |:4015|            |
+                    |   +-----+            |
+                    |      |               |
+                    v      v               v
               +------------------------------------+
               |         Protocol Core              |
               |  Contributions | Claims | Frontier |
@@ -99,6 +105,9 @@ contributions:
                               Gossip Federation
                               (CYCLON protocol)
 ```
+
+> MCP is optional -- only presets with `services.mcp: true` (currently
+> `swarm-ops`) start the MCP server. All presets start the HTTP server.
 
 **Surfaces at a glance:**
 


### PR DESCRIPTION
## Summary

- **Badges row**: CI status, TypeScript strict, Bun 1.3.x, MCP-compatible, Apache-2.0 license
- **Navigation bar**: Quick links to Quick Start, Full Walkthrough, Presets, Architecture, MCP Guide
- **Features section**: 12-item highlight list for at-a-glance scanning
- **Architecture diagram**: ASCII art from `grove init` through Protocol Core to storage backends
- **Complete presets table**: All 6 presets (adds missing `pr-review` and `federated-swarm`) with roles, topology, mode, backend, and "best for" columns
- **`grove up`/`grove down` section**: Full lifecycle documentation with startup steps and graceful shutdown sequence
- **Collapsible `<details>` blocks**: CLI options, agent metadata env vars, and detailed API exports tucked away to reduce visual noise
- **Contributing section**: 5-step guide for new contributors
- **Read Next with descriptions**: Links to QUICKSTART.md, ask-user docs, MCP guide, and AGENTS.md
- **Environment variables table**: Added Default column for quick reference
- **Concepts table in "Why Grove"**: Scannable table replacing wall of bullets
- **Two-column TUI hotkey table**: Compact layout
- **Development tooling table**: Version-pinned tool list

All existing technical depth (HTTP routes, MCP tools, TypeScript API, env vars) is preserved — nothing was removed, only reorganized and expanded.

## Test plan

- [ ] Verify README renders correctly on GitHub (badges, tables, collapsible sections, ASCII diagram)
- [ ] Confirm all internal links resolve (QUICKSTART.md, packages/ask-user/README.md, docs/guides/mcp-setup.md, AGENTS.md)
- [ ] Check badge URLs load correctly