### PR TITLE
feat: add read/ack/reply semantics with deadline tracking

### DIFF
--- a/src/core/bounty-index-sweep.ts
+++ b/src/core/bounty-index-sweep.ts
@@ -52,7 +52,7 @@ export class BountyIndexSweep implements SweepStrategy {
 
           if (needsRepair) {
             found++;
-            await this.bountyStore.repairIndex!(bounty.bountyId);
+            await this.bountyStore.repairIndex?.(bounty.bountyId);
             repaired++;
           }
         } catch (err) {

--- a/src/core/deadline-watcher.test.ts
+++ b/src/core/deadline-watcher.test.ts
@@ -11,6 +11,25 @@ import { HandoffStatus } from "./handoff.js";
 import { InMemoryHandoffStore } from "./in-memory-handoff-store.js";
 import { LocalEventBus } from "./local-event-bus.js";
 
+/**
+ * Poll `check` up to `timeoutMs` (default 2s) with `intervalMs` waits
+ * between attempts. Returns once `check` returns truthy or throws if
+ * the timeout is hit. Used instead of fixed sleeps in timer tests so
+ * slow CI runners don't produce false negatives when the event loop
+ * schedules our setTimeout slightly later than the optimistic wait.
+ */
+async function waitFor(
+  check: () => Promise<boolean> | boolean,
+  { timeoutMs = 2000, intervalMs = 25 } = {},
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+}
+
 function makeHandoff(overrides?: Partial<Handoff>): Handoff {
   return {
     handoffId: crypto.randomUUID(),
@@ -152,8 +171,7 @@ describe("DeadlineWatcher", () => {
 
     watcher.watch(h);
 
-    // setTimeout(0) fires on next tick
-    await new Promise((r) => setTimeout(r, 50));
+    await waitFor(() => events.length > 0);
 
     expect(events).toHaveLength(1);
     expect(events[0]?.type).toBe("handoff.overdue");
@@ -177,8 +195,12 @@ describe("DeadlineWatcher", () => {
     watcher.watch(h);
     watcher2.watch(h);
 
-    // Wait for both to fire
-    await new Promise((r) => setTimeout(r, 300));
+    // Poll up to 2s for expiry — avoids CI timing flakes where a loaded
+    // runner can miss the fixed-duration window between setTimeout fire
+    // and expireStale commit.
+    await waitFor(
+      async () => (await store.get(h.handoffId))?.status === HandoffStatus.Expired,
+    );
 
     // Only ONE overdue event should be emitted — the watcher whose
     // expireStale() CAS flipped the row wins; the other sees empty and
@@ -201,8 +223,11 @@ describe("DeadlineWatcher", () => {
 
     watcher.watch(h);
 
-    // Wait for timer to fire and expire the handoff
-    await new Promise((r) => setTimeout(r, 200));
+    // Poll for expiry instead of sleeping a fixed duration — under CI
+    // load the 50ms deadline + expireStale can take longer than 200ms.
+    await waitFor(
+      async () => (await store.get(h.handoffId))?.status === HandoffStatus.Expired,
+    );
 
     const afterExpiry = await store.get(h.handoffId);
     expect(afterExpiry?.status).toBe(HandoffStatus.Expired);

--- a/src/core/deadline-watcher.test.ts
+++ b/src/core/deadline-watcher.test.ts
@@ -198,9 +198,7 @@ describe("DeadlineWatcher", () => {
     // Poll up to 2s for expiry — avoids CI timing flakes where a loaded
     // runner can miss the fixed-duration window between setTimeout fire
     // and expireStale commit.
-    await waitFor(
-      async () => (await store.get(h.handoffId))?.status === HandoffStatus.Expired,
-    );
+    await waitFor(async () => (await store.get(h.handoffId))?.status === HandoffStatus.Expired);
 
     // Only ONE overdue event should be emitted — the watcher whose
     // expireStale() CAS flipped the row wins; the other sees empty and
@@ -225,9 +223,7 @@ describe("DeadlineWatcher", () => {
 
     // Poll for expiry instead of sleeping a fixed duration — under CI
     // load the 50ms deadline + expireStale can take longer than 200ms.
-    await waitFor(
-      async () => (await store.get(h.handoffId))?.status === HandoffStatus.Expired,
-    );
+    await waitFor(async () => (await store.get(h.handoffId))?.status === HandoffStatus.Expired);
 
     const afterExpiry = await store.get(h.handoffId);
     expect(afterExpiry?.status).toBe(HandoffStatus.Expired);

--- a/src/core/deadline-watcher.test.ts
+++ b/src/core/deadline-watcher.test.ts
@@ -159,6 +159,37 @@ describe("DeadlineWatcher", () => {
     expect(events[0]?.type).toBe("handoff.overdue");
   });
 
+  test("two watchers on same handoff emit overdue at most once (single-owner)", async () => {
+    const h = await store.create({
+      sourceCid: "blake3:test",
+      fromRole: "coder",
+      toRole: "reviewer",
+      requiresReply: true,
+      replyDueAt: new Date(Date.now() + 50).toISOString(),
+    });
+
+    const events: GroveEvent[] = [];
+    bus.subscribe("reviewer", (e) => events.push(e));
+
+    // Two watchers observe the same store — simulates two MCP processes
+    const watcher2 = new DeadlineWatcher({ handoffStore: store, eventBus: bus });
+
+    watcher.watch(h);
+    watcher2.watch(h);
+
+    // Wait for both to fire
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Only ONE overdue event should be emitted — the watcher whose
+    // expireStale() CAS flipped the row wins; the other sees empty and
+    // skips emission.
+    const overdueEvents = events.filter((e) => e.type === "handoff.overdue");
+    expect(overdueEvents).toHaveLength(1);
+    expect(overdueEvents[0]?.payload.handoffId).toBe(h.handoffId);
+
+    watcher2.close();
+  });
+
   test("late reply is rejected after timer fires (expiry flush)", async () => {
     const h = await store.create({
       sourceCid: "blake3:test",

--- a/src/core/deadline-watcher.test.ts
+++ b/src/core/deadline-watcher.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for DeadlineWatcher — proactive deadline enforcement.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { DeadlineWatcher } from "./deadline-watcher.js";
+import type { GroveEvent } from "./event-bus.js";
+import type { Handoff } from "./handoff.js";
+import { HandoffStatus } from "./handoff.js";
+import { InMemoryHandoffStore } from "./in-memory-handoff-store.js";
+import { LocalEventBus } from "./local-event-bus.js";
+
+function makeHandoff(overrides?: Partial<Handoff>): Handoff {
+  return {
+    handoffId: crypto.randomUUID(),
+    sourceCid: "blake3:test",
+    fromRole: "coder",
+    toRole: "reviewer",
+    status: HandoffStatus.PendingPickup,
+    requiresReply: true,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("DeadlineWatcher", () => {
+  let store: InMemoryHandoffStore;
+  let bus: LocalEventBus;
+  let watcher: DeadlineWatcher;
+
+  beforeEach(() => {
+    store = new InMemoryHandoffStore();
+    bus = new LocalEventBus();
+    watcher = new DeadlineWatcher({ handoffStore: store, eventBus: bus });
+  });
+
+  afterEach(() => {
+    watcher.close();
+    bus.close();
+    store.close();
+  });
+
+  // ------------------------------------------------------------------
+  // watch / cancel
+  // ------------------------------------------------------------------
+
+  test("watch registers a timer for handoff with deadline", () => {
+    const h = makeHandoff({
+      replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    watcher.watch(h);
+    expect(watcher.activeCount).toBe(1);
+  });
+
+  test("watch is no-op when handoff has no replyDueAt", () => {
+    const h = makeHandoff({ replyDueAt: undefined });
+    watcher.watch(h);
+    expect(watcher.activeCount).toBe(0);
+  });
+
+  test("cancel removes the timer", () => {
+    const h = makeHandoff({
+      replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    watcher.watch(h);
+    expect(watcher.activeCount).toBe(1);
+
+    watcher.cancel(h.handoffId);
+    expect(watcher.activeCount).toBe(0);
+  });
+
+  test("cancel is safe for non-existent handoffId", () => {
+    watcher.cancel("nonexistent");
+    expect(watcher.activeCount).toBe(0);
+  });
+
+  test("watch replaces existing timer for same handoffId", () => {
+    const h = makeHandoff({
+      replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    watcher.watch(h);
+    watcher.watch(h);
+    expect(watcher.activeCount).toBe(1);
+  });
+
+  // ------------------------------------------------------------------
+  // overdue event emission
+  // ------------------------------------------------------------------
+
+  test("emits handoff.overdue when deadline passes and handoff still unresolved", async () => {
+    // Create a real handoff in the store
+    const h = await store.create({
+      sourceCid: "blake3:test",
+      fromRole: "coder",
+      toRole: "reviewer",
+      replyDueAt: new Date(Date.now() + 50).toISOString(), // 50ms from now
+      requiresReply: true,
+    });
+
+    const events: GroveEvent[] = [];
+    bus.subscribe("reviewer", (e) => events.push(e));
+
+    watcher.watch(h);
+
+    // Wait for the timer to fire
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("handoff.overdue");
+    expect(events[0]?.sourceRole).toBe("coder");
+    expect(events[0]?.targetRole).toBe("reviewer");
+    expect(events[0]?.payload.handoffId).toBe(h.handoffId);
+  });
+
+  test("does not emit overdue when handoff is already replied", async () => {
+    const h = await store.create({
+      sourceCid: "blake3:test",
+      fromRole: "coder",
+      toRole: "reviewer",
+      replyDueAt: new Date(Date.now() + 50).toISOString(),
+      requiresReply: true,
+    });
+
+    const events: GroveEvent[] = [];
+    bus.subscribe("reviewer", (e) => events.push(e));
+
+    watcher.watch(h);
+
+    // Resolve the handoff before deadline fires
+    await store.markDelivered(h.handoffId);
+    await store.markReplied(h.handoffId, "blake3:reply-cid");
+
+    // Wait for the timer
+    await new Promise((r) => setTimeout(r, 200));
+
+    // No overdue event because the handoff was resolved
+    expect(events).toHaveLength(0);
+  });
+
+  test("emits immediately when deadline is already past", async () => {
+    const h = await store.create({
+      sourceCid: "blake3:test",
+      fromRole: "coder",
+      toRole: "reviewer",
+      replyDueAt: new Date(Date.now() - 1000).toISOString(), // already past
+      requiresReply: true,
+    });
+
+    const events: GroveEvent[] = [];
+    bus.subscribe("reviewer", (e) => events.push(e));
+
+    watcher.watch(h);
+
+    // setTimeout(0) fires on next tick
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("handoff.overdue");
+  });
+
+  // ------------------------------------------------------------------
+  // rebuildFromStore
+  // ------------------------------------------------------------------
+
+  test("rebuildFromStore re-registers timers for unresolved handoffs", async () => {
+    await store.create({
+      sourceCid: "blake3:a",
+      fromRole: "coder",
+      toRole: "reviewer",
+      replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+      requiresReply: true,
+    });
+    await store.create({
+      sourceCid: "blake3:b",
+      fromRole: "coder",
+      toRole: "tester",
+      replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+      requiresReply: true,
+    });
+    // This one has no deadline — should not get a timer
+    await store.create({
+      sourceCid: "blake3:c",
+      fromRole: "coder",
+      toRole: "auditor",
+    });
+
+    const registered = await watcher.rebuildFromStore();
+    expect(registered).toBe(2);
+    expect(watcher.activeCount).toBe(2);
+  });
+
+  test("rebuildFromStore skips already-resolved handoffs", async () => {
+    const h = await store.create({
+      sourceCid: "blake3:a",
+      fromRole: "coder",
+      toRole: "reviewer",
+      replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+      requiresReply: true,
+    });
+    await store.markDelivered(h.handoffId);
+    await store.markReplied(h.handoffId, "blake3:reply");
+
+    const registered = await watcher.rebuildFromStore();
+    expect(registered).toBe(0);
+    expect(watcher.activeCount).toBe(0);
+  });
+
+  // ------------------------------------------------------------------
+  // close
+  // ------------------------------------------------------------------
+
+  test("close cancels all timers", () => {
+    const h1 = makeHandoff({
+      replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const h2 = makeHandoff({
+      replyDueAt: new Date(Date.now() + 120_000).toISOString(),
+    });
+    watcher.watch(h1);
+    watcher.watch(h2);
+    expect(watcher.activeCount).toBe(2);
+
+    watcher.close();
+    expect(watcher.activeCount).toBe(0);
+  });
+});

--- a/src/core/deadline-watcher.test.ts
+++ b/src/core/deadline-watcher.test.ts
@@ -159,6 +159,27 @@ describe("DeadlineWatcher", () => {
     expect(events[0]?.type).toBe("handoff.overdue");
   });
 
+  test("late reply is rejected after timer fires (expiry flush)", async () => {
+    const h = await store.create({
+      sourceCid: "blake3:test",
+      fromRole: "coder",
+      toRole: "reviewer",
+      requiresReply: true,
+      replyDueAt: new Date(Date.now() + 50).toISOString(),
+    });
+
+    watcher.watch(h);
+
+    // Wait for timer to fire and expire the handoff
+    await new Promise((r) => setTimeout(r, 200));
+
+    const afterExpiry = await store.get(h.handoffId);
+    expect(afterExpiry?.status).toBe(HandoffStatus.Expired);
+
+    // Late reply attempt must be rejected because the handoff is now expired
+    await expect(store.markReplied(h.handoffId, "blake3:reply-cid")).rejects.toThrow();
+  });
+
   // ------------------------------------------------------------------
   // rebuildFromStore
   // ------------------------------------------------------------------

--- a/src/core/deadline-watcher.ts
+++ b/src/core/deadline-watcher.ts
@@ -65,7 +65,9 @@ export class DeadlineWatcher {
     const deadlineMs = new Date(handoff.replyDueAt).getTime();
     const delayMs = Math.max(0, deadlineMs - Date.now());
 
-    log(`WATCH handoff=${handoff.handoffId.slice(0, 8)} toRole=${handoff.toRole} delayMs=${delayMs} replyDueAt=${handoff.replyDueAt}`);
+    log(
+      `WATCH handoff=${handoff.handoffId.slice(0, 8)} toRole=${handoff.toRole} delayMs=${delayMs} replyDueAt=${handoff.replyDueAt}`,
+    );
 
     const timer = setTimeout(() => {
       log(`TIMER FIRED handoff=${handoff.handoffId.slice(0, 8)} — checking if still unresolved`);
@@ -116,19 +118,12 @@ export class DeadlineWatcher {
 
     const cutoffDate = new Date(Date.now() - this.maxRebuildAgeMs).toISOString();
     const unresolved = await this.handoffStore.listForCurrentSession({
-      status: [
-        HandoffStatus.PendingPickup,
-        HandoffStatus.Delivered,
-        HandoffStatus.Processed,
-      ],
+      status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered, HandoffStatus.Processed],
     });
 
     let registered = 0;
     for (const h of unresolved) {
-      if (
-        h.replyDueAt !== undefined &&
-        h.createdAt >= cutoffDate
-      ) {
+      if (h.replyDueAt !== undefined && h.createdAt >= cutoffDate) {
         this.watch(h);
         registered++;
       }
@@ -173,7 +168,9 @@ export class DeadlineWatcher {
         handoff.status !== HandoffStatus.Delivered &&
         handoff.status !== HandoffStatus.Processed
       ) {
-        log(`TIMER FIRED handoff=${handoffId.slice(0, 8)} status=${handoff.status} — already resolved, skipping`);
+        log(
+          `TIMER FIRED handoff=${handoffId.slice(0, 8)} status=${handoff.status} — already resolved, skipping`,
+        );
         return;
       }
 
@@ -197,7 +194,9 @@ export class DeadlineWatcher {
       // Emit overdue events for every handoff that just transitioned. Each
       // event targets the handoff's own toRole, not the firing timer's toRole.
       for (const h of expired) {
-        log(`OVERDUE handoff=${h.handoffId.slice(0, 8)} toRole=${h.toRole} — emitting handoff.overdue event`);
+        log(
+          `OVERDUE handoff=${h.handoffId.slice(0, 8)} toRole=${h.toRole} — emitting handoff.overdue event`,
+        );
         this.eventBus.publish({
           type: "handoff.overdue",
           sourceRole: h.fromRole,
@@ -219,10 +218,14 @@ export class DeadlineWatcher {
       // fallback event — that would produce duplicate overdue notifications
       // in multi-watcher/multi-process setups.
       if (expired.length === 0) {
-        log(`TIMER FIRED handoff=${handoffId.slice(0, 8)} — already transitioned by another actor, skipping emit (from/to=${fromRole}/${toRole})`);
+        log(
+          `TIMER FIRED handoff=${handoffId.slice(0, 8)} — already transitioned by another actor, skipping emit (from/to=${fromRole}/${toRole})`,
+        );
       }
     } catch (err) {
-      log(`TIMER ERROR handoff=${handoffId.slice(0, 8)} err=${err instanceof Error ? err.message : String(err)}`);
+      log(
+        `TIMER ERROR handoff=${handoffId.slice(0, 8)} err=${err instanceof Error ? err.message : String(err)}`,
+      );
       // Best-effort — timer callback failures are non-fatal
     }
   }

--- a/src/core/deadline-watcher.ts
+++ b/src/core/deadline-watcher.ts
@@ -169,11 +169,14 @@ export class DeadlineWatcher {
         return;
       }
 
-      // Flush expiry for ALL overdue handoffs at this point. If the event
-      // loop was stalled across multiple deadlines, expireStale returns
-      // every newly-expired handoff. We must emit one overdue event per
-      // handoff — without this, stalled-loop scenarios silently drop
-      // overdue events for peers the current timer callback did not own.
+      // Flush expiry for ALL overdue handoffs at this point. Only handoffs
+      // returned by expireStale() are ones THIS process atomically transitioned
+      // from unresolved → expired; other processes with their own watchers
+      // would have their own expireStale() return different subsets. Emitting
+      // only on transition ownership deduplicates overdue events across
+      // processes — if another watcher already expired our handoff, expireStale
+      // here returns empty, and we emit nothing. This is intentional: the
+      // other watcher already emitted (single-owner semantics via store CAS).
       let expired: readonly Handoff[] = [];
       try {
         expired = await this.handoffStore.expireStale();
@@ -182,10 +185,9 @@ export class DeadlineWatcher {
       }
 
       const timestamp = new Date().toISOString();
-      const emitted = new Set<string>();
 
-      // Emit overdue events for every handoff that just expired. Each event
-      // targets the handoff's own toRole, not the firing timer's toRole.
+      // Emit overdue events for every handoff that just transitioned. Each
+      // event targets the handoff's own toRole, not the firing timer's toRole.
       for (const h of expired) {
         log(`OVERDUE handoff=${h.handoffId.slice(0, 8)} toRole=${h.toRole} — emitting handoff.overdue event`);
         this.eventBus.publish({
@@ -200,28 +202,16 @@ export class DeadlineWatcher {
           },
           timestamp,
         });
-        emitted.add(h.handoffId);
         // Cancel any peer timer so it doesn't fire and emit a duplicate
         this.cancel(h.handoffId);
       }
 
-      // If expireStale didn't return our handoff (e.g. the store flipped it
-      // between our read and the sweep, or expireStale failed), fall back
-      // to emitting based on the snapshot we already have.
-      if (!emitted.has(handoffId)) {
-        log(`OVERDUE handoff=${handoffId.slice(0, 8)} (fallback from snapshot) toRole=${toRole}`);
-        this.eventBus.publish({
-          type: "handoff.overdue",
-          sourceRole: fromRole,
-          targetRole: toRole,
-          payload: {
-            handoffId,
-            sourceCid: handoff.sourceCid,
-            replyDueAt: handoff.replyDueAt,
-            status: handoff.status,
-          },
-          timestamp,
-        });
+      // If expireStale didn't return our handoff, another watcher (or a
+      // reply that raced the timer) already transitioned it. Do NOT emit a
+      // fallback event — that would produce duplicate overdue notifications
+      // in multi-watcher/multi-process setups.
+      if (expired.length === 0) {
+        log(`TIMER FIRED handoff=${handoffId.slice(0, 8)} — already transitioned by another actor, skipping emit (from/to=${fromRole}/${toRole})`);
       }
     } catch (err) {
       log(`TIMER ERROR handoff=${handoffId.slice(0, 8)} err=${err instanceof Error ? err.message : String(err)}`);

--- a/src/core/deadline-watcher.ts
+++ b/src/core/deadline-watcher.ts
@@ -160,11 +160,23 @@ export class DeadlineWatcher {
       const handoff = await this.handoffStore.get(handoffId);
       if (handoff === undefined) return;
 
-      // Only emit overdue if still in an unresolved state
+      // Only transition and emit overdue if still unresolved
       if (
         handoff.status === HandoffStatus.PendingPickup ||
         handoff.status === HandoffStatus.Delivered
       ) {
+        // Flush expiry first: without this, a late reply arriving after the
+        // timer fires but before expireStale() runs would still succeed via
+        // markReplied() (since the stored status is still delivered/pending),
+        // retroactively "satisfying" a missed SLA. Calling expireStale() now
+        // atomically flips eligible handoffs to expired, so markReplied will
+        // throw InvalidTransitionError against an expired handoff.
+        try {
+          await this.handoffStore.expireStale();
+        } catch {
+          // best-effort — fall through to emit even if expiry failed
+        }
+
         log(`OVERDUE handoff=${handoffId.slice(0, 8)} status=${handoff.status} toRole=${toRole} — emitting handoff.overdue event`);
         this.eventBus.publish({
           type: "handoff.overdue",

--- a/src/core/deadline-watcher.ts
+++ b/src/core/deadline-watcher.ts
@@ -1,0 +1,159 @@
+/**
+ * Proactive deadline enforcement for handoffs with reply deadlines.
+ *
+ * Instead of relying on passive expiry (expireStale() called on read),
+ * the DeadlineWatcher registers per-handoff timers that fire when a
+ * deadline passes. On fire, it checks whether the handoff is still
+ * unresolved and emits a "handoff.overdue" event if so.
+ *
+ * Lifecycle:
+ *   1. Call watch(handoff) for each new handoff with a replyDueAt.
+ *   2. Call cancel(handoffId) when a handoff is resolved (replied/expired).
+ *   3. Call rebuildFromStore() on process startup to re-register timers
+ *      for any unresolved handoffs with future deadlines.
+ *   4. Call close() to cancel all timers on shutdown.
+ */
+
+import type { EventBus } from "./event-bus.js";
+import type { Handoff, HandoffStore } from "./handoff.js";
+import { HandoffStatus } from "./handoff.js";
+
+export interface DeadlineWatcherOpts {
+  /** HandoffStore to query on timer fire (verify still unresolved). */
+  readonly handoffStore: HandoffStore;
+  /** EventBus to emit "handoff.overdue" events. */
+  readonly eventBus: EventBus;
+  /** Maximum age (ms) of handoffs to consider on cold-start rebuild. Default: 7 days. */
+  readonly maxRebuildAgeMs?: number;
+}
+
+const DEFAULT_MAX_REBUILD_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export class DeadlineWatcher {
+  private readonly handoffStore: HandoffStore;
+  private readonly eventBus: EventBus;
+  private readonly maxRebuildAgeMs: number;
+
+  /** Active timers keyed by handoffId. */
+  private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor(opts: DeadlineWatcherOpts) {
+    this.handoffStore = opts.handoffStore;
+    this.eventBus = opts.eventBus;
+    this.maxRebuildAgeMs = opts.maxRebuildAgeMs ?? DEFAULT_MAX_REBUILD_AGE_MS;
+  }
+
+  /**
+   * Register a deadline timer for a handoff.
+   *
+   * If the deadline is already past, fires immediately (async check).
+   * If the handoff has no replyDueAt, this is a no-op.
+   * If a timer already exists for this handoffId, it is replaced.
+   */
+  watch(handoff: Handoff): void {
+    if (handoff.replyDueAt === undefined) return;
+
+    // Cancel any existing timer for this handoff
+    this.cancel(handoff.handoffId);
+
+    const deadlineMs = new Date(handoff.replyDueAt).getTime();
+    const delayMs = Math.max(0, deadlineMs - Date.now());
+
+    const timer = setTimeout(() => {
+      this.timers.delete(handoff.handoffId);
+      void this.onDeadlineFired(handoff.handoffId, handoff.fromRole, handoff.toRole);
+    }, delayMs);
+
+    // Prevent timer from keeping the process alive
+    if (timer.unref) timer.unref();
+
+    this.timers.set(handoff.handoffId, timer);
+  }
+
+  /**
+   * Cancel the deadline timer for a handoff (e.g., when resolved).
+   */
+  cancel(handoffId: string): void {
+    const timer = this.timers.get(handoffId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.timers.delete(handoffId);
+    }
+  }
+
+  /**
+   * Rebuild timers from the store on process startup.
+   *
+   * Scans for unresolved handoffs (pending_pickup or delivered) with
+   * future deadlines created within the max rebuild age window.
+   */
+  async rebuildFromStore(): Promise<number> {
+    const cutoffDate = new Date(Date.now() - this.maxRebuildAgeMs).toISOString();
+    const unresolved = await this.handoffStore.list({
+      status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
+    });
+
+    let registered = 0;
+    for (const h of unresolved) {
+      if (
+        h.replyDueAt !== undefined &&
+        h.createdAt >= cutoffDate
+      ) {
+        this.watch(h);
+        registered++;
+      }
+    }
+
+    return registered;
+  }
+
+  /** Number of active deadline timers. */
+  get activeCount(): number {
+    return this.timers.size;
+  }
+
+  /** Cancel all timers and release resources. */
+  close(): void {
+    for (const timer of this.timers.values()) {
+      clearTimeout(timer);
+    }
+    this.timers.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  private async onDeadlineFired(
+    handoffId: string,
+    fromRole: string,
+    toRole: string,
+  ): Promise<void> {
+    try {
+      // Re-read the handoff to check if it's still unresolved
+      const handoff = await this.handoffStore.get(handoffId);
+      if (handoff === undefined) return;
+
+      // Only emit overdue if still in an unresolved state
+      if (
+        handoff.status === HandoffStatus.PendingPickup ||
+        handoff.status === HandoffStatus.Delivered
+      ) {
+        this.eventBus.publish({
+          type: "handoff.overdue",
+          sourceRole: fromRole,
+          targetRole: toRole,
+          payload: {
+            handoffId,
+            sourceCid: handoff.sourceCid,
+            replyDueAt: handoff.replyDueAt,
+            status: handoff.status,
+          },
+          timestamp: new Date().toISOString(),
+        });
+      }
+    } catch {
+      // Best-effort — timer callback failures are non-fatal
+    }
+  }
+}

--- a/src/core/deadline-watcher.ts
+++ b/src/core/deadline-watcher.ts
@@ -162,22 +162,54 @@ export class DeadlineWatcher {
 
       // Only transition and emit overdue if still unresolved
       if (
-        handoff.status === HandoffStatus.PendingPickup ||
-        handoff.status === HandoffStatus.Delivered
+        handoff.status !== HandoffStatus.PendingPickup &&
+        handoff.status !== HandoffStatus.Delivered
       ) {
-        // Flush expiry first: without this, a late reply arriving after the
-        // timer fires but before expireStale() runs would still succeed via
-        // markReplied() (since the stored status is still delivered/pending),
-        // retroactively "satisfying" a missed SLA. Calling expireStale() now
-        // atomically flips eligible handoffs to expired, so markReplied will
-        // throw InvalidTransitionError against an expired handoff.
-        try {
-          await this.handoffStore.expireStale();
-        } catch {
-          // best-effort — fall through to emit even if expiry failed
-        }
+        log(`TIMER FIRED handoff=${handoffId.slice(0, 8)} status=${handoff.status} — already resolved, skipping`);
+        return;
+      }
 
-        log(`OVERDUE handoff=${handoffId.slice(0, 8)} status=${handoff.status} toRole=${toRole} — emitting handoff.overdue event`);
+      // Flush expiry for ALL overdue handoffs at this point. If the event
+      // loop was stalled across multiple deadlines, expireStale returns
+      // every newly-expired handoff. We must emit one overdue event per
+      // handoff — without this, stalled-loop scenarios silently drop
+      // overdue events for peers the current timer callback did not own.
+      let expired: readonly Handoff[] = [];
+      try {
+        expired = await this.handoffStore.expireStale();
+      } catch {
+        // best-effort
+      }
+
+      const timestamp = new Date().toISOString();
+      const emitted = new Set<string>();
+
+      // Emit overdue events for every handoff that just expired. Each event
+      // targets the handoff's own toRole, not the firing timer's toRole.
+      for (const h of expired) {
+        log(`OVERDUE handoff=${h.handoffId.slice(0, 8)} toRole=${h.toRole} — emitting handoff.overdue event`);
+        this.eventBus.publish({
+          type: "handoff.overdue",
+          sourceRole: h.fromRole,
+          targetRole: h.toRole,
+          payload: {
+            handoffId: h.handoffId,
+            sourceCid: h.sourceCid,
+            replyDueAt: h.replyDueAt,
+            status: HandoffStatus.Expired,
+          },
+          timestamp,
+        });
+        emitted.add(h.handoffId);
+        // Cancel any peer timer so it doesn't fire and emit a duplicate
+        this.cancel(h.handoffId);
+      }
+
+      // If expireStale didn't return our handoff (e.g. the store flipped it
+      // between our read and the sweep, or expireStale failed), fall back
+      // to emitting based on the snapshot we already have.
+      if (!emitted.has(handoffId)) {
+        log(`OVERDUE handoff=${handoffId.slice(0, 8)} (fallback from snapshot) toRole=${toRole}`);
         this.eventBus.publish({
           type: "handoff.overdue",
           sourceRole: fromRole,
@@ -188,10 +220,8 @@ export class DeadlineWatcher {
             replyDueAt: handoff.replyDueAt,
             status: handoff.status,
           },
-          timestamp: new Date().toISOString(),
+          timestamp,
         });
-      } else {
-        log(`TIMER FIRED handoff=${handoffId.slice(0, 8)} status=${handoff.status} — already resolved, skipping`);
       }
     } catch (err) {
       log(`TIMER ERROR handoff=${handoffId.slice(0, 8)} err=${err instanceof Error ? err.message : String(err)}`);

--- a/src/core/deadline-watcher.ts
+++ b/src/core/deadline-watcher.ts
@@ -18,6 +18,12 @@ import type { EventBus } from "./event-bus.js";
 import type { Handoff, HandoffStore } from "./handoff.js";
 import { HandoffStatus } from "./handoff.js";
 
+const DEBUG = process.env.GROVE_DEBUG === "1";
+function log(msg: string): void {
+  if (!DEBUG) return;
+  process.stderr.write(`[grove:deadline-watcher] ${msg}\n`);
+}
+
 export interface DeadlineWatcherOpts {
   /** HandoffStore to query on timer fire (verify still unresolved). */
   readonly handoffStore: HandoffStore;
@@ -59,7 +65,10 @@ export class DeadlineWatcher {
     const deadlineMs = new Date(handoff.replyDueAt).getTime();
     const delayMs = Math.max(0, deadlineMs - Date.now());
 
+    log(`WATCH handoff=${handoff.handoffId.slice(0, 8)} toRole=${handoff.toRole} delayMs=${delayMs} replyDueAt=${handoff.replyDueAt}`);
+
     const timer = setTimeout(() => {
+      log(`TIMER FIRED handoff=${handoff.handoffId.slice(0, 8)} — checking if still unresolved`);
       this.timers.delete(handoff.handoffId);
       void this.onDeadlineFired(handoff.handoffId, handoff.fromRole, handoff.toRole);
     }, delayMs);
@@ -76,6 +85,7 @@ export class DeadlineWatcher {
   cancel(handoffId: string): void {
     const timer = this.timers.get(handoffId);
     if (timer !== undefined) {
+      log(`CANCEL handoff=${handoffId.slice(0, 8)} — resolved before deadline`);
       clearTimeout(timer);
       this.timers.delete(handoffId);
     }
@@ -104,6 +114,7 @@ export class DeadlineWatcher {
       }
     }
 
+    log(`REBUILD registered=${registered} from ${unresolved.length} unresolved handoffs`);
     return registered;
   }
 
@@ -139,6 +150,7 @@ export class DeadlineWatcher {
         handoff.status === HandoffStatus.PendingPickup ||
         handoff.status === HandoffStatus.Delivered
       ) {
+        log(`OVERDUE handoff=${handoffId.slice(0, 8)} status=${handoff.status} toRole=${toRole} — emitting handoff.overdue event`);
         this.eventBus.publish({
           type: "handoff.overdue",
           sourceRole: fromRole,
@@ -151,8 +163,11 @@ export class DeadlineWatcher {
           },
           timestamp: new Date().toISOString(),
         });
+      } else {
+        log(`TIMER FIRED handoff=${handoffId.slice(0, 8)} status=${handoff.status} — already resolved, skipping`);
       }
-    } catch {
+    } catch (err) {
+      log(`TIMER ERROR handoff=${handoffId.slice(0, 8)} err=${err instanceof Error ? err.message : String(err)}`);
       // Best-effort — timer callback failures are non-fatal
     }
   }

--- a/src/core/deadline-watcher.ts
+++ b/src/core/deadline-watcher.ts
@@ -99,7 +99,14 @@ export class DeadlineWatcher {
    */
   async rebuildFromStore(): Promise<number> {
     const cutoffDate = new Date(Date.now() - this.maxRebuildAgeMs).toISOString();
-    const unresolved = await this.handoffStore.list({
+    // Use session-scoped enumeration when the store supports it. Without this
+    // scoping, a Nexus-backed store would return handoffs from ALL sessions
+    // in the zone and we'd arm timers for unrelated sessions, emitting
+    // cross-session handoff.overdue events.
+    const enumerate =
+      this.handoffStore.listForCurrentSession?.bind(this.handoffStore) ??
+      this.handoffStore.list.bind(this.handoffStore);
+    const unresolved = await enumerate({
       status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
     });
 

--- a/src/core/deadline-watcher.ts
+++ b/src/core/deadline-watcher.ts
@@ -98,15 +98,23 @@ export class DeadlineWatcher {
    * future deadlines created within the max rebuild age window.
    */
   async rebuildFromStore(): Promise<number> {
+    // Rebuild requires session-scoped enumeration. Stores that don't
+    // implement listForCurrentSession share data across sessions (e.g.
+    // SQLite without a session_id column on handoffs, or Nexus in certain
+    // configurations), so falling back to list() would arm timers for
+    // handoffs in other sessions and emit cross-session overdue events.
+    //
+    // When unavailable, skip rebuild entirely — timers will still be
+    // registered for newly-created handoffs via watch(). The only impact
+    // is that mid-process restarts won't re-arm existing deadlines, which
+    // is safer than the alternative.
+    if (this.handoffStore.listForCurrentSession === undefined) {
+      log(`REBUILD skipped — store does not support session-scoped enumeration`);
+      return 0;
+    }
+
     const cutoffDate = new Date(Date.now() - this.maxRebuildAgeMs).toISOString();
-    // Use session-scoped enumeration when the store supports it. Without this
-    // scoping, a Nexus-backed store would return handoffs from ALL sessions
-    // in the zone and we'd arm timers for unrelated sessions, emitting
-    // cross-session handoff.overdue events.
-    const enumerate =
-      this.handoffStore.listForCurrentSession?.bind(this.handoffStore) ??
-      this.handoffStore.list.bind(this.handoffStore);
-    const unresolved = await enumerate({
+    const unresolved = await this.handoffStore.listForCurrentSession({
       status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
     });
 

--- a/src/core/deadline-watcher.ts
+++ b/src/core/deadline-watcher.ts
@@ -94,8 +94,9 @@ export class DeadlineWatcher {
   /**
    * Rebuild timers from the store on process startup.
    *
-   * Scans for unresolved handoffs (pending_pickup or delivered) with
-   * future deadlines created within the max rebuild age window.
+   * Scans for unresolved handoffs (pending_pickup, delivered, processed)
+   * with future deadlines created within the max rebuild age window.
+   * Processed handoffs are still deadline-backed until they reply.
    */
   async rebuildFromStore(): Promise<number> {
     // Rebuild requires session-scoped enumeration. Stores that don't
@@ -115,7 +116,11 @@ export class DeadlineWatcher {
 
     const cutoffDate = new Date(Date.now() - this.maxRebuildAgeMs).toISOString();
     const unresolved = await this.handoffStore.listForCurrentSession({
-      status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
+      status: [
+        HandoffStatus.PendingPickup,
+        HandoffStatus.Delivered,
+        HandoffStatus.Processed,
+      ],
     });
 
     let registered = 0;
@@ -160,10 +165,13 @@ export class DeadlineWatcher {
       const handoff = await this.handoffStore.get(handoffId);
       if (handoff === undefined) return;
 
-      // Only transition and emit overdue if still unresolved
+      // Only transition and emit overdue if still unresolved. Processed
+      // handoffs are still SLA-deadline-backed (agent started work but
+      // hasn't replied yet), so they must fire overdue events too.
       if (
         handoff.status !== HandoffStatus.PendingPickup &&
-        handoff.status !== HandoffStatus.Delivered
+        handoff.status !== HandoffStatus.Delivered &&
+        handoff.status !== HandoffStatus.Processed
       ) {
         log(`TIMER FIRED handoff=${handoffId.slice(0, 8)} status=${handoff.status} — already resolved, skipping`);
         return;

--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -6,9 +6,19 @@
  * - Future: RedisEventBus, NatsEventBus for federated setups
  */
 
-/** An event published through the bus. */
+/**
+ * An event published through the bus.
+ *
+ * Convention for type names: "namespace.action"
+ *   - contribution  — a contribution was created
+ *   - stop          — session termination signal
+ *   - idle          — agent entered idle state
+ *   - handoff.overdue — a handoff reply deadline has passed
+ *   - handoff.seen  — a handoff was observed by the target agent
+ *   - handoff.acked — a handoff was acknowledged by the target agent
+ */
 export interface GroveEvent {
-  readonly type: "contribution" | "stop" | "idle";
+  readonly type: string;
   readonly sourceRole: string;
   readonly targetRole: string;
   readonly payload: Record<string, unknown>;

--- a/src/core/handoff-store.conformance.test.ts
+++ b/src/core/handoff-store.conformance.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Run HandoffStore conformance suite against InMemoryHandoffStore.
+ */
+
+import { runHandoffStoreTests } from "./handoff-store.conformance.js";
+import { InMemoryHandoffStore } from "./in-memory-handoff-store.js";
+
+runHandoffStoreTests(async () => {
+  const store = new InMemoryHandoffStore();
+  return {
+    store,
+    cleanup: async () => {
+      /* in-memory — nothing to clean up */
+    },
+  };
+});

--- a/src/core/handoff-store.conformance.ts
+++ b/src/core/handoff-store.conformance.ts
@@ -254,9 +254,7 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
 
     test("expireStale marks overdue pending_pickup handoffs as expired", async () => {
       const pastDeadline = new Date(Date.now() - 60_000).toISOString();
-      const h = await store.create(
-        makeHandoffInput({ replyDueAt: pastDeadline }),
-      );
+      const h = await store.create(makeHandoffInput({ replyDueAt: pastDeadline }));
 
       const expired = await store.expireStale();
       const updated = await store.get(h.handoffId);
@@ -277,9 +275,7 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
 
     test("expireStale does not expire handoffs with future deadline", async () => {
       const futureDeadline = new Date(Date.now() + 600_000).toISOString();
-      const h = await store.create(
-        makeHandoffInput({ replyDueAt: futureDeadline }),
-      );
+      const h = await store.create(makeHandoffInput({ replyDueAt: futureDeadline }));
 
       await store.expireStale();
       const updated = await store.get(h.handoffId);
@@ -301,9 +297,7 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
 
     test("expireStale expires delivered handoffs with past deadline", async () => {
       const pastDeadline = new Date(Date.now() - 60_000).toISOString();
-      const h = await store.create(
-        makeHandoffInput({ replyDueAt: pastDeadline }),
-      );
+      const h = await store.create(makeHandoffInput({ replyDueAt: pastDeadline }));
       // Transition to delivered (not pending_pickup)
       await store.markDelivered(h.handoffId);
 
@@ -320,9 +314,7 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
       // deadline passes. (Stores reject late replies via deadline check, so
       // this test exercises the replied-before-deadline path.)
       const futureDeadline = new Date(Date.now() + 60_000).toISOString();
-      const h = await store.create(
-        makeHandoffInput({ replyDueAt: futureDeadline }),
-      );
+      const h = await store.create(makeHandoffInput({ replyDueAt: futureDeadline }));
       await store.markDelivered(h.handoffId);
       await store.markReplied(h.handoffId, "blake3:reply-cid");
 
@@ -335,9 +327,7 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
 
     test("markReplied rejects late replies (deadline passed)", async () => {
       const pastDeadline = new Date(Date.now() - 60_000).toISOString();
-      const h = await store.create(
-        makeHandoffInput({ replyDueAt: pastDeadline }),
-      );
+      const h = await store.create(makeHandoffInput({ replyDueAt: pastDeadline }));
       // State machine requires delivered before replied — mark delivered
       // first so we exercise the deadline-check path, not the transition check.
       await store.markDelivered(h.handoffId);
@@ -498,9 +488,9 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
       const h = await store.create(makeHandoffInput({ replyDueAt: pastDeadline }));
       await store.expireStale();
 
-      await expect(
-        store.markReplied(h.handoffId, "blake3:reply"),
-      ).rejects.toThrow(InvalidTransitionError);
+      await expect(store.markReplied(h.handoffId, "blake3:reply")).rejects.toThrow(
+        InvalidTransitionError,
+      );
     });
 
     test("markAcked is atomic under concurrent retries — same timestamp returned", async () => {
@@ -515,10 +505,11 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
 
       // Subsequent calls must not overwrite
       const originalAckedAt = updated?.ackedAt;
+      expect(originalAckedAt).toBeDefined();
       await new Promise((r) => setTimeout(r, 20));
       await store.markAcked(h.handoffId);
       const after = await store.get(h.handoffId);
-      expect(after?.ackedAt).toBe(originalAckedAt!);
+      expect(after?.ackedAt).toBe(originalAckedAt as string);
     });
 
     test("markReplied on already-replied handoff throws InvalidTransitionError", async () => {
@@ -526,9 +517,9 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
       await store.markDelivered(h.handoffId);
       await store.markReplied(h.handoffId, "blake3:reply-1");
 
-      await expect(
-        store.markReplied(h.handoffId, "blake3:reply-2"),
-      ).rejects.toThrow(InvalidTransitionError);
+      await expect(store.markReplied(h.handoffId, "blake3:reply-2")).rejects.toThrow(
+        InvalidTransitionError,
+      );
     });
   });
 }

--- a/src/core/handoff-store.conformance.ts
+++ b/src/core/handoff-store.conformance.ts
@@ -299,6 +299,21 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
       expect(second).toHaveLength(0);
     });
 
+    test("expireStale expires delivered handoffs with past deadline", async () => {
+      const pastDeadline = new Date(Date.now() - 60_000).toISOString();
+      const h = await store.create(
+        makeHandoffInput({ replyDueAt: pastDeadline }),
+      );
+      // Transition to delivered (not pending_pickup)
+      await store.markDelivered(h.handoffId);
+
+      const expired = await store.expireStale();
+      const updated = await store.get(h.handoffId);
+
+      expect(expired.map((e) => e.handoffId)).toContain(h.handoffId);
+      expect(updated?.status).toBe(HandoffStatus.Expired);
+    });
+
     test("expireStale does not expire already-replied handoffs with past deadline", async () => {
       const pastDeadline = new Date(Date.now() - 60_000).toISOString();
       const h = await store.create(

--- a/src/core/handoff-store.conformance.ts
+++ b/src/core/handoff-store.conformance.ts
@@ -478,6 +478,24 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
       ).rejects.toThrow(InvalidTransitionError);
     });
 
+    test("markAcked is atomic under concurrent retries — same timestamp returned", async () => {
+      const h = await store.create(makeHandoffInput());
+
+      // Fire 5 concurrent markAcked calls — they should all succeed and
+      // converge on a single ackedAt timestamp (not stamp different times).
+      await Promise.all(Array.from({ length: 5 }, () => store.markAcked(h.handoffId)));
+
+      const updated = await store.get(h.handoffId);
+      expect(updated?.ackedAt).toBeDefined();
+
+      // Subsequent calls must not overwrite
+      const originalAckedAt = updated?.ackedAt;
+      await new Promise((r) => setTimeout(r, 20));
+      await store.markAcked(h.handoffId);
+      const after = await store.get(h.handoffId);
+      expect(after?.ackedAt).toBe(originalAckedAt!);
+    });
+
     test("markReplied on already-replied handoff throws InvalidTransitionError", async () => {
       const h = await store.create(makeHandoffInput());
       await store.markDelivered(h.handoffId);

--- a/src/core/handoff-store.conformance.ts
+++ b/src/core/handoff-store.conformance.ts
@@ -1,0 +1,476 @@
+/**
+ * Conformance test suite for HandoffStore implementations.
+ *
+ * Any backend that implements HandoffStore can validate its behavior
+ * by calling `runHandoffStoreTests()` with a factory that creates
+ * fresh store instances.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { HandoffStatus, type HandoffStore, InvalidTransitionError } from "./handoff.js";
+import { makeHandoffInput } from "./test-helpers.js";
+
+/** Factory that creates a fresh HandoffStore and returns a cleanup function. */
+export type HandoffStoreFactory = () => Promise<{
+  store: HandoffStore;
+  cleanup: () => Promise<void>;
+}>;
+
+/**
+ * Run the full HandoffStore conformance test suite.
+ *
+ * Call this from your backend-specific test file with a factory
+ * that creates and tears down store instances.
+ */
+export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
+  describe("HandoffStore conformance", () => {
+    let store: HandoffStore;
+    let cleanup: () => Promise<void>;
+
+    beforeEach(async () => {
+      const result = await factory();
+      store = result.store;
+      cleanup = result.cleanup;
+    });
+
+    afterEach(async () => {
+      store.close();
+      await cleanup();
+    });
+
+    // ------------------------------------------------------------------
+    // create / get
+    // ------------------------------------------------------------------
+
+    test("create stores and returns a handoff", async () => {
+      const input = makeHandoffInput();
+      const handoff = await store.create(input);
+      expect(handoff.sourceCid).toBe(input.sourceCid);
+      expect(handoff.fromRole).toBe(input.fromRole);
+      expect(handoff.toRole).toBe(input.toRole);
+      expect(typeof handoff.handoffId).toBe("string");
+      expect(handoff.handoffId.length).toBeGreaterThan(0);
+      expect(handoff.createdAt).toBeDefined();
+    });
+
+    test("create assigns a UUID when handoffId is omitted", async () => {
+      const input = makeHandoffInput({ handoffId: undefined });
+      const handoff = await store.create(input);
+      expect(handoff.handoffId).toBeDefined();
+      expect(handoff.handoffId.length).toBeGreaterThan(0);
+    });
+
+    test("create uses provided handoffId when given", async () => {
+      const input = makeHandoffInput({ handoffId: "custom-id-123" });
+      const handoff = await store.create(input);
+      expect(handoff.handoffId).toBe("custom-id-123");
+    });
+
+    test("create defaults requiresReply to false", async () => {
+      const input = makeHandoffInput({ requiresReply: undefined });
+      const handoff = await store.create(input);
+      expect(handoff.requiresReply).toBe(false);
+    });
+
+    test("create respects requiresReply=true", async () => {
+      const input = makeHandoffInput({ requiresReply: true });
+      const handoff = await store.create(input);
+      expect(handoff.requiresReply).toBe(true);
+    });
+
+    test("create stores replyDueAt when provided", async () => {
+      const deadline = new Date(Date.now() + 60_000).toISOString();
+      const input = makeHandoffInput({ replyDueAt: deadline });
+      const handoff = await store.create(input);
+      expect(handoff.replyDueAt).toBe(deadline);
+    });
+
+    test("create omits replyDueAt when not provided", async () => {
+      const input = makeHandoffInput({ replyDueAt: undefined });
+      const handoff = await store.create(input);
+      expect(handoff.replyDueAt).toBeUndefined();
+    });
+
+    test("get returns stored handoff", async () => {
+      const handoff = await store.create(makeHandoffInput());
+      const retrieved = await store.get(handoff.handoffId);
+      expect(retrieved).toBeDefined();
+      expect(retrieved?.handoffId).toBe(handoff.handoffId);
+      expect(retrieved?.sourceCid).toBe(handoff.sourceCid);
+      expect(retrieved?.fromRole).toBe(handoff.fromRole);
+      expect(retrieved?.toRole).toBe(handoff.toRole);
+    });
+
+    test("get returns undefined for non-existent handoff", async () => {
+      const result = await store.get("nonexistent");
+      expect(result).toBeUndefined();
+    });
+
+    // ------------------------------------------------------------------
+    // createMany
+    // ------------------------------------------------------------------
+
+    test("createMany stores multiple handoffs", async () => {
+      if (store.createMany === undefined) return; // optional method
+
+      const inputs = [
+        makeHandoffInput({ toRole: "reviewer" }),
+        makeHandoffInput({ toRole: "tester" }),
+        makeHandoffInput({ toRole: "auditor" }),
+      ];
+
+      const handoffs = await store.createMany(inputs);
+      expect(handoffs).toHaveLength(3);
+
+      const roles = handoffs.map((h) => h.toRole);
+      expect(roles).toContain("reviewer");
+      expect(roles).toContain("tester");
+      expect(roles).toContain("auditor");
+    });
+
+    test("createMany returns empty array for empty input", async () => {
+      if (store.createMany === undefined) return;
+
+      const handoffs = await store.createMany([]);
+      expect(handoffs).toHaveLength(0);
+    });
+
+    test("createMany preserves input order", async () => {
+      if (store.createMany === undefined) return;
+
+      const inputs = [
+        makeHandoffInput({ toRole: "alpha" }),
+        makeHandoffInput({ toRole: "beta" }),
+        makeHandoffInput({ toRole: "gamma" }),
+      ];
+
+      const handoffs = await store.createMany(inputs);
+      expect(handoffs[0]?.toRole).toBe("alpha");
+      expect(handoffs[1]?.toRole).toBe("beta");
+      expect(handoffs[2]?.toRole).toBe("gamma");
+    });
+
+    // ------------------------------------------------------------------
+    // list
+    // ------------------------------------------------------------------
+
+    test("list returns all handoffs when no query", async () => {
+      await store.create(makeHandoffInput({ toRole: "a" }));
+      await store.create(makeHandoffInput({ toRole: "b" }));
+
+      const all = await store.list();
+      expect(all.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test("list filters by toRole", async () => {
+      await store.create(makeHandoffInput({ toRole: "reviewer" }));
+      await store.create(makeHandoffInput({ toRole: "tester" }));
+
+      const results = await store.list({ toRole: "reviewer" });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      for (const h of results) {
+        expect(h.toRole).toBe("reviewer");
+      }
+    });
+
+    test("list filters by fromRole", async () => {
+      await store.create(makeHandoffInput({ fromRole: "coder" }));
+      await store.create(makeHandoffInput({ fromRole: "planner" }));
+
+      const results = await store.list({ fromRole: "coder" });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      for (const h of results) {
+        expect(h.fromRole).toBe("coder");
+      }
+    });
+
+    test("list filters by sourceCid", async () => {
+      await store.create(makeHandoffInput({ sourceCid: "blake3:aaa" }));
+      await store.create(makeHandoffInput({ sourceCid: "blake3:bbb" }));
+
+      const results = await store.list({ sourceCid: "blake3:aaa" });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      for (const h of results) {
+        expect(h.sourceCid).toBe("blake3:aaa");
+      }
+    });
+
+    test("list filters by status", async () => {
+      const h = await store.create(makeHandoffInput());
+      await store.markDelivered(h.handoffId);
+      await store.create(makeHandoffInput()); // stays at initial status
+
+      const delivered = await store.list({ status: HandoffStatus.Delivered });
+      expect(delivered.length).toBeGreaterThanOrEqual(1);
+      for (const d of delivered) {
+        expect(d.status).toBe(HandoffStatus.Delivered);
+      }
+    });
+
+    test("list respects limit", async () => {
+      await store.create(makeHandoffInput({ toRole: "a" }));
+      await store.create(makeHandoffInput({ toRole: "b" }));
+      await store.create(makeHandoffInput({ toRole: "c" }));
+
+      const results = await store.list({ limit: 2 });
+      expect(results).toHaveLength(2);
+    });
+
+    test("list returns empty array when no matches", async () => {
+      const results = await store.list({ toRole: "nonexistent-role" });
+      expect(results).toHaveLength(0);
+    });
+
+    // ------------------------------------------------------------------
+    // markDelivered
+    // ------------------------------------------------------------------
+
+    test("markDelivered transitions status to delivered", async () => {
+      const h = await store.create(makeHandoffInput());
+      await store.markDelivered(h.handoffId);
+
+      const updated = await store.get(h.handoffId);
+      expect(updated?.status).toBe(HandoffStatus.Delivered);
+    });
+
+    // ------------------------------------------------------------------
+    // markReplied
+    // ------------------------------------------------------------------
+
+    test("markReplied transitions status to replied and sets resolvedByCid", async () => {
+      const h = await store.create(makeHandoffInput());
+      await store.markDelivered(h.handoffId);
+      await store.markReplied(h.handoffId, "blake3:reply-cid");
+
+      const updated = await store.get(h.handoffId);
+      expect(updated?.status).toBe(HandoffStatus.Replied);
+      expect(updated?.resolvedByCid).toBe("blake3:reply-cid");
+    });
+
+    // ------------------------------------------------------------------
+    // expireStale
+    // ------------------------------------------------------------------
+
+    test("expireStale marks overdue pending_pickup handoffs as expired", async () => {
+      const pastDeadline = new Date(Date.now() - 60_000).toISOString();
+      const h = await store.create(
+        makeHandoffInput({ replyDueAt: pastDeadline }),
+      );
+
+      const expired = await store.expireStale();
+      const updated = await store.get(h.handoffId);
+
+      expect(expired.map((e) => e.handoffId)).toContain(h.handoffId);
+      expect(updated?.status).toBe(HandoffStatus.Expired);
+    });
+
+    test("expireStale does not expire handoffs without replyDueAt", async () => {
+      const h = await store.create(makeHandoffInput({ replyDueAt: undefined }));
+
+      await store.expireStale();
+      const updated = await store.get(h.handoffId);
+
+      // Should still be at initial status, not expired
+      expect(updated?.status).not.toBe(HandoffStatus.Expired);
+    });
+
+    test("expireStale does not expire handoffs with future deadline", async () => {
+      const futureDeadline = new Date(Date.now() + 600_000).toISOString();
+      const h = await store.create(
+        makeHandoffInput({ replyDueAt: futureDeadline }),
+      );
+
+      await store.expireStale();
+      const updated = await store.get(h.handoffId);
+
+      expect(updated?.status).not.toBe(HandoffStatus.Expired);
+    });
+
+    test("expireStale is idempotent — second call returns empty for already expired", async () => {
+      const pastDeadline = new Date(Date.now() - 60_000).toISOString();
+      await store.create(makeHandoffInput({ replyDueAt: pastDeadline }));
+
+      const first = await store.expireStale();
+      expect(first.length).toBeGreaterThanOrEqual(1);
+
+      const second = await store.expireStale();
+      // Already expired — nothing new to expire
+      expect(second).toHaveLength(0);
+    });
+
+    test("expireStale does not expire already-replied handoffs with past deadline", async () => {
+      const pastDeadline = new Date(Date.now() - 60_000).toISOString();
+      const h = await store.create(
+        makeHandoffInput({ replyDueAt: pastDeadline }),
+      );
+      // Transition to delivered then replied before expiry runs
+      await store.markDelivered(h.handoffId);
+      await store.markReplied(h.handoffId, "blake3:reply-cid");
+
+      const expired = await store.expireStale();
+      const updated = await store.get(h.handoffId);
+
+      expect(expired.map((e) => e.handoffId)).not.toContain(h.handoffId);
+      expect(updated?.status).toBe(HandoffStatus.Replied);
+    });
+
+    // ------------------------------------------------------------------
+    // countPending
+    // ------------------------------------------------------------------
+
+    test("countPending returns count of pending_pickup handoffs for role", async () => {
+      await store.create(makeHandoffInput({ toRole: "reviewer" }));
+      await store.create(makeHandoffInput({ toRole: "reviewer" }));
+      await store.create(makeHandoffInput({ toRole: "tester" }));
+
+      const count = await store.countPending("reviewer");
+      expect(count).toBeGreaterThanOrEqual(2);
+    });
+
+    test("countPending returns 0 when no pending handoffs for role", async () => {
+      const count = await store.countPending("nonexistent-role");
+      expect(count).toBe(0);
+    });
+
+    test("countPending excludes delivered handoffs", async () => {
+      const h = await store.create(makeHandoffInput({ toRole: "reviewer" }));
+      await store.markDelivered(h.handoffId);
+
+      const count = await store.countPending("reviewer");
+      expect(count).toBe(0);
+    });
+
+    // ------------------------------------------------------------------
+    // markSeen
+    // ------------------------------------------------------------------
+
+    test("markSeen sets seenAt timestamp", async () => {
+      const h = await store.create(makeHandoffInput());
+      expect(h.seenAt).toBeUndefined();
+
+      await store.markSeen(h.handoffId);
+
+      const updated = await store.get(h.handoffId);
+      expect(updated?.seenAt).toBeDefined();
+      expect(typeof updated?.seenAt).toBe("string");
+    });
+
+    test("markSeen is idempotent — second call preserves original timestamp", async () => {
+      const h = await store.create(makeHandoffInput());
+      await store.markSeen(h.handoffId);
+
+      const first = await store.get(h.handoffId);
+      const originalSeenAt = first?.seenAt;
+
+      // Brief delay to ensure different timestamp if re-set
+      await new Promise((r) => setTimeout(r, 10));
+      await store.markSeen(h.handoffId);
+
+      const second = await store.get(h.handoffId);
+      expect(second?.seenAt).toBe(originalSeenAt);
+    });
+
+    test("markSeen throws for non-existent handoff", async () => {
+      await expect(store.markSeen("nonexistent")).rejects.toThrow();
+    });
+
+    // ------------------------------------------------------------------
+    // markAcked
+    // ------------------------------------------------------------------
+
+    test("markAcked sets ackedAt timestamp", async () => {
+      const h = await store.create(makeHandoffInput());
+      expect(h.ackedAt).toBeUndefined();
+
+      await store.markAcked(h.handoffId);
+
+      const updated = await store.get(h.handoffId);
+      expect(updated?.ackedAt).toBeDefined();
+      expect(typeof updated?.ackedAt).toBe("string");
+    });
+
+    test("markAcked auto-fills seenAt if not already set", async () => {
+      const h = await store.create(makeHandoffInput());
+      expect(h.seenAt).toBeUndefined();
+
+      await store.markAcked(h.handoffId);
+
+      const updated = await store.get(h.handoffId);
+      expect(updated?.seenAt).toBeDefined();
+      expect(updated?.ackedAt).toBeDefined();
+    });
+
+    test("markAcked preserves existing seenAt", async () => {
+      const h = await store.create(makeHandoffInput());
+      await store.markSeen(h.handoffId);
+      const seen = await store.get(h.handoffId);
+      const originalSeenAt = seen?.seenAt;
+
+      await new Promise((r) => setTimeout(r, 10));
+      await store.markAcked(h.handoffId);
+
+      const updated = await store.get(h.handoffId);
+      expect(updated?.seenAt).toBe(originalSeenAt);
+      expect(updated?.ackedAt).toBeDefined();
+    });
+
+    test("markAcked is idempotent — second call preserves original timestamp", async () => {
+      const h = await store.create(makeHandoffInput());
+      await store.markAcked(h.handoffId);
+
+      const first = await store.get(h.handoffId);
+      const originalAckedAt = first?.ackedAt;
+
+      await new Promise((r) => setTimeout(r, 10));
+      await store.markAcked(h.handoffId);
+
+      const second = await store.get(h.handoffId);
+      expect(second?.ackedAt).toBe(originalAckedAt);
+    });
+
+    test("markAcked throws for non-existent handoff", async () => {
+      await expect(store.markAcked("nonexistent")).rejects.toThrow();
+    });
+
+    // ------------------------------------------------------------------
+    // Invalid state transitions
+    // ------------------------------------------------------------------
+
+    test("markDelivered on expired handoff throws InvalidTransitionError", async () => {
+      const pastDeadline = new Date(Date.now() - 60_000).toISOString();
+      const h = await store.create(makeHandoffInput({ replyDueAt: pastDeadline }));
+      await store.expireStale();
+
+      await expect(store.markDelivered(h.handoffId)).rejects.toThrow(InvalidTransitionError);
+    });
+
+    test("markDelivered on replied handoff throws InvalidTransitionError", async () => {
+      const h = await store.create(makeHandoffInput());
+      await store.markDelivered(h.handoffId);
+      await store.markReplied(h.handoffId, "blake3:reply");
+
+      await expect(store.markDelivered(h.handoffId)).rejects.toThrow(InvalidTransitionError);
+    });
+
+    test("markReplied on expired handoff throws InvalidTransitionError", async () => {
+      const pastDeadline = new Date(Date.now() - 60_000).toISOString();
+      const h = await store.create(makeHandoffInput({ replyDueAt: pastDeadline }));
+      await store.expireStale();
+
+      await expect(
+        store.markReplied(h.handoffId, "blake3:reply"),
+      ).rejects.toThrow(InvalidTransitionError);
+    });
+
+    test("markReplied on already-replied handoff throws InvalidTransitionError", async () => {
+      const h = await store.create(makeHandoffInput());
+      await store.markDelivered(h.handoffId);
+      await store.markReplied(h.handoffId, "blake3:reply-1");
+
+      await expect(
+        store.markReplied(h.handoffId, "blake3:reply-2"),
+      ).rejects.toThrow(InvalidTransitionError);
+    });
+  });
+}

--- a/src/core/handoff-store.conformance.ts
+++ b/src/core/handoff-store.conformance.ts
@@ -314,12 +314,15 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
       expect(updated?.status).toBe(HandoffStatus.Expired);
     });
 
-    test("expireStale does not expire already-replied handoffs with past deadline", async () => {
-      const pastDeadline = new Date(Date.now() - 60_000).toISOString();
+    test("expireStale does not expire already-replied handoffs", async () => {
+      // Use a future deadline so the reply is accepted, then verify
+      // expireStale doesn't touch already-replied handoffs even after the
+      // deadline passes. (Stores reject late replies via deadline check, so
+      // this test exercises the replied-before-deadline path.)
+      const futureDeadline = new Date(Date.now() + 60_000).toISOString();
       const h = await store.create(
-        makeHandoffInput({ replyDueAt: pastDeadline }),
+        makeHandoffInput({ replyDueAt: futureDeadline }),
       );
-      // Transition to delivered then replied before expiry runs
       await store.markDelivered(h.handoffId);
       await store.markReplied(h.handoffId, "blake3:reply-cid");
 
@@ -328,6 +331,17 @@ export function runHandoffStoreTests(factory: HandoffStoreFactory): void {
 
       expect(expired.map((e) => e.handoffId)).not.toContain(h.handoffId);
       expect(updated?.status).toBe(HandoffStatus.Replied);
+    });
+
+    test("markReplied rejects late replies (deadline passed)", async () => {
+      const pastDeadline = new Date(Date.now() - 60_000).toISOString();
+      const h = await store.create(
+        makeHandoffInput({ replyDueAt: pastDeadline }),
+      );
+      await expect(store.markReplied(h.handoffId, "blake3:late-reply")).rejects.toThrow();
+      // The handoff should be flipped to expired by the rejection path
+      const after = await store.get(h.handoffId);
+      expect(after?.status).toBe(HandoffStatus.Expired);
     });
 
     // ------------------------------------------------------------------

--- a/src/core/handoff.ts
+++ b/src/core/handoff.ts
@@ -122,5 +122,18 @@ export interface HandoffStore {
   markAcked(id: string): Promise<void>;
   expireStale(now?: string): Promise<readonly Handoff[]>;
   countPending(toRole: string): Promise<number>;
+  /**
+   * Session-scoped enumeration for deadline rebuild on MCP server startup.
+   *
+   * Unlike list() which may return handoffs across all sessions (Nexus
+   * scans the zone-wide directory), this must ONLY return handoffs created
+   * within the active session. Without this scoping, a restarting MCP
+   * server for session A could re-arm timers for session B's handoffs
+   * and emit cross-session overdue events.
+   *
+   * Default: delegates to list() for stores that are inherently session-
+   * scoped (SQLite, InMemory — one DB per session).
+   */
+  listForCurrentSession?(query?: HandoffQuery): Promise<readonly Handoff[]>;
   close(): void;
 }

--- a/src/core/handoff.ts
+++ b/src/core/handoff.ts
@@ -131,9 +131,23 @@ export interface HandoffStore {
    * server for session A could re-arm timers for session B's handoffs
    * and emit cross-session overdue events.
    *
-   * Default: delegates to list() for stores that are inherently session-
-   * scoped (SQLite, InMemory — one DB per session).
+   * Returning an empty array signals "session scoping is not supported on
+   * this backend" — callers (DeadlineWatcher rebuild, grove_ack_handoff
+   * authorization) use that as a signal to disable features that require
+   * it.
    */
   listForCurrentSession?(query?: HandoffQuery): Promise<readonly Handoff[]>;
+  /**
+   * O(1) session ownership check. Returns true iff the handoff exists AND
+   * belongs to the caller's current session. Used by grove_ack_handoff to
+   * reject cross-session receipt mutations without a full enumeration scan
+   * (which is bounded in memory and unusable for sessions with many
+   * handoffs).
+   *
+   * Must return false when the backend cannot answer the question (e.g.
+   * SQLite today has no session_id column). Absence of the method means
+   * the backend does not support session-scoped receipt mutations at all.
+   */
+  isInCurrentSession?(handoffId: string): Promise<boolean>;
   close(): void;
 }

--- a/src/core/handoff.ts
+++ b/src/core/handoff.ts
@@ -55,9 +55,7 @@ export class InvalidTransitionError extends Error {
   readonly toStatus: HandoffStatus;
 
   constructor(handoffId: string, fromStatus: HandoffStatus, toStatus: HandoffStatus) {
-    super(
-      `Invalid handoff transition: '${fromStatus}' → '${toStatus}' for handoff '${handoffId}'`,
-    );
+    super(`Invalid handoff transition: '${fromStatus}' → '${toStatus}' for handoff '${handoffId}'`);
     this.name = "InvalidTransitionError";
     this.handoffId = handoffId;
     this.fromStatus = fromStatus;

--- a/src/core/handoff.ts
+++ b/src/core/handoff.ts
@@ -7,6 +7,56 @@ export const HandoffStatus = {
 
 export type HandoffStatus = (typeof HandoffStatus)[keyof typeof HandoffStatus];
 
+/**
+ * Valid status transitions for handoffs.
+ *
+ * pending_pickup → delivered → replied
+ * pending_pickup → replied (direct reply without explicit delivery marking)
+ * pending_pickup → expired
+ * delivered → expired
+ *
+ * Terminal states (replied, expired) cannot transition further.
+ */
+export const VALID_TRANSITIONS: Readonly<Record<HandoffStatus, readonly HandoffStatus[]>> = {
+  [HandoffStatus.PendingPickup]: [HandoffStatus.Delivered, HandoffStatus.Replied, HandoffStatus.Expired],
+  [HandoffStatus.Delivered]: [HandoffStatus.Replied, HandoffStatus.Expired],
+  [HandoffStatus.Replied]: [],
+  [HandoffStatus.Expired]: [],
+};
+
+/**
+ * Thrown when a handoff status transition is invalid (e.g., expired → delivered).
+ */
+export class InvalidTransitionError extends Error {
+  readonly handoffId: string;
+  readonly fromStatus: HandoffStatus;
+  readonly toStatus: HandoffStatus;
+
+  constructor(handoffId: string, fromStatus: HandoffStatus, toStatus: HandoffStatus) {
+    super(
+      `Invalid handoff transition: '${fromStatus}' → '${toStatus}' for handoff '${handoffId}'`,
+    );
+    this.name = "InvalidTransitionError";
+    this.handoffId = handoffId;
+    this.fromStatus = fromStatus;
+    this.toStatus = toStatus;
+  }
+}
+
+/**
+ * Validate a handoff status transition. Throws InvalidTransitionError if invalid.
+ */
+export function validateTransition(
+  handoffId: string,
+  currentStatus: HandoffStatus,
+  targetStatus: HandoffStatus,
+): void {
+  const allowed = VALID_TRANSITIONS[currentStatus];
+  if (!allowed.includes(targetStatus)) {
+    throw new InvalidTransitionError(handoffId, currentStatus, targetStatus);
+  }
+}
+
 export interface Handoff {
   readonly handoffId: string;
   readonly sourceCid: string;
@@ -16,6 +66,10 @@ export interface Handoff {
   readonly requiresReply: boolean;
   readonly replyDueAt?: string | undefined;
   readonly resolvedByCid?: string | undefined;
+  /** ISO 8601 timestamp when the target agent first observed this handoff. */
+  readonly seenAt?: string | undefined;
+  /** ISO 8601 timestamp when the target agent acknowledged intent to act. */
+  readonly ackedAt?: string | undefined;
   readonly createdAt: string;
 }
 
@@ -56,6 +110,16 @@ export interface HandoffStore {
   list(query?: HandoffQuery): Promise<readonly Handoff[]>;
   markDelivered(id: string): Promise<void>;
   markReplied(id: string, resolvedByCid: string): Promise<void>;
+  /**
+   * Record that the target agent has seen this handoff.
+   * Sets seenAt if not already set. No-op if already seen.
+   */
+  markSeen(id: string): Promise<void>;
+  /**
+   * Record that the target agent acknowledges this handoff and intends to act.
+   * Sets ackedAt (and seenAt if not already set). No-op if already acked.
+   */
+  markAcked(id: string): Promise<void>;
   expireStale(now?: string): Promise<readonly Handoff[]>;
   countPending(toRole: string): Promise<number>;
   close(): void;

--- a/src/core/in-memory-handoff-store.ts
+++ b/src/core/in-memory-handoff-store.ts
@@ -97,8 +97,7 @@ export class InMemoryHandoffStore implements HandoffStore {
     // can transition to replied per the state machine.
     const now = new Date().toISOString();
     if (
-      (handoff.status === HandoffStatus.Delivered ||
-        handoff.status === HandoffStatus.Processed) &&
+      (handoff.status === HandoffStatus.Delivered || handoff.status === HandoffStatus.Processed) &&
       handoff.replyDueAt !== undefined &&
       handoff.replyDueAt < now
     ) {

--- a/src/core/in-memory-handoff-store.ts
+++ b/src/core/in-memory-handoff-store.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from "./errors.js";
+import { NotFoundError, StateConflictError } from "./errors.js";
 import {
   type Handoff,
   type HandoffInput,
@@ -79,6 +79,21 @@ export class InMemoryHandoffStore implements HandoffStore {
     const handoff = this.handoffs.get(id);
     if (handoff === undefined) {
       throw new NotFoundError({ resource: "Handoff", identifier: id });
+    }
+    // Reject late replies in the store itself, so correctness does not
+    // depend on the DeadlineWatcher having already flipped status.
+    const now = new Date().toISOString();
+    if (
+      (handoff.status === HandoffStatus.PendingPickup ||
+        handoff.status === HandoffStatus.Delivered) &&
+      handoff.replyDueAt !== undefined &&
+      handoff.replyDueAt < now
+    ) {
+      this.handoffs.set(id, { ...handoff, status: HandoffStatus.Expired });
+      throw new StateConflictError({
+        resource: "Handoff",
+        reason: `Reply deadline passed at ${handoff.replyDueAt} (now ${now})`,
+      });
     }
     validateTransition(id, handoff.status, HandoffStatus.Replied);
     this.handoffs.set(id, {

--- a/src/core/in-memory-handoff-store.ts
+++ b/src/core/in-memory-handoff-store.ts
@@ -5,6 +5,7 @@ import {
   type HandoffQuery,
   HandoffStatus,
   type HandoffStore,
+  validateTransition,
 } from "./handoff.js";
 
 function toHandoff(input: HandoffInput): Handoff {
@@ -62,6 +63,7 @@ export class InMemoryHandoffStore implements HandoffStore {
     if (handoff === undefined) {
       throw new NotFoundError({ resource: "Handoff", identifier: id });
     }
+    validateTransition(id, handoff.status, HandoffStatus.Delivered);
     this.handoffs.set(id, { ...handoff, status: HandoffStatus.Delivered });
   }
 
@@ -70,10 +72,37 @@ export class InMemoryHandoffStore implements HandoffStore {
     if (handoff === undefined) {
       throw new NotFoundError({ resource: "Handoff", identifier: id });
     }
+    validateTransition(id, handoff.status, HandoffStatus.Replied);
     this.handoffs.set(id, {
       ...handoff,
       status: HandoffStatus.Replied,
       resolvedByCid,
+    });
+  }
+
+  async markSeen(id: string): Promise<void> {
+    const handoff = this.handoffs.get(id);
+    if (handoff === undefined) {
+      throw new NotFoundError({ resource: "Handoff", identifier: id });
+    }
+    // No-op if already seen
+    if (handoff.seenAt !== undefined) return;
+    this.handoffs.set(id, { ...handoff, seenAt: new Date().toISOString() });
+  }
+
+  async markAcked(id: string): Promise<void> {
+    const handoff = this.handoffs.get(id);
+    if (handoff === undefined) {
+      throw new NotFoundError({ resource: "Handoff", identifier: id });
+    }
+    // No-op if already acked
+    if (handoff.ackedAt !== undefined) return;
+    const now = new Date().toISOString();
+    this.handoffs.set(id, {
+      ...handoff,
+      // Auto-fill seenAt if not already set
+      ...(handoff.seenAt === undefined ? { seenAt: now } : {}),
+      ackedAt: now,
     });
   }
 

--- a/src/core/in-memory-handoff-store.ts
+++ b/src/core/in-memory-handoff-store.ts
@@ -112,7 +112,8 @@ export class InMemoryHandoffStore implements HandoffStore {
 
     for (const [handoffId, handoff] of this.handoffs) {
       if (
-        handoff.status === HandoffStatus.PendingPickup &&
+        (handoff.status === HandoffStatus.PendingPickup ||
+          handoff.status === HandoffStatus.Delivered) &&
         handoff.replyDueAt !== undefined &&
         handoff.replyDueAt < cutoff
       ) {

--- a/src/core/in-memory-handoff-store.ts
+++ b/src/core/in-memory-handoff-store.ts
@@ -58,6 +58,14 @@ export class InMemoryHandoffStore implements HandoffStore {
     return handoffs;
   }
 
+  /**
+   * InMemory is inherently session-scoped: one store instance per session,
+   * so every handoff in the map belongs to the current session.
+   */
+  async listForCurrentSession(query?: HandoffQuery): Promise<readonly Handoff[]> {
+    return this.list(query);
+  }
+
   async markDelivered(id: string): Promise<void> {
     const handoff = this.handoffs.get(id);
     if (handoff === undefined) {

--- a/src/core/in-memory-handoff-store.ts
+++ b/src/core/in-memory-handoff-store.ts
@@ -66,6 +66,10 @@ export class InMemoryHandoffStore implements HandoffStore {
     return this.list(query);
   }
 
+  async isInCurrentSession(handoffId: string): Promise<boolean> {
+    return this.handoffs.has(handoffId);
+  }
+
   async markDelivered(id: string): Promise<void> {
     const handoff = this.handoffs.get(id);
     if (handoff === undefined) {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -111,7 +111,16 @@ export {
   RateLimitError,
   RetryExhaustedError,
 } from "./errors.js";
+export type { DeadlineWatcherOpts } from "./deadline-watcher.js";
+export { DeadlineWatcher } from "./deadline-watcher.js";
 export type { EventBus, EventHandler, GroveEvent } from "./event-bus.js";
+export type { Handoff, HandoffInput, HandoffQuery, HandoffStore } from "./handoff.js";
+export {
+  HandoffStatus,
+  InvalidTransitionError,
+  VALID_TRANSITIONS,
+  validateTransition as validateHandoffTransition,
+} from "./handoff.js";
 export type {
   Frontier,
   FrontierCalculator,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -101,6 +101,8 @@ export type {
   Reservation,
   TransferResult,
 } from "./credits.js";
+export type { DeadlineWatcherOpts } from "./deadline-watcher.js";
+export { DeadlineWatcher } from "./deadline-watcher.js";
 export { EnforcingClaimStore, EnforcingContributionStore } from "./enforcing-store.js";
 export {
   ArtifactLimitError,
@@ -111,9 +113,14 @@ export {
   RateLimitError,
   RetryExhaustedError,
 } from "./errors.js";
-export type { DeadlineWatcherOpts } from "./deadline-watcher.js";
-export { DeadlineWatcher } from "./deadline-watcher.js";
 export type { EventBus, EventHandler, GroveEvent, PublishResult } from "./event-bus.js";
+export type {
+  Frontier,
+  FrontierCalculator,
+  FrontierEntry,
+  FrontierQuery,
+} from "./frontier.js";
+export { DefaultFrontierCalculator, getScore } from "./frontier.js";
 export type { Handoff, HandoffInput, HandoffQuery, HandoffStore } from "./handoff.js";
 export {
   canTransition,
@@ -122,13 +129,6 @@ export {
   VALID_TRANSITIONS,
   validateTransition as validateHandoffTransition,
 } from "./handoff.js";
-export type {
-  Frontier,
-  FrontierCalculator,
-  FrontierEntry,
-  FrontierQuery,
-} from "./frontier.js";
-export { DefaultFrontierCalculator, getScore } from "./frontier.js";
 export {
   type HookEntry,
   HookEntrySchema,

--- a/src/core/operations/contribute-routing.test.ts
+++ b/src/core/operations/contribute-routing.test.ts
@@ -486,7 +486,15 @@ describe("contributeOperation: plan and ephemeral routing rules", () => {
     const handoffStore = createMockHandoffStore({
       create: async (input: unknown) => {
         handoffCreates.push(input);
-        return { handoffId: "fake-handoff", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" };
+        return {
+          handoffId: "fake-handoff",
+          sourceCid: "",
+          fromRole: "",
+          toRole: "",
+          status: "pending_pickup" as const,
+          requiresReply: false,
+          createdAt: "",
+        };
       },
     });
 
@@ -537,7 +545,15 @@ describe("contributeOperation: plan and ephemeral routing rules", () => {
     const handoffStore = createMockHandoffStore({
       create: async (input: unknown) => {
         handoffCreates.push(input);
-        return { handoffId: "fake-handoff", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" };
+        return {
+          handoffId: "fake-handoff",
+          sourceCid: "",
+          fromRole: "",
+          toRole: "",
+          status: "pending_pickup" as const,
+          requiresReply: false,
+          createdAt: "",
+        };
       },
     });
 
@@ -583,7 +599,15 @@ describe("contributeOperation: plan and ephemeral routing rules", () => {
     const handoffStore = createMockHandoffStore({
       create: async (input: unknown) => {
         handoffCreates.push(input);
-        return { handoffId: "fake-handoff", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" };
+        return {
+          handoffId: "fake-handoff",
+          sourceCid: "",
+          fromRole: "",
+          toRole: "",
+          status: "pending_pickup" as const,
+          requiresReply: false,
+          createdAt: "",
+        };
       },
     });
 
@@ -720,7 +744,15 @@ describe("contributeOperation: plan and ephemeral routing rules", () => {
     const handoffStore = createMockHandoffStore({
       create: async (input: unknown) => {
         handoffCreates.push(input);
-        return { handoffId: "fake-handoff", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" };
+        return {
+          handoffId: "fake-handoff",
+          sourceCid: "",
+          fromRole: "",
+          toRole: "",
+          status: "pending_pickup" as const,
+          requiresReply: false,
+          createdAt: "",
+        };
       },
     });
 
@@ -783,7 +815,15 @@ describe("contributeOperation: plan and ephemeral routing rules", () => {
     const handoffStore = createMockHandoffStore({
       create: async (input: unknown) => {
         handoffCreates.push(input);
-        return { handoffId: "fake-handoff", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" };
+        return {
+          handoffId: "fake-handoff",
+          sourceCid: "",
+          fromRole: "",
+          toRole: "",
+          status: "pending_pickup" as const,
+          requiresReply: false,
+          createdAt: "",
+        };
       },
     });
 

--- a/src/core/operations/contribute-routing.test.ts
+++ b/src/core/operations/contribute-routing.test.ts
@@ -17,7 +17,7 @@ import type { AgentTopology } from "../topology.js";
 import { TopologyRouter } from "../topology-router.js";
 import { contributeOperation } from "./contribute.js";
 import type { OperationDeps } from "./deps.js";
-import { makeInMemoryContributionStore } from "./test-helpers.js";
+import { createMockHandoffStore, makeInMemoryContributionStore } from "./test-helpers.js";
 
 /** A simple two-role topology: coder -> reviewer -> coder. */
 const reviewLoopTopology: AgentTopology = {
@@ -483,19 +483,12 @@ describe("contributeOperation: plan and ephemeral routing rules", () => {
 
     // Spy handoff store: tracks any create() calls.
     const handoffCreates: unknown[] = [];
-    const handoffStore = {
+    const handoffStore = createMockHandoffStore({
       create: async (input: unknown) => {
         handoffCreates.push(input);
-        return { handoffId: "fake-handoff" };
+        return { handoffId: "fake-handoff", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" };
       },
-      get: async () => undefined,
-      list: async () => [],
-      markDelivered: async () => undefined,
-      markReplied: async () => undefined,
-      expireStale: async () => [],
-      countPending: async () => 0,
-      close: () => undefined,
-    } as unknown as NonNullable<OperationDeps["handoffStore"]>;
+    });
 
     const deps: OperationDeps = {
       contributionStore: store,
@@ -541,19 +534,12 @@ describe("contributeOperation: plan and ephemeral routing rules", () => {
     bus.subscribe("reviewer", (e) => received.push(e));
 
     const handoffCreates: unknown[] = [];
-    const handoffStore = {
+    const handoffStore = createMockHandoffStore({
       create: async (input: unknown) => {
         handoffCreates.push(input);
-        return { handoffId: "fake-handoff" };
+        return { handoffId: "fake-handoff", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" };
       },
-      get: async () => undefined,
-      list: async () => [],
-      markDelivered: async () => undefined,
-      markReplied: async () => undefined,
-      expireStale: async () => [],
-      countPending: async () => 0,
-      close: () => undefined,
-    } as unknown as NonNullable<OperationDeps["handoffStore"]>;
+    });
 
     const deps: OperationDeps = {
       contributionStore: store,
@@ -594,19 +580,12 @@ describe("contributeOperation: plan and ephemeral routing rules", () => {
     bus.subscribe("reviewer", (e) => received.push(e));
 
     const handoffCreates: unknown[] = [];
-    const handoffStore = {
+    const handoffStore = createMockHandoffStore({
       create: async (input: unknown) => {
         handoffCreates.push(input);
-        return { handoffId: "fake-handoff" };
+        return { handoffId: "fake-handoff", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" };
       },
-      get: async () => undefined,
-      list: async () => [],
-      markDelivered: async () => undefined,
-      markReplied: async () => undefined,
-      expireStale: async () => [],
-      countPending: async () => 0,
-      close: () => undefined,
-    } as unknown as NonNullable<OperationDeps["handoffStore"]>;
+    });
 
     const deps: OperationDeps = {
       contributionStore: store,
@@ -738,19 +717,12 @@ describe("contributeOperation: plan and ephemeral routing rules", () => {
     bus.subscribe("coder", (e) => received.push(e));
 
     const handoffCreates: unknown[] = [];
-    const handoffStore = {
+    const handoffStore = createMockHandoffStore({
       create: async (input: unknown) => {
         handoffCreates.push(input);
-        return { handoffId: "fake-handoff" };
+        return { handoffId: "fake-handoff", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" };
       },
-      get: async () => undefined,
-      list: async () => [],
-      markDelivered: async () => undefined,
-      markReplied: async () => undefined,
-      expireStale: async () => [],
-      countPending: async () => 0,
-      close: () => undefined,
-    } as unknown as NonNullable<OperationDeps["handoffStore"]>;
+    });
 
     const deps: OperationDeps = {
       contributionStore: store,
@@ -808,19 +780,12 @@ describe("contributeOperation: plan and ephemeral routing rules", () => {
     bus.subscribe("reviewer", (e) => received.push(e));
 
     const handoffCreates: unknown[] = [];
-    const handoffStore = {
+    const handoffStore = createMockHandoffStore({
       create: async (input: unknown) => {
         handoffCreates.push(input);
-        return { handoffId: "fake-handoff" };
+        return { handoffId: "fake-handoff", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" };
       },
-      get: async () => undefined,
-      list: async () => [],
-      markDelivered: async () => undefined,
-      markReplied: async () => undefined,
-      expireStale: async () => [],
-      countPending: async () => 0,
-      close: () => undefined,
-    } as unknown as NonNullable<OperationDeps["handoffStore"]>;
+    });
 
     const deps: OperationDeps = {
       contributionStore: store,

--- a/src/core/operations/contribute.test.ts
+++ b/src/core/operations/contribute.test.ts
@@ -904,8 +904,12 @@ describe("writeSerial: best-effort handoff failure paths", () => {
 
   test("contribution is committed even when handoffStore.createMany throws", async () => {
     const faultyHandoffStore = createMockHandoffStore({
-      create: async () => { throw new Error("should not be called"); },
-      createMany: async () => { throw new Error("simulated handoff store failure"); },
+      create: async () => {
+        throw new Error("should not be called");
+      },
+      createMany: async () => {
+        throw new Error("simulated handoff store failure");
+      },
     });
 
     const deps = makeSerialDeps(faultyHandoffStore);
@@ -933,8 +937,12 @@ describe("writeSerial: best-effort handoff failure paths", () => {
     const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
     const faultyHandoffStore = createMockHandoffStore({
-      create: async () => { throw new Error("should not be called"); },
-      createMany: async () => { throw new Error("handoff store down"); },
+      create: async () => {
+        throw new Error("should not be called");
+      },
+      createMany: async () => {
+        throw new Error("handoff store down");
+      },
     });
 
     const deps = makeSerialDeps(faultyHandoffStore);

--- a/src/core/operations/contribute.test.ts
+++ b/src/core/operations/contribute.test.ts
@@ -17,6 +17,7 @@ import {
 import type { OperationDeps } from "./deps.js";
 import type { FullOperationDeps, TestOperationDeps } from "./test-helpers.js";
 import {
+  createMockHandoffStore,
   createTestOperationDeps,
   makeInMemoryContributionStore,
   storeTestContent,
@@ -902,21 +903,10 @@ describe("writeSerial: best-effort handoff failure paths", () => {
   }
 
   test("contribution is committed even when handoffStore.createMany throws", async () => {
-    const faultyHandoffStore: OperationDeps["handoffStore"] = {
-      create: async () => {
-        throw new Error("should not be called");
-      },
-      createMany: async () => {
-        throw new Error("simulated handoff store failure");
-      },
-      get: async () => undefined,
-      list: async () => [],
-      markDelivered: async () => undefined,
-      markReplied: async () => undefined,
-      expireStale: async () => [],
-      countPending: async () => 0,
-      close: () => undefined,
-    };
+    const faultyHandoffStore = createMockHandoffStore({
+      create: async () => { throw new Error("should not be called"); },
+      createMany: async () => { throw new Error("simulated handoff store failure"); },
+    });
 
     const deps = makeSerialDeps(faultyHandoffStore);
 
@@ -942,21 +932,10 @@ describe("writeSerial: best-effort handoff failure paths", () => {
     // biome-ignore lint/suspicious/noEmptyBlockStatements: spy suppresses output intentionally
     const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
-    const faultyHandoffStore: OperationDeps["handoffStore"] = {
-      create: async () => {
-        throw new Error("should not be called");
-      },
-      createMany: async () => {
-        throw new Error("handoff store down");
-      },
-      get: async () => undefined,
-      list: async () => [],
-      markDelivered: async () => undefined,
-      markReplied: async () => undefined,
-      expireStale: async () => [],
-      countPending: async () => 0,
-      close: () => undefined,
-    };
+    const faultyHandoffStore = createMockHandoffStore({
+      create: async () => { throw new Error("should not be called"); },
+      createMany: async () => { throw new Error("handoff store down"); },
+    });
 
     const deps = makeSerialDeps(faultyHandoffStore);
 
@@ -989,17 +968,10 @@ describe("writeSerial: best-effort handoff failure paths", () => {
       throw new Error("simulated synchronous throw from create()");
     }) as unknown as NonNullable<OperationDeps["handoffStore"]>["create"];
 
-    const syncThrowingHandoffStore: OperationDeps["handoffStore"] = {
+    const syncThrowingHandoffStore = createMockHandoffStore({
       create: syncThrowingCreate,
       // No createMany — forces the fallback path.
-      get: async () => undefined,
-      list: async () => [],
-      markDelivered: async () => undefined,
-      markReplied: async () => undefined,
-      expireStale: async () => [],
-      countPending: async () => 0,
-      close: () => undefined,
-    };
+    });
 
     const deps = makeSerialDeps(syncThrowingHandoffStore);
 

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1188,9 +1188,17 @@ export async function contributeOperation(
           fireAndForget("handoff reply transition", async () => {
             for (const rel of replyRelations) {
               try {
+                // Include Processed too: agents following the IPC workflow
+                // (grove_process_handoff before grove_submit_*) leave the
+                // handoff in Processed state. Without this, their valid
+                // replies would never auto-resolve the handoff.
                 const unresolved = await deps.handoffStore?.list({
                   sourceCid: rel.targetCid,
-                  status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
+                  status: [
+                    HandoffStatus.PendingPickup,
+                    HandoffStatus.Delivered,
+                    HandoffStatus.Processed,
+                  ],
                   toRole: replyingRole,
                 });
                 for (const h of unresolved ?? []) {

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -998,6 +998,12 @@ export async function contributeOperation(
           }
           if (timeoutMap.size > 0) replyTimeouts = timeoutMap;
         }
+        if (process.env.GROVE_DEBUG === "1") {
+          const timeoutInfo = replyTimeouts ? [...replyTimeouts.entries()].map(([r, t]) => `${r}=${t}s`).join(", ") : "none";
+          process.stderr.write(
+            `[grove:handoff] ROUTE role=${contribution.agent.role} targets=[${routedTo?.join(",")}] deadlines={${timeoutInfo}}\n`,
+          );
+        }
       }
     }
 
@@ -1044,6 +1050,12 @@ export async function contributeOperation(
       idempotencyOnCommit,
       replyTimeouts,
     );
+
+    if (process.env.GROVE_DEBUG === "1" && handoffIds.length > 0) {
+      process.stderr.write(
+        `[grove:handoff] CREATED cid=${contribution.cid.slice(0, 20)}.. handoffIds=[${handoffIds.map((h) => h.slice(0, 8)).join(",")}] targets=[${handoffsRoutedTo?.join(",") ?? ""}]\n`,
+      );
+    }
 
     // ┌──────────────────────────────────────────────────────────────────┐
     // │ DURABLE COMMIT BOUNDARY                                          │
@@ -1128,6 +1140,11 @@ export async function contributeOperation(
           try {
             const h = await deps.handoffStore?.get(hid);
             if (h?.replyDueAt !== undefined) {
+              if (process.env.GROVE_DEBUG === "1") {
+                process.stderr.write(
+                  `[grove:handoff] WATCH handoff=${hid.slice(0, 8)} toRole=${h.toRole} replyDueAt=${h.replyDueAt}\n`,
+                );
+              }
               deps.deadlineWatcher?.watch(h);
             }
           } catch {
@@ -1158,6 +1175,11 @@ export async function contributeOperation(
                 status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
               });
               for (const h of unresolved ?? []) {
+                if (process.env.GROVE_DEBUG === "1") {
+                  process.stderr.write(
+                    `[grove:handoff] REPLY handoff=${h.handoffId.slice(0, 8)} resolvedBy=${contribution.cid.slice(0, 20)}.. relation=${rel.relationType}\n`,
+                  );
+                }
                 await deps.handoffStore?.markReplied(h.handoffId, contribution.cid);
                 // Cancel deadline timer for resolved handoff
                 deps.deadlineWatcher?.cancel(h.handoffId);

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1167,38 +1167,49 @@ export async function contributeOperation(
           r.relationType === "adopts",
       );
       if (replyRelations.length > 0) {
-        // Only resolve handoffs addressed to the replying role. In fan-out
-        // topologies (coder → [reviewer, tester, auditor]), one downstream
-        // role responding must NOT close peer handoffs for others who haven't
-        // acted yet. Without this scope, Nexus handoffs (created as
-        // `delivered` by default) would all get marked replied by the first
-        // response, silently wiping out outstanding work for other roles.
+        // Scope reply resolution to the replying role. In fan-out topologies
+        // (coder → [reviewer, tester, auditor]) one downstream response must
+        // NOT close peer handoffs for others who haven't acted yet.
+        //
+        // Fallback for role-less contributions (e.g. HTTP contribution
+        // submissions where agent.role is optional): if exactly one handoff
+        // is unresolved for the sourceCid, resolve that one. If multiple
+        // peers are unresolved we abstain — resolving them all would strand
+        // peer work, resolving none would leak the handoff. A single-match
+        // fallback covers the common case without the fan-out hazard.
         const replyingRole = contribution.agent.role;
-        if (replyingRole !== undefined) {
-          fireAndForget("handoff reply transition", async () => {
-            for (const rel of replyRelations) {
-              try {
-                const unresolved = await deps.handoffStore?.list({
-                  sourceCid: rel.targetCid,
-                  status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
-                  toRole: replyingRole,
-                });
-                for (const h of unresolved ?? []) {
-                  if (process.env.GROVE_DEBUG === "1") {
-                    process.stderr.write(
-                      `[grove:handoff] REPLY handoff=${h.handoffId.slice(0, 8)} resolvedBy=${contribution.cid.slice(0, 20)}.. relation=${rel.relationType} role=${replyingRole}\n`,
-                    );
-                  }
-                  await deps.handoffStore?.markReplied(h.handoffId, contribution.cid);
-                  // Cancel deadline timer for resolved handoff
-                  deps.deadlineWatcher?.cancel(h.handoffId);
+        fireAndForget("handoff reply transition", async () => {
+          for (const rel of replyRelations) {
+            try {
+              let unresolved = await deps.handoffStore?.list({
+                sourceCid: rel.targetCid,
+                status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
+                ...(replyingRole !== undefined ? { toRole: replyingRole } : {}),
+              });
+              // Role-less fallback: only act when exactly one unresolved peer exists
+              if (replyingRole === undefined && (unresolved?.length ?? 0) > 1) {
+                if (process.env.GROVE_DEBUG === "1") {
+                  process.stderr.write(
+                    `[grove:handoff] REPLY SKIPPED cid=${contribution.cid.slice(0, 20)}.. — role-less reply with ${unresolved?.length} unresolved peers (ambiguous)\n`,
+                  );
                 }
-              } catch {
-                // Best-effort — don't fail contribution over handoff transition
+                unresolved = [];
               }
+              for (const h of unresolved ?? []) {
+                if (process.env.GROVE_DEBUG === "1") {
+                  process.stderr.write(
+                    `[grove:handoff] REPLY handoff=${h.handoffId.slice(0, 8)} resolvedBy=${contribution.cid.slice(0, 20)}.. relation=${rel.relationType} role=${replyingRole ?? "role-less-fallback"}\n`,
+                  );
+                }
+                await deps.handoffStore?.markReplied(h.handoffId, contribution.cid);
+                // Cancel deadline timer for resolved handoff
+                deps.deadlineWatcher?.cancel(h.handoffId);
+              }
+            } catch {
+              // Best-effort — don't fail contribution over handoff transition
             }
-          });
-        }
+          }
+        });
       }
     }
 

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1167,28 +1167,38 @@ export async function contributeOperation(
           r.relationType === "adopts",
       );
       if (replyRelations.length > 0) {
-        fireAndForget("handoff reply transition", async () => {
-          for (const rel of replyRelations) {
-            try {
-              const unresolved = await deps.handoffStore?.list({
-                sourceCid: rel.targetCid,
-                status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
-              });
-              for (const h of unresolved ?? []) {
-                if (process.env.GROVE_DEBUG === "1") {
-                  process.stderr.write(
-                    `[grove:handoff] REPLY handoff=${h.handoffId.slice(0, 8)} resolvedBy=${contribution.cid.slice(0, 20)}.. relation=${rel.relationType}\n`,
-                  );
+        // Only resolve handoffs addressed to the replying role. In fan-out
+        // topologies (coder → [reviewer, tester, auditor]), one downstream
+        // role responding must NOT close peer handoffs for others who haven't
+        // acted yet. Without this scope, Nexus handoffs (created as
+        // `delivered` by default) would all get marked replied by the first
+        // response, silently wiping out outstanding work for other roles.
+        const replyingRole = contribution.agent.role;
+        if (replyingRole !== undefined) {
+          fireAndForget("handoff reply transition", async () => {
+            for (const rel of replyRelations) {
+              try {
+                const unresolved = await deps.handoffStore?.list({
+                  sourceCid: rel.targetCid,
+                  status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
+                  toRole: replyingRole,
+                });
+                for (const h of unresolved ?? []) {
+                  if (process.env.GROVE_DEBUG === "1") {
+                    process.stderr.write(
+                      `[grove:handoff] REPLY handoff=${h.handoffId.slice(0, 8)} resolvedBy=${contribution.cid.slice(0, 20)}.. relation=${rel.relationType} role=${replyingRole}\n`,
+                    );
+                  }
+                  await deps.handoffStore?.markReplied(h.handoffId, contribution.cid);
+                  // Cancel deadline timer for resolved handoff
+                  deps.deadlineWatcher?.cancel(h.handoffId);
                 }
-                await deps.handoffStore?.markReplied(h.handoffId, contribution.cid);
-                // Cancel deadline timer for resolved handoff
-                deps.deadlineWatcher?.cancel(h.handoffId);
+              } catch {
+                // Best-effort — don't fail contribution over handoff transition
               }
-            } catch {
-              // Best-effort — don't fail contribution over handoff transition
             }
-          }
-        });
+          });
+        }
       }
     }
 

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1171,45 +1171,44 @@ export async function contributeOperation(
         // (coder → [reviewer, tester, auditor]) one downstream response must
         // NOT close peer handoffs for others who haven't acted yet.
         //
-        // Fallback for role-less contributions (e.g. HTTP contribution
-        // submissions where agent.role is optional): if exactly one handoff
-        // is unresolved for the sourceCid, resolve that one. If multiple
-        // peers are unresolved we abstain — resolving them all would strand
-        // peer work, resolving none would leak the handoff. A single-match
-        // fallback covers the common case without the fan-out hazard.
+        // REQUIRED: agent.role must be set. Role-less contributions (e.g.
+        // from the unauthenticated HTTP contribution surface) CANNOT auto-
+        // resolve handoffs — without a verified role, any HTTP client could
+        // mark a reviewer/tester/auditor handoff replied and satisfy an SLA
+        // they don't own. Such submissions leave the handoff unresolved; an
+        // operator or role-bound caller must resolve it explicitly.
         const replyingRole = contribution.agent.role;
-        fireAndForget("handoff reply transition", async () => {
-          for (const rel of replyRelations) {
-            try {
-              let unresolved = await deps.handoffStore?.list({
-                sourceCid: rel.targetCid,
-                status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
-                ...(replyingRole !== undefined ? { toRole: replyingRole } : {}),
-              });
-              // Role-less fallback: only act when exactly one unresolved peer exists
-              if (replyingRole === undefined && (unresolved?.length ?? 0) > 1) {
-                if (process.env.GROVE_DEBUG === "1") {
-                  process.stderr.write(
-                    `[grove:handoff] REPLY SKIPPED cid=${contribution.cid.slice(0, 20)}.. — role-less reply with ${unresolved?.length} unresolved peers (ambiguous)\n`,
-                  );
-                }
-                unresolved = [];
-              }
-              for (const h of unresolved ?? []) {
-                if (process.env.GROVE_DEBUG === "1") {
-                  process.stderr.write(
-                    `[grove:handoff] REPLY handoff=${h.handoffId.slice(0, 8)} resolvedBy=${contribution.cid.slice(0, 20)}.. relation=${rel.relationType} role=${replyingRole ?? "role-less-fallback"}\n`,
-                  );
-                }
-                await deps.handoffStore?.markReplied(h.handoffId, contribution.cid);
-                // Cancel deadline timer for resolved handoff
-                deps.deadlineWatcher?.cancel(h.handoffId);
-              }
-            } catch {
-              // Best-effort — don't fail contribution over handoff transition
-            }
+        if (replyingRole === undefined) {
+          if (process.env.GROVE_DEBUG === "1") {
+            process.stderr.write(
+              `[grove:handoff] REPLY SKIPPED cid=${contribution.cid.slice(0, 20)}.. — role-less reply not allowed to resolve handoffs\n`,
+            );
           }
-        });
+        } else {
+          fireAndForget("handoff reply transition", async () => {
+            for (const rel of replyRelations) {
+              try {
+                const unresolved = await deps.handoffStore?.list({
+                  sourceCid: rel.targetCid,
+                  status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
+                  toRole: replyingRole,
+                });
+                for (const h of unresolved ?? []) {
+                  if (process.env.GROVE_DEBUG === "1") {
+                    process.stderr.write(
+                      `[grove:handoff] REPLY handoff=${h.handoffId.slice(0, 8)} resolvedBy=${contribution.cid.slice(0, 20)}.. relation=${rel.relationType} role=${replyingRole}\n`,
+                    );
+                  }
+                  await deps.handoffStore?.markReplied(h.handoffId, contribution.cid);
+                  // Cancel deadline timer for resolved handoff
+                  deps.deadlineWatcher?.cancel(h.handoffId);
+                }
+              } catch {
+                // Best-effort — don't fail contribution over handoff transition
+              }
+            }
+          });
+        }
       }
     }
 

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -9,7 +9,7 @@
 
 import { fireAndForget } from "../../shared/fire-and-forget.js";
 import { pickDefined } from "../../shared/pick-defined.js";
-import { HandoffStatus, type HandoffInput, type HandoffStore } from "../handoff.js";
+import { type HandoffInput, HandoffStatus, type HandoffStore } from "../handoff.js";
 import { createContribution } from "../manifest.js";
 import {
   ContributionKind as CK,
@@ -708,7 +708,15 @@ async function writeContributionWithHandoffs(
     );
   }
 
-  return writeSerial(contribution, routedTo, agentRole, store, handoffStore, onCommit, replyTimeouts);
+  return writeSerial(
+    contribution,
+    routedTo,
+    agentRole,
+    store,
+    handoffStore,
+    onCommit,
+    replyTimeouts,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -999,7 +1007,9 @@ export async function contributeOperation(
           if (timeoutMap.size > 0) replyTimeouts = timeoutMap;
         }
         if (process.env.GROVE_DEBUG === "1") {
-          const timeoutInfo = replyTimeouts ? [...replyTimeouts.entries()].map(([r, t]) => `${r}=${t}s`).join(", ") : "none";
+          const timeoutInfo = replyTimeouts
+            ? [...replyTimeouts.entries()].map(([r, t]) => `${r}=${t}s`).join(", ")
+            : "none";
           process.stderr.write(
             `[grove:handoff] ROUTE role=${contribution.agent.role} targets=[${routedTo?.join(",")}] deadlines={${timeoutInfo}}\n`,
           );
@@ -1033,11 +1043,11 @@ export async function contributeOperation(
               relationCount: contribution.relations.length,
               createdAt: contribution.createdAt,
             };
-            deps.idempotencyStore?.store(
-              idempotencyCacheLookupKey!,
-              idempotencyFingerprint!,
-              JSON.stringify(earlyResult),
-            );
+            // Guarded above by idempotencyCacheLookupKey/idempotencyFingerprint
+            // both being defined — non-null assertions here are safe.
+            const key = idempotencyCacheLookupKey as string;
+            const fingerprint = idempotencyFingerprint as string;
+            deps.idempotencyStore?.store(key, fingerprint, JSON.stringify(earlyResult));
           }
         : undefined;
 
@@ -1134,7 +1144,11 @@ export async function contributeOperation(
     }
 
     // --- Post-write: register deadline timers for new handoffs ---
-    if (deps.deadlineWatcher !== undefined && handoffIds.length > 0 && deps.handoffStore !== undefined) {
+    if (
+      deps.deadlineWatcher !== undefined &&
+      handoffIds.length > 0 &&
+      deps.handoffStore !== undefined
+    ) {
       fireAndForget("deadline watcher registration", async () => {
         for (const hid of handoffIds) {
           try {
@@ -1204,15 +1218,16 @@ export async function contributeOperation(
                 // Include Processed too: agents following the IPC workflow
                 // (grove_process_handoff before grove_submit_*) leave the
                 // handoff in Processed state.
-                unresolved = (await listFn?.({
-                  sourceCid: rel.targetCid,
-                  status: [
-                    HandoffStatus.PendingPickup,
-                    HandoffStatus.Delivered,
-                    HandoffStatus.Processed,
-                  ],
-                  toRole: replyingRole,
-                })) ?? [];
+                unresolved =
+                  (await listFn?.({
+                    sourceCid: rel.targetCid,
+                    status: [
+                      HandoffStatus.PendingPickup,
+                      HandoffStatus.Delivered,
+                      HandoffStatus.Processed,
+                    ],
+                    toRole: replyingRole,
+                  })) ?? [];
               } catch {
                 // List failure is best-effort; move on to next relation.
                 continue;

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -9,7 +9,7 @@
 
 import { fireAndForget } from "../../shared/fire-and-forget.js";
 import { pickDefined } from "../../shared/pick-defined.js";
-import type { HandoffInput, HandoffStore } from "../handoff.js";
+import { HandoffStatus, type HandoffInput, type HandoffStore } from "../handoff.js";
 import { createContribution } from "../manifest.js";
 import {
   ContributionKind as CK,
@@ -536,15 +536,20 @@ async function writeAtomic(
   putWithCowrite: (c: Contribution, fn: () => void) => void | Promise<void>,
   insertSync: (input: HandoffInput) => string,
   onCommit?: () => void,
+  replyTimeouts?: ReadonlyMap<string, number> | undefined,
 ): Promise<readonly string[]> {
   const handoffIds: string[] = [];
   const maybePromise = putWithCowrite(contribution, () => {
     for (const targetRole of routedTo) {
+      const timeoutSec = replyTimeouts?.get(targetRole);
       const hid = insertSync({
         sourceCid: contribution.cid,
         fromRole: agentRole,
         toRole: targetRole,
-        requiresReply: false,
+        requiresReply: timeoutSec !== undefined,
+        ...(timeoutSec !== undefined
+          ? { replyDueAt: new Date(Date.now() + timeoutSec * 1000).toISOString() }
+          : {}),
       });
       if (hid !== undefined) handoffIds.push(hid);
     }
@@ -583,6 +588,7 @@ async function writeSerial(
   store: ContributionStore,
   handoffStore: HandoffStore | undefined,
   onCommit?: () => void,
+  replyTimeouts?: ReadonlyMap<string, number> | undefined,
 ): Promise<readonly string[]> {
   await store.put(contribution);
   // For non-atomic stores (Nexus, in-memory), write the idempotency row
@@ -596,12 +602,18 @@ async function writeSerial(
     return handoffIds;
   }
 
-  const inputs: HandoffInput[] = routedTo.map((targetRole) => ({
-    sourceCid: contribution.cid,
-    fromRole: agentRole,
-    toRole: targetRole,
-    requiresReply: false,
-  }));
+  const inputs: HandoffInput[] = routedTo.map((targetRole) => {
+    const timeoutSec = replyTimeouts?.get(targetRole);
+    return {
+      sourceCid: contribution.cid,
+      fromRole: agentRole,
+      toRole: targetRole,
+      requiresReply: timeoutSec !== undefined,
+      ...(timeoutSec !== undefined
+        ? { replyDueAt: new Date(Date.now() + timeoutSec * 1000).toISOString() }
+        : {}),
+    };
+  });
 
   if (handoffStore.createMany !== undefined) {
     try {
@@ -653,6 +665,7 @@ async function writeContributionWithHandoffs(
   store: ContributionStore,
   handoffStore: HandoffStore | undefined,
   onCommit?: () => void,
+  replyTimeouts?: ReadonlyMap<string, number> | undefined,
 ): Promise<readonly string[]> {
   const needsHandoffs =
     handoffStore !== undefined &&
@@ -676,6 +689,7 @@ async function writeContributionWithHandoffs(
         cowriteStore.putWithCowrite.bind(cowriteStore),
         sqliteHandoffStore.insertSync.bind(sqliteHandoffStore),
         onCommit,
+        replyTimeouts,
       );
     }
   }
@@ -694,7 +708,7 @@ async function writeContributionWithHandoffs(
     );
   }
 
-  return writeSerial(contribution, routedTo, agentRole, store, handoffStore, onCommit);
+  return writeSerial(contribution, routedTo, agentRole, store, handoffStore, onCommit, replyTimeouts);
 }
 
 // ---------------------------------------------------------------------------
@@ -955,6 +969,9 @@ export async function contributeOperation(
 
     // --- Pre-write: determine routing targets synchronously (no I/O) ---
     let routedTo: readonly string[] | undefined;
+    // Map target role → reply timeout seconds (from edge config). When multiple
+    // edges point to the same target, the shortest timeout wins.
+    let replyTimeouts: ReadonlyMap<string, number> | undefined;
     if (deps.topologyRouter !== undefined) {
       if (contribution.agent.role === undefined) {
         // Issue 4A: warn when topology is active but contributing agent has no role
@@ -967,7 +984,20 @@ export async function contributeOperation(
         // delegates + feeds) pointing at the same downstream role. Creating
         // one handoff per (source, target) pair is correct; creating one per
         // edge type would produce duplicate pending handoffs for the same work.
-        if (edges.length > 0) routedTo = [...new Set(edges.map((e) => e.target))];
+        if (edges.length > 0) {
+          routedTo = [...new Set(edges.map((e) => e.target))];
+          // Collect reply timeouts from edges — shortest timeout per target wins
+          const timeoutMap = new Map<string, number>();
+          for (const edge of edges) {
+            if (edge.replyTimeoutSeconds !== undefined) {
+              const existing = timeoutMap.get(edge.target);
+              if (existing === undefined || edge.replyTimeoutSeconds < existing) {
+                timeoutMap.set(edge.target, edge.replyTimeoutSeconds);
+              }
+            }
+          }
+          if (timeoutMap.size > 0) replyTimeouts = timeoutMap;
+        }
       }
     }
 
@@ -1012,6 +1042,7 @@ export async function contributeOperation(
       deps.contributionStore,
       deps.handoffStore,
       idempotencyOnCommit,
+      replyTimeouts,
     );
 
     // ┌──────────────────────────────────────────────────────────────────┐
@@ -1090,9 +1121,27 @@ export async function contributeOperation(
       );
     }
 
+    // --- Post-write: register deadline timers for new handoffs ---
+    if (deps.deadlineWatcher !== undefined && handoffIds.length > 0 && deps.handoffStore !== undefined) {
+      fireAndForget("deadline watcher registration", async () => {
+        for (const hid of handoffIds) {
+          try {
+            const h = await deps.handoffStore?.get(hid);
+            if (h?.replyDueAt !== undefined) {
+              deps.deadlineWatcher?.watch(h);
+            }
+          } catch {
+            // Best-effort — timer registration failure is non-fatal
+          }
+        }
+      });
+    }
+
     // --- Post-write: mark upstream handoffs as replied (fire-and-forget) ---
     // When this contribution targets another CID (reviews/responds_to), find
-    // any pending handoffs with sourceCid = targetCid and mark them replied.
+    // any unresolved handoffs with sourceCid = targetCid and mark them replied.
+    // Query both pending_pickup and delivered — Nexus creates handoffs as
+    // delivered (skipping pending_pickup) due to cross-client CAS limitations.
     if (deps.handoffStore !== undefined && contribution.relations.length > 0) {
       const replyRelations = contribution.relations.filter(
         (r) =>
@@ -1104,12 +1153,14 @@ export async function contributeOperation(
         fireAndForget("handoff reply transition", async () => {
           for (const rel of replyRelations) {
             try {
-              const pending = await deps.handoffStore?.list({
+              const unresolved = await deps.handoffStore?.list({
                 sourceCid: rel.targetCid,
-                status: "pending_pickup",
+                status: [HandoffStatus.PendingPickup, HandoffStatus.Delivered],
               });
-              for (const h of pending ?? []) {
+              for (const h of unresolved ?? []) {
                 await deps.handoffStore?.markReplied(h.handoffId, contribution.cid);
+                // Cancel deadline timer for resolved handoff
+                deps.deadlineWatcher?.cancel(h.handoffId);
               }
             } catch {
               // Best-effort — don't fail contribution over handoff transition

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1186,13 +1186,25 @@ export async function contributeOperation(
           }
         } else {
           fireAndForget("handoff reply transition", async () => {
+            // Use session-scoped enumeration when the store supports it.
+            // Contribution CIDs are global DAG IDs, so the same sourceCid
+            // can appear in multiple sessions' handoff files. list() on
+            // Nexus scans zone-wide; resolving a peer session's handoff
+            // from here would cross-session-mutate and fail with NotFound,
+            // aborting the loop before the current session's own handoff
+            // is resolved. listForCurrentSession scopes to the active
+            // session; fall back to list() on backends that don't support
+            // scoping (rare).
+            const listFn =
+              deps.handoffStore?.listForCurrentSession?.bind(deps.handoffStore) ??
+              deps.handoffStore?.list.bind(deps.handoffStore);
             for (const rel of replyRelations) {
+              let unresolved: readonly import("../handoff.js").Handoff[] = [];
               try {
                 // Include Processed too: agents following the IPC workflow
                 // (grove_process_handoff before grove_submit_*) leave the
-                // handoff in Processed state. Without this, their valid
-                // replies would never auto-resolve the handoff.
-                const unresolved = await deps.handoffStore?.list({
+                // handoff in Processed state.
+                unresolved = (await listFn?.({
                   sourceCid: rel.targetCid,
                   status: [
                     HandoffStatus.PendingPickup,
@@ -1200,17 +1212,20 @@ export async function contributeOperation(
                     HandoffStatus.Processed,
                   ],
                   toRole: replyingRole,
-                });
-                for (const h of unresolved ?? []) {
+                })) ?? [];
+              } catch {
+                // List failure is best-effort; move on to next relation.
+                continue;
+              }
+              // Per-handoff error isolation: one foreign or stale row
+              // must not abort resolution of the remaining handoffs.
+              for (const h of unresolved) {
+                try {
                   if (process.env.GROVE_DEBUG === "1") {
                     process.stderr.write(
                       `[grove:handoff] REPLY handoff=${h.handoffId.slice(0, 8)} resolvedBy=${contribution.cid.slice(0, 20)}.. relation=${rel.relationType} role=${replyingRole}\n`,
                     );
                   }
-                  // The state machine requires pending_pickup → delivered
-                  // before → replied. If the handoff is still pending_pickup
-                  // (reply arrived before an explicit delivery mark), mark
-                  // delivered first. Best-effort on concurrent advancement.
                   if (h.status === HandoffStatus.PendingPickup) {
                     try {
                       await deps.handoffStore?.markDelivered(h.handoffId);
@@ -1219,11 +1234,10 @@ export async function contributeOperation(
                     }
                   }
                   await deps.handoffStore?.markReplied(h.handoffId, contribution.cid);
-                  // Cancel deadline timer for resolved handoff
                   deps.deadlineWatcher?.cancel(h.handoffId);
+                } catch {
+                  /* skip this handoff, continue with peers */
                 }
-              } catch {
-                // Best-effort — don't fail contribution over handoff transition
               }
             }
           });

--- a/src/core/operations/deps.ts
+++ b/src/core/operations/deps.ts
@@ -9,6 +9,7 @@ import type { BountyStore } from "../bounty-store.js";
 import type { ContentStore } from "../cas.js";
 import type { GroveContract } from "../contract.js";
 import type { CreditsService } from "../credits.js";
+import type { DeadlineWatcher } from "../deadline-watcher.js";
 import type { EventBus } from "../event-bus.js";
 import type { FrontierCalculator } from "../frontier.js";
 import type { HandoffStore } from "../handoff.js";
@@ -86,4 +87,6 @@ export interface OperationDeps {
   readonly hookCwd?: string | undefined;
   /** Persistent idempotency store for cross-process deduplication. */
   readonly idempotencyStore?: IdempotencyStore | undefined;
+  /** Optional deadline watcher for proactive overdue detection. */
+  readonly deadlineWatcher?: DeadlineWatcher | undefined;
 }

--- a/src/core/operations/error-parity.test.ts
+++ b/src/core/operations/error-parity.test.ts
@@ -153,10 +153,11 @@ describe("error codes are exhaustive", () => {
     expect(codes).toContain("LEASE_VIOLATION");
     expect(codes).toContain("NOT_FOUND");
     expect(codes).toContain("STATE_CONFLICT");
+    expect(codes).toContain("INVALID_STATE");
     expect(codes).toContain("POLICY_VIOLATION");
     expect(codes).toContain("VALIDATION_ERROR");
     expect(codes).toContain("INTERNAL_ERROR");
-    expect(codes.length).toBe(11);
+    expect(codes.length).toBe(12);
   });
 
   test("OperationErrorCode matches MCP McpErrorCode", async () => {

--- a/src/core/operations/handoff.test.ts
+++ b/src/core/operations/handoff.test.ts
@@ -162,4 +162,64 @@ describe("handoff integration", () => {
     expect(expired.map((item) => item.handoffId)).toContain(handoff.handoffId);
     expect(updated?.status).toBe(HandoffStatus.Expired);
   });
+
+  test("reply contribution resolves upstream handoff via resolvedByCid (E2E)", async () => {
+    const { deps, cleanup } = await createTestOperationDeps();
+    const bus = new LocalEventBus();
+    const depsWithRouter = {
+      ...deps,
+      topologyRouter: new TopologyRouter(reviewLoopTopology, bus),
+    };
+
+    try {
+      // Step 1: coder submits work → handoff created for reviewer
+      const workResult = await contributeOperation(
+        {
+          kind: "work",
+          summary: "Implement feature X",
+          agent: { agentId: "coder-1", role: "coder" },
+        },
+        depsWithRouter,
+      );
+
+      expect(workResult.ok).toBe(true);
+      if (!workResult.ok) return;
+
+      const handoffsBefore = await deps.handoffStore.list();
+      expect(handoffsBefore).toHaveLength(1);
+      const handoff = handoffsBefore[0]!;
+      expect(handoff.fromRole).toBe("coder");
+      expect(handoff.toRole).toBe("reviewer");
+
+      // Step 2: reviewer submits review targeting the work CID → handoff auto-resolved
+      const reviewResult = await contributeOperation(
+        {
+          kind: "review",
+          summary: "LGTM with minor nits",
+          scores: { quality: { value: 0.9, direction: "maximize" } },
+          relations: [
+            {
+              targetCid: workResult.value.cid,
+              relationType: "reviews",
+            },
+          ],
+          agent: { agentId: "reviewer-1", role: "reviewer" },
+        },
+        depsWithRouter,
+      );
+
+      expect(reviewResult.ok).toBe(true);
+      if (!reviewResult.ok) return;
+
+      // Fire-and-forget runs asynchronously — give it a moment to settle
+      await new Promise((r) => setTimeout(r, 50));
+
+      const resolved = await deps.handoffStore.get(handoff.handoffId);
+      expect(resolved?.status).toBe(HandoffStatus.Replied);
+      expect(resolved?.resolvedByCid).toBe(reviewResult.value.cid);
+    } finally {
+      bus.close();
+      await cleanup();
+    }
+  });
 });

--- a/src/core/operations/handoff.test.ts
+++ b/src/core/operations/handoff.test.ts
@@ -163,6 +163,77 @@ describe("handoff integration", () => {
     expect(updated?.status).toBe(HandoffStatus.Expired);
   });
 
+  test("fan-out: one role's reply does not close peer handoffs for other roles", async () => {
+    const { deps, cleanup } = await createTestOperationDeps();
+    const bus = new LocalEventBus();
+    // coder fans out to reviewer + tester via broadcast mode
+    const fanOutTopology = {
+      structure: "graph" as const,
+      roles: [
+        {
+          name: "coder",
+          mode: "broadcast" as const,
+          edges: [
+            { target: "reviewer", edgeType: "delegates" as const },
+            { target: "tester", edgeType: "delegates" as const },
+          ],
+        },
+        { name: "reviewer", edges: [] },
+        { name: "tester", edges: [] },
+      ],
+    };
+    const depsWithRouter = {
+      ...deps,
+      topologyRouter: new TopologyRouter(fanOutTopology, bus),
+    };
+
+    try {
+      // Coder submits work → fans out to reviewer + tester
+      const workResult = await contributeOperation(
+        {
+          kind: "work",
+          summary: "Implement feature",
+          agent: { agentId: "coder-1", role: "coder" },
+        },
+        depsWithRouter,
+      );
+      expect(workResult.ok).toBe(true);
+      if (!workResult.ok) return;
+
+      const allHandoffs = await deps.handoffStore.list();
+      expect(allHandoffs).toHaveLength(2);
+      const reviewerHandoff = allHandoffs.find((h) => h.toRole === "reviewer");
+      const testerHandoff = allHandoffs.find((h) => h.toRole === "tester");
+      expect(reviewerHandoff).toBeDefined();
+      expect(testerHandoff).toBeDefined();
+
+      // Reviewer replies (tester has NOT acted yet)
+      const reviewResult = await contributeOperation(
+        {
+          kind: "review",
+          summary: "LGTM",
+          scores: { quality: { value: 0.9, direction: "maximize" } },
+          relations: [{ targetCid: workResult.value.cid, relationType: "reviews" }],
+          agent: { agentId: "reviewer-1", role: "reviewer" },
+        },
+        depsWithRouter,
+      );
+      expect(reviewResult.ok).toBe(true);
+
+      // Wait for fire-and-forget reply transition
+      await new Promise((r) => setTimeout(r, 100));
+
+      // reviewer's handoff should be replied; tester's MUST remain unresolved
+      const reviewerAfter = await deps.handoffStore.get(reviewerHandoff!.handoffId);
+      const testerAfter = await deps.handoffStore.get(testerHandoff!.handoffId);
+      expect(reviewerAfter?.status).toBe(HandoffStatus.Replied);
+      expect(testerAfter?.status).not.toBe(HandoffStatus.Replied);
+    } finally {
+      bus.close();
+      await cleanup();
+    }
+  });
+
   test("reply contribution resolves upstream handoff via resolvedByCid (E2E)", async () => {
     const { deps, cleanup } = await createTestOperationDeps();
     const bus = new LocalEventBus();

--- a/src/core/operations/result.ts
+++ b/src/core/operations/result.ts
@@ -33,6 +33,7 @@ export const OperationErrorCode = {
   LeaseViolation: "LEASE_VIOLATION",
   NotFound: "NOT_FOUND",
   StateConflict: "STATE_CONFLICT",
+  InvalidState: "INVALID_STATE",
   PolicyViolation: "POLICY_VIOLATION",
   ValidationError: "VALIDATION_ERROR",
   InternalError: "INTERNAL_ERROR",

--- a/src/core/operations/test-helpers.ts
+++ b/src/core/operations/test-helpers.ts
@@ -170,11 +170,17 @@ export async function createTestOperationDeps(): Promise<TestOperationDeps> {
  * interface changes (e.g., adding markSeen/markAcked), update this one
  * factory instead of N inline mocks across test files.
  */
-export function createMockHandoffStore(
-  overrides?: Partial<HandoffStore>,
-): HandoffStore {
+export function createMockHandoffStore(overrides?: Partial<HandoffStore>): HandoffStore {
   return {
-    create: async () => ({ handoffId: "mock", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" }),
+    create: async () => ({
+      handoffId: "mock",
+      sourceCid: "",
+      fromRole: "",
+      toRole: "",
+      status: "pending_pickup" as const,
+      requiresReply: false,
+      createdAt: "",
+    }),
     get: async () => undefined,
     list: async () => [],
     markDelivered: async () => undefined,

--- a/src/core/operations/test-helpers.ts
+++ b/src/core/operations/test-helpers.ts
@@ -20,6 +20,7 @@ import { LocalWorkspaceManager } from "../../local/workspace.js";
 import type { ContentStore } from "../cas.js";
 import type { GroveContract } from "../contract.js";
 import { DefaultFrontierCalculator } from "../frontier.js";
+import type { HandoffStore } from "../handoff.js";
 import { InMemoryCreditsService } from "../in-memory-credits.js";
 import { InMemoryHandoffStore } from "../in-memory-handoff-store.js";
 import type { Contribution } from "../models.js";
@@ -148,6 +149,7 @@ export async function createTestOperationDeps(): Promise<TestOperationDeps> {
     topologyRouter: undefined as unknown as NonNullable<OperationDeps["topologyRouter"]>,
     hookRunner: undefined as unknown as NonNullable<OperationDeps["hookRunner"]>,
     hookCwd: undefined as unknown as string,
+    deadlineWatcher: undefined as unknown as NonNullable<OperationDeps["deadlineWatcher"]>,
   };
 
   return {
@@ -159,6 +161,31 @@ export async function createTestOperationDeps(): Promise<TestOperationDeps> {
       await rm(tempDir, { recursive: true, force: true });
     },
   };
+}
+
+/**
+ * Create a mock HandoffStore with sensible no-op defaults.
+ *
+ * Override specific methods for test assertions. When the HandoffStore
+ * interface changes (e.g., adding markSeen/markAcked), update this one
+ * factory instead of N inline mocks across test files.
+ */
+export function createMockHandoffStore(
+  overrides?: Partial<HandoffStore>,
+): HandoffStore {
+  return {
+    create: async () => ({ handoffId: "mock", sourceCid: "", fromRole: "", toRole: "", status: "pending_pickup" as const, requiresReply: false, createdAt: "" }),
+    get: async () => undefined,
+    list: async () => [],
+    markDelivered: async () => undefined,
+    markReplied: async () => undefined,
+    markSeen: async () => undefined,
+    markAcked: async () => undefined,
+    expireStale: async () => [],
+    countPending: async () => 0,
+    close: () => undefined,
+    ...overrides,
+  } as HandoffStore;
 }
 
 /**

--- a/src/core/test-helpers.ts
+++ b/src/core/test-helpers.ts
@@ -7,6 +7,7 @@
 
 import type { Bounty, RewardRecord } from "./bounty.js";
 import { BountyStatus, RewardType } from "./bounty.js";
+import type { HandoffInput } from "./handoff.js";
 import { createContribution } from "./manifest.js";
 import type {
   AgentIdentity,
@@ -128,6 +129,16 @@ export function makeReward(overrides?: Partial<RewardRecord>): RewardRecord {
     amount: 10,
     contributionCid: "blake3:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
     createdAt: now,
+    ...overrides,
+  };
+}
+
+/** Create a HandoffInput with sensible defaults. */
+export function makeHandoffInput(overrides?: Partial<HandoffInput>): HandoffInput {
+  return {
+    sourceCid: "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    fromRole: "coder",
+    toRole: "reviewer",
     ...overrides,
   };
 }

--- a/src/core/topology-router.ts
+++ b/src/core/topology-router.ts
@@ -48,7 +48,12 @@ export class TopologyRouter {
           const key = `${edge.target}:${edge.edgeType}`;
           if (!seenForRole.has(key)) {
             seenForRole.add(key);
-            edges.push({ target: edge.target, edgeType: edge.edgeType });
+            edges.push({
+              target: edge.target,
+              edgeType: edge.edgeType,
+              ...(edge.workspace !== undefined ? { workspace: edge.workspace } : {}),
+              ...(edge.replyTimeoutSeconds !== undefined ? { replyTimeoutSeconds: edge.replyTimeoutSeconds } : {}),
+            });
           }
         }
       }
@@ -135,10 +140,20 @@ export class TopologyRouter {
     const mode = role?.mode ?? "explicit";
 
     if (mode === "broadcast") {
-      // Broadcast: return synthetic edges to all other roles
+      // Broadcast: notify all other roles. When explicit edges exist for a
+      // target, carry their metadata (replyTimeoutSeconds, workspace) so
+      // handoff creation can use edge-level config even in broadcast mode.
+      const explicitEdges = this.edgeMap.get(sourceRole);
+      const explicitByTarget = new Map<string, RoleEdge>();
+      if (explicitEdges) {
+        for (const e of explicitEdges) explicitByTarget.set(e.target, e);
+      }
       return this.topology.roles
         .filter((r) => r.name !== sourceRole)
-        .map((r) => ({ target: r.name, edgeType: "delegates" as const }));
+        .map((r) => {
+          const explicit = explicitByTarget.get(r.name);
+          return explicit ?? { target: r.name, edgeType: "delegates" as const };
+        });
     }
 
     return this.edgeMap.get(sourceRole) ?? [];

--- a/src/core/topology-router.ts
+++ b/src/core/topology-router.ts
@@ -65,7 +65,9 @@ export class TopologyRouter {
               target: edge.target,
               edgeType: edge.edgeType,
               ...(edge.workspace !== undefined ? { workspace: edge.workspace } : {}),
-              ...(edge.replyTimeoutSeconds !== undefined ? { replyTimeoutSeconds: edge.replyTimeoutSeconds } : {}),
+              ...(edge.replyTimeoutSeconds !== undefined
+                ? { replyTimeoutSeconds: edge.replyTimeoutSeconds }
+                : {}),
             });
           }
         }

--- a/src/core/topology.ts
+++ b/src/core/topology.ts
@@ -377,7 +377,9 @@ export function wireToTopology(wire: z.infer<typeof AgentTopologySchema>): Agent
               target: edge.target,
               edgeType: edge.edge_type,
               ...(edge.workspace !== undefined && { workspace: edge.workspace }),
-              ...(edge.reply_timeout_seconds !== undefined && { replyTimeoutSeconds: edge.reply_timeout_seconds }),
+              ...(edge.reply_timeout_seconds !== undefined && {
+                replyTimeoutSeconds: edge.reply_timeout_seconds,
+              }),
             }),
           ),
         }),

--- a/src/core/topology.ts
+++ b/src/core/topology.ts
@@ -31,6 +31,8 @@ const RoleEdgeSchema = z
     target: z.string().min(1).max(64),
     edge_type: EdgeTypeEnum,
     workspace: WorkspaceStrategyEnum.optional(),
+    /** Seconds the target role has to reply before the handoff is overdue. */
+    reply_timeout_seconds: z.number().int().min(10).max(86400).optional(),
   })
   .strict();
 
@@ -90,6 +92,7 @@ interface WireAgentTopology {
             | "requests"
             | "escalates";
           readonly workspace?: "branch_from_source" | "independent" | undefined;
+          readonly reply_timeout_seconds?: number | undefined;
         }[]
       | undefined;
     readonly command?: string | undefined;
@@ -309,6 +312,8 @@ export interface RoleEdge {
   readonly edgeType: EdgeType;
   /** Workspace strategy — default: independent (HEAD). */
   readonly workspace?: WorkspaceStrategy | undefined;
+  /** Seconds the target role has to reply before the handoff is marked overdue. */
+  readonly replyTimeoutSeconds?: number | undefined;
 }
 
 /** Supported agent platform identifiers (boardroom). */
@@ -372,6 +377,7 @@ export function wireToTopology(wire: z.infer<typeof AgentTopologySchema>): Agent
               target: edge.target,
               edgeType: edge.edge_type,
               ...(edge.workspace !== undefined && { workspace: edge.workspace }),
+              ...(edge.reply_timeout_seconds !== undefined && { replyTimeoutSeconds: edge.reply_timeout_seconds }),
             }),
           ),
         }),

--- a/src/local/runtime.ts
+++ b/src/local/runtime.ts
@@ -81,7 +81,16 @@ export function createLocalRuntime(options: LocalRuntimeOptions): LocalRuntime {
   const casPath = join(groveDir, "cas");
   const groveRoot = resolve(groveDir, "..");
 
-  const stores = createSqliteStores(dbPath);
+  // Pass GROVE_SESSION_ID to the handoff store so it scopes all
+  // reads/writes to the active session. This enables proactive deadline
+  // timers and ack receipts safely — session A's watcher cannot flip
+  // session B's rows, and a role-bound ack cannot cross session boundaries.
+  // When GROVE_SESSION_ID is unset (CLI/tests), the store falls back to
+  // unscoped mode for backwards compatibility.
+  const envSessionId = process.env.GROVE_SESSION_ID;
+  const stores = createSqliteStores(dbPath, {
+    ...(envSessionId ? { sessionId: envSessionId } : {}),
+  });
   const cas = new FsCas(casPath);
 
   const baseFrontier = new DefaultFrontierCalculator(stores.contributionStore);

--- a/src/local/runtime.ts
+++ b/src/local/runtime.ts
@@ -43,6 +43,13 @@ export interface LocalRuntimeOptions {
 
 /** All local stores, services, and resources. */
 export interface LocalRuntime {
+  /**
+   * Raw SQLite database handle. Exposed for callers that need to construct
+   * additional session-scoped store instances after startup (e.g.
+   * serve-http.ts building a per-request SqliteHandoffStore once it has
+   * resolved the current session ID).
+   */
+  readonly db: import("bun:sqlite").Database;
   readonly contributionStore: SqliteContributionStore;
   readonly claimStore: SqliteClaimStore;
   readonly bountyStore: SqliteBountyStore;
@@ -144,6 +151,7 @@ export function createLocalRuntime(options: LocalRuntimeOptions): LocalRuntime {
   }
 
   return {
+    db: stores.db,
     contributionStore: stores.contributionStore,
     claimStore: stores.claimStore,
     bountyStore: stores.bountyStore,

--- a/src/local/sqlite-handoff-store.conformance.test.ts
+++ b/src/local/sqlite-handoff-store.conformance.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Run HandoffStore conformance suite against SqliteHandoffStore.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runHandoffStoreTests } from "../core/handoff-store.conformance.js";
+import { SqliteHandoffStore } from "./sqlite-handoff-store.js";
+import { initSqliteDb } from "./sqlite-store.js";
+
+runHandoffStoreTests(async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "grove-handoff-test-"));
+  const dbPath = join(tempDir, "test.db");
+  const db = initSqliteDb(dbPath);
+  const store = new SqliteHandoffStore(db);
+  return {
+    store,
+    cleanup: async () => {
+      db.close();
+      await rm(tempDir, { recursive: true, force: true });
+    },
+  };
+});

--- a/src/local/sqlite-handoff-store.session.test.ts
+++ b/src/local/sqlite-handoff-store.session.test.ts
@@ -256,4 +256,62 @@ describe("SqliteHandoffStore session scoping", () => {
 
     db.close();
   });
+
+  test("first scoped mutation claims a legacy row — peer session cannot mutate after", async () => {
+    const db = initSqliteDb(dbPath);
+    const legacy = new SqliteHandoffStore(db);
+    const hLegacy = await legacy.create({
+      sourceCid: "blake3:legacy",
+      fromRole: "coder",
+      toRole: "reviewer",
+    });
+
+    const storeA = new SqliteHandoffStore(db, "session-A");
+    const storeB = new SqliteHandoffStore(db, "session-B");
+
+    // Session A claims via markDelivered — backfills session_id = session-A
+    await storeA.markDelivered(hLegacy.handoffId);
+
+    // Session B's scope clause no longer matches: the row now owns session-A,
+    // so list / get / isInCurrentSession all stop resolving it from B.
+    const listB = await storeB.list();
+    expect(listB.find((h) => h.handoffId === hLegacy.handoffId)).toBeUndefined();
+    expect(await storeB.get(hLegacy.handoffId)).toBeUndefined();
+    expect(await storeB.isInCurrentSession?.(hLegacy.handoffId)).toBe(false);
+
+    // Session B's mutations throw NotFoundError — the row is owned by A
+    await expect(storeB.markProcessed(hLegacy.handoffId)).rejects.toThrow();
+    await expect(storeB.markReplied(hLegacy.handoffId, "blake3:r")).rejects.toThrow();
+
+    // Session A can still complete the lifecycle
+    await storeA.markProcessed(hLegacy.handoffId);
+    const afterA = await storeA.get(hLegacy.handoffId);
+    expect(afterA?.status).toBe(HandoffStatus.Processed);
+
+    db.close();
+  });
+
+  test("expireStale claims legacy row on first fire — peer session cannot re-expire", async () => {
+    const db = initSqliteDb(dbPath);
+    const legacy = new SqliteHandoffStore(db);
+    const pastDeadline = new Date(Date.now() - 60_000).toISOString();
+    const hLegacy = await legacy.create({
+      sourceCid: "blake3:legacy",
+      fromRole: "coder",
+      toRole: "reviewer",
+      replyDueAt: pastDeadline,
+    });
+
+    const storeA = new SqliteHandoffStore(db, "session-A");
+    const storeB = new SqliteHandoffStore(db, "session-B");
+
+    const expiredByA = await storeA.expireStale();
+    expect(expiredByA.map((h) => h.handoffId)).toEqual([hLegacy.handoffId]);
+
+    // Row now owns session-A; session B's scoped expireStale is a no-op.
+    const expiredByB = await storeB.expireStale();
+    expect(expiredByB).toHaveLength(0);
+
+    db.close();
+  });
 });

--- a/src/local/sqlite-handoff-store.session.test.ts
+++ b/src/local/sqlite-handoff-store.session.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Session isolation tests for SqliteHandoffStore.
+ *
+ * Two stores sharing the same DB but scoped to different sessions must
+ * not see, expire, or mutate each other's handoffs.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { DeadlineWatcher } from "../core/deadline-watcher.js";
+import { HandoffStatus } from "../core/handoff.js";
+import { LocalEventBus } from "../core/local-event-bus.js";
+import { SqliteHandoffStore } from "./sqlite-handoff-store.js";
+import { initSqliteDb } from "./sqlite-store.js";
+
+describe("SqliteHandoffStore session scoping", () => {
+  let tempDir: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "grove-handoff-session-"));
+    dbPath = join(tempDir, "test.db");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("scoped stores see only their own session's handoffs", async () => {
+    const db = initSqliteDb(dbPath);
+    const storeA = new SqliteHandoffStore(db, "session-A");
+    const storeB = new SqliteHandoffStore(db, "session-B");
+
+    const hA = await storeA.create({
+      sourceCid: "blake3:a",
+      fromRole: "coder",
+      toRole: "reviewer",
+    });
+    const hB = await storeB.create({
+      sourceCid: "blake3:b",
+      fromRole: "coder",
+      toRole: "reviewer",
+    });
+
+    const listA = await storeA.list();
+    const listB = await storeB.list();
+
+    expect(listA).toHaveLength(1);
+    expect(listA[0]?.handoffId).toBe(hA.handoffId);
+    expect(listB).toHaveLength(1);
+    expect(listB[0]?.handoffId).toBe(hB.handoffId);
+
+    // get() must not leak across sessions either
+    expect(await storeA.get(hB.handoffId)).toBeUndefined();
+    expect(await storeB.get(hA.handoffId)).toBeUndefined();
+
+    db.close();
+  });
+
+  test("expireStale in session A does not flip session B's overdue handoffs", async () => {
+    const db = initSqliteDb(dbPath);
+    const storeA = new SqliteHandoffStore(db, "session-A");
+    const storeB = new SqliteHandoffStore(db, "session-B");
+
+    const pastDeadline = new Date(Date.now() - 60_000).toISOString();
+
+    const hA = await storeA.create({
+      sourceCid: "blake3:a",
+      fromRole: "coder",
+      toRole: "reviewer",
+      replyDueAt: pastDeadline,
+    });
+    const hB = await storeB.create({
+      sourceCid: "blake3:b",
+      fromRole: "coder",
+      toRole: "reviewer",
+      replyDueAt: pastDeadline,
+    });
+
+    // Session A's watcher expires only session A's row
+    const expiredByA = await storeA.expireStale();
+    expect(expiredByA.map((h) => h.handoffId)).toEqual([hA.handoffId]);
+
+    // Session B's handoff should still be unresolved — NOT flipped by A
+    const bRow = await storeB.get(hB.handoffId);
+    expect(bRow?.status).toBe(HandoffStatus.PendingPickup);
+
+    db.close();
+  });
+
+  test("isInCurrentSession rejects cross-session handoff ids", async () => {
+    const db = initSqliteDb(dbPath);
+    const storeA = new SqliteHandoffStore(db, "session-A");
+    const storeB = new SqliteHandoffStore(db, "session-B");
+
+    const hA = await storeA.create({
+      sourceCid: "blake3:a",
+      fromRole: "coder",
+      toRole: "reviewer",
+    });
+
+    // Session A owns it
+    expect(await storeA.isInCurrentSession?.(hA.handoffId)).toBe(true);
+    // Session B does not
+    expect(await storeB.isInCurrentSession?.(hA.handoffId)).toBe(false);
+    // Nonexistent handoff returns false
+    expect(await storeA.isInCurrentSession?.("nonexistent")).toBe(false);
+
+    db.close();
+  });
+
+  test("markReplied in session A cannot resolve session B's handoff", async () => {
+    const db = initSqliteDb(dbPath);
+    const storeA = new SqliteHandoffStore(db, "session-A");
+    const storeB = new SqliteHandoffStore(db, "session-B");
+
+    const hB = await storeB.create({
+      sourceCid: "blake3:b",
+      fromRole: "coder",
+      toRole: "reviewer",
+    });
+
+    // Session A tries to resolve B's handoff — should fail with NotFound
+    // (scoped get() returns undefined, so scoped mark* treats it as missing).
+    await expect(storeA.markReplied(hB.handoffId, "blake3:reply")).rejects.toThrow();
+
+    // B's handoff should be unaffected
+    const bRow = await storeB.get(hB.handoffId);
+    expect(bRow?.status).toBe(HandoffStatus.PendingPickup);
+    expect(bRow?.resolvedByCid).toBeUndefined();
+
+    db.close();
+  });
+
+  test("unscoped store (no sessionId) does not expose session capability methods", () => {
+    const db = initSqliteDb(dbPath);
+    const unscoped = new SqliteHandoffStore(db);
+
+    expect(unscoped.listForCurrentSession).toBeUndefined();
+    expect(unscoped.isInCurrentSession).toBeUndefined();
+
+    db.close();
+  });
+
+  test("scoped store exposes session capability methods", () => {
+    const db = initSqliteDb(dbPath);
+    const scoped = new SqliteHandoffStore(db, "session-X");
+
+    expect(typeof scoped.listForCurrentSession).toBe("function");
+    expect(typeof scoped.isInCurrentSession).toBe("function");
+
+    db.close();
+  });
+
+  test("DeadlineWatcher rebuild is session-scoped — does not arm peer timers", async () => {
+    const db = initSqliteDb(dbPath);
+    const storeA = new SqliteHandoffStore(db, "session-A");
+    const storeB = new SqliteHandoffStore(db, "session-B");
+    const bus = new LocalEventBus();
+
+    // Both sessions have unresolved handoffs with future deadlines
+    await storeA.create({
+      sourceCid: "blake3:a",
+      fromRole: "coder",
+      toRole: "reviewer",
+      requiresReply: true,
+      replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    await storeB.create({
+      sourceCid: "blake3:b",
+      fromRole: "coder",
+      toRole: "reviewer",
+      requiresReply: true,
+      replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // A watcher scoped to session A must arm exactly ONE timer (for A's row)
+    const watcherA = new DeadlineWatcher({ handoffStore: storeA, eventBus: bus });
+    const countA = await watcherA.rebuildFromStore();
+    expect(countA).toBe(1);
+    expect(watcherA.activeCount).toBe(1);
+
+    watcherA.close();
+    bus.close();
+    db.close();
+  });
+
+  test("pre-#164 NULL-session rows are invisible to scoped sessions", async () => {
+    const db = initSqliteDb(dbPath);
+    // Simulate a legacy row by inserting with session_id=NULL via unscoped store
+    const legacy = new SqliteHandoffStore(db);
+    const hLegacy = await legacy.create({
+      sourceCid: "blake3:legacy",
+      fromRole: "coder",
+      toRole: "reviewer",
+    });
+
+    // A scoped session should NOT see the legacy row — it doesn't belong
+    // to any active session, so attributing it to one would be wrong.
+    const scoped = new SqliteHandoffStore(db, "new-session");
+    const list = await scoped.list();
+    expect(list.find((h) => h.handoffId === hLegacy.handoffId)).toBeUndefined();
+
+    // But the unscoped legacy store can still see it (for CLI/admin paths)
+    const legacyList = await legacy.list();
+    expect(legacyList.find((h) => h.handoffId === hLegacy.handoffId)).toBeDefined();
+
+    db.close();
+  });
+});

--- a/src/local/sqlite-handoff-store.session.test.ts
+++ b/src/local/sqlite-handoff-store.session.test.ts
@@ -5,11 +5,10 @@
  * not see, expire, or mutate each other's handoffs.
  */
 
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { DeadlineWatcher } from "../core/deadline-watcher.js";
 import { HandoffStatus } from "../core/handoff.js";

--- a/src/local/sqlite-handoff-store.session.test.ts
+++ b/src/local/sqlite-handoff-store.session.test.ts
@@ -189,7 +189,7 @@ describe("SqliteHandoffStore session scoping", () => {
     db.close();
   });
 
-  test("pre-#164 NULL-session rows are invisible to scoped sessions", async () => {
+  test("pre-#164 NULL-session rows are visible to scoped sessions (migration shim)", async () => {
     const db = initSqliteDb(dbPath);
     // Simulate a legacy row by inserting with session_id=NULL via unscoped store
     const legacy = new SqliteHandoffStore(db);
@@ -199,15 +199,42 @@ describe("SqliteHandoffStore session scoping", () => {
       toRole: "reviewer",
     });
 
-    // A scoped session should NOT see the legacy row — it doesn't belong
-    // to any active session, so attributing it to one would be wrong.
+    // Scoped sessions MUST still see NULL-session rows after upgrade so
+    // in-flight pre-#164 handoffs don't strand the coder→reviewer loop.
     const scoped = new SqliteHandoffStore(db, "new-session");
     const list = await scoped.list();
-    expect(list.find((h) => h.handoffId === hLegacy.handoffId)).toBeUndefined();
+    expect(list.find((h) => h.handoffId === hLegacy.handoffId)).toBeDefined();
 
-    // But the unscoped legacy store can still see it (for CLI/admin paths)
+    // Unscoped stores still see legacy rows (for CLI/admin paths)
     const legacyList = await legacy.list();
     expect(legacyList.find((h) => h.handoffId === hLegacy.handoffId)).toBeDefined();
+
+    db.close();
+  });
+
+  test("legacy NULL-session rows do NOT leak between scoped sessions (only the first resolver wins)", async () => {
+    const db = initSqliteDb(dbPath);
+    // Pre-#164 row with session_id=NULL
+    const legacy = new SqliteHandoffStore(db);
+    const hLegacy = await legacy.create({
+      sourceCid: "blake3:legacy",
+      fromRole: "coder",
+      toRole: "reviewer",
+    });
+
+    // Two scoped sessions both see the legacy row (migration shim)
+    const storeA = new SqliteHandoffStore(db, "session-A");
+    const storeB = new SqliteHandoffStore(db, "session-B");
+
+    const listA = await storeA.list();
+    const listB = await storeB.list();
+    expect(listA.find((h) => h.handoffId === hLegacy.handoffId)).toBeDefined();
+    expect(listB.find((h) => h.handoffId === hLegacy.handoffId)).toBeDefined();
+
+    // Scoped mark* operations work on legacy rows (pending_pickup → delivered)
+    await storeA.markDelivered(hLegacy.handoffId);
+    const afterA = await storeA.get(hLegacy.handoffId);
+    expect(afterA?.status).toBe(HandoffStatus.Delivered);
 
     db.close();
   });

--- a/src/local/sqlite-handoff-store.session.test.ts
+++ b/src/local/sqlite-handoff-store.session.test.ts
@@ -212,6 +212,24 @@ describe("SqliteHandoffStore session scoping", () => {
     db.close();
   });
 
+  test("isInCurrentSession honors the NULL-session migration shim", async () => {
+    const db = initSqliteDb(dbPath);
+    // Legacy row with session_id=NULL (pre-#164)
+    const legacy = new SqliteHandoffStore(db);
+    const hLegacy = await legacy.create({
+      sourceCid: "blake3:legacy",
+      fromRole: "coder",
+      toRole: "reviewer",
+    });
+
+    const scoped = new SqliteHandoffStore(db, "active-session");
+    // Without the shim, receipt tools would find the legacy row via get()
+    // but reject it in isInCurrentSession, stranding it post-upgrade.
+    expect(await scoped.isInCurrentSession?.(hLegacy.handoffId)).toBe(true);
+
+    db.close();
+  });
+
   test("legacy NULL-session rows do NOT leak between scoped sessions (only the first resolver wins)", async () => {
     const db = initSqliteDb(dbPath);
     // Pre-#164 row with session_id=NULL

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -145,6 +145,22 @@ export class SqliteHandoffStore implements HandoffStore {
     return { sql: "(session_id = ? OR session_id IS NULL)", params: [this.sessionId] };
   }
 
+  /**
+   * Claim-on-write SET fragment — backfills `session_id` on the first
+   * successful mutation of a legacy NULL-session row so peer sessions
+   * lose visibility via scopeClause. No-op for unscoped stores.
+   *
+   * Callers splice `fragment` into SET immediately after their first
+   * SET expression and `params` before the WHERE params.
+   */
+  private claimFragment(): { fragment: string; params: readonly string[] } {
+    if (this.sessionId === undefined) return { fragment: "", params: [] };
+    return {
+      fragment: ", session_id = COALESCE(session_id, ?)",
+      params: [this.sessionId],
+    };
+  }
+
   async create(input: HandoffInput): Promise<Handoff> {
     const handoffId = this.insertSync(input);
     const handoff = await this.get(handoffId);
@@ -247,12 +263,19 @@ export class SqliteHandoffStore implements HandoffStore {
   async markDelivered(id: string): Promise<void> {
     const { sql: scopeSql, params: scopeParams } = this.scopeClause();
     const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
+    const { fragment: claimSet, params: claimParams } = this.claimFragment();
     const result = this.db
       .prepare(
-        `UPDATE handoffs SET status = ?
+        `UPDATE handoffs SET status = ?${claimSet}
          WHERE handoff_id = ? AND status = ?${scopeExtra}`,
       )
-      .run(HandoffStatus.Delivered, id, HandoffStatus.PendingPickup, ...scopeParams);
+      .run(
+        HandoffStatus.Delivered,
+        ...claimParams,
+        id,
+        HandoffStatus.PendingPickup,
+        ...scopeParams,
+      );
     if (result.changes === 0) {
       const current = await this.get(id);
       if (current === undefined) {
@@ -269,18 +292,20 @@ export class SqliteHandoffStore implements HandoffStore {
     const now = new Date().toISOString();
     const { sql: scopeSql, params: scopeParams } = this.scopeClause();
     const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
+    const { fragment: claimSet, params: claimParams } = this.claimFragment();
     // Valid transitions: delivered → replied, processed → replied.
     // pending_pickup → replied is NOT allowed — callers must markDelivered
     // first. The state machine enforces the IPC ack invariant.
     const result = this.db
       .prepare(
-        `UPDATE handoffs SET status = ?, resolved_by_cid = ?
+        `UPDATE handoffs SET status = ?, resolved_by_cid = ?${claimSet}
          WHERE handoff_id = ? AND status IN (?, ?)
            AND (reply_due_at IS NULL OR reply_due_at >= ?)${scopeExtra}`,
       )
       .run(
         HandoffStatus.Replied,
         resolvedByCid,
+        ...claimParams,
         id,
         HandoffStatus.Delivered,
         HandoffStatus.Processed,
@@ -300,11 +325,12 @@ export class SqliteHandoffStore implements HandoffStore {
       ) {
         this.db
           .prepare(
-            `UPDATE handoffs SET status = ?
+            `UPDATE handoffs SET status = ?${claimSet}
              WHERE handoff_id = ? AND status IN (?, ?)${scopeExtra}`,
           )
           .run(
             HandoffStatus.Expired,
+            ...claimParams,
             id,
             HandoffStatus.Delivered,
             HandoffStatus.Processed,
@@ -322,12 +348,19 @@ export class SqliteHandoffStore implements HandoffStore {
   async markProcessed(id: string): Promise<void> {
     const { sql: scopeSql, params: scopeParams } = this.scopeClause();
     const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
+    const { fragment: claimSet, params: claimParams } = this.claimFragment();
     const result = this.db
       .prepare(
-        `UPDATE handoffs SET status = ?
+        `UPDATE handoffs SET status = ?${claimSet}
          WHERE handoff_id = ? AND status = ?${scopeExtra}`,
       )
-      .run(HandoffStatus.Processed, id, HandoffStatus.Delivered, ...scopeParams);
+      .run(
+        HandoffStatus.Processed,
+        ...claimParams,
+        id,
+        HandoffStatus.Delivered,
+        ...scopeParams,
+      );
     if (result.changes === 0) {
       const current = await this.get(id);
       if (current === undefined) {
@@ -343,13 +376,15 @@ export class SqliteHandoffStore implements HandoffStore {
   async markDeadLettered(id: string): Promise<void> {
     const { sql: scopeSql, params: scopeParams } = this.scopeClause();
     const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
+    const { fragment: claimSet, params: claimParams } = this.claimFragment();
     const result = this.db
       .prepare(
-        `UPDATE handoffs SET status = ?
+        `UPDATE handoffs SET status = ?${claimSet}
          WHERE handoff_id = ? AND status IN (?, ?)${scopeExtra}`,
       )
       .run(
         HandoffStatus.DeadLettered,
+        ...claimParams,
         id,
         HandoffStatus.PendingPickup,
         HandoffStatus.Delivered,
@@ -372,12 +407,13 @@ export class SqliteHandoffStore implements HandoffStore {
     // scoped store only mutates its own session's rows.
     const { sql: scopeSql, params: scopeParams } = this.scopeClause();
     const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
+    const { fragment: claimSet, params: claimParams } = this.claimFragment();
     const result = this.db
       .prepare(
-        `UPDATE handoffs SET ipc_message_id = ?
+        `UPDATE handoffs SET ipc_message_id = ?${claimSet}
          WHERE handoff_id = ?${scopeExtra}`,
       )
-      .run(ipcMessageId, id, ...scopeParams);
+      .run(ipcMessageId, ...claimParams, id, ...scopeParams);
     if (result.changes === 0) {
       const current = await this.get(id);
       if (current === undefined) {
@@ -389,12 +425,13 @@ export class SqliteHandoffStore implements HandoffStore {
   async markSeen(id: string): Promise<void> {
     const { sql: scopeSql, params: scopeParams } = this.scopeClause();
     const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
+    const { fragment: claimSet, params: claimParams } = this.claimFragment();
     const result = this.db
       .prepare(
-        `UPDATE handoffs SET seen_at = ?
+        `UPDATE handoffs SET seen_at = ?${claimSet}
          WHERE handoff_id = ? AND seen_at IS NULL${scopeExtra}`,
       )
-      .run(new Date().toISOString(), id, ...scopeParams);
+      .run(new Date().toISOString(), ...claimParams, id, ...scopeParams);
     if (result.changes === 0) {
       const current = await this.get(id);
       if (current === undefined) {
@@ -408,13 +445,14 @@ export class SqliteHandoffStore implements HandoffStore {
     const now = new Date().toISOString();
     const { sql: scopeSql, params: scopeParams } = this.scopeClause();
     const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
+    const { fragment: claimSet, params: claimParams } = this.claimFragment();
     const result = this.db
       .prepare(
         `UPDATE handoffs
-         SET acked_at = ?, seen_at = COALESCE(seen_at, ?)
+         SET acked_at = ?, seen_at = COALESCE(seen_at, ?)${claimSet}
          WHERE handoff_id = ? AND acked_at IS NULL${scopeExtra}`,
       )
-      .run(now, now, id, ...scopeParams);
+      .run(now, now, ...claimParams, id, ...scopeParams);
     if (result.changes === 0) {
       const current = await this.get(id);
       if (current === undefined) {
@@ -463,16 +501,18 @@ export class SqliteHandoffStore implements HandoffStore {
     // transitioned rows).
     const { sql: scopeSql, params: scopeParams } = this.scopeClause();
     const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
+    const { fragment: claimSet, params: claimParams } = this.claimFragment();
     const rows = this.db
       .prepare(
         `UPDATE handoffs
-         SET status = ?
+         SET status = ?${claimSet}
          WHERE status IN (?, ?, ?)
            AND reply_due_at IS NOT NULL AND reply_due_at < ?${scopeExtra}
          RETURNING ${SELECT_COLS}`,
       )
       .all(
         HandoffStatus.Expired,
+        ...claimParams,
         HandoffStatus.PendingPickup,
         HandoffStatus.Delivered,
         HandoffStatus.Processed,

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -1,5 +1,5 @@
 import type { Database } from "bun:sqlite";
-import { NotFoundError } from "../core/errors.js";
+import { NotFoundError, StateConflictError } from "../core/errors.js";
 import {
   type Handoff,
   type HandoffInput,
@@ -195,11 +195,17 @@ export class SqliteHandoffStore implements HandoffStore {
   }
 
   async markReplied(id: string, resolvedByCid: string): Promise<void> {
-    // Valid transitions: pending_pickup → replied, delivered → replied
+    const now = new Date().toISOString();
+    // Valid transitions: pending_pickup → replied, delivered → replied.
+    // Reject late replies in-database: the WHERE clause rejects rows whose
+    // reply_due_at is in the past, closing the SLA loophole even when a
+    // background DeadlineWatcher has not yet flipped status to expired.
+    // This makes correctness independent of the watcher being present.
     const result = this.db
       .prepare(
         `UPDATE handoffs SET status = ?, resolved_by_cid = ?
-         WHERE handoff_id = ? AND status IN (?, ?)`,
+         WHERE handoff_id = ? AND status IN (?, ?)
+           AND (reply_due_at IS NULL OR reply_due_at >= ?)`,
       )
       .run(
         HandoffStatus.Replied,
@@ -207,11 +213,37 @@ export class SqliteHandoffStore implements HandoffStore {
         id,
         HandoffStatus.PendingPickup,
         HandoffStatus.Delivered,
+        now,
       );
     if (result.changes === 0) {
       const current = await this.get(id);
       if (current === undefined) {
         throw new NotFoundError({ resource: "Handoff", identifier: id });
+      }
+      // Distinguish "already replied/expired" (invalid transition) from
+      // "deadline passed" (SLA breach). Both deny the update, but the
+      // caller may want to log them differently.
+      if (
+        (current.status === HandoffStatus.PendingPickup ||
+          current.status === HandoffStatus.Delivered) &&
+        current.replyDueAt !== undefined &&
+        current.replyDueAt < now
+      ) {
+        // Flip to expired so a subsequent expireStale() sees consistent state
+        this.db
+          .prepare(
+            `UPDATE handoffs SET status = ? WHERE handoff_id = ? AND status IN (?, ?)`,
+          )
+          .run(
+            HandoffStatus.Expired,
+            id,
+            HandoffStatus.PendingPickup,
+            HandoffStatus.Delivered,
+          );
+        throw new StateConflictError({
+          resource: "Handoff",
+          reason: `Reply deadline passed at ${current.replyDueAt} (now ${now})`,
+        });
       }
       validateTransition(id, current.status, HandoffStatus.Replied);
     }

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -21,6 +21,7 @@ export const HANDOFF_DDL = `
     resolved_by_cid TEXT,
     seen_at TEXT,
     acked_at TEXT,
+    session_id TEXT,
     created_at TEXT NOT NULL
   );
 
@@ -29,6 +30,7 @@ export const HANDOFF_DDL = `
   CREATE INDEX IF NOT EXISTS idx_handoffs_from_role ON handoffs(from_role);
   CREATE INDEX IF NOT EXISTS idx_handoffs_reply_due_pending
     ON handoffs(reply_due_at) WHERE status = 'pending_pickup';
+  CREATE INDEX IF NOT EXISTS idx_handoffs_session_id ON handoffs(session_id);
 `;
 
 interface HandoffRow {
@@ -42,6 +44,7 @@ interface HandoffRow {
   readonly resolved_by_cid: string | null;
   readonly seen_at: string | null;
   readonly acked_at: string | null;
+  readonly session_id: string | null;
   readonly created_at: string;
 }
 
@@ -62,27 +65,54 @@ function rowToHandoff(row: HandoffRow): Handoff {
 }
 
 const SELECT_COLS = `handoff_id, source_cid, from_role, to_role, status,
-                requires_reply, reply_due_at, resolved_by_cid, seen_at, acked_at, created_at`;
+                requires_reply, reply_due_at, resolved_by_cid, seen_at, acked_at,
+                session_id, created_at`;
 
+/**
+ * SQLite-backed handoff store with optional session scoping.
+ *
+ * When constructed with a `sessionId`, every write stamps the row with that
+ * id and every read/mutation filters by it — providing the same session
+ * isolation as NexusHandoffStore. This makes it safe to run proactive
+ * deadline timers and ack/seen receipts on the local path without cross-
+ * session state corruption.
+ *
+ * When constructed without a `sessionId` (legacy / unscoped callers), the
+ * store behaves like before: writes leave session_id NULL, reads don't
+ * filter by session. This preserves compatibility with CLI tools and
+ * tests that want to see every handoff in the DB.
+ *
+ * The `listForCurrentSession` / `isInCurrentSession` capability methods
+ * are only exposed in scoped mode — their presence is the signal to
+ * callers (DeadlineWatcher, grove_ack_handoff) that this backend can
+ * safely answer "does this handoff belong to me?"
+ */
 export class SqliteHandoffStore implements HandoffStore {
   private readonly db: Database;
+  private readonly sessionId: string | undefined;
 
-  constructor(db: Database) {
+  constructor(db: Database, sessionId?: string) {
     this.db = db;
-    // Column-safe migration: add seen_at/acked_at if missing (pre-#164 databases).
-    //
-    // This runs outside the serialized initSqliteDb transaction, so two
-    // concurrent processes upgrading the same DB can both see the missing
-    // column and race on ALTER TABLE. Catch "duplicate column" errors and
-    // treat them as success — the column exists either way after the race.
+    this.sessionId = sessionId;
+    // Column-safe migration for pre-#164 databases. Runs outside the
+    // serialized initSqliteDb transaction, so two concurrent processes
+    // upgrading the same DB can both observe the missing column and race
+    // on ALTER TABLE — catch "duplicate column" and treat as success.
     const columns = (
       this.db.prepare("PRAGMA table_info(handoffs)").all() as readonly { name: string }[]
     ).map((c) => c.name);
-    if (!columns.includes("seen_at")) {
-      this.safeAddColumn("seen_at");
-    }
-    if (!columns.includes("acked_at")) {
-      this.safeAddColumn("acked_at");
+    if (!columns.includes("seen_at")) this.safeAddColumn("seen_at");
+    if (!columns.includes("acked_at")) this.safeAddColumn("acked_at");
+    if (!columns.includes("session_id")) this.safeAddColumn("session_id");
+
+    // Conditionally expose session-scoped capability methods only when
+    // operating in scoped mode. Unscoped stores leave them undefined so
+    // callers correctly interpret that as "no session scoping available".
+    if (sessionId === undefined) {
+      // Remove the methods so the presence check (method !== undefined)
+      // returns false on unscoped stores.
+      (this as { listForCurrentSession?: unknown }).listForCurrentSession = undefined;
+      (this as { isInCurrentSession?: unknown }).isInCurrentSession = undefined;
     }
   }
 
@@ -91,11 +121,17 @@ export class SqliteHandoffStore implements HandoffStore {
       this.db.run(`ALTER TABLE handoffs ADD COLUMN ${column} TEXT`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      // "duplicate column name" — another process added it between our
-      // PRAGMA check and this ALTER. That's expected during concurrent
-      // upgrades; the column exists now either way.
       if (!/duplicate column/i.test(msg)) throw err;
     }
+  }
+
+  /**
+   * Return a WHERE fragment + params that restrict queries to the current
+   * session. Returns empty when the store is unscoped (legacy mode).
+   */
+  private scopeClause(): { sql: string; params: readonly string[] } {
+    if (this.sessionId === undefined) return { sql: "", params: [] };
+    return { sql: "session_id = ?", params: [this.sessionId] };
   }
 
   async create(input: HandoffInput): Promise<Handoff> {
@@ -109,11 +145,7 @@ export class SqliteHandoffStore implements HandoffStore {
 
   /**
    * Insert a handoff record synchronously inside an active SQLite transaction.
-   *
-   * Capability extension: `contributeOperation` duck-types for this method when
-   * selecting the atomic write path (`writeAtomic`). It is called as the cowrite
-   * callback inside `putWithCowrite`, so it must be synchronous. Stores that do
-   * NOT implement this method fall back to `writeSerial` (best-effort handoffs).
+   * Stamps the row with the current sessionId when the store is scoped.
    */
   insertSync(input: HandoffInput): string {
     const handoffId = input.handoffId ?? crypto.randomUUID();
@@ -121,8 +153,9 @@ export class SqliteHandoffStore implements HandoffStore {
       .prepare(
         `INSERT INTO handoffs (
           handoff_id, source_cid, from_role, to_role, status,
-          requires_reply, reply_due_at, resolved_by_cid, seen_at, acked_at, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          requires_reply, reply_due_at, resolved_by_cid, seen_at, acked_at,
+          session_id, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         handoffId,
@@ -135,15 +168,20 @@ export class SqliteHandoffStore implements HandoffStore {
         null,
         null,
         null,
+        this.sessionId ?? null,
         new Date().toISOString(),
       );
     return handoffId;
   }
 
   async get(id: string): Promise<Handoff | undefined> {
+    // Scoped: a handoff from a different session must not leak through
+    // get() or it could be mutated via mark* methods by the wrong process.
+    const { sql: scopeSql, params: scopeParams } = this.scopeClause();
+    const where = scopeSql ? `handoff_id = ? AND ${scopeSql}` : "handoff_id = ?";
     const row = this.db
-      .prepare(`SELECT ${SELECT_COLS} FROM handoffs WHERE handoff_id = ?`)
-      .get(id) as HandoffRow | null;
+      .prepare(`SELECT ${SELECT_COLS} FROM handoffs WHERE ${where}`)
+      .get(id, ...scopeParams) as HandoffRow | null;
     return row === null ? undefined : rowToHandoff(row);
   }
 
@@ -169,10 +207,16 @@ export class SqliteHandoffStore implements HandoffStore {
       params.push(...statuses);
     }
 
-    let sql = `SELECT ${SELECT_COLS} FROM handoffs`;
-    if (clauses.length > 0) {
-      sql += ` WHERE ${clauses.join(" AND ")}`;
+    // Scope by session when set — prevents list() from returning handoffs
+    // from other sessions that share the same .grove/grove.db file.
+    const { sql: scopeSql, params: scopeParams } = this.scopeClause();
+    if (scopeSql) {
+      clauses.push(scopeSql);
+      params.push(...scopeParams);
     }
+
+    let sql = `SELECT ${SELECT_COLS} FROM handoffs`;
+    if (clauses.length > 0) sql += ` WHERE ${clauses.join(" AND ")}`;
     sql += " ORDER BY created_at ASC";
     if (query?.limit !== undefined) {
       sql += " LIMIT ?";
@@ -184,22 +228,20 @@ export class SqliteHandoffStore implements HandoffStore {
   }
 
   // All transitions below are implemented as single conditional UPDATEs
-  // with status guards in the WHERE clause. This closes the read-then-write
-  // TOCTOU window against concurrent expireStale / markReplied / etc: if
-  // the state changed between our check and write, result.changes === 0
-  // and we surface the right error (not-found vs invalid-transition).
+  // with status + session_id guards in the WHERE clause. Closes TOCTOU
+  // against concurrent expireStale / markReplied AND prevents a process
+  // scoped to session A from mutating session B's rows.
 
   async markDelivered(id: string): Promise<void> {
-    // Valid transition: pending_pickup → delivered
+    const { sql: scopeSql, params: scopeParams } = this.scopeClause();
+    const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
     const result = this.db
       .prepare(
         `UPDATE handoffs SET status = ?
-         WHERE handoff_id = ? AND status = ?`,
+         WHERE handoff_id = ? AND status = ?${scopeExtra}`,
       )
-      .run(HandoffStatus.Delivered, id, HandoffStatus.PendingPickup);
+      .run(HandoffStatus.Delivered, id, HandoffStatus.PendingPickup, ...scopeParams);
     if (result.changes === 0) {
-      // Either the handoff doesn't exist or it's in a status from which
-      // delivered is invalid (replied/expired). Disambiguate via a get().
       const current = await this.get(id);
       if (current === undefined) {
         throw new NotFoundError({ resource: "Handoff", identifier: id });
@@ -207,22 +249,19 @@ export class SqliteHandoffStore implements HandoffStore {
       if (current.status !== HandoffStatus.Delivered) {
         validateTransition(id, current.status, HandoffStatus.Delivered);
       }
-      // Already delivered — treat as idempotent no-op
+      // Already delivered — idempotent no-op
     }
   }
 
   async markReplied(id: string, resolvedByCid: string): Promise<void> {
     const now = new Date().toISOString();
-    // Valid transitions: pending_pickup → replied, delivered → replied.
-    // Reject late replies in-database: the WHERE clause rejects rows whose
-    // reply_due_at is in the past, closing the SLA loophole even when a
-    // background DeadlineWatcher has not yet flipped status to expired.
-    // This makes correctness independent of the watcher being present.
+    const { sql: scopeSql, params: scopeParams } = this.scopeClause();
+    const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
     const result = this.db
       .prepare(
         `UPDATE handoffs SET status = ?, resolved_by_cid = ?
          WHERE handoff_id = ? AND status IN (?, ?)
-           AND (reply_due_at IS NULL OR reply_due_at >= ?)`,
+           AND (reply_due_at IS NULL OR reply_due_at >= ?)${scopeExtra}`,
       )
       .run(
         HandoffStatus.Replied,
@@ -231,31 +270,30 @@ export class SqliteHandoffStore implements HandoffStore {
         HandoffStatus.PendingPickup,
         HandoffStatus.Delivered,
         now,
+        ...scopeParams,
       );
     if (result.changes === 0) {
       const current = await this.get(id);
       if (current === undefined) {
         throw new NotFoundError({ resource: "Handoff", identifier: id });
       }
-      // Distinguish "already replied/expired" (invalid transition) from
-      // "deadline passed" (SLA breach). Both deny the update, but the
-      // caller may want to log them differently.
       if (
         (current.status === HandoffStatus.PendingPickup ||
           current.status === HandoffStatus.Delivered) &&
         current.replyDueAt !== undefined &&
         current.replyDueAt < now
       ) {
-        // Flip to expired so a subsequent expireStale() sees consistent state
         this.db
           .prepare(
-            `UPDATE handoffs SET status = ? WHERE handoff_id = ? AND status IN (?, ?)`,
+            `UPDATE handoffs SET status = ?
+             WHERE handoff_id = ? AND status IN (?, ?)${scopeExtra}`,
           )
           .run(
             HandoffStatus.Expired,
             id,
             HandoffStatus.PendingPickup,
             HandoffStatus.Delivered,
+            ...scopeParams,
           );
         throw new StateConflictError({
           resource: "Handoff",
@@ -267,63 +305,79 @@ export class SqliteHandoffStore implements HandoffStore {
   }
 
   async markSeen(id: string): Promise<void> {
-    // Only stamp seenAt if not already set. Conditional WHERE prevents
-    // concurrent callers from each writing a different timestamp.
+    const { sql: scopeSql, params: scopeParams } = this.scopeClause();
+    const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
     const result = this.db
       .prepare(
         `UPDATE handoffs SET seen_at = ?
-         WHERE handoff_id = ? AND seen_at IS NULL`,
+         WHERE handoff_id = ? AND seen_at IS NULL${scopeExtra}`,
       )
-      .run(new Date().toISOString(), id);
+      .run(new Date().toISOString(), id, ...scopeParams);
     if (result.changes === 0) {
-      // Either the handoff doesn't exist, or seenAt was already set (idempotent)
       const current = await this.get(id);
       if (current === undefined) {
         throw new NotFoundError({ resource: "Handoff", identifier: id });
       }
-      // Already seen — no-op
+      // Already seen — idempotent no-op
     }
   }
 
   async markAcked(id: string): Promise<void> {
-    // Single conditional UPDATE that atomically stamps ackedAt (and seenAt
-    // if unset) only when ackedAt is currently NULL. Uses COALESCE so
-    // seenAt preserves its existing value, or fills with now() if null.
     const now = new Date().toISOString();
+    const { sql: scopeSql, params: scopeParams } = this.scopeClause();
+    const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
     const result = this.db
       .prepare(
         `UPDATE handoffs
          SET acked_at = ?, seen_at = COALESCE(seen_at, ?)
-         WHERE handoff_id = ? AND acked_at IS NULL`,
+         WHERE handoff_id = ? AND acked_at IS NULL${scopeExtra}`,
       )
-      .run(now, now, id);
+      .run(now, now, id, ...scopeParams);
     if (result.changes === 0) {
       const current = await this.get(id);
       if (current === undefined) {
         throw new NotFoundError({ resource: "Handoff", identifier: id });
       }
-      // Already acked — no-op
+      // Already acked — idempotent no-op
     }
   }
 
-  // Deliberately NOT implementing listForCurrentSession() / isInCurrentSession()
-  // on SQLite. The handoffs table has no session_id column, so any attempt
-  // to answer "is this in my session?" would have to return a conservative
-  // false — which callers (grove_ack_handoff, DeadlineWatcher.rebuildFromStore)
-  // already handle as "this backend doesn't support session scoping, skip the
-  // feature". Leaving these methods undefined is the explicit opt-out signal.
-  //
-  // When session scoping is added to the SQLite schema, implement both here.
+  /**
+   * Session-scoped enumeration. Only defined in scoped mode — unscoped
+   * stores have this property set to undefined in the constructor so
+   * callers correctly detect the capability is unavailable.
+   */
+  async listForCurrentSession(query?: HandoffQuery): Promise<readonly Handoff[]> {
+    // In scoped mode, list() is already scoped by session — just delegate.
+    return this.list(query);
+  }
+
+  /**
+   * O(1) session ownership check. Only defined in scoped mode. Returns
+   * true iff the row exists AND belongs to the caller's session.
+   */
+  async isInCurrentSession(handoffId: string): Promise<boolean> {
+    if (this.sessionId === undefined) return false;
+    const row = this.db
+      .prepare("SELECT 1 FROM handoffs WHERE handoff_id = ? AND session_id = ?")
+      .get(handoffId, this.sessionId);
+    return row !== null;
+  }
 
   async expireStale(now?: string): Promise<readonly Handoff[]> {
     const cutoff = now ?? new Date().toISOString();
-    // Expire both pending_pickup AND delivered unresolved handoffs with past
-    // deadlines. RETURNING ensures idempotency (only newly-transitioned rows).
+    // Expire both pending_pickup AND delivered unresolved handoffs with
+    // past deadlines. Scoped by session so session A's watcher cannot
+    // flip session B's rows. RETURNING ensures idempotency (only newly-
+    // transitioned rows).
+    const { sql: scopeSql, params: scopeParams } = this.scopeClause();
+    const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
     const rows = this.db
       .prepare(
         `UPDATE handoffs
          SET status = ?
-         WHERE status IN (?, ?) AND reply_due_at IS NOT NULL AND reply_due_at < ?
+         WHERE status IN (?, ?)
+           AND reply_due_at IS NOT NULL AND reply_due_at < ?${scopeExtra}
          RETURNING ${SELECT_COLS}`,
       )
       .all(
@@ -331,14 +385,20 @@ export class SqliteHandoffStore implements HandoffStore {
         HandoffStatus.PendingPickup,
         HandoffStatus.Delivered,
         cutoff,
+        ...scopeParams,
       ) as readonly HandoffRow[];
     return rows.map(rowToHandoff);
   }
 
   async countPending(toRole: string): Promise<number> {
+    const { sql: scopeSql, params: scopeParams } = this.scopeClause();
+    const scopeExtra = scopeSql ? ` AND ${scopeSql}` : "";
     const row = this.db
-      .prepare("SELECT COUNT(*) as count FROM handoffs WHERE to_role = ? AND status = ?")
-      .get(toRole, HandoffStatus.PendingPickup) as { count: number } | null;
+      .prepare(
+        `SELECT COUNT(*) as count FROM handoffs
+         WHERE to_role = ? AND status = ?${scopeExtra}`,
+      )
+      .get(toRole, HandoffStatus.PendingPickup, ...scopeParams) as { count: number } | null;
     return row?.count ?? 0;
   }
 

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -222,16 +222,21 @@ export class SqliteHandoffStore implements HandoffStore {
 
   async expireStale(now?: string): Promise<readonly Handoff[]> {
     const cutoff = now ?? new Date().toISOString();
-    // Use RETURNING to get only the rows that were actually transitioned
-    // (not rows that were already expired from a previous call).
+    // Expire both pending_pickup AND delivered unresolved handoffs with past
+    // deadlines. RETURNING ensures idempotency (only newly-transitioned rows).
     const rows = this.db
       .prepare(
         `UPDATE handoffs
          SET status = ?
-         WHERE status = ? AND reply_due_at IS NOT NULL AND reply_due_at < ?
+         WHERE status IN (?, ?) AND reply_due_at IS NOT NULL AND reply_due_at < ?
          RETURNING ${SELECT_COLS}`,
       )
-      .all(HandoffStatus.Expired, HandoffStatus.PendingPickup, cutoff) as readonly HandoffRow[];
+      .all(
+        HandoffStatus.Expired,
+        HandoffStatus.PendingPickup,
+        HandoffStatus.Delivered,
+        cutoff,
+      ) as readonly HandoffRow[];
     return rows.map(rowToHandoff);
   }
 

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -354,13 +354,7 @@ export class SqliteHandoffStore implements HandoffStore {
         `UPDATE handoffs SET status = ?${claimSet}
          WHERE handoff_id = ? AND status = ?${scopeExtra}`,
       )
-      .run(
-        HandoffStatus.Processed,
-        ...claimParams,
-        id,
-        HandoffStatus.Delivered,
-        ...scopeParams,
-      );
+      .run(HandoffStatus.Processed, ...claimParams, id, HandoffStatus.Delivered, ...scopeParams);
     if (result.changes === 0) {
       const current = await this.get(id);
       if (current === undefined) {
@@ -491,7 +485,6 @@ export class SqliteHandoffStore implements HandoffStore {
       .get(handoffId, this.sessionId);
     return row !== null;
   }
-
 
   async expireStale(now?: string): Promise<readonly Handoff[]> {
     const cutoff = now ?? new Date().toISOString();

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -132,10 +132,17 @@ export class SqliteHandoffStore implements HandoffStore {
   /**
    * Return a WHERE fragment + params that restrict queries to the current
    * session. Returns empty when the store is unscoped (legacy mode).
+   *
+   * Scoped queries match BOTH `session_id = ?` AND `session_id IS NULL`:
+   * the null branch is a migration shim for rows created before the
+   * session_id column existed. Without it, in-flight handoffs from a
+   * pre-#164 process would become invisible after upgrade and strand
+   * the coder→reviewer loop. Rows written by a scoped store always
+   * have a non-null session_id, so this only affects legacy data.
    */
   private scopeClause(): { sql: string; params: readonly string[] } {
     if (this.sessionId === undefined) return { sql: "", params: [] };
-    return { sql: "session_id = ?", params: [this.sessionId] };
+    return { sql: "(session_id = ? OR session_id IS NULL)", params: [this.sessionId] };
   }
 
   async create(input: HandoffInput): Promise<Handoff> {

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -306,21 +306,14 @@ export class SqliteHandoffStore implements HandoffStore {
     }
   }
 
-  /**
-   * Session-scoped enumeration for deadline rebuild.
-   *
-   * SQLite has no `session_id` column on the handoffs table, so we cannot
-   * attribute rows to a session. Returning list() here would re-arm timers
-   * for unrelated sessions on restart — exactly the leak this method was
-   * introduced to prevent. Return an empty array to disable rebuild on
-   * SQLite until proper session scoping is added to the schema.
-   *
-   * New handoffs still get timers via DeadlineWatcher.watch() on creation.
-   * The only impact: mid-process restarts won't re-arm existing deadlines.
-   */
-  async listForCurrentSession(_query?: HandoffQuery): Promise<readonly Handoff[]> {
-    return [];
-  }
+  // Deliberately NOT implementing listForCurrentSession() / isInCurrentSession()
+  // on SQLite. The handoffs table has no session_id column, so any attempt
+  // to answer "is this in my session?" would have to return a conservative
+  // false — which callers (grove_ack_handoff, DeadlineWatcher.rebuildFromStore)
+  // already handle as "this backend doesn't support session scoping, skip the
+  // feature". Leaving these methods undefined is the explicit opt-out signal.
+  //
+  // When session scoping is added to the SQLite schema, implement both here.
 
   async expireStale(now?: string): Promise<readonly Handoff[]> {
     const cutoff = now ?? new Date().toISOString();

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -166,58 +166,108 @@ export class SqliteHandoffStore implements HandoffStore {
     return rows.map(rowToHandoff);
   }
 
+  // All transitions below are implemented as single conditional UPDATEs
+  // with status guards in the WHERE clause. This closes the read-then-write
+  // TOCTOU window against concurrent expireStale / markReplied / etc: if
+  // the state changed between our check and write, result.changes === 0
+  // and we surface the right error (not-found vs invalid-transition).
+
   async markDelivered(id: string): Promise<void> {
-    const handoff = await this.get(id);
-    if (handoff === undefined) {
-      throw new NotFoundError({ resource: "Handoff", identifier: id });
+    // Valid transition: pending_pickup → delivered
+    const result = this.db
+      .prepare(
+        `UPDATE handoffs SET status = ?
+         WHERE handoff_id = ? AND status = ?`,
+      )
+      .run(HandoffStatus.Delivered, id, HandoffStatus.PendingPickup);
+    if (result.changes === 0) {
+      // Either the handoff doesn't exist or it's in a status from which
+      // delivered is invalid (replied/expired). Disambiguate via a get().
+      const current = await this.get(id);
+      if (current === undefined) {
+        throw new NotFoundError({ resource: "Handoff", identifier: id });
+      }
+      if (current.status !== HandoffStatus.Delivered) {
+        validateTransition(id, current.status, HandoffStatus.Delivered);
+      }
+      // Already delivered — treat as idempotent no-op
     }
-    validateTransition(id, handoff.status, HandoffStatus.Delivered);
-    this.db
-      .prepare("UPDATE handoffs SET status = ? WHERE handoff_id = ?")
-      .run(HandoffStatus.Delivered, id);
   }
 
   async markReplied(id: string, resolvedByCid: string): Promise<void> {
-    const handoff = await this.get(id);
-    if (handoff === undefined) {
-      throw new NotFoundError({ resource: "Handoff", identifier: id });
+    // Valid transitions: pending_pickup → replied, delivered → replied
+    const result = this.db
+      .prepare(
+        `UPDATE handoffs SET status = ?, resolved_by_cid = ?
+         WHERE handoff_id = ? AND status IN (?, ?)`,
+      )
+      .run(
+        HandoffStatus.Replied,
+        resolvedByCid,
+        id,
+        HandoffStatus.PendingPickup,
+        HandoffStatus.Delivered,
+      );
+    if (result.changes === 0) {
+      const current = await this.get(id);
+      if (current === undefined) {
+        throw new NotFoundError({ resource: "Handoff", identifier: id });
+      }
+      validateTransition(id, current.status, HandoffStatus.Replied);
     }
-    validateTransition(id, handoff.status, HandoffStatus.Replied);
-    this.db
-      .prepare("UPDATE handoffs SET status = ?, resolved_by_cid = ? WHERE handoff_id = ?")
-      .run(HandoffStatus.Replied, resolvedByCid, id);
   }
 
   async markSeen(id: string): Promise<void> {
-    const handoff = await this.get(id);
-    if (handoff === undefined) {
-      throw new NotFoundError({ resource: "Handoff", identifier: id });
-    }
-    // No-op if already seen
-    if (handoff.seenAt !== undefined) return;
-    this.db
-      .prepare("UPDATE handoffs SET seen_at = ? WHERE handoff_id = ?")
+    // Only stamp seenAt if not already set. Conditional WHERE prevents
+    // concurrent callers from each writing a different timestamp.
+    const result = this.db
+      .prepare(
+        `UPDATE handoffs SET seen_at = ?
+         WHERE handoff_id = ? AND seen_at IS NULL`,
+      )
       .run(new Date().toISOString(), id);
+    if (result.changes === 0) {
+      // Either the handoff doesn't exist, or seenAt was already set (idempotent)
+      const current = await this.get(id);
+      if (current === undefined) {
+        throw new NotFoundError({ resource: "Handoff", identifier: id });
+      }
+      // Already seen — no-op
+    }
   }
 
   async markAcked(id: string): Promise<void> {
-    const handoff = await this.get(id);
-    if (handoff === undefined) {
-      throw new NotFoundError({ resource: "Handoff", identifier: id });
-    }
-    // No-op if already acked
-    if (handoff.ackedAt !== undefined) return;
+    // Single conditional UPDATE that atomically stamps ackedAt (and seenAt
+    // if unset) only when ackedAt is currently NULL. Uses COALESCE so
+    // seenAt preserves its existing value, or fills with now() if null.
     const now = new Date().toISOString();
-    // Auto-fill seenAt if not already set
-    if (handoff.seenAt === undefined) {
-      this.db
-        .prepare("UPDATE handoffs SET seen_at = ?, acked_at = ? WHERE handoff_id = ?")
-        .run(now, now, id);
-    } else {
-      this.db
-        .prepare("UPDATE handoffs SET acked_at = ? WHERE handoff_id = ?")
-        .run(now, id);
+    const result = this.db
+      .prepare(
+        `UPDATE handoffs
+         SET acked_at = ?, seen_at = COALESCE(seen_at, ?)
+         WHERE handoff_id = ? AND acked_at IS NULL`,
+      )
+      .run(now, now, id);
+    if (result.changes === 0) {
+      const current = await this.get(id);
+      if (current === undefined) {
+        throw new NotFoundError({ resource: "Handoff", identifier: id });
+      }
+      // Already acked — no-op
     }
+  }
+
+  /**
+   * Session-scoped enumeration for deadline rebuild.
+   *
+   * SQLite stores have no session_id column today — this contract relies
+   * on the caller opening ONE SqliteHandoffStore per session database.
+   * That is how grove currently runs (one .grove/grove.db per worktree,
+   * one active session at a time). If multi-session-per-DB is added later,
+   * a session_id column must be introduced and this method updated.
+   */
+  async listForCurrentSession(query?: HandoffQuery): Promise<readonly Handoff[]> {
+    return this.list(query);
   }
 
   async expireStale(now?: string): Promise<readonly Handoff[]> {

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -70,14 +70,31 @@ export class SqliteHandoffStore implements HandoffStore {
   constructor(db: Database) {
     this.db = db;
     // Column-safe migration: add seen_at/acked_at if missing (pre-#164 databases).
+    //
+    // This runs outside the serialized initSqliteDb transaction, so two
+    // concurrent processes upgrading the same DB can both see the missing
+    // column and race on ALTER TABLE. Catch "duplicate column" errors and
+    // treat them as success — the column exists either way after the race.
     const columns = (
       this.db.prepare("PRAGMA table_info(handoffs)").all() as readonly { name: string }[]
     ).map((c) => c.name);
     if (!columns.includes("seen_at")) {
-      this.db.run("ALTER TABLE handoffs ADD COLUMN seen_at TEXT");
+      this.safeAddColumn("seen_at");
     }
     if (!columns.includes("acked_at")) {
-      this.db.run("ALTER TABLE handoffs ADD COLUMN acked_at TEXT");
+      this.safeAddColumn("acked_at");
+    }
+  }
+
+  private safeAddColumn(column: string): void {
+    try {
+      this.db.run(`ALTER TABLE handoffs ADD COLUMN ${column} TEXT`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // "duplicate column name" — another process added it between our
+      // PRAGMA check and this ALTER. That's expected during concurrent
+      // upgrades; the column exists now either way.
+      if (!/duplicate column/i.test(msg)) throw err;
     }
   }
 

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -436,12 +436,20 @@ export class SqliteHandoffStore implements HandoffStore {
 
   /**
    * O(1) session ownership check. Only defined in scoped mode. Returns
-   * true iff the row exists AND belongs to the caller's session.
+   * true iff the row exists AND (belongs to the caller's session OR is
+   * a legacy NULL-session row from a pre-#164 upgrade).
+   *
+   * Mirrors the migration shim in scopeClause(): without this, a legacy
+   * row would show up in list() but then be rejected by the receipt
+   * tools' session ownership check, stranding the handoff.
    */
   async isInCurrentSession(handoffId: string): Promise<boolean> {
     if (this.sessionId === undefined) return false;
     const row = this.db
-      .prepare("SELECT 1 FROM handoffs WHERE handoff_id = ? AND session_id = ?")
+      .prepare(
+        `SELECT 1 FROM handoffs
+         WHERE handoff_id = ? AND (session_id = ? OR session_id IS NULL)`,
+      )
       .get(handoffId, this.sessionId);
     return row !== null;
   }

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -292,14 +292,17 @@ export class SqliteHandoffStore implements HandoffStore {
   /**
    * Session-scoped enumeration for deadline rebuild.
    *
-   * SQLite stores have no session_id column today — this contract relies
-   * on the caller opening ONE SqliteHandoffStore per session database.
-   * That is how grove currently runs (one .grove/grove.db per worktree,
-   * one active session at a time). If multi-session-per-DB is added later,
-   * a session_id column must be introduced and this method updated.
+   * SQLite has no `session_id` column on the handoffs table, so we cannot
+   * attribute rows to a session. Returning list() here would re-arm timers
+   * for unrelated sessions on restart — exactly the leak this method was
+   * introduced to prevent. Return an empty array to disable rebuild on
+   * SQLite until proper session scoping is added to the schema.
+   *
+   * New handoffs still get timers via DeadlineWatcher.watch() on creation.
+   * The only impact: mid-process restarts won't re-arm existing deadlines.
    */
-  async listForCurrentSession(query?: HandoffQuery): Promise<readonly Handoff[]> {
-    return this.list(query);
+  async listForCurrentSession(_query?: HandoffQuery): Promise<readonly Handoff[]> {
+    return [];
   }
 
   async expireStale(now?: string): Promise<readonly Handoff[]> {

--- a/src/local/sqlite-handoff-store.ts
+++ b/src/local/sqlite-handoff-store.ts
@@ -6,6 +6,7 @@ import {
   type HandoffQuery,
   HandoffStatus,
   type HandoffStore,
+  validateTransition,
 } from "../core/handoff.js";
 
 export const HANDOFF_DDL = `
@@ -18,6 +19,8 @@ export const HANDOFF_DDL = `
     requires_reply INTEGER NOT NULL DEFAULT 0,
     reply_due_at TEXT,
     resolved_by_cid TEXT,
+    seen_at TEXT,
+    acked_at TEXT,
     created_at TEXT NOT NULL
   );
 
@@ -37,6 +40,8 @@ interface HandoffRow {
   readonly requires_reply: number;
   readonly reply_due_at: string | null;
   readonly resolved_by_cid: string | null;
+  readonly seen_at: string | null;
+  readonly acked_at: string | null;
   readonly created_at: string;
 }
 
@@ -50,15 +55,30 @@ function rowToHandoff(row: HandoffRow): Handoff {
     requiresReply: row.requires_reply !== 0,
     ...(row.reply_due_at !== null ? { replyDueAt: row.reply_due_at } : {}),
     ...(row.resolved_by_cid !== null ? { resolvedByCid: row.resolved_by_cid } : {}),
+    ...(row.seen_at !== null ? { seenAt: row.seen_at } : {}),
+    ...(row.acked_at !== null ? { ackedAt: row.acked_at } : {}),
     createdAt: row.created_at,
   };
 }
+
+const SELECT_COLS = `handoff_id, source_cid, from_role, to_role, status,
+                requires_reply, reply_due_at, resolved_by_cid, seen_at, acked_at, created_at`;
 
 export class SqliteHandoffStore implements HandoffStore {
   private readonly db: Database;
 
   constructor(db: Database) {
     this.db = db;
+    // Column-safe migration: add seen_at/acked_at if missing (pre-#164 databases).
+    const columns = (
+      this.db.prepare("PRAGMA table_info(handoffs)").all() as readonly { name: string }[]
+    ).map((c) => c.name);
+    if (!columns.includes("seen_at")) {
+      this.db.run("ALTER TABLE handoffs ADD COLUMN seen_at TEXT");
+    }
+    if (!columns.includes("acked_at")) {
+      this.db.run("ALTER TABLE handoffs ADD COLUMN acked_at TEXT");
+    }
   }
 
   async create(input: HandoffInput): Promise<Handoff> {
@@ -84,8 +104,8 @@ export class SqliteHandoffStore implements HandoffStore {
       .prepare(
         `INSERT INTO handoffs (
           handoff_id, source_cid, from_role, to_role, status,
-          requires_reply, reply_due_at, resolved_by_cid, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          requires_reply, reply_due_at, resolved_by_cid, seen_at, acked_at, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         handoffId,
@@ -96,6 +116,8 @@ export class SqliteHandoffStore implements HandoffStore {
         input.requiresReply ? 1 : 0,
         input.replyDueAt ?? null,
         null,
+        null,
+        null,
         new Date().toISOString(),
       );
     return handoffId;
@@ -103,12 +125,7 @@ export class SqliteHandoffStore implements HandoffStore {
 
   async get(id: string): Promise<Handoff | undefined> {
     const row = this.db
-      .prepare(
-        `SELECT handoff_id, source_cid, from_role, to_role, status,
-                requires_reply, reply_due_at, resolved_by_cid, created_at
-         FROM handoffs
-         WHERE handoff_id = ?`,
-      )
+      .prepare(`SELECT ${SELECT_COLS} FROM handoffs WHERE handoff_id = ?`)
       .get(id) as HandoffRow | null;
     return row === null ? undefined : rowToHandoff(row);
   }
@@ -135,9 +152,7 @@ export class SqliteHandoffStore implements HandoffStore {
       params.push(...statuses);
     }
 
-    let sql = `SELECT handoff_id, source_cid, from_role, to_role, status,
-                      requires_reply, reply_due_at, resolved_by_cid, created_at
-               FROM handoffs`;
+    let sql = `SELECT ${SELECT_COLS} FROM handoffs`;
     if (clauses.length > 0) {
       sql += ` WHERE ${clauses.join(" AND ")}`;
     }
@@ -152,42 +167,71 @@ export class SqliteHandoffStore implements HandoffStore {
   }
 
   async markDelivered(id: string): Promise<void> {
-    const result = this.db
-      .prepare("UPDATE handoffs SET status = ? WHERE handoff_id = ?")
-      .run(HandoffStatus.Delivered, id);
-    if (result.changes === 0) {
+    const handoff = await this.get(id);
+    if (handoff === undefined) {
       throw new NotFoundError({ resource: "Handoff", identifier: id });
     }
+    validateTransition(id, handoff.status, HandoffStatus.Delivered);
+    this.db
+      .prepare("UPDATE handoffs SET status = ? WHERE handoff_id = ?")
+      .run(HandoffStatus.Delivered, id);
   }
 
   async markReplied(id: string, resolvedByCid: string): Promise<void> {
-    const result = this.db
+    const handoff = await this.get(id);
+    if (handoff === undefined) {
+      throw new NotFoundError({ resource: "Handoff", identifier: id });
+    }
+    validateTransition(id, handoff.status, HandoffStatus.Replied);
+    this.db
       .prepare("UPDATE handoffs SET status = ?, resolved_by_cid = ? WHERE handoff_id = ?")
       .run(HandoffStatus.Replied, resolvedByCid, id);
-    if (result.changes === 0) {
+  }
+
+  async markSeen(id: string): Promise<void> {
+    const handoff = await this.get(id);
+    if (handoff === undefined) {
       throw new NotFoundError({ resource: "Handoff", identifier: id });
+    }
+    // No-op if already seen
+    if (handoff.seenAt !== undefined) return;
+    this.db
+      .prepare("UPDATE handoffs SET seen_at = ? WHERE handoff_id = ?")
+      .run(new Date().toISOString(), id);
+  }
+
+  async markAcked(id: string): Promise<void> {
+    const handoff = await this.get(id);
+    if (handoff === undefined) {
+      throw new NotFoundError({ resource: "Handoff", identifier: id });
+    }
+    // No-op if already acked
+    if (handoff.ackedAt !== undefined) return;
+    const now = new Date().toISOString();
+    // Auto-fill seenAt if not already set
+    if (handoff.seenAt === undefined) {
+      this.db
+        .prepare("UPDATE handoffs SET seen_at = ?, acked_at = ? WHERE handoff_id = ?")
+        .run(now, now, id);
+    } else {
+      this.db
+        .prepare("UPDATE handoffs SET acked_at = ? WHERE handoff_id = ?")
+        .run(now, id);
     }
   }
 
   async expireStale(now?: string): Promise<readonly Handoff[]> {
     const cutoff = now ?? new Date().toISOString();
-    this.db
+    // Use RETURNING to get only the rows that were actually transitioned
+    // (not rows that were already expired from a previous call).
+    const rows = this.db
       .prepare(
         `UPDATE handoffs
          SET status = ?
-         WHERE status = ? AND reply_due_at IS NOT NULL AND reply_due_at < ?`,
-      )
-      .run(HandoffStatus.Expired, HandoffStatus.PendingPickup, cutoff);
-
-    const rows = this.db
-      .prepare(
-        `SELECT handoff_id, source_cid, from_role, to_role, status,
-                requires_reply, reply_due_at, resolved_by_cid, created_at
-         FROM handoffs
          WHERE status = ? AND reply_due_at IS NOT NULL AND reply_due_at < ?
-         ORDER BY created_at ASC`,
+         RETURNING ${SELECT_COLS}`,
       )
-      .all(HandoffStatus.Expired, cutoff) as readonly HandoffRow[];
+      .all(HandoffStatus.Expired, HandoffStatus.PendingPickup, cutoff) as readonly HandoffRow[];
     return rows.map(rowToHandoff);
   }
 

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -518,8 +518,15 @@ export class SqliteIdempotencyStore {
 /**
  * Convenience factory that creates a shared Database and returns both stores.
  * The returned close() disposes the database connection.
+ *
+ * Pass `sessionId` to get a session-scoped handoff store. When set, all
+ * handoff reads/writes/mutations filter by session_id, enabling proactive
+ * deadline timers and ack receipts without cross-session corruption.
  */
-export function createSqliteStores(dbPath: string): {
+export function createSqliteStores(
+  dbPath: string,
+  opts?: { readonly sessionId?: string | undefined },
+): {
   db: Database;
   contributionStore: SqliteContributionStore;
   claimStore: SqliteClaimStore;
@@ -538,7 +545,7 @@ export function createSqliteStores(dbPath: string): {
     bountyStore: new SqliteBountyStore(db),
     outcomeStore: new SqliteOutcomeStore(db),
     goalSessionStore: new SqliteGoalSessionStore(db),
-    handoffStore: new SqliteHandoffStore(db),
+    handoffStore: new SqliteHandoffStore(db, opts?.sessionId),
     idempotencyStore: new SqliteIdempotencyStore(db),
     close: () => {
       db.run("PRAGMA optimize");

--- a/src/mcp/deps.ts
+++ b/src/mcp/deps.ts
@@ -11,6 +11,7 @@
 import type { BountyStore } from "../core/bounty-store.js";
 import type { GroveContract } from "../core/contract.js";
 import type { CreditsService } from "../core/credits.js";
+import type { DeadlineWatcher } from "../core/deadline-watcher.js";
 import type { EventBus } from "../core/event-bus.js";
 import type { HandoffStore } from "../core/handoff.js";
 import type { TopologyRouter } from "../core/topology-router.js";
@@ -40,4 +41,6 @@ export interface McpDeps extends ServerDeps {
    * Typically the project root containing the .grove/ directory.
    */
   readonly workspaceBoundary: string;
+  /** Optional deadline watcher for proactive overdue detection. */
+  readonly deadlineWatcher?: DeadlineWatcher | undefined;
 }

--- a/src/mcp/error-handler.ts
+++ b/src/mcp/error-handler.ts
@@ -18,6 +18,7 @@ import {
   RetryExhaustedError,
   StateConflictError,
 } from "../core/errors.js";
+import { InvalidTransitionError } from "../core/handoff.js";
 
 /** Error codes returned to MCP clients for programmatic handling. */
 export const McpErrorCode = {
@@ -29,6 +30,7 @@ export const McpErrorCode = {
   LeaseViolation: "LEASE_VIOLATION",
   NotFound: "NOT_FOUND",
   StateConflict: "STATE_CONFLICT",
+  InvalidState: "INVALID_STATE",
   PolicyViolation: "POLICY_VIOLATION",
   ValidationError: "VALIDATION_ERROR",
   InternalError: "INTERNAL_ERROR",
@@ -97,6 +99,10 @@ export function handleToolError(error: unknown): CallToolResult {
 
   if (error instanceof StateConflictError) {
     return toolError(McpErrorCode.StateConflict, error.message);
+  }
+
+  if (error instanceof InvalidTransitionError) {
+    return toolError(McpErrorCode.InvalidState, error.message);
   }
 
   if (error instanceof GroveError) {

--- a/src/mcp/operation-adapter.ts
+++ b/src/mcp/operation-adapter.ts
@@ -40,6 +40,7 @@ export function toOperationDeps(deps: McpDeps): OperationDeps {
     ...(deps.topologyRouter !== undefined ? { topologyRouter: deps.topologyRouter } : {}),
     ...(deps.handoffStore !== undefined ? { handoffStore: deps.handoffStore } : {}),
     ...(deps.idempotencyStore !== undefined ? { idempotencyStore: deps.idempotencyStore } : {}),
+    ...(deps.deadlineWatcher !== undefined ? { deadlineWatcher: deps.deadlineWatcher } : {}),
   };
 }
 

--- a/src/mcp/serve-http.ts
+++ b/src/mcp/serve-http.ts
@@ -316,13 +316,14 @@ async function buildScopedDeps(sessionId: string | undefined): Promise<ScopedDep
     topologyRouter = new TopologyRouter(loadedContract.topology, eventBus);
   }
 
-  // Wire DeadlineWatcher for proactive overdue detection when both
-  // a handoff store and event bus are available.
+  // Wire DeadlineWatcher only for session-scoped stores (Nexus). See
+  // serve.ts for the rationale: SQLite handoffs aren't session-scoped so
+  // cross-session timer bleeding is possible; gate it off here too.
   let deadlineWatcher: import("../core/deadline-watcher.js").DeadlineWatcher | undefined;
   const activeHandoffStore = nexusHandoffStore ?? runtime.handoffStore;
-  if (activeHandoffStore !== undefined && eventBus !== undefined) {
+  if (nexusHandoffStore !== undefined && eventBus !== undefined) {
     const { DeadlineWatcher } = await import("../core/deadline-watcher.js");
-    deadlineWatcher = new DeadlineWatcher({ handoffStore: activeHandoffStore, eventBus });
+    deadlineWatcher = new DeadlineWatcher({ handoffStore: nexusHandoffStore, eventBus });
     void deadlineWatcher.rebuildFromStore().catch(() => {
       /* non-fatal */
     });

--- a/src/mcp/serve-http.ts
+++ b/src/mcp/serve-http.ts
@@ -357,12 +357,30 @@ async function buildScopedDeps(sessionId: string | undefined): Promise<ScopedDep
     topologyRouter = new TopologyRouter(loadedContract.topology, eventBus);
   }
 
+  // Build a session-scoped handoff store per request. In Nexus mode, use the
+  // already-scoped nexusHandoffStore. In local mode, construct a fresh
+  // SqliteHandoffStore bound to THIS request's session ID (not the process-
+  // global runtime.handoffStore, which was created at startup before any
+  // session existed and would reuse unscoped mode). Without this, local
+  // HTTP callers would silently bypass session isolation, grove_ack_handoff
+  // would be omitted (isInCurrentSession undefined), and deadline rebuild
+  // would skip.
+  let activeHandoffStore: import("../core/handoff.js").HandoffStore | undefined;
+  if (nexusHandoffStore !== undefined) {
+    activeHandoffStore = nexusHandoffStore;
+  } else if (sessionId !== undefined) {
+    const { SqliteHandoffStore } = await import("../local/sqlite-handoff-store.js");
+    activeHandoffStore = new SqliteHandoffStore(runtime.db, sessionId);
+  } else {
+    // Bootstrap/pre-session: no session to scope to — fall back to unscoped
+    activeHandoffStore = runtime.handoffStore;
+  }
+
   // Wire DeadlineWatcher when any handoff store + event bus are available.
   // Both Nexus and session-scoped SQLite (GROVE_SESSION_ID set) safely
   // support it; unscoped SQLite stores leave listForCurrentSession undefined
   // so rebuildFromStore skips automatically. See serve.ts for more context.
   let deadlineWatcher: import("../core/deadline-watcher.js").DeadlineWatcher | undefined;
-  const activeHandoffStore = nexusHandoffStore ?? runtime.handoffStore;
   if (activeHandoffStore !== undefined && eventBus !== undefined) {
     const { DeadlineWatcher } = await import("../core/deadline-watcher.js");
     deadlineWatcher = new DeadlineWatcher({ handoffStore: activeHandoffStore, eventBus });

--- a/src/mcp/serve-http.ts
+++ b/src/mcp/serve-http.ts
@@ -316,14 +316,15 @@ async function buildScopedDeps(sessionId: string | undefined): Promise<ScopedDep
     topologyRouter = new TopologyRouter(loadedContract.topology, eventBus);
   }
 
-  // Wire DeadlineWatcher only for session-scoped stores (Nexus). See
-  // serve.ts for the rationale: SQLite handoffs aren't session-scoped so
-  // cross-session timer bleeding is possible; gate it off here too.
+  // Wire DeadlineWatcher when any handoff store + event bus are available.
+  // Both Nexus and session-scoped SQLite (GROVE_SESSION_ID set) safely
+  // support it; unscoped SQLite stores leave listForCurrentSession undefined
+  // so rebuildFromStore skips automatically. See serve.ts for more context.
   let deadlineWatcher: import("../core/deadline-watcher.js").DeadlineWatcher | undefined;
   const activeHandoffStore = nexusHandoffStore ?? runtime.handoffStore;
-  if (nexusHandoffStore !== undefined && eventBus !== undefined) {
+  if (activeHandoffStore !== undefined && eventBus !== undefined) {
     const { DeadlineWatcher } = await import("../core/deadline-watcher.js");
-    deadlineWatcher = new DeadlineWatcher({ handoffStore: nexusHandoffStore, eventBus });
+    deadlineWatcher = new DeadlineWatcher({ handoffStore: activeHandoffStore, eventBus });
     void deadlineWatcher.rebuildFromStore().catch(() => {
       /* non-fatal */
     });

--- a/src/mcp/serve-http.ts
+++ b/src/mcp/serve-http.ts
@@ -309,6 +309,18 @@ async function buildScopedDeps(sessionId: string | undefined): Promise<ScopedDep
     topologyRouter = new TopologyRouter(loadedContract.topology, eventBus);
   }
 
+  // Wire DeadlineWatcher for proactive overdue detection when both
+  // a handoff store and event bus are available.
+  let deadlineWatcher: import("../core/deadline-watcher.js").DeadlineWatcher | undefined;
+  const activeHandoffStore = nexusHandoffStore ?? runtime.handoffStore;
+  if (activeHandoffStore !== undefined && eventBus !== undefined) {
+    const { DeadlineWatcher } = await import("../core/deadline-watcher.js");
+    deadlineWatcher = new DeadlineWatcher({ handoffStore: activeHandoffStore, eventBus });
+    void deadlineWatcher.rebuildFromStore().catch(() => {
+      /* non-fatal */
+    });
+  }
+
   const deps: McpDeps = {
     contributionStore,
     claimStore,
@@ -324,8 +336,9 @@ async function buildScopedDeps(sessionId: string | undefined): Promise<ScopedDep
     ...(eventBus ? { eventBus } : {}),
     ...(topologyRouter ? { topologyRouter } : {}),
     // Nexus handoff store when available, falls back to local SQLite
-    handoffStore: nexusHandoffStore ?? runtime.handoffStore,
+    handoffStore: activeHandoffStore,
     idempotencyStore: runtime.idempotencyStore,
+    ...(deadlineWatcher ? { deadlineWatcher } : {}),
   };
   return { deps, sessionId };
 }

--- a/src/mcp/serve-http.ts
+++ b/src/mcp/serve-http.ts
@@ -582,7 +582,10 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
     // opted in via GROVE_MCP_EVAL_ENABLED=true. Unauthenticated HTTP exposure
     // of shell execution is a remote-code-execution risk.
     const evalEnabled = AUTH_TOKEN !== undefined && process.env.GROVE_MCP_EVAL_ENABLED === "true";
-    const server = await createMcpServer(scopedDeps, { eval: evalEnabled });
+    const server = await createMcpServer(scopedDeps, {
+      eval: evalEnabled,
+      transport: "http",
+    });
 
     transport.onclose = () => {
       const sid = transport.sessionId;

--- a/src/mcp/serve-http.ts
+++ b/src/mcp/serve-http.ts
@@ -140,6 +140,13 @@ try {
 interface ScopedDeps {
   readonly deps: McpDeps;
   readonly sessionId: string | undefined;
+  /**
+   * Cleanup for scoped per-session resources (DeadlineWatcher timers,
+   * scoped EventBus, etc.). Must be invoked on cache eviction and session
+   * invalidation/reap so timers cannot outlive their session and emit
+   * cross-session overdue events.
+   */
+  readonly close: () => void;
 }
 
 /**
@@ -340,7 +347,12 @@ async function buildScopedDeps(sessionId: string | undefined): Promise<ScopedDep
     idempotencyStore: runtime.idempotencyStore,
     ...(deadlineWatcher ? { deadlineWatcher } : {}),
   };
-  return { deps, sessionId };
+  const close = () => {
+    deadlineWatcher?.close();
+    // eventBus is shared with the TUI/other surfaces for Nexus-backed IPC,
+    // so don't close it here — only per-scope resources.
+  };
+  return { deps, sessionId, close };
 }
 
 async function resolveDeps(): Promise<ScopedDeps> {
@@ -385,6 +397,15 @@ async function resolveDeps(): Promise<ScopedDeps> {
   const cached = depsCache.get(key);
   if (cached) return cached;
   // A new session id invalidates the entire cache so we never mix scopes.
+  // Close each evicted entry's scoped resources (timers, watchers) so
+  // they cannot outlive the session they were bound to.
+  for (const prev of depsCache.values()) {
+    try {
+      prev.close();
+    } catch {
+      // best-effort
+    }
+  }
   depsCache.clear();
   const scoped = await buildScopedDeps(sessionId);
   depsCache.set(key, scoped);

--- a/src/mcp/serve.ts
+++ b/src/mcp/serve.ts
@@ -297,13 +297,16 @@ try {
     deadlineWatcher = new DeadlineWatcher({ handoffStore: activeHandoffStore, eventBus });
     const backend = nexusHandoffStore !== undefined ? "Nexus" : "SQLite";
     process.stderr.write(`grove-mcp: DeadlineWatcher created (${backend} backend)\n`);
-    void deadlineWatcher.rebuildFromStore().then((count) => {
-      if (count > 0) {
-        process.stderr.write(`grove-mcp: DeadlineWatcher rebuilt ${count} timer(s) from store\n`);
-      }
-    }).catch(() => {
-      /* non-fatal — timers will be registered for new handoffs going forward */
-    });
+    void deadlineWatcher
+      .rebuildFromStore()
+      .then((count) => {
+        if (count > 0) {
+          process.stderr.write(`grove-mcp: DeadlineWatcher rebuilt ${count} timer(s) from store\n`);
+        }
+      })
+      .catch(() => {
+        /* non-fatal — timers will be registered for new handoffs going forward */
+      });
   }
 
   deps = {

--- a/src/mcp/serve.ts
+++ b/src/mcp/serve.ts
@@ -281,6 +281,19 @@ try {
         }
       : undefined;
 
+  // Wire DeadlineWatcher for proactive overdue detection when both
+  // a handoff store and event bus are available.
+  let deadlineWatcher: import("../core/deadline-watcher.js").DeadlineWatcher | undefined;
+  const activeHandoffStore = nexusHandoffStore ?? runtime.handoffStore;
+  if (activeHandoffStore !== undefined && eventBus !== undefined) {
+    const { DeadlineWatcher } = await import("../core/deadline-watcher.js");
+    deadlineWatcher = new DeadlineWatcher({ handoffStore: activeHandoffStore, eventBus });
+    // Rebuild timers for any unresolved handoffs from previous sessions (best-effort)
+    void deadlineWatcher.rebuildFromStore().catch(() => {
+      /* non-fatal — timers will be registered for new handoffs going forward */
+    });
+  }
+
   deps = {
     contributionStore,
     claimStore,
@@ -297,8 +310,9 @@ try {
     ...(eventBus ? { eventBus } : {}),
     ...(topologyRouter ? { topologyRouter } : {}),
     // Nexus handoff store when available, falls back to local SQLite
-    handoffStore: nexusHandoffStore ?? runtime.handoffStore,
+    handoffStore: activeHandoffStore,
     idempotencyStore: runtime.idempotencyStore,
+    ...(deadlineWatcher ? { deadlineWatcher } : {}),
   };
   // Derive MCP tool preset from contract mode — #11 MCP Tool Surface + #12 Concept Usage
   const contractMode = loadedContract?.mode ?? "exploration";
@@ -339,6 +353,7 @@ try {
         };
 
   close = () => {
+    deadlineWatcher?.close();
     eventBus?.close();
     nexusClient?.close();
     runtime.close();

--- a/src/mcp/serve.ts
+++ b/src/mcp/serve.ts
@@ -281,20 +281,19 @@ try {
         }
       : undefined;
 
-  // Wire DeadlineWatcher for proactive overdue detection ONLY when the
-  // handoff store is session-scoped. The local SQLite handoff table is
-  // shared across all sessions in .grove/grove.db (no session_id column),
-  // so expireStale() and watch() there would let session A's timers flip
-  // session B's handoffs. Until the SQLite schema carries session_id, we
-  // gate proactive deadlines off on SQLite. Late replies are still
-  // rejected by markReplied at the store level, so SLA correctness is
-  // preserved — only the push/escalation path is disabled.
+  // Wire DeadlineWatcher for proactive overdue detection. Both Nexus and
+  // SQLite (session-scoped via GROVE_SESSION_ID) safely support it: every
+  // query filters by session, so session A's timers cannot touch session B.
+  // Stores that don't implement listForCurrentSession (e.g. unscoped SQLite
+  // when GROVE_SESSION_ID is unset) are detected by rebuildFromStore and
+  // skip the startup rebuild automatically.
   let deadlineWatcher: import("../core/deadline-watcher.js").DeadlineWatcher | undefined;
   const activeHandoffStore = nexusHandoffStore ?? runtime.handoffStore;
-  if (nexusHandoffStore !== undefined && eventBus !== undefined) {
+  if (activeHandoffStore !== undefined && eventBus !== undefined) {
     const { DeadlineWatcher } = await import("../core/deadline-watcher.js");
-    deadlineWatcher = new DeadlineWatcher({ handoffStore: nexusHandoffStore, eventBus });
-    process.stderr.write(`grove-mcp: DeadlineWatcher created (Nexus session-scoped store)\n`);
+    deadlineWatcher = new DeadlineWatcher({ handoffStore: activeHandoffStore, eventBus });
+    const backend = nexusHandoffStore !== undefined ? "Nexus" : "SQLite";
+    process.stderr.write(`grove-mcp: DeadlineWatcher created (${backend} backend)\n`);
     void deadlineWatcher.rebuildFromStore().then((count) => {
       if (count > 0) {
         process.stderr.write(`grove-mcp: DeadlineWatcher rebuilt ${count} timer(s) from store\n`);
@@ -302,10 +301,6 @@ try {
     }).catch(() => {
       /* non-fatal — timers will be registered for new handoffs going forward */
     });
-  } else if (activeHandoffStore !== undefined) {
-    process.stderr.write(
-      `grove-mcp: DeadlineWatcher NOT created (SQLite is not session-scoped; proactive overdue disabled).\n`,
-    );
   }
 
   deps = {

--- a/src/mcp/serve.ts
+++ b/src/mcp/serve.ts
@@ -281,15 +281,20 @@ try {
         }
       : undefined;
 
-  // Wire DeadlineWatcher for proactive overdue detection when both
-  // a handoff store and event bus are available.
+  // Wire DeadlineWatcher for proactive overdue detection ONLY when the
+  // handoff store is session-scoped. The local SQLite handoff table is
+  // shared across all sessions in .grove/grove.db (no session_id column),
+  // so expireStale() and watch() there would let session A's timers flip
+  // session B's handoffs. Until the SQLite schema carries session_id, we
+  // gate proactive deadlines off on SQLite. Late replies are still
+  // rejected by markReplied at the store level, so SLA correctness is
+  // preserved — only the push/escalation path is disabled.
   let deadlineWatcher: import("../core/deadline-watcher.js").DeadlineWatcher | undefined;
   const activeHandoffStore = nexusHandoffStore ?? runtime.handoffStore;
-  if (activeHandoffStore !== undefined && eventBus !== undefined) {
+  if (nexusHandoffStore !== undefined && eventBus !== undefined) {
     const { DeadlineWatcher } = await import("../core/deadline-watcher.js");
-    deadlineWatcher = new DeadlineWatcher({ handoffStore: activeHandoffStore, eventBus });
-    process.stderr.write(`grove-mcp: DeadlineWatcher created (handoffStore + eventBus wired)\n`);
-    // Rebuild timers for any unresolved handoffs from previous sessions (best-effort)
+    deadlineWatcher = new DeadlineWatcher({ handoffStore: nexusHandoffStore, eventBus });
+    process.stderr.write(`grove-mcp: DeadlineWatcher created (Nexus session-scoped store)\n`);
     void deadlineWatcher.rebuildFromStore().then((count) => {
       if (count > 0) {
         process.stderr.write(`grove-mcp: DeadlineWatcher rebuilt ${count} timer(s) from store\n`);
@@ -297,6 +302,10 @@ try {
     }).catch(() => {
       /* non-fatal — timers will be registered for new handoffs going forward */
     });
+  } else if (activeHandoffStore !== undefined) {
+    process.stderr.write(
+      `grove-mcp: DeadlineWatcher NOT created (SQLite is not session-scoped; proactive overdue disabled).\n`,
+    );
   }
 
   deps = {

--- a/src/mcp/serve.ts
+++ b/src/mcp/serve.ts
@@ -288,8 +288,13 @@ try {
   if (activeHandoffStore !== undefined && eventBus !== undefined) {
     const { DeadlineWatcher } = await import("../core/deadline-watcher.js");
     deadlineWatcher = new DeadlineWatcher({ handoffStore: activeHandoffStore, eventBus });
+    process.stderr.write(`grove-mcp: DeadlineWatcher created (handoffStore + eventBus wired)\n`);
     // Rebuild timers for any unresolved handoffs from previous sessions (best-effort)
-    void deadlineWatcher.rebuildFromStore().catch(() => {
+    void deadlineWatcher.rebuildFromStore().then((count) => {
+      if (count > 0) {
+        process.stderr.write(`grove-mcp: DeadlineWatcher rebuilt ${count} timer(s) from store\n`);
+      }
+    }).catch(() => {
       /* non-fatal — timers will be registered for new handoffs going forward */
     });
   }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -57,6 +57,14 @@ export interface McpPresetConfig {
   readonly goals?: boolean;
   /** Register eval harness tool (grove_eval). Default: false (opt-in via GROVE_MCP_EVAL_ENABLED). */
   readonly eval?: boolean;
+  /**
+   * Transport the server is being attached to. Some tools are unsafe on
+   * shared transports where one process role is shared across all clients
+   * (HTTP MCP): receipt mutations (grove_ack_handoff) require a per-agent
+   * role binding that only the stdio transport provides.
+   * Default: "stdio" (backwards-compatible for existing callers).
+   */
+  readonly transport?: "stdio" | "http";
 }
 
 // ---------------------------------------------------------------------------
@@ -86,8 +94,13 @@ export async function createMcpServer(deps: McpDeps, preset?: McpPresetConfig): 
   // Contribution + done tools are always registered (core functionality).
   registerContributionTools(server, deps);
   registerDoneTools(server, deps);
-  // Handoff tools are always registered when topology is active (agents need to query pending work).
-  if (deps.handoffStore !== undefined) registerHandoffTools(server, deps);
+  // Handoff tools are always registered when topology is active (agents need
+  // to query pending work). grove_ack_handoff (receipt mutation) is gated on
+  // transport: only stdio has per-process role binding via GROVE_AGENT_ROLE.
+  // On HTTP the tool is omitted because all clients would share one role.
+  if (deps.handoffStore !== undefined) {
+    registerHandoffTools(server, deps, { includeAckTool: preset?.transport !== "http" });
+  }
 
   if (preset?.claims !== false) registerClaimTools(server, deps);
   if (preset?.queries !== false) registerQueryTools(server, deps);

--- a/src/mcp/tools/handoffs.test.ts
+++ b/src/mcp/tools/handoffs.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for grove_ack_handoff role authorization.
+ *
+ * Only the target role (handoff.toRole) may mark a handoff seen/acked.
+ * Cross-role ack attempts must be rejected with PERMISSION_DENIED.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { InMemoryHandoffStore } from "../../core/in-memory-handoff-store.js";
+import type { McpDeps } from "../deps.js";
+import type { TestMcpDeps } from "../test-helpers.js";
+import { createTestMcpDeps } from "../test-helpers.js";
+import { registerHandoffTools } from "./handoffs.js";
+
+async function callTool(
+  server: McpServer,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ isError: boolean | undefined; text: string }> {
+  const registeredTools = (
+    server as unknown as {
+      _registeredTools: Record<string, { handler: (args: unknown) => Promise<unknown> }>;
+    }
+  )._registeredTools;
+  const tool = registeredTools[name];
+  if (!tool) throw new Error(`Tool ${name} not registered`);
+  const result = (await tool.handler(args)) as {
+    isError?: boolean;
+    content: Array<{ type: string; text: string }>;
+  };
+  return { isError: result.isError, text: result.content[0]?.text ?? "" };
+}
+
+describe("grove_ack_handoff authorization", () => {
+  let testDeps: TestMcpDeps;
+  let deps: McpDeps;
+  let server: McpServer;
+  let handoffStore: InMemoryHandoffStore;
+  let handoffId: string;
+  const originalRole = process.env.GROVE_AGENT_ROLE;
+
+  beforeEach(async () => {
+    testDeps = await createTestMcpDeps();
+    handoffStore = new InMemoryHandoffStore();
+    deps = { ...testDeps.deps, handoffStore };
+    server = new McpServer({ name: "test", version: "0.0.1" }, { capabilities: { tools: {} } });
+    registerHandoffTools(server, deps);
+
+    // Seed a handoff addressed to "reviewer"
+    const h = await handoffStore.create({
+      sourceCid: "blake3:test",
+      fromRole: "coder",
+      toRole: "reviewer",
+    });
+    handoffId = h.handoffId;
+  });
+
+  afterEach(async () => {
+    if (originalRole === undefined) {
+      delete process.env.GROVE_AGENT_ROLE;
+    } else {
+      process.env.GROVE_AGENT_ROLE = originalRole;
+    }
+    await testDeps.cleanup();
+  });
+
+  test("rejects cross-role ack attempts", async () => {
+    // Caller role is "coder" but handoff is addressed to "reviewer"
+    process.env.GROVE_AGENT_ROLE = "coder";
+    const result = await callTool(server, "grove_ack_handoff", {
+      handoffId,
+      level: "acked",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("PERMISSION_DENIED");
+    // Handoff state must not have changed
+    const after = await handoffStore.get(handoffId);
+    expect(after?.ackedAt).toBeUndefined();
+    expect(after?.seenAt).toBeUndefined();
+  });
+
+  test("rejects when caller role is unset", async () => {
+    delete process.env.GROVE_AGENT_ROLE;
+    const result = await callTool(server, "grove_ack_handoff", {
+      handoffId,
+      level: "seen",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("PERMISSION_DENIED");
+  });
+
+  test("allows ack when caller role matches toRole", async () => {
+    process.env.GROVE_AGENT_ROLE = "reviewer";
+    const result = await callTool(server, "grove_ack_handoff", {
+      handoffId,
+      level: "acked",
+    });
+    expect(result.isError).toBeUndefined();
+    const after = await handoffStore.get(handoffId);
+    expect(after?.ackedAt).toBeDefined();
+    expect(after?.seenAt).toBeDefined(); // auto-filled
+  });
+
+  test("allows seen when caller role matches toRole", async () => {
+    process.env.GROVE_AGENT_ROLE = "reviewer";
+    const result = await callTool(server, "grove_ack_handoff", {
+      handoffId,
+      level: "seen",
+    });
+    expect(result.isError).toBeUndefined();
+    const after = await handoffStore.get(handoffId);
+    expect(after?.seenAt).toBeDefined();
+    expect(after?.ackedAt).toBeUndefined();
+  });
+});

--- a/src/mcp/tools/handoffs.test.ts
+++ b/src/mcp/tools/handoffs.test.ts
@@ -114,4 +114,19 @@ describe("grove_ack_handoff authorization", () => {
     expect(after?.seenAt).toBeDefined();
     expect(after?.ackedAt).toBeUndefined();
   });
+
+  test("grove_ack_handoff is NOT registered when includeAckTool is false (HTTP)", () => {
+    // Simulate HTTP transport registration — ack tool must be omitted.
+    const httpServer = new McpServer(
+      { name: "test-http", version: "0.0.1" },
+      { capabilities: { tools: {} } },
+    );
+    registerHandoffTools(httpServer, deps, { includeAckTool: false });
+    const registeredTools = (
+      httpServer as unknown as { _registeredTools: Record<string, unknown> }
+    )._registeredTools;
+    expect(registeredTools["grove_list_handoffs"]).toBeDefined();
+    expect(registeredTools["grove_get_handoff"]).toBeDefined();
+    expect(registeredTools["grove_ack_handoff"]).toBeUndefined();
+  });
 });

--- a/src/mcp/tools/handoffs.test.ts
+++ b/src/mcp/tools/handoffs.test.ts
@@ -5,8 +5,8 @@
  * Cross-role ack attempts must be rejected with PERMISSION_DENIED.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { InMemoryHandoffStore } from "../../core/in-memory-handoff-store.js";
 import type { McpDeps } from "../deps.js";
@@ -122,11 +122,10 @@ describe("grove_ack_handoff authorization", () => {
       { capabilities: { tools: {} } },
     );
     registerHandoffTools(httpServer, deps, { includeAckTool: false });
-    const registeredTools = (
-      httpServer as unknown as { _registeredTools: Record<string, unknown> }
-    )._registeredTools;
-    expect(registeredTools["grove_list_handoffs"]).toBeDefined();
-    expect(registeredTools["grove_get_handoff"]).toBeDefined();
-    expect(registeredTools["grove_ack_handoff"]).toBeUndefined();
+    const registeredTools = (httpServer as unknown as { _registeredTools: Record<string, unknown> })
+      ._registeredTools;
+    expect(registeredTools.grove_list_handoffs).toBeDefined();
+    expect(registeredTools.grove_get_handoff).toBeDefined();
+    expect(registeredTools.grove_ack_handoff).toBeUndefined();
   });
 });

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -11,13 +11,37 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import { NotFoundError, StateConflictError } from "../../core/errors.js";
 import {
   canTransition,
   HandoffStatus,
+  InvalidTransitionError,
   type HandoffStore,
 } from "../../core/handoff.js";
 import type { McpDeps } from "../deps.js";
 import { toolError } from "../error-handler.js";
+
+/**
+ * Translate a store-layer throw into a structured MCP tool error.
+ * Concurrent sweeps (DeadlineWatcher expireStale) and peer mutations
+ * (auto-reply, parallel ack from another client) can race between the
+ * tool's preflight (get / canTransition) and the actual mark* call.
+ * Without this helper those races surface as unstructured exceptions;
+ * here we normalize them to NOT_FOUND / INVALID_STATE / CONFLICT so
+ * the caller can retry or give up deterministically.
+ */
+function markToToolError(handoffId: string, err: unknown): CallToolResult {
+  if (err instanceof NotFoundError) {
+    return toolError("NOT_FOUND", `Handoff '${handoffId}' not found.`);
+  }
+  if (err instanceof InvalidTransitionError) {
+    return toolError("INVALID_STATE", err.message);
+  }
+  if (err instanceof StateConflictError) {
+    return toolError("CONFLICT", err.message);
+  }
+  throw err;
+}
 
 /**
  * Guard: require handoffStore to be configured.
@@ -267,7 +291,11 @@ export function registerHandoffTools(
         );
       }
 
-      await store.markProcessed(args.handoffId);
+      try {
+        await store.markProcessed(args.handoffId);
+      } catch (err) {
+        return markToToolError(args.handoffId, err);
+      }
 
       return {
         content: [
@@ -327,10 +355,14 @@ export function registerHandoffTools(
         );
       }
 
-      if (args.level === "seen") {
-        await store.markSeen(args.handoffId);
-      } else {
-        await store.markAcked(args.handoffId);
+      try {
+        if (args.level === "seen") {
+          await store.markSeen(args.handoffId);
+        } else {
+          await store.markAcked(args.handoffId);
+        }
+      } catch (err) {
+        return markToToolError(args.handoffId, err);
       }
 
       if (process.env.GROVE_DEBUG === "1") {

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -1,15 +1,36 @@
 /**
- * MCP tools for querying handoff coordination records.
+ * MCP tools for querying and interacting with handoff coordination records.
  *
  * grove_list_handoffs — List handoffs, optionally filtered by role or status.
  * grove_get_handoff   — Get a single handoff by ID.
+ * grove_ack_handoff   — Signal that the target agent has seen or acknowledged a handoff.
  */
 
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { HandoffStatus } from "../../core/handoff.js";
+import { HandoffStatus, type HandoffStore } from "../../core/handoff.js";
 import type { McpDeps } from "../deps.js";
 import { toolError } from "../error-handler.js";
+
+/**
+ * Guard: require handoffStore to be configured.
+ * Returns the store if available, or a NOT_CONFIGURED error result.
+ */
+function requireHandoffStore(
+  deps: McpDeps,
+): { ok: true; store: HandoffStore } | { ok: false; error: CallToolResult } {
+  if (deps.handoffStore !== undefined) {
+    return { ok: true, store: deps.handoffStore };
+  }
+  return {
+    ok: false,
+    error: toolError(
+      "NOT_CONFIGURED",
+      "Handoff store is not available. Topology routing must be active.",
+    ),
+  };
+}
 
 const listHandoffsInputSchema = z.object({
   toRole: z
@@ -50,6 +71,15 @@ const getHandoffInputSchema = z.object({
   handoffId: z.string().min(1).describe("ID of the handoff to retrieve."),
 });
 
+const ackHandoffInputSchema = z.object({
+  handoffId: z.string().min(1).describe("ID of the handoff to acknowledge."),
+  level: z
+    .enum(["seen", "acked"])
+    .describe(
+      "Receipt level: 'seen' = agent observed the handoff; 'acked' = agent acknowledges and intends to act on it. 'acked' auto-fills 'seen' if not already set.",
+    ),
+});
+
 export function registerHandoffTools(server: McpServer, deps: McpDeps): void {
   server.registerTool(
     "grove_list_handoffs",
@@ -59,18 +89,14 @@ export function registerHandoffTools(server: McpServer, deps: McpDeps): void {
       inputSchema: listHandoffsInputSchema,
     },
     async (args) => {
-      const { handoffStore } = deps;
-      if (handoffStore === undefined) {
-        return toolError(
-          "NOT_CONFIGURED",
-          "Handoff store is not available. Topology routing must be active.",
-        );
-      }
+      const guard = requireHandoffStore(deps);
+      if (!guard.ok) return guard.error;
+      const { store } = guard;
 
       // Expire stale handoffs before listing so callers always see fresh status.
-      await handoffStore.expireStale();
+      await store.expireStale();
 
-      const handoffs = await handoffStore.list({
+      const handoffs = await store.list({
         toRole: args.toRole,
         fromRole: args.fromRole,
         status: args.status,
@@ -91,18 +117,47 @@ export function registerHandoffTools(server: McpServer, deps: McpDeps): void {
       inputSchema: getHandoffInputSchema,
     },
     async (args) => {
-      const { handoffStore } = deps;
-      if (handoffStore === undefined) {
-        return toolError("NOT_CONFIGURED", "Handoff store is not available.");
-      }
+      const guard = requireHandoffStore(deps);
+      if (!guard.ok) return guard.error;
+      const { store } = guard;
 
-      const handoff = await handoffStore.get(args.handoffId);
+      const handoff = await store.get(args.handoffId);
       if (handoff === undefined) {
         return toolError("NOT_FOUND", `Handoff '${args.handoffId}' not found.`);
       }
 
       return {
         content: [{ type: "text" as const, text: JSON.stringify(handoff) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "grove_ack_handoff",
+    {
+      description:
+        "Signal that you have seen or acknowledged a handoff. Use level='seen' when you first observe a handoff routed to your role, and level='acked' when you intend to act on it. Acknowledging auto-fills 'seen' if not already set. Idempotent — safe to call multiple times.",
+      inputSchema: ackHandoffInputSchema,
+    },
+    async (args) => {
+      const guard = requireHandoffStore(deps);
+      if (!guard.ok) return guard.error;
+      const { store } = guard;
+
+      const handoff = await store.get(args.handoffId);
+      if (handoff === undefined) {
+        return toolError("NOT_FOUND", `Handoff '${args.handoffId}' not found.`);
+      }
+
+      if (args.level === "seen") {
+        await store.markSeen(args.handoffId);
+      } else {
+        await store.markAcked(args.handoffId);
+      }
+
+      const updated = await store.get(args.handoffId);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(updated) }],
       };
     },
   );

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -145,6 +145,14 @@ export function registerHandoffTools(
 
   if (!includeAck) return;
 
+  // grove_ack_handoff requires a session-scoped backend. Without the
+  // isInCurrentSession capability, we cannot reliably tell whether a
+  // caller owns the handoff they're acking (SQLite today shares the
+  // handoffs table across sessions — a reviewer in session A could ack
+  // session B's handoffs). Register the tool only when the active store
+  // can answer the ownership question.
+  if (deps.handoffStore?.isInCurrentSession === undefined) return;
+
   server.registerTool(
     "grove_ack_handoff",
     {
@@ -174,17 +182,16 @@ export function registerHandoffTools(
           `Only the target role '${handoff.toRole}' can acknowledge this handoff (caller role: '${callerRole ?? "unset"}').`,
         );
       }
-      // Session ownership check: only valid on stores that implement
-      // listForCurrentSession. If the store cannot enumerate by session
-      // (SQLite with no session_id column), refuse the mutation.
-      if (store.listForCurrentSession === undefined) {
+      // Session ownership check via direct O(1) API. Registration guards
+      // above guarantee isInCurrentSession is defined, so a missing method
+      // is a programming error not a runtime fallback path.
+      if (store.isInCurrentSession === undefined) {
         return toolError(
           "NOT_SUPPORTED",
-          "Handoff store does not support session-scoped access; grove_ack_handoff requires a session-scoped backend (e.g. Nexus).",
+          "Handoff store does not support session-scoped access.",
         );
       }
-      const sessionHandoffs = await store.listForCurrentSession({ limit: 1000 });
-      const inSession = sessionHandoffs.some((h) => h.handoffId === args.handoffId);
+      const inSession = await store.isInCurrentSession(args.handoffId);
       if (!inSession) {
         return toolError(
           "PERMISSION_DENIED",

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -149,6 +149,17 @@ export function registerHandoffTools(server: McpServer, deps: McpDeps): void {
         return toolError("NOT_FOUND", `Handoff '${args.handoffId}' not found.`);
       }
 
+      // Authorization: only the target role can mark seen/acked. Without
+      // this check any connected agent could forge receipts for handoffs
+      // addressed to other roles, making SLA/deadline signals untrustworthy.
+      const callerRole = process.env.GROVE_AGENT_ROLE;
+      if (callerRole === undefined || callerRole !== handoff.toRole) {
+        return toolError(
+          "PERMISSION_DENIED",
+          `Only the target role '${handoff.toRole}' can acknowledge this handoff (caller role: '${callerRole ?? "unset"}').`,
+        );
+      }
+
       if (args.level === "seen") {
         await store.markSeen(args.handoffId);
       } else {

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -80,7 +80,18 @@ const ackHandoffInputSchema = z.object({
     ),
 });
 
-export function registerHandoffTools(server: McpServer, deps: McpDeps): void {
+/**
+ * Register handoff tools. `includeAckTool` gates the receipt mutation tool
+ * (grove_ack_handoff), which is unsafe on shared transports because it
+ * authorizes on a process-global role. Defaults to true for backwards
+ * compatibility with stdio callers.
+ */
+export function registerHandoffTools(
+  server: McpServer,
+  deps: McpDeps,
+  opts?: { readonly includeAckTool?: boolean },
+): void {
+  const includeAck = opts?.includeAckTool !== false;
   server.registerTool(
     "grove_list_handoffs",
     {
@@ -131,6 +142,8 @@ export function registerHandoffTools(server: McpServer, deps: McpDeps): void {
       };
     },
   );
+
+  if (!includeAck) return;
 
   server.registerTool(
     "grove_ack_handoff",

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -11,11 +11,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import {
-  canTransition,
-  HandoffStatus,
-  type HandoffStore,
-} from "../../core/handoff.js";
+import { canTransition, HandoffStatus, type HandoffStore } from "../../core/handoff.js";
 import type { McpDeps } from "../deps.js";
 import { handleToolError, toolError } from "../error-handler.js";
 

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -207,6 +207,15 @@ export function registerHandoffTools(
     },
   );
 
+  // grove_process_handoff and grove_ack_handoff both mutate per-session
+  // receipt state, so they share the same safety gates:
+  //   - includeAckTool=false disables them on the shared HTTP transport
+  //     (one process role is shared across clients there).
+  //   - A session-scoped backend (isInCurrentSession present) is required
+  //     so cross-session IDs can be rejected.
+  if (!includeAck) return;
+  if (deps.handoffStore?.isInCurrentSession === undefined) return;
+
   server.registerTool(
     "grove_process_handoff",
     {
@@ -224,6 +233,30 @@ export function registerHandoffTools(
       const handoff = await store.get(args.handoffId);
       if (handoff === undefined) {
         return toolError("NOT_FOUND", `Handoff '${args.handoffId}' not found.`);
+      }
+
+      // Authorization: only the target role can mark processed. Handoff IDs
+      // are discoverable via read tools, so without this check any agent in
+      // the session could forge "processed" signals for peer handoffs.
+      const callerRole = process.env.GROVE_AGENT_ROLE;
+      if (callerRole === undefined || callerRole !== handoff.toRole) {
+        return toolError(
+          "PERMISSION_DENIED",
+          `Only the target role '${handoff.toRole}' can mark this handoff processed (caller role: '${callerRole ?? "unset"}').`,
+        );
+      }
+      if (store.isInCurrentSession === undefined) {
+        return toolError(
+          "NOT_SUPPORTED",
+          "Handoff store does not support session-scoped access.",
+        );
+      }
+      const inSession = await store.isInCurrentSession(args.handoffId);
+      if (!inSession) {
+        return toolError(
+          "PERMISSION_DENIED",
+          `Handoff '${args.handoffId}' does not belong to the current session.`,
+        );
       }
 
       if (!canTransition(handoff.status, HandoffStatus.Processed)) {
@@ -250,12 +283,6 @@ export function registerHandoffTools(
       };
     },
   );
-
-  // grove_ack_handoff (receipt tracking): gated on session-scoped transports
-  // AND session-scoped store backends. See opts.includeAckTool and
-  // isInCurrentSession rationale above.
-  if (!includeAck) return;
-  if (deps.handoffStore?.isInCurrentSession === undefined) return;
 
   server.registerTool(
     "grove_ack_handoff",

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -11,37 +11,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { NotFoundError, StateConflictError } from "../../core/errors.js";
 import {
   canTransition,
   HandoffStatus,
-  InvalidTransitionError,
   type HandoffStore,
 } from "../../core/handoff.js";
 import type { McpDeps } from "../deps.js";
-import { toolError } from "../error-handler.js";
-
-/**
- * Translate a store-layer throw into a structured MCP tool error.
- * Concurrent sweeps (DeadlineWatcher expireStale) and peer mutations
- * (auto-reply, parallel ack from another client) can race between the
- * tool's preflight (get / canTransition) and the actual mark* call.
- * Without this helper those races surface as unstructured exceptions;
- * here we normalize them to NOT_FOUND / INVALID_STATE / CONFLICT so
- * the caller can retry or give up deterministically.
- */
-function markToToolError(handoffId: string, err: unknown): CallToolResult {
-  if (err instanceof NotFoundError) {
-    return toolError("NOT_FOUND", `Handoff '${handoffId}' not found.`);
-  }
-  if (err instanceof InvalidTransitionError) {
-    return toolError("INVALID_STATE", err.message);
-  }
-  if (err instanceof StateConflictError) {
-    return toolError("CONFLICT", err.message);
-  }
-  throw err;
-}
+import { handleToolError, toolError } from "../error-handler.js";
 
 /**
  * Guard: require handoffStore to be configured.
@@ -159,20 +135,24 @@ export function registerHandoffTools(
       if (!guard.ok) return guard.error;
       const { store } = guard;
 
-      // Expire stale handoffs before listing so callers always see fresh status.
-      await store.expireStale();
+      try {
+        // Expire stale handoffs before listing so callers always see fresh status.
+        await store.expireStale();
 
-      const handoffs = await store.list({
-        toRole: args.toRole,
-        fromRole: args.fromRole,
-        status: args.status,
-        sourceCid: args.sourceCid,
-        limit: args.limit ?? 50,
-      });
+        const handoffs = await store.list({
+          toRole: args.toRole,
+          fromRole: args.fromRole,
+          status: args.status,
+          sourceCid: args.sourceCid,
+          limit: args.limit ?? 50,
+        });
 
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify({ handoffs }) }],
-      };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ handoffs }) }],
+        };
+      } catch (err) {
+        return handleToolError(err);
+      }
     },
   );
 
@@ -187,14 +167,18 @@ export function registerHandoffTools(
       if (!guard.ok) return guard.error;
       const { store } = guard;
 
-      const handoff = await store.get(args.handoffId);
-      if (handoff === undefined) {
-        return toolError("NOT_FOUND", `Handoff '${args.handoffId}' not found.`);
-      }
+      try {
+        const handoff = await store.get(args.handoffId);
+        if (handoff === undefined) {
+          return toolError("NOT_FOUND", `Handoff '${args.handoffId}' not found.`);
+        }
 
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(handoff) }],
-      };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(handoff) }],
+        };
+      } catch (err) {
+        return handleToolError(err);
+      }
     },
   );
 
@@ -213,21 +197,25 @@ export function registerHandoffTools(
       if (!guard.ok) return guard.error;
       const { store } = guard;
 
-      const handoffs = await store.list({
-        toRole: args.toRole,
-        fromRole: args.fromRole,
-        status: HandoffStatus.DeadLettered,
-        limit: args.limit ?? 50,
-      });
+      try {
+        const handoffs = await store.list({
+          toRole: args.toRole,
+          fromRole: args.fromRole,
+          status: HandoffStatus.DeadLettered,
+          limit: args.limit ?? 50,
+        });
 
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({ count: handoffs.length, handoffs }),
-          },
-        ],
-      };
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ count: handoffs.length, handoffs }),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleToolError(err);
+      }
     },
   );
 
@@ -254,61 +242,61 @@ export function registerHandoffTools(
       if (!guard.ok) return guard.error;
       const { store } = guard;
 
-      const handoff = await store.get(args.handoffId);
-      if (handoff === undefined) {
-        return toolError("NOT_FOUND", `Handoff '${args.handoffId}' not found.`);
-      }
-
-      // Authorization: only the target role can mark processed. Handoff IDs
-      // are discoverable via read tools, so without this check any agent in
-      // the session could forge "processed" signals for peer handoffs.
-      const callerRole = process.env.GROVE_AGENT_ROLE;
-      if (callerRole === undefined || callerRole !== handoff.toRole) {
-        return toolError(
-          "PERMISSION_DENIED",
-          `Only the target role '${handoff.toRole}' can mark this handoff processed (caller role: '${callerRole ?? "unset"}').`,
-        );
-      }
-      if (store.isInCurrentSession === undefined) {
-        return toolError(
-          "NOT_SUPPORTED",
-          "Handoff store does not support session-scoped access.",
-        );
-      }
-      const inSession = await store.isInCurrentSession(args.handoffId);
-      if (!inSession) {
-        return toolError(
-          "PERMISSION_DENIED",
-          `Handoff '${args.handoffId}' does not belong to the current session.`,
-        );
-      }
-
-      if (!canTransition(handoff.status, HandoffStatus.Processed)) {
-        return toolError(
-          "INVALID_STATE",
-          `Cannot process handoff in status '${handoff.status}'. ` +
-            `Only 'delivered' handoffs can be processed.`,
-        );
-      }
-
       try {
-        await store.markProcessed(args.handoffId);
-      } catch (err) {
-        return markToToolError(args.handoffId, err);
-      }
+        const handoff = await store.get(args.handoffId);
+        if (handoff === undefined) {
+          return toolError("NOT_FOUND", `Handoff '${args.handoffId}' not found.`);
+        }
 
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({
-              handoffId: args.handoffId,
-              previousStatus: handoff.status,
-              status: HandoffStatus.Processed,
-            }),
-          },
-        ],
-      };
+        // Authorization: only the target role can mark processed. Handoff IDs
+        // are discoverable via read tools, so without this check any agent in
+        // the session could forge "processed" signals for peer handoffs.
+        const callerRole = process.env.GROVE_AGENT_ROLE;
+        if (callerRole === undefined || callerRole !== handoff.toRole) {
+          return toolError(
+            "PERMISSION_DENIED",
+            `Only the target role '${handoff.toRole}' can mark this handoff processed (caller role: '${callerRole ?? "unset"}').`,
+          );
+        }
+        if (store.isInCurrentSession === undefined) {
+          return toolError(
+            "NOT_SUPPORTED",
+            "Handoff store does not support session-scoped access.",
+          );
+        }
+        const inSession = await store.isInCurrentSession(args.handoffId);
+        if (!inSession) {
+          return toolError(
+            "PERMISSION_DENIED",
+            `Handoff '${args.handoffId}' does not belong to the current session.`,
+          );
+        }
+
+        if (!canTransition(handoff.status, HandoffStatus.Processed)) {
+          return toolError(
+            "INVALID_STATE",
+            `Cannot process handoff in status '${handoff.status}'. ` +
+              `Only 'delivered' handoffs can be processed.`,
+          );
+        }
+
+        await store.markProcessed(args.handoffId);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                handoffId: args.handoffId,
+                previousStatus: handoff.status,
+                status: HandoffStatus.Processed,
+              }),
+            },
+          ],
+        };
+      } catch (err) {
+        return handleToolError(err);
+      }
     },
   );
 
@@ -324,57 +312,57 @@ export function registerHandoffTools(
       if (!guard.ok) return guard.error;
       const { store } = guard;
 
-      const handoff = await store.get(args.handoffId);
-      if (handoff === undefined) {
-        return toolError("NOT_FOUND", `Handoff '${args.handoffId}' not found.`);
-      }
-
-      // Authorization: the caller role must match the handoff's toRole,
-      // AND the handoff must belong to the caller's current session.
-      // Without the session check on a non-scoped store (e.g. SQLite where
-      // the handoff table is shared across sessions), a reviewer in session
-      // A could enumerate and ack a reviewer handoff in session B.
-      const callerRole = process.env.GROVE_AGENT_ROLE;
-      if (callerRole === undefined || callerRole !== handoff.toRole) {
-        return toolError(
-          "PERMISSION_DENIED",
-          `Only the target role '${handoff.toRole}' can acknowledge this handoff (caller role: '${callerRole ?? "unset"}').`,
-        );
-      }
-      if (store.isInCurrentSession === undefined) {
-        return toolError(
-          "NOT_SUPPORTED",
-          "Handoff store does not support session-scoped access.",
-        );
-      }
-      const inSession = await store.isInCurrentSession(args.handoffId);
-      if (!inSession) {
-        return toolError(
-          "PERMISSION_DENIED",
-          `Handoff '${args.handoffId}' does not belong to the current session.`,
-        );
-      }
-
       try {
+        const handoff = await store.get(args.handoffId);
+        if (handoff === undefined) {
+          return toolError("NOT_FOUND", `Handoff '${args.handoffId}' not found.`);
+        }
+
+        // Authorization: the caller role must match the handoff's toRole,
+        // AND the handoff must belong to the caller's current session.
+        // Without the session check on a non-scoped store (e.g. SQLite where
+        // the handoff table is shared across sessions), a reviewer in session
+        // A could enumerate and ack a reviewer handoff in session B.
+        const callerRole = process.env.GROVE_AGENT_ROLE;
+        if (callerRole === undefined || callerRole !== handoff.toRole) {
+          return toolError(
+            "PERMISSION_DENIED",
+            `Only the target role '${handoff.toRole}' can acknowledge this handoff (caller role: '${callerRole ?? "unset"}').`,
+          );
+        }
+        if (store.isInCurrentSession === undefined) {
+          return toolError(
+            "NOT_SUPPORTED",
+            "Handoff store does not support session-scoped access.",
+          );
+        }
+        const inSession = await store.isInCurrentSession(args.handoffId);
+        if (!inSession) {
+          return toolError(
+            "PERMISSION_DENIED",
+            `Handoff '${args.handoffId}' does not belong to the current session.`,
+          );
+        }
+
         if (args.level === "seen") {
           await store.markSeen(args.handoffId);
         } else {
           await store.markAcked(args.handoffId);
         }
+
+        if (process.env.GROVE_DEBUG === "1") {
+          process.stderr.write(
+            `[grove:handoff] ACK handoff=${args.handoffId.slice(0, 8)} level=${args.level} toRole=${handoff.toRole}\n`,
+          );
+        }
+
+        const updated = await store.get(args.handoffId);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(updated) }],
+        };
       } catch (err) {
-        return markToToolError(args.handoffId, err);
+        return handleToolError(err);
       }
-
-      if (process.env.GROVE_DEBUG === "1") {
-        process.stderr.write(
-          `[grove:handoff] ACK handoff=${args.handoffId.slice(0, 8)} level=${args.level} toRole=${handoff.toRole}\n`,
-        );
-      }
-
-      const updated = await store.get(args.handoffId);
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(updated) }],
-      };
     },
   );
 }

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -155,6 +155,12 @@ export function registerHandoffTools(server: McpServer, deps: McpDeps): void {
         await store.markAcked(args.handoffId);
       }
 
+      if (process.env.GROVE_DEBUG === "1") {
+        process.stderr.write(
+          `[grove:handoff] ACK handoff=${args.handoffId.slice(0, 8)} level=${args.level} toRole=${handoff.toRole}\n`,
+        );
+      }
+
       const updated = await store.get(args.handoffId);
       return {
         content: [{ type: "text" as const, text: JSON.stringify(updated) }],

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -162,14 +162,33 @@ export function registerHandoffTools(
         return toolError("NOT_FOUND", `Handoff '${args.handoffId}' not found.`);
       }
 
-      // Authorization: only the target role can mark seen/acked. Without
-      // this check any connected agent could forge receipts for handoffs
-      // addressed to other roles, making SLA/deadline signals untrustworthy.
+      // Authorization: the caller role must match the handoff's toRole,
+      // AND the handoff must belong to the caller's current session.
+      // Without the session check on a non-scoped store (e.g. SQLite where
+      // the handoff table is shared across sessions), a reviewer in session
+      // A could enumerate and ack a reviewer handoff in session B.
       const callerRole = process.env.GROVE_AGENT_ROLE;
       if (callerRole === undefined || callerRole !== handoff.toRole) {
         return toolError(
           "PERMISSION_DENIED",
           `Only the target role '${handoff.toRole}' can acknowledge this handoff (caller role: '${callerRole ?? "unset"}').`,
+        );
+      }
+      // Session ownership check: only valid on stores that implement
+      // listForCurrentSession. If the store cannot enumerate by session
+      // (SQLite with no session_id column), refuse the mutation.
+      if (store.listForCurrentSession === undefined) {
+        return toolError(
+          "NOT_SUPPORTED",
+          "Handoff store does not support session-scoped access; grove_ack_handoff requires a session-scoped backend (e.g. Nexus).",
+        );
+      }
+      const sessionHandoffs = await store.listForCurrentSession({ limit: 1000 });
+      const inSession = sessionHandoffs.some((h) => h.handoffId === args.handoffId);
+      if (!inSession) {
+        return toolError(
+          "PERMISSION_DENIED",
+          `Handoff '${args.handoffId}' does not belong to the current session.`,
         );
       }
 

--- a/src/nexus/nexus-handoff-store.test.ts
+++ b/src/nexus/nexus-handoff-store.test.ts
@@ -64,25 +64,42 @@ describe("NexusHandoffStore: Nexus-specific behavior", () => {
     }
   });
 
-  test("list scans all session files when no sessionId filter", async () => {
+  test("scoped list does NOT leak peer sessions' handoffs", async () => {
     const client = new MockNexusClient();
     // Create handoffs in two different sessions
     const store1 = new NexusHandoffStore(client, "sess-1", "default");
     const store2 = new NexusHandoffStore(client, "sess-2", "default");
     try {
-      await store1.create({ sourceCid: "blake3:a", fromRole: "coder", toRole: "reviewer" });
-      await store2.create({ sourceCid: "blake3:b", fromRole: "reviewer", toRole: "coder" });
+      const h1 = await store1.create({
+        sourceCid: "blake3:a",
+        fromRole: "coder",
+        toRole: "reviewer",
+      });
+      const h2 = await store2.create({
+        sourceCid: "blake3:b",
+        fromRole: "reviewer",
+        toRole: "coder",
+      });
 
-      // A store should see handoffs from all sessions via readAllHandoffs
-      const all = await store1.list();
+      // store1 must only see its own handoff
+      const listed1 = await store1.list();
+      expect(listed1.map((h) => h.handoffId)).toEqual([h1.handoffId]);
+      // store2 must only see its own handoff
+      const listed2 = await store2.list();
+      expect(listed2.map((h) => h.handoffId)).toEqual([h2.handoffId]);
+
+      // Unscoped store (CLI/admin) walks the whole dir and sees both
+      const admin = new NexusHandoffStore(client, undefined, "default");
+      const all = await admin.list();
       expect(all.length).toBeGreaterThanOrEqual(2);
+      admin.close();
     } finally {
       store1.close();
       store2.close();
     }
   });
 
-  test("get falls back to scanning all files for cross-session lookups", async () => {
+  test("scoped get does NOT leak peer sessions' handoffs", async () => {
     const client = new MockNexusClient();
     const store1 = new NexusHandoffStore(client, "sess-1", "default");
     const store2 = new NexusHandoffStore(client, "sess-2", "default");
@@ -94,13 +111,39 @@ describe("NexusHandoffStore: Nexus-specific behavior", () => {
         toRole: "reviewer",
       });
 
-      // store1 is scoped to sess-1 but should find sess-2's handoff via scanAll
+      // store1 must NOT find store2's handoff — cross-session reads are rejected
       const found = await store1.get("cross-session-id");
-      expect(found).toBeDefined();
-      expect(found!.handoffId).toBe("cross-session-id");
+      expect(found).toBeUndefined();
+
+      // Unscoped admin store still resolves across sessions
+      const admin = new NexusHandoffStore(client, undefined, "default");
+      const adminFound = await admin.get("cross-session-id");
+      expect(adminFound).toBeDefined();
+      admin.close();
     } finally {
       store1.close();
       store2.close();
+    }
+  });
+
+  test("scoped list includes pre-#164 _global migration rows", async () => {
+    const client = new MockNexusClient();
+    const legacy = new NexusHandoffStore(client, undefined, "default");
+    const scoped = new NexusHandoffStore(client, "new-session", "default");
+    try {
+      const hLegacy = await legacy.create({
+        sourceCid: "blake3:legacy",
+        fromRole: "coder",
+        toRole: "reviewer",
+      });
+
+      const listed = await scoped.list();
+      expect(listed.find((h) => h.handoffId === hLegacy.handoffId)).toBeDefined();
+      const got = await scoped.get(hLegacy.handoffId);
+      expect(got?.handoffId).toBe(hLegacy.handoffId);
+    } finally {
+      legacy.close();
+      scoped.close();
     }
   });
 

--- a/src/nexus/nexus-handoff-store.test.ts
+++ b/src/nexus/nexus-handoff-store.test.ts
@@ -203,6 +203,42 @@ describe("NexusHandoffStore: Nexus-specific behavior", () => {
     }
   });
 
+  test("first scoped mutation claims a _global row — peer session stops seeing it", async () => {
+    const client = new MockNexusClient();
+    const legacy = new NexusHandoffStore(client, undefined, "default");
+    const storeA = new NexusHandoffStore(client, "sess-A", "default");
+    const storeB = new NexusHandoffStore(client, "sess-B", "default");
+    try {
+      const hLegacy = await legacy.create({
+        sourceCid: "blake3:legacy",
+        fromRole: "coder",
+        toRole: "reviewer",
+      });
+
+      // Both sessions see the legacy row pre-claim
+      expect(await storeA.isInCurrentSession(hLegacy.handoffId)).toBe(true);
+      expect(await storeB.isInCurrentSession(hLegacy.handoffId)).toBe(true);
+
+      // A claims via markAcked (mutation moves row from _global → sess-A file)
+      await storeA.markAcked(hLegacy.handoffId);
+
+      // B can no longer see / resolve it — claim-on-move completed
+      expect(await storeB.isInCurrentSession(hLegacy.handoffId)).toBe(false);
+      expect(await storeB.get(hLegacy.handoffId)).toBeUndefined();
+      const listB = await storeB.list();
+      expect(listB.find((h) => h.handoffId === hLegacy.handoffId)).toBeUndefined();
+
+      // A still owns it
+      const got = await storeA.get(hLegacy.handoffId);
+      expect(got?.handoffId).toBe(hLegacy.handoffId);
+      expect(got?.ackedAt).toBeDefined();
+    } finally {
+      legacy.close();
+      storeA.close();
+      storeB.close();
+    }
+  });
+
   test("store without sessionId uses _global.json", async () => {
     const client = new MockNexusClient();
     const store = new NexusHandoffStore(client, undefined, "default");

--- a/src/nexus/nexus-handoff-store.test.ts
+++ b/src/nexus/nexus-handoff-store.test.ts
@@ -147,6 +147,62 @@ describe("NexusHandoffStore: Nexus-specific behavior", () => {
     }
   });
 
+  test("scoped isInCurrentSession accepts pre-#164 _global rows", async () => {
+    const client = new MockNexusClient();
+    const legacy = new NexusHandoffStore(client, undefined, "default");
+    const scoped = new NexusHandoffStore(client, "new-session", "default");
+    try {
+      const hLegacy = await legacy.create({
+        sourceCid: "blake3:legacy",
+        fromRole: "coder",
+        toRole: "reviewer",
+      });
+      expect(await scoped.isInCurrentSession(hLegacy.handoffId)).toBe(true);
+    } finally {
+      legacy.close();
+      scoped.close();
+    }
+  });
+
+  test("scoped listForCurrentSession includes pre-#164 _global rows (watcher rebuild)", async () => {
+    const client = new MockNexusClient();
+    const legacy = new NexusHandoffStore(client, undefined, "default");
+    const scoped = new NexusHandoffStore(client, "new-session", "default");
+    try {
+      await legacy.create({
+        sourceCid: "blake3:legacy",
+        fromRole: "coder",
+        toRole: "reviewer",
+        requiresReply: true,
+        replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+      });
+      const listed = await scoped.listForCurrentSession();
+      expect(listed.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      legacy.close();
+      scoped.close();
+    }
+  });
+
+  test("scoped markAcked can mutate pre-#164 _global rows", async () => {
+    const client = new MockNexusClient();
+    const legacy = new NexusHandoffStore(client, undefined, "default");
+    const scoped = new NexusHandoffStore(client, "new-session", "default");
+    try {
+      const hLegacy = await legacy.create({
+        sourceCid: "blake3:legacy",
+        fromRole: "coder",
+        toRole: "reviewer",
+      });
+      await scoped.markAcked(hLegacy.handoffId);
+      const after = await scoped.get(hLegacy.handoffId);
+      expect(after?.ackedAt).toBeDefined();
+    } finally {
+      legacy.close();
+      scoped.close();
+    }
+  });
+
   test("store without sessionId uses _global.json", async () => {
     const client = new MockNexusClient();
     const store = new NexusHandoffStore(client, undefined, "default");

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -216,41 +216,30 @@ export class NexusHandoffStore implements HandoffStore {
   }
 
   async get(handoffId: string): Promise<Handoff | undefined> {
-    // When scoped to a session, only return handoffs from this session's
-    // file (plus the _global file for pre-#164 migration). Scanning every
-    // session file would leak peer sessions' handoffs to scoped callers.
-    const { handoffs } = await this.readFile(this.filePath());
-    const found = handoffs.find((h) => h.handoffId === handoffId);
+    // When scoped to a session, only look in this session's file plus the
+    // _global file (pre-#164 migration shim). An unscoped store walks the
+    // full directory. Use the directory-listing path even in the scoped
+    // branch — plain readFile() is documented as not cross-client-visible
+    // (see readAllHandoffs), so a handoff written by another client into
+    // the same session file could otherwise vanish from get().
+    const scopedHandoffs =
+      this.sessionId !== undefined
+        ? await this.readScopedHandoffs()
+        : await this.readAllHandoffs();
+    const found = scopedHandoffs.find((h) => h.handoffId === handoffId);
     if (found) return found;
-
-    if (this.sessionId !== undefined) {
-      // Migration shim: pre-#164 handoffs were written to _global.json before
-      // per-session file scoping existed. A scoped caller may still need to
-      // resolve those in-flight handoffs after upgrade.
-      const { handoffs: globalHandoffs } = await this.readFile(globalFile(this.zoneId));
-      return globalHandoffs.find((h) => h.handoffId === handoffId);
-    }
-
-    // Unscoped store (CLI/admin) — fall back to scanning every file.
-    return this.scanAll((h) => h.handoffId === handoffId);
+    if (this.sessionId !== undefined) return undefined;
+    // Unscoped store (CLI/admin) — already searched all files above.
+    return undefined;
   }
 
   async list(query?: HandoffQuery): Promise<readonly Handoff[]> {
-    // When scoped to a session, read only the session's own file plus the
-    // _global migration file. An unscoped store walks the full directory
-    // (CLI / admin path) via readAllHandoffs.
-    let allHandoffs: Handoff[];
-    if (this.sessionId !== undefined) {
-      const [sessionFile, migrationFile] = await Promise.all([
-        this.readFile(this.filePath()),
-        this.readFile(globalFile(this.zoneId)),
-      ]);
-      allHandoffs = [...sessionFile.handoffs, ...migrationFile.handoffs];
-    } else {
-      // Unscoped: directory listing gives cross-client visibility that
-      // readFile doesn't guarantee.
-      allHandoffs = await this.readAllHandoffs();
-    }
+    // Use the directory-listing path for both scoped and unscoped reads —
+    // see get() for why plain readFile() isn't cross-client-visible.
+    const allHandoffs =
+      this.sessionId !== undefined
+        ? await this.readScopedHandoffs()
+        : await this.readAllHandoffs();
     debugLog(
       "nexus-handoff",
       `LIST sessionId=${this.sessionId ?? "none"} path=${this.filePath()} total=${allHandoffs.length}`,
@@ -383,14 +372,24 @@ export class NexusHandoffStore implements HandoffStore {
         return h;
       });
 
-    // Sweep the session's own file
+    // Sweep the session's own file first — any rows expired here MUST be
+    // reported even if the follow-up _global sweep fails, otherwise the
+    // DeadlineWatcher would swallow the error and drop overdue events for
+    // rows that have already been flipped.
     await this.readModifyWrite(this.filePath(), expireIn);
 
     // Migration shim: also sweep _global for pre-#164 legacy rows when
-    // scoped. The readModifyWrite on _global claims the row atomically —
-    // if a peer session races us, only the winner mutates.
+    // scoped. Errors here are recoverable (next tick retries) and must
+    // not mask the session-file sweep's already-expired rows.
     if (this.sessionId !== undefined) {
-      await this.readModifyWrite(globalFile(this.zoneId), expireIn);
+      try {
+        await this.readModifyWrite(globalFile(this.zoneId), expireIn);
+      } catch (err) {
+        debugLog(
+          "NexusHandoffStore.expireStale",
+          `_global sweep failed (session sweep already committed) err=${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
     return expired;
@@ -415,10 +414,8 @@ export class NexusHandoffStore implements HandoffStore {
   async isInCurrentSession(handoffId: string): Promise<boolean> {
     if (this.sessionId === undefined) return false;
     try {
-      const { handoffs } = await this.readFile(this.filePath());
-      if (handoffs.some((h) => h.handoffId === handoffId)) return true;
-      const { handoffs: legacy } = await this.readFile(globalFile(this.zoneId));
-      return legacy.some((h) => h.handoffId === handoffId);
+      const handoffs = await this.readScopedHandoffs();
+      return handoffs.some((h) => h.handoffId === handoffId);
     } catch {
       return false;
     }
@@ -440,13 +437,42 @@ export class NexusHandoffStore implements HandoffStore {
    */
   async listForCurrentSession(query?: HandoffQuery): Promise<readonly Handoff[]> {
     if (this.sessionId === undefined) return [];
+    try {
+      let results = (await this.readScopedHandoffs()).filter(
+        (h) => h.handoffId && h.createdAt,
+      );
+      if (query?.toRole !== undefined) results = results.filter((h) => h.toRole === query.toRole);
+      if (query?.fromRole !== undefined)
+        results = results.filter((h) => h.fromRole === query.fromRole);
+      if (query?.sourceCid !== undefined)
+        results = results.filter((h) => h.sourceCid === query.sourceCid);
+      if (query?.status !== undefined) {
+        const statuses = Array.isArray(query.status) ? query.status : [query.status];
+        results = results.filter((h) => (statuses as string[]).includes(h.status));
+      }
+      results.sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
+      if (query?.limit !== undefined) results = results.slice(0, query.limit);
+      return results;
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Read handoffs from the current session's file plus the _global
+   * migration file, but via the directory-listing path so cross-client
+   * writes are visible. This mirrors readAllHandoffs's pattern (which
+   * the original comment documents as the cross-client-visible source
+   * of truth) but restricts the file set to the scoped caller.
+   *
+   * Requires sessionId to be set — unscoped callers should use
+   * readAllHandoffs directly.
+   */
+  private async readScopedHandoffs(): Promise<Handoff[]> {
     const sessionPath = this.filePath();
+    const globalPath = globalFile(this.zoneId);
     try {
       const listing = await this.client.list(handoffsDir(this.zoneId));
-      // Include the session's own file plus the _global migration file so
-      // DeadlineWatcher.rebuildFromStore re-arms timers for pre-#164 rows
-      // and auto-reply resolution in contribute.ts can resolve them.
-      const globalPath = globalFile(this.zoneId);
       const pickable = listing.files.filter(
         (f) => !f.isDirectory && (f.path === sessionPath || f.path === globalPath),
       );
@@ -460,19 +486,7 @@ export class NexusHandoffStore implements HandoffStore {
           }
         }),
       );
-      let results = perFile.flat().filter((h) => h.handoffId && h.createdAt);
-      if (query?.toRole !== undefined) results = results.filter((h) => h.toRole === query.toRole);
-      if (query?.fromRole !== undefined)
-        results = results.filter((h) => h.fromRole === query.fromRole);
-      if (query?.sourceCid !== undefined)
-        results = results.filter((h) => h.sourceCid === query.sourceCid);
-      if (query?.status !== undefined) {
-        const statuses = Array.isArray(query.status) ? query.status : [query.status];
-        results = results.filter((h) => (statuses as string[]).includes(h.status));
-      }
-      results.sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
-      if (query?.limit !== undefined) results = results.slice(0, query.limit);
-      return results;
+      return perFile.flat();
     } catch {
       return [];
     }
@@ -509,6 +523,14 @@ export class NexusHandoffStore implements HandoffStore {
       // live in _global.json. Without this, grove_ack_handoff /
       // grove_process_handoff / markReplied would reject legacy handoffs
       // that isInCurrentSession / list() surface via the same shim.
+      //
+      // Pre-#164 rows have no session ownership by definition (they were
+      // created before session scoping existed), so "any session can
+      // resolve them" is the intended migration semantics. Concurrent
+      // resolutions are still first-wins via validateTransition inside
+      // `fn`: the second mutation sees the already-resolved status and
+      // the state-machine guard throws InvalidTransitionError, which the
+      // MCP tool surface translates to a structured INVALID_STATE error.
       await this.readModifyWrite(globalFile(this.zoneId), (handoffs) =>
         handoffs.map((h) => {
           if (h.handoffId === handoffId) {

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -480,23 +480,37 @@ export class NexusHandoffStore implements HandoffStore {
       const name = path.split("/").pop() ?? "";
       return name.replace(/\.json$/, "");
     };
-    const want = new Set([sessionId, "_global"]);
     try {
       const listing = await this.client.list(handoffsDir(this.zoneId));
-      const pickable = listing.files.filter(
-        (f) => !f.isDirectory && want.has(basenameNoExt(f.path)),
+      // Split pickable files into session-owned vs _global so a
+      // half-completed claim-move (session file has the mutated row,
+      // _global still has a stale copy) doesn't surface both. The
+      // session file wins.
+      const sessionFiles = listing.files.filter(
+        (f) => !f.isDirectory && basenameNoExt(f.path) === sessionId,
       );
-      const perFile = await Promise.all(
-        pickable.map(async (f) => {
-          try {
-            const { handoffs } = await this.readFile(f.path);
-            return handoffs;
-          } catch {
-            return [] as Handoff[];
-          }
-        }),
+      const globalFiles = listing.files.filter(
+        (f) => !f.isDirectory && basenameNoExt(f.path) === "_global",
       );
-      return perFile.flat();
+      const readHandoffs = async (
+        f: import("./client.js").ListEntry,
+      ): Promise<readonly Handoff[]> => {
+        try {
+          const { handoffs } = await this.readFile(f.path);
+          return handoffs;
+        } catch {
+          return [];
+        }
+      };
+      const [sessionPerFile, globalPerFile] = await Promise.all([
+        Promise.all(sessionFiles.map(readHandoffs)),
+        Promise.all(globalFiles.map(readHandoffs)),
+      ]);
+      const sessionHandoffs = sessionPerFile.flat();
+      const sessionIds = new Set(sessionHandoffs.map((h) => h.handoffId));
+      // Legacy rows only appear if the session file hasn't claimed them yet.
+      const legacyOnly = globalPerFile.flat().filter((h) => !sessionIds.has(h.handoffId));
+      return [...sessionHandoffs, ...legacyOnly];
     } catch {
       return [];
     }

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -531,39 +531,58 @@ export class NexusHandoffStore implements HandoffStore {
     if (!found && this.sessionId !== undefined) {
       // Migration shim with claim-on-move: pre-#164 rows in _global.json
       // are visible and mutable to every scoped session, so the first
-      // session to mutate them must ALSO move the row out of _global and
-      // into its session file — otherwise peer sessions keep seeing them
-      // in list()/listForCurrentSession() forever, re-acking or
-      // re-processing a row that the first session already resolved.
+      // session to mutate them must claim ownership — otherwise peer
+      // sessions keep seeing them in list/listForCurrentSession forever
+      // and could re-ack or re-process a row already resolved.
       //
-      // This mirrors the SQLite backend's claim-on-write pattern (SET
-      // session_id = COALESCE(session_id, ?) in every scoped UPDATE):
-      // after the first mutation, scopeClause / readScopedHandoffs stop
-      // matching the row from every other session.
-      let claimed: Handoff | undefined;
+      // Mirrors SQLite's claim-on-write pattern (SET session_id =
+      // COALESCE(session_id, ?)). Sequence:
+      //   1. Mutate in _global via readModifyWrite (CAS-protected —
+      //      state-machine guard inside fn prevents double resolution).
+      //   2. Best-effort copy to session file (idempotent — dedupe by id).
+      //   3. Best-effort delete from _global.
+      //
+      // We mutate FIRST instead of deleting first so a failure between
+      // steps never produces data loss — the mutated row always survives
+      // in at least _global. `mutatedRow` is reset on every readModifyWrite
+      // attempt so a retry after losing a CAS race doesn't carry a stale
+      // snapshot from attempt 1 into the session file.
+      let mutatedRow: Handoff | undefined;
       await this.readModifyWrite(globalFile(this.zoneId), (handoffs) => {
+        mutatedRow = undefined; // reset per retry — avoids stale snapshot on race
         const idx = handoffs.findIndex((h) => h.handoffId === handoffId);
         if (idx === -1) return handoffs;
         const current = handoffs[idx];
         if (current === undefined) return handoffs;
-        claimed = fn(current);
-        // Remove from _global — the row has been claimed by this session.
-        // A concurrent writer that raced us for the CAS will retry against
-        // the updated _global (without this row) and bail out.
-        return handoffs.filter((h) => h.handoffId !== handoffId);
+        const applied = fn(current);
+        mutatedRow = applied;
+        const copy = [...handoffs];
+        copy[idx] = applied;
+        return copy;
       });
-      if (claimed !== undefined) {
-        const snapshot = claimed;
+      if (mutatedRow !== undefined) {
         found = true;
-        // Insert into the session's own file so future reads resolve it
-        // locally. If this write fails after _global delete committed,
-        // the row survives only in the in-memory snapshot — but the
-        // readModifyWrite retry loop gives us 8 attempts with backoff
-        // before that becomes a real data-loss event.
-        await this.readModifyWrite(this.filePath(), (handoffs) => {
-          const deduped = handoffs.filter((h) => h.handoffId !== handoffId);
-          return [...deduped, snapshot];
-        });
+        const snapshot = mutatedRow;
+        // Best-effort move: copy to session file, then delete from
+        // _global. A failure here leaves the row in _global with the
+        // mutation already applied — peer sessions will still see it
+        // until the next retry, but state-machine guards prevent double
+        // resolution. expireStale / a subsequent claim attempt will
+        // eventually complete the move.
+        try {
+          await this.readModifyWrite(this.filePath(), (handoffs) => {
+            const deduped = handoffs.filter((h) => h.handoffId !== handoffId);
+            return [...deduped, snapshot];
+          });
+          await this.readModifyWrite(globalFile(this.zoneId), (handoffs) =>
+            handoffs.filter((h) => h.handoffId !== handoffId),
+          );
+        } catch (moveErr) {
+          debugLog(
+            "NexusHandoffStore.updateHandoff",
+            `claim-move follow-up failed for ${handoffId} (mutation in _global already committed) err=${moveErr instanceof Error ? moveErr.message : String(moveErr)}`,
+          );
+        }
       }
     }
 

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -14,7 +14,6 @@
 
 import { StateConflictError } from "../core/errors.js";
 import {
-  canTransition,
   type Handoff,
   type HandoffInput,
   type HandoffQuery,
@@ -129,11 +128,7 @@ export class NexusHandoffStore implements HandoffStore {
         //     unconditional-write branch and the later write would overwrite
         //     the earlier one, silently dropping a peer's handoffs.
         const writeOpts = etag ? { ifMatch: etag } : { ifNoneMatch: "*" };
-        const writeResult = await this.client.write(
-          path,
-          encode({ handoffs: updated }),
-          writeOpts,
-        );
+        const writeResult = await this.client.write(path, encode({ handoffs: updated }), writeOpts);
         debugLog(
           "NexusHandoffStore.readModifyWrite",
           `WRITE OK path=${path} etag=${etag || "(empty)"} bytesWritten=${writeResult.bytesWritten} newEtag=${writeResult.etag} count=${updated.length} attempt=${attempt}`,
@@ -223,9 +218,7 @@ export class NexusHandoffStore implements HandoffStore {
     // (see readAllHandoffs), so a handoff written by another client into
     // the same session file could otherwise vanish from get().
     const scopedHandoffs =
-      this.sessionId !== undefined
-        ? await this.readScopedHandoffs()
-        : await this.readAllHandoffs();
+      this.sessionId !== undefined ? await this.readScopedHandoffs() : await this.readAllHandoffs();
     const found = scopedHandoffs.find((h) => h.handoffId === handoffId);
     if (found) return found;
     if (this.sessionId !== undefined) return undefined;
@@ -237,9 +230,7 @@ export class NexusHandoffStore implements HandoffStore {
     // Use the directory-listing path for both scoped and unscoped reads —
     // see get() for why plain readFile() isn't cross-client-visible.
     const allHandoffs =
-      this.sessionId !== undefined
-        ? await this.readScopedHandoffs()
-        : await this.readAllHandoffs();
+      this.sessionId !== undefined ? await this.readScopedHandoffs() : await this.readAllHandoffs();
     debugLog(
       "nexus-handoff",
       `LIST sessionId=${this.sessionId ?? "none"} path=${this.filePath()} total=${allHandoffs.length}`,
@@ -287,8 +278,7 @@ export class NexusHandoffStore implements HandoffStore {
     let deadlineBreached = false;
     await this.updateHandoff(handoffId, (h) => {
       if (
-        (h.status === HandoffStatus.Delivered ||
-          h.status === HandoffStatus.Processed) &&
+        (h.status === HandoffStatus.Delivered || h.status === HandoffStatus.Processed) &&
         h.replyDueAt !== undefined &&
         h.replyDueAt < now
       ) {
@@ -438,9 +428,7 @@ export class NexusHandoffStore implements HandoffStore {
   async listForCurrentSession(query?: HandoffQuery): Promise<readonly Handoff[]> {
     if (this.sessionId === undefined) return [];
     try {
-      let results = (await this.readScopedHandoffs()).filter(
-        (h) => h.handoffId && h.createdAt,
-      );
+      let results = (await this.readScopedHandoffs()).filter((h) => h.handoffId && h.createdAt);
       if (query?.toRole !== undefined) results = results.filter((h) => h.toRole === query.toRole);
       if (query?.fromRole !== undefined)
         results = results.filter((h) => h.fromRole === query.fromRole);
@@ -608,55 +596,6 @@ export class NexusHandoffStore implements HandoffStore {
     }
   }
 
-  /**
-   * Transition a handoff's status with state machine validation.
-   * Rejects the write (no-op) if the current status doesn't allow the transition,
-   * which guards against concurrent writers clobbering each other with stale state.
-   */
-  /**
-   * Transition a handoff's status with state machine validation.
-   *
-   * Reads the current file, checks canTransition, and only writes back
-   * if the transition is valid. Skips the write entirely on no-op to
-   * avoid clobbering concurrent changes with a stale snapshot.
-   */
-  private async transitionHandoff(
-    handoffId: string,
-    targetStatus: HandoffStatus,
-    extraFields?: Partial<Handoff>,
-  ): Promise<void> {
-    await this.ensureDir();
-    const path = this.filePath();
-    const { handoffs } = await this.readFile(path);
-
-    const idx = handoffs.findIndex((h) => h.handoffId === handoffId);
-    if (idx === -1) return; // handoff not in this file
-
-    const current = handoffs[idx];
-    if (!current) return;
-    if (!canTransition(current.status, targetStatus)) {
-      debugLog(
-        "NexusHandoffStore.transitionHandoff",
-        `REJECTED ${handoffId} ${current.status}→${targetStatus} (invalid transition, skipping write)`,
-      );
-      return; // skip write entirely — don't clobber concurrent changes
-    }
-
-    // Valid transition — do the write
-    handoffs[idx] = { ...current, ...extraFields, status: targetStatus };
-    await this.client.write(path, new TextEncoder().encode(JSON.stringify({ handoffs })));
-    this.invalidateCache();
-    debugLog(
-      "NexusHandoffStore.transitionHandoff",
-      `OK ${handoffId} ${current.status}→${targetStatus}`,
-    );
-  }
-
-  private async scanAll(predicate: (h: Handoff) => boolean): Promise<Handoff | undefined> {
-    const all = await this.readAllHandoffs();
-    return all.find(predicate);
-  }
-
   private async readAllHandoffs(): Promise<Handoff[]> {
     // Short TTL cache — invalidated on own-process writes and when callers
     // know external mutation happened (SSE events, cross-client reply).
@@ -667,7 +606,6 @@ export class NexusHandoffStore implements HandoffStore {
     ) {
       return this.allHandoffsCache.data;
     }
-
 
     try {
       const listing = await this.client.list(handoffsDir(this.zoneId));

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -216,20 +216,41 @@ export class NexusHandoffStore implements HandoffStore {
   }
 
   async get(handoffId: string): Promise<Handoff | undefined> {
-    // Check session file first, then scan all files
+    // When scoped to a session, only return handoffs from this session's
+    // file (plus the _global file for pre-#164 migration). Scanning every
+    // session file would leak peer sessions' handoffs to scoped callers.
     const { handoffs } = await this.readFile(this.filePath());
     const found = handoffs.find((h) => h.handoffId === handoffId);
     if (found) return found;
 
-    // Fall back: scan all session files (for cross-session lookups)
+    if (this.sessionId !== undefined) {
+      // Migration shim: pre-#164 handoffs were written to _global.json before
+      // per-session file scoping existed. A scoped caller may still need to
+      // resolve those in-flight handoffs after upgrade.
+      const { handoffs: globalHandoffs } = await this.readFile(globalFile(this.zoneId));
+      return globalHandoffs.find((h) => h.handoffId === handoffId);
+    }
+
+    // Unscoped store (CLI/admin) — fall back to scanning every file.
     return this.scanAll((h) => h.handoffId === handoffId);
   }
 
   async list(query?: HandoffQuery): Promise<readonly Handoff[]> {
-    // Always scan all handoff files — readFile fails cross-client (Nexus VFS
-    // doesn't guarantee read-after-write visibility across NexusHttpClient instances).
-    // readAllHandoffs uses directory listing which has broader visibility.
-    const allHandoffs = await this.readAllHandoffs();
+    // When scoped to a session, read only the session's own file plus the
+    // _global migration file. An unscoped store walks the full directory
+    // (CLI / admin path) via readAllHandoffs.
+    let allHandoffs: Handoff[];
+    if (this.sessionId !== undefined) {
+      const [sessionFile, migrationFile] = await Promise.all([
+        this.readFile(this.filePath()),
+        this.readFile(globalFile(this.zoneId)),
+      ]);
+      allHandoffs = [...sessionFile.handoffs, ...migrationFile.handoffs];
+    } else {
+      // Unscoped: directory listing gives cross-client visibility that
+      // readFile doesn't guarantee.
+      allHandoffs = await this.readAllHandoffs();
+    }
     debugLog(
       "nexus-handoff",
       `LIST sessionId=${this.sessionId ?? "none"} path=${this.filePath()} total=${allHandoffs.length}`,

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -312,25 +312,45 @@ export class NexusHandoffStore implements HandoffStore {
   }
 
   /**
-   * Session-scoped list — reads ONLY the current session's handoff file,
-   * not the zone-wide directory. Used by DeadlineWatcher.rebuildFromStore()
-   * to avoid re-arming timers for handoffs from other sessions.
+   * Session-scoped list — returns handoffs from the current session only,
+   * used by DeadlineWatcher.rebuildFromStore() to avoid re-arming timers
+   * for handoffs in other sessions.
+   *
+   * Uses the same directory-listing path as list() (not a direct readFile)
+   * because Nexus does not guarantee cross-client read-after-write
+   * visibility via readFile — a restarting MCP server could miss handoffs
+   * written by another client. The directory listing path is documented as
+   * the cross-client-visible source of truth.
+   *
+   * When sessionId is unset (global fallback), returns an empty array —
+   * global handoffs can't be attributed to a specific session for rebuild.
    */
   async listForCurrentSession(query?: HandoffQuery): Promise<readonly Handoff[]> {
-    const { handoffs } = await this.readFile(this.filePath());
-    let results = handoffs.filter((h) => h.handoffId && h.createdAt);
-    if (query?.toRole !== undefined) results = results.filter((h) => h.toRole === query.toRole);
-    if (query?.fromRole !== undefined)
-      results = results.filter((h) => h.fromRole === query.fromRole);
-    if (query?.sourceCid !== undefined)
-      results = results.filter((h) => h.sourceCid === query.sourceCid);
-    if (query?.status !== undefined) {
-      const statuses = Array.isArray(query.status) ? query.status : [query.status];
-      results = results.filter((h) => (statuses as string[]).includes(h.status));
+    if (this.sessionId === undefined) return [];
+    const sessionPath = this.filePath();
+    // Scan all handoff files (same visibility path as list()) and filter to
+    // the current session's file.
+    try {
+      const listing = await this.client.list(handoffsDir(this.zoneId));
+      const file = listing.files.find((f) => !f.isDirectory && f.path === sessionPath);
+      if (!file) return [];
+      const { handoffs } = await this.readFile(file.path);
+      let results = handoffs.filter((h) => h.handoffId && h.createdAt);
+      if (query?.toRole !== undefined) results = results.filter((h) => h.toRole === query.toRole);
+      if (query?.fromRole !== undefined)
+        results = results.filter((h) => h.fromRole === query.fromRole);
+      if (query?.sourceCid !== undefined)
+        results = results.filter((h) => h.sourceCid === query.sourceCid);
+      if (query?.status !== undefined) {
+        const statuses = Array.isArray(query.status) ? query.status : [query.status];
+        results = results.filter((h) => (statuses as string[]).includes(h.status));
+      }
+      results.sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
+      if (query?.limit !== undefined) results = results.slice(0, query.limit);
+      return results;
+    } catch {
+      return [];
     }
-    results.sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
-    if (query?.limit !== undefined) results = results.slice(0, query.limit);
-    return results;
   }
 
   close(): void {

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -311,6 +311,28 @@ export class NexusHandoffStore implements HandoffStore {
     return pending.length;
   }
 
+  /**
+   * Session-scoped list — reads ONLY the current session's handoff file,
+   * not the zone-wide directory. Used by DeadlineWatcher.rebuildFromStore()
+   * to avoid re-arming timers for handoffs from other sessions.
+   */
+  async listForCurrentSession(query?: HandoffQuery): Promise<readonly Handoff[]> {
+    const { handoffs } = await this.readFile(this.filePath());
+    let results = handoffs.filter((h) => h.handoffId && h.createdAt);
+    if (query?.toRole !== undefined) results = results.filter((h) => h.toRole === query.toRole);
+    if (query?.fromRole !== undefined)
+      results = results.filter((h) => h.fromRole === query.fromRole);
+    if (query?.sourceCid !== undefined)
+      results = results.filter((h) => h.sourceCid === query.sourceCid);
+    if (query?.status !== undefined) {
+      const statuses = Array.isArray(query.status) ? query.status : [query.status];
+      results = results.filter((h) => (statuses as string[]).includes(h.status));
+    }
+    results.sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
+    if (query?.limit !== undefined) results = results.slice(0, query.limit);
+    return results;
+  }
+
   close(): void {
     // NexusClient is shared — caller owns its lifecycle
   }

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -284,11 +284,14 @@ export class NexusHandoffStore implements HandoffStore {
     const cutoff = now ?? new Date().toISOString();
     const expired: Handoff[] = [];
 
-    // Only scan the current session file for expiry (on-demand sweep)
+    // Expire both pending_pickup AND delivered — Nexus creates handoffs as
+    // delivered by default (see createMany), so restricting to pending_pickup
+    // would leave every deadline-backed Nexus handoff unresolvable forever.
     await this.casUpdate(this.filePath(), (handoffs) =>
       handoffs.map((h) => {
         if (
-          h.status === HandoffStatus.PendingPickup &&
+          (h.status === HandoffStatus.PendingPickup ||
+            h.status === HandoffStatus.Delivered) &&
           h.replyDueAt !== undefined &&
           h.replyDueAt < cutoff
         ) {

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -369,8 +369,7 @@ export class NexusHandoffStore implements HandoffStore {
       HandoffStatus.Processed,
     ]);
 
-    // Only scan the current session file for expiry (on-demand sweep)
-    await this.readModifyWrite(this.filePath(), (handoffs) =>
+    const expireIn = (handoffs: Handoff[]): Handoff[] =>
       handoffs.map((h) => {
         if (
           expirableStatuses.has(h.status) &&
@@ -382,8 +381,17 @@ export class NexusHandoffStore implements HandoffStore {
           return updated;
         }
         return h;
-      }),
-    );
+      });
+
+    // Sweep the session's own file
+    await this.readModifyWrite(this.filePath(), expireIn);
+
+    // Migration shim: also sweep _global for pre-#164 legacy rows when
+    // scoped. The readModifyWrite on _global claims the row atomically —
+    // if a peer session races us, only the winner mutates.
+    if (this.sessionId !== undefined) {
+      await this.readModifyWrite(globalFile(this.zoneId), expireIn);
+    }
 
     return expired;
   }
@@ -398,12 +406,19 @@ export class NexusHandoffStore implements HandoffStore {
    * read of the session file) vs. listForCurrentSession's bounded-scan
    * pattern. Returns false when there is no active sessionId (global
    * fallback) since global handoffs can't be attributed to a session.
+   *
+   * Also accepts pre-#164 legacy rows stored in _global.json so the
+   * receipt tools (grove_ack_handoff, grove_process_handoff) can resolve
+   * in-flight handoffs after upgrade — list()/get() already honor the
+   * same migration shim.
    */
   async isInCurrentSession(handoffId: string): Promise<boolean> {
     if (this.sessionId === undefined) return false;
     try {
       const { handoffs } = await this.readFile(this.filePath());
-      return handoffs.some((h) => h.handoffId === handoffId);
+      if (handoffs.some((h) => h.handoffId === handoffId)) return true;
+      const { handoffs: legacy } = await this.readFile(globalFile(this.zoneId));
+      return legacy.some((h) => h.handoffId === handoffId);
     } catch {
       return false;
     }
@@ -426,14 +441,26 @@ export class NexusHandoffStore implements HandoffStore {
   async listForCurrentSession(query?: HandoffQuery): Promise<readonly Handoff[]> {
     if (this.sessionId === undefined) return [];
     const sessionPath = this.filePath();
-    // Scan all handoff files (same visibility path as list()) and filter to
-    // the current session's file.
     try {
       const listing = await this.client.list(handoffsDir(this.zoneId));
-      const file = listing.files.find((f) => !f.isDirectory && f.path === sessionPath);
-      if (!file) return [];
-      const { handoffs } = await this.readFile(file.path);
-      let results = handoffs.filter((h) => h.handoffId && h.createdAt);
+      // Include the session's own file plus the _global migration file so
+      // DeadlineWatcher.rebuildFromStore re-arms timers for pre-#164 rows
+      // and auto-reply resolution in contribute.ts can resolve them.
+      const globalPath = globalFile(this.zoneId);
+      const pickable = listing.files.filter(
+        (f) => !f.isDirectory && (f.path === sessionPath || f.path === globalPath),
+      );
+      const perFile = await Promise.all(
+        pickable.map(async (f) => {
+          try {
+            const { handoffs } = await this.readFile(f.path);
+            return handoffs;
+          } catch {
+            return [] as Handoff[];
+          }
+        }),
+      );
+      let results = perFile.flat().filter((h) => h.handoffId && h.createdAt);
       if (query?.toRole !== undefined) results = results.filter((h) => h.toRole === query.toRole);
       if (query?.fromRole !== undefined)
         results = results.filter((h) => h.fromRole === query.fromRole);
@@ -476,6 +503,23 @@ export class NexusHandoffStore implements HandoffStore {
         return h;
       }),
     );
+
+    if (!found && this.sessionId !== undefined) {
+      // Migration shim: scoped stores can also mutate pre-#164 rows that
+      // live in _global.json. Without this, grove_ack_handoff /
+      // grove_process_handoff / markReplied would reject legacy handoffs
+      // that isInCurrentSession / list() surface via the same shim.
+      await this.readModifyWrite(globalFile(this.zoneId), (handoffs) =>
+        handoffs.map((h) => {
+          if (h.handoffId === handoffId) {
+            found = true;
+            return fn(h);
+          }
+          return h;
+        }),
+      );
+    }
+
     if (!found) {
       // Matches the InMemory/SQLite contract — mark* on a missing handoff is
       // a NotFoundError, not a silent no-op.

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -107,16 +107,15 @@ export class NexusHandoffStore implements HandoffStore {
       const { handoffs, etag } = await this.readFile(path);
       const updated = fn(handoffs);
       try {
-        // Attempt an etag-conditional write for CAS. Nexus server versions
-        // vary in how they handle if_match: older versions silently dropped
-        // these writes; current versions return 412 on mismatch. We pass the
-        // observed etag when present (non-empty) to get concurrency safety
-        // where supported, and fall back to the retry loop when not.
-        //
-        // For new files (empty etag), write unconditionally — if_none_match
-        // would prevent overwriting, but we've just read empty so this is
-        // the first writer by definition.
-        const writeOpts = etag ? { ifMatch: etag } : undefined;
+        // CAS via Nexus conditional write:
+        //   - Non-empty etag → ifMatch (detect overwrites-between-read-and-write)
+        //   - Empty etag (file not yet created) → ifNoneMatch: "*" so only the
+        //     FIRST writer succeeds; peers racing initial creation get a 412
+        //     and retry, re-reading the now-populated file and merging.
+        //     Without ifNoneMatch, both concurrent creators would take the
+        //     unconditional-write branch and the later write would overwrite
+        //     the earlier one, silently dropping a peer's handoffs.
+        const writeOpts = etag ? { ifMatch: etag } : { ifNoneMatch: "*" };
         const writeResult = await this.client.write(
           path,
           encode({ handoffs: updated }),
@@ -326,6 +325,22 @@ export class NexusHandoffStore implements HandoffStore {
   async countPending(toRole: string): Promise<number> {
     const pending = await this.list({ toRole, status: HandoffStatus.PendingPickup });
     return pending.length;
+  }
+
+  /**
+   * Direct session-scoped ownership check. O(1) per-session cost (single
+   * read of the session file) vs. listForCurrentSession's bounded-scan
+   * pattern. Returns false when there is no active sessionId (global
+   * fallback) since global handoffs can't be attributed to a session.
+   */
+  async isInCurrentSession(handoffId: string): Promise<boolean> {
+    if (this.sessionId === undefined) return false;
+    try {
+      const { handoffs } = await this.readFile(this.filePath());
+      return handoffs.some((h) => h.handoffId === handoffId);
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -107,11 +107,21 @@ export class NexusHandoffStore implements HandoffStore {
       const { handoffs, etag } = await this.readFile(path);
       const updated = fn(handoffs);
       try {
-        // Unconditional write — Nexus sys_write silently drops writes when
-        // if_match or if_none_match are set (returns success but doesn't persist).
-        // Without CAS, concurrent writes may lose data, but handoffs are append-only
-        // per session so conflicts are rare and the retry loop handles it.
-        const writeResult = await this.client.write(path, encode({ handoffs: updated }));
+        // Attempt an etag-conditional write for CAS. Nexus server versions
+        // vary in how they handle if_match: older versions silently dropped
+        // these writes; current versions return 412 on mismatch. We pass the
+        // observed etag when present (non-empty) to get concurrency safety
+        // where supported, and fall back to the retry loop when not.
+        //
+        // For new files (empty etag), write unconditionally — if_none_match
+        // would prevent overwriting, but we've just read empty so this is
+        // the first writer by definition.
+        const writeOpts = etag ? { ifMatch: etag } : undefined;
+        const writeResult = await this.client.write(
+          path,
+          encode({ handoffs: updated }),
+          writeOpts,
+        );
         debugLog(
           "NexusHandoffStore.casUpdate",
           `WRITE OK path=${path} etag=${etag || "(empty)"} bytesWritten=${writeResult.bytesWritten} newEtag=${writeResult.etag} count=${updated.length} attempt=${attempt}`,

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -469,12 +469,22 @@ export class NexusHandoffStore implements HandoffStore {
    * readAllHandoffs directly.
    */
   private async readScopedHandoffs(): Promise<Handoff[]> {
-    const sessionPath = this.filePath();
-    const globalPath = globalFile(this.zoneId);
+    const sessionId = this.sessionId;
+    if (sessionId === undefined) return [];
+    // Some Nexus versions return listing entries without the .json suffix
+    // even though files are written with it; readAllHandoffs accounts for
+    // this by accepting every non-directory entry. Here we match by
+    // basename with the extension stripped so the session file and
+    // _global file are picked up in both listing styles.
+    const basenameNoExt = (path: string): string => {
+      const name = path.split("/").pop() ?? "";
+      return name.replace(/\.json$/, "");
+    };
+    const want = new Set([sessionId, "_global"]);
     try {
       const listing = await this.client.list(handoffsDir(this.zoneId));
       const pickable = listing.files.filter(
-        (f) => !f.isDirectory && (f.path === sessionPath || f.path === globalPath),
+        (f) => !f.isDirectory && want.has(basenameNoExt(f.path)),
       );
       const perFile = await Promise.all(
         pickable.map(async (f) => {
@@ -519,27 +529,42 @@ export class NexusHandoffStore implements HandoffStore {
     );
 
     if (!found && this.sessionId !== undefined) {
-      // Migration shim: scoped stores can also mutate pre-#164 rows that
-      // live in _global.json. Without this, grove_ack_handoff /
-      // grove_process_handoff / markReplied would reject legacy handoffs
-      // that isInCurrentSession / list() surface via the same shim.
+      // Migration shim with claim-on-move: pre-#164 rows in _global.json
+      // are visible and mutable to every scoped session, so the first
+      // session to mutate them must ALSO move the row out of _global and
+      // into its session file — otherwise peer sessions keep seeing them
+      // in list()/listForCurrentSession() forever, re-acking or
+      // re-processing a row that the first session already resolved.
       //
-      // Pre-#164 rows have no session ownership by definition (they were
-      // created before session scoping existed), so "any session can
-      // resolve them" is the intended migration semantics. Concurrent
-      // resolutions are still first-wins via validateTransition inside
-      // `fn`: the second mutation sees the already-resolved status and
-      // the state-machine guard throws InvalidTransitionError, which the
-      // MCP tool surface translates to a structured INVALID_STATE error.
-      await this.readModifyWrite(globalFile(this.zoneId), (handoffs) =>
-        handoffs.map((h) => {
-          if (h.handoffId === handoffId) {
-            found = true;
-            return fn(h);
-          }
-          return h;
-        }),
-      );
+      // This mirrors the SQLite backend's claim-on-write pattern (SET
+      // session_id = COALESCE(session_id, ?) in every scoped UPDATE):
+      // after the first mutation, scopeClause / readScopedHandoffs stop
+      // matching the row from every other session.
+      let claimed: Handoff | undefined;
+      await this.readModifyWrite(globalFile(this.zoneId), (handoffs) => {
+        const idx = handoffs.findIndex((h) => h.handoffId === handoffId);
+        if (idx === -1) return handoffs;
+        const current = handoffs[idx];
+        if (current === undefined) return handoffs;
+        claimed = fn(current);
+        // Remove from _global — the row has been claimed by this session.
+        // A concurrent writer that raced us for the CAS will retry against
+        // the updated _global (without this row) and bail out.
+        return handoffs.filter((h) => h.handoffId !== handoffId);
+      });
+      if (claimed !== undefined) {
+        const snapshot = claimed;
+        found = true;
+        // Insert into the session's own file so future reads resolve it
+        // locally. If this write fails after _global delete committed,
+        // the row survives only in the in-memory snapshot — but the
+        // readModifyWrite retry loop gives us 8 attempts with backoff
+        // before that becomes a real data-loss event.
+        await this.readModifyWrite(this.filePath(), (handoffs) => {
+          const deduped = handoffs.filter((h) => h.handoffId !== handoffId);
+          return [...deduped, snapshot];
+        });
+      }
     }
 
     if (!found) {

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -12,6 +12,7 @@
  * falls back to a shared "handoffs/_global.json" file.
  */
 
+import { StateConflictError } from "../core/errors.js";
 import {
   type Handoff,
   type HandoffInput,
@@ -235,7 +236,20 @@ export class NexusHandoffStore implements HandoffStore {
   }
 
   async markReplied(handoffId: string, resolvedByCid: string): Promise<void> {
+    // Reject late replies at the store level so correctness does not
+    // depend on the DeadlineWatcher flipping status first.
+    const now = new Date().toISOString();
+    let deadlineBreached = false;
     await this.updateHandoff(handoffId, (h) => {
+      if (
+        (h.status === HandoffStatus.PendingPickup ||
+          h.status === HandoffStatus.Delivered) &&
+        h.replyDueAt !== undefined &&
+        h.replyDueAt < now
+      ) {
+        deadlineBreached = true;
+        return { ...h, status: HandoffStatus.Expired };
+      }
       validateTransition(handoffId, h.status, HandoffStatus.Replied);
       return {
         ...h,
@@ -243,6 +257,12 @@ export class NexusHandoffStore implements HandoffStore {
         resolvedByCid,
       };
     });
+    if (deadlineBreached) {
+      throw new StateConflictError({
+        resource: "Handoff",
+        reason: `Reply deadline passed (now ${now})`,
+      });
+    }
   }
 
   async markSeen(handoffId: string): Promise<void> {

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -25,9 +25,6 @@ import type { NexusClient } from "./client.js";
 
 const MAX_CAS_RETRIES = 8;
 
-/** TTL for the readAllHandoffs cache (milliseconds). */
-const LIST_CACHE_TTL_MS = 15_000;
-
 function handoffsDir(zoneId: string): string {
   return `/zones/${zoneId}/handoffs`;
 }
@@ -47,9 +44,6 @@ export class NexusHandoffStore implements HandoffStore {
   private readonly sessionId: string | undefined;
   private readonly zoneId: string;
   private dirEnsured = false;
-
-  /** Cached result of readAllHandoffs() with TTL. */
-  private listCache: { handoffs: Handoff[]; expiry: number } | undefined;
 
   constructor(
     client: NexusClient,
@@ -81,11 +75,6 @@ export class NexusHandoffStore implements HandoffStore {
       // Best-effort — write may auto-create parent dirs on some Nexus versions
     }
     this.dirEnsured = true;
-  }
-
-  /** Invalidate the list cache (called after writes). */
-  private invalidateCache(): void {
-    this.listCache = undefined;
   }
 
   private async readFile(path: string): Promise<{ handoffs: Handoff[]; etag: string }> {
@@ -126,8 +115,6 @@ export class NexusHandoffStore implements HandoffStore {
           "NexusHandoffStore.casUpdate",
           `WRITE OK path=${path} etag=${etag || "(empty)"} bytesWritten=${writeResult.bytesWritten} newEtag=${writeResult.etag} count=${updated.length} attempt=${attempt}`,
         );
-        // Invalidate cache after successful write
-        this.invalidateCache();
         return updated;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -373,11 +360,10 @@ export class NexusHandoffStore implements HandoffStore {
   }
 
   private async readAllHandoffs(): Promise<Handoff[]> {
-    // Return cached result if fresh
-    if (this.listCache !== undefined && Date.now() < this.listCache.expiry) {
-      return this.listCache.handoffs;
-    }
-
+    // No TTL cache: handoff coordination state is written by multiple
+    // processes (different agents) and stale reads cause missed overdue
+    // events and false ack suppression. Freshness matters more than the
+    // extra round-trip.
     try {
       const listing = await this.client.list(handoffsDir(this.zoneId));
       // Nexus list may return entries without the .json extension even though
@@ -405,12 +391,7 @@ export class NexusHandoffStore implements HandoffStore {
           }
         }),
       );
-      const handoffs = results.flat();
-
-      // Cache the result
-      this.listCache = { handoffs, expiry: Date.now() + LIST_CACHE_TTL_MS };
-
-      return handoffs;
+      return results.flat();
     } catch (listErr) {
       debugLog(
         "NexusHandoffStore.readAllHandoffs",

--- a/src/nexus/nexus-handoff-store.ts
+++ b/src/nexus/nexus-handoff-store.ts
@@ -18,11 +18,15 @@ import {
   type HandoffQuery,
   HandoffStatus,
   type HandoffStore,
+  validateTransition,
 } from "../core/handoff.js";
 import { debugLog } from "../tui/debug-log.js";
 import type { NexusClient } from "./client.js";
 
 const MAX_CAS_RETRIES = 8;
+
+/** TTL for the readAllHandoffs cache (milliseconds). */
+const LIST_CACHE_TTL_MS = 15_000;
 
 function handoffsDir(zoneId: string): string {
   return `/zones/${zoneId}/handoffs`;
@@ -43,6 +47,9 @@ export class NexusHandoffStore implements HandoffStore {
   private readonly sessionId: string | undefined;
   private readonly zoneId: string;
   private dirEnsured = false;
+
+  /** Cached result of readAllHandoffs() with TTL. */
+  private listCache: { handoffs: Handoff[]; expiry: number } | undefined;
 
   constructor(
     client: NexusClient,
@@ -74,6 +81,11 @@ export class NexusHandoffStore implements HandoffStore {
       // Best-effort — write may auto-create parent dirs on some Nexus versions
     }
     this.dirEnsured = true;
+  }
+
+  /** Invalidate the list cache (called after writes). */
+  private invalidateCache(): void {
+    this.listCache = undefined;
   }
 
   private async readFile(path: string): Promise<{ handoffs: Handoff[]; etag: string }> {
@@ -114,6 +126,8 @@ export class NexusHandoffStore implements HandoffStore {
           "NexusHandoffStore.casUpdate",
           `WRITE OK path=${path} etag=${etag || "(empty)"} bytesWritten=${writeResult.bytesWritten} newEtag=${writeResult.etag} count=${updated.length} attempt=${attempt}`,
         );
+        // Invalidate cache after successful write
+        this.invalidateCache();
         return updated;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -123,12 +137,13 @@ export class NexusHandoffStore implements HandoffStore {
         );
         // Conflict = another writer updated between our read and write — retry
         if (msg.includes("412") || msg.includes("conflict") || msg.includes("mismatch")) {
-          // Brief backoff before retry
-          await new Promise((r) => setTimeout(r, 20 * (attempt + 1)));
+          // Exponential backoff with jitter to prevent retry storms
+          const backoff = Math.min(20 * 2 ** attempt, 500) + Math.random() * 50;
+          await new Promise((r) => setTimeout(r, backoff));
           continue;
         }
         // First write hit a conflict because file was just created — retry as update
-        if (msg.includes("412") || msg.includes("none_match")) {
+        if (msg.includes("none_match")) {
           continue;
         }
         // Rate limit — backoff and retry (handoff writes are critical for IPC tracking)
@@ -226,15 +241,43 @@ export class NexusHandoffStore implements HandoffStore {
   }
 
   async markDelivered(handoffId: string): Promise<void> {
-    await this.updateHandoff(handoffId, (h) => ({ ...h, status: HandoffStatus.Delivered }));
+    await this.updateHandoff(handoffId, (h) => {
+      validateTransition(handoffId, h.status, HandoffStatus.Delivered);
+      return { ...h, status: HandoffStatus.Delivered };
+    });
   }
 
   async markReplied(handoffId: string, resolvedByCid: string): Promise<void> {
-    await this.updateHandoff(handoffId, (h) => ({
-      ...h,
-      status: HandoffStatus.Replied,
-      resolvedByCid,
-    }));
+    await this.updateHandoff(handoffId, (h) => {
+      validateTransition(handoffId, h.status, HandoffStatus.Replied);
+      return {
+        ...h,
+        status: HandoffStatus.Replied,
+        resolvedByCid,
+      };
+    });
+  }
+
+  async markSeen(handoffId: string): Promise<void> {
+    await this.updateHandoff(handoffId, (h) => {
+      // No-op if already seen
+      if (h.seenAt !== undefined) return h;
+      return { ...h, seenAt: new Date().toISOString() };
+    });
+  }
+
+  async markAcked(handoffId: string): Promise<void> {
+    await this.updateHandoff(handoffId, (h) => {
+      // No-op if already acked
+      if (h.ackedAt !== undefined) return h;
+      const now = new Date().toISOString();
+      return {
+        ...h,
+        // Auto-fill seenAt if not already set
+        ...(h.seenAt === undefined ? { seenAt: now } : {}),
+        ackedAt: now,
+      };
+    });
   }
 
   async expireStale(now?: string): Promise<readonly Handoff[]> {
@@ -285,6 +328,11 @@ export class NexusHandoffStore implements HandoffStore {
   }
 
   private async readAllHandoffs(): Promise<Handoff[]> {
+    // Return cached result if fresh
+    if (this.listCache !== undefined && Date.now() < this.listCache.expiry) {
+      return this.listCache.handoffs;
+    }
+
     try {
       const listing = await this.client.list(handoffsDir(this.zoneId));
       // Nexus list may return entries without the .json extension even though
@@ -312,7 +360,12 @@ export class NexusHandoffStore implements HandoffStore {
           }
         }),
       );
-      return results.flat();
+      const handoffs = results.flat();
+
+      // Cache the result
+      this.listCache = { handoffs, expiry: Date.now() + LIST_CACHE_TTL_MS };
+
+      return handoffs;
     } catch (listErr) {
       debugLog(
         "NexusHandoffStore.readAllHandoffs",

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -37,6 +37,17 @@ export interface ServerDeps {
   readonly contract?: GroveContract | undefined;
   /** Optional handoff store. Routes return 501 when not configured. */
   readonly handoffStore?: HandoffStore | undefined;
+  /**
+   * Factory for session-scoped handoff stores. Optional: when provided,
+   * HTTP routes that need session isolation (e.g. GET/list under a
+   * ?sessionId= query) can construct a scoped store per request. When
+   * omitted, routes fall back to the global `handoffStore` (unscoped).
+   *
+   * This is primarily needed for the grove-server HTTP surface in local
+   * mode, where the process-global store spans all sessions and remote
+   * TUI reads would leak cross-session handoffs otherwise.
+   */
+  readonly handoffStoreForSession?: (sessionId: string) => HandoffStore | undefined;
   /** Optional idempotency store for cross-process deduplication. */
   readonly idempotencyStore?: IdempotencyStore | undefined;
 }

--- a/src/server/routes/handoffs.ts
+++ b/src/server/routes/handoffs.ts
@@ -39,6 +39,15 @@ handoffs.use("/*", async (c, next) => {
  *
  * Callers that care about session isolation (remote TUI reads) should
  * always pass ?sessionId=.
+ *
+ * NOTE: `sessionId` is caller-asserted scope, not caller-authenticated
+ * identity. The HTTP surface is documented as unauthenticated and the
+ * deployment trust boundary is localhost-binding (see serve.ts warning
+ * for non-localhost binds). Role-sensitive mutations are NOT exposed on
+ * this surface — they flow through MCP stdio with GROVE_AGENT_ROLE +
+ * session-scoped store guards. The scoping here is a correctness filter
+ * that keeps a well-behaved remote TUI from seeing peer sessions'
+ * handoffs; it is NOT a security boundary against a hostile client.
  */
 function resolveStore(c: Context<ServerEnv>): HandoffStore | undefined {
   const { handoffStore, handoffStoreForSession } = c.get("deps");

--- a/src/server/routes/handoffs.ts
+++ b/src/server/routes/handoffs.ts
@@ -1,11 +1,13 @@
 /**
- * Handoff endpoints (read-only).
+ * Handoff endpoints.
  *
- * GET /api/handoffs       — List handoffs (filtered by role, status, etc.)
- * GET /api/handoffs/:id   — Get a single handoff by ID
+ * GET  /api/handoffs              — List handoffs (filtered by role, status, etc.)
+ * GET  /api/handoffs/:id          — Get a single handoff by ID
+ * POST /api/handoffs/:id/delivered — Mark a handoff delivered (IPC transport ack)
  *
- * All state mutations (delivered / replied / seen / acked) are deliberately
- * NOT exposed here — see the comment below for rationale.
+ * Other state mutations (replied / seen / acked / processed) are deliberately
+ * NOT exposed here — they are role-sensitive and the HTTP surface is
+ * unauthenticated. See comments below for rationale.
  */
 
 import type { Hono as HonoType } from "hono";
@@ -70,15 +72,45 @@ handoffs.get("/:id", async (c) => {
   return c.json(handoff);
 });
 
-// Intentionally no HTTP routes for handoff mutations (delivered / replied /
-// seen / acked). The grove-server HTTP surface is unauthenticated — any
-// client that can reach it can claim any role. Exposing these routes would
-// let a caller mark another role's handoff replied and suppress SLA/overdue
-// handling. The authoritative mutation paths are:
-//   - delivered: driven by IPC routing inside the agent runtime
-//   - replied:   driven by contributeOperation when a role submits a
-//                reviews/responds_to/adopts contribution (requires agent.role)
-//   - seen/acked: only via MCP grove_ack_handoff on stdio transport
-//                 (per-agent GROVE_AGENT_ROLE binding is enforced there)
+/**
+ * POST /api/handoffs/:id/delivered — Transition pending_pickup → delivered.
+ *
+ * This is a transport-layer IPC acknowledgement, not a role-sensitive
+ * action. It's safe on the unauthenticated HTTP surface because:
+ *   - delivered means "IPC successfully routed the message to the agent's
+ *     inbox," which is observable infrastructure state, not a claim about
+ *     what a role did with the message.
+ *   - The target role hasn't processed or replied — those transitions are
+ *     still gated by the MCP tools (grove_process_handoff, contribute
+ *     operations) with role+session authorization.
+ *   - The remote TUI (RemoteDataProvider.markHandoffDelivered) calls this
+ *     endpoint when SpawnManager detects a new contribution arriving at
+ *     a target agent, so removing it would strand handoffs in
+ *     pending_pickup and block grove_process_handoff on the target role.
+ *
+ * Role-sensitive mutations (replied, seen, acked, processed) are NOT
+ * exposed here. They flow through MCP tools with GROVE_AGENT_ROLE +
+ * session-scoped store guards.
+ */
+handoffs.post("/:id/delivered", async (c) => {
+  const { handoffStore } = c.get("deps");
+  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
+
+  const id = c.req.param("id");
+  if (id === undefined) {
+    return c.json({ error: { code: "BAD_REQUEST", message: "Missing handoff id" } }, 400);
+  }
+
+  try {
+    await handoffStore.markDelivered(id);
+    const updated = await handoffStore.get(id);
+    if (updated === undefined) {
+      return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
+    }
+    return c.json(updated);
+  } catch {
+    return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
+  }
+});
 
 export { handoffs };

--- a/src/server/routes/handoffs.ts
+++ b/src/server/routes/handoffs.ts
@@ -1,13 +1,11 @@
 /**
- * Handoff endpoints.
+ * Handoff endpoints (read-only).
  *
- * GET  /api/handoffs             — List handoffs (filtered by role, status, etc.)
- * GET  /api/handoffs/:id         — Get a single handoff by ID
- * POST /api/handoffs/:id/delivered — Mark a handoff as delivered
- * POST /api/handoffs/:id/replied   — Mark a handoff as replied
+ * GET /api/handoffs       — List handoffs (filtered by role, status, etc.)
+ * GET /api/handoffs/:id   — Get a single handoff by ID
  *
- * Note: receipt mutations (seen/acked) are deliberately not exposed here.
- * See the comment below `handoffs.post("/:id/replied")` for rationale.
+ * All state mutations (delivered / replied / seen / acked) are deliberately
+ * NOT exposed here — see the comment below for rationale.
  */
 
 import type { Hono as HonoType } from "hono";
@@ -72,53 +70,15 @@ handoffs.get("/:id", async (c) => {
   return c.json(handoff);
 });
 
-/** POST /api/handoffs/:id/delivered — Transition handoff to delivered. */
-handoffs.post("/:id/delivered", async (c) => {
-  const { handoffStore } = c.get("deps");
-  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
-
-  try {
-    await handoffStore.markDelivered(c.req.param("id"));
-    const updated = await handoffStore.get(c.req.param("id"));
-    return c.json(updated);
-  } catch {
-    return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
-  }
-});
-
-/** POST /api/handoffs/:id/replied — Transition handoff to replied. */
-handoffs.post("/:id/replied", async (c) => {
-  const { handoffStore } = c.get("deps");
-  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
-
-  let body: { resolvedByCid: string };
-  try {
-    body = await c.req.json<{ resolvedByCid: string }>();
-  } catch {
-    return c.json(
-      { error: { code: "BAD_REQUEST", message: "Body must be JSON with resolvedByCid" } },
-      400,
-    );
-  }
-
-  if (!body.resolvedByCid) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "resolvedByCid is required" } }, 400);
-  }
-
-  try {
-    await handoffStore.markReplied(c.req.param("id"), body.resolvedByCid);
-    const updated = await handoffStore.get(c.req.param("id"));
-    return c.json(updated);
-  } catch {
-    return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
-  }
-});
-
-// Intentionally no HTTP routes for seen/acked mutations. The grove-server
-// HTTP surface is not authenticated — any client that can reach it can
-// claim any role. Because receipt mutations must be bound to the actual
-// target role to be trustworthy, they are exposed ONLY through the MCP
-// tool grove_ack_handoff, where GROVE_AGENT_ROLE is set by the spawning
-// process (TUI/runtime) and not controllable by the tool caller.
+// Intentionally no HTTP routes for handoff mutations (delivered / replied /
+// seen / acked). The grove-server HTTP surface is unauthenticated — any
+// client that can reach it can claim any role. Exposing these routes would
+// let a caller mark another role's handoff replied and suppress SLA/overdue
+// handling. The authoritative mutation paths are:
+//   - delivered: driven by IPC routing inside the agent runtime
+//   - replied:   driven by contributeOperation when a role submits a
+//                reviews/responds_to/adopts contribution (requires agent.role)
+//   - seen/acked: only via MCP grove_ack_handoff on stdio transport
+//                 (per-agent GROVE_AGENT_ROLE binding is enforced there)
 
 export { handoffs };

--- a/src/server/routes/handoffs.ts
+++ b/src/server/routes/handoffs.ts
@@ -1,10 +1,12 @@
 /**
  * Handoff endpoints.
  *
- * GET  /api/handoffs      — List handoffs (filtered by role, status, etc.)
- * GET  /api/handoffs/:id  — Get a single handoff by ID
+ * GET  /api/handoffs             — List handoffs (filtered by role, status, etc.)
+ * GET  /api/handoffs/:id         — Get a single handoff by ID
  * POST /api/handoffs/:id/delivered — Mark a handoff as delivered
  * POST /api/handoffs/:id/replied   — Mark a handoff as replied
+ * POST /api/handoffs/:id/seen      — Mark a handoff as seen
+ * POST /api/handoffs/:id/acked     — Mark a handoff as acknowledged
  */
 
 import type { Hono as HonoType } from "hono";
@@ -14,8 +16,11 @@ import type { ServerEnv } from "../deps.js";
 
 const handoffs: HonoType<ServerEnv> = new Hono<ServerEnv>();
 
-/** GET /api/handoffs — List handoffs with optional filters. */
-handoffs.get("/", async (c) => {
+/**
+ * Middleware: require handoffStore to be configured.
+ * Returns 501 if not available, otherwise passes through.
+ */
+handoffs.use("/*", async (c, next) => {
   const { handoffStore } = c.get("deps");
   if (handoffStore === undefined) {
     return c.json(
@@ -23,6 +28,14 @@ handoffs.get("/", async (c) => {
       501,
     );
   }
+  await next();
+});
+
+/** GET /api/handoffs — List handoffs with optional filters. */
+handoffs.get("/", async (c) => {
+  const { handoffStore } = c.get("deps");
+  // handoffStore is guaranteed by middleware, but TypeScript needs the check
+  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
 
   // Expire stale handoffs before listing so callers always see fresh status.
   await handoffStore.expireStale();
@@ -48,12 +61,7 @@ handoffs.get("/", async (c) => {
 /** GET /api/handoffs/:id — Get a single handoff. */
 handoffs.get("/:id", async (c) => {
   const { handoffStore } = c.get("deps");
-  if (handoffStore === undefined) {
-    return c.json(
-      { error: { code: "NOT_CONFIGURED", message: "Handoff store not available" } },
-      501,
-    );
-  }
+  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
 
   const handoff = await handoffStore.get(c.req.param("id"));
   if (handoff === undefined) {
@@ -66,12 +74,7 @@ handoffs.get("/:id", async (c) => {
 /** POST /api/handoffs/:id/delivered — Transition handoff to delivered. */
 handoffs.post("/:id/delivered", async (c) => {
   const { handoffStore } = c.get("deps");
-  if (handoffStore === undefined) {
-    return c.json(
-      { error: { code: "NOT_CONFIGURED", message: "Handoff store not available" } },
-      501,
-    );
-  }
+  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
 
   try {
     await handoffStore.markDelivered(c.req.param("id"));
@@ -85,12 +88,7 @@ handoffs.post("/:id/delivered", async (c) => {
 /** POST /api/handoffs/:id/replied — Transition handoff to replied. */
 handoffs.post("/:id/replied", async (c) => {
   const { handoffStore } = c.get("deps");
-  if (handoffStore === undefined) {
-    return c.json(
-      { error: { code: "NOT_CONFIGURED", message: "Handoff store not available" } },
-      501,
-    );
-  }
+  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
 
   let body: { resolvedByCid: string };
   try {
@@ -108,6 +106,34 @@ handoffs.post("/:id/replied", async (c) => {
 
   try {
     await handoffStore.markReplied(c.req.param("id"), body.resolvedByCid);
+    const updated = await handoffStore.get(c.req.param("id"));
+    return c.json(updated);
+  } catch {
+    return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
+  }
+});
+
+/** POST /api/handoffs/:id/seen — Record that the target agent has seen this handoff. */
+handoffs.post("/:id/seen", async (c) => {
+  const { handoffStore } = c.get("deps");
+  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
+
+  try {
+    await handoffStore.markSeen(c.req.param("id"));
+    const updated = await handoffStore.get(c.req.param("id"));
+    return c.json(updated);
+  } catch {
+    return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
+  }
+});
+
+/** POST /api/handoffs/:id/acked — Record that the target agent acknowledges this handoff. */
+handoffs.post("/:id/acked", async (c) => {
+  const { handoffStore } = c.get("deps");
+  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
+
+  try {
+    await handoffStore.markAcked(c.req.param("id"));
     const updated = await handoffStore.get(c.req.param("id"));
     return c.json(updated);
   } catch {

--- a/src/server/routes/handoffs.ts
+++ b/src/server/routes/handoffs.ts
@@ -10,9 +10,9 @@
  * unauthenticated. See comments below for rationale.
  */
 
-import type { Hono as HonoType } from "hono";
+import type { Context, Hono as HonoType } from "hono";
 import { Hono } from "hono";
-import type { HandoffStatus } from "../../core/handoff.js";
+import type { HandoffStatus, HandoffStore } from "../../core/handoff.js";
 import type { ServerEnv } from "../deps.js";
 
 const handoffs: HonoType<ServerEnv> = new Hono<ServerEnv>();
@@ -32,14 +32,30 @@ handoffs.use("/*", async (c, next) => {
   await next();
 });
 
+/**
+ * Resolve the right handoff store for this request. When `?sessionId=X` is
+ * present and the deps expose a session-scoped factory, build a scoped
+ * store. Otherwise fall back to the process-global store.
+ *
+ * Callers that care about session isolation (remote TUI reads) should
+ * always pass ?sessionId=.
+ */
+function resolveStore(c: Context<ServerEnv>): HandoffStore | undefined {
+  const { handoffStore, handoffStoreForSession } = c.get("deps");
+  const sessionId = c.req.query("sessionId");
+  if (sessionId && handoffStoreForSession) {
+    return handoffStoreForSession(sessionId) ?? handoffStore;
+  }
+  return handoffStore;
+}
+
 /** GET /api/handoffs — List handoffs with optional filters. */
 handoffs.get("/", async (c) => {
-  const { handoffStore } = c.get("deps");
-  // handoffStore is guaranteed by middleware, but TypeScript needs the check
-  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
+  const store = resolveStore(c);
+  if (store === undefined) return c.json({ error: "unreachable" }, 500);
 
   // Expire stale handoffs before listing so callers always see fresh status.
-  await handoffStore.expireStale();
+  await store.expireStale();
 
   const toRole = c.req.query("toRole");
   const fromRole = c.req.query("fromRole");
@@ -48,7 +64,7 @@ handoffs.get("/", async (c) => {
   const limitRaw = c.req.query("limit");
   const limit = limitRaw !== undefined ? Math.min(parseInt(limitRaw, 10) || 50, 200) : 50;
 
-  const results = await handoffStore.list({
+  const results = await store.list({
     ...(toRole !== undefined ? { toRole } : {}),
     ...(fromRole !== undefined ? { fromRole } : {}),
     ...(status !== undefined ? { status } : {}),
@@ -61,10 +77,14 @@ handoffs.get("/", async (c) => {
 
 /** GET /api/handoffs/:id — Get a single handoff. */
 handoffs.get("/:id", async (c) => {
-  const { handoffStore } = c.get("deps");
-  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
+  const store = resolveStore(c);
+  if (store === undefined) return c.json({ error: "unreachable" }, 500);
 
-  const handoff = await handoffStore.get(c.req.param("id"));
+  const id = c.req.param("id");
+  if (id === undefined) {
+    return c.json({ error: { code: "BAD_REQUEST", message: "Missing handoff id" } }, 400);
+  }
+  const handoff = await store.get(id);
   if (handoff === undefined) {
     return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
   }
@@ -93,8 +113,8 @@ handoffs.get("/:id", async (c) => {
  * session-scoped store guards.
  */
 handoffs.post("/:id/delivered", async (c) => {
-  const { handoffStore } = c.get("deps");
-  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
+  const store = resolveStore(c);
+  if (store === undefined) return c.json({ error: "unreachable" }, 500);
 
   const id = c.req.param("id");
   if (id === undefined) {
@@ -102,8 +122,8 @@ handoffs.post("/:id/delivered", async (c) => {
   }
 
   try {
-    await handoffStore.markDelivered(id);
-    const updated = await handoffStore.get(id);
+    await store.markDelivered(id);
+    const updated = await store.get(id);
     if (updated === undefined) {
       return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
     }

--- a/src/server/routes/handoffs.ts
+++ b/src/server/routes/handoffs.ts
@@ -5,13 +5,14 @@
  * GET  /api/handoffs/:id         — Get a single handoff by ID
  * POST /api/handoffs/:id/delivered — Mark a handoff as delivered
  * POST /api/handoffs/:id/replied   — Mark a handoff as replied
- * POST /api/handoffs/:id/seen      — Mark a handoff as seen
- * POST /api/handoffs/:id/acked     — Mark a handoff as acknowledged
+ *
+ * Note: receipt mutations (seen/acked) are deliberately not exposed here.
+ * See the comment below `handoffs.post("/:id/replied")` for rationale.
  */
 
-import type { Context, Hono as HonoType } from "hono";
+import type { Hono as HonoType } from "hono";
 import { Hono } from "hono";
-import type { Handoff, HandoffStatus, HandoffStore } from "../../core/handoff.js";
+import type { HandoffStatus } from "../../core/handoff.js";
 import type { ServerEnv } from "../deps.js";
 
 const handoffs: HonoType<ServerEnv> = new Hono<ServerEnv>();
@@ -113,90 +114,11 @@ handoffs.post("/:id/replied", async (c) => {
   }
 });
 
-/**
- * Verify the caller role matches the handoff's toRole before mutating
- * receipt state. Reads the role from the X-Grove-Role header or a JSON
- * body field. Returns an error Response if unauthorized; otherwise returns
- * the handoff for the route handler to use.
- */
-async function authorizeReceiptMutation(
-  c: Context<ServerEnv>,
-  handoffStore: HandoffStore,
-): Promise<{ ok: true; handoff: Handoff } | { ok: false; response: Response }> {
-  const id = c.req.param("id");
-  if (id === undefined) {
-    return {
-      ok: false,
-      response: c.json({ error: { code: "BAD_REQUEST", message: "Missing handoff id" } }, 400),
-    };
-  }
-  const handoff = await handoffStore.get(id);
-  if (handoff === undefined) {
-    return {
-      ok: false,
-      response: c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404),
-    };
-  }
-  const headerRole = c.req.header("x-grove-role");
-  let bodyRole: string | undefined;
-  try {
-    const body = (await c.req.json<{ role?: string }>().catch(() => undefined)) as
-      | { role?: string }
-      | undefined;
-    bodyRole = body?.role;
-  } catch {
-    // ignore
-  }
-  const callerRole = headerRole ?? bodyRole;
-  if (callerRole === undefined || callerRole !== handoff.toRole) {
-    return {
-      ok: false,
-      response: c.json(
-        {
-          error: {
-            code: "PERMISSION_DENIED",
-            message: `Only the target role '${handoff.toRole}' can acknowledge this handoff (caller role: '${callerRole ?? "unset"}'). Set X-Grove-Role header or include {"role": "..."} in the body.`,
-          },
-        },
-        403,
-      ),
-    };
-  }
-  return { ok: true, handoff };
-}
-
-/** POST /api/handoffs/:id/seen — Record that the target agent has seen this handoff. */
-handoffs.post("/:id/seen", async (c) => {
-  const { handoffStore } = c.get("deps");
-  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
-
-  const authz = await authorizeReceiptMutation(c, handoffStore);
-  if (!authz.ok) return authz.response;
-
-  try {
-    await handoffStore.markSeen(c.req.param("id"));
-    const updated = await handoffStore.get(c.req.param("id"));
-    return c.json(updated);
-  } catch {
-    return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
-  }
-});
-
-/** POST /api/handoffs/:id/acked — Record that the target agent acknowledges this handoff. */
-handoffs.post("/:id/acked", async (c) => {
-  const { handoffStore } = c.get("deps");
-  if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
-
-  const authz = await authorizeReceiptMutation(c, handoffStore);
-  if (!authz.ok) return authz.response;
-
-  try {
-    await handoffStore.markAcked(c.req.param("id"));
-    const updated = await handoffStore.get(c.req.param("id"));
-    return c.json(updated);
-  } catch {
-    return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
-  }
-});
+// Intentionally no HTTP routes for seen/acked mutations. The grove-server
+// HTTP surface is not authenticated — any client that can reach it can
+// claim any role. Because receipt mutations must be bound to the actual
+// target role to be trustworthy, they are exposed ONLY through the MCP
+// tool grove_ack_handoff, where GROVE_AGENT_ROLE is set by the spawning
+// process (TUI/runtime) and not controllable by the tool caller.
 
 export { handoffs };

--- a/src/server/routes/handoffs.ts
+++ b/src/server/routes/handoffs.ts
@@ -9,9 +9,9 @@
  * POST /api/handoffs/:id/acked     — Mark a handoff as acknowledged
  */
 
-import type { Hono as HonoType } from "hono";
+import type { Context, Hono as HonoType } from "hono";
 import { Hono } from "hono";
-import type { HandoffStatus } from "../../core/handoff.js";
+import type { Handoff, HandoffStatus, HandoffStore } from "../../core/handoff.js";
 import type { ServerEnv } from "../deps.js";
 
 const handoffs: HonoType<ServerEnv> = new Hono<ServerEnv>();
@@ -113,10 +113,65 @@ handoffs.post("/:id/replied", async (c) => {
   }
 });
 
+/**
+ * Verify the caller role matches the handoff's toRole before mutating
+ * receipt state. Reads the role from the X-Grove-Role header or a JSON
+ * body field. Returns an error Response if unauthorized; otherwise returns
+ * the handoff for the route handler to use.
+ */
+async function authorizeReceiptMutation(
+  c: Context<ServerEnv>,
+  handoffStore: HandoffStore,
+): Promise<{ ok: true; handoff: Handoff } | { ok: false; response: Response }> {
+  const id = c.req.param("id");
+  if (id === undefined) {
+    return {
+      ok: false,
+      response: c.json({ error: { code: "BAD_REQUEST", message: "Missing handoff id" } }, 400),
+    };
+  }
+  const handoff = await handoffStore.get(id);
+  if (handoff === undefined) {
+    return {
+      ok: false,
+      response: c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404),
+    };
+  }
+  const headerRole = c.req.header("x-grove-role");
+  let bodyRole: string | undefined;
+  try {
+    const body = (await c.req.json<{ role?: string }>().catch(() => undefined)) as
+      | { role?: string }
+      | undefined;
+    bodyRole = body?.role;
+  } catch {
+    // ignore
+  }
+  const callerRole = headerRole ?? bodyRole;
+  if (callerRole === undefined || callerRole !== handoff.toRole) {
+    return {
+      ok: false,
+      response: c.json(
+        {
+          error: {
+            code: "PERMISSION_DENIED",
+            message: `Only the target role '${handoff.toRole}' can acknowledge this handoff (caller role: '${callerRole ?? "unset"}'). Set X-Grove-Role header or include {"role": "..."} in the body.`,
+          },
+        },
+        403,
+      ),
+    };
+  }
+  return { ok: true, handoff };
+}
+
 /** POST /api/handoffs/:id/seen — Record that the target agent has seen this handoff. */
 handoffs.post("/:id/seen", async (c) => {
   const { handoffStore } = c.get("deps");
   if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
+
+  const authz = await authorizeReceiptMutation(c, handoffStore);
+  if (!authz.ok) return authz.response;
 
   try {
     await handoffStore.markSeen(c.req.param("id"));
@@ -131,6 +186,9 @@ handoffs.post("/:id/seen", async (c) => {
 handoffs.post("/:id/acked", async (c) => {
   const { handoffStore } = c.get("deps");
   if (handoffStore === undefined) return c.json({ error: "unreachable" }, 500);
+
+  const authz = await authorizeReceiptMutation(c, handoffStore);
+  if (!authz.ok) return authz.response;
 
   try {
     await handoffStore.markAcked(c.req.param("id"));

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -138,11 +138,19 @@ sessions.post("/", async (c) => {
     resolvedTopology = resolution.topology;
   }
 
+  // Build config: start from the server's GROVE.md contract, but override
+  // topology with the resolved topology from the request (which may include
+  // TUI-edited edge config like replyTimeoutSeconds). Without this override,
+  // the server's config.topology would silently discard per-session edits.
+  const sessionConfig = resolvedTopology
+    ? { ...contract, topology: resolvedTopology }
+    : contract;
+
   const session = await goalSessionStore.createSession({
     goal: parsed.data.goal,
     presetName,
     topology: resolvedTopology,
-    config: contract,
+    config: sessionConfig,
   });
   return c.json(toSessionResponse(session), 201);
 });

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -142,9 +142,7 @@ sessions.post("/", async (c) => {
   // topology with the resolved topology from the request (which may include
   // TUI-edited edge config like replyTimeoutSeconds). Without this override,
   // the server's config.topology would silently discard per-session edits.
-  const sessionConfig = resolvedTopology
-    ? { ...contract, topology: resolvedTopology }
-    : contract;
+  const sessionConfig = resolvedTopology ? { ...contract, topology: resolvedTopology } : contract;
 
   const session = await goalSessionStore.createSession({
     goal: parsed.data.goal,

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -176,6 +176,32 @@ if (runtime.contract?.topology !== undefined) {
 // Start server (with optional WebSocket upgrade)
 // ---------------------------------------------------------------------------
 
+// Refuse to bind a non-localhost address without an explicit operator
+// opt-in. The HTTP surface has no authentication (role-sensitive mutations
+// are gated to MCP stdio, but read routes and `?sessionId=` scoping are
+// caller-asserted), so the deployment trust boundary is the localhost
+// binding. Operators who want remote access MUST set
+// `GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true` to acknowledge the risk;
+// typical production usage places the server behind an authenticated
+// reverse proxy.
+//
+// MUST run BEFORE Bun.serve() — otherwise the socket would already be
+// bound and listening before we decided to exit.
+const LOCALHOST_ADDRESSES = new Set(["localhost", "127.0.0.1", "::1"]);
+if (HOST && !LOCALHOST_ADDRESSES.has(HOST)) {
+  if (process.env.GROVE_ALLOW_UNAUTHENTICATED_REMOTE !== "true") {
+    console.error(
+      "\u26a0 Refusing to bind non-localhost address without authentication.\n" +
+        "  Set GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true to opt in explicitly,\n" +
+        "  or front this process with an authenticated reverse proxy and bind to localhost.",
+    );
+    process.exit(1);
+  }
+  console.warn(
+    "\u26a0 Server bound to non-localhost address without authentication (GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true).",
+  );
+}
+
 function startServer() {
   const hostnameOpts = HOST ? { hostname: HOST } : {};
 
@@ -218,29 +244,6 @@ function startServer() {
 }
 
 const server = startServer();
-
-// Refuse to bind a non-localhost address without an explicit operator
-// opt-in. The HTTP surface has no authentication (role-sensitive mutations
-// are gated to MCP stdio, but read routes and `?sessionId=` scoping are
-// caller-asserted), so the deployment trust boundary is the localhost
-// binding. Operators who want remote access MUST set
-// `GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true` to acknowledge the risk;
-// typical production usage places the server behind an authenticated
-// reverse proxy.
-const LOCALHOST_ADDRESSES = new Set(["localhost", "127.0.0.1", "::1"]);
-if (HOST && !LOCALHOST_ADDRESSES.has(HOST)) {
-  if (process.env.GROVE_ALLOW_UNAUTHENTICATED_REMOTE !== "true") {
-    console.error(
-      "\u26a0 Refusing to bind non-localhost address without authentication.\n" +
-        "  Set GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true to opt in explicitly,\n" +
-        "  or front this process with an authenticated reverse proxy and bind to localhost.",
-    );
-    process.exit(1);
-  }
-  console.warn(
-    "\u26a0 Server bound to non-localhost address without authentication (GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true).",
-  );
-}
 
 // Start gossip after server is listening
 if (gossipService) {

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -78,6 +78,16 @@ const serverFrontier: import("../core/frontier.js").FrontierCalculator = runtime
 // Nexus VFS hits rate limits with N reads per list() call.
 // Nexus is used for IPC only (via NexusWsBridge SSE), not for data storage.
 
+// Per-request session-scoped handoff store factory. The HTTP handoff
+// routes accept ?sessionId= and use this factory to build a scoped
+// SqliteHandoffStore on demand, preventing cross-session reads/mutations
+// from remote TUIs that share the same process-global runtime.
+const { SqliteHandoffStore: _SqliteHandoffStore } = await import(
+  "../local/sqlite-handoff-store.js"
+);
+const handoffStoreForSession = (sessionId: string) =>
+  new _SqliteHandoffStore(runtime.db, sessionId) as import("../core/handoff.js").HandoffStore;
+
 const deps: ServerDeps = {
   contributionStore: serverContributionStore,
   claimStore: serverClaimStore,
@@ -85,6 +95,7 @@ const deps: ServerDeps = {
   bountyStore: serverBountyStore,
   goalSessionStore: runtime.goalSessionStore,
   handoffStore: runtime.handoffStore,
+  handoffStoreForSession,
   cas: serverCas,
   frontier: serverFrontier,
   gossip: gossipService,

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -219,11 +219,26 @@ function startServer() {
 
 const server = startServer();
 
-// Warn when bound to a non-localhost address (no auth is enforced).
+// Refuse to bind a non-localhost address without an explicit operator
+// opt-in. The HTTP surface has no authentication (role-sensitive mutations
+// are gated to MCP stdio, but read routes and `?sessionId=` scoping are
+// caller-asserted), so the deployment trust boundary is the localhost
+// binding. Operators who want remote access MUST set
+// `GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true` to acknowledge the risk;
+// typical production usage places the server behind an authenticated
+// reverse proxy.
 const LOCALHOST_ADDRESSES = new Set(["localhost", "127.0.0.1", "::1"]);
 if (HOST && !LOCALHOST_ADDRESSES.has(HOST)) {
+  if (process.env.GROVE_ALLOW_UNAUTHENTICATED_REMOTE !== "true") {
+    console.error(
+      "\u26a0 Refusing to bind non-localhost address without authentication.\n" +
+        "  Set GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true to opt in explicitly,\n" +
+        "  or front this process with an authenticated reverse proxy and bind to localhost.",
+    );
+    process.exit(1);
+  }
   console.warn(
-    "\u26a0 Server bound to non-localhost address without authentication. See security docs for securing.",
+    "\u26a0 Server bound to non-localhost address without authentication (GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true).",
   );
 }
 

--- a/src/tui/provider.ts
+++ b/src/tui/provider.ts
@@ -339,7 +339,12 @@ export interface TuiGossipProvider {
 /** Handoff queries — available when capabilities.handoffs is true. */
 export interface TuiHandoffProvider {
   getHandoffs(query?: HandoffQuery): Promise<readonly Handoff[]>;
-  markHandoffDelivered(handoffId: string): Promise<void>;
+  /**
+   * Mark a handoff delivered. Optional `sessionId` pins the POST scope
+   * so a session switch between the preceding getHandoffs() and this
+   * call can't strand the handoff in pending_pickup.
+   */
+  markHandoffDelivered(handoffId: string, sessionId?: string): Promise<void>;
 }
 
 /** Type guard: does the provider support handoff queries? */

--- a/src/tui/remote-provider.ts
+++ b/src/tui/remote-provider.ts
@@ -126,8 +126,20 @@ export class RemoteDataProvider
 
     const frontierSummary = buildFrontierSummary(frontier);
 
+    // `/api/grove` aggregates contributionCount/activeClaimCount across every
+    // session. When the dashboard is scoped (activeSessionId set), those
+    // global counts are inconsistent with the rest of the view (recent
+    // contributions, claims, frontier all session-scoped). Zero them out so
+    // the header doesn't mislead the operator about the current session's
+    // activity — the scoped recentContributions / frontier already tell the
+    // true story.
+    const scopedMetadata =
+      this.activeSessionId !== undefined
+        ? { ...metadata, contributionCount: 0, activeClaimCount: 0 }
+        : metadata;
+
     return {
-      metadata,
+      metadata: scopedMetadata,
       activeClaims,
       recentContributions,
       frontierSummary,

--- a/src/tui/remote-provider.ts
+++ b/src/tui/remote-provider.ts
@@ -675,9 +675,15 @@ export class RemoteDataProvider
     };
   }
 
-  async markHandoffDelivered(handoffId: string): Promise<void> {
+  async markHandoffDelivered(handoffId: string, sessionId?: string): Promise<void> {
+    // Callers may pass an explicit `sessionId` to pin the scope to whatever
+    // was active when they read the handoff — guards against activeSessionId
+    // flipping between the preceding getHandoffs() and this POST (rare, but
+    // would otherwise strand the handoff in pending_pickup when the POST
+    // lands in the new session's scoped store that doesn't know this id).
     const params = new URLSearchParams();
-    if (this.activeSessionId) params.set("sessionId", this.activeSessionId);
+    const effective = sessionId ?? this.activeSessionId;
+    if (effective) params.set("sessionId", effective);
     const qs = params.toString();
     await fetch(
       `${this.baseUrl}/api/handoffs/${encodeURIComponent(handoffId)}/delivered${qs ? `?${qs}` : ""}`,

--- a/src/tui/remote-provider.ts
+++ b/src/tui/remote-provider.ts
@@ -676,9 +676,13 @@ export class RemoteDataProvider
   }
 
   async markHandoffDelivered(handoffId: string): Promise<void> {
-    await fetch(`${this.baseUrl}/api/handoffs/${encodeURIComponent(handoffId)}/delivered`, {
-      method: "POST",
-    });
+    const params = new URLSearchParams();
+    if (this.activeSessionId) params.set("sessionId", this.activeSessionId);
+    const qs = params.toString();
+    await fetch(
+      `${this.baseUrl}/api/handoffs/${encodeURIComponent(handoffId)}/delivered${qs ? `?${qs}` : ""}`,
+      { method: "POST" },
+    );
   }
 
   async getHandoffs(
@@ -691,6 +695,7 @@ export class RemoteDataProvider
     if (query?.status)
       params.set("status", Array.isArray(query.status) ? (query.status[0] ?? "") : query.status);
     if (query?.limit) params.set("limit", String(query.limit));
+    if (this.activeSessionId) params.set("sessionId", this.activeSessionId);
     const qs = params.toString();
     const resp = await fetch(`${this.baseUrl}/api/handoffs${qs ? `?${qs}` : ""}`);
     if (!resp.ok) return [];

--- a/src/tui/screens/agent-detect.tsx
+++ b/src/tui/screens/agent-detect.tsx
@@ -36,6 +36,7 @@ export interface AgentDetectProps {
     detected: Map<string, boolean>,
     roleMapping: Map<string, string>,
     rolePrompts: Map<string, string>,
+    edgeTimeouts: Map<string, number>,
   ) => void;
   readonly onBack: () => void;
 }
@@ -71,6 +72,34 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
     });
 
     const roles = topology?.roles ?? [];
+
+    // Edge reply timeouts — initialized from topology, editable by user via [t] key
+    const [edgeTimeouts, setEdgeTimeouts] = useState<Map<string, number>>(() => {
+      const map = new Map<string, number>();
+      if (topology) {
+        for (const role of topology.roles) {
+          for (const edge of role.edges ?? []) {
+            if (edge.replyTimeoutSeconds !== undefined) {
+              map.set(`${role.name}:${edge.target}`, edge.replyTimeoutSeconds);
+            }
+          }
+        }
+      }
+      return map;
+    });
+    const [editingTimeout, setEditingTimeout] = useState(false);
+    const [timeoutBuffer, setTimeoutBuffer] = useState("");
+
+    // Collect all edges for display
+    const allEdges = useMemo(() => {
+      const edges: { source: string; target: string; edgeType: string }[] = [];
+      for (const role of roles) {
+        for (const edge of role.edges ?? []) {
+          edges.push({ source: role.name, target: edge.target, edgeType: edge.edgeType });
+        }
+      }
+      return edges;
+    }, [roles]);
 
     // Auto-detect CLIs on mount
     useEffect(() => {
@@ -138,6 +167,46 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
     useKeyboard(
       useCallback(
         (key) => {
+          if (editingTimeout) {
+            if (key.name === "escape" || key.name === "return" || key.name === "enter") {
+              // Save timeout on exit
+              const roleName = roles[cursor]?.name;
+              if (roleName) {
+                const edges = roles[cursor]?.edges ?? [];
+                const parsed = parseInt(timeoutBuffer, 10);
+                for (const edge of edges) {
+                  const edgeKey = `${roleName}:${edge.target}`;
+                  if (!isNaN(parsed) && parsed >= 10) {
+                    setEdgeTimeouts((prev) => {
+                      const next = new Map(prev);
+                      next.set(edgeKey, parsed);
+                      return next;
+                    });
+                  } else if (timeoutBuffer.trim() === "" || timeoutBuffer.trim() === "0") {
+                    // Remove timeout (no deadline)
+                    setEdgeTimeouts((prev) => {
+                      const next = new Map(prev);
+                      next.delete(edgeKey);
+                      return next;
+                    });
+                  }
+                }
+              }
+              setEditingTimeout(false);
+              return;
+            }
+            // Allow digits and backspace
+            if (key.name === "backspace") {
+              setTimeoutBuffer((b) => b.slice(0, -1));
+              return;
+            }
+            if (/^[0-9]$/.test(key.sequence ?? "")) {
+              setTimeoutBuffer((b) => b + (key.sequence ?? ""));
+              return;
+            }
+            return;
+          }
+
           if (editing) {
             if (key.name === "escape") {
               // Save on exit
@@ -192,10 +261,21 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
             }
             return;
           }
+          // t: edit reply timeout for edges from the selected role
+          if (key.name === "t") {
+            const role = roles[cursor];
+            if (role && role.edges && role.edges.length > 0) {
+              const firstEdgeKey = `${role.name}:${role.edges[0]?.target}`;
+              const current = edgeTimeouts.get(firstEdgeKey);
+              setTimeoutBuffer(current !== undefined ? String(current) : "");
+              setEditingTimeout(true);
+            }
+            return;
+          }
           // Enter: launch agents (only Enter, not Tab/Space/Right which caused accidental spawns)
           if (key.name === "return" || key.name === "enter") {
             if (!scanning) {
-              onContinue(detected, roleMapping, rolePrompts);
+              onContinue(detected, roleMapping, rolePrompts, edgeTimeouts);
             }
             return;
           }
@@ -209,10 +289,13 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
           detected,
           roleMapping,
           rolePrompts,
+          edgeTimeouts,
           onContinue,
           onBack,
           editing,
           editBuffer,
+          editingTimeout,
+          timeoutBuffer,
           cursor,
           roles,
           availableClis,
@@ -309,6 +392,39 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
           </box>
         ) : null}
 
+        {/* Edge Deadlines — editable via [t] key */}
+        {allEdges.length > 0 ? (
+          <box flexDirection="column" marginX={2} marginTop={1} paddingX={1}>
+            <text color={theme.text} bold>
+              Reply Deadlines (t:set timeout on selected role's edges)
+            </text>
+            {allEdges.map((edge) => {
+              const edgeKey = `${edge.source}:${edge.target}`;
+              const timeout = edgeTimeouts.get(edgeKey);
+              const isSelectedRole = roles[cursor]?.name === edge.source;
+              const isEditingThis = editingTimeout && isSelectedRole;
+              return (
+                <box key={edgeKey} flexDirection="row">
+                  <text color={isSelectedRole ? theme.focus : theme.secondary}>
+                    {isSelectedRole ? " > " : "   "}
+                  </text>
+                  <text color={theme.text}>{edge.source}</text>
+                  <text color={theme.secondary}> {"\u2192"} </text>
+                  <text color={theme.text}>{edge.target}</text>
+                  <text color={theme.secondary}> ({edge.edgeType}) </text>
+                  {isEditingThis ? (
+                    <text color={theme.focus}>[{timeoutBuffer || "0"}_]s</text>
+                  ) : timeout !== undefined ? (
+                    <text color={theme.warning}>{timeout}s</text>
+                  ) : (
+                    <text color={theme.disabled}>{"\u2014"}</text>
+                  )}
+                </box>
+              );
+            })}
+          </box>
+        ) : null}
+
         {/* Role prompts — editable */}
         {roles.length > 0 ? (
           <box
@@ -375,11 +491,13 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
         {/* Hints */}
         <box paddingX={2} marginTop={1}>
           <text color={theme.secondary}>
-            {editing
-              ? "Edit prompt (vim keys)  Esc:save & close"
-              : scanning
-                ? "Scanning..."
-                : "c:change CLI  e:edit prompt  j/k:navigate  Enter:launch  Esc:back"}
+            {editingTimeout
+              ? "Type timeout in seconds (min 10, 0 or empty = no deadline)  Enter/Esc:save"
+              : editing
+                ? "Edit prompt (vim keys)  Esc:save & close"
+                : scanning
+                  ? "Scanning..."
+                  : "c:change CLI  e:edit prompt  t:set deadline  j/k:navigate  Enter:launch  Esc:back"}
           </text>
         </box>
       </box>

--- a/src/tui/screens/agent-detect.tsx
+++ b/src/tui/screens/agent-detect.tsx
@@ -176,7 +176,7 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
                 const parsed = parseInt(timeoutBuffer, 10);
                 for (const edge of edges) {
                   const edgeKey = `${roleName}:${edge.target}`;
-                  if (!isNaN(parsed) && parsed >= 10) {
+                  if (!Number.isNaN(parsed) && parsed >= 10) {
                     setEdgeTimeouts((prev) => {
                       const next = new Map(prev);
                       next.set(edgeKey, parsed);
@@ -264,7 +264,7 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
           // t: edit reply timeout for edges from the selected role
           if (key.name === "t") {
             const role = roles[cursor];
-            if (role && role.edges && role.edges.length > 0) {
+            if (role?.edges && role.edges.length > 0) {
               const firstEdgeKey = `${role.name}:${role.edges[0]?.target}`;
               const current = edgeTimeouts.get(firstEdgeKey);
               setTimeoutBuffer(current !== undefined ? String(current) : "");

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -314,6 +314,40 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
       return () => clearInterval(id);
     }, [provider, sessionStartedAt, intervalMs]);
 
+    // Subscribe to handoff lifecycle events (handoff.overdue, handoff.seen,
+    // handoff.acked) for real-time panel updates. When any handoff event
+    // arrives, trigger an immediate re-fetch so the panel reflects the change
+    // without waiting for the next polling interval.
+    useEffect(() => {
+      if (!eventBus) return;
+      const roles = topology?.roles.map((r) => r.name) ?? [];
+      if (roles.length === 0) return;
+      const hasMethod = "getHandoffs" in provider;
+      if (!hasMethod) return;
+      const p = provider as {
+        getHandoffs: (q?: unknown) => Promise<readonly import("../../core/handoff.js").Handoff[]>;
+      };
+      const handler = () => {
+        debugLog("eventBus", "handoff event — refreshing handoffs");
+        void p
+          .getHandoffs({ limit: 200 })
+          .then((all) => {
+            const cutoff =
+              sessionStartedAt ?? new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+            setHandoffs(all.filter((h) => h.createdAt >= cutoff));
+          })
+          .catch(() => {});
+      };
+      for (const role of roles) {
+        eventBus.subscribe(role, handler);
+      }
+      return () => {
+        for (const role of roles) {
+          eventBus.unsubscribe(role, handler);
+        }
+      };
+    }, [eventBus, topology, provider, sessionStartedAt]);
+
     // Session scoping is handled server-side (provider.setSessionScope).
     // The feed already contains only this session's contributions.
     const feed = contributions ?? [];

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -336,7 +336,9 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
               sessionStartedAt ?? new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
             setHandoffs(all.filter((h) => h.createdAt >= cutoff));
           })
-          .catch(() => {});
+          .catch(() => {
+            /* handoff refresh errors are non-fatal — the next bus event will retry */
+          });
       };
       for (const role of roles) {
         eventBus.subscribe(role, handler);

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -415,9 +415,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
           try {
             const sessionTopology = sessionTopologyRef.current ?? topology;
             const sessionConfig =
-              contract && sessionTopology
-                ? { ...contract, topology: sessionTopology }
-                : contract;
+              contract && sessionTopology ? { ...contract, topology: sessionTopology } : contract;
             const session = await provider.createSession({
               goal,
               presetName: state.selectedPreset,
@@ -597,7 +595,10 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
           return;
         }
         hasSpawnedRef.current = true;
-        debugLog("handleLaunchConfirm", `spawning with ${roleMappingFromPreview.size} roles, ${edgeTimeouts.size} edge timeouts`);
+        debugLog(
+          "handleLaunchConfirm",
+          `spawning with ${roleMappingFromPreview.size} roles, ${edgeTimeouts.size} edge timeouts`,
+        );
 
         // Apply edge timeouts from TUI to a DEEP CLONE of the topology so
         // session-specific edits don't mutate the shared preset object (which
@@ -635,7 +636,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         }));
         spawnAgents(state.goal ?? "", roleMappingFromPreview);
       },
-      [state.goal, spawnAgents, topology, contract],
+      [state.goal, spawnAgents, topology],
     );
 
     // Screen 3.5 -> Screen 4: all spawns resolved

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -579,8 +579,9 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         hasSpawnedRef.current = true;
         debugLog("handleLaunchConfirm", `spawning with ${roleMappingFromPreview.size} roles, ${edgeTimeouts.size} edge timeouts`);
 
-        // Apply edge timeouts from TUI into the topology so they're
-        // persisted in the session record and used by the MCP server.
+        // Apply edge timeouts from TUI into the topology. The HTTP server
+        // uses this topology (from the request body) to override config.topology
+        // when creating the session record, so MCP servers pick up the edit.
         if (edgeTimeouts.size > 0 && topology) {
           for (const role of topology.roles) {
             if (role.edges) {
@@ -588,10 +589,8 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
                 const key = `${role.name}:${edge.target}`;
                 const timeout = edgeTimeouts.get(key);
                 if (timeout !== undefined) {
-                  // Mutate in place — topology is owned by this session
                   (edge as { replyTimeoutSeconds?: number }).replyTimeoutSeconds = timeout;
                 } else {
-                  // User removed timeout
                   delete (edge as { replyTimeoutSeconds?: number }).replyTimeoutSeconds;
                 }
               }
@@ -607,7 +606,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         }));
         spawnAgents(state.goal ?? "", roleMappingFromPreview);
       },
-      [state.goal, spawnAgents, topology],
+      [state.goal, spawnAgents, topology, contract],
     );
 
     // Screen 3.5 -> Screen 4: all spawns resolved

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -13,6 +13,7 @@
 import { useKeyboard, useRenderer } from "@opentui/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { lookupPresetTopology } from "../../core/presets.js";
+import type { AgentTopology } from "../../core/topology.js";
 import { topologicalSortRoles } from "../../core/topology.js";
 import type { AppProps } from "../app.js";
 import { App } from "../app.js";
@@ -360,6 +361,14 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
 
     // Screen 2 -> Screen 3: goal entered → go to launch preview (auto-detect)
     const rolePromptsRef = useRef<Map<string, string>>(new Map());
+    /**
+     * Per-launch topology override set by handleLaunchConfirm after applying
+     * TUI edge timeout edits. spawnAgents reads this (via ref) to bypass the
+     * stale closure on `topology` state, and to ensure the cloned topology
+     * is what reaches createSession — without it, session-specific edits
+     * would either not apply (stale closure) or mutate the shared preset.
+     */
+    const sessionTopologyRef = useRef<AgentTopology | undefined>(undefined);
     const handleGoalToPreview = useCallback((goal: string) => {
       setState((s) => ({
         ...s,
@@ -396,13 +405,24 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
 
         // Create session BEFORE spawning agents so MCP gets GROVE_SESSION_ID
         // for session-scoped contribution paths (avoids N+1 VFS reads on 47+ old contributions).
+        //
+        // Use sessionTopologyRef (set by handleLaunchConfirm after applying
+        // TUI edge edits) when available. React state updates are async so
+        // the closed-over `topology` variable would still reference the
+        // pre-edit object here — using the ref ensures we send the cloned,
+        // edited topology to createSession.
         if (isSessionProvider(provider)) {
           try {
+            const sessionTopology = sessionTopologyRef.current ?? topology;
+            const sessionConfig =
+              contract && sessionTopology
+                ? { ...contract, topology: sessionTopology }
+                : contract;
             const session = await provider.createSession({
               goal,
               presetName: state.selectedPreset,
-              topology,
-              config: contract,
+              topology: sessionTopology,
+              config: sessionConfig,
             });
             spawnManager.setSessionId(session.id);
             if ("setSessionScope" in provider) {
@@ -579,14 +599,18 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         hasSpawnedRef.current = true;
         debugLog("handleLaunchConfirm", `spawning with ${roleMappingFromPreview.size} roles, ${edgeTimeouts.size} edge timeouts`);
 
-        // Apply edge timeouts from TUI into the topology. Always walk every
-        // edge so that clearing a previously-set deadline (removing it from
-        // edgeTimeouts) also removes it from the topology — otherwise the
-        // preset/GROVE.md default would leak through as a "removed" deadline
-        // that still fires. The HTTP server uses this topology to override
-        // config.topology when creating the session record.
+        // Apply edge timeouts from TUI to a DEEP CLONE of the topology so
+        // session-specific edits don't mutate the shared preset object (which
+        // is memoized by lookupPresetTopology and reused across launches) or
+        // the GROVE.md topology. Without cloning, editing deadlines in one
+        // session silently leaks into later sessions in the same TUI process.
+        //
+        // We store the cloned topology in a ref (sessionTopologyRef) so
+        // spawnAgents picks it up bypassing React's async state update. Also
+        // call setTopology so the UI reflects the current session's config.
         if (topology) {
-          for (const role of topology.roles) {
+          const sessionTopology = structuredClone(topology);
+          for (const role of sessionTopology.roles) {
             if (role.edges) {
               for (const edge of role.edges) {
                 const key = `${role.name}:${edge.target}`;
@@ -599,6 +623,8 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
               }
             }
           }
+          sessionTopologyRef.current = sessionTopology;
+          setTopology(sessionTopology);
         }
 
         rolePromptsRef.current = rolePrompts;

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -568,6 +568,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         detected: Map<string, boolean>,
         roleMappingFromPreview: Map<string, string>,
         rolePrompts: Map<string, string>,
+        edgeTimeouts: Map<string, number>,
       ) => {
         // Guard: prevent duplicate spawn when user presses Escape → Enter twice.
         // hasSpawnedRef is set to true here and only reset in handleNewSession.
@@ -576,7 +577,28 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
           return;
         }
         hasSpawnedRef.current = true;
-        debugLog("handleLaunchConfirm", `spawning with ${roleMappingFromPreview.size} roles`);
+        debugLog("handleLaunchConfirm", `spawning with ${roleMappingFromPreview.size} roles, ${edgeTimeouts.size} edge timeouts`);
+
+        // Apply edge timeouts from TUI into the topology so they're
+        // persisted in the session record and used by the MCP server.
+        if (edgeTimeouts.size > 0 && topology) {
+          for (const role of topology.roles) {
+            if (role.edges) {
+              for (const edge of role.edges) {
+                const key = `${role.name}:${edge.target}`;
+                const timeout = edgeTimeouts.get(key);
+                if (timeout !== undefined) {
+                  // Mutate in place — topology is owned by this session
+                  (edge as { replyTimeoutSeconds?: number }).replyTimeoutSeconds = timeout;
+                } else {
+                  // User removed timeout
+                  delete (edge as { replyTimeoutSeconds?: number }).replyTimeoutSeconds;
+                }
+              }
+            }
+          }
+        }
+
         rolePromptsRef.current = rolePrompts;
         setState((s) => ({
           ...s,
@@ -585,7 +607,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         }));
         spawnAgents(state.goal ?? "", roleMappingFromPreview);
       },
-      [state.goal, spawnAgents],
+      [state.goal, spawnAgents, topology],
     );
 
     // Screen 3.5 -> Screen 4: all spawns resolved

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -579,10 +579,13 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         hasSpawnedRef.current = true;
         debugLog("handleLaunchConfirm", `spawning with ${roleMappingFromPreview.size} roles, ${edgeTimeouts.size} edge timeouts`);
 
-        // Apply edge timeouts from TUI into the topology. The HTTP server
-        // uses this topology (from the request body) to override config.topology
-        // when creating the session record, so MCP servers pick up the edit.
-        if (edgeTimeouts.size > 0 && topology) {
+        // Apply edge timeouts from TUI into the topology. Always walk every
+        // edge so that clearing a previously-set deadline (removing it from
+        // edgeTimeouts) also removes it from the topology — otherwise the
+        // preset/GROVE.md default would leak through as a "removed" deadline
+        // that still fires. The HTTP server uses this topology to override
+        // config.topology when creating the session record.
+        if (topology) {
           for (const role of topology.roles) {
             if (role.edges) {
               for (const edge of role.edges) {

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -1043,12 +1043,16 @@ export class SpawnManager {
             // Mark handoffs as delivered
             if ((provider as { getHandoffs?: unknown }).getHandoffs) {
               const hp = provider as unknown as import("./provider.js").TuiHandoffProvider;
+              // Snapshot the session scope before the async read so the
+              // follow-up markHandoffDelivered POST can't drift to a
+              // different session if the user switches mid-loop.
+              const pinnedSessionId = this.sessionId;
               void hp
                 .getHandoffs({ sourceCid: c.cid, status: "pending_pickup" })
                 .then((hs) => {
                   for (const h of hs) {
                     // biome-ignore lint/suspicious/noEmptyBlockStatements: delivery errors silently swallowed per fire-and-forget pattern
-                    void hp.markHandoffDelivered(h.handoffId).catch(() => {});
+                    void hp.markHandoffDelivered(h.handoffId, pinnedSessionId).catch(() => {});
                   }
                 })
                 // biome-ignore lint/suspicious/noEmptyBlockStatements: getHandoffs errors silently swallowed
@@ -1081,11 +1085,14 @@ export class SpawnManager {
               // Mark upstream handoffs as delivered — the contribution reached the routing layer
               if ((provider as { getHandoffs?: unknown }).getHandoffs) {
                 const hp = provider as unknown as import("./provider.js").TuiHandoffProvider;
+                // Pin sessionId before the async read so the follow-up POST
+                // targets the session that the read was scoped to.
+                const pinnedSessionId = this.sessionId;
                 void hp
                   .getHandoffs({ sourceCid: c.cid, status: "pending_pickup" })
                   .then((hs) => {
                     for (const h of hs) {
-                      void hp.markHandoffDelivered(h.handoffId).catch(() => {
+                      void hp.markHandoffDelivered(h.handoffId, pinnedSessionId).catch(() => {
                         /* best-effort */
                       });
                     }

--- a/src/tui/views/handoffs-view.tsx
+++ b/src/tui/views/handoffs-view.tsx
@@ -41,14 +41,14 @@ const STATUS_LABELS: Record<string, string> = {
  * Follows opencode's colored-dot status pattern.
  */
 function receiptLabel(h: Handoff): string {
-  if (h.ackedAt !== undefined) return "\u25CF acked";   // ● solid dot
-  if (h.seenAt !== undefined) return "\u25D0 seen";     // ◐ half dot
-  return "\u25CB unseen";                                // ○ empty dot
+  if (h.ackedAt !== undefined) return "\u25CF acked"; // ● solid dot
+  if (h.seenAt !== undefined) return "\u25D0 seen"; // ◐ half dot
+  return "\u25CB unseen"; // ○ empty dot
 }
 
 /** Deadline state — shows remaining time or overdue indicator. */
 function deadlineLabel(h: Handoff): string {
-  if (h.replyDueAt === undefined) return "\u2014";       // — no deadline
+  if (h.replyDueAt === undefined) return "\u2014"; // — no deadline
   const now = Date.now();
   const deadline = new Date(h.replyDueAt).getTime();
   const diff = deadline - now;
@@ -171,9 +171,7 @@ export const HandoffsView: React.NamedExoticComponent<HandoffsViewProps> = React
               ? `  ${handoffs.length} total, ${pending} pending`
               : "  (no handoffs yet)"}
           </text>
-          {overdueCount > 0 && (
-            <text color={theme.error}>{`  ${overdueCount} overdue`}</text>
-          )}
+          {overdueCount > 0 && <text color={theme.error}>{`  ${overdueCount} overdue`}</text>}
         </box>
         {handoffs.length === 0 ? (
           <text opacity={0.4}>

--- a/src/tui/views/handoffs-view.tsx
+++ b/src/tui/views/handoffs-view.tsx
@@ -2,7 +2,8 @@
  * Handoffs panel — shows topology routing coordination records.
  *
  * Displays pending, delivered, replied, and expired handoffs so operators
- * and agents can see what work is in-flight between roles.
+ * and agents can see what work is in-flight between roles, with receipt
+ * tracking (seen/acked) and deadline/overdue indicators.
  *
  * Accessible via key "5" in the running view.
  */
@@ -15,21 +16,59 @@ import { Table } from "../components/table.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
 import { isHandoffProvider } from "../provider.js";
+import { theme } from "../theme.js";
 
 const COLUMNS = [
-  { header: "FROM", key: "from", width: 12 },
-  { header: "TO", key: "to", width: 12 },
+  { header: "FROM", key: "from", width: 10 },
+  { header: "TO", key: "to", width: 10 },
   { header: "STATUS", key: "status", width: 16 },
-  { header: "SOURCE CID", key: "cid", width: 22 },
-  { header: "CREATED", key: "created", width: 12 },
+  { header: "RECEIPT", key: "receipt", width: 10 },
+  { header: "DEADLINE", key: "deadline", width: 12 },
+  { header: "SOURCE CID", key: "cid", width: 18 },
+  { header: "CREATED", key: "created", width: 7 },
 ] as const;
 
+/** Status labels with emoji indicators. */
 const STATUS_LABELS: Record<string, string> = {
-  [HandoffStatus.PendingPickup]: "⏳ pending",
-  [HandoffStatus.Delivered]: "📬 delivered",
-  [HandoffStatus.Replied]: "✅ replied",
-  [HandoffStatus.Expired]: "⌛ expired",
+  [HandoffStatus.PendingPickup]: "\u23F3 pending",
+  [HandoffStatus.Delivered]: "\uD83D\uDCEC delivered",
+  [HandoffStatus.Replied]: "\u2705 replied",
+  [HandoffStatus.Expired]: "\u231B expired",
 };
+
+/**
+ * Receipt state — derived from seenAt/ackedAt timestamps.
+ * Follows opencode's colored-dot status pattern.
+ */
+function receiptLabel(h: Handoff): string {
+  if (h.ackedAt !== undefined) return "\u25CF acked";   // ● solid dot
+  if (h.seenAt !== undefined) return "\u25D0 seen";     // ◐ half dot
+  return "\u25CB unseen";                                // ○ empty dot
+}
+
+/** Deadline state — shows remaining time or overdue indicator. */
+function deadlineLabel(h: Handoff): string {
+  if (h.replyDueAt === undefined) return "\u2014";       // — no deadline
+  const now = Date.now();
+  const deadline = new Date(h.replyDueAt).getTime();
+  const diff = deadline - now;
+
+  // Already resolved — show checkmark
+  if (h.status === HandoffStatus.Replied) return "\u2713 met";
+  if (h.status === HandoffStatus.Expired) return "\u2717 expired";
+
+  // Overdue
+  if (diff < 0) {
+    const overdueMins = Math.floor(-diff / 60_000);
+    if (overdueMins < 60) return `\uD83D\uDD34 ${overdueMins}m over`;
+    return `\uD83D\uDD34 ${Math.floor(overdueMins / 60)}h over`;
+  }
+
+  // Remaining
+  const remainMins = Math.floor(diff / 60_000);
+  if (remainMins < 60) return `${remainMins}m left`;
+  return `${Math.floor(remainMins / 60)}h left`;
+}
 
 function formatTime(iso: string): string {
   try {
@@ -38,6 +77,13 @@ function formatTime(iso: string): string {
   } catch {
     return "--:--";
   }
+}
+
+/** Check if a handoff is overdue (has deadline, unresolved, past due). */
+function isOverdue(h: Handoff): boolean {
+  if (h.replyDueAt === undefined) return false;
+  if (h.status === HandoffStatus.Replied || h.status === HandoffStatus.Expired) return false;
+  return new Date(h.replyDueAt).getTime() < Date.now();
 }
 
 export interface HandoffsViewProps {
@@ -104,11 +150,14 @@ export const HandoffsView: React.NamedExoticComponent<HandoffsViewProps> = React
 
     const handoffs = data ?? [];
     const pending = handoffs.filter((h) => h.status === HandoffStatus.PendingPickup).length;
+    const overdueCount = handoffs.filter(isOverdue).length;
 
     const rows = handoffs.map((h) => ({
       from: h.fromRole,
       to: h.toRole,
       status: STATUS_LABELS[h.status] ?? h.status,
+      receipt: receiptLabel(h),
+      deadline: deadlineLabel(h),
       cid: truncateCid(h.sourceCid),
       created: formatTime(h.createdAt),
     }));
@@ -122,6 +171,9 @@ export const HandoffsView: React.NamedExoticComponent<HandoffsViewProps> = React
               ? `  ${handoffs.length} total, ${pending} pending`
               : "  (no handoffs yet)"}
           </text>
+          {overdueCount > 0 && (
+            <text color={theme.error}>{`  ${overdueCount} overdue`}</text>
+          )}
         </box>
         {handoffs.length === 0 ? (
           <text opacity={0.4}>

--- a/tests/e2e/handoff-deadline-e2e.test.ts
+++ b/tests/e2e/handoff-deadline-e2e.test.ts
@@ -1,0 +1,259 @@
+/**
+ * E2E test: handoff deadline lifecycle with real stores.
+ *
+ * Exercises the full flow:
+ * 1. Parse contract with reply_timeout_seconds on edges
+ * 2. Coder submits work → handoff created with replyDueAt + requiresReply
+ * 3. DeadlineWatcher registers timer
+ * 4. grove_ack_handoff marks seen/acked
+ * 5. Reviewer replies → handoff resolved, timer cancelled
+ * 6. Overdue path: no reply → handoff.overdue event fires
+ *
+ * Uses real SQLite stores — no Nexus needed.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DeadlineWatcher } from "../../src/core/deadline-watcher.js";
+import type { GroveEvent } from "../../src/core/event-bus.js";
+import { HandoffStatus } from "../../src/core/handoff.js";
+import { LocalEventBus } from "../../src/core/local-event-bus.js";
+import { contributeOperation } from "../../src/core/operations/contribute.js";
+import type { OperationDeps } from "../../src/core/operations/deps.js";
+import { parseGroveContract } from "../../src/core/contract.js";
+import { TopologyRouter } from "../../src/core/topology-router.js";
+import { initSqliteDb, SqliteContributionStore } from "../../src/local/sqlite-store.js";
+import { SqliteHandoffStore } from "../../src/local/sqlite-handoff-store.js";
+
+const CONTRACT_YAML = `---
+contract_version: 3
+name: deadline-e2e
+mode: exploration
+agent_topology:
+  structure: graph
+  roles:
+    - name: coder
+      edges:
+        - target: reviewer
+          edge_type: delegates
+          reply_timeout_seconds: 30
+    - name: reviewer
+      edges:
+        - target: coder
+          edge_type: feedback
+---
+`;
+
+describe("handoff deadline E2E", () => {
+  let tempDir: string;
+  let cleanup: () => Promise<void>;
+
+  afterEach(async () => {
+    await cleanup?.();
+  });
+
+  async function setup() {
+    tempDir = await mkdtemp(join(tmpdir(), "grove-deadline-e2e-"));
+    const db = initSqliteDb(join(tempDir, "test.db"));
+    const contributionStore = new SqliteContributionStore(db);
+    const handoffStore = new SqliteHandoffStore(db);
+    const bus = new LocalEventBus();
+
+    const contract = parseGroveContract(CONTRACT_YAML);
+    expect(contract).toBeDefined();
+    const topology = contract!.topology!;
+
+    // Verify edge has replyTimeoutSeconds
+    const coderRole = topology.roles.find((r) => r.name === "coder");
+    const delegatesEdge = coderRole?.edges?.find((e) => e.target === "reviewer");
+    expect(delegatesEdge?.replyTimeoutSeconds).toBe(30);
+
+    const router = new TopologyRouter(topology, bus);
+    const watcher = new DeadlineWatcher({ handoffStore, eventBus: bus });
+
+    const deps: OperationDeps = {
+      contributionStore,
+      handoffStore,
+      topologyRouter: router,
+      eventBus: bus,
+      deadlineWatcher: watcher,
+    };
+
+    cleanup = async () => {
+      watcher.close();
+      bus.close();
+      db.close();
+      await rm(tempDir, { recursive: true, force: true });
+    };
+
+    return { deps, handoffStore, bus, watcher };
+  }
+
+  test("coder submit creates handoff with deadline from edge config", async () => {
+    const { deps, handoffStore } = await setup();
+
+    const result = await contributeOperation(
+      {
+        kind: "work",
+        summary: "Implement feature",
+        agent: { agentId: "coder-1", role: "coder" },
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Wait for fire-and-forget handoff creation + watcher registration
+    await new Promise((r) => setTimeout(r, 100));
+
+    const handoffs = await handoffStore.list();
+    expect(handoffs.length).toBeGreaterThanOrEqual(1);
+
+    const h = handoffs.find((h) => h.toRole === "reviewer");
+    expect(h).toBeDefined();
+    expect(h!.requiresReply).toBe(true);
+    expect(h!.replyDueAt).toBeDefined();
+
+    // Verify deadline is ~30s from now (within 5s tolerance)
+    const deadline = new Date(h!.replyDueAt!).getTime();
+    const expectedDeadline = Date.now() + 30_000;
+    expect(Math.abs(deadline - expectedDeadline)).toBeLessThan(5000);
+  });
+
+  test("markSeen and markAcked update receipt timestamps", async () => {
+    const { deps, handoffStore } = await setup();
+
+    const result = await contributeOperation(
+      {
+        kind: "work",
+        summary: "Implement feature",
+        agent: { agentId: "coder-1", role: "coder" },
+      },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    await new Promise((r) => setTimeout(r, 100));
+    const handoffs = await handoffStore.list();
+    const h = handoffs.find((h) => h.toRole === "reviewer")!;
+
+    // Mark seen
+    await handoffStore.markSeen(h.handoffId);
+    const seen = await handoffStore.get(h.handoffId);
+    expect(seen?.seenAt).toBeDefined();
+    expect(seen?.ackedAt).toBeUndefined();
+
+    // Mark acked
+    await handoffStore.markAcked(h.handoffId);
+    const acked = await handoffStore.get(h.handoffId);
+    expect(acked?.ackedAt).toBeDefined();
+    expect(acked?.seenAt).toBe(seen?.seenAt); // preserved original seenAt
+  });
+
+  test("reviewer reply resolves handoff and cancels deadline timer", async () => {
+    const { deps, handoffStore, watcher } = await setup();
+
+    // Coder submits work
+    const workResult = await contributeOperation(
+      {
+        kind: "work",
+        summary: "Implement feature",
+        agent: { agentId: "coder-1", role: "coder" },
+      },
+      deps,
+    );
+    expect(workResult.ok).toBe(true);
+    if (!workResult.ok) return;
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Verify timer is registered
+    expect(watcher.activeCount).toBeGreaterThanOrEqual(1);
+
+    // Reviewer submits review targeting the work
+    const reviewResult = await contributeOperation(
+      {
+        kind: "review",
+        summary: "LGTM",
+        scores: { quality: { value: 0.9, direction: "maximize" } },
+        relations: [
+          { targetCid: workResult.value.cid, relationType: "reviews" },
+        ],
+        agent: { agentId: "reviewer-1", role: "reviewer" },
+      },
+      deps,
+    );
+    expect(reviewResult.ok).toBe(true);
+
+    // Wait for fire-and-forget reply marking + timer cancellation
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Handoff should be replied
+    const handoffs = await handoffStore.list({ status: HandoffStatus.Replied });
+    expect(handoffs.length).toBeGreaterThanOrEqual(1);
+    const resolved = handoffs.find((h) => h.toRole === "reviewer");
+    expect(resolved?.resolvedByCid).toBe(reviewResult.ok ? reviewResult.value.cid : undefined);
+
+    // Timer should be cancelled
+    expect(watcher.activeCount).toBe(0);
+  });
+
+  test("overdue handoff emits handoff.overdue event", async () => {
+    const { deps, handoffStore, bus } = await setup();
+
+    // Collect events
+    const events: GroveEvent[] = [];
+    bus.subscribe("reviewer", (e) => events.push(e));
+
+    // Create a handoff with a very short deadline (we'll manually create one)
+    const h = await handoffStore.create({
+      sourceCid: "blake3:test-overdue",
+      fromRole: "coder",
+      toRole: "reviewer",
+      requiresReply: true,
+      replyDueAt: new Date(Date.now() + 100).toISOString(), // 100ms
+    });
+
+    // Register with deadline watcher
+    const watcher = new DeadlineWatcher({ handoffStore, eventBus: bus });
+    watcher.watch(h);
+
+    // Wait for deadline to pass + timer to fire
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Should have emitted handoff.overdue
+    const overdueEvents = events.filter((e) => e.type === "handoff.overdue");
+    expect(overdueEvents).toHaveLength(1);
+    expect(overdueEvents[0]?.payload.handoffId).toBe(h.handoffId);
+    expect(overdueEvents[0]?.targetRole).toBe("reviewer");
+
+    watcher.close();
+  });
+
+  test("rebuildFromStore restores timers after restart", async () => {
+    const { deps, handoffStore, bus } = await setup();
+
+    // Create handoff with future deadline
+    await handoffStore.create({
+      sourceCid: "blake3:test-rebuild",
+      fromRole: "coder",
+      toRole: "reviewer",
+      requiresReply: true,
+      replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    // Simulate process restart: new watcher, rebuild from store
+    const watcher2 = new DeadlineWatcher({ handoffStore, eventBus: bus });
+    const count = await watcher2.rebuildFromStore();
+
+    expect(count).toBeGreaterThanOrEqual(1);
+    expect(watcher2.activeCount).toBeGreaterThanOrEqual(1);
+
+    watcher2.close();
+  });
+});

--- a/tests/e2e/handoff-deadline-e2e.test.ts
+++ b/tests/e2e/handoff-deadline-e2e.test.ts
@@ -251,8 +251,13 @@ describe("handoff deadline E2E", () => {
     const watcher2 = new DeadlineWatcher({ handoffStore, eventBus: bus });
     const count = await watcher2.rebuildFromStore();
 
-    expect(count).toBeGreaterThanOrEqual(1);
-    expect(watcher2.activeCount).toBeGreaterThanOrEqual(1);
+    // SQLite disables rebuild (no session_id column — returns empty from
+    // listForCurrentSession) to avoid cross-session timer leakage. New
+    // handoffs still get timers via watch() on creation; only restart
+    // rebuild is skipped for SQLite. Deadline enforcement remains
+    // correct because markReplied rejects late replies at the store level.
+    expect(count).toBe(0);
+    expect(watcher2.activeCount).toBe(0);
 
     watcher2.close();
   });

--- a/tests/e2e/handoff-deadline-e2e.test.ts
+++ b/tests/e2e/handoff-deadline-e2e.test.ts
@@ -235,10 +235,12 @@ describe("handoff deadline E2E", () => {
     watcher.close();
   });
 
-  test("rebuildFromStore restores timers after restart", async () => {
-    const { deps, handoffStore, bus } = await setup();
+  test("rebuildFromStore skips unscoped SQLite stores (no session scoping)", async () => {
+    const { handoffStore, bus } = await setup();
 
-    // Create handoff with future deadline
+    // Unscoped setup() uses new SqliteHandoffStore(db) without a sessionId.
+    // Without session scoping, rebuild must refuse to arm timers since
+    // list() would return handoffs from every session in the DB.
     await handoffStore.create({
       sourceCid: "blake3:test-rebuild",
       fromRole: "coder",
@@ -247,18 +249,41 @@ describe("handoff deadline E2E", () => {
       replyDueAt: new Date(Date.now() + 60_000).toISOString(),
     });
 
-    // Simulate process restart: new watcher, rebuild from store
     const watcher2 = new DeadlineWatcher({ handoffStore, eventBus: bus });
     const count = await watcher2.rebuildFromStore();
 
-    // SQLite disables rebuild (no session_id column — returns empty from
-    // listForCurrentSession) to avoid cross-session timer leakage. New
-    // handoffs still get timers via watch() on creation; only restart
-    // rebuild is skipped for SQLite. Deadline enforcement remains
-    // correct because markReplied rejects late replies at the store level.
     expect(count).toBe(0);
     expect(watcher2.activeCount).toBe(0);
 
     watcher2.close();
+  });
+
+  test("rebuildFromStore restores timers on scoped SQLite stores", async () => {
+    const tempDir2 = await mkdtemp(join(tmpdir(), "grove-scoped-rebuild-"));
+    const db = initSqliteDb(join(tempDir2, "test.db"));
+    const scoped = new SqliteHandoffStore(db, "session-X");
+    const bus = new LocalEventBus();
+
+    try {
+      await scoped.create({
+        sourceCid: "blake3:test-rebuild",
+        fromRole: "coder",
+        toRole: "reviewer",
+        requiresReply: true,
+        replyDueAt: new Date(Date.now() + 60_000).toISOString(),
+      });
+
+      const watcher2 = new DeadlineWatcher({ handoffStore: scoped, eventBus: bus });
+      const count = await watcher2.rebuildFromStore();
+
+      expect(count).toBe(1);
+      expect(watcher2.activeCount).toBe(1);
+
+      watcher2.close();
+    } finally {
+      bus.close();
+      db.close();
+      await rm(tempDir2, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/e2e/handoff-deadline-e2e.test.ts
+++ b/tests/e2e/handoff-deadline-e2e.test.ts
@@ -16,17 +16,16 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
+import { parseGroveContract } from "../../src/core/contract.js";
 import { DeadlineWatcher } from "../../src/core/deadline-watcher.js";
 import type { GroveEvent } from "../../src/core/event-bus.js";
 import { HandoffStatus } from "../../src/core/handoff.js";
 import { LocalEventBus } from "../../src/core/local-event-bus.js";
 import { contributeOperation } from "../../src/core/operations/contribute.js";
 import type { OperationDeps } from "../../src/core/operations/deps.js";
-import { parseGroveContract } from "../../src/core/contract.js";
 import { TopologyRouter } from "../../src/core/topology-router.js";
-import { initSqliteDb, SqliteContributionStore } from "../../src/local/sqlite-store.js";
 import { SqliteHandoffStore } from "../../src/local/sqlite-handoff-store.js";
+import { initSqliteDb, SqliteContributionStore } from "../../src/local/sqlite-store.js";
 
 const CONTRACT_YAML = `---
 contract_version: 3
@@ -181,9 +180,7 @@ describe("handoff deadline E2E", () => {
         kind: "review",
         summary: "LGTM",
         scores: { quality: { value: 0.9, direction: "maximize" } },
-        relations: [
-          { targetCid: workResult.value.cid, relationType: "reviews" },
-        ],
+        relations: [{ targetCid: workResult.value.cid, relationType: "reviews" }],
         agent: { agentId: "reviewer-1", role: "reviewer" },
       },
       deps,
@@ -204,7 +201,7 @@ describe("handoff deadline E2E", () => {
   });
 
   test("overdue handoff emits handoff.overdue event", async () => {
-    const { deps, handoffStore, bus } = await setup();
+    const { handoffStore, bus } = await setup();
 
     // Collect events
     const events: GroveEvent[] = [];

--- a/tests/tui/handoffs-harness.tsx
+++ b/tests/tui/handoffs-harness.tsx
@@ -35,7 +35,8 @@ const stubHandoffs: readonly Handoff[] = [
     fromRole: "coder",
     toRole: "reviewer",
     status: HandoffStatus.PendingPickup,
-    requiresReply: false,
+    requiresReply: true,
+    replyDueAt: new Date(Date.now() - 120_000).toISOString(), // 2min overdue
     createdAt: new Date(Date.now() - 30_000).toISOString(),
   },
   {
@@ -46,6 +47,8 @@ const stubHandoffs: readonly Handoff[] = [
     status: HandoffStatus.Replied,
     requiresReply: false,
     resolvedByCid: "blake3:cccc0000333333333333333333333333333333333333333333333333333333333",
+    seenAt: new Date(Date.now() - 100_000).toISOString(),
+    ackedAt: new Date(Date.now() - 95_000).toISOString(),
     createdAt: new Date(Date.now() - 90_000).toISOString(),
   },
   {
@@ -57,6 +60,17 @@ const stubHandoffs: readonly Handoff[] = [
     requiresReply: true,
     replyDueAt: new Date(Date.now() - 10_000).toISOString(),
     createdAt: new Date(Date.now() - 180_000).toISOString(),
+  },
+  {
+    handoffId: "h-004",
+    sourceCid: "blake3:eeee0000555555555555555555555555555555555555555555555555555555555",
+    fromRole: "coder",
+    toRole: "tester",
+    status: HandoffStatus.Delivered,
+    requiresReply: true,
+    replyDueAt: new Date(Date.now() + 300_000).toISOString(), // 5min left
+    seenAt: new Date(Date.now() - 20_000).toISOString(),
+    createdAt: new Date(Date.now() - 60_000).toISOString(),
   },
 ];
 


### PR DESCRIPTION
## Summary

Closes #164. Builds the missing semantics above IPC delivery: whether a routed handoff was actually seen, acknowledged, and replied to, with deadline enforcement.

- **Receipt tracking**: `seenAt` and `ackedAt` timestamps on Handoff, independent from IPC processed state. New `grove_ack_handoff` MCP tool and HTTP routes (`POST /handoffs/:id/seen`, `/acked`).
- **Edge-level deadlines**: `reply_timeout_seconds` on topology edges auto-sets `requiresReply` and `replyDueAt` on handoff creation.
- **Proactive overdue detection**: `DeadlineWatcher` uses per-handoff `setTimeout` (no polling), emits `handoff.overdue` events, rebuilds timers from store on startup.
- **State machine guards**: `validateTransition()` prevents invalid status transitions (e.g., expired→delivered). `InvalidTransitionError` for programmatic handling.
- **TUI visibility**: New RECEIPT and DEADLINE columns, red overdue badge in header, event-driven refresh on handoff lifecycle events.
- **Bug fixes**: Reply-marking query now includes `delivered` status (was only `pending_pickup`). SQLite `expireStale` uses RETURNING for idempotent results.
- **DRY**: `createMockHandoffStore()` factory replaces 8 inline test mocks. `requireHandoffStore()` guard helper for MCP/HTTP layers. Nexus store gets 15s TTL cache + exponential backoff with jitter.

### Architecture decisions (reviewed interactively)

| Decision | Choice |
|----------|--------|
| seen/acked model | Independent timestamps, not new status values |
| Overdue detection | Per-handoff setTimeout + store rebuild on startup |
| MCP tool | Single `grove_ack_handoff` with `level: seen \| acked` |
| Event type system | Widened `GroveEvent.type` to `string` with namespace convention |
| Deadline source | `reply_timeout_seconds` on topology edges |

### Files changed

- **New**: `deadline-watcher.ts`, `handoff-store.conformance.ts`, E2E test
- **Modified**: 25 files across core, stores, MCP, HTTP, TUI layers

## Test plan

- [x] HandoffStore conformance suite: 29 tests × 2 backends (InMemory + SQLite) — 58 tests
- [x] DeadlineWatcher unit tests: 11 tests (watch/cancel/overdue/rebuild/close)
- [x] E2E reply-resolution integration test in handoff.test.ts
- [x] E2E deadline lifecycle test with real SQLite stores (5 tests)
- [x] Real MCP server E2E: contract → handoff with deadline → seen → acked → reply → resolved
- [x] Overdue expiry verified (30s timeout expired during E2E)
- [x] Idempotency verified (repeated ack returns same timestamp)
- [x] All 1524 existing tests pass, 0 type errors