### PR TITLE
fix: replace broken $GROVE shell variable with bun link

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -11,24 +11,30 @@ without installing global binaries.
 
 ```bash
 bun install
-
-export GROVE_AGENT_ID=codex-local
-export GROVE_AGENT_NAME="Codex Local"
-export GROVE="bun run src/cli/main.ts"
+bun run build
+bun link          # puts "grove" on your PATH
 ```
 
-Why set agent identity first:
+Optionally set agent identity (used when contributing/claiming, not required for init):
+
+```bash
+export GROVE_AGENT_ID=codex-local
+export GROVE_AGENT_NAME="Codex Local"
+```
+
+Why set agent identity:
 
 - Contributions and claims record the agent that created them
 - MCP tools use the same env vars when tool calls omit explicit agent metadata
 - TUI, frontier output, and thread views become much easier to read
+- **Not needed for `grove init`** — only matters at `contribute`/`claim` time
 
 ## 2. Create A Grove
 
 ### Option A: Quick start with a preset (recommended)
 
 ```bash
-$GROVE init "Latency hunt" --preset review-loop
+grove init "Latency hunt" --preset review-loop
 ```
 
 This creates the full `.grove/` directory, a `GROVE.md` contract with
@@ -40,13 +46,13 @@ Available presets: `review-loop`, `exploration`, `swarm-ops`, `research-loop`.
 For Nexus-backed presets, supply the URL:
 
 ```bash
-$GROVE init "Latency hunt" --preset swarm-ops --nexus-url http://localhost:2026
+grove init "Latency hunt" --preset swarm-ops --nexus-url http://localhost:2026
 ```
 
 ### Option B: Manual configuration
 
 ```bash
-$GROVE init "Latency hunt" \
+grove init "Latency hunt" \
   --description "Explore parser and cache changes for lower tail latency" \
   --mode evaluation \
   --metric latency_ms:minimize \
@@ -67,7 +73,7 @@ contribution, add `--seed <path>` one or more times during `init`.
 ## 2a. Start Everything With One Command
 
 ```bash
-$GROVE up
+grove up
 ```
 
 `grove up` reads `.grove/grove.json`, starts the HTTP server and MCP server
@@ -77,7 +83,7 @@ for CI environments or `--no-tui` for server-only mode.
 To stop all services:
 
 ```bash
-$GROVE down
+grove down
 ```
 
 ## 3. Publish Your First Contributions
@@ -85,7 +91,7 @@ $GROVE down
 ### File-backed contribution
 
 ```bash
-$GROVE contribute \
+grove contribute \
   --summary "Baseline notes and reproduction steps" \
   --description "Initial capture of current behavior before optimization work." \
   --artifacts README.md \
@@ -95,7 +101,7 @@ $GROVE contribute \
 ### Snapshot the current git tree
 
 ```bash
-$GROVE contribute \
+grove contribute \
   --summary "Repository snapshot before parser experiment" \
   --from-git-tree \
   --tag snapshot
@@ -104,25 +110,25 @@ $GROVE contribute \
 ### Open a discussion thread
 
 ```bash
-$GROVE discuss "Should we optimize the parser or cache first?" --tag architecture
+grove discuss "Should we optimize the parser or cache first?" --tag architecture
 ```
 
 ### Reply to a thread
 
 ```bash
-$GROVE discuss blake3:<thread-root-cid> "Parser first. It dominates p99." --tag architecture
+grove discuss blake3:<thread-root-cid> "Parser first. It dominates p99." --tag architecture
 ```
 
 ### Publish a review or reproduction
 
 ```bash
-$GROVE contribute \
+grove contribute \
   --kind review \
   --summary "Review: parser branch is simpler and keeps cache behavior intact" \
   --reviews blake3:<target-cid> \
   --score quality=8
 
-$GROVE contribute \
+grove contribute \
   --kind reproduction \
   --summary "Confirmed parser speedup on local workload" \
   --reproduces blake3:<target-cid> \
@@ -134,33 +140,33 @@ $GROVE contribute \
 Inspect the frontier:
 
 ```bash
-$GROVE frontier
-$GROVE frontier --metric latency_ms
-$GROVE frontier --mode exploration
+grove frontier
+grove frontier --metric latency_ms
+grove frontier --mode exploration
 ```
 
 Search and browse recency:
 
 ```bash
-$GROVE search --query "parser"
-$GROVE log
+grove search --query "parser"
+grove log
 ```
 
 Explore structure and discussion state:
 
 ```bash
-$GROVE tree blake3:<cid>
-$GROVE thread blake3:<thread-root-cid>
-$GROVE threads
+grove tree blake3:<cid>
+grove thread blake3:<thread-root-cid>
+grove threads
 ```
 
 Materialize artifacts into a workspace:
 
 ```bash
-$GROVE checkout blake3:<cid> --to ./workspace/current
+grove checkout blake3:<cid> --to ./workspace/current
 
 # Or checkout the current best contribution for a metric
-$GROVE checkout --frontier latency_ms --to ./workspace/best-latency
+grove checkout --frontier latency_ms --to ./workspace/best-latency
 ```
 
 ## 5. Coordinate With Claims
@@ -170,20 +176,20 @@ Claims are the lightweight way to avoid duplicate effort.
 Create a claim:
 
 ```bash
-$GROVE claim parser-hot-path --lease 30m --intent "Benchmark vectorized tokenizer"
+grove claim parser-hot-path --lease 30m --intent "Benchmark vectorized tokenizer"
 ```
 
 Inspect active claims:
 
 ```bash
-$GROVE claims
+grove claims
 ```
 
 Release or complete a claim:
 
 ```bash
-$GROVE release <claim-id>
-$GROVE release <claim-id> --completed
+grove release <claim-id>
+grove release <claim-id> --completed
 ```
 
 Use claims for tasks, components, benchmarks, or bounty ids. The target is an
@@ -250,20 +256,20 @@ Registered Grove tools include:
 ## 8. Launch The TUI
 
 ```bash
-$GROVE tui
+grove tui
 ```
 
 Common modes:
 
 ```bash
 # Local mode
-$GROVE tui
+grove tui
 
 # Remote server mode
-$GROVE tui --url http://localhost:4515
+grove tui --url http://localhost:4515
 
 # Nexus-backed mode
-$GROVE tui --nexus http://localhost:2026
+grove tui --nexus http://localhost:2026
 ```
 
 The TUI gives you a multi-panel operator view over:
@@ -301,7 +307,7 @@ Point Grove at it:
 
 ```bash
 export GROVE_ASK_USER_CONFIG=$PWD/ask-user.json
-$GROVE ask "Should we keep the existing pattern or rewrite it?" --options "keep existing,rewrite"
+grove ask "Should we keep the existing pattern or rewrite it?" --options "keep existing,rewrite"
 ```
 
 See [packages/ask-user/README.md](packages/ask-user/README.md) for strategy and
@@ -311,10 +317,10 @@ standalone server details.
 
 Once the local path is working, the next advanced surfaces are:
 
-- **Presets**: `$GROVE init "Name" --preset swarm-ops` for turnkey multi-agent
+- **Presets**: `grove init "Name" --preset swarm-ops` for turnkey multi-agent
   topologies with seed data, metrics, and concurrency settings
-- **One-command startup**: `$GROVE up` to launch server, MCP, and TUI together;
-  `$GROVE down` to stop everything
+- **One-command startup**: `grove up` to launch server, MCP, and TUI together;
+  `grove down` to stop everything
 - GitHub bridge:
   `bun run src/cli/main.ts export --to-discussion <owner/repo> <cid>`
   and

--- a/README.md
+++ b/README.md
@@ -126,17 +126,16 @@ contributions:
 > **Requires [Bun](https://bun.sh/) 1.3.x**
 
 ```bash
-# Install
+# Install and build
 bun install
 bun run build
 
-# Set agent identity
-export GROVE_AGENT_ID=codex-local
-export GROVE="bun run src/cli/main.ts"
+# Link the CLI so "grove" is on your PATH
+bun link
 
 # Initialize with a preset and start everything
-$GROVE init "Latency hunt" --preset review-loop
-$GROVE up
+grove init "Latency hunt" --preset review-loop
+grove up
 ```
 
 That's it. `grove up` reads `.grove/grove.json` and starts whichever services
@@ -146,16 +145,16 @@ server-only mode.
 
 ```bash
 # Or go manual
-$GROVE init "Latency hunt" --metric latency_ms:minimize
-$GROVE contribute --summary "Baseline measurements" --artifacts README.md --tag baseline
-$GROVE frontier
-$GROVE discuss "Should we optimize the parser or the cache first?"
+grove init "Latency hunt" --metric latency_ms:minimize
+grove contribute --summary "Baseline measurements" --artifacts README.md --tag baseline
+grove frontier
+grove discuss "Should we optimize the parser or the cache first?"
 ```
 
 Stop everything:
 
 ```bash
-$GROVE down
+grove down
 ```
 
 For the full end-to-end walkthrough -- including claims, threads, checkout,
@@ -167,7 +166,7 @@ Presets bundle topology, metrics, gates, concurrency settings, and seed data
 into a single named configuration. Initialize with `--preset <name>`:
 
 ```bash
-$GROVE init "My project" --preset swarm-ops
+grove init "My project" --preset swarm-ops
 ```
 
 | Preset | Roles | Topology | Mode | Backend | Services | Best for |
@@ -188,12 +187,12 @@ contributions, and configures services. Nexus-backed presets support
 `grove up` is the orchestrator that starts your entire Grove environment:
 
 ```bash
-$GROVE up                     # Configured services + TUI
-$GROVE up --headless          # Services only (CI mode)
-$GROVE up --no-tui            # Services, no interactive dashboard
-$GROVE up --grove /custom     # Custom .grove directory
-$GROVE up --nexus-source ~/nexus  # Build Nexus from local source checkout
-$GROVE up --build                 # Same, using NEXUS_SOURCE env var
+grove up                     # Configured services + TUI
+grove up --headless          # Services only (CI mode)
+grove up --no-tui            # Services, no interactive dashboard
+grove up --grove /custom     # Custom .grove directory
+grove up --nexus-source ~/nexus  # Build Nexus from local source checkout
+grove up --build                 # Same, using NEXUS_SOURCE env var
 ```
 
 **What it does:**
@@ -224,8 +223,8 @@ VFS backend for multi-agent coordination. Three connection modes are supported:
 `grove up` handles the full Nexus lifecycle automatically:
 
 ```bash
-$GROVE init "My project" --preset review-loop   # nexusManaged: true
-$GROVE up                                        # nexus init + nexus up + health check + TUI
+grove init "My project" --preset review-loop   # nexusManaged: true
+grove up                                        # nexus init + nexus up + health check + TUI
 ```
 
 On startup, Grove:
@@ -241,13 +240,13 @@ Connect to an existing Nexus server (local or remote):
 
 ```bash
 # At init time (persisted in grove.json)
-$GROVE init "My project" --preset review-loop --nexus-url http://nexus.example.com:2026
+grove init "My project" --preset review-loop --nexus-url http://nexus.example.com:2026
 
 # Via environment variable
-GROVE_NEXUS_URL=http://nexus.example.com:2026 $GROVE up
+GROVE_NEXUS_URL=http://nexus.example.com:2026 grove up
 
 # TUI-only override
-$GROVE tui --nexus http://nexus.example.com:2026
+grove tui --nexus http://nexus.example.com:2026
 ```
 
 When `--nexus-url` is set, Grove skips all lifecycle management and assumes the
@@ -260,11 +259,11 @@ pre-built images from GHCR:
 
 ```bash
 # Build from a local nexus repo checkout
-$GROVE up --nexus-source ~/nexus
+grove up --nexus-source ~/nexus
 
 # Same, using the NEXUS_SOURCE environment variable
 export NEXUS_SOURCE=~/nexus
-$GROVE up --build
+grove up --build
 ```
 
 `--nexus-source` (or `--build` with `NEXUS_SOURCE` set) passes `--build
@@ -373,9 +372,9 @@ bun run src/mcp/serve-http.ts
 ## TUI Operator Dashboard
 
 ```bash
-$GROVE tui                                 # Local mode
-$GROVE tui --url http://localhost:4515     # Remote server
-$GROVE tui --nexus http://localhost:2026   # Nexus-backed
+grove tui                                 # Local mode
+grove tui --url http://localhost:4515     # Remote server
+grove tui --nexus http://localhost:2026   # Nexus-backed
 ```
 
 Core panels (always visible): DAG, Detail, Frontier, Claims.
@@ -505,10 +504,10 @@ See [packages/ask-user/README.md](packages/ask-user/README.md) for full docs.
 ### GitHub Import / Export
 
 ```bash
-$GROVE export --to-discussion owner/repo <cid>
-$GROVE export --to-pr owner/repo <cid>
-$GROVE import --from-pr owner/repo#123
-$GROVE import --from-discussion owner/repo#456
+grove export --to-discussion owner/repo <cid>
+grove export --to-pr owner/repo <cid>
+grove import --from-pr owner/repo#123
+grove import --from-discussion owner/repo#456
 ```
 
 ### Gossip Federation


### PR DESCRIPTION
## Summary
- The `export GROVE="bun run src/cli/main.ts"` / `$GROVE init` pattern in README.md and QUICKSTART.md is broken in zsh — zsh does not word-split unquoted variable expansions, so `$GROVE init` tries to run a single command named `"bun run src/cli/main.ts"` instead of `bun` with arguments
- Replaced with `bun link` after build, which registers the `grove` binary (already declared in package.json `bin`) on PATH — works in all shells
- Clarified that `GROVE_AGENT_ID` is not needed at `grove init` time — only at `contribute`/`claim` time when agents join

## Test plan
- [ ] Verify `bun install && bun run build && bun link` makes `grove` available on PATH
- [ ] Verify `grove init "test" --preset review-loop` works in zsh
- [ ] Verify all code examples in README.md and QUICKSTART.md use `grove` directly (no `$GROVE`)