### PR TITLE
feat: add grove greet command

### DIFF
--- a/src/cli/commands/greet.ts
+++ b/src/cli/commands/greet.ts
@@ -1,0 +1,23 @@
+/**
+ * `grove greet <name>` — print a greeting.
+ */
+
+import { parseArgs } from "node:util";
+
+export async function handleGreet(args: readonly string[]): Promise<void> {
+  const { positionals } = parseArgs({
+    args: args as string[],
+    options: {},
+    allowPositionals: true,
+    strict: true,
+  });
+
+  if (positionals.length === 0) {
+    console.error("Usage: grove greet <name>");
+    process.exitCode = 1;
+    return;
+  }
+
+  const name = positionals.join(" ");
+  console.log(`Hello, ${name}! Welcome to the grove.`);
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -366,6 +366,15 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "greet",
+      description: "Print a greeting",
+      needsStore: false,
+      handler: async (args) => {
+        const { handleGreet } = await import("./commands/greet.js");
+        await handleGreet(args);
+      },
+    },
+    {
       name: "whoami",
       description: "Show resolved agent identity",
       needsStore: false,
@@ -509,6 +518,7 @@ Usage:
 
   grove inbox send "msg" --to @agent  Send a message to an agent
   grove inbox read [--from <id>]     Read inbox messages
+  grove greet <name>                  Print a greeting
   grove whoami                       Show resolved agent identity
   grove status [--json]              Show agent status overview
 


### PR DESCRIPTION
## Summary
- Adds a new `grove greet <name>` CLI command that takes a name argument and prints a greeting message
- Registers the command in the CLI dispatcher and usage help

## Test plan
- [ ] Run `grove greet World` and verify it prints `Hello, World! Welcome to the grove.`
- [ ] Run `grove greet` with no args and verify it shows usage error
- [ ] Run `grove greet --help` exits cleanly