### PR TITLE
feat: add grove hello command

### DIFF
--- a/src/cli/commands/hello.ts
+++ b/src/cli/commands/hello.ts
@@ -1,0 +1,7 @@
+/**
+ * `grove hello` — print a greeting from grove.
+ */
+
+export async function handleHello(): Promise<void> {
+  console.log("hello from grove");
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -386,6 +386,15 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "hello",
+      description: "Print hello from grove",
+      needsStore: false,
+      handler: async () => {
+        const { handleHello } = await import("./commands/hello.js");
+        await handleHello();
+      },
+    },
+    {
       name: "completions",
       description: "Generate shell completion scripts",
       needsStore: false,
@@ -509,6 +518,7 @@ Usage:
 
   grove inbox send "msg" --to @agent  Send a message to an agent
   grove inbox read [--from <id>]     Read inbox messages
+  grove hello                        Print hello from grove
   grove whoami                       Show resolved agent identity
   grove status [--json]              Show agent status overview
 

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -237,6 +237,11 @@ export const COMMANDS: readonly CommandMeta[] = [
     flags: ["json"],
   },
   {
+    name: "hello",
+    description: "Print hello from grove",
+    flags: [],
+  },
+  {
     name: "completions",
     description: "Generate shell completion scripts",
     flags: [],


### PR DESCRIPTION
## Summary
- Adds a `grove hello` command that prints "hello from grove"
- Registered in CLI dispatcher (`main.ts`), command registry (`registry.ts`), and help text
- New command handler in `src/cli/commands/hello.ts`

## Test plan
- [ ] Run `grove hello` and verify it prints "hello from grove"
- [ ] Run `grove --help` and verify the command appears in the help text