### PR TITLE
feat: add grove greet command

### DIFF
--- a/src/cli/commands/greet.ts
+++ b/src/cli/commands/greet.ts
@@ -1,0 +1,23 @@
+/**
+ * `grove greet <name>` — print a greeting.
+ */
+
+import { parseArgs } from "node:util";
+
+import { UsageError } from "../errors.js";
+
+export async function handleGreet(args: readonly string[]): Promise<void> {
+  const { positionals } = parseArgs({
+    args: args as string[],
+    options: {},
+    allowPositionals: true,
+    strict: true,
+  });
+
+  const name = positionals[0];
+  if (!name) {
+    throw new UsageError("usage: grove greet <name>");
+  }
+
+  console.log(`hello ${name}`);
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -366,6 +366,15 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "greet",
+      description: "Greet someone by name",
+      needsStore: false,
+      handler: async (args) => {
+        const { handleGreet } = await import("./commands/greet.js");
+        await handleGreet(args);
+      },
+    },
+    {
       name: "whoami",
       description: "Show resolved agent identity",
       needsStore: false,


### PR DESCRIPTION
## Summary
- Adds a `grove greet <name>` command that prints `hello <name>`
- New file: `src/cli/commands/greet.ts`
- Registered in CLI command registry in `src/cli/main.ts`

## Test plan
- [x] `bun run src/cli/main.ts greet world` → prints `hello world`
- [x] `bun run src/cli/main.ts greet` → shows usage error