### PR TITLE
fix(session): resume reuses running Nexus, no Docker pull (#205)

### DIFF
--- a/src/cli/nexus-lifecycle.test.ts
+++ b/src/cli/nexus-lifecycle.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Unit tests for nexus-lifecycle core functions.
+ *
+ * Covers:
+ *   Issue 9A  — ensureNexusRunning() fast path, quick-restart path, and cold-start path
+ *   Issue 10A — parseNexusPortFromDockerPs() port-parsing regex
+ *   Issue 11A — nexusUp() version-compatibility fallback (--timeout not supported)
+ *   Issue 12A — waitForNexusHealth() state transitions (healthy, starting, timeout)
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { parseNexusPortFromDockerPs, waitForNexusHealth } from "./nexus-lifecycle.js";
+
+// ---------------------------------------------------------------------------
+// Issue 10A — parseNexusPortFromDockerPs (pure function, table tests)
+// ---------------------------------------------------------------------------
+
+describe("parseNexusPortFromDockerPs", () => {
+  test("IPv4 host-bound port", () => {
+    expect(parseNexusPortFromDockerPs("0.0.0.0:27960->2026/tcp")).toBe(27960);
+  });
+
+  test("IPv6 host-bound port", () => {
+    expect(parseNexusPortFromDockerPs(":::27960->2026/tcp")).toBe(27960);
+  });
+
+  test("default port 2026 bound to host", () => {
+    expect(parseNexusPortFromDockerPs("0.0.0.0:2026->2026/tcp")).toBe(2026);
+  });
+
+  test("unbound internal port — no host mapping", () => {
+    expect(parseNexusPortFromDockerPs("2026/tcp")).toBeUndefined();
+  });
+
+  test("different port (not 2026)", () => {
+    expect(parseNexusPortFromDockerPs("0.0.0.0:8080->8080/tcp")).toBeUndefined();
+  });
+
+  test("empty string", () => {
+    expect(parseNexusPortFromDockerPs("")).toBeUndefined();
+  });
+
+  test("multiple port mappings — picks 2026", () => {
+    expect(parseNexusPortFromDockerPs("0.0.0.0:5432->5432/tcp, 0.0.0.0:33219->2026/tcp")).toBe(
+      33219,
+    );
+  });
+
+  test("port 0 is rejected as invalid", () => {
+    expect(parseNexusPortFromDockerPs("0.0.0.0:0->2026/tcp")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue 12A — waitForNexusHealth (uses Bun.serve pattern from resolve-backend.test.ts)
+// ---------------------------------------------------------------------------
+
+describe("waitForNexusHealth", () => {
+  test("resolves immediately when server responds healthy on first poll", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(JSON.stringify({ status: "healthy" }), { status: 200 });
+      },
+    });
+    try {
+      await expect(
+        waitForNexusHealth(`http://localhost:${server.port}`, 5_000),
+      ).resolves.toBeUndefined();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("keeps polling through 'starting' responses until 'healthy'", async () => {
+    let callCount = 0;
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        callCount++;
+        // First two calls: starting; third: healthy
+        const status = callCount < 3 ? "starting" : "healthy";
+        return new Response(JSON.stringify({ status }), { status: 200 });
+      },
+    });
+    try {
+      await expect(
+        waitForNexusHealth(`http://localhost:${server.port}`, 10_000),
+      ).resolves.toBeUndefined();
+      expect(callCount).toBeGreaterThanOrEqual(3);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("throws after timeoutMs if server never becomes healthy", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(JSON.stringify({ status: "starting" }), { status: 200 });
+      },
+    });
+    try {
+      await expect(
+        waitForNexusHealth(`http://localhost:${server.port}`, 1_500),
+      ).rejects.toThrow("timed out");
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("handles non-ok HTTP status without throwing (keeps polling)", async () => {
+    let callCount = 0;
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        callCount++;
+        if (callCount < 3) return new Response("error", { status: 503 });
+        return new Response(JSON.stringify({ status: "healthy" }), { status: 200 });
+      },
+    });
+    try {
+      await expect(
+        waitForNexusHealth(`http://localhost:${server.port}`, 10_000),
+      ).resolves.toBeUndefined();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("throws on unreachable server", async () => {
+    await expect(waitForNexusHealth("http://127.0.0.1:1", 800)).rejects.toThrow("timed out");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue 11A — nexusUp() version-compatibility fallback
+//
+// We stub Bun.spawn to return controlled exit codes and stderr strings.
+// ---------------------------------------------------------------------------
+
+describe("nexusUp fallback (--timeout not supported)", () => {
+  // We import the module dynamically so we can replace Bun.spawn per-test.
+  // Bun's module cache means we need to use mock() on the global Bun.spawn.
+
+  const originalSpawn = Bun.spawn.bind(Bun);
+
+  afterEach(() => {
+    // Restore Bun.spawn after each test
+    // @ts-ignore
+    Bun.spawn = originalSpawn;
+  });
+
+  /** Build a fake proc that immediately exits with the given code and fixed stdio. */
+  function fakeProc(exitCode: number, stdoutText: string, stderrText: string) {
+    const enc = new TextEncoder();
+    return {
+      exited: Promise.resolve(exitCode),
+      stdout: new ReadableStream({
+        start(c) {
+          c.enqueue(enc.encode(stdoutText));
+          c.close();
+        },
+      }),
+      stderr: new ReadableStream({
+        start(c) {
+          c.enqueue(enc.encode(stderrText));
+          c.close();
+        },
+      }),
+    };
+  }
+
+  test("falls back to args without --timeout when CLI says 'no such option'", async () => {
+    const calls: string[][] = [];
+
+    // @ts-ignore – replace Bun.spawn for this test
+    Bun.spawn = (args: string[], _opts?: unknown) => {
+      calls.push(args);
+      // First call (with --timeout): simulate old CLI rejecting the flag
+      if (args.includes("--timeout")) {
+        return fakeProc(1, "", "Error: no such option: --timeout");
+      }
+      // Fallback call (without --timeout): succeed
+      return fakeProc(0, "nexus  http://localhost:2026\n", "");
+    };
+
+    const { nexusUp } = await import("./nexus-lifecycle.js");
+    const out = await nexusUp("/tmp/test-proj");
+
+    expect(calls.length).toBe(2);
+    expect(calls[0]).toContain("--timeout");
+    expect(calls[1]).not.toContain("--timeout");
+    expect(out).toContain("http://localhost:2026");
+  });
+
+  test("falls back when CLI says 'unrecognized arguments'", async () => {
+    const calls: string[][] = [];
+
+    // @ts-ignore
+    Bun.spawn = (args: string[], _opts?: unknown) => {
+      calls.push(args);
+      if (args.includes("--timeout")) {
+        return fakeProc(1, "", "unrecognized arguments: --timeout");
+      }
+      return fakeProc(0, "nexus  http://localhost:2026\n", "");
+    };
+
+    const { nexusUp } = await import("./nexus-lifecycle.js");
+    await nexusUp("/tmp/test-proj");
+
+    expect(calls.length).toBe(2);
+  });
+
+  test("throws immediately for unrelated errors — no fallback attempted", async () => {
+    const calls: string[][] = [];
+
+    // @ts-ignore
+    Bun.spawn = (args: string[], _opts?: unknown) => {
+      calls.push(args);
+      return fakeProc(1, "", "Docker daemon not running");
+    };
+
+    const { nexusUp } = await import("./nexus-lifecycle.js");
+    await expect(nexusUp("/tmp/test-proj")).rejects.toThrow("nexus up failed");
+    expect(calls.length).toBe(1); // no fallback attempt
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue 9A — ensureNexusRunning() fast path
+//
+// We test by spinning up a real local HTTP server to simulate a healthy Nexus,
+// then verify ensureNexusRunning() returns early without invoking Bun.spawn
+// (i.e. without running nexus up / nexus init).
+// ---------------------------------------------------------------------------
+
+describe("ensureNexusRunning — fast path", () => {
+  const originalSpawn = Bun.spawn.bind(Bun);
+  let spawnCalls: string[][] = [];
+
+  beforeEach(() => {
+    spawnCalls = [];
+    // Track any spawn calls — the fast path must not spawn anything.
+    // @ts-ignore
+    Bun.spawn = (args: string[], opts?: unknown) => {
+      spawnCalls.push(args);
+      // discoverRunningNexus calls `docker ps` — let it return empty (no containers).
+      if (args[0] === "docker") {
+        return {
+          exited: Promise.resolve(0),
+          stdout: new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("")); c.close(); } }),
+          stderr: new ReadableStream({ start(c) { c.close(); } }),
+        };
+      }
+      // Any other spawn (nexus up, nexus init) should not be reached in fast path.
+      throw new Error(`Unexpected spawn: ${args.join(" ")}`);
+    };
+  });
+
+  afterEach(() => {
+    // @ts-ignore
+    Bun.spawn = originalSpawn;
+  });
+
+  test("returns early when GROVE_NEXUS_URL points to a healthy server", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(JSON.stringify({ status: "healthy" }), { status: 200 });
+      },
+    });
+
+    const savedEnv = process.env.GROVE_NEXUS_URL;
+    process.env.GROVE_NEXUS_URL = `http://localhost:${server.port}`;
+
+    try {
+      const { ensureNexusRunning } = await import("./nexus-lifecycle.js");
+      const result = await ensureNexusRunning(
+        "/tmp/test-proj",
+        { mode: "nexus", nexusManaged: true } as import("../core/config.js").GroveConfig,
+      );
+
+      expect(result.url).toBe(`http://localhost:${server.port}`);
+      // No nexus up or nexus init should have been spawned
+      const nexusCalls = spawnCalls.filter((a) => a[0] === "nexus");
+      expect(nexusCalls.length).toBe(0);
+    } finally {
+      server.stop(true);
+      if (savedEnv !== undefined) process.env.GROVE_NEXUS_URL = savedEnv;
+      else delete process.env.GROVE_NEXUS_URL;
+    }
+  });
+
+  test("waits through 'starting' status before returning", async () => {
+    let callCount = 0;
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        callCount++;
+        const status = callCount < 2 ? "starting" : "healthy";
+        return new Response(JSON.stringify({ status }), { status: 200 });
+      },
+    });
+
+    const savedEnv = process.env.GROVE_NEXUS_URL;
+    process.env.GROVE_NEXUS_URL = `http://localhost:${server.port}`;
+
+    try {
+      const { ensureNexusRunning } = await import("./nexus-lifecycle.js");
+      const result = await ensureNexusRunning(
+        "/tmp/test-proj",
+        { mode: "nexus", nexusManaged: true } as import("../core/config.js").GroveConfig,
+      );
+
+      expect(result.url).toBe(`http://localhost:${server.port}`);
+      // Must have polled at least twice (starting → healthy)
+      expect(callCount).toBeGreaterThanOrEqual(2);
+      const nexusCalls = spawnCalls.filter((a) => a[0] === "nexus");
+      expect(nexusCalls.length).toBe(0);
+    } finally {
+      server.stop(true);
+      if (savedEnv !== undefined) process.env.GROVE_NEXUS_URL = savedEnv;
+      else delete process.env.GROVE_NEXUS_URL;
+    }
+  });
+});

--- a/src/cli/nexus-lifecycle.ts
+++ b/src/cli/nexus-lifecycle.ts
@@ -203,11 +203,13 @@ export async function nexusUp(_projectRoot: string, opts: NexusUpOptions = {}): 
     }
   }
 
-  const args = ["nexus", "up", "--timeout", String(timeout), "--port-strategy", "auto"];
-  if (wantsBuild && sourceDir) {
-    args.push("--build");
-    args.push("--compose-file", join(sourceDir, "nexus-stack.yml"));
-  }
+  // Issue 6A: build args from a shared base so the --timeout fallback path
+  // never diverges (previously the --build / --compose-file block was copy-pasted).
+  const buildArgs =
+    wantsBuild && sourceDir
+      ? ["--build", "--compose-file", join(sourceDir, "nexus-stack.yml")]
+      : [];
+  const args = ["nexus", "up", "--timeout", String(timeout), "--port-strategy", "auto", ...buildArgs];
 
   const report = opts.onProgress;
 
@@ -217,8 +219,11 @@ export async function nexusUp(_projectRoot: string, opts: NexusUpOptions = {}): 
     stderr: "pipe",
   });
 
-  // Collect stderr while optionally streaming to progress callback
-  const stderrChunks: string[] = [];
+  // Issue 16A: ring buffer — keep only the last MAX_STDERR_LINES lines.
+  // During a Docker pull, nexus up streams verbose progress to stderr (potentially MBs).
+  // We only need the tail for error reporting; the head is discarded to bound memory usage.
+  const MAX_STDERR_LINES = 50;
+  const stderrLines: string[] = [];
   const stderrPromise = (async () => {
     if (!proc.stderr) return "";
     const reader = proc.stderr.getReader();
@@ -228,7 +233,10 @@ export async function nexusUp(_projectRoot: string, opts: NexusUpOptions = {}): 
         const { done, value } = await reader.read();
         if (done) break;
         const text = decoder.decode(value, { stream: true });
-        stderrChunks.push(text);
+        for (const line of text.split("\n")) {
+          stderrLines.push(line);
+          if (stderrLines.length > MAX_STDERR_LINES) stderrLines.shift();
+        }
         if (report) {
           for (const line of text.split("\n")) {
             const trimmed = line.trim();
@@ -239,7 +247,7 @@ export async function nexusUp(_projectRoot: string, opts: NexusUpOptions = {}): 
     } catch {
       // Stream closed
     }
-    return stderrChunks.join("");
+    return stderrLines.join("\n");
   })();
 
   const [code, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
@@ -247,11 +255,8 @@ export async function nexusUp(_projectRoot: string, opts: NexusUpOptions = {}): 
   if (code !== 0) {
     // Retry without --timeout if the flag is unsupported
     if (stderr.includes("no such option") || stderr.includes("unrecognized arguments")) {
-      const fallbackArgs = ["nexus", "up", "--port-strategy", "auto"];
-      if (wantsBuild && sourceDir) {
-        fallbackArgs.push("--build");
-        fallbackArgs.push("--compose-file", join(sourceDir, "nexus-stack.yml"));
-      }
+      // Issue 6A: reuse buildArgs — no duplication of --build / --compose-file logic.
+      const fallbackArgs = ["nexus", "up", "--port-strategy", "auto", ...buildArgs];
       const fallback = Bun.spawn(fallbackArgs, {
         cwd: projectRoot,
         stdout: "pipe",
@@ -358,6 +363,23 @@ function parseNexusUrlFromOutput(stdout: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Parse the host-bound port for Nexus (2026/tcp) from a `docker ps` Ports field.
+ *
+ * Matches both IPv4 (`0.0.0.0:PORT->2026/tcp`) and IPv6 (`:::PORT->2026/tcp`) formats.
+ * Returns the host port number, or undefined if no host binding for port 2026 is found.
+ *
+ * Extracted as a pure function for testability.
+ */
+export function parseNexusPortFromDockerPs(portsField: string): number | undefined {
+  // IPv4: "0.0.0.0:PORT->2026/tcp"  — the colon is part of "0.0.0.0:"
+  // IPv6: ":::PORT->2026/tcp"        — three colons immediately precede PORT (no extra colon)
+  const match = portsField.match(/(?:0\.0\.0\.0:|:::)(\d+)->2026\/tcp/);
+  if (!match?.[1]) return undefined;
+  const port = Number.parseInt(match[1], 10);
+  return port > 0 && port <= 65535 ? port : undefined;
+}
+
 // ---------------------------------------------------------------------------
 // API key discovery
 // ---------------------------------------------------------------------------
@@ -450,48 +472,53 @@ export async function waitForNexusHealth(
 /**
  * Discover a running Nexus container via Docker and return its URL.
  *
- * First checks host-bound port mappings (0.0.0.0:PORT->2026/tcp).
- * Then falls back to container internal IPs (for containers started without
- * host port bindings, e.g. via docker compose without ports: section).
- * This lets Grove reuse any Nexus stack regardless of how it was started.
+ * Issue 1A: no image-ancestor filter — works for any channel (edge, stable, nightly)
+ * and source builds. Port 2026 presence in the docker ps output identifies candidates.
+ *
+ * Issue 13A: batch-inspects all containers needing an IP lookup in a single subprocess
+ * call, then probes all candidate URLs in parallel via Promise.any().
  */
 export async function discoverRunningNexus(): Promise<string | undefined> {
   try {
-    // Get container IDs + ports for any container exposing 2026 (Nexus port)
-    const proc = Bun.spawn(
-      [
-        "docker",
-        "ps",
-        "--filter",
-        "ancestor=ghcr.io/nexi-lab/nexus:edge",
-        "--format",
-        "{{.ID}}|{{.Ports}}",
-      ],
-      { stdout: "pipe", stderr: "pipe" },
-    );
+    // Query all running containers with their port mappings.
+    // No image filter — port 2026 presence is the selector.
+    const proc = Bun.spawn(["docker", "ps", "--format", "{{.ID}}|{{.Ports}}"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
     const [code, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
     if (code !== 0 || !stdout.trim()) return undefined;
 
-    const candidateUrls: string[] = [];
+    const hostUrls: string[] = [];
+    const containerIdsForInspect: string[] = [];
 
     for (const line of stdout.trim().split("\n")) {
       const [id, ports] = line.split("|");
       if (!id || !ports) continue;
 
-      // 1. Prefer host-bound port: "0.0.0.0:27960->2026/tcp"
-      const hostMatch = ports.match(/(?:0\.0\.0\.0|:::):(\d+)->2026\/tcp/);
-      if (hostMatch?.[1]) {
-        candidateUrls.push(`http://localhost:${hostMatch[1]}`);
+      // 1. Host-bound port: "0.0.0.0:PORT->2026/tcp" or ":::PORT->2026/tcp"
+      const port = parseNexusPortFromDockerPs(ports);
+      if (port !== undefined) {
+        hostUrls.push(`http://localhost:${port}`);
         continue;
       }
 
-      // 2. Fall back: inspect container for internal IP + use Nexus default port 2026
+      // 2. Unbound internal port: "2026/tcp" without a host mapping — need container IP.
+      //    Only inspect containers that explicitly reference port 2026.
+      if (ports.includes("2026")) {
+        containerIdsForInspect.push(id.trim());
+      }
+    }
+
+    // Issue 13A: batch-inspect all containers in one subprocess call instead of N sequential ones.
+    const containerUrls: string[] = [];
+    if (containerIdsForInspect.length > 0) {
       try {
         const inspectProc = Bun.spawn(
           [
             "docker",
             "inspect",
-            id.trim(),
+            ...containerIdsForInspect,
             "--format",
             "{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}",
           ],
@@ -502,22 +529,29 @@ export async function discoverRunningNexus(): Promise<string | undefined> {
           new Response(inspectProc.stdout).text(),
         ]);
         for (const ip of inspectOut.trim().split(/\s+/)) {
-          if (ip && ip !== "") candidateUrls.push(`http://${ip}:2026`);
+          if (ip && ip !== "") containerUrls.push(`http://${ip}:2026`);
         }
       } catch {
-        // Docker inspect failed — skip
+        // Docker inspect failed — skip container IP fallback
       }
     }
 
-    for (const url of candidateUrls) {
-      try {
-        const res = await fetch(`${url}/health`, { signal: AbortSignal.timeout(3_000) });
-        const body = (await res.json().catch(() => ({}))) as { status?: string };
-        // Accept both healthy and starting (starting = Raft election, will become healthy)
-        if (body.status === "healthy" || body.status === "starting") return url;
-      } catch {
-        // Not reachable — try next candidate
-      }
+    const candidateUrls = [...hostUrls, ...containerUrls];
+    if (candidateUrls.length === 0) return undefined;
+
+    // Issue 13A: parallel health probes — first healthy/starting wins.
+    try {
+      return await Promise.any(
+        candidateUrls.map(async (url) => {
+          const res = await fetch(`${url}/health`, { signal: AbortSignal.timeout(3_000) });
+          const body = (await res.json().catch(() => ({}))) as { status?: string };
+          if (body.status === "healthy" || body.status === "starting") return url;
+          throw new Error(`not healthy: ${body.status}`);
+        }),
+      );
+    } catch {
+      // All probes failed — no reachable Nexus found
+      return undefined;
     }
   } catch {
     // Docker not available or command failed
@@ -610,27 +644,36 @@ export async function ensureNexusRunning(
 
   const urlsToTry = [...new Set(candidateUrls)];
 
+  // Issue 2A: probe all candidate URLs concurrently — first healthy/starting wins.
+  // Worst-case latency drops from N×3s (sequential) to 3s (parallel).
   report(`[nexus] checking URLs: ${urlsToTry.join(", ")}`);
-  for (const url of urlsToTry) {
-    try {
-      const res = await fetch(`${url}/health`, { signal: AbortSignal.timeout(3_000) });
-      const body = (await res.json().catch(() => ({}))) as { status?: string };
-      report(`[nexus] ${url} → status=${body.status}`);
-      if (body.status === "healthy") {
-        const apiKey = readNexusApiKey(projectRoot);
-        report("Nexus is ready (already running)");
-        return { url, apiKey };
-      }
-      if (body.status === "starting") {
-        report("Nexus is starting (waiting for Raft election)...");
-        await waitForNexusHealth(url);
-        const apiKey = readNexusApiKey(projectRoot);
-        report("Nexus is ready");
-        return { url, apiKey };
-      }
-    } catch {
-      // Not reachable — try next
+  let fastResult: { url: string; starting: boolean } | undefined;
+  try {
+    fastResult = await Promise.any(
+      urlsToTry.map(async (url) => {
+        const res = await fetch(`${url}/health`, { signal: AbortSignal.timeout(3_000) });
+        if (!res.ok) throw new Error("not ok");
+        const body = (await res.json().catch(() => ({}))) as { status?: string };
+        report(`[nexus] ${url} → status=${body.status}`);
+        if (body.status === "healthy") return { url, starting: false };
+        if (body.status === "starting") return { url, starting: true };
+        throw new Error(`not healthy: ${body.status}`);
+      }),
+    );
+  } catch {
+    // All probes failed (AggregateError from Promise.any) — fall through to restart/start
+    fastResult = undefined;
+  }
+
+  if (fastResult) {
+    if (fastResult.starting) {
+      report("Nexus is starting (waiting for Raft election)...");
+      await waitForNexusHealth(fastResult.url);
     }
+    // Issue 14A: read apiKey once, scoped to this return path — avoids repeated disk reads.
+    const apiKey = readNexusApiKey(projectRoot);
+    report("Nexus is ready (already running)");
+    return { url: fastResult.url, apiKey };
   }
 
   // -----------------------------------------------------------------------
@@ -670,11 +713,17 @@ export async function ensureNexusRunning(
         const httpPort = stateData.ports?.http;
         if (projectName && httpPort) {
           report(`[ensureNexus] quick restart: project=${projectName} port=${httpPort}`);
-          const restart = Bun.spawn(["docker", "compose", "-p", projectName, "restart", "nexus"], {
-            cwd: groveHomeDir,
-            stdout: "pipe",
-            stderr: "pipe",
-          });
+          // Issue 4A: "up --no-pull -d" handles both stopped and running containers without
+          // triggering a Docker pull. "restart" only works on already-running containers and
+          // is a no-op when containers are stopped (e.g. after machine reboot).
+          const restart = Bun.spawn(
+            ["docker", "compose", "-p", projectName, "up", "--no-pull", "-d", "nexus"],
+            {
+              cwd: groveHomeDir,
+              stdout: "pipe",
+              stderr: "pipe",
+            },
+          );
           const restartCode = await restart.exited;
           if (restartCode === 0) {
             quickRestartUrl = `http://localhost:${httpPort}`;

--- a/src/shared/service-lifecycle.ts
+++ b/src/shared/service-lifecycle.ts
@@ -5,7 +5,7 @@
  * plus graceful shutdown of all spawned processes.
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
@@ -72,75 +72,49 @@ export async function startServices(options: ServiceStartOptions): Promise<Runni
   const { parseGroveConfig } = await import("../core/config.js");
   const config = parseGroveConfig(raw);
 
-  // Start managed Nexus if configured — skip if GROVE_NEXUS_URL already set (reuse existing)
+  // Start managed Nexus if configured — skip if GROVE_NEXUS_URL already set (reuse existing).
+  // Issue 3A: removed the duplicate config.nexusUrl fast-path health check that previously
+  // preceded ensureNexusRunning(). ensureNexusRunning() already probes config.nexusUrl as
+  // one of its candidates (including parallel probing per Issue 2A), so the outer check was
+  // redundant and kept two copies of the "is Nexus healthy?" logic in sync.
   if (
     !process.env.GROVE_NEXUS_URL &&
     (config.nexusManaged || (config.mode === "nexus" && !config.nexusUrl))
   ) {
-    // Fast path: if grove.json has nexusUrl, check health before running ensureNexusRunning.
-    // This avoids spawning a duplicate compose project when the existing Nexus just needs
-    // a moment to start up (e.g., after machine reboot or container auto-restart).
-    if (config.nexusUrl) {
+    try {
+      const { ensureNexusRunning } = await import("../cli/nexus-lifecycle.js");
+      const nexusInfo = await ensureNexusRunning(projectRoot, config, {
+        build: options.build ?? false,
+        nexusSource: options.nexusSource,
+        onProgress: options.onProgress,
+      });
+      nexusManaged = true;
+      // Only set env vars if not already configured (user may have set explicit Nexus URL)
+      if (!process.env.GROVE_NEXUS_URL) {
+        process.env.GROVE_NEXUS_URL = nexusInfo.url;
+      }
+      if (!process.env.NEXUS_API_KEY && nexusInfo.apiKey) {
+        process.env.NEXUS_API_KEY = nexusInfo.apiKey;
+      }
+      // Issue 15A: reuse already-parsed config and raw string — avoids a redundant readFileSync.
+      // Persist Nexus URL to grove.json so Resume can find it without re-discovery.
       try {
-        const { readNexusApiKey } = await import("../cli/nexus-lifecycle.js");
-        const res = await fetch(`${config.nexusUrl}/health`, {
-          signal: AbortSignal.timeout(5_000),
-        });
-        const body = (await res.json().catch(() => ({}))) as { status?: string };
-        if (body.status === "healthy" || body.status === "starting") {
-          const apiKey = readNexusApiKey(projectRoot);
-          if (body.status === "starting") {
-            const { waitForNexusHealth } = await import("../cli/nexus-lifecycle.js");
-            await waitForNexusHealth(config.nexusUrl, 60_000);
-          }
-          process.env.GROVE_NEXUS_URL = config.nexusUrl;
-          if (apiKey) process.env.NEXUS_API_KEY = apiKey;
-          nexusManaged = true;
-          options.onProgress?.("Nexus is ready (from grove.json)");
-          // Don't return — fall through to start other services (HTTP server, etc.)
+        if (config.nexusUrl !== nexusInfo.url) {
+          const updated = { ...JSON.parse(raw), nexusUrl: nexusInfo.url };
+          writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`, "utf-8");
         }
       } catch {
-        // Not reachable — fall through to ensureNexusRunning
+        // Best-effort — don't fail startup over config persistence
       }
+    } catch (err) {
+      // If user explicitly asked for --build, don't silently fall back — surface the error
+      if (options.build) {
+        throw err;
+      }
+      // Fall back to local mode — log the reason for debugging
+      const errMsg = err instanceof Error ? err.message : String(err);
+      options.onProgress?.(`Nexus unavailable (${errMsg}), using local mode`);
     }
-
-    if (!nexusManaged)
-      try {
-        const { ensureNexusRunning } = await import("../cli/nexus-lifecycle.js");
-        const nexusInfo = await ensureNexusRunning(projectRoot, config, {
-          build: options.build ?? false,
-          nexusSource: options.nexusSource,
-          onProgress: options.onProgress,
-        });
-        nexusManaged = true;
-        // Only set env vars if not already configured (user may have set explicit Nexus URL)
-        if (!process.env.GROVE_NEXUS_URL) {
-          process.env.GROVE_NEXUS_URL = nexusInfo.url;
-        }
-        if (!process.env.NEXUS_API_KEY && nexusInfo.apiKey) {
-          process.env.NEXUS_API_KEY = nexusInfo.apiKey;
-        }
-        // Persist Nexus URL to grove.json so Resume can find it without re-discovery.
-        // This prevents spinning up a duplicate Nexus stack on subsequent TUI launches.
-        try {
-          const { writeFileSync } = await import("node:fs");
-          const currentConfig = JSON.parse(readFileSync(configPath, "utf-8"));
-          if (currentConfig.nexusUrl !== nexusInfo.url) {
-            currentConfig.nexusUrl = nexusInfo.url;
-            writeFileSync(configPath, `${JSON.stringify(currentConfig, null, 2)}\n`, "utf-8");
-          }
-        } catch {
-          // Best-effort — don't fail startup over config persistence
-        }
-      } catch (err) {
-        // If user explicitly asked for --build, don't silently fall back — surface the error
-        if (options.build) {
-          throw err;
-        }
-        // Fall back to local mode — log the reason for debugging
-        const errMsg = err instanceof Error ? err.message : String(err);
-        options.onProgress?.(`Nexus unavailable (${errMsg}), using local mode`);
-      }
   }
 
   // Spawn services in parallel
@@ -247,7 +221,6 @@ export async function stopServices(services: RunningServices): Promise<void> {
 
   // Clean up PID file
   try {
-    const { unlinkSync } = require("node:fs") as typeof import("node:fs");
     unlinkSync(pidFilePath);
   } catch {
     /* ignore */
@@ -292,15 +265,38 @@ async function spawnService(
     const pid = child.pid ?? 0;
     child.unref();
 
-    // Wait for process to start. Server with Nexus stores may take longer
-    // to initialize (dynamic imports + NexusHttpClient construction).
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-
-    // Check if the process is running
-    try {
-      process.kill(pid, 0); // Signal 0 = check existence
-    } catch {
-      return null; // Process died during startup
+    // Issue 7A: poll the health endpoint with exponential backoff instead of a blind 5s sleep.
+    // In the common case (service starts in < 1s) this returns immediately rather than blocking.
+    // Cap at 10s; if the service is alive but not responding to health, return it anyway.
+    if (port) {
+      const deadline = Date.now() + 10_000;
+      let delay = 200;
+      while (Date.now() < deadline) {
+        try {
+          const resp = await fetch(`http://localhost:${port}/health`, {
+            signal: AbortSignal.timeout(500),
+          });
+          if (resp.ok) break;
+        } catch {
+          // Not ready yet
+        }
+        // Confirm the process is still alive before waiting again
+        try {
+          process.kill(pid, 0);
+        } catch {
+          return null; // process died during startup
+        }
+        await new Promise((r) => setTimeout(r, delay));
+        delay = Math.min(delay * 1.5, 2_000);
+      }
+    } else {
+      // No known port — brief wait then existence check
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+      try {
+        process.kill(pid, 0);
+      } catch {
+        return null;
+      }
     }
 
     // Wrap for the ChildProcess interface

--- a/src/tui/resolve-backend.ts
+++ b/src/tui/resolve-backend.ts
@@ -72,7 +72,7 @@ export async function resolveBackend(flags: ResolveBackendFlags): Promise<Resolv
   // 4. grove.json nexusUrl or nexus.yaml port — trust config without health check.
   // The URL comes from user configuration (nexusUrl) or managed Nexus (nexus.yaml).
   // Both are authoritative. Health checking happens downstream at connect time.
-  const { url: configUrl } = readNexusUrlFromConfig(flags.groveOverride);
+  const { url: configUrl } = await readNexusUrlFromConfig(flags.groveOverride);
   if (configUrl) {
     return {
       mode: "nexus",
@@ -86,8 +86,9 @@ export async function resolveBackend(flags: ResolveBackendFlags): Promise<Resolv
   // was found (no nexus.yaml, no explicit nexusUrl). Try Docker port mapping.
   if (isNexusManagedConfig(flags.groveOverride)) {
     try {
-      const { discoverRunningNexus, readNexusApiKey } =
-        require("../cli/nexus-lifecycle.js") as typeof import("../cli/nexus-lifecycle.js");
+      // Issue 5A: use await import() consistently — require() was used here because
+      // the surrounding helper was synchronous; resolveBackend is async so import() is correct.
+      const { discoverRunningNexus, readNexusApiKey } = await import("../cli/nexus-lifecycle.js");
       const discovered = await discoverRunningNexus();
       if (discovered) {
         // Set the API key env so downstream code (health checks, providers) can use it
@@ -139,10 +140,14 @@ function isNexusManagedConfig(groveOverride?: string): boolean {
 // Config file reader
 // ---------------------------------------------------------------------------
 
-/** Read nexusUrl from .grove/grove.json if it exists. Returns the URL and whether it was explicit. */
-function readNexusUrlFromConfig(
+/**
+ * Read nexusUrl from .grove/grove.json if it exists. Returns the URL and whether it was explicit.
+ *
+ * Issue 5A: made async so it can use await import() consistently instead of require().
+ */
+async function readNexusUrlFromConfig(
   groveOverride?: string,
-): { url: string; fromExplicit: boolean } | { url: undefined; fromExplicit: false } {
+): Promise<{ url: string; fromExplicit: boolean } | { url: undefined; fromExplicit: false }> {
   const none = { url: undefined, fromExplicit: false } as const;
   try {
     const { groveDir } = resolveGroveDir(groveOverride);
@@ -153,8 +158,7 @@ function readNexusUrlFromConfig(
 
     // Try typed parsing first; fall back to raw JSON for backward compat
     try {
-      const { parseGroveConfig } =
-        require("../core/config.js") as typeof import("../core/config.js");
+      const { parseGroveConfig } = await import("../core/config.js");
       const config = parseGroveConfig(raw);
       if (config.nexusUrl) return { url: config.nexusUrl, fromExplicit: true };
 
@@ -162,8 +166,7 @@ function readNexusUrlFromConfig(
       // This handles standalone `grove tui` on a managed-Nexus grove where
       // `grove up` already started Nexus but didn't set GROVE_NEXUS_URL.
       if (config.nexusManaged && config.mode === "nexus") {
-        const { readNexusUrl } =
-          require("../cli/nexus-lifecycle.js") as typeof import("../cli/nexus-lifecycle.js");
+        const { readNexusUrl } = await import("../cli/nexus-lifecycle.js");
         const yamlUrl = readNexusUrl(join(groveDir, ".."));
         if (yamlUrl) return { url: yamlUrl, fromExplicit: false };
       }
@@ -181,8 +184,7 @@ function readNexusUrlFromConfig(
       // Managed Nexus fallback: discover from nexus.yaml
       if (parsed.nexusManaged && parsed.mode === "nexus") {
         try {
-          const { readNexusUrl } =
-            require("../cli/nexus-lifecycle.js") as typeof import("../cli/nexus-lifecycle.js");
+          const { readNexusUrl } = await import("../cli/nexus-lifecycle.js");
           const yamlUrl = readNexusUrl(join(groveDir, ".."));
           if (yamlUrl) return { url: yamlUrl, fromExplicit: false };
         } catch {


### PR DESCRIPTION
## Problem

Fixes #205. Selecting "Continue session" triggered a full `grove up` → `nexus up` → Docker pull (~500 MB) even when Nexus was already running.

Three distinct root causes:

1. `discoverRunningNexus` filtered by `ancestor=ghcr.io/nexi-lab/nexus:edge` — missed `stable`, `nightly`, and source-build containers
2. `ensureNexusRunning` probed candidate URLs sequentially (up to 18s worst case before falling through to `nexus up`)
3. `docker compose restart` is a no-op on stopped containers (e.g. after machine reboot), causing a fall-through to a full pull

## Changes

### Architecture (root cause fixes)
| | Change |
|---|---|
| 1A | `discoverRunningNexus`: drop `--filter ancestor=` — port 2026 presence + health probe is the selector |
| 2A | `ensureNexusRunning` fast path: sequential loop → `Promise.any()`, worst-case 3s not 18s |
| 3A | Remove duplicate health-check fast path from `startServices()`; `ensureNexusRunning()` owns it |
| 4A | Quick-restart: `docker compose restart` → `docker compose up --no-pull -d` (starts stopped containers without pulling) |

### Code quality
| | Change |
|---|---|
| 5A | `resolve-backend.ts`: `require()` → `await import()`, `readNexusUrlFromConfig` made async |
| 6A | `nexusUp`: extract shared `buildArgs` — fallback path no longer copy-pastes `--build`/`--compose-file` |
| 7A | `spawnService`: replace blind 5s sleep with health-endpoint poll (exponential backoff, 10s cap) |
| 8A | `unlinkSync` added to top-level import; stray `require("node:fs")` removed |
| 15A | Reuse already-parsed config/raw for `nexusUrl` persistence — no extra `readFileSync` |
| 16A | `nexusUp` stderr: ring buffer (last 50 lines) instead of unbounded accumulation during Docker pull |

### New export + bug fix
`parseNexusPortFromDockerPs()` extracted as a pure function. Also fixes a latent IPv6 regex bug in the original: `:::PORT` was matched as `::::PORT` (extra colon in alternation).

### Tests (18 new in `nexus-lifecycle.test.ts`)
- `parseNexusPortFromDockerPs`: 8 table tests (IPv4, IPv6, unbound, wrong port, multi-port, port 0)
- `waitForNexusHealth`: immediate healthy, `starting`→`healthy` transition, timeout, non-ok HTTP, unreachable
- `nexusUp` fallback: `no such option`, `unrecognized arguments`, no fallback on unrelated errors
- `ensureNexusRunning` fast path: returns without spawning `nexus up` when URL is healthy; polls through `"starting"`

## Live validation

Tested against real running Docker containers:

```
✓ IPv4 port parse: 40970
✓ IPv6 port parse: 19411
✓ unbound 2026/tcp: undefined
✓ wrong port: undefined

[discoverRunningNexus — real docker]
✓ discovers live nexus without ancestor filter: http://localhost:40970

[ensureNexusRunning fast path]
[nexus] checking URLs: http://localhost:40970, http://localhost:2026
[nexus] http://localhost:40970 → status=healthy
Nexus is ready (already running)
✓ fast path returns url: http://localhost:40970
✓ nexus up NOT called: ok

7/7 passed
```

The non-edge container (`nexus-134214a5`, previously invisible to discovery) was found and returned in <1s. `nexus up` was not called.

## Test plan
- [ ] `bun test src/cli/nexus-lifecycle.test.ts` — 18 tests pass
- [ ] `bun test` — full suite passes (4900 tests)
- [ ] Resume session with Nexus already running → no Docker pull
- [ ] Resume session after machine reboot (containers stopped) → `up --no-pull -d`, no pull
- [ ] Resume session with non-edge Nexus channel → discovered via port filter