### PR TITLE
feat: add grove-status command

### DIFF
--- a/src/cli/commands/grove-status.ts
+++ b/src/cli/commands/grove-status.ts
@@ -1,0 +1,38 @@
+/**
+ * `grove grove-status` — show grove-level summary.
+ *
+ * Reads .grove/grove.json and prints grove name, mode, preset,
+ * and total contribution count from the SQLite DB.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { parseGroveConfig } from "../../core/config.js";
+import { resolveGroveDir } from "../utils/grove-dir.js";
+
+export async function handleGroveStatus(groveOverride?: string): Promise<void> {
+  const { groveDir, dbPath } = resolveGroveDir(groveOverride);
+
+  // Read grove.json
+  const raw = readFileSync(join(groveDir, "grove.json"), "utf-8");
+  const config = parseGroveConfig(raw);
+
+  // Count contributions from SQLite
+  const { initSqliteDb } = await import("../../local/sqlite-store.js");
+  const db = initSqliteDb(dbPath);
+  let count = 0;
+  try {
+    const row = db.prepare("SELECT COUNT(*) as cnt FROM contributions").get() as
+      | { cnt: number }
+      | undefined;
+    count = row?.cnt ?? 0;
+  } finally {
+    db.close();
+  }
+
+  console.log(`Grove:          ${config.name}`);
+  console.log(`Mode:           ${config.mode}`);
+  console.log(`Preset:         ${config.preset ?? "none"}`);
+  console.log(`Contributions:  ${count}`);
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -366,6 +366,15 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "grove-status",
+      description: "Show grove-level summary",
+      needsStore: false,
+      handler: async () => {
+        const { handleGroveStatus } = await import("./commands/grove-status.js");
+        await handleGroveStatus(groveOverride);
+      },
+    },
+    {
       name: "whoami",
       description: "Show resolved agent identity",
       needsStore: false,
@@ -509,6 +518,7 @@ Usage:
 
   grove inbox send "msg" --to @agent  Send a message to an agent
   grove inbox read [--from <id>]     Read inbox messages
+  grove grove-status                 Show grove-level summary (name, mode, preset, contributions)
   grove whoami                       Show resolved agent identity
   grove status [--json]              Show agent status overview
 


### PR DESCRIPTION
## Summary
- Adds `grove grove-status` command that reads `.grove/grove.json` and prints grove name, mode, preset, and total contribution count from the SQLite DB
- Registers the command in `main.ts` with help text
- Implementation is 37 lines in `src/cli/commands/grove-status.ts`

## Test plan
- [ ] Run `grove grove-status` in an initialized grove and verify output
- [ ] Run `grove grove-status` outside a grove and verify error message
- [ ] Run `grove --help` and verify the new command appears