### PR TITLE
feat: add grove hello command

### DIFF
--- a/src/cli/commands/hello.ts
+++ b/src/cli/commands/hello.ts
@@ -1,0 +1,7 @@
+/**
+ * `grove hello` — print a greeting.
+ */
+
+export async function handleHello(): Promise<void> {
+  console.log("hello grove");
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -386,6 +386,15 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "hello",
+      description: "Print a greeting",
+      needsStore: false,
+      handler: async () => {
+        const { handleHello } = await import("./commands/hello.js");
+        await handleHello();
+      },
+    },
+    {
       name: "completions",
       description: "Generate shell completion scripts",
       needsStore: false,


### PR DESCRIPTION
## Summary
- Adds a `grove hello` command that prints `hello grove`
- New command file: `src/cli/commands/hello.ts`
- Registered in the CLI command registry in `src/cli/main.ts`

## Test plan
- [x] Verified `bun run src/cli/main.ts hello` outputs `hello grove`