### PR TITLE
feat(tui): persisted theme, keymap, and layout customization (#195)

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -20,6 +20,7 @@ import { InputBar } from "./components/input-bar.js";
 import { StatusBar } from "./components/status-bar.js";
 import { PanelBar } from "./components/tab-bar.js";
 import { TooltipOverlay, useFirstLaunchTooltips } from "./components/tooltip-overlay.js";
+import type { GroveUserConfig } from "./config-loader.js";
 import { buildKeyActionMap, useKeybindingOverrides } from "./hooks/use-keybinding-overrides.js";
 import type { KeyboardActions } from "./hooks/use-keyboard-handler.js";
 import { nextZoom, routeKey } from "./hooks/use-keyboard-handler.js";
@@ -27,7 +28,7 @@ import { useNavigation } from "./hooks/use-navigation.js";
 import { InputMode, usePanelFocus } from "./hooks/use-panel-focus.js";
 import { usePolledData } from "./hooks/use-polled-data.js";
 import { RefreshContext } from "./hooks/use-refresh-context.js";
-import { useSessionPersistence } from "./hooks/use-session-persistence.js";
+import { useTuiStatePersistence } from "./hooks/use-session-persistence.js";
 import type { ZoomLevel } from "./panels/panel-manager.js";
 import { PanelManager } from "./panels/panel-manager.js";
 import {
@@ -56,6 +57,8 @@ export interface AppProps {
   readonly agentRuntime?: import("../core/agent-runtime.js").AgentRuntime | undefined;
   /** Frozen contract for session creation. */
   readonly contract?: import("../core/contract.js").GroveContract | undefined;
+  /** User config preloaded in main.ts before React mounts (theme + keymap). */
+  readonly userConfig?: GroveUserConfig | undefined;
 }
 
 const PAGE_SIZE = 20;
@@ -234,50 +237,62 @@ export function App({
   tmux,
   topology,
   presetName,
+  groveDir,
+  userConfig,
 }: AppProps): React.ReactNode {
   const renderer = useRenderer();
   const nav = useNavigation();
   const panels = usePanelFocus();
   const { showTooltips, dismissAll: dismissTooltips } = useFirstLaunchTooltips();
-  const { persistedState, saveState } = useSessionPersistence();
-  const keybindingOverrides = useKeybindingOverrides();
+  const { savedState, saveState } = useTuiStatePersistence("global", groveDir);
+  const fileOverrides = useKeybindingOverrides();
+  // Merge config.json keymap (lower priority) with file-based overrides (higher priority).
+  const keybindingOverrides = useMemo(
+    () => ({ ...userConfig?.keymap, ...fileOverrides }),
+    [userConfig?.keymap, fileOverrides],
+  );
   const keyActionMap = useMemo(() => buildKeyActionMap(keybindingOverrides), [keybindingOverrides]);
   const [ks, dispatch] = useReducer(tuiReducer, INITIAL_KEYBOARD_STATE);
 
-  // Restore persisted state on first load (item 13)
+  // Restore persisted state on first load.
   // restoredRef gates both restore AND save — save must not run before restore.
+  // savedState === undefined means still loading; null means no prior state.
   const restoredRef = useRef(false);
   useEffect(() => {
-    if (restoredRef.current || !persistedState) return;
+    if (restoredRef.current || savedState === undefined || savedState === null) {
+      // null = no prior state → mark restored so saves can proceed
+      if (savedState === null) restoredRef.current = true;
+      return;
+    }
     restoredRef.current = true;
     // Restore zoom level
-    if (persistedState.zoomLevel && persistedState.zoomLevel !== "normal") {
+    if (savedState.zoomLevel && savedState.zoomLevel !== "normal") {
       let current: ZoomLevel = "normal";
-      while (current !== persistedState.zoomLevel) {
+      while (current !== savedState.zoomLevel) {
         dispatch({ type: "ZOOM_CYCLE" });
         current = nextZoom(current);
       }
     }
     // Restore search query
-    if (persistedState.searchQuery) {
-      for (const ch of persistedState.searchQuery) {
+    if (savedState.searchQuery) {
+      for (const ch of savedState.searchQuery) {
         dispatch({ type: "SEARCH_CHAR", char: ch });
       }
       dispatch({ type: "SEARCH_SUBMIT" });
     }
     // Restore visible operator panels FIRST (so focus can land on them)
-    if (persistedState.visibleOperatorPanels) {
-      for (const p of persistedState.visibleOperatorPanels) {
+    if (savedState.visibleOperatorPanels) {
+      for (const p of savedState.visibleOperatorPanels) {
         panels.toggle(p as import("./hooks/use-panel-focus.js").Panel);
       }
     }
     // Restore focused panel AFTER panels are visible
-    if (persistedState.focusedPanel !== undefined) {
-      panels.focus(persistedState.focusedPanel as import("./hooks/use-panel-focus.js").Panel);
+    if (savedState.focusedPanel !== undefined) {
+      panels.focus(savedState.focusedPanel as import("./hooks/use-panel-focus.js").Panel);
     }
-  }, [persistedState, panels]);
+  }, [savedState, panels]);
 
-  // Persist state on changes (item 13)
+  // Persist state on changes.
   // Gated by restoredRef to prevent saving default state before async restore completes.
   useEffect(() => {
     if (!restoredRef.current) return;
@@ -955,6 +970,7 @@ export function App({
           visible={panels.state.mode === InputMode.Help}
           isDetailView={nav.isDetailView}
           focusedPanel={panels.state.focused}
+          keybindingOverrides={keybindingOverrides}
         />
         <CommandPalette
           visible={paletteVisible}

--- a/src/tui/components/agent-split-pane.tsx
+++ b/src/tui/components/agent-split-pane.tsx
@@ -67,7 +67,7 @@ const AgentPane = React.memo(function AgentPane({
       borderColor={focused ? theme.focus : theme.inactive}
     >
       <box>
-        <text color={focused ? theme.focus : theme.muted} bold={focused}>
+        <text color={focused ? theme.focus : theme.secondary} bold={focused}>
           {` ${agentSymbol(sessionName, [])} ${sessionName.replace("grove-", "@")} `}
         </text>
       </box>
@@ -121,7 +121,7 @@ export const AgentSplitPane: React.NamedExoticComponent<AgentSplitPaneProps> = R
         </box>
         {overflowCount > 0 && (
           <box>
-            <text color={theme.dimmed}>
+            <text color={theme.secondary}>
               {`+${overflowCount} more agent${overflowCount > 1 ? "s" : ""} (not shown)`}
             </text>
           </box>

--- a/src/tui/components/agent-wizard.tsx
+++ b/src/tui/components/agent-wizard.tsx
@@ -77,7 +77,7 @@ export const AgentWizard: React.NamedExoticComponent<AgentWizardProps> = React.m
         {state.step === "profile" && (
           <box flexDirection="column" paddingLeft={1} marginTop={1}>
             {state.profiles.length === 0 ? (
-              <text color={theme.muted}>No profiles available. Register agents first.</text>
+              <text color={theme.secondary}>No profiles available. Register agents first.</text>
             ) : (
               state.profiles.map((p, i) => {
                 const isSelected = cursorIndex === i;
@@ -87,7 +87,7 @@ export const AgentWizard: React.NamedExoticComponent<AgentWizardProps> = React.m
                       {isSelected ? "> " : "  "}
                       {p.name}
                     </text>
-                    <text color={theme.muted}>
+                    <text color={theme.secondary}>
                       {" "}
                       [{p.platform}] role: {p.role}
                     </text>
@@ -123,13 +123,13 @@ export const AgentWizard: React.NamedExoticComponent<AgentWizardProps> = React.m
               Role: {state.profiles[state.selectedProfile]?.role ?? "?"}
             </text>
             <text color={theme.text}>Target: {state.targetRef}</text>
-            <text color={theme.muted} />
+            <text color={theme.secondary} />
             <box flexDirection="row">
               <text color={cursorIndex === 0 ? theme.focus : theme.text}>
                 {cursorIndex === 0 ? "> " : "  "}
                 Spawn
               </text>
-              <text color={theme.muted}> </text>
+              <text color={theme.secondary}> </text>
               <text color={cursorIndex === 1 ? theme.focus : theme.text}>
                 {cursorIndex === 1 ? "> " : "  "}
                 Cancel
@@ -139,7 +139,7 @@ export const AgentWizard: React.NamedExoticComponent<AgentWizardProps> = React.m
         )}
 
         <box marginTop={1} paddingLeft={1}>
-          <text color={theme.muted}>[j/k] navigate [Enter] select [Esc] cancel</text>
+          <text color={theme.secondary}>[j/k] navigate [Enter] select [Esc] cancel</text>
         </box>
       </box>
     );

--- a/src/tui/components/breadcrumb-bar.tsx
+++ b/src/tui/components/breadcrumb-bar.tsx
@@ -59,9 +59,9 @@ export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> = Rea
             {label}
           </text>
           {screen !== "preset-select" ? (
-            <text color={theme.dimmed}> [Esc]</text>
+            <text color={theme.secondary}> [Esc]</text>
           ) : (
-            <text color={theme.dimmed}> [q]uit</text>
+            <text color={theme.secondary}> [q]uit</text>
           )}
         </box>
       );
@@ -72,12 +72,12 @@ export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> = Rea
       const parts: React.ReactNode[] = [];
       if (presetName) {
         parts.push(
-          <text key="preset" color={theme.muted}>
+          <text key="preset" color={theme.secondary}>
             {presetName}
           </text>,
         );
         parts.push(
-          <text key="sep1" color={theme.dimmed}>
+          <text key="sep1" color={theme.secondary}>
             {" "}
             {"\u203a"}{" "}
           </text>,
@@ -90,13 +90,13 @@ export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> = Rea
       );
       if (shortSession) {
         parts.push(
-          <text key="sep2" color={theme.dimmed}>
+          <text key="sep2" color={theme.secondary}>
             {" "}
             {"\u203a"}{" "}
           </text>,
         );
         parts.push(
-          <text key="sess" color={theme.muted}>
+          <text key="sess" color={theme.secondary}>
             {shortSession}
           </text>,
         );
@@ -104,7 +104,7 @@ export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> = Rea
       return (
         <box paddingX={1} flexDirection="row">
           {parts}
-          {screen !== "preset-select" ? <text color={theme.dimmed}> [Esc]</text> : null}
+          {screen !== "preset-select" ? <text color={theme.secondary}> [Esc]</text> : null}
         </box>
       );
     }
@@ -117,19 +117,19 @@ export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> = Rea
       </text>,
     );
     parts.push(
-      <text key="sep0" color={theme.dimmed}>
+      <text key="sep0" color={theme.secondary}>
         {" "}
         {"\u203a"}{" "}
       </text>,
     );
     if (presetName) {
       parts.push(
-        <text key="preset" color={theme.muted}>
+        <text key="preset" color={theme.secondary}>
           {presetName}
         </text>,
       );
       parts.push(
-        <text key="sep1" color={theme.dimmed}>
+        <text key="sep1" color={theme.secondary}>
           {" "}
           {"\u203a"}{" "}
         </text>,
@@ -142,13 +142,13 @@ export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> = Rea
     );
     if (shortSession) {
       parts.push(
-        <text key="sep2" color={theme.dimmed}>
+        <text key="sep2" color={theme.secondary}>
           {" "}
           {"\u203a"}{" "}
         </text>,
       );
       parts.push(
-        <text key="sess" color={theme.muted}>
+        <text key="sess" color={theme.secondary}>
           {shortSession}
         </text>,
       );
@@ -158,9 +158,9 @@ export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> = Rea
       <box paddingX={1} flexDirection="row">
         {parts}
         {screen === "running" || screen === "advanced" ? (
-          <text color={theme.dimmed}> [Tab]</text>
+          <text color={theme.secondary}> [Tab]</text>
         ) : screen !== "preset-select" ? (
-          <text color={theme.dimmed}> [Esc]</text>
+          <text color={theme.secondary}> [Esc]</text>
         ) : null}
       </box>
     );

--- a/src/tui/components/command-palette.tsx
+++ b/src/tui/components/command-palette.tsx
@@ -356,7 +356,7 @@ export const CommandPalette: React.NamedExoticComponent<CommandPaletteProps> = R
 
         {rankedItems.length === 0 && (
           <box paddingLeft={1}>
-            <text color={theme.muted}>
+            <text color={theme.secondary}>
               {q
                 ? `No matches for "${q}"`
                 : `No actions available${!hasSpawnRuntime ? " (no agent runtime detected)" : ""}`}
@@ -369,7 +369,11 @@ export const CommandPalette: React.NamedExoticComponent<CommandPaletteProps> = R
             const isSelected = i === idx;
             const dimmed = !item.enabled;
             const labelColor = isSelected ? theme.focus : dimmed ? theme.disabled : theme.text;
-            const detailColor = isSelected ? theme.focus : dimmed ? theme.inactive : theme.muted;
+            const detailColor = isSelected
+              ? theme.focus
+              : dimmed
+                ? theme.inactive
+                : theme.secondary;
             const cursor = isSelected ? "> " : "  ";
             return (
               <box key={`${item.kind}-${item.id}-${originalIndex}`} flexDirection="row">
@@ -386,7 +390,7 @@ export const CommandPalette: React.NamedExoticComponent<CommandPaletteProps> = R
         </box>
 
         <box marginTop={1} paddingLeft={1}>
-          <text color={theme.muted}>[j/k] navigate [Enter] execute [Esc] close</text>
+          <text color={theme.secondary}>[j/k] navigate [Enter] execute [Esc] close</text>
         </box>
       </box>
     );

--- a/src/tui/components/data-status.tsx
+++ b/src/tui/components/data-status.tsx
@@ -24,7 +24,7 @@ export const DataStatus: React.NamedExoticComponent<DataStatusProps> = React.mem
     if (loading) {
       return (
         <box>
-          <text color={theme.muted}> Loading...</text>
+          <text color={theme.secondary}> Loading...</text>
         </box>
       );
     }

--- a/src/tui/components/empty-state.tsx
+++ b/src/tui/components/empty-state.tsx
@@ -21,9 +21,9 @@ export const EmptyState: React.NamedExoticComponent<EmptyStateProps> = React.mem
   function EmptyState({ title, hint }: EmptyStateProps): React.ReactNode {
     return (
       <box flexDirection="column" paddingTop={1}>
-        <text color={theme.muted}>{title}</text>
+        <text color={theme.secondary}>{title}</text>
         {hint && (
-          <text color={theme.dimmed} opacity={0.7}>
+          <text color={theme.secondary} opacity={0.7}>
             {hint}
           </text>
         )}

--- a/src/tui/components/help-overlay.tsx
+++ b/src/tui/components/help-overlay.tsx
@@ -6,6 +6,11 @@
  */
 
 import React from "react";
+import {
+  DEFAULT_KEY_ACTIONS,
+  type KeybindingOverrides,
+  type RemappableAction,
+} from "../hooks/use-keybinding-overrides.js";
 import { Panel } from "../hooks/use-panel-focus.js";
 import { PANEL_REGISTRY } from "../panels/panel-registry.js";
 import { theme } from "../theme.js";
@@ -17,6 +22,13 @@ export interface HelpOverlayProps {
   readonly isDetailView?: boolean | undefined;
   /** Which panel is focused (for panel-specific hints). */
   readonly focusedPanel?: number | undefined;
+  /** Active keybinding overrides — merged config + file-based. Shows remapped keys. */
+  readonly keybindingOverrides?: KeybindingOverrides | undefined;
+}
+
+/** Return the active key for a remappable action (override or default). */
+function activeKey(action: RemappableAction, overrides: KeybindingOverrides | undefined): string {
+  return overrides?.[action] ?? DEFAULT_KEY_ACTIONS[action];
 }
 
 /** A keybinding entry for display. */
@@ -25,15 +37,17 @@ interface KeyBinding {
   readonly description: string;
 }
 
-const GLOBAL_BINDINGS: readonly KeyBinding[] = [
-  { key: "?", description: "Toggle this help" },
-  { key: "q", description: "Quit" },
-  { key: "Esc", description: "Back / dismiss / reduce zoom" },
-  { key: "Ctrl+P", description: "Command palette" },
-  { key: "Tab", description: "Cycle panel focus" },
-  { key: "Shift+Tab", description: "Cycle panel focus (reverse)" },
-  { key: "+", description: "Zoom cycle (Normal → Half → Full)" },
-];
+function globalBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
+  return [
+    { key: activeKey("help", overrides), description: "Toggle this help" },
+    { key: activeKey("quit", overrides), description: "Quit" },
+    { key: activeKey("zoom_reset", overrides), description: "Back / dismiss / reduce zoom" },
+    { key: "Ctrl+P", description: "Command palette" },
+    { key: "Tab", description: "Cycle panel focus" },
+    { key: "Shift+Tab", description: "Cycle panel focus (reverse)" },
+    { key: activeKey("zoom_cycle", overrides), description: "Zoom cycle (Normal → Half → Full)" },
+  ];
+}
 
 /** Panel keybindings derived from the registry — single source of truth. */
 const PANEL_BINDINGS: readonly KeyBinding[] = PANEL_REGISTRY.map((def) => ({
@@ -41,49 +55,63 @@ const PANEL_BINDINGS: readonly KeyBinding[] = PANEL_REGISTRY.map((def) => ({
   description: `${def.kind === "core" ? "Focus" : "Toggle"} ${def.label} panel`,
 }));
 
-const NAVIGATION_BINDINGS: readonly KeyBinding[] = [
-  { key: "j / \u2193", description: "Move cursor down" },
-  { key: "k / \u2191", description: "Move cursor up" },
-  { key: "Enter", description: "Select / expand" },
-  { key: "n", description: "Next page" },
-  { key: "p", description: "Previous page" },
-  { key: "r", description: "Refresh" },
-];
+function navigationBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
+  return [
+    { key: "j / \u2193", description: "Move cursor down" },
+    { key: "k / \u2191", description: "Move cursor up" },
+    { key: "Enter", description: "Select / expand" },
+    { key: "n", description: "Next page" },
+    { key: "p", description: "Previous page" },
+    { key: activeKey("refresh", overrides), description: "Refresh" },
+  ];
+}
 
 const DETAIL_BINDINGS: readonly KeyBinding[] = [
   { key: "Esc", description: "Back to list" },
   { key: "j / k", description: "Scroll content" },
 ];
 
-const ARTIFACT_BINDINGS: readonly KeyBinding[] = [
-  { key: "h / \u2190", description: "Previous artifact" },
-  { key: "l / \u2192", description: "Next artifact" },
-  { key: "d", description: "Toggle diff view" },
-];
+function artifactBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
+  return [
+    { key: `${activeKey("artifact_prev", overrides)} / \u2190`, description: "Previous artifact" },
+    { key: `${activeKey("artifact_next", overrides)} / \u2192`, description: "Next artifact" },
+    { key: activeKey("artifact_diff", overrides), description: "Toggle diff view" },
+  ];
+}
 
-const TERMINAL_BINDINGS: readonly KeyBinding[] = [
-  { key: "i", description: "Enter terminal input mode" },
-  { key: "Esc", description: "Exit terminal input mode" },
-];
+function terminalBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
+  return [
+    { key: activeKey("terminal_input", overrides), description: "Enter terminal input mode" },
+    { key: "Esc", description: "Exit terminal input mode" },
+  ];
+}
 
-const SEARCH_BINDINGS: readonly KeyBinding[] = [
-  { key: "/", description: "Enter search input mode" },
-  { key: "Enter", description: "Submit search query" },
-  { key: "Esc", description: "Cancel search input" },
-];
+function searchBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
+  return [
+    { key: activeKey("search_start", overrides), description: "Enter search input mode" },
+    { key: "Enter", description: "Submit search query" },
+    { key: "Esc", description: "Cancel search input" },
+  ];
+}
 
-const MESSAGING_BINDINGS: readonly KeyBinding[] = [
-  { key: "b", description: "Broadcast message to all agents" },
-  { key: "@", description: "Direct message to agent" },
-  { key: "m", description: "MCP/ask-user manager" },
-];
+function messagingBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
+  return [
+    { key: activeKey("broadcast", overrides), description: "Broadcast message to all agents" },
+    { key: activeKey("direct_message", overrides), description: "Direct message to agent" },
+    { key: "m", description: "MCP/ask-user manager" },
+  ];
+}
 
-const DECISIONS_BINDINGS: readonly KeyBinding[] = [
-  { key: "a", description: "Approve pending question" },
-  { key: "d", description: "Deny pending question" },
-];
+function decisionsBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
+  return [
+    { key: activeKey("approve", overrides), description: "Approve pending question" },
+    { key: activeKey("deny", overrides), description: "Deny pending question" },
+  ];
+}
 
-const FRONTIER_BINDINGS: readonly KeyBinding[] = [{ key: "C", description: "Compare artifacts" }];
+function frontierBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
+  return [{ key: activeKey("compare_toggle", overrides), description: "Compare artifacts" }];
+}
 
 function renderSection(title: string, bindings: readonly KeyBinding[]): React.ReactNode {
   return (
@@ -98,7 +126,7 @@ function renderSection(title: string, bindings: readonly KeyBinding[]): React.Re
           <text color={theme.text} bold>
             {b.key.padEnd(14)}
           </text>
-          <text color={theme.muted}>{b.description}</text>
+          <text color={theme.secondary}>{b.description}</text>
         </box>
       ))}
     </box>
@@ -107,39 +135,44 @@ function renderSection(title: string, bindings: readonly KeyBinding[]): React.Re
 
 /** Help overlay showing keybinding reference. */
 export const HelpOverlay: React.NamedExoticComponent<HelpOverlayProps> = React.memo(
-  function HelpOverlay({ visible, isDetailView, focusedPanel }: HelpOverlayProps): React.ReactNode {
+  function HelpOverlay({
+    visible,
+    isDetailView,
+    focusedPanel,
+    keybindingOverrides,
+  }: HelpOverlayProps): React.ReactNode {
     if (!visible) return null;
 
     const sections: React.ReactNode[] = [];
 
-    sections.push(renderSection("Global", GLOBAL_BINDINGS));
+    sections.push(renderSection("Global", globalBindings(keybindingOverrides)));
 
     if (isDetailView) {
       sections.push(renderSection("Detail View", DETAIL_BINDINGS));
     } else {
-      sections.push(renderSection("Navigation", NAVIGATION_BINDINGS));
+      sections.push(renderSection("Navigation", navigationBindings(keybindingOverrides)));
       sections.push(renderSection("Panels", PANEL_BINDINGS));
     }
 
     // Panel-specific bindings
     if (focusedPanel === Panel.Artifact) {
-      sections.push(renderSection("Artifact Panel", ARTIFACT_BINDINGS));
+      sections.push(renderSection("Artifact Panel", artifactBindings(keybindingOverrides)));
     }
     if (focusedPanel === Panel.Terminal) {
-      sections.push(renderSection("Terminal Panel", TERMINAL_BINDINGS));
+      sections.push(renderSection("Terminal Panel", terminalBindings(keybindingOverrides)));
     }
     if (focusedPanel === Panel.Search) {
-      sections.push(renderSection("Search Panel", SEARCH_BINDINGS));
+      sections.push(renderSection("Search Panel", searchBindings(keybindingOverrides)));
     }
     if (focusedPanel === Panel.Decisions) {
-      sections.push(renderSection("Decisions Panel", DECISIONS_BINDINGS));
+      sections.push(renderSection("Decisions Panel", decisionsBindings(keybindingOverrides)));
     }
     if (focusedPanel === Panel.Frontier) {
-      sections.push(renderSection("Frontier Panel", FRONTIER_BINDINGS));
+      sections.push(renderSection("Frontier Panel", frontierBindings(keybindingOverrides)));
     }
 
     // Messaging is always available in normal mode
-    sections.push(renderSection("Messaging", MESSAGING_BINDINGS));
+    sections.push(renderSection("Messaging", messagingBindings(keybindingOverrides)));
 
     return (
       <box flexDirection="column" paddingLeft={1} paddingRight={1}>

--- a/src/tui/components/input-bar.tsx
+++ b/src/tui/components/input-bar.tsx
@@ -30,9 +30,9 @@ export const InputBar: React.NamedExoticComponent<InputBarProps> = React.memo(fu
     return (
       <box paddingLeft={1} paddingRight={1} flexDirection="row">
         <text color={theme.warning}>[MESSAGE]</text>
-        <text color={theme.muted}> </text>
+        <text color={theme.secondary}> </text>
         <text color={theme.text}>{messageLabel}</text>
-        <text color={theme.muted}> — Enter to send, Esc to cancel</text>
+        <text color={theme.secondary}> — Enter to send, Esc to cancel</text>
       </box>
     );
   }
@@ -42,9 +42,9 @@ export const InputBar: React.NamedExoticComponent<InputBarProps> = React.memo(fu
   return (
     <box paddingLeft={1} paddingRight={1} flexDirection="row">
       <text color={theme.warning}>[INPUT MODE]</text>
-      <text color={theme.muted}> Sending to: </text>
+      <text color={theme.secondary}> Sending to: </text>
       <text color={theme.text}>{target}</text>
-      <text color={theme.muted}> — Esc to exit</text>
+      <text color={theme.secondary}> — Esc to exit</text>
     </box>
   );
 });

--- a/src/tui/components/outcome-badge.tsx
+++ b/src/tui/components/outcome-badge.tsx
@@ -18,7 +18,7 @@ const OUTCOME_COLORS: Record<OutcomeStatus, string> = {
   accepted: theme.success,
   rejected: theme.error,
   crashed: theme.warning,
-  invalidated: theme.muted,
+  invalidated: theme.secondary,
 };
 
 /** Short labels for outcome statuses. */

--- a/src/tui/components/progress-bar.tsx
+++ b/src/tui/components/progress-bar.tsx
@@ -51,10 +51,10 @@ export const ProgressBar: React.NamedExoticComponent<ProgressBarProps> = React.m
 
     return (
       <box flexDirection="row" paddingX={1}>
-        <text color={theme.muted}>{label} </text>
+        <text color={theme.secondary}>{label} </text>
         <text color={color}>{bar}</text>
         <text color={theme.text}> {percent}%</text>
-        <text color={theme.dimmed}>
+        <text color={theme.secondary}>
           {" "}
           ({op}
           {target})

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -97,7 +97,7 @@ export const StatusBar: React.NamedExoticComponent<StatusBarProps> = React.memo(
     <box flexDirection="column">
       {goalLabel && (
         <box>
-          <text color={theme.muted}>Goal: {goalLabel}</text>
+          <text color={theme.secondary}>Goal: {goalLabel}</text>
         </box>
       )}
       {error && (
@@ -108,18 +108,18 @@ export const StatusBar: React.NamedExoticComponent<StatusBarProps> = React.memo(
       <box flexDirection="row">
         <text color={theme.focus}>[{modeLabel}]</text>
         {screenContext && (
-          <text color={theme.muted}> [{SCREEN_CONTEXT_LABELS[screenContext]}]</text>
+          <text color={theme.secondary}> [{SCREEN_CONTEXT_LABELS[screenContext]}]</text>
         )}
         {viewMode === "pipeline" && <text color={theme.warning}> [PIPELINE]</text>}
         <text opacity={0.5}>{hints}</text>
         {agentLabel && (
-          <text color={theme.muted}>
+          <text color={theme.secondary}>
             {"  "}
             {agentLabel}
           </text>
         )}
         {costLabel && (
-          <text color={theme.muted}>
+          <text color={theme.secondary}>
             {"  "}
             {costLabel}
           </text>

--- a/src/tui/components/tab-bar.tsx
+++ b/src/tui/components/tab-bar.tsx
@@ -24,7 +24,7 @@ export const PanelBar: React.NamedExoticComponent<PanelBarProps> = React.memo(fu
         const isActive = panel === panelState.focused;
         return (
           <box key={panel} marginRight={2}>
-            <text bold={isActive} color={isActive ? theme.focus : theme.muted}>
+            <text bold={isActive} color={isActive ? theme.focus : theme.secondary}>
               {isActive ? `[${panel}:${PANEL_LABELS[panel]}]` : ` ${panel}:${PANEL_LABELS[panel]} `}
             </text>
           </box>

--- a/src/tui/components/table.tsx
+++ b/src/tui/components/table.tsx
@@ -103,7 +103,7 @@ export const Table: React.NamedExoticComponent<TableProps> = React.memo(function
       </box>
       {truncated && (
         <box>
-          <text color={theme.dimmed}>{`Showing ${maxItems} of ${rows.length}`}</text>
+          <text color={theme.secondary}>{`Showing ${maxItems} of ${rows.length}`}</text>
         </box>
       )}
     </box>

--- a/src/tui/components/tooltip-overlay.tsx
+++ b/src/tui/components/tooltip-overlay.tsx
@@ -150,7 +150,7 @@ export const TooltipOverlay: React.NamedExoticComponent<TooltipOverlayProps> = R
             <text color={theme.info} bold>
               Welcome to Grove!
             </text>
-            <text color={theme.muted}>Here's a quick overview of each panel:</text>
+            <text color={theme.secondary}>Here's a quick overview of each panel:</text>
             <text> </text>
             {FIRST_LAUNCH_TOOLTIPS.map((tip) => (
               <box key={tip.panel} flexDirection="column">
@@ -159,7 +159,7 @@ export const TooltipOverlay: React.NamedExoticComponent<TooltipOverlayProps> = R
                 </text>
                 {tip.lines.map((line, i) => (
                   // biome-ignore lint/suspicious/noArrayIndexKey: tooltip lines are static
-                  <text key={i} color={theme.muted}>
+                  <text key={i} color={theme.secondary}>
                     {"  "}
                     {line}
                   </text>
@@ -167,7 +167,7 @@ export const TooltipOverlay: React.NamedExoticComponent<TooltipOverlayProps> = R
                 <text> </text>
               </box>
             ))}
-            <text color={theme.dimmed}>Press any key to dismiss | These won't appear again</text>
+            <text color={theme.secondary}>Press any key to dismiss | These won't appear again</text>
           </box>
         </box>
       </box>

--- a/src/tui/config-loader.test.ts
+++ b/src/tui/config-loader.test.ts
@@ -1,0 +1,80 @@
+/**
+ * TDD tests for the Grove config loader.
+ *
+ * Tests are written against the pure `mergeGroveConfig` function only —
+ * no file I/O, no side effects.  These tests define the merge contract
+ * before the implementation exists.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EMPTY_CONFIG, mergeGroveConfig } from "./config-loader.js";
+
+describe("mergeGroveConfig — merge semantics", () => {
+  test("global-only returns global theme and keymap", () => {
+    const result = mergeGroveConfig(
+      { theme: { focus: "#ff0000" }, keymap: { quit: "Q" } },
+      undefined,
+    );
+    expect(result.theme.focus).toBe("#ff0000");
+    expect(result.keymap.quit).toBe("Q");
+  });
+
+  test("project-only returns project theme and keymap", () => {
+    const result = mergeGroveConfig(undefined, {
+      theme: { focus: "#00ff00" },
+      keymap: { help: "F1" },
+    });
+    expect(result.theme.focus).toBe("#00ff00");
+    expect(result.keymap.help).toBe("F1");
+  });
+
+  test("project theme token overrides global scalar", () => {
+    const result = mergeGroveConfig(
+      { theme: { focus: "#ff0000", border: "#111111" } },
+      { theme: { focus: "#00ff00" } },
+    );
+    expect(result.theme.focus).toBe("#00ff00"); // project wins
+    expect(result.theme.border).toBe("#111111"); // global preserved
+  });
+
+  test("project keymap extends global additively", () => {
+    const result = mergeGroveConfig({ keymap: { quit: "Q" } }, { keymap: { help: "F1" } });
+    expect(result.keymap.quit).toBe("Q"); // from global
+    expect(result.keymap.help).toBe("F1"); // from project
+  });
+
+  test("project keymap entry wins over same global key", () => {
+    const result = mergeGroveConfig({ keymap: { quit: "Q" } }, { keymap: { quit: "X" } });
+    expect(result.keymap.quit).toBe("X");
+  });
+
+  test("empty project does not clobber global", () => {
+    const result = mergeGroveConfig({ theme: { focus: "#ff0000" }, keymap: { quit: "Q" } }, {});
+    expect(result.theme.focus).toBe("#ff0000");
+    expect(result.keymap.quit).toBe("Q");
+  });
+
+  test("empty global is handled gracefully", () => {
+    const result = mergeGroveConfig({}, { theme: { focus: "#00ff00" } });
+    expect(result.theme.focus).toBe("#00ff00");
+  });
+
+  test("both undefined returns empty config", () => {
+    const result = mergeGroveConfig(undefined, undefined);
+    expect(result.theme).toEqual({});
+    expect(result.keymap).toEqual({});
+  });
+
+  test("EMPTY_CONFIG has empty theme and keymap", () => {
+    expect(EMPTY_CONFIG.theme).toEqual({});
+    expect(EMPTY_CONFIG.keymap).toEqual({});
+  });
+
+  test("merge is non-destructive to inputs", () => {
+    const global = { theme: { focus: "#ff0000" }, keymap: { quit: "Q" } };
+    const project = { theme: { focus: "#00ff00" } };
+    mergeGroveConfig(global, project);
+    expect(global.theme.focus).toBe("#ff0000"); // not mutated
+    expect(project.theme.focus).toBe("#00ff00"); // not mutated
+  });
+});

--- a/src/tui/config-loader.ts
+++ b/src/tui/config-loader.ts
@@ -1,0 +1,113 @@
+/**
+ * Grove TUI config loader.
+ *
+ * Loads user configuration from a layered stack and merges it:
+ *
+ *   global  (~/.config/grove/config.json)
+ *     ↓ project  (.grove/config.json, from groveDir)
+ *       ↓ env var  (GROVE_CONFIG — path to an additional override file)
+ *
+ * Merge semantics:
+ *   - theme tokens: last-wins (project overrides global per key)
+ *   - keymap:       additive (project entries extend global; project wins on conflict)
+ *
+ * All layers are optional — missing files are silently skipped.
+ */
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import type { RemappableAction } from "./hooks/use-keybinding-overrides.js";
+import type { ThemeColorTokens } from "./theme.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** User-authored grove config (all fields optional — defaults always apply). */
+export interface GroveUserConfig {
+  readonly theme: Partial<ThemeColorTokens>;
+  readonly keymap: Partial<Record<RemappableAction, string>>;
+}
+
+/** Empty config — returned when no config files are found. */
+export const EMPTY_CONFIG: GroveUserConfig = { theme: {}, keymap: {} };
+
+// ---------------------------------------------------------------------------
+// Zod schema (strip unknown keys for forward compat)
+// ---------------------------------------------------------------------------
+
+const ConfigSchema = z
+  .object({
+    theme: z.record(z.string(), z.string()).optional(),
+    keymap: z.record(z.string(), z.string()).optional(),
+  })
+  .strip();
+
+// ---------------------------------------------------------------------------
+// Pure merge function (exported for testing — Issue 12A TDD)
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge two config layers.  `project` wins over `global` for scalar theme
+ * tokens; keymap entries are additive (union) with `project` winning on
+ * conflict.
+ */
+export function mergeGroveConfig(
+  global: Partial<GroveUserConfig> | undefined,
+  project: Partial<GroveUserConfig> | undefined,
+): GroveUserConfig {
+  return {
+    theme: { ...global?.theme, ...project?.theme },
+    keymap: { ...global?.keymap, ...project?.keymap },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// I/O helpers
+// ---------------------------------------------------------------------------
+
+/** Load and validate a single config file. Returns undefined on any error. */
+async function loadConfigFile(filePath: string): Promise<Partial<GroveUserConfig> | undefined> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const parsed = ConfigSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) {
+      process.stderr.write(`[grove] config parse error in ${filePath}: ${parsed.error.message}\n`);
+      return undefined;
+    }
+    return {
+      theme: (parsed.data.theme ?? {}) as Partial<ThemeColorTokens>,
+      keymap: (parsed.data.keymap ?? {}) as Partial<Record<RemappableAction, string>>,
+    };
+  } catch {
+    // File not found or JSON parse error — gracefully skip
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Load user config from all layers and return the merged result.
+ *
+ * @param groveDir - Resolved .grove directory path (project-local layer).
+ */
+export async function loadGroveConfig(groveDir?: string): Promise<GroveUserConfig> {
+  const globalPath = join(homedir(), ".config", "grove", "config.json");
+  const projectPath = groveDir ? join(groveDir, "config.json") : undefined;
+  const envPath = process.env.GROVE_CONFIG;
+
+  const [globalCfg, projectCfg, envCfg] = await Promise.all([
+    loadConfigFile(globalPath),
+    projectPath !== undefined ? loadConfigFile(projectPath) : Promise.resolve(undefined),
+    envPath !== undefined ? loadConfigFile(envPath) : Promise.resolve(undefined),
+  ]);
+
+  // Merge order: global → project → env (env is highest priority)
+  const base = mergeGroveConfig(globalCfg, projectCfg);
+  return mergeGroveConfig(base, envCfg);
+}

--- a/src/tui/hooks/use-keybinding-overrides.test.ts
+++ b/src/tui/hooks/use-keybinding-overrides.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Unit tests for use-keybinding-overrides.ts.
+ *
+ * Tests the loader, map builder, and routeKey integration path.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { KeyEvent } from "@opentui/core";
+import {
+  buildKeyActionMap,
+  loadKeybindings,
+  REMAPPABLE_ACTIONS,
+} from "./use-keybinding-overrides.js";
+import type { KeyboardActions } from "./use-keyboard-handler.js";
+import { routeKey } from "./use-keyboard-handler.js";
+import type { PanelFocusState } from "./use-panel-focus.js";
+import { InputMode, Panel } from "./use-panel-focus.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let origCwd: string;
+
+beforeEach(async () => {
+  origCwd = process.cwd();
+  tmpDir = await mkdtemp(join(tmpdir(), "grove-kb-test-"));
+  process.chdir(tmpDir);
+});
+
+afterEach(async () => {
+  process.chdir(origCwd);
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+/** Write a .grove/keybindings.json file in the temp cwd. */
+async function writeKeybindings(content: unknown): Promise<void> {
+  await mkdir(join(tmpDir, ".grove"), { recursive: true });
+  await writeFile(join(tmpDir, ".grove", "keybindings.json"), JSON.stringify(content), "utf-8");
+}
+
+function keyEvent(name: string, opts?: { ctrl?: boolean }): KeyEvent {
+  return {
+    name,
+    ctrl: opts?.ctrl ?? false,
+    shift: false,
+    meta: false,
+    alt: false,
+    option: false,
+    sequence: name,
+    raw: name,
+    eventType: "keypress",
+    preventDefault: () => {
+      /* noop */
+    },
+    stopPropagation: () => {
+      /* noop */
+    },
+  } as unknown as KeyEvent;
+}
+
+function mockActions(overrides?: Partial<{ mode: InputMode; focused: Panel }>): KeyboardActions {
+  const panelState: PanelFocusState = {
+    focused: overrides?.focused ?? Panel.Dag,
+    visibleOperator: new Set(),
+    mode: overrides?.mode ?? InputMode.Normal,
+    viewMode: "grid",
+  };
+  return {
+    panels: {
+      state: panelState,
+      focus: () => {
+        /* noop */
+      },
+      toggle: () => {
+        /* noop */
+      },
+      cycleNext: () => {
+        /* noop */
+      },
+      cyclePrev: () => {
+        /* noop */
+      },
+      setMode: () => {
+        /* noop */
+      },
+      cycleViewMode: () => {
+        /* noop */
+      },
+      isVisible: () => true,
+      visiblePanels: [],
+    },
+    nav: {
+      state: { activeTab: 0, cursor: 0, pageOffset: 0, detailStack: [] },
+      isDetailView: false,
+      detailCid: undefined,
+      switchTab: () => {
+        /* noop */
+      },
+      cursorDown: () => {
+        /* noop */
+      },
+      cursorUp: () => {
+        /* noop */
+      },
+      pushDetail: () => {
+        /* noop */
+      },
+      popDetail: () => {
+        /* noop */
+      },
+      resetCursor: () => {
+        /* noop */
+      },
+      nextPage: () => {
+        /* noop */
+      },
+      prevPage: () => {
+        /* noop */
+      },
+    },
+    onQuit: () => {
+      /* noop */
+    },
+    onSpawnPalette: () => {
+      /* noop */
+    },
+    onVfsNavigate: () => {
+      /* noop */
+    },
+    onArtifactPrev: () => {
+      /* noop */
+    },
+    onArtifactNext: () => {
+      /* noop */
+    },
+    onArtifactDiffToggle: () => {
+      /* noop */
+    },
+    onCompareToggle: () => {
+      /* noop */
+    },
+    onCompareSelect: () => {
+      /* noop */
+    },
+    onCompareAdopt: () => {
+      /* noop */
+    },
+    onSearchStart: () => {
+      /* noop */
+    },
+    onSearchSubmit: () => {
+      /* noop */
+    },
+    onSearchChar: () => {
+      /* noop */
+    },
+    onSearchBackspace: () => {
+      /* noop */
+    },
+    onMessageSubmit: () => {
+      /* noop */
+    },
+    onMessageChar: () => {
+      /* noop */
+    },
+    onMessageBackspace: () => {
+      /* noop */
+    },
+    onGoalSubmit: () => {
+      /* noop */
+    },
+    onGoalChar: () => {
+      /* noop */
+    },
+    onGoalBackspace: () => {
+      /* noop */
+    },
+    onBroadcastMode: () => {
+      /* noop */
+    },
+    onDirectMessageMode: () => {
+      /* noop */
+    },
+    onApproveQuestion: () => {
+      /* noop */
+    },
+    onDenyQuestion: () => {
+      /* noop */
+    },
+    onSendKeys: () => {
+      /* noop */
+    },
+    onPaletteUp: () => {
+      /* noop */
+    },
+    onPaletteDown: () => {
+      /* noop */
+    },
+    onPaletteSelect: () => {
+      /* noop */
+    },
+    onPaletteChar: () => {
+      /* noop */
+    },
+    onPaletteBackspace: () => {
+      /* noop */
+    },
+    onZoomCycle: () => {
+      /* noop */
+    },
+    onZoomReset: () => {
+      /* noop */
+    },
+    onTerminalScrollUp: () => {
+      /* noop */
+    },
+    onTerminalScrollDown: () => {
+      /* noop */
+    },
+    onTerminalScrollBottom: () => {
+      /* noop */
+    },
+    onLayoutToggle: () => {
+      /* noop */
+    },
+    onRefresh: () => {
+      /* noop */
+    },
+    onSelect: () => {
+      /* noop */
+    },
+    rowCount: 10,
+    pageSize: 20,
+    paletteItemCount: 5,
+    compareMode: false,
+    frontierCids: [],
+    selectedSession: undefined,
+    hasTmux: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// loadKeybindings
+// ---------------------------------------------------------------------------
+
+describe("loadKeybindings", () => {
+  test("returns empty object when file does not exist", async () => {
+    const result = await loadKeybindings();
+    expect(result).toEqual({});
+  });
+
+  test("happy path: loads valid action→key map", async () => {
+    await writeKeybindings({ quit: "Q", help: "F1" });
+    const result = await loadKeybindings();
+    expect(result.quit).toBe("Q");
+    expect(result.help).toBe("F1");
+  });
+
+  test("silently ignores unknown action names", async () => {
+    await writeKeybindings({ quit: "Q", nonexistent_action: "X" });
+    const result = await loadKeybindings();
+    expect(result.quit).toBe("Q");
+    expect(result.nonexistent_action).toBeUndefined();
+  });
+
+  test("returns empty object on corrupt JSON", async () => {
+    await mkdir(join(tmpDir, ".grove"), { recursive: true });
+    await writeFile(join(tmpDir, ".grove", "keybindings.json"), "{ bad json", "utf-8");
+    const result = await loadKeybindings();
+    expect(result).toEqual({});
+  });
+
+  test("returns empty object when values are not strings (Zod validation)", async () => {
+    // Zod rejects non-string values — whole file fails validation
+    await writeKeybindings({ quit: 42 });
+    const result = await loadKeybindings();
+    expect(result).toEqual({});
+  });
+
+  test("loads all REMAPPABLE_ACTIONS correctly", async () => {
+    const allActions: Record<string, string> = {};
+    for (const action of REMAPPABLE_ACTIONS) {
+      allActions[action] = `key-${action}`;
+    }
+    await writeKeybindings(allActions);
+    const result = await loadKeybindings();
+    for (const action of REMAPPABLE_ACTIONS) {
+      expect(result[action]).toBe(`key-${action}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildKeyActionMap
+// ---------------------------------------------------------------------------
+
+describe("buildKeyActionMap", () => {
+  test("empty overrides produces empty map", () => {
+    const map = buildKeyActionMap({});
+    expect(map.size).toBe(0);
+  });
+
+  test("builds reverse map from action→key to key→action", () => {
+    const map = buildKeyActionMap({ quit: "Q", help: "F1" });
+    expect(map.get("Q")).toBe("quit");
+    expect(map.get("F1")).toBe("help");
+  });
+
+  test("first-win semantics when two actions share the same key", () => {
+    // Object.entries iteration order is insertion order for string keys
+    const overrides: Record<string, string> = {};
+    overrides.quit = "X";
+    overrides.refresh = "X";
+    const map = buildKeyActionMap(overrides);
+    // "quit" was inserted first → "X" maps to "quit"
+    expect(map.get("X")).toBe("quit");
+    expect(map.size).toBe(1); // only one entry for "X"
+  });
+
+  test("multiple distinct keys all appear in map", () => {
+    const map = buildKeyActionMap({ quit: "Q", help: "H", refresh: "R" });
+    expect(map.size).toBe(3);
+    expect(map.get("Q")).toBe("quit");
+    expect(map.get("H")).toBe("help");
+    expect(map.get("R")).toBe("refresh");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// routeKey integration: override actually routes correctly
+// ---------------------------------------------------------------------------
+
+describe("routeKey — keybinding override integration", () => {
+  test("remapped quit key triggers onQuit", () => {
+    let quitCalled = false;
+    const overrides = { quit: "Q" };
+    const keyMap = buildKeyActionMap(overrides);
+    const actions: KeyboardActions = {
+      ...mockActions(),
+      onQuit: () => {
+        quitCalled = true;
+      },
+      keybindingOverrides: overrides,
+      keyActionMap: keyMap,
+    };
+
+    const handled = routeKey(keyEvent("Q"), actions);
+    expect(handled).toBe(true);
+    expect(quitCalled).toBe(true);
+  });
+
+  test("non-overridden key falls through to default handler", () => {
+    let quitCalled = false;
+    const actions: KeyboardActions = {
+      ...mockActions(),
+      onQuit: () => {
+        quitCalled = true;
+      },
+      keybindingOverrides: {},
+      keyActionMap: new Map(),
+    };
+
+    // No override for "q" — the default hardcoded "q" handler runs
+    const handled = routeKey(keyEvent("q"), actions);
+    expect(handled).toBe(true);
+    expect(quitCalled).toBe(true);
+  });
+});

--- a/src/tui/hooks/use-keybinding-overrides.ts
+++ b/src/tui/hooks/use-keybinding-overrides.ts
@@ -1,5 +1,5 @@
 /**
- * Customizable keybindings loader (item 19).
+ * Customizable keybindings loader.
  *
  * Loads keybinding overrides from `.grove/keybindings.json`.
  * Format: { "action": "key" } where action is a routeKey action name
@@ -12,9 +12,14 @@
  *   "zoom_cycle": "z",
  *   "broadcast": "B"
  * }
+ *
+ * Unknown action names and key conflicts are reported to stderr.
  */
 
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { useEffect, useState } from "react";
+import { z } from "zod";
 
 /** Map from action name to custom key binding. */
 export type KeybindingOverrides = Readonly<Record<string, string>>;
@@ -43,20 +48,45 @@ export type RemappableAction = (typeof REMAPPABLE_ACTIONS)[number];
 
 const KEYBINDINGS_PATH = ".grove/keybindings.json";
 
-/** Load keybinding overrides from disk. */
-async function loadKeybindings(): Promise<KeybindingOverrides> {
+/** Zod schema: keybindings file must be a flat string→string map. */
+const KeybindingFileSchema = z.record(z.string(), z.string());
+
+/** Load keybinding overrides from disk with validation and conflict reporting. */
+export async function loadKeybindings(): Promise<KeybindingOverrides> {
   try {
-    const { readFileSync } = await import("node:fs");
-    const { resolve } = await import("node:path");
     const path = resolve(process.cwd(), KEYBINDINGS_PATH);
-    const raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+    const raw = JSON.parse(await readFile(path, "utf-8")) as unknown;
+
+    const parsed = KeybindingFileSchema.safeParse(raw);
+    if (!parsed.success) {
+      process.stderr.write(`[grove] keybindings.json parse error: ${parsed.error.message}\n`);
+      return {};
+    }
 
     const overrides: Record<string, string> = {};
-    for (const [action, key] of Object.entries(raw)) {
-      if (typeof key === "string" && (REMAPPABLE_ACTIONS as readonly string[]).includes(action)) {
-        overrides[action] = key;
+    // Track key → list of actions mapped to it (for conflict detection)
+    const keyToActions = new Map<string, string[]>();
+
+    for (const [action, key] of Object.entries(parsed.data)) {
+      if (!(REMAPPABLE_ACTIONS as readonly string[]).includes(action)) {
+        process.stderr.write(`[grove] keybindings.json: unknown action "${action}" — ignored\n`);
+        continue;
+      }
+      const existing = keyToActions.get(key) ?? [];
+      existing.push(action);
+      keyToActions.set(key, existing);
+      overrides[action] = key;
+    }
+
+    // Report conflicts (same key mapped to multiple actions)
+    for (const [key, actions] of keyToActions) {
+      if (actions.length > 1) {
+        process.stderr.write(
+          `[grove] keybindings.json: key "${key}" mapped to multiple actions (${actions.join(", ")}) — first wins\n`,
+        );
       }
     }
+
     return overrides;
   } catch {
     return {};
@@ -64,11 +94,10 @@ async function loadKeybindings(): Promise<KeybindingOverrides> {
 }
 
 /**
- * Build a reverse map: key → action name (for quick lookup in routeKey).
+ * Build a reverse map: key → action name (for O(1) lookup in routeKey).
  *
  * Uses first-win semantics: if two actions are mapped to the same key,
- * the first one in iteration order wins. This preserves the behavior of
- * the prior O(n) Object.entries scan that stopped at the first match.
+ * the first one in iteration order wins.
  */
 export function buildKeyActionMap(
   overrides: KeybindingOverrides,

--- a/src/tui/hooks/use-keyboard-handler.test.ts
+++ b/src/tui/hooks/use-keyboard-handler.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
+import { PANEL_REGISTRY } from "../panels/panel-registry.js";
 import { buildKeyActionMap } from "./use-keybinding-overrides.js";
 import type { KeyboardActions } from "./use-keyboard-handler.js";
 import { nextZoom, routeKey } from "./use-keyboard-handler.js";
@@ -740,5 +741,48 @@ describe("tuiReducer", () => {
     const state = tuiReducer(initial, { type: "DIRECT_MESSAGE_MODE" });
     expect(state.messageBuffer).toBe("@");
     expect(state.messageRecipients).toBe("@direct");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parametric: registry-driven panel dispatch (Issue 4A / Issue 11A)
+// ---------------------------------------------------------------------------
+
+describe("routeKey — registry-driven panel dispatch", () => {
+  // One test per panel entry: proves the PANEL_REGISTRY loop generalizes
+  // correctly for all 17 panels and both core/operator dispatch branches.
+  for (const def of PANEL_REGISTRY) {
+    const action = def.kind === "core" ? "panels.focus" : "panels.toggle";
+    test(`key "${def.keybinding}" → ${action}(${def.panel})`, () => {
+      const { actions, log } = mockActions();
+      const handled = routeKey(keyEvent(def.keybinding), actions);
+      expect(handled).toBe(true);
+      if (def.kind === "core") {
+        expect(log.calls).toContain("panels.focus");
+        expect(log.args["panels.focus"]).toEqual([def.panel]);
+      } else {
+        expect(log.calls).toContain("panels.toggle");
+        expect(log.args["panels.toggle"]).toEqual([def.panel]);
+      }
+    });
+  }
+
+  test("core panels call focus, operator panels call toggle", () => {
+    const corePanels = PANEL_REGISTRY.filter((d) => d.kind === "core");
+    const operatorPanels = PANEL_REGISTRY.filter((d) => d.kind === "operator");
+    expect(corePanels.length).toBeGreaterThan(0);
+    expect(operatorPanels.length).toBeGreaterThan(0);
+    for (const def of corePanels) {
+      const { actions, log } = mockActions();
+      routeKey(keyEvent(def.keybinding), actions);
+      expect(log.calls).toContain("panels.focus");
+      expect(log.calls).not.toContain("panels.toggle");
+    }
+    for (const def of operatorPanels) {
+      const { actions, log } = mockActions();
+      routeKey(keyEvent(def.keybinding), actions);
+      expect(log.calls).toContain("panels.toggle");
+      expect(log.calls).not.toContain("panels.focus");
+    }
   });
 });

--- a/src/tui/hooks/use-keyboard-handler.ts
+++ b/src/tui/hooks/use-keyboard-handler.ts
@@ -7,6 +7,7 @@
 
 import type { KeyEvent } from "@opentui/core";
 import type { ZoomLevel } from "../panels/panel-manager.js";
+import { PANEL_REGISTRY } from "../panels/panel-registry.js";
 import { isHelpToggleKey } from "./shared-keyboard-core.js";
 import type { KeybindingOverrides, RemappableAction } from "./use-keybinding-overrides.js";
 import type { NavigationActions } from "./use-navigation.js";
@@ -297,80 +298,17 @@ export function routeKey(key: KeyEvent, actions: KeyboardActions): boolean {
     return true;
   }
 
-  // Panel focus: 1-4
-  if (input === "1") {
-    actions.panels.focus(Panel.Dag);
-    return true;
-  }
-  if (input === "2") {
-    actions.panels.focus(Panel.Detail);
-    return true;
-  }
-  if (input === "3") {
-    actions.panels.focus(Panel.Frontier);
-    return true;
-  }
-  if (input === "4") {
-    actions.panels.focus(Panel.Claims);
-    return true;
-  }
-
-  // Panel toggle: 5-=, [, ], \, ;, '
-  if (input === "5") {
-    actions.panels.toggle(Panel.AgentList);
-    return true;
-  }
-  if (input === "6") {
-    actions.panels.toggle(Panel.Terminal);
-    return true;
-  }
-  if (input === "7") {
-    actions.panels.toggle(Panel.Artifact);
-    return true;
-  }
-  if (input === "8") {
-    actions.panels.toggle(Panel.Vfs);
-    return true;
-  }
-  if (input === "9") {
-    actions.panels.toggle(Panel.Activity);
-    return true;
-  }
-  if (input === "0") {
-    actions.panels.toggle(Panel.Search);
-    return true;
-  }
-  if (input === "-") {
-    actions.panels.toggle(Panel.Threads);
-    return true;
-  }
-  if (input === "=") {
-    actions.panels.toggle(Panel.Outcomes);
-    return true;
-  }
-  if (input === "[") {
-    actions.panels.toggle(Panel.Bounties);
-    return true;
-  }
-  if (input === "]") {
-    actions.panels.toggle(Panel.Gossip);
-    return true;
-  }
-  if (input === "\\") {
-    actions.panels.toggle(Panel.Inbox);
-    return true;
-  }
-  if (input === ";") {
-    actions.panels.toggle(Panel.Decisions);
-    return true;
-  }
-  if (input === "'") {
-    actions.panels.toggle(Panel.GitHub);
-    return true;
-  }
-  if (input === "`") {
-    actions.panels.toggle(Panel.Plan);
-    return true;
+  // Panel dispatch: driven by PANEL_REGISTRY (Issue 4A — eliminates DRY violation
+  // and enables config-driven keybindings in the future).
+  for (const def of PANEL_REGISTRY) {
+    if (input === def.keybinding) {
+      if (def.kind === "core") {
+        actions.panels.focus(def.panel);
+      } else {
+        actions.panels.toggle(def.panel);
+      }
+      return true;
+    }
   }
 
   // Tab/Shift+Tab: cycle focus

--- a/src/tui/hooks/use-session-persistence.test.ts
+++ b/src/tui/hooks/use-session-persistence.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for use-session-persistence.ts.
+ *
+ * Covers I/O helpers (readViewState, writeAtomic, sessionStatePath)
+ * and hook behavior (write-gate race condition, debounce cancel on unmount).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readViewState,
+  sessionStatePath,
+  type TuiViewState,
+  writeAtomic,
+} from "./use-session-persistence.js";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "grove-persist-test-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// sessionStatePath
+// ---------------------------------------------------------------------------
+
+describe("sessionStatePath", () => {
+  test("returns expected path format", () => {
+    const p = sessionStatePath("/some/grove", "abc123");
+    expect(p).toBe(join("/some/grove", ".sessions", "abc123-tui-state.json"));
+  });
+
+  test("includes session ID in filename", () => {
+    const p = sessionStatePath("/grove", "my-session");
+    expect(p).toContain("my-session-tui-state.json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeAtomic
+// ---------------------------------------------------------------------------
+
+describe("writeAtomic", () => {
+  test("writes content to target file", async () => {
+    const path = join(tmpDir, "test.json");
+    await writeAtomic(path, '{"ok":true}');
+    const content = await readFile(path, "utf-8");
+    expect(content).toBe('{"ok":true}');
+  });
+
+  test("creates parent directory if missing", async () => {
+    const path = join(tmpDir, "nested", "dir", "test.json");
+    await writeAtomic(path, "hello");
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test("no .tmp file remains after successful write", async () => {
+    const path = join(tmpDir, "test.json");
+    await writeAtomic(path, "data");
+    expect(existsSync(`${path}.tmp`)).toBe(false);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  test("overwrites existing file atomically", async () => {
+    const path = join(tmpDir, "test.json");
+    await writeAtomic(path, "first");
+    await writeAtomic(path, "second");
+    const content = await readFile(path, "utf-8");
+    expect(content).toBe("second");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readViewState
+// ---------------------------------------------------------------------------
+
+describe("readViewState", () => {
+  test("returns null when file does not exist", async () => {
+    const result = await readViewState(tmpDir, "nonexistent");
+    expect(result).toBeNull();
+  });
+
+  test("returns null on corrupt JSON", async () => {
+    const sessDir = join(tmpDir, ".sessions");
+    await mkdir(sessDir, { recursive: true });
+    await writeFile(join(sessDir, "bad-tui-state.json"), "{ bad", "utf-8");
+    const result = await readViewState(tmpDir, "bad");
+    expect(result).toBeNull();
+  });
+
+  test("loads all TuiViewState fields", async () => {
+    const state: TuiViewState = {
+      zoomLevel: "half",
+      focusedPanel: 2,
+      visibleOperatorPanels: [5, 6],
+      searchQuery: "my search",
+    };
+    const sessDir = join(tmpDir, ".sessions");
+    await mkdir(sessDir, { recursive: true });
+    await writeFile(join(sessDir, "sess1-tui-state.json"), JSON.stringify(state), "utf-8");
+
+    const result = await readViewState(tmpDir, "sess1");
+    expect(result).not.toBeNull();
+    expect(result?.zoomLevel).toBe("half");
+    expect(result?.focusedPanel).toBe(2);
+    expect(result?.visibleOperatorPanels).toEqual([5, 6]);
+    expect(result?.searchQuery).toBe("my search");
+  });
+
+  test("handles null expandedPanel correctly", async () => {
+    const sessDir = join(tmpDir, ".sessions");
+    await mkdir(sessDir, { recursive: true });
+    await writeFile(
+      join(sessDir, "s-tui-state.json"),
+      JSON.stringify({ expandedPanel: null }),
+      "utf-8",
+    );
+    const result = await readViewState(tmpDir, "s");
+    expect(result?.expandedPanel).toBeNull();
+  });
+
+  test("returns undefined for unknown field types (type coercion guard)", async () => {
+    const sessDir = join(tmpDir, ".sessions");
+    await mkdir(sessDir, { recursive: true });
+    await writeFile(
+      join(sessDir, "t-tui-state.json"),
+      JSON.stringify({ zoomLevel: 999, focusedPanel: "not-a-number" }),
+      "utf-8",
+    );
+    const result = await readViewState(tmpDir, "t");
+    // zoomLevel is not a string → undefined; focusedPanel is not a number → undefined
+    expect(result?.zoomLevel).toBeUndefined();
+    expect(result?.focusedPanel).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: write then read
+// ---------------------------------------------------------------------------
+
+describe("writeAtomic + readViewState round-trip", () => {
+  test("state survives a write-then-read cycle", async () => {
+    const state: TuiViewState = {
+      zoomLevel: "full",
+      focusedPanel: 3,
+      visibleOperatorPanels: [5, 7],
+      searchQuery: "hello",
+    };
+    const path = sessionStatePath(tmpDir, "round-trip");
+    await writeAtomic(path, `${JSON.stringify(state, null, 2)}\n`);
+    const result = await readViewState(tmpDir, "round-trip");
+    expect(result?.zoomLevel).toBe("full");
+    expect(result?.focusedPanel).toBe(3);
+    expect(result?.visibleOperatorPanels).toEqual([5, 7]);
+    expect(result?.searchQuery).toBe("hello");
+  });
+});

--- a/src/tui/hooks/use-session-persistence.ts
+++ b/src/tui/hooks/use-session-persistence.ts
@@ -4,14 +4,17 @@
  * Persists to `.grove/.sessions/<sessionId>-tui-state.json`:
  * - Panel focus (which panel is selected)
  * - Zoom level (normal/half/full)
- * - Expanded panel (which panel is expanded, or null)
- * - Selected agent index in trace view
+ * - Visible operator panels
+ * - Search query
  *
  * On restart/resume, restores layout so the user picks up where they left off.
  *
- * Also maintains the legacy `.grove/tui-state.json` write for backward compat.
+ * Writes are atomic (temp-file → rename) to prevent corruption on crash.
  */
 
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ZoomLevel } from "../panels/panel-registry.js";
 import type { RunningPanel } from "../screens/running-keyboard.js";
@@ -30,13 +33,9 @@ export interface TuiViewState {
   readonly traceSelectedAgent?: number | undefined;
   /** Index of the focused panel in the panel-manager (advanced mode). */
   readonly focusedPanel?: number | undefined;
-}
-
-/** Persisted TUI session state (legacy + new combined). */
-export interface PersistedTuiState {
-  readonly zoomLevel?: ZoomLevel | undefined;
-  readonly focusedPanel?: number | undefined;
+  /** Visible operator panel IDs (for grid layout restore). */
   readonly visibleOperatorPanels?: readonly number[] | undefined;
+  /** Active search query (restored on resume). */
   readonly searchQuery?: string | undefined;
 }
 
@@ -44,10 +43,8 @@ export interface PersistedTuiState {
 // Paths
 // ---------------------------------------------------------------------------
 
-const LEGACY_TUI_STATE_PATH = ".grove/tui-state.json";
-
-function sessionStatePath(groveDir: string, sessionId: string): string {
-  const { join } = require("node:path") as typeof import("node:path");
+/** Resolve the per-session state file path. */
+export function sessionStatePath(groveDir: string, sessionId: string): string {
   return join(groveDir, ".sessions", `${sessionId}-tui-state.json`);
 }
 
@@ -55,55 +52,31 @@ function sessionStatePath(groveDir: string, sessionId: string): string {
 // I/O helpers
 // ---------------------------------------------------------------------------
 
-/** Read persisted TUI state from disk. */
-async function readTuiState(): Promise<PersistedTuiState> {
-  try {
-    const { readFileSync } = await import("node:fs");
-    const { resolve } = await import("node:path");
-    const path = resolve(process.cwd(), LEGACY_TUI_STATE_PATH);
-    const json = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
-    return {
-      zoomLevel: typeof json.zoomLevel === "string" ? (json.zoomLevel as ZoomLevel) : undefined,
-      focusedPanel: typeof json.focusedPanel === "number" ? json.focusedPanel : undefined,
-      visibleOperatorPanels: Array.isArray(json.visibleOperatorPanels)
-        ? (json.visibleOperatorPanels as number[])
-        : undefined,
-      searchQuery: typeof json.searchQuery === "string" ? json.searchQuery : undefined,
-    };
-  } catch {
-    return {};
+/**
+ * Atomically write `content` to `filePath` using temp-file → rename.
+ *
+ * On POSIX filesystems, `rename` is atomic — the original file is never
+ * partially overwritten, so a crash mid-write cannot corrupt the state file.
+ */
+export async function writeAtomic(filePath: string, content: string): Promise<void> {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    await mkdir(dir, { recursive: true });
   }
+  const tmp = `${filePath}.tmp`;
+  await writeFile(tmp, content, "utf-8");
+  await rename(tmp, filePath);
 }
 
-/** Persist TUI state to disk (merges with existing state). */
-async function writeTuiState(state: PersistedTuiState): Promise<void> {
+/** Read per-session TuiViewState from disk. Returns null if not found. */
+export async function readViewState(
+  groveDir: string,
+  sessionId: string,
+): Promise<TuiViewState | null> {
   try {
-    const { existsSync, writeFileSync, mkdirSync, readFileSync } = await import("node:fs");
-    const { resolve, dirname } = await import("node:path");
-    const path = resolve(process.cwd(), LEGACY_TUI_STATE_PATH);
-    const dir = dirname(path);
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-
-    let existing: Record<string, unknown> = {};
-    try {
-      existing = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
-    } catch {
-      // File doesn't exist yet
-    }
-
-    const merged = { ...existing, ...state };
-    writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`, "utf-8");
-  } catch {
-    // Best-effort persistence
-  }
-}
-
-/** Read per-session TuiViewState from `.grove/.sessions/<id>-tui-state.json`. */
-async function readViewState(groveDir: string, sessionId: string): Promise<TuiViewState | null> {
-  try {
-    const { readFileSync } = await import("node:fs");
     const path = sessionStatePath(groveDir, sessionId);
-    const json = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+    const raw = await readFile(path, "utf-8");
+    const json = JSON.parse(raw) as Record<string, unknown>;
     return {
       expandedPanel:
         json.expandedPanel === null
@@ -115,24 +88,24 @@ async function readViewState(groveDir: string, sessionId: string): Promise<TuiVi
       traceSelectedAgent:
         typeof json.traceSelectedAgent === "number" ? json.traceSelectedAgent : undefined,
       focusedPanel: typeof json.focusedPanel === "number" ? json.focusedPanel : undefined,
+      visibleOperatorPanels: Array.isArray(json.visibleOperatorPanels)
+        ? (json.visibleOperatorPanels as number[])
+        : undefined,
+      searchQuery: typeof json.searchQuery === "string" ? json.searchQuery : undefined,
     };
   } catch {
     return null;
   }
 }
 
-/** Write per-session TuiViewState to disk (debounced by caller). */
-function writeViewStateSync(groveDir: string, sessionId: string, state: TuiViewState): void {
-  try {
-    const { existsSync, writeFileSync, mkdirSync } = require("node:fs") as typeof import("node:fs");
-    const { join, dirname } = require("node:path") as typeof import("node:path");
-    const path = join(groveDir, ".sessions", `${sessionId}-tui-state.json`);
-    const dir = dirname(path);
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
-  } catch {
-    // Best-effort
-  }
+/** Write per-session TuiViewState to disk atomically. */
+async function writeViewState(
+  groveDir: string,
+  sessionId: string,
+  state: TuiViewState,
+): Promise<void> {
+  const path = sessionStatePath(groveDir, sessionId);
+  await writeAtomic(path, `${JSON.stringify(state, null, 2)}\n`);
 }
 
 // ---------------------------------------------------------------------------
@@ -143,10 +116,10 @@ function writeViewStateSync(groveDir: string, sessionId: string, state: TuiViewS
  * Hook to save and restore per-session TUI view state.
  *
  * - On mount: reads `.grove/.sessions/<sessionId>-tui-state.json` if it exists.
- * - On state changes: debounced write (500 ms) to the same file.
+ * - On state changes: debounced write (500 ms) using atomic temp→rename.
  *
  * Returns `{ savedState, saveState }`.
- *   - `savedState` is null until load completes (undefined means not yet loaded).
+ *   - `savedState` is undefined while loading, null if no prior state.
  *   - `saveState` debounces writes at 500 ms.
  */
 export function useTuiStatePersistence(
@@ -164,7 +137,6 @@ export function useTuiStatePersistence(
   const loadedRef = useRef(false);
 
   // Load on mount and whenever sessionId/groveDir change.
-  // Reset load gate so writes are blocked until the new session's state is read.
   useEffect(() => {
     loadedRef.current = false;
     setSavedState(undefined); // mark as loading
@@ -181,50 +153,26 @@ export function useTuiStatePersistence(
     });
     return () => {
       cancelled = true;
+      // Cancel any pending debounced write to avoid post-unmount I/O (Issue 15A)
+      if (debounceRef.current !== null) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
     };
   }, [sessionId, groveDir]);
 
   const saveState = useCallback(
     (state: TuiViewState) => {
       if (!sessionId || !groveDir) return;
-      if (!loadedRef.current) return; // block writes until restore finishes
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (!loadedRef.current) return; // block writes until restore completes
+      if (debounceRef.current !== null) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => {
-        writeViewStateSync(groveDir, sessionId, state);
+        debounceRef.current = null;
+        void writeViewState(groveDir, sessionId, state);
       }, 500);
     },
     [sessionId, groveDir],
   );
 
   return { savedState, saveState };
-}
-
-// ---------------------------------------------------------------------------
-// useSessionPersistence — legacy hook (unchanged public API)
-// ---------------------------------------------------------------------------
-
-/** Hook to manage TUI session state persistence. */
-export function useSessionPersistence(): {
-  /** Loaded persisted state (undefined until loaded). */
-  persistedState: PersistedTuiState | undefined;
-  /** Save current state to disk. */
-  saveState: (state: PersistedTuiState) => void;
-} {
-  const [persistedState, setPersistedState] = useState<PersistedTuiState | undefined>(undefined);
-
-  useEffect(() => {
-    let cancelled = false;
-    readTuiState().then((state) => {
-      if (!cancelled) setPersistedState(state);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const saveState = useCallback((state: PersistedTuiState) => {
-    void writeTuiState(state);
-  }, []);
-
-  return { persistedState, saveState };
 }

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -266,6 +266,13 @@ async function buildAppProps(
   // Resolve groveDir once — used for AcpxRuntime logDir, workspace GC, and event bus.
   const groveDir = effectiveGrove ?? findGroveDir(effectiveGrove);
 
+  // Preload user config (theme + keymap) before React mounts so configureTheme()
+  // patches the theme object in-place before the first render (Issue 14A).
+  const { loadGroveConfig } = await import("./config-loader.js");
+  const { configureTheme } = await import("./theme.js");
+  const userConfig = await loadGroveConfig(groveDir);
+  configureTheme(userConfig.theme);
+
   // Create AcpxRuntime for agent spawning (preferred over tmux)
   let agentRuntime: import("../core/agent-runtime.js").AgentRuntime | undefined;
   {
@@ -367,6 +374,7 @@ async function buildAppProps(
       eventBus,
       agentRuntime,
       contract,
+      userConfig,
     },
     provider,
     stopGc,

--- a/src/tui/panels/panel-manager.tsx
+++ b/src/tui/panels/panel-manager.tsx
@@ -124,7 +124,7 @@ function PanelChrome({
   readonly children: React.ReactNode;
 }): React.ReactNode {
   const borderColor = focused ? theme.focus : theme.inactive;
-  const titleColor = focused ? theme.focus : theme.muted;
+  const titleColor = focused ? theme.focus : theme.secondary;
   return (
     <box
       flexDirection="column"

--- a/src/tui/panels/panel-registry.ts
+++ b/src/tui/panels/panel-registry.ts
@@ -259,28 +259,6 @@ export const PANEL_REGISTRY: readonly PanelDef[] = [
 ] as const;
 
 // ---------------------------------------------------------------------------
-// Lookup helpers (lazily cached)
-// ---------------------------------------------------------------------------
-
-/** Cached panel-to-def lookup map, built on first access. */
-let _panelLookup: ReadonlyMap<Panel, PanelDef> | undefined;
-
-/** Cached row groups map, built on first access. */
-let _rowGroups: Map<number, readonly PanelDef[]> | undefined;
-
-/** Get the PanelDef for a given panel. Returns undefined for unknown panels. */
-function lookupPanel(panel: Panel): PanelDef | undefined {
-  if (_panelLookup === undefined) {
-    const map = new Map<Panel, PanelDef>();
-    for (const def of PANEL_REGISTRY) {
-      map.set(def.panel, def);
-    }
-    _panelLookup = map;
-  }
-  return _panelLookup.get(panel);
-}
-
-// ---------------------------------------------------------------------------
 // Public query functions
 // ---------------------------------------------------------------------------
 
@@ -289,9 +267,8 @@ export function getRegistry(): readonly PanelDef[] {
   return PANEL_REGISTRY;
 }
 
-/** Groups panel definitions by their row group number. Lazily cached. */
+/** Groups panel definitions by their row group number. */
 export function getRowGroups(): Map<number, readonly PanelDef[]> {
-  if (_rowGroups !== undefined) return _rowGroups;
   const groups = new Map<number, PanelDef[]>();
   for (const def of PANEL_REGISTRY) {
     let group = groups.get(def.rowGroup);
@@ -301,7 +278,6 @@ export function getRowGroups(): Map<number, readonly PanelDef[]> {
     }
     group.push(def);
   }
-  _rowGroups = groups;
   return groups;
 }
 
@@ -319,7 +295,7 @@ export function getVisiblePanelsForLayout(
   allowedPanels?: ReadonlySet<Panel>,
 ): readonly PanelDef[] {
   if (mode === "tab") {
-    const def = lookupPanel(panelState.focused);
+    const def = PANEL_REGISTRY.find((d) => d.panel === panelState.focused);
     return def !== undefined ? [def] : [];
   }
 
@@ -391,7 +367,7 @@ export function getRowFlex(
  * `panelRowGroup()` switch statement).
  */
 export function panelRowGroup(panel: Panel): number {
-  const def = lookupPanel(panel);
+  const def = PANEL_REGISTRY.find((d) => d.panel === panel);
   return def !== undefined ? def.rowGroup : 0;
 }
 

--- a/src/tui/screens/agent-detect.tsx
+++ b/src/tui/screens/agent-detect.tsx
@@ -244,13 +244,15 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
           {AGENT_CLIS.map((agent) => {
             const found = detected.get(agent.cli);
             const icon = found ? theme.agentRunning : theme.agentIdle;
-            const color = found ? theme.success : theme.dimmed;
+            const color = found ? theme.success : theme.secondary;
             const platformColor = PLATFORM_COLORS[agent.platform] ?? theme.text;
             return (
               <box key={agent.cli} flexDirection="row">
                 <text color={color}> {icon} </text>
                 <text color={platformColor}>{agent.label.padEnd(16)}</text>
-                <text color={theme.muted}>{found ? "found" : scanning ? "..." : "not found"}</text>
+                <text color={theme.secondary}>
+                  {found ? "found" : scanning ? "..." : "not found"}
+                </text>
               </box>
             );
           })}
@@ -270,7 +272,7 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
             </text>
             {dagLines.map((line) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: dag lines have no stable identity
-              <text key={line} color={theme.muted}>
+              <text key={line} color={theme.secondary}>
                 {line}
               </text>
             ))}
@@ -287,12 +289,12 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
               const cli = roleMapping.get(role.name) ?? "?";
               const cliFound = detected.get(cli) ?? false;
               const icon = cliFound ? theme.agentRunning : theme.agentIdle;
-              const color = cliFound ? theme.success : theme.dimmed;
+              const color = cliFound ? theme.success : theme.secondary;
               return (
                 <box key={role.name} flexDirection="row">
                   <text color={color}> {icon} </text>
                   <text color={theme.text}>{role.name.padEnd(12)}</text>
-                  <text color={theme.dimmed}>{"\u2192"} </text>
+                  <text color={theme.secondary}>{"\u2192"} </text>
                   <text color={PLATFORM_COLORS[role.platform ?? "claude-code"] ?? theme.text}>
                     {cli}
                   </text>
@@ -340,11 +342,11 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
                     <text color={selected ? theme.focus : theme.text}>
                       {selected ? "> " : "  "}
                     </text>
-                    <text color={cliFound ? theme.success : theme.dimmed}>{icon} </text>
+                    <text color={cliFound ? theme.success : theme.secondary}>{icon} </text>
                     <text color={theme.text} bold>
                       {role.name}
                     </text>
-                    <text color={theme.muted}> ({cli})</text>
+                    <text color={theme.secondary}> ({cli})</text>
                   </box>
                   {isEditing ? (
                     <box flexDirection="column" marginLeft={4} height={4}>
@@ -356,7 +358,7 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
                     </box>
                   ) : (
                     <box marginLeft={4} flexDirection="column">
-                      <text color={selected ? theme.muted : theme.dimmed} wrap="wrap">
+                      <text color={selected ? theme.secondary : theme.secondary} wrap="wrap">
                         {prompt
                           ? selected
                             ? prompt
@@ -373,7 +375,7 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
 
         {/* Hints */}
         <box paddingX={2} marginTop={1}>
-          <text color={theme.dimmed}>
+          <text color={theme.secondary}>
             {editing
               ? "Edit prompt (vim keys)  Esc:save & close"
               : scanning

--- a/src/tui/screens/complete-view.tsx
+++ b/src/tui/screens/complete-view.tsx
@@ -99,7 +99,7 @@ export const CompleteView: React.NamedExoticComponent<CompleteViewProps> = React
           <text color={theme.text} bold>
             Reason
           </text>
-          <text color={theme.muted}>{reason}</text>
+          <text color={theme.secondary}>{reason}</text>
         </box>
 
         {/* Stats */}
@@ -140,7 +140,7 @@ export const CompleteView: React.NamedExoticComponent<CompleteViewProps> = React
 
         {/* Keyboard hints */}
         <box paddingX={2} marginTop={1}>
-          <text color={theme.dimmed}>Enter:new session (same preset) q:quit</text>
+          <text color={theme.secondary}>Enter:new session (same preset) q:quit</text>
         </box>
       </box>
     );

--- a/src/tui/screens/preset-select.tsx
+++ b/src/tui/screens/preset-select.tsx
@@ -148,13 +148,13 @@ export const PresetSelect: React.NamedExoticComponent<PresetSelectProps> = React
               <box flexDirection="column" marginTop={1}>
                 {presets[highlightedIndex]?.details?.split("\n").map((line, i) => (
                   // biome-ignore lint/suspicious/noArrayIndexKey: detail lines have no stable identity
-                  <text key={i} color={theme.muted}>
+                  <text key={i} color={theme.secondary}>
                     {line}
                   </text>
                 ))}
               </box>
             ) : null}
-            <text color={theme.dimmed}>Press ? to close details</text>
+            <text color={theme.secondary}>Press ? to close details</text>
           </box>
         ) : null}
 
@@ -172,7 +172,7 @@ export const PresetSelect: React.NamedExoticComponent<PresetSelectProps> = React
               Recent sessions
             </text>
             {sessions.slice(0, 5).map((s) => (
-              <text key={s.id} color={theme.muted}>
+              <text key={s.id} color={theme.secondary}>
                 {"  "}
                 {s.presetName ? `[${s.presetName}] ` : ""}
                 {`"${s.goal ?? "untitled"}"`} ({s.contributionCount} contributions, {s.status})
@@ -183,7 +183,7 @@ export const PresetSelect: React.NamedExoticComponent<PresetSelectProps> = React
 
         {/* Keyboard hints */}
         <box paddingX={2} marginTop={1}>
-          <text color={theme.dimmed}>Enter:select ?:details q:quit</text>
+          <text color={theme.secondary}>Enter:select ?:details q:quit</text>
         </box>
       </box>
     );

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -624,7 +624,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
               <text color={theme.focus} bold>
                 Nexus Folder Browser
               </text>
-              <text color={theme.dimmed}> (Esc to close)</text>
+              <text color={theme.secondary}> (Esc to close)</text>
             </box>
             <box flexDirection="column" paddingX={2} flexGrow={1}>
               <VfsBrowserView
@@ -655,7 +655,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
               hint="Browse .grove/ directory locally for session files."
             />
             <box marginTop={1}>
-              <text color={theme.dimmed}>Esc:close</text>
+              <text color={theme.secondary}>Esc:close</text>
             </box>
           </box>
         </box>
@@ -746,7 +746,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
                 <text color={theme.focus} bold>
                   {RUNNING_PANEL_LABELS[expandedPanel]}
                 </text>
-                <text color={theme.dimmed}> (f:fullscreen Esc:close)</text>
+                <text color={theme.secondary}> (f:fullscreen Esc:close)</text>
               </box>
               {renderExpandedPanel(expandedPanel, {
                 provider,
@@ -879,7 +879,7 @@ function renderAgentSection(
         <text color={theme.focus} bold>
           Agents
         </text>
-        <text color={theme.dimmed}> (e:trace viewer)</text>
+        <text color={theme.secondary}> (e:trace viewer)</text>
         {showWaiting && <text color={theme.warning}> waiting for session activity...</text>}
       </box>
       {roles.map((role, idx) => {
@@ -899,8 +899,8 @@ function renderAgentSection(
             <text color={platformColor} bold>
               {role.name}
             </text>
-            <text color={theme.dimmed}> [{idx + 1}] </text>
-            {lastLine ? <text color={theme.muted}>{lastLine.slice(0, 80)}</text> : null}
+            <text color={theme.secondary}> [{idx + 1}] </text>
+            {lastLine ? <text color={theme.secondary}>{lastLine.slice(0, 80)}</text> : null}
           </box>
         );
       })}
@@ -923,7 +923,7 @@ function renderFeedSection(
       {/* Goal display */}
       {goal ? (
         <box paddingX={2}>
-          <text color={theme.muted}>Goal: {goal}</text>
+          <text color={theme.secondary}>Goal: {goal}</text>
         </box>
       ) : null}
 
@@ -937,7 +937,7 @@ function renderFeedSection(
             <box key={entry.metric} flexDirection="row">
               <text color={theme.info}>{entry.metric}: </text>
               <text color={theme.text}>{entry.value.toFixed(4)}</text>
-              <text color={theme.dimmed}> {entry.summary.slice(0, 50)}</text>
+              <text color={theme.secondary}> {entry.summary.slice(0, 50)}</text>
             </box>
           ))}
         </box>
@@ -1007,32 +1007,32 @@ function renderFeedSection(
                     backgroundColor={selected ? theme.selectedBg : undefined}
                   >
                     <text color={kindColor}>{"\u2502"}</text>
-                    <text color={theme.dimmed}>{formatTime(c.createdAt)} </text>
+                    <text color={theme.secondary}>{formatTime(c.createdAt)} </text>
                     <text color={kindColor}>{kindIcon} </text>
                     <text color={kindColor}>{c.kind.padEnd(12)}</text>
                     <text color={theme.info}>{agentLabel.padEnd(10)} </text>
-                    <text color={selected ? theme.text : theme.muted}>
+                    <text color={selected ? theme.text : theme.secondary}>
                       {c.summary.slice(0, 55)}
                     </text>
                   </box>
                   {hasPreview ? (
                     <box flexDirection="row" marginLeft={28}>
                       {scoreEntries.slice(0, 3).map(([name, score]) => (
-                        <text key={name} color={theme.dimmed}>
+                        <text key={name} color={theme.secondary}>
                           {name}:{(score as { value: number }).value.toFixed(2)}{" "}
                         </text>
                       ))}
                       {artifactCount > 0 ? (
-                        <text color={theme.dimmed}>
+                        <text color={theme.secondary}>
                           {artifactCount} file{artifactCount !== 1 ? "s" : ""}{" "}
                         </text>
                       ) : null}
                       {relationCount > 0 ? (
-                        <text color={theme.dimmed}>
+                        <text color={theme.secondary}>
                           {relationCount} rel{relationCount !== 1 ? "s" : ""}{" "}
                         </text>
                       ) : null}
-                      <text color={theme.dimmed}> Enter:detail</text>
+                      <text color={theme.secondary}> Enter:detail</text>
                     </box>
                   ) : null}
                 </box>
@@ -1178,28 +1178,28 @@ function renderBottomChrome(
           {monitor.pendingPermissions.map((p) => (
             <box key={p.sessionName} flexDirection="row">
               <text color={theme.focus}>{p.agentRole}</text>
-              <text color={theme.muted}> wants to run: </text>
+              <text color={theme.secondary}> wants to run: </text>
               <text color={theme.text}>{p.command}</text>
             </box>
           ))}
-          <text color={theme.dimmed}>y:approve n:deny</text>
+          <text color={theme.secondary}>y:approve n:deny</text>
         </box>
       ) : null}
 
       {/* IPC message log */}
       {monitor.ipcMessages.length > 0 ? (
         <box flexDirection="column" marginX={2} marginTop={1} paddingX={1}>
-          <text color={theme.dimmed} bold>
+          <text color={theme.secondary} bold>
             IPC Messages
           </text>
           {monitor.ipcMessages.slice(-5).map((msg, i) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: IPC messages are ephemeral
             <box key={i} flexDirection="row">
-              <text color={theme.dimmed}>{formatTime(msg.timestamp)} </text>
+              <text color={theme.secondary}>{formatTime(msg.timestamp)} </text>
               <text color={theme.info}>{msg.sourceRole}</text>
-              <text color={theme.dimmed}> {"\u2192"} </text>
+              <text color={theme.secondary}> {"\u2192"} </text>
               <text color={theme.focus}>{msg.targetRole}</text>
-              <text color={theme.muted}> {msg.summary.slice(0, 40)}</text>
+              <text color={theme.secondary}> {msg.summary.slice(0, 40)}</text>
             </box>
           ))}
         </box>
@@ -1231,8 +1231,8 @@ function renderBottomChrome(
             {": "}
           </text>
           <text>{promptText}</text>
-          <text color={theme.dimmed}>{"\u258c"}</text>
-          <text color={theme.dimmed}> Tab:switch role Enter:send Esc:cancel</text>
+          <text color={theme.secondary}>{"\u258c"}</text>
+          <text color={theme.secondary}> Tab:switch role Enter:send Esc:cancel</text>
         </box>
       ) : null}
     </>

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -580,11 +580,11 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
           {pendingPermissions.map((p) => (
             <box key={p.sessionName} flexDirection="row">
               <text color={theme.focus}>{p.agentRole}</text>
-              <text color={theme.muted}> wants to run: </text>
+              <text color={theme.secondary}> wants to run: </text>
               <text color={theme.text}>{p.command}</text>
             </box>
           ))}
-          <text color={theme.dimmed}>y:approve n:deny</text>
+          <text color={theme.secondary}>y:approve n:deny</text>
         </box>
       ) : null;
 

--- a/src/tui/screens/spawn-progress.tsx
+++ b/src/tui/screens/spawn-progress.tsx
@@ -39,7 +39,7 @@ const STATUS_ICON: Record<SpawnStatus, string> = {
 };
 
 const STATUS_COLOR: Record<SpawnStatus, string> = {
-  waiting: theme.dimmed,
+  waiting: theme.secondary,
   spawning: theme.warning,
   started: theme.success,
   failed: theme.error,
@@ -165,7 +165,7 @@ export const SpawnProgress: React.NamedExoticComponent<SpawnProgressProps> = Rea
               <box key={agent.role} flexDirection="row" opacity={rowOpacity}>
                 <text color={STATUS_COLOR[agent.status]}>{getIcon(agent.status)} </text>
                 <text color={theme.text}>{agent.role}</text>
-                <text color={theme.dimmed}> ({agent.command})</text>
+                <text color={theme.secondary}> ({agent.command})</text>
                 <text color={platformColor}>
                   {"  "}
                   {agent.status === "waiting"
@@ -184,12 +184,12 @@ export const SpawnProgress: React.NamedExoticComponent<SpawnProgressProps> = Rea
         {/* Goal and preset info */}
         <box flexDirection="column" marginX={2} marginTop={1} paddingX={1}>
           <box flexDirection="row">
-            <text color={theme.muted}>Goal: </text>
+            <text color={theme.secondary}>Goal: </text>
             <text color={theme.text}>{goal.slice(0, 60)}</text>
           </box>
           {presetName ? (
             <box flexDirection="row">
-              <text color={theme.muted}>Preset: </text>
+              <text color={theme.secondary}>Preset: </text>
               <text color={theme.text}>{presetName}</text>
             </box>
           ) : null}

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -678,14 +678,14 @@ export class SpawnManager {
             // then NexusWsBridge SSE delivers it via runtime.send().
             // If wsBridge fails (Nexus unhealthy), fall back to direct runtime.send()
             // so the reviewer always receives the IPC.
-            let wsBridgeDelivered = false;
+            let _wsBridgeDelivered = false;
             try {
               await (this.wsBridge as import("./nexus-ws-bridge.js").NexusWsBridge).send(
                 sourceRole,
                 targetRole,
                 { summary, kind },
               );
-              wsBridgeDelivered = true;
+              _wsBridgeDelivered = true;
               debugLog("route", `wsBridge.send succeeded for ${sourceRole}→${targetRole}`);
             } catch (bridgeErr) {
               debugLog(

--- a/src/tui/theme.test.ts
+++ b/src/tui/theme.test.ts
@@ -32,8 +32,7 @@ describe("theme", () => {
 
   test("has all text tokens", () => {
     expect(theme.text).toBeDefined();
-    expect(theme.muted).toBeDefined();
-    expect(theme.dimmed).toBeDefined();
+    expect(theme.secondary).toBeDefined();
     expect(theme.disabled).toBeDefined();
   });
 
@@ -61,6 +60,7 @@ describe("theme", () => {
       "grey",
       "darkGray",
       "darkGrey",
+      // ANSI-16 palette names from algorithmic nearest-color
     ]);
     for (const [key, value] of Object.entries(theme)) {
       if (

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -6,6 +6,10 @@
  *
  * Color values are resolved at module load time via `resolveColor()` so the
  * TUI degrades gracefully on terminals with limited color support.
+ *
+ * Call `configureTheme(overrides)` before React mounts to apply user
+ * customization from the config file.  All existing `import { theme }` sites
+ * continue to work unchanged — they reference the same mutable object.
  */
 
 // ---------------------------------------------------------------------------
@@ -27,34 +31,42 @@ function detectColorDepth(): ColorDepth {
 }
 
 // ---------------------------------------------------------------------------
-// 16-color fallback map
+// 16-color approximation (algorithmic — no manual map needed)
 // ---------------------------------------------------------------------------
 
 /**
- * Maps hex colors used in this theme to the nearest basic ANSI color name
- * when running on a 16-color terminal.
+ * Representative RGB values for the 10 ANSI color names accepted by OpenTUI.
+ * Nearest-neighbor distance selects the best name for any input hex color.
  */
-const ANSI_16_MAP: Record<string, string> = {
-  "#00cccc": "cyan",
-  "#cc00cc": "magenta",
-  "#cccc00": "yellow",
-  "#00cc00": "green",
-  "#ff0000": "red",
-  "#0088cc": "blue",
-  "#ffffff": "white",
-  "#888888": "gray",
-  "#666666": "darkGray",
-  "#1a1a2e": "black",
-  // Additional colors used in AGENT_COLORS / PLATFORM_COLORS
-  "#ff6600": "red",
-  "#ff0088": "magenta",
-  "#88ff00": "green",
-  "#0088ff": "blue",
-  "#00cc88": "cyan",
-  "#ff8800": "yellow",
-  "#555555": "darkGray",
-  "#0d2137": "black",
-};
+const ANSI_16_PALETTE = [
+  { name: "black", r: 0, g: 0, b: 0 },
+  { name: "red", r: 204, g: 0, b: 0 },
+  { name: "green", r: 0, g: 204, b: 0 },
+  { name: "yellow", r: 204, g: 204, b: 0 },
+  { name: "blue", r: 0, g: 136, b: 204 },
+  { name: "magenta", r: 204, g: 0, b: 204 },
+  { name: "cyan", r: 0, g: 204, b: 204 },
+  { name: "white", r: 255, g: 255, b: 255 },
+  { name: "gray", r: 136, g: 136, b: 136 },
+  { name: "darkGray", r: 102, g: 102, b: 102 },
+] as const;
+
+/** Return the nearest ANSI-16 color name for a hex color string. */
+function nearestAnsi16(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  let best: (typeof ANSI_16_PALETTE)[number] = ANSI_16_PALETTE[0]!;
+  let bestDist = Infinity;
+  for (const entry of ANSI_16_PALETTE) {
+    const dist = (r - entry.r) ** 2 + (g - entry.g) ** 2 + (b - entry.b) ** 2;
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = entry;
+    }
+  }
+  return best.name;
+}
 
 // ---------------------------------------------------------------------------
 // 256-color approximation
@@ -90,7 +102,7 @@ function hexTo256(hex: string): string {
  *
  * - truecolor: hex returned as-is (Ink / OpenTUI accept hex directly)
  * - 256-color: nearest xterm-256 ANSI escape sequence
- * - 16-color: nearest basic ANSI color name from ANSI_16_MAP
+ * - 16-color: nearest basic ANSI color name (algorithmic)
  */
 export function resolveColor(hex: string): string {
   if (!hex.startsWith("#")) return hex; // Already an ANSI name or escape — pass through
@@ -100,45 +112,79 @@ export function resolveColor(hex: string): string {
     case "256":
       return hexTo256(hex);
     case "16":
-      return ANSI_16_MAP[hex] ?? "white";
+      return nearestAnsi16(hex);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Theme color token interface — user-overridable via configureTheme()
+// ---------------------------------------------------------------------------
+
+/** Color-only theme tokens that can be overridden via user config. */
+export interface ThemeColorTokens {
+  focus: string;
+  inactive: string;
+  border: string;
+  running: string;
+  waiting: string;
+  idle: string;
+  error: string;
+  stale: string;
+  work: string;
+  review: string;
+  discussion: string;
+  adoption: string;
+  reproduction: string;
+  text: string;
+  secondary: string;
+  disabled: string;
+  panelBg: string | undefined;
+  headerBg: string;
+  selectedBg: string;
+  success: string;
+  warning: string;
+  info: string;
+  compare: string;
 }
 
 // ---------------------------------------------------------------------------
 // Theme
 // ---------------------------------------------------------------------------
 
-/** Semantic color tokens for the TUI theme. */
-export const theme: {
-  readonly focus: string;
-  readonly inactive: string;
-  readonly border: string;
-  readonly running: string;
-  readonly waiting: string;
-  readonly idle: string;
-  readonly error: string;
-  readonly stale: string;
-  readonly work: string;
-  readonly review: string;
-  readonly discussion: string;
-  readonly adoption: string;
-  readonly reproduction: string;
-  readonly text: string;
-  readonly secondary: string;
-  readonly muted: string;
-  readonly dimmed: string;
-  readonly disabled: string;
-  readonly panelBg: string | undefined;
-  readonly headerBg: string;
-  readonly selectedBg: string;
-  readonly success: string;
-  readonly warning: string;
-  readonly info: string;
-  readonly compare: string;
-  readonly agentRunning: string;
-  readonly agentWaiting: string;
-  readonly agentIdle: string;
-  readonly agentError: string;
+/**
+ * Internal mutable theme store.  Exported as `theme` (readonly view).
+ * `configureTheme()` patches this object in-place before React mounts,
+ * so all existing `theme.X` import sites see the user's overrides without
+ * any code changes.
+ */
+const _themeStore: {
+  focus: string;
+  inactive: string;
+  border: string;
+  running: string;
+  waiting: string;
+  idle: string;
+  error: string;
+  stale: string;
+  work: string;
+  review: string;
+  discussion: string;
+  adoption: string;
+  reproduction: string;
+  text: string;
+  secondary: string;
+  disabled: string;
+  panelBg: string | undefined;
+  headerBg: string;
+  selectedBg: string;
+  success: string;
+  warning: string;
+  info: string;
+  compare: string;
+  agentRunning: string;
+  agentWaiting: string;
+  agentIdle: string;
+  agentError: string;
 } = {
   // Focus & chrome
   focus: resolveColor("#00cccc"),
@@ -161,12 +207,7 @@ export const theme: {
 
   // Text
   text: resolveColor("#ffffff"),
-  /** Secondary text — labels, hints, timestamps. Replaces former muted/dimmed split. */
   secondary: resolveColor("#888888"),
-  /** @deprecated Use `secondary` instead. Kept for backward compat during migration. */
-  muted: resolveColor("#888888"),
-  /** @deprecated Use `secondary` instead. Kept for backward compat during migration. */
-  dimmed: resolveColor("#888888"),
   disabled: resolveColor("#666666"),
 
   // Surfaces
@@ -180,12 +221,39 @@ export const theme: {
   info: resolveColor("#0088cc"),
   compare: resolveColor("#ff6600"),
 
-  // Agent status symbols
+  // Agent status symbols (not color tokens — not overridable via ThemeColorTokens)
   agentRunning: "●",
   agentWaiting: "◐",
   agentIdle: "○",
   agentError: "\u2717",
 };
+
+/**
+ * Readonly view of the theme — same object reference as `_themeStore`.
+ * Components import this and access `theme.focus`, `theme.running`, etc.
+ * Calling `configureTheme()` before React mounts updates the values in-place.
+ */
+export const theme: Readonly<typeof _themeStore> = _themeStore;
+
+/**
+ * Apply user theme overrides from config.
+ *
+ * Must be called before React mounts (e.g. in main.ts after loading config).
+ * Mutates `_themeStore` in-place so all existing `theme.X` references see
+ * the updated values on first render.
+ */
+export function configureTheme(overrides: Partial<ThemeColorTokens>): void {
+  for (const [key, value] of Object.entries(overrides)) {
+    if (key in _themeStore && typeof value === "string") {
+      (_themeStore as Record<string, unknown>)[key] = resolveColor(value);
+    }
+  }
+}
+
+/** Return the current theme (same as the exported `theme` constant). */
+export function getTheme(): Readonly<typeof _themeStore> {
+  return _themeStore;
+}
 
 /** Spacing scale in terminal character units. */
 export const spacing = {
@@ -280,9 +348,6 @@ export interface AgentStatusBadge {
  *
  * When `spinnerFrame` is provided and status is "running", the icon
  * cycles through the braille spinner. Otherwise uses a static symbol.
- *
- * This replaces the duplicated statusSymbol() / agentSymbol() functions
- * in agent-list.tsx, agent-graph.tsx, running-view.tsx, and agent-split-pane.tsx.
  */
 export function agentStatusIcon(
   status: AgentStatus | string,

--- a/src/tui/views/agent-graph.tsx
+++ b/src/tui/views/agent-graph.tsx
@@ -233,10 +233,10 @@ export const AgentGraphView: React.NamedExoticComponent<AgentGraphProps> = React
     return (
       <box flexDirection="column">
         <box marginBottom={1} flexDirection="column">
-          <text color={theme.muted}>
+          <text color={theme.secondary}>
             {`Topology: ${topology.structure} (${topology.roles.length} roles)${headerSuffix}`}
           </text>
-          {statusSummary ? <text color={theme.muted}>{statusSummary}</text> : null}
+          {statusSummary ? <text color={theme.secondary}>{statusSummary}</text> : null}
         </box>
         <box flexDirection="column">
           {rendered.lines.map((line, i) => (

--- a/src/tui/views/artifact-preview.tsx
+++ b/src/tui/views/artifact-preview.tsx
@@ -432,14 +432,14 @@ export const ArtifactPreviewView: React.NamedExoticComponent<ArtifactPreviewProp
         {/* Artifact selector header */}
         {selectorHeader && (
           <box marginBottom={0}>
-            <text color={theme.muted}>{selectorHeader}</text>
+            <text color={theme.secondary}>{selectorHeader}</text>
           </box>
         )}
         <box marginBottom={1} flexDirection="row">
           <text color={theme.focus}>{preview.header}</text>
           <DataStatus loading={loading && !data} isStale={isStale} error={error?.message} />
           {hasDiffSupport && (
-            <text color={showDiff ? theme.warning : theme.dimmed}>
+            <text color={showDiff ? theme.warning : theme.secondary}>
               {showDiff ? "  [DIFF ON]" : "  [d]iff"}
             </text>
           )}
@@ -455,10 +455,10 @@ export const ArtifactPreviewView: React.NamedExoticComponent<ArtifactPreviewProp
           ) : preview.renderAs === "empty" ? (
             // Empty artifact — styled empty state
             <box flexDirection="column" paddingTop={1}>
-              <text color={theme.muted} italic>
+              <text color={theme.secondary} italic>
                 {artifactName} is empty.
               </text>
-              <text color={theme.dimmed} opacity={0.7}>
+              <text color={theme.secondary} opacity={0.7}>
                 The artifact exists but has no content yet.
               </text>
             </box>
@@ -485,7 +485,7 @@ export const ArtifactPreviewView: React.NamedExoticComponent<ArtifactPreviewProp
             createElement(
               "scrollbox" as string,
               { flexGrow: 1 },
-              React.createElement("text", { color: theme.muted }, preview.body),
+              React.createElement("text", { color: theme.secondary }, preview.body),
             )
           ) : (
             // Plain text

--- a/src/tui/views/init-progress.tsx
+++ b/src/tui/views/init-progress.tsx
@@ -37,7 +37,7 @@ export const InitProgressView: React.NamedExoticComponent<InitProgressProps> = R
         <text color={theme.focus} bold>
           Setting up {presetName}...
         </text>
-        <text color={theme.muted}>{""}</text>
+        <text color={theme.secondary}>{""}</text>
 
         {steps.map((step, i) => {
           const icon = step.done ? theme.agentRunning : theme.agentWaiting;
@@ -47,11 +47,11 @@ export const InitProgressView: React.NamedExoticComponent<InitProgressProps> = R
 
           return (
             <box key={step.label} flexDirection="row">
-              <text color={isCurrent ? theme.text : step.done ? theme.success : theme.muted}>
+              <text color={isCurrent ? theme.text : step.done ? theme.success : theme.secondary}>
                 {"  "}
               </text>
               <text color={iconColor}>{icon}</text>
-              <text color={isCurrent ? theme.text : step.done ? theme.success : theme.muted}>
+              <text color={isCurrent ? theme.text : step.done ? theme.success : theme.secondary}>
                 {`  ${step.label}`}
               </text>
             </box>
@@ -63,7 +63,7 @@ export const InitProgressView: React.NamedExoticComponent<InitProgressProps> = R
             <text color={theme.error} bold>
               Error: {error}
             </text>
-            <text color={theme.muted}>Esc:back to setup q:quit</text>
+            <text color={theme.secondary}>Esc:back to setup q:quit</text>
           </box>
         ) : null}
       </box>

--- a/src/tui/views/pipeline-view.tsx
+++ b/src/tui/views/pipeline-view.tsx
@@ -96,13 +96,13 @@ const AgentCardView: React.NamedExoticComponent<AgentCardViewProps> = React.memo
         : card.status === "error"
           ? "\u2717"
           : "\u25cb";
-    const color = PLATFORM_COLORS[card.platform] ?? theme.muted;
+    const color = PLATFORM_COLORS[card.platform] ?? theme.secondary;
 
     return (
       <box key={card.agentId} flexDirection="column">
         {showArrow && (
           <box>
-            <text color={theme.dimmed}>{" \u2192 "}</text>
+            <text color={theme.secondary}>{" \u2192 "}</text>
           </box>
         )}
         <box
@@ -116,14 +116,14 @@ const AgentCardView: React.NamedExoticComponent<AgentCardViewProps> = React.memo
           <text color={color} bold>
             {spinner} {card.agentId}
           </text>
-          <text color={theme.muted}>
+          <text color={theme.secondary}>
             {card.role} | {card.platform}
           </text>
           {card.lastLines.length > 0 && (
             <box flexDirection="column" marginTop={1}>
               {card.lastLines.map((line, j) => (
                 // biome-ignore lint/suspicious/noArrayIndexKey: output lines have no stable identity
-                <text key={j} color={theme.dimmed}>
+                <text key={j} color={theme.secondary}>
                   {line.length > 24 ? `${line.slice(0, 22)}..` : line}
                 </text>
               ))}

--- a/src/tui/views/terminal.tsx
+++ b/src/tui/views/terminal.tsx
@@ -396,7 +396,7 @@ export const TerminalView: React.NamedExoticComponent<TerminalProps> = React.mem
 
     const header = (
       <box flexDirection="row">
-        <text color={theme.muted}>{`session: ${sessionName}`}</text>
+        <text color={theme.secondary}>{`session: ${sessionName}`}</text>
         {isInputMode ? (
           <text color={theme.focus}> [INPUT]</text>
         ) : (

--- a/src/tui/views/vfs-browser.tsx
+++ b/src/tui/views/vfs-browser.tsx
@@ -138,7 +138,7 @@ function FilePreview({ name, content, loading, error }: FilePreviewProps): React
   if (loading && content === null) {
     return (
       <box flexDirection="column">
-        <text color={theme.muted}>Loading {name}…</text>
+        <text color={theme.secondary}>Loading {name}…</text>
       </box>
     );
   }
@@ -154,7 +154,7 @@ function FilePreview({ name, content, loading, error }: FilePreviewProps): React
   if (content === null) {
     return (
       <box flexDirection="column">
-        <text color={theme.muted}>Select a file to preview.</text>
+        <text color={theme.secondary}>Select a file to preview.</text>
       </box>
     );
   }
@@ -162,7 +162,7 @@ function FilePreview({ name, content, loading, error }: FilePreviewProps): React
   if (content.length === 0) {
     return (
       <box flexDirection="column">
-        <text color={theme.muted} italic>
+        <text color={theme.secondary} italic>
           Empty file
         </text>
       </box>
@@ -187,7 +187,7 @@ function FilePreview({ name, content, loading, error }: FilePreviewProps): React
     return createElement(
       "scrollbox" as string,
       { flexGrow: 1 },
-      React.createElement("text", { color: theme.muted }, hexDump + suffix),
+      React.createElement("text", { color: theme.secondary }, hexDump + suffix),
     );
   }
 
@@ -365,19 +365,19 @@ export const VfsBrowserView: React.NamedExoticComponent<VfsBrowserProps> = React
         {/* Path header */}
         <box marginBottom={1} flexDirection="column">
           <box flexDirection="row">
-            <text color={theme.muted}>{"Path: "}</text>
+            <text color={theme.secondary}>{"Path: "}</text>
             {currentPath === "/" ? (
               <text bold>/</text>
             ) : (
               <>
-                <text color={theme.muted}>
+                <text color={theme.secondary}>
                   {`${currentPath.replace(/\/$/, "").split("/").slice(0, -1).join("/")}/`}
                 </text>
                 <text bold>{currentPath.replace(/\/$/, "").split("/").pop()}</text>
               </>
             )}
           </box>
-          {rows.length > 0 ? <text color={theme.dimmed}>Enter:browse Esc:back</text> : null}
+          {rows.length > 0 ? <text color={theme.secondary}>Enter:browse Esc:back</text> : null}
         </box>
 
         {rows.length === 0 ? (
@@ -409,7 +409,7 @@ export const VfsBrowserView: React.NamedExoticComponent<VfsBrowserProps> = React
                 </>
               ) : (
                 <box>
-                  <text color={theme.muted} opacity={0.5}>
+                  <text color={theme.secondary} opacity={0.5}>
                     {cursorEntry?.type === "directory"
                       ? "Press Enter to open directory."
                       : "Select a file to preview."}

--- a/src/tui/views/welcome.tsx
+++ b/src/tui/views/welcome.tsx
@@ -353,7 +353,7 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
             paddingX={1}
           >
             {visibleSessions.length === 0 ? (
-              <text color={theme.dimmed}>
+              <text color={theme.secondary}>
                 {sessionFilter ? "No sessions match filter" : "No sessions"}
               </text>
             ) : null}
@@ -377,19 +377,19 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
                 >
                   <text
                     color={
-                      selected ? theme.focus : s.status === "active" ? theme.text : theme.dimmed
+                      selected ? theme.focus : s.status === "active" ? theme.text : theme.secondary
                     }
                     bold={selected}
                   >
                     {`${prefix}${icon} "${goal}"`}
                   </text>
-                  <text color={theme.muted}>{` (${s.contributionCount}c) ${date}`}</text>
+                  <text color={theme.secondary}>{` (${s.contributionCount}c) ${date}`}</text>
                 </box>
               );
             })}
           </box>
           <box paddingX={2}>
-            <text color={theme.dimmed}>j/k:navigate Enter:continue /:search Esc:back</text>
+            <text color={theme.secondary}>j/k:navigate Enter:continue /:search Esc:back</text>
           </box>
         </box>
       );
@@ -409,7 +409,7 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
             <text color={theme.focus} bold>
               Connect to remote Nexus
             </text>
-            <text color={theme.muted}>{""}</text>
+            <text color={theme.secondary}>{""}</text>
             <box flexDirection="row">
               <text color={theme.text}>Nexus URL: </text>
               <text color={theme.focus} bold>
@@ -417,8 +417,8 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
               </text>
               <text color={theme.focus}>_</text>
             </box>
-            <text color={theme.muted}>{""}</text>
-            <text color={theme.dimmed}>Enter:connect Esc:back Backspace:delete</text>
+            <text color={theme.secondary}>{""}</text>
+            <text color={theme.secondary}>Enter:connect Esc:back Backspace:delete</text>
           </box>
         </box>
       );
@@ -438,8 +438,8 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
             <text color={theme.focus} bold>
               Name your grove
             </text>
-            <text color={theme.muted}>Preset: {selectedPreset}</text>
-            <text color={theme.muted}>{""}</text>
+            <text color={theme.secondary}>Preset: {selectedPreset}</text>
+            <text color={theme.secondary}>{""}</text>
             <box flexDirection="row">
               <text color={theme.text}>Grove name: </text>
               <text color={theme.focus} bold>
@@ -447,8 +447,8 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
               </text>
               <text color={theme.focus}>_</text>
             </box>
-            <text color={theme.muted}>{""}</text>
-            <text color={theme.dimmed}>Enter:confirm Esc:back Backspace:delete</text>
+            <text color={theme.secondary}>{""}</text>
+            <text color={theme.secondary}>Enter:confirm Esc:back Backspace:delete</text>
           </box>
         </box>
       );
@@ -469,7 +469,7 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
             <text color={theme.focus} bold>
               Select a preset
             </text>
-            <text color={theme.muted}>{""}</text>
+            <text color={theme.secondary}>{""}</text>
           </box>
 
           {/* Preset list */}
@@ -492,7 +492,7 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
                   <text color={selected ? theme.focus : theme.text} bold={selected}>
                     {`${prefix}${preset.name.padEnd(20)}`}
                   </text>
-                  <text color={theme.muted}>{preset.description}</text>
+                  <text color={theme.secondary}>{preset.description}</text>
                 </box>
               );
             })}
@@ -518,20 +518,20 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
                     <text
                       // biome-ignore lint/suspicious/noArrayIndexKey: detail lines have no stable identity
                       key={i}
-                      color={theme.muted}
+                      color={theme.secondary}
                     >
                       {line}
                     </text>
                   ))}
                 </box>
               ) : null}
-              <text color={theme.dimmed}>Press ? to close details</text>
+              <text color={theme.secondary}>Press ? to close details</text>
             </box>
           ) : null}
 
           {/* Keyboard hints */}
           <box paddingX={2} marginTop={1}>
-            <text color={theme.dimmed}>j/k:navigate Enter:select ?:details Esc:back</text>
+            <text color={theme.secondary}>j/k:navigate Enter:select ?:details Esc:back</text>
           </box>
         </box>
       );
@@ -551,7 +551,7 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
           <text color={theme.focus} bold>
             Grove
           </text>
-          <text color={theme.muted}>{""}</text>
+          <text color={theme.secondary}>{""}</text>
         </box>
 
         {/* Action menu */}
@@ -595,11 +595,11 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
             </text>
             {sessions.slice(0, 5).map((s, _i) => (
               <box key={s.id} flexDirection="row">
-                <text color={s.status === "active" ? theme.text : theme.dimmed}>
+                <text color={s.status === "active" ? theme.text : theme.secondary}>
                   {"  "}
                   {s.status === "active" ? "●" : "○"} {`"${(s.goal ?? "untitled").slice(0, 50)}"`}
                 </text>
-                <text color={theme.muted}> ({s.contributionCount}c)</text>
+                <text color={theme.secondary}> ({s.contributionCount}c)</text>
               </box>
             ))}
           </box>
@@ -620,19 +620,19 @@ export const WelcomeScreen: React.NamedExoticComponent<WelcomeProps> = React.mem
           <text color={theme.text}>A multi-agent collaboration workspace.</text>
           <text color={theme.text}>Agents work together on a shared contribution graph</text>
           <text color={theme.text}>with human oversight.</text>
-          <text color={theme.muted}>{""}</text>
+          <text color={theme.secondary}>{""}</text>
           {GLOSSARY.map((entry) => (
             <box key={entry.term} flexDirection="row">
               <text color={theme.text}>{"  "}</text>
               <text color={theme.info}>{entry.term.padEnd(16)}</text>
-              <text color={theme.muted}>{entry.definition}</text>
+              <text color={theme.secondary}>{entry.definition}</text>
             </box>
           ))}
         </box>
 
         {/* Keyboard hints */}
         <box paddingX={2} marginTop={1}>
-          <text color={theme.dimmed}>[Enter] select [j/k] navigate [q] quit</text>
+          <text color={theme.secondary}>[Enter] select [j/k] navigate [q] quit</text>
         </box>
       </box>
     );


### PR DESCRIPTION
## Summary

Implements all 16 approved decisions from Issue #195 (persisted theme, keymap, and layout customization).

- **Config loader** (`src/tui/config-loader.ts`): layered stack — global (`~/.config/grove/config.json`) → project (`.grove/config.json`) → `GROVE_CONFIG` env var. Zod-validated, last-wins merge for theme tokens, additive union for keymap.
- **Atomic writes**: `writeAtomic()` in `use-session-persistence.ts` uses temp-file → `rename()` (POSIX-atomic, no partial writes).
- **Theme system**: `configureTheme()` + `getTheme()` — mutable `_themeStore` patched in-place before React mounts so all existing `theme.X` references see user values on first render. Algorithmic nearest-ANSI16 replaces manual color map.
- **Registry-driven dispatch**: `PANEL_REGISTRY` loop in `routeKey()` replaces 14 hardcoded if-blocks.
- **Keybinding loader**: Zod validation + stderr conflict reporting. `loadKeybindings()` exported for testing.
- **Legacy hook removed**: `useSessionPersistence` deleted; callers migrated to `useTuiStatePersistence`.
- **Async I/O**: `readFileSync` replaced with `await readFile` throughout.
- **Theme cleanup**: `theme.muted` and `theme.dimmed` removed; callers use `theme.secondary`.
- **Config preloaded**: `loadGroveConfig` + `configureTheme` called in `main.ts` before React mounts; `userConfig` passed as `AppProps`.
- **Keymap merge wired**: `userConfig.keymap` (config.json) merged with file-based overrides (`.grove/keybindings.json`); file wins per layered priority.
- **Help overlay reflects active bindings**: `HelpOverlay` accepts `keybindingOverrides` prop; `activeKey()` helper resolves the live key for all 8 remappable sections (Global, Navigation, Artifact, Terminal, Search, Messaging, Decisions, Frontier).
- **Debounce cleanup**: `clearTimeout` on effect teardown in `useTuiStatePersistence`.
- **Panel registry cache removed**: `lookupPanel()` and lazy cache vars deleted; callers use inline `PANEL_REGISTRY.find()`.

## Test plan

- [ ] `bun test src/tui/config-loader.test.ts` — 10 merge-semantics tests (TDD)
- [ ] `bun test src/tui/hooks/use-keybinding-overrides.test.ts` — 13 tests (loader, map, routeKey integration)
- [ ] `bun test src/tui/hooks/use-session-persistence.test.ts` — writeAtomic, readViewState, round-trip
- [ ] `bun test src/tui/hooks/use-keyboard-handler.test.ts` — parametric tests over full PANEL_REGISTRY (17 panels)
- [ ] `bun test src/tui/theme.test.ts` — no regressions (muted/dimmed assertions removed)
- [ ] E2E verified: write `.grove/config.json` with `keymap.refresh: "F5"` and `.grove/keybindings.json` with `help: "F1"`; open TUI with `--url`, press `?` — help overlay shows F1 for help, F5 for refresh