### PR TITLE
feat: enhance grove whoami with environment context

### DIFF
--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -1,14 +1,28 @@
 /**
- * `grove whoami` — display the resolved agent identity.
+ * `grove whoami` — display the resolved agent identity and environment.
  *
- * Reads GROVE_AGENT_* env vars and prints the resolved identity.
- * Useful for debugging agent configuration in spawned environments.
+ * Reads GROVE_AGENT_* env vars and prints the resolved identity,
+ * along with grove directory and git context for diagnostics.
  */
 
+import { execSync } from "node:child_process";
 import { parseArgs } from "node:util";
 
 import { resolveAgent } from "../../core/operations/agent.js";
 import { outputJson } from "../format.js";
+import { resolveGroveDir } from "../utils/grove-dir.js";
+
+/** Try to resolve the current git branch, or return undefined. */
+function gitBranch(): string | undefined {
+  try {
+    return execSync("git rev-parse --abbrev-ref HEAD", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
 
 export async function handleWhoami(args: readonly string[]): Promise<void> {
   const { values } = parseArgs({
@@ -22,11 +36,26 @@ export async function handleWhoami(args: readonly string[]): Promise<void> {
 
   const agent = resolveAgent();
 
+  // Resolve grove directory (may not exist)
+  let groveDir: string | undefined;
+  try {
+    groveDir = resolveGroveDir().groveDir;
+  } catch {
+    // Not inside a grove — that's fine
+  }
+
+  const branch = gitBranch();
+
   if (values.json) {
-    outputJson(agent);
+    outputJson({
+      ...agent,
+      ...(groveDir !== undefined && { groveDir }),
+      ...(branch !== undefined && { branch }),
+    });
     return;
   }
 
+  // Agent identity
   console.log(`Agent ID:  ${agent.agentId}`);
   if (agent.role) console.log(`Role:      ${agent.role}`);
   if (agent.agentName) console.log(`Name:      ${agent.agentName}`);
@@ -36,4 +65,11 @@ export async function handleWhoami(args: readonly string[]): Promise<void> {
   if (agent.toolchain) console.log(`Toolchain: ${agent.toolchain}`);
   if (agent.runtime) console.log(`Runtime:   ${agent.runtime}`);
   if (agent.version) console.log(`Version:   ${agent.version}`);
+
+  // Environment context
+  if (groveDir || branch) {
+    console.log();
+    if (groveDir) console.log(`Grove:     ${groveDir}`);
+    if (branch) console.log(`Branch:    ${branch}`);
+  }
 }


### PR DESCRIPTION
## Summary
- Enhances `grove whoami` to show grove directory and current git branch alongside agent identity
- Makes the command a proper diagnostic tool for debugging agent configuration in spawned environments
- Adds `groveDir` and `branch` fields to `--json` output

## Test plan
- [x] `tsc --noEmit` passes (0 errors)
- [x] All 490 CLI tests pass
- [ ] Manual: `grove whoami` shows grove dir and branch when available
- [ ] Manual: `grove whoami --json` includes groveDir and branch fields
- [ ] Manual: works gracefully outside a grove directory (no grove line shown)