### PR TITLE
feat(bounty): compensation pattern for create/claim/settle [BLOCKED ON #240]

### DIFF
--- a/src/core/operations/bounty.test.ts
+++ b/src/core/operations/bounty.test.ts
@@ -101,6 +101,55 @@ describe("createBountyOperation", () => {
       expect(result.error.code).toBe("VALIDATION_ERROR");
     }
   });
+
+  test("voids reservation when bountyStore.createBounty throws (credits returned)", async () => {
+    (deps.creditsService as InMemoryCreditsService).seed("agent-1", 500);
+
+    const balanceBefore = await (deps.creditsService as InMemoryCreditsService).balance("agent-1");
+
+    // Inject fault: bountyStore.createBounty always throws
+    const originalCreate = deps.bountyStore!.createBounty.bind(deps.bountyStore);
+    deps.bountyStore!.createBounty = async () => {
+      throw new Error("simulated store failure");
+    };
+
+    const result = await createBountyOperation(
+      {
+        title: "Store fail bounty",
+        amount: 200,
+        criteria: { description: "Some task" },
+        agent: { agentId: "agent-1" },
+      },
+      deps,
+    );
+
+    deps.bountyStore!.createBounty = originalCreate;
+
+    expect(result.ok).toBe(false);
+
+    // Credits should be fully available again — the reservation was voided
+    const balanceAfter = await (deps.creditsService as InMemoryCreditsService).balance("agent-1");
+    expect(balanceAfter.available).toBe(balanceBefore.available);
+  });
+
+  test("returns error and creates no bounty when creditsService.reserve throws (insufficient credits)", async () => {
+    // Do NOT seed — agent has 0 credits
+    const result = await createBountyOperation(
+      {
+        title: "No credits bounty",
+        amount: 100,
+        criteria: { description: "Needs credits" },
+        agent: { agentId: "broke-agent" },
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(false);
+
+    // No bounty should have been persisted
+    const listed = await deps.bountyStore!.listBounties({});
+    expect(listed).toHaveLength(0);
+  });
 });
 
 describe("listBountiesOperation", () => {
@@ -236,6 +285,111 @@ describe("claimBountyOperation", () => {
     if (!result.ok) {
       expect(result.error.code).toBe("NOT_FOUND");
     }
+  });
+
+  test("returns VALIDATION_ERROR when bounty is not open (pre-flight check)", async () => {
+    (deps.creditsService as InMemoryCreditsService).seed("creator", 1000);
+
+    const bounty = await createBountyOperation(
+      {
+        title: "Pre-flight test",
+        amount: 100,
+        criteria: { description: "Do the work" },
+        agent: { agentId: "creator" },
+      },
+      deps,
+    );
+    expect(bounty.ok).toBe(true);
+    if (!bounty.ok) return;
+
+    // Claim it once to move status to 'claimed'
+    const first = await claimBountyOperation(
+      { bountyId: bounty.value.bountyId, agent: { agentId: "agent-a" } },
+      deps,
+    );
+    expect(first.ok).toBe(true);
+
+    // Second claim attempt by a different agent: pre-flight should catch status !== open
+    const second = await claimBountyOperation(
+      { bountyId: bounty.value.bountyId, agent: { agentId: "agent-b" } },
+      deps,
+    );
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.error.code).toBe("VALIDATION_ERROR");
+      expect(second.error.message).toContain("not open");
+    }
+  });
+
+  test("releases dangling claim when bountyStore.claimBounty throws (compensation)", async () => {
+    (deps.creditsService as InMemoryCreditsService).seed("creator", 1000);
+
+    const bounty = await createBountyOperation(
+      {
+        title: "Compensation test",
+        amount: 100,
+        criteria: { description: "Do the work" },
+        agent: { agentId: "creator" },
+      },
+      deps,
+    );
+    expect(bounty.ok).toBe(true);
+    if (!bounty.ok) return;
+
+    // Inject fault: bountyStore.claimBounty always throws
+    const originalClaimBounty = deps.bountyStore!.claimBounty.bind(deps.bountyStore);
+    deps.bountyStore!.claimBounty = async () => {
+      throw new Error("simulated store failure");
+    };
+
+    const result = await claimBountyOperation(
+      { bountyId: bounty.value.bountyId, agent: { agentId: "claimer" } },
+      deps,
+    );
+
+    // Restore original so cleanup can run
+    deps.bountyStore!.claimBounty = originalClaimBounty;
+
+    // Operation should fail
+    expect(result.ok).toBe(false);
+
+    // Compensation: no active claim should remain for this bounty
+    const activeClaims = await deps.claimStore!.activeClaims(`bounty:${bounty.value.bountyId}`);
+    expect(activeClaims).toHaveLength(0);
+  });
+
+  test("returns error when different agent has an active claim (claimOrRenew rejects)", async () => {
+    (deps.creditsService as InMemoryCreditsService).seed("creator", 1000);
+
+    const bounty = await createBountyOperation(
+      {
+        title: "Concurrency test",
+        amount: 100,
+        criteria: { description: "Do the work" },
+        agent: { agentId: "creator" },
+      },
+      deps,
+    );
+    expect(bounty.ok).toBe(true);
+    if (!bounty.ok) return;
+
+    // Agent A claims first
+    const claimA = await claimBountyOperation(
+      { bountyId: bounty.value.bountyId, agent: { agentId: "agent-a" } },
+      deps,
+    );
+    expect(claimA.ok).toBe(true);
+
+    // After agent-a claimed, the bounty is no longer open — pre-flight rejects agent-b
+    const claimB = await claimBountyOperation(
+      { bountyId: bounty.value.bountyId, agent: { agentId: "agent-b" } },
+      deps,
+    );
+    expect(claimB.ok).toBe(false);
+    // agent-a's claim is untouched
+    const activeClaims = await deps.claimStore!.activeClaims(`bounty:${bounty.value.bountyId}`);
+    expect(activeClaims).toHaveLength(1);
+    expect(activeClaims[0]!.agent.agentId).toBe("agent-a");
   });
 });
 
@@ -395,5 +549,133 @@ describe("settleBountyOperation", () => {
       expect(result.error.code).toBe("VALIDATION_ERROR");
       expect(result.error.message).toContain("does not meet bounty criteria");
     }
+  });
+
+  test("does not capture payment when state transition fails (state-first ordering)", async () => {
+    (deps.creditsService as InMemoryCreditsService).seed("creator", 1000);
+
+    const bounty = await createBountyOperation(
+      {
+        title: "Ordering test",
+        amount: 100,
+        criteria: { description: "Any work", requiredTags: ["fix"] },
+        agent: { agentId: "creator" },
+      },
+      deps,
+    );
+    expect(bounty.ok).toBe(true);
+    if (!bounty.ok) return;
+
+    await claimBountyOperation(
+      { bountyId: bounty.value.bountyId, agent: { agentId: "worker" } },
+      deps,
+    );
+
+    const contrib = await contributeOperation(
+      { kind: "work", summary: "Fix", tags: ["fix"], agent: { agentId: "worker" } },
+      deps,
+    );
+    expect(contrib.ok).toBe(true);
+    if (!contrib.ok) return;
+
+    // Inject fault: completeBounty throws (simulates store failure mid-settle)
+    const originalComplete = deps.bountyStore!.completeBounty.bind(deps.bountyStore);
+    deps.bountyStore!.completeBounty = async () => {
+      throw new Error("simulated state transition failure");
+    };
+
+    const balanceBefore = await (deps.creditsService as InMemoryCreditsService).balance("creator");
+
+    const result = await settleBountyOperation(
+      { bountyId: bounty.value.bountyId, contributionCid: contrib.value.cid },
+      deps,
+    );
+
+    deps.bountyStore!.completeBounty = originalComplete;
+
+    expect(result.ok).toBe(false);
+
+    // Payment must NOT have been captured — state-first ordering means
+    // capture runs only after successful state transition.
+    const balanceAfter = await (deps.creditsService as InMemoryCreditsService).balance("creator");
+    expect(balanceAfter.reserved).toBe(balanceBefore.reserved);
+  });
+
+  test("returns error when settling an already-settled bounty", async () => {
+    (deps.creditsService as InMemoryCreditsService).seed("creator", 1000);
+
+    const bounty = await createBountyOperation(
+      {
+        title: "Double-settle test",
+        amount: 100,
+        criteria: { description: "Any work", requiredTags: ["fix"] },
+        agent: { agentId: "creator" },
+      },
+      deps,
+    );
+    expect(bounty.ok).toBe(true);
+    if (!bounty.ok) return;
+
+    await claimBountyOperation(
+      { bountyId: bounty.value.bountyId, agent: { agentId: "worker" } },
+      deps,
+    );
+
+    const contrib = await contributeOperation(
+      { kind: "work", summary: "Fix", tags: ["fix"], agent: { agentId: "worker" } },
+      deps,
+    );
+    expect(contrib.ok).toBe(true);
+    if (!contrib.ok) return;
+
+    // First settle succeeds
+    const first = await settleBountyOperation(
+      { bountyId: bounty.value.bountyId, contributionCid: contrib.value.cid },
+      deps,
+    );
+    expect(first.ok).toBe(true);
+
+    // Second settle should fail — bounty is already settled
+    const second = await settleBountyOperation(
+      { bountyId: bounty.value.bountyId, contributionCid: contrib.value.cid },
+      deps,
+    );
+    expect(second.ok).toBe(false);
+  });
+
+  test("captures payment without recipient when bounty has no claimedBy", async () => {
+    (deps.creditsService as InMemoryCreditsService).seed("creator", 1000);
+
+    // Create a bounty (no claim step — leaves claimedBy null)
+    const bounty = await createBountyOperation(
+      {
+        title: "No-recipient settle",
+        amount: 100,
+        criteria: { description: "Any work" },
+        agent: { agentId: "creator" },
+      },
+      deps,
+    );
+    expect(bounty.ok).toBe(true);
+    if (!bounty.ok) return;
+
+    const contrib = await contributeOperation(
+      { kind: "work", summary: "Direct work", agent: { agentId: "worker" } },
+      deps,
+    );
+    expect(contrib.ok).toBe(true);
+    if (!contrib.ok) return;
+
+    // Settle without claiming first — store must handle this transition
+    const result = await settleBountyOperation(
+      { bountyId: bounty.value.bountyId, contributionCid: contrib.value.cid },
+      deps,
+    );
+
+    // May fail if store enforces claimed-before-settle; what matters is no crash
+    // and credits are not left in an inconsistent state.
+    const balance = await (deps.creditsService as InMemoryCreditsService).balance("creator");
+    // Either settled (capture ran) or failed (reservation still pending) — never NaN
+    expect(typeof balance.available).toBe("number");
   });
 });

--- a/src/core/operations/bounty.ts
+++ b/src/core/operations/bounty.ts
@@ -107,6 +107,8 @@ export interface SettleBountyInput {
 
 const DEFAULT_DEADLINE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
+const MISSING_BOUNTY_STORE = "Bounty operations not available (missing bountyStore)";
+
 /** Create a new bounty with optional credit reservation. */
 export async function createBountyOperation(
   input: CreateBountyInput,
@@ -114,7 +116,7 @@ export async function createBountyOperation(
 ): Promise<OperationResult<CreateBountyResult>> {
   try {
     if (deps.bountyStore === undefined) {
-      return validationErr("Bounty operations not available (missing bountyStore)");
+      return validationErr(MISSING_BOUNTY_STORE);
     }
 
     const agent = resolveAgent(input.agent);
@@ -151,16 +153,28 @@ export async function createBountyOperation(
       ...(input.context !== undefined ? { context: input.context } : {}),
     };
 
-    const result = await deps.bountyStore.createBounty(bounty);
-
-    return ok({
-      bountyId: result.bountyId,
-      title: result.title,
-      amount: result.amount,
-      status: result.status,
-      deadline: result.deadline,
-      reservationId: result.reservationId,
-    });
+    try {
+      const result = await deps.bountyStore.createBounty(bounty);
+      return ok({
+        bountyId: result.bountyId,
+        title: result.title,
+        amount: result.amount,
+        status: result.status,
+        deadline: result.deadline,
+        reservationId: result.reservationId,
+      });
+    } catch (storeErr) {
+      // Compensating action: void the reservation so credits are returned
+      // to the agent's available balance. void() is idempotent and non-fatal.
+      if (reservationId !== undefined && deps.creditsService !== undefined) {
+        try {
+          await deps.creditsService.void(reservationId);
+        } catch {
+          // Best-effort — reservation will auto-expire at its timeout.
+        }
+      }
+      return fromGroveError(storeErr);
+    }
   } catch (error) {
     return fromGroveError(error);
   }
@@ -173,7 +187,7 @@ export async function listBountiesOperation(
 ): Promise<OperationResult<ListBountiesResult>> {
   try {
     if (deps.bountyStore === undefined) {
-      return validationErr("Bounty operations not available");
+      return validationErr(MISSING_BOUNTY_STORE);
     }
 
     const bounties = await deps.bountyStore.listBounties({
@@ -204,7 +218,7 @@ export async function claimBountyOperation(
 ): Promise<OperationResult<ClaimBountyResult>> {
   try {
     if (deps.bountyStore === undefined) {
-      return validationErr("Bounty operations not available");
+      return validationErr(MISSING_BOUNTY_STORE);
     }
 
     if (deps.claimStore === undefined) {
@@ -216,12 +230,20 @@ export async function claimBountyOperation(
       return notFound("Bounty", input.bountyId);
     }
 
+    // Pre-flight: only open bounties can be claimed. Checking here avoids
+    // creating a dangling claim record before the store rejects the transition.
+    if (bounty.status !== BS.Open) {
+      return validationErr(
+        `Bounty '${input.bountyId}' is not open (status: ${bounty.status})`,
+      );
+    }
+
     const agent = resolveAgent(input.agent);
     const now = new Date();
     const claimId = crypto.randomUUID();
     const leaseDurationMs = input.leaseDurationMs ?? 1_800_000;
 
-    // Create claim via existing claim system
+    // Step 1: Create claim via existing claim system
     const claim = await deps.claimStore.claimOrRenew({
       claimId,
       targetRef: `bounty:${input.bountyId}`,
@@ -233,7 +255,19 @@ export async function claimBountyOperation(
       leaseExpiresAt: new Date(now.getTime() + leaseDurationMs).toISOString(),
     });
 
-    const claimed = await deps.bountyStore.claimBounty(input.bountyId, agent, claim.claimId);
+    // Step 2: Update bounty status. On failure, release the claim so it doesn't
+    // block other agents from claiming until the lease expires.
+    let claimed;
+    try {
+      claimed = await deps.bountyStore.claimBounty(input.bountyId, agent, claim.claimId);
+    } catch (bountyErr) {
+      try {
+        await deps.claimStore.release(claim.claimId);
+      } catch {
+        // Best-effort: the claim lease will expire on its own.
+      }
+      return fromGroveError(bountyErr);
+    }
 
     return ok({
       bountyId: claimed.bountyId,
@@ -282,7 +316,14 @@ export async function settleBountyOperation(
       );
     }
 
-    // Capture payment before state transition
+    // Persist state transitions first, then capture payment.
+    // Order matters: a failed state update before payment leaves the bounty
+    // recoverable (retry settle); a failed state update after payment would
+    // orphan captured funds with no record to reconcile against.
+    const completed = await deps.bountyStore.completeBounty(input.bountyId, input.contributionCid);
+    const settled = await deps.bountyStore.settleBounty(completed.bountyId);
+
+    // Capture payment after state is persisted
     if (deps.creditsService && bounty.reservationId && bounty.claimedBy) {
       await deps.creditsService.capture(bounty.reservationId, {
         toAgentId: bounty.claimedBy.agentId,
@@ -290,10 +331,6 @@ export async function settleBountyOperation(
     } else if (deps.creditsService && bounty.reservationId) {
       await deps.creditsService.capture(bounty.reservationId);
     }
-
-    // Persist state transitions
-    const completed = await deps.bountyStore.completeBounty(input.bountyId, input.contributionCid);
-    const settled = await deps.bountyStore.settleBounty(completed.bountyId);
 
     return ok({
       bountyId: settled.bountyId,


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE.** This is a draft PR tracking work blocked on design issue #240.

## Summary

Adds compensation try/catch logic around \`createBountyOperation\`, \`claimBountyOperation\`, and \`settleBountyOperation\` so failed store writes can be rolled back cleanly. Also extracts a shared error message constant and adds a pre-flight \`open\` status check before claiming.

## Why it's blocked

Three independent codex adversarial-review rounds all flagged the same correctness bugs in this compensation logic. Details + design options are in #240.

- **[CRITICAL]** Settlement commits terminal \`settled\` state **before** \`creditsService.capture()\` runs. A failed capture leaves the bounty "paid" with no funds transferred and no reconciler to fix it.
- **[HIGH]** \`createBounty\` catch voids the reservation on any error, including post-commit failures from \`NexusBountyStore\`'s two-step write, leaking an open bounty with empty escrow.
- **[HIGH]** \`claimBounty\` catch releases the claim on any error, leaving the bounty stuck in \`claimed\` pointing at a released lease.

The compensation code is correct for *pre*-persistence failures but wrong for *post*-persistence failures, and the NexusBountyStore layer doesn't tell the caller which mode a given throw came from.

## Design options (from #240)

- **(a)** Full saga: \`pending_settlement\` state + background reconciler + CAS confirmation on post-commit failures. ~200-500 lines, 1-2 days.
- **(b)** CAS confirmation only: re-read before compensating. Doesn't fix the settle-before-pay race. ~100-200 lines.
- **(c)** Revert the compensation refactor, keep only the cosmetic changes (\`MISSING_BOUNTY_STORE\` const + pre-flight claim status check). Relies on reservation/lease expiry for recovery. ~50-100 lines.

Recommendation: start with **(c)** to stop the bleed, then do **(a)** as a proper RFC-backed saga-log project.

## Why this PR exists

This code was sitting uncommitted in the \`ancient-nibbling-anchor\` worktree alongside the TUI/MCP session-scoping work in #239. Rather than leave it in limbo where it could be accidentally restaged, this PR makes it visible, reviewable, and explicitly linked to the design issue it depends on.

## Current test state

\`bun test src/core/operations/bounty.test.ts\` → 55 pass, 0 fail. The tests cover the happy path and basic error injection; the codex findings are latent partial-failure scenarios that the current test harness doesn't reproduce (they need a way to mock \`NexusBountyStore.transitionBounty\` to throw *after* the bounty document CAS-write but *before* the status-index write, which isn't currently possible with the in-memory store used here).

## Checklist before merging

- [ ] Design decision made on #240 (a / b / c)
- [ ] Partial-failure test harness added for NexusBountyStore
- [ ] All three codex findings fixed
- [ ] Re-run adversarial review — no new HIGH/CRITICAL findings
- [ ] Remove the \`[BLOCKED ON #240]\` tag from the title and convert from draft