### PR TITLE
fix: resolve TypeScript Buffer/Uint8Array type errors

### DIFF
--- a/src/core/cas.conformance.ts
+++ b/src/core/cas.conformance.ts
@@ -168,9 +168,8 @@ export function runContentStoreTests(factory: ContentStoreFactory): void {
       const found = await store.getToFile(hash, outPath);
       expect(found).toBe(true);
 
-      const file = Bun.file(outPath);
-      const written = new Uint8Array(await file.arrayBuffer());
-      expect(written).toEqual(data);
+      const written = await Bun.file(outPath).bytes();
+      expect(written).toEqual(new Uint8Array(data));
     });
 
     test("getToFile returns false for non-existent content", async () => {

--- a/src/mcp/serve-http.test.ts
+++ b/src/mcp/serve-http.test.ts
@@ -57,9 +57,12 @@ function buildTestServer(deps: McpDeps, sessionTtlMs: number): TestServerContext
 
   function readBody(req: IncomingMessage): Promise<string> {
     return new Promise((resolve, reject) => {
-      const chunks: Buffer[] = [];
-      req.on("data", (chunk: Buffer) => chunks.push(chunk));
-      req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+      let body = "";
+      req.setEncoding("utf-8");
+      req.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      req.on("end", () => resolve(body));
       req.on("error", reject);
     });
   }

--- a/src/mcp/serve-http.ts
+++ b/src/mcp/serve-http.ts
@@ -223,9 +223,12 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
 
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
-    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    let body = "";
+    req.setEncoding("utf-8");
+    req.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    req.on("end", () => resolve(body));
     req.on("error", reject);
   });
 }


### PR DESCRIPTION
## Summary
- cas.conformance.ts: use Bun.file().bytes() to get properly typed Uint8Array
- serve-http.ts/test: use string encoding instead of Buffer[] for HTTP body reading

Fixes 3 TS2769/TS2345 errors caused by Buffer vs Uint8Array incompatibility in newer TypeScript.

## Test plan
- tsc --noEmit passes with 0 errors (was 3)
- 3360 tests pass, 0 failures

Generated with Claude Code