### PR TITLE
feat: add grove uptime command with robust init time

### DIFF
--- a/src/cli/commands/uptime.ts
+++ b/src/cli/commands/uptime.ts
@@ -1,0 +1,67 @@
+/**
+ * `grove uptime` — print seconds since grove init.
+ *
+ * Derives the init time from the `.grove/` directory birthtime (robust against
+ * contribution pruning), with a fallback to the oldest contribution's createdAt.
+ */
+
+import { stat } from "node:fs/promises";
+import { parseArgs } from "node:util";
+
+import type { CliDeps } from "../context.js";
+import { outputJson } from "../format.js";
+
+export function parseUptimeArgs(args: readonly string[]): { json: boolean } {
+  const { values } = parseArgs({
+    args: args as string[],
+    options: {
+      json: { type: "boolean", default: false },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  return { json: values.json ?? false };
+}
+
+/**
+ * Resolve the grove init time. Prefers `.grove/` directory birthtime;
+ * falls back to the oldest contribution's createdAt if stat fails.
+ */
+async function resolveInitTime(deps: CliDeps): Promise<Date | undefined> {
+  try {
+    const st = await stat(deps.groveRoot);
+    // birthtimeMs is 0 on some Linux filesystems — fall through if so
+    if (st.birthtimeMs > 0) return st.birthtime;
+  } catch {
+    // stat failed — fall through to contribution-based fallback
+  }
+
+  // Fallback: oldest contribution (list returns ASC order)
+  const oldest = await deps.store.list({ limit: 1 });
+  if (oldest.length > 0) {
+    return new Date(oldest[0]!.createdAt);
+  }
+
+  return undefined;
+}
+
+export async function runUptime(opts: { json: boolean }, deps: CliDeps): Promise<void> {
+  const initTime = await resolveInitTime(deps);
+
+  if (initTime === undefined) {
+    if (opts.json) {
+      outputJson({ seconds: 0, message: "no contributions yet" });
+    } else {
+      console.log("no contributions yet");
+    }
+    return;
+  }
+
+  const seconds = Math.floor((Date.now() - initTime.getTime()) / 1000);
+
+  if (opts.json) {
+    outputJson({ seconds, since: initTime.toISOString() });
+  } else {
+    console.log(String(seconds));
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -386,6 +386,17 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "uptime",
+      description: "Print seconds since grove init",
+      needsStore: false,
+      handler: async (args) => {
+        const { parseUptimeArgs, runUptime } = await import("./commands/uptime.js");
+        await withCliDeps(async (a, deps) => {
+          await runUptime(parseUptimeArgs([...a]), deps);
+        }, args);
+      },
+    },
+    {
       name: "completions",
       description: "Generate shell completion scripts",
       needsStore: false,

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -237,6 +237,11 @@ export const COMMANDS: readonly CommandMeta[] = [
     flags: ["json"],
   },
   {
+    name: "uptime",
+    description: "Print seconds since grove init",
+    flags: ["json"],
+  },
+  {
     name: "completions",
     description: "Generate shell completion scripts",
     flags: [],


### PR DESCRIPTION
## Summary
- Adds `grove uptime` command that prints seconds since grove init
- Uses `.grove/` directory birthtime as the primary init time source (robust against contribution pruning)
- Falls back to oldest contribution's `createdAt` if `stat` fails or `birthtimeMs` is 0 (some Linux filesystems)
- Plain-text output for empty groves prints "no contributions yet" instead of "0" for clarity
- Supports `--json` flag for structured output

## Addresses review feedback from PR #154
- **Sort-order concern**: The original reviewers cited `sqlite-store.ts:775` (`ORDER BY DESC`), but that line is in `findExisting`, not `list`. The `list` method already uses `ORDER BY ASC`. Regardless, this implementation avoids the fragility by preferring directory birthtime.
- **Robustness**: Contributions can be pruned/compacted, so init time derived from the earliest contribution is fragile. Directory birthtime survives pruning.
- **Zero-contributions UX**: Plain-text now prints "no contributions yet" instead of "0" (matches JSON output behavior).

## Test plan
- [ ] Run `grove uptime` in an initialized grove — should print seconds elapsed
- [ ] Run `grove uptime --json` — should print `{"seconds": N, "since": "..."}`
- [ ] Run `grove uptime` in an empty grove — should print "no contributions yet"
- [ ] Verify type-checks clean: `tsc --noEmit`