### PR TITLE
feat: add grove uptime command

### DIFF
--- a/src/cli/commands/uptime.ts
+++ b/src/cli/commands/uptime.ts
@@ -1,0 +1,44 @@
+/**
+ * `grove uptime` — print seconds since grove init.
+ *
+ * Derives the init time from the earliest contribution's createdAt timestamp.
+ */
+
+import { parseArgs } from "node:util";
+
+import type { CliDeps } from "../context.js";
+import { outputJson } from "../format.js";
+
+export function parseUptimeArgs(args: readonly string[]): { json: boolean } {
+  const { values } = parseArgs({
+    args: args as string[],
+    options: {
+      json: { type: "boolean", default: false },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  return { json: values.json ?? false };
+}
+
+export async function runUptime(opts: { json: boolean }, deps: CliDeps): Promise<void> {
+  const all = await deps.store.list({ limit: 1 });
+  if (all.length === 0) {
+    if (opts.json) {
+      outputJson({ seconds: 0, message: "no contributions yet" });
+    } else {
+      console.log("0");
+    }
+    return;
+  }
+
+  const first = all[0]!;
+  const startTime = Date.parse(first.createdAt);
+  const seconds = Math.floor((Date.now() - startTime) / 1000);
+
+  if (opts.json) {
+    outputJson({ seconds, since: first.createdAt });
+  } else {
+    console.log(String(seconds));
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -386,6 +386,17 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "uptime",
+      description: "Print seconds since grove init",
+      needsStore: false,
+      handler: async (args) => {
+        const { parseUptimeArgs, runUptime } = await import("./commands/uptime.js");
+        await withCliDeps(async (a, deps) => {
+          await runUptime(parseUptimeArgs([...a]), deps);
+        }, args);
+      },
+    },
+    {
       name: "completions",
       description: "Generate shell completion scripts",
       needsStore: false,

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -237,6 +237,11 @@ export const COMMANDS: readonly CommandMeta[] = [
     flags: ["json"],
   },
   {
+    name: "uptime",
+    description: "Print seconds since grove init",
+    flags: ["json"],
+  },
+  {
     name: "completions",
     description: "Generate shell completion scripts",
     flags: [],


### PR DESCRIPTION
## Summary
- Adds `grove uptime` command that prints seconds since grove init
- Derives init time from the earliest contribution's `createdAt` timestamp
- Supports `--json` flag for structured output

## Test plan
- [ ] Run `grove uptime` in an initialized grove — should print seconds elapsed
- [ ] Run `grove uptime --json` — should print `{"seconds": N, "since": "..."}`
- [ ] Run `grove uptime` in an empty grove — should print `0`