### PR TITLE
feat: add grove uptime command

### DIFF
--- a/src/cli/commands/uptime.ts
+++ b/src/cli/commands/uptime.ts
@@ -1,0 +1,68 @@
+/**
+ * `grove uptime` — show how long the grove has been running.
+ *
+ * Derives init time from the filesystem birthtime of the .grove directory,
+ * which is set once at `grove init` and never changes. This avoids relying
+ * on contribution ordering (store.list returns DESC, not ASC).
+ */
+
+import { statSync } from "node:fs";
+import { parseArgs } from "node:util";
+
+import { resolveGroveDir } from "../utils/grove-dir.js";
+
+export interface UptimeOptions {
+  readonly json: boolean;
+}
+
+export function parseUptimeArgs(args: readonly string[]): UptimeOptions {
+  const { values } = parseArgs({
+    args: args as string[],
+    options: {
+      json: { type: "boolean", default: false },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  return { json: values.json ?? false };
+}
+
+function formatDuration(seconds: number): string {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+
+  const parts: string[] = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0) parts.push(`${m}m`);
+  parts.push(`${s}s`);
+  return parts.join(" ");
+}
+
+export function runUptime(opts: UptimeOptions, groveOverride?: string): void {
+  const { groveDir } = resolveGroveDir(groveOverride);
+  const stat = statSync(groveDir);
+  const initTime = stat.birthtime;
+  const now = new Date();
+  const uptimeSeconds = Math.floor((now.getTime() - initTime.getTime()) / 1000);
+
+  if (opts.json) {
+    console.log(
+      JSON.stringify({
+        uptimeSeconds,
+        initTime: initTime.toISOString(),
+        currentTime: now.toISOString(),
+      }),
+    );
+  } else {
+    console.log(`Uptime: ${formatDuration(uptimeSeconds)} (${uptimeSeconds}s)`);
+    console.log(`Init:   ${initTime.toISOString()}`);
+  }
+}
+
+export async function handleUptime(args: readonly string[], groveOverride?: string): Promise<void> {
+  const opts = parseUptimeArgs([...args]);
+  runUptime(opts, groveOverride);
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -375,6 +375,15 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "uptime",
+      description: "Show grove uptime since init",
+      needsStore: false,
+      handler: async (args) => {
+        const { handleUptime } = await import("./commands/uptime.js");
+        await handleUptime(args, groveOverride);
+      },
+    },
+    {
       name: "status",
       description: "Show agent status overview",
       needsStore: false,
@@ -511,6 +520,7 @@ Usage:
   grove inbox read [--from <id>]     Read inbox messages
   grove whoami                       Show resolved agent identity
   grove status [--json]              Show agent status overview
+  grove uptime [--json]              Show grove uptime since init
 
   grove export --to-discussion <owner/repo> <cid>   Export to GitHub Discussion
   grove export --to-pr <owner/repo> <cid>           Export to GitHub PR


### PR DESCRIPTION
## Summary
- Adds `grove uptime` command that shows how long the grove has been running
- Uses filesystem birthtime of `.grove/` directory as init timestamp — a durable, immutable source set at `grove init`
- Avoids the sort-order bug identified in PR #154 where `store.list({limit:1})` returns newest (DESC), not oldest
- Supports `--json` flag for machine-readable output

## Test plan
- [ ] Run `grove uptime` in an initialized grove — should show duration and init timestamp
- [ ] Run `grove uptime --json` — should output JSON with uptimeSeconds, initTime, currentTime
- [ ] Run `grove uptime` outside a grove — should error with "No grove found"
- [ ] Verify `grove --help` lists the uptime command