### PR TITLE
feat: add grove uptime command (fix sort-order bug)

### DIFF
--- a/src/cli/commands/uptime.ts
+++ b/src/cli/commands/uptime.ts
@@ -1,0 +1,50 @@
+/**
+ * `grove uptime` — print seconds since grove init.
+ *
+ * Derives the init time from the grove.db file's birthtime,
+ * which is created during `grove init`.
+ */
+
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+
+import type { CliDeps } from "../context.js";
+import { outputJson } from "../format.js";
+
+export function parseUptimeArgs(args: readonly string[]): { json: boolean } {
+  const { values } = parseArgs({
+    args: args as string[],
+    options: {
+      json: { type: "boolean", default: false },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  return { json: values.json ?? false };
+}
+
+export async function runUptime(opts: { json: boolean }, deps: CliDeps): Promise<void> {
+  const dbPath = join(deps.groveRoot, "grove.db");
+  let birthtime: Date;
+  try {
+    const info = await stat(dbPath);
+    birthtime = info.birthtime;
+  } catch {
+    if (opts.json) {
+      outputJson({ seconds: 0, message: "grove not initialized" });
+    } else {
+      console.log("grove not initialized");
+    }
+    return;
+  }
+
+  const seconds = Math.floor((Date.now() - birthtime.getTime()) / 1000);
+  const since = birthtime.toISOString();
+
+  if (opts.json) {
+    outputJson({ seconds, since });
+  } else {
+    console.log(String(seconds));
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -386,6 +386,17 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "uptime",
+      description: "Print seconds since grove init",
+      needsStore: false,
+      handler: async (args) => {
+        const { parseUptimeArgs, runUptime } = await import("./commands/uptime.js");
+        await withCliDeps(async (a, deps) => {
+          await runUptime(parseUptimeArgs([...a]), deps);
+        }, args);
+      },
+    },
+    {
       name: "completions",
       description: "Generate shell completion scripts",
       needsStore: false,

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -237,6 +237,11 @@ export const COMMANDS: readonly CommandMeta[] = [
     flags: ["json"],
   },
   {
+    name: "uptime",
+    description: "Print seconds since grove init",
+    flags: ["json"],
+  },
+  {
     name: "completions",
     description: "Generate shell completion scripts",
     flags: [],


### PR DESCRIPTION
## Summary
- Adds `grove uptime` command that prints seconds since grove init
- Derives init time from `grove.db` file birthtime instead of `store.list({limit:1})` which returns newest contribution (DESC order), not oldest
- Supports `--json` flag for structured output
- Addresses sort-order bug identified in PR #154 reviews

## Changes
- `src/cli/commands/uptime.ts` — new command using `fs.stat` on grove.db
- `src/cli/main.ts` — register uptime command handler
- `src/cli/registry.ts` — add uptime to command registry

## Test plan
- [ ] Run `grove uptime` in an initialized grove — should print seconds elapsed since init
- [ ] Run `grove uptime --json` — should print `{"seconds": N, "since": "..."}`
- [ ] Run `grove uptime` without a grove — should print "grove not initialized"