### PR TITLE
feat: add grove stats command

### DIFF
--- a/src/cli/commands/stats.ts
+++ b/src/cli/commands/stats.ts
@@ -1,0 +1,75 @@
+/**
+ * `grove stats` — show contribution statistics for the grove.
+ *
+ * Displays total contributions, breakdown by kind, and per-agent counts.
+ * Uses the `withCliDeps` pattern for store access.
+ */
+
+import { parseArgs } from "node:util";
+
+import { ContributionKind } from "../../core/models.js";
+import type { CliDeps } from "../context.js";
+import { outputJson } from "../format.js";
+
+export function parseStatsArgs(args: readonly string[]): { json: boolean } {
+  const { values } = parseArgs({
+    args: args as string[],
+    options: {
+      json: { type: "boolean", default: false },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  return { json: values.json ?? false };
+}
+
+export async function runStats(opts: { json: boolean }, deps: CliDeps): Promise<void> {
+  const all = await deps.store.list({});
+
+  // Count by kind
+  const byKind: Record<string, number> = {};
+  for (const kind of Object.values(ContributionKind)) {
+    byKind[kind] = 0;
+  }
+  // Count by agent
+  const byAgent: Record<string, number> = {};
+
+  for (const c of all) {
+    byKind[c.kind] = (byKind[c.kind] ?? 0) + 1;
+    const agentLabel = c.agent.agentName || c.agent.agentId;
+    byAgent[agentLabel] = (byAgent[agentLabel] ?? 0) + 1;
+  }
+
+  // Active claims
+  const claims = await deps.claimStore.activeClaims();
+
+  if (opts.json) {
+    outputJson({ total: all.length, byKind, byAgent, activeClaims: claims.length });
+    return;
+  }
+
+  console.log(`Contributions: ${all.length}`);
+  console.log();
+
+  // By kind
+  console.log("By kind:");
+  for (const [kind, count] of Object.entries(byKind)) {
+    if (count > 0) {
+      console.log(`  ${kind.padEnd(14)} ${count}`);
+    }
+  }
+  console.log();
+
+  // By agent
+  const agentEntries = Object.entries(byAgent).sort((a, b) => b[1] - a[1]);
+  if (agentEntries.length > 0) {
+    console.log("By agent:");
+    for (const [agent, count] of agentEntries) {
+      const label = agent.length > 30 ? `${agent.slice(0, 28)}..` : agent;
+      console.log(`  ${label.padEnd(30)} ${count}`);
+    }
+    console.log();
+  }
+
+  console.log(`Active claims: ${claims.length}`);
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -375,6 +375,17 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "stats",
+      description: "Show contribution statistics",
+      needsStore: false,
+      handler: async (args) => {
+        const { parseStatsArgs, runStats } = await import("./commands/stats.js");
+        await withCliDeps(async (a, deps) => {
+          await runStats(parseStatsArgs([...a]), deps);
+        }, args);
+      },
+    },
+    {
       name: "status",
       description: "Show agent status overview",
       needsStore: false,

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -232,6 +232,11 @@ export const COMMANDS: readonly CommandMeta[] = [
     flags: ["json"],
   },
   {
+    name: "stats",
+    description: "Show contribution statistics",
+    flags: ["json"],
+  },
+  {
     name: "status",
     description: "Show agent status overview",
     flags: ["json"],


### PR DESCRIPTION
## Summary
- Adds `grove stats` CLI command that shows contribution statistics
- Displays total contributions, breakdown by kind (work, review, discussion, etc.), per-agent counts, and active claims
- Supports `--json` flag for machine-readable output

## Test plan
- [ ] Run `grove stats` in an active grove — verify output shows correct counts
- [ ] Run `grove stats --json` — verify structured JSON output
- [ ] Run in empty grove — verify zero counts display correctly