### PR TITLE
feat: PolicyEnforcer + EnforcingStore read config from session (#199)

### DIFF
--- a/docs/superpowers/plans/2026-04-15-session-config-consumers.md
+++ b/docs/superpowers/plans/2026-04-15-session-config-consumers.md
@@ -1,0 +1,362 @@
+# Session-Config Consumers Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor PolicyEnforcer, EnforcingStore, and evaluateStopConditions to accept `SessionRuntimeConfig` instead of `GroveContract`, decoupling enforcement consumers from the contract type.
+
+**Architecture:** Narrow constructor/function parameter types from `GroveContract` to `SessionRuntimeConfig` (a `Pick<GroveContract, ...>` already defined in `src/core/session-config.ts`). Rename internal `this.contract` fields to `this.config`. All existing callers continue to type-check since `GroveContract` structurally satisfies `SessionRuntimeConfig`. Add one integration test proving session config overrides contract.
+
+**Tech Stack:** TypeScript, Vitest
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/core/stop-conditions.ts` | Modify | Change function parameter type |
+| `src/core/policy-enforcer.ts` | Modify | Change constructor type + internal rename |
+| `src/core/enforcing-store.ts` | Modify | Change both class constructors + internal rename |
+| `src/core/policy-enforcer.test.ts` | Modify | Update type import |
+| `src/core/stop-conditions.test.ts` | Modify | Update type import |
+| `src/core/enforcing-store.test.ts` | Modify | Update type import |
+
+Callers that pass `GroveContract` values don't need code changes — the value already satisfies the narrowed `SessionRuntimeConfig` type. TypeScript structural typing handles this.
+
+---
+
+### Task 1: Change `evaluateStopConditions` signature
+
+This is the leaf dependency — PolicyEnforcer calls it, so change it first.
+
+**Files:**
+- Modify: `src/core/stop-conditions.ts:12,59-62`
+- Test: `src/core/stop-conditions.test.ts`
+
+- [ ] **Step 1: Update function signature and import**
+
+In `src/core/stop-conditions.ts`, change the import and parameter type:
+
+```typescript
+// Line 12: replace GroveContract import
+// Before:
+import type { GroveContract, MetricDefinition } from "./contract.js";
+// After:
+import type { MetricDefinition } from "./contract.js";
+import type { SessionRuntimeConfig } from "./session-config.js";
+```
+
+```typescript
+// Lines 59-62: change parameter type
+// Before:
+export async function evaluateStopConditions(
+  contract: GroveContract,
+  store: ContributionStore,
+): Promise<StopEvaluationResult> {
+// After:
+export async function evaluateStopConditions(
+  config: SessionRuntimeConfig,
+  store: ContributionStore,
+): Promise<StopEvaluationResult> {
+```
+
+Then rename all internal references from `contract` to `config` within this function body. Specifically:
+- Line 64: `const stopConditions = contract.stopConditions;` → `const stopConditions = config.stopConditions;`
+- Line 81 (approx): where `contract.metrics` is passed → `config.metrics`
+
+- [ ] **Step 2: Run tests to verify nothing breaks**
+
+Run: `npx vitest run src/core/stop-conditions.test.ts`
+Expected: All tests pass. The tests construct `GroveContract`-shaped objects and pass them — these satisfy `SessionRuntimeConfig` structurally.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/stop-conditions.ts
+git commit -m "refactor: evaluateStopConditions accepts SessionRuntimeConfig (#199)"
+```
+
+---
+
+### Task 2: Change `PolicyEnforcer` constructor
+
+**Files:**
+- Modify: `src/core/policy-enforcer.ts:25,89,103-111`
+- Test: `src/core/policy-enforcer.test.ts`
+
+- [ ] **Step 1: Update imports**
+
+In `src/core/policy-enforcer.ts`:
+
+```typescript
+// Line 25: narrow the import
+// Before:
+import type { Gate, GroveContract, MetricDefinition } from "./contract.js";
+// After:
+import type { Gate, MetricDefinition } from "./contract.js";
+import type { SessionRuntimeConfig } from "./session-config.js";
+```
+
+- [ ] **Step 2: Update class field and constructor**
+
+```typescript
+// Line 89: rename field
+// Before:
+  private readonly contract: GroveContract;
+// After:
+  private readonly config: SessionRuntimeConfig;
+
+// Lines 103-111: change constructor parameter
+// Before:
+  constructor(
+    contract: GroveContract,
+    contributionStore: ContributionStore,
+    outcomeStore?: OutcomeStore | undefined,
+  ) {
+    this.contract = contract;
+// After:
+  constructor(
+    config: SessionRuntimeConfig,
+    contributionStore: ContributionStore,
+    outcomeStore?: OutcomeStore | undefined,
+  ) {
+    this.config = config;
+```
+
+- [ ] **Step 3: Rename all `this.contract` references to `this.config`**
+
+Search-and-replace within `policy-enforcer.ts`: `this.contract` → `this.config`. Affected lines (approx):
+- Line 229: `this.contract.gates`
+- Line 247: `this.contract.outcomePolicy`
+- Line 268: `this.contract.stopConditions`
+- Line 270: `evaluateStopConditions(this.contract, ...)` → `evaluateStopConditions(this.config, ...)`
+- Line 315: `this.contract.agentConstraints`
+- Line 382: `this.contract.agentConstraints`
+- Line 410: `this.contract.agentConstraints`
+- Line 438: `this.contract.evaluation`
+- Line 552, 676, 791: `this.contract.metrics`
+- Line 665, 708: `this.contract.outcomePolicy`, `this.contract.gates`
+
+Also update the JSDoc comments referencing "contract" where they describe the parameter.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run src/core/policy-enforcer.test.ts`
+Expected: All 67+ tests pass. Test code passes `GroveContract`-shaped objects which satisfy `SessionRuntimeConfig`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/policy-enforcer.ts
+git commit -m "refactor: PolicyEnforcer accepts SessionRuntimeConfig (#199)"
+```
+
+---
+
+### Task 3: Change `EnforcingContributionStore` and `EnforcingClaimStore` constructors
+
+**Files:**
+- Modify: `src/core/enforcing-store.ts:18,137-138,153-166,496-503`
+- Test: `src/core/enforcing-store.test.ts`
+
+- [ ] **Step 1: Update import**
+
+In `src/core/enforcing-store.ts`:
+
+```typescript
+// Line 18: replace import
+// Before:
+import type { GroveContract } from "./contract.js";
+// After:
+import type { SessionRuntimeConfig } from "./session-config.js";
+```
+
+- [ ] **Step 2: Update EnforcingContributionStore**
+
+```typescript
+// Line 137: rename field
+// Before:
+  private readonly contract: GroveContract;
+// After:
+  private readonly config: SessionRuntimeConfig;
+
+// Lines 153-166: change constructor parameter
+// Before:
+  constructor(
+    inner: ContributionStore,
+    contract: GroveContract,
+    options?: {
+      cas?: ContentStore;
+      clock?: () => Date;
+    },
+  ) {
+    this.inner = inner;
+    this.contract = contract;
+// After:
+  constructor(
+    inner: ContributionStore,
+    config: SessionRuntimeConfig,
+    options?: {
+      cas?: ContentStore;
+      clock?: () => Date;
+    },
+  ) {
+    this.inner = inner;
+    this.config = config;
+```
+
+Then rename all `this.contract` references in `EnforcingContributionStore` to `this.config` (rate limit checks around lines 321, 343).
+
+- [ ] **Step 3: Update EnforcingClaimStore**
+
+```typescript
+// Line 496: rename field
+// Before:
+  private readonly contract: GroveContract;
+// After:
+  private readonly config: SessionRuntimeConfig;
+
+// Line 499: change constructor parameter
+// Before:
+  constructor(inner: ClaimStore, contract: GroveContract) {
+    this.inner = inner;
+    this.contract = contract;
+// After:
+  constructor(inner: ClaimStore, config: SessionRuntimeConfig) {
+    this.inner = inner;
+    this.config = config;
+```
+
+Then rename all `this.contract` references in `EnforcingClaimStore` to `this.config` (execution/concurrency checks around lines 515-522, 578).
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run src/core/enforcing-store.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/enforcing-store.ts
+git commit -m "refactor: EnforcingStore classes accept SessionRuntimeConfig (#199)"
+```
+
+---
+
+### Task 4: Update JSDoc and module-level comments
+
+**Files:**
+- Modify: `src/core/policy-enforcer.ts` (module docstring line 1-22)
+- Modify: `src/core/enforcing-store.ts` (module docstring lines 1-15)
+- Modify: `src/core/stop-conditions.ts` (module docstring lines 1-10)
+
+- [ ] **Step 1: Update references from "contract" to "config" in doc comments**
+
+In `policy-enforcer.ts` module docstring:
+- Line 133: Update "Contract hot-reload" comment to reference config instead of contract.
+
+In `enforcing-store.ts` module docstring:
+- Line 4: `These decorators compose a raw store with a GroveContract to enforce:` → `These decorators compose a raw store with a SessionRuntimeConfig to enforce:`
+
+In `stop-conditions.ts`:
+- Line 6: Update "grove contract" reference to "session config".
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/core/policy-enforcer.ts src/core/enforcing-store.ts src/core/stop-conditions.ts
+git commit -m "docs: update module docstrings for session-config refactor (#199)"
+```
+
+---
+
+### Task 5: Add session-config-wins integration test
+
+Prove that a PolicyEnforcer constructed with session config enforces different rules than the original contract would.
+
+**Files:**
+- Modify: `src/core/policy-enforcer.test.ts`
+
+- [ ] **Step 1: Add test for session config override**
+
+Add to the end of `src/core/policy-enforcer.test.ts`:
+
+```typescript
+describe("session config override", () => {
+  test("session config with different agentConstraints overrides contract", async () => {
+    // Session config allows only "review" kind
+    const sessionConfig: SessionRuntimeConfig = {
+      mode: ContributionMode.Evaluation,
+      agentConstraints: { allowedKinds: ["review"] },
+    };
+
+    const store = makeStore();
+    const enforcer = new PolicyEnforcer(sessionConfig, store);
+
+    // "work" kind should be rejected by session config
+    const workContribution = makeContribution({ kind: "work", mode: "evaluation" });
+    const result = await enforcer.enforce(workContribution, false);
+    expect(result.passed).toBe(false);
+    expect(result.violations).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "role_kind" })]),
+    );
+
+    // "review" kind should pass
+    const reviewContribution = makeContribution({ kind: "review", mode: "evaluation" });
+    const reviewResult = await enforcer.enforce(reviewContribution, false);
+    expect(reviewResult.violations.filter((v) => v.type === "role_kind")).toHaveLength(0);
+  });
+
+  test("session config with different stopConditions is used", async () => {
+    // Session config with a very low budget
+    const sessionConfig: SessionRuntimeConfig = {
+      stopConditions: { budget: { maxContributions: 1 } },
+    };
+
+    // Store already has 1 contribution → budget should be exhausted
+    const store = makeStore([
+      makeContribution({ kind: "work" }),
+    ]);
+    const enforcer = new PolicyEnforcer(sessionConfig, store);
+    const contribution = makeContribution({ kind: "work" });
+    const result = await enforcer.enforce(contribution, false);
+    expect(result.stopResult?.stopped).toBe(true);
+  });
+});
+```
+
+Ensure `SessionRuntimeConfig` is imported at the top of the test file:
+```typescript
+import type { SessionRuntimeConfig } from "./session-config.js";
+```
+
+- [ ] **Step 2: Run the new test**
+
+Run: `npx vitest run src/core/policy-enforcer.test.ts`
+Expected: All tests pass including the new ones.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/policy-enforcer.test.ts
+git commit -m "test: add session-config-wins tests for PolicyEnforcer (#199)"
+```
+
+---
+
+### Task 6: Full test verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass. No type errors.
+
+- [ ] **Step 2: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: No errors. All callers passing `GroveContract` still compile against `SessionRuntimeConfig` parameters.
+
+- [ ] **Step 3: Run lint**
+
+Run: `npx biome check src/core/policy-enforcer.ts src/core/enforcing-store.ts src/core/stop-conditions.ts`
+Expected: No issues.

--- a/docs/superpowers/specs/2026-04-15-session-config-consumers-design.md
+++ b/docs/superpowers/specs/2026-04-15-session-config-consumers-design.md
@@ -1,0 +1,146 @@
+# PolicyEnforcer + EnforcingStore Read Config from Session
+
+**Issue:** [#199](https://github.com/windoliver/grove/issues/199)
+**Depends on:** #198 (merged — sessions already snapshot full GroveContract)
+**Date:** 2026-04-15
+
+## Problem
+
+PolicyEnforcer, EnforcingStore, and evaluateStopConditions are hard-coupled to `GroveContract`. All sessions share a single GROVE.md config, so mid-session contract edits can break running sessions and there is no way to run sessions with different configs.
+
+## Solution
+
+Refactor these consumers to accept `SessionRuntimeConfig` (a `Pick<GroveContract, ...>` that already exists from #198) instead of `GroveContract`. Callers resolve config from the session record first, falling back to the contract for sessions created before #198.
+
+## Approach
+
+**Selected: Narrow constructor types to `SessionRuntimeConfig`**
+
+`SessionRuntimeConfig` (defined in `src/core/session-config.ts`) is:
+
+```typescript
+type SessionRuntimeConfig = Pick<
+  GroveContract,
+  | "mode" | "metrics" | "gates" | "stopConditions"
+  | "agentConstraints" | "concurrency" | "execution"
+  | "outcomePolicy" | "evaluation" | "rateLimits"
+  | "hooks" | "topology"
+>;
+```
+
+Since this is a `Pick` of `GroveContract`, any `GroveContract` value structurally satisfies `SessionRuntimeConfig`. Backward compatibility is free — no runtime migration needed.
+
+**Rejected alternatives:**
+- Per-consumer narrow interfaces (PolicyConfig, StoreConfig) — over-engineered for three consumers.
+- Pass full GroveContract sourced from session — doesn't decouple consumers from the contract type.
+
+## Changes
+
+### 1. PolicyEnforcer (`src/core/policy-enforcer.ts`)
+
+**Constructor:**
+```typescript
+// Before
+constructor(contract: GroveContract, store: ContributionStore, outcomeStore?: OutcomeStore)
+
+// After
+constructor(config: SessionRuntimeConfig, store: ContributionStore, outcomeStore?: OutcomeStore)
+```
+
+- Rename internal `this.contract` to `this.config`.
+- All field access (metrics, gates, stopConditions, agentConstraints, outcomePolicy, evaluation) stays identical — all are fields of `SessionRuntimeConfig`.
+- Update import: add `SessionRuntimeConfig`, remove `GroveContract` if unused.
+
+### 2. EnforcingContributionStore (`src/core/enforcing-store.ts`)
+
+**Constructor:**
+```typescript
+// Before
+constructor(inner: ContributionStore, contract: GroveContract, options?)
+
+// After
+constructor(inner: ContributionStore, config: SessionRuntimeConfig, options?)
+```
+
+- Rename internal `this.contract` to `this.config`.
+- Fields accessed: rateLimits, execution (via EnforcingClaimStore), concurrency — all in `SessionRuntimeConfig`.
+
+### 3. EnforcingClaimStore (`src/core/enforcing-store.ts`)
+
+**Constructor:**
+```typescript
+// Before
+constructor(inner: ClaimStore, contract: GroveContract, options?)
+
+// After
+constructor(inner: ClaimStore, config: SessionRuntimeConfig, options?)
+```
+
+- Rename internal `this.contract` to `this.config`.
+- Fields accessed: execution, concurrency — all in `SessionRuntimeConfig`.
+
+### 4. evaluateStopConditions (`src/core/stop-conditions.ts`)
+
+**Signature:**
+```typescript
+// Before
+evaluateStopConditions(contract: GroveContract, store: ContributionStore)
+
+// After
+evaluateStopConditions(config: SessionRuntimeConfig, store: ContributionStore)
+```
+
+- Reads stopConditions and metrics — both in `SessionRuntimeConfig`.
+
+### 5. Caller resolution (`src/core/operations/contribute.ts`)
+
+Where PolicyEnforcer and EnforcingStore are instantiated, resolve config from session:
+
+```typescript
+import { getSessionRuntimeConfig } from "../session-config.js";
+
+const config = getSessionRuntimeConfig(session) ?? deps.contract;
+const enforcer = new PolicyEnforcer(config, deps.contributionStore, deps.outcomeStore);
+```
+
+`getSessionRuntimeConfig()` already exists from #198. If the session has a config snapshot, use it. Otherwise fall back to the global contract.
+
+### 6. Server routes (`src/server/routes/contributions.ts`)
+
+Same pattern — resolve session config before passing to PolicyEnforcer. The attach/enforce endpoint already re-runs enforcement; it should use session config.
+
+### 7. OperationDeps (`src/core/operations/deps.ts`)
+
+No structural change. `deps.contract` remains available as the fallback source. Callers do the `session.config ?? deps.contract` resolution before passing to consumers.
+
+## Backward Compatibility
+
+- `GroveContract` satisfies `SessionRuntimeConfig` structurally (it's a Pick). Callers passing a raw contract still compile.
+- Sessions without config (created before #198) fall back to `deps.contract` via `getSessionRuntimeConfig(session) ?? deps.contract`.
+- No runtime migration needed. No database changes.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/core/policy-enforcer.ts` | Constructor type + internal rename |
+| `src/core/enforcing-store.ts` | Constructor types (both classes) + internal rename |
+| `src/core/stop-conditions.ts` | Function signature |
+| `src/core/operations/contribute.ts` | Resolve config from session |
+| `src/server/routes/contributions.ts` | Resolve config from session |
+| `src/core/policy-enforcer.test.ts` | Update test instantiation |
+| `src/core/enforcing-store.test.ts` | Update test instantiation |
+| `src/core/stop-conditions.test.ts` | Update test instantiation |
+
+## Testing
+
+- Existing test suites for PolicyEnforcer (67 tests), EnforcingStore, and stop-conditions pass with `SessionRuntimeConfig` instead of `GroveContract` — no behavioral change.
+- Add test: PolicyEnforcer with session config that differs from contract verifies session config wins.
+- Add test: Fallback when session has no config uses contract.
+- Add test: EnforcingStore rate limits use session config, not contract.
+
+## Out of Scope
+
+- SessionOrchestrator changes — it already snapshots config on session creation (#198).
+- Lifecycle state derivation — `deriveLifecycleState()` is graph-only, doesn't read contract.
+- New SessionConfig interfaces — `SessionRuntimeConfig` already covers all needed fields.

--- a/src/cli/commands/contribute.ts
+++ b/src/cli/commands/contribute.ts
@@ -10,7 +10,7 @@
  * contract loading, and output formatting.
  */
 
-import { access, readFile } from "node:fs/promises";
+import { access } from "node:fs/promises";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 
@@ -329,7 +329,6 @@ export async function executeContribute(options: ContributeOptions): Promise<{ c
     await import("../../local/sqlite-store.js");
   const { FsCas } = await import("../../local/fs-cas.js");
   const { DefaultFrontierCalculator } = await import("../../core/frontier.js");
-  const { parseGroveContract } = await import("../../core/contract.js");
   const { EnforcingContributionStore } = await import("../../core/enforcing-store.js");
 
   const dbPath = join(grovePath, "grove.db");
@@ -342,34 +341,15 @@ export async function executeContribute(options: ContributeOptions): Promise<{ c
   const frontier = new DefaultFrontierCalculator(rawStore);
 
   // 3. Load contract for enforcement, default mode, and metric directions.
-  //    Session-scoped: when GROVE_SESSION_ID is set, load the frozen contract
-  //    from the session record to guarantee all agents see the same config.
-  let contract: Awaited<ReturnType<typeof parseGroveContract>> | undefined;
-  const envSessionId = process.env.GROVE_SESSION_ID;
-  if (envSessionId) {
-    const { SqliteGoalSessionStore } = await import("../../local/sqlite-goal-session-store.js");
-    const sessionConfig = new SqliteGoalSessionStore(db).getSessionConfigSync(envSessionId);
-    if (!sessionConfig) {
-      throw new Error(
-        `Session ${envSessionId} has no stored config. ` +
-          `Cannot enforce contract for GROVE_SESSION_ID=${envSessionId}.`,
-      );
-    }
-    contract = sessionConfig;
-  } else {
-    const grovemdPath = join(options.cwd, "GROVE.md");
-    let grovemdContent: string | undefined;
-    try {
-      grovemdContent = await readFile(grovemdPath, "utf-8");
-    } catch {
-      // GROVE.md does not exist — proceed without enforcement
-    }
-    if (grovemdContent !== undefined) {
-      // File exists — parse errors must propagate so malformed contracts
-      // are not silently ignored (which would bypass enforcement).
-      contract = parseGroveContract(grovemdContent);
-    }
-  }
+  //    Shared bootstrap: session.config > GROVE.md > no enforcement.
+  //    See src/cli/utils/resolve-contract.ts for the full precedence chain.
+  const { SqliteGoalSessionStore } = await import("../../local/sqlite-goal-session-store.js");
+  const { resolveContract } = await import("../utils/resolve-contract.js");
+  const contract = await resolveContract({
+    goalSessionStore: new SqliteGoalSessionStore(db),
+    groveRoot: options.cwd,
+    envSessionId: process.env.GROVE_SESSION_ID,
+  });
 
   // Wrap store with enforcement if contract is available
   const store = contract ? new EnforcingContributionStore(rawStore, contract, { cas }) : rawStore;

--- a/src/cli/commands/discuss.ts
+++ b/src/cli/commands/discuss.ts
@@ -109,23 +109,33 @@ export async function executeDiscuss(options: DiscussOptions): Promise<{ cid: st
 
   // Load contract for enforcement and mode resolution.
   //
-  // Config resolution precedence:
-  //   1. session.config (frozen snapshot from #198) when GROVE_SESSION_ID is set
-  //      and the session has a stored config — use it, skip GROVE.md entirely.
-  //   2. Live GROVE.md — used when no session, or when session exists but
-  //      has no stored config (configless sessions are valid: orchestrator
-  //      calls createSession with config=undefined when GROVE.md is absent;
-  //      legacy pre-#198 sessions also lack config).
-  //   3. No enforcement — neither session config nor GROVE.md available.
+  // Config resolution precedence when GROVE_SESSION_ID is set:
+  //   - ok:          use the frozen session config, skip GROVE.md entirely
+  //   - configless:  session exists without config (orchestrator created
+  //                  session when GROVE.md was absent, or pre-#198 session);
+  //                  fall through to GROVE.md as compat
+  //   - not-found:   bogus/stale session id — fail closed
+  //   - malformed:   corrupted config_json — fail closed
   //
-  // Falling back to GROVE.md on missing session config preserves pre-PR
-  // behavior for configless sessions. This is a compat case, not silent
-  // drift — the only path where drift matters (session with config) takes
-  // precedence and never falls through.
+  // When GROVE_SESSION_ID is absent, fall through to live GROVE.md.
   let contract: Awaited<ReturnType<typeof parseGroveContract>> | undefined;
   const envSessionId = process.env.GROVE_SESSION_ID;
   if (envSessionId) {
-    contract = stores.goalSessionStore.getSessionConfigSync(envSessionId);
+    const result = stores.goalSessionStore.resolveSessionConfigSync(envSessionId);
+    if (result.kind === "ok") {
+      contract = result.config;
+    } else if (result.kind === "not-found") {
+      throw new Error(
+        `Session ${envSessionId} not found. GROVE_SESSION_ID points at a ` +
+          `session that does not exist in this grove's session store.`,
+      );
+    } else if (result.kind === "malformed") {
+      throw new Error(
+        `Session ${envSessionId} has malformed config_json: ${result.reason}. ` +
+          `Refusing to proceed with unknown enforcement state.`,
+      );
+    }
+    // kind === "configless" — fall through to GROVE.md
   }
   if (contract === undefined) {
     // Load GROVE.md from the grove root (parent of .grove/).

--- a/src/cli/commands/discuss.ts
+++ b/src/cli/commands/discuss.ts
@@ -108,25 +108,26 @@ export async function executeDiscuss(options: DiscussOptions): Promise<{ cid: st
   const frontier = new DefaultFrontierCalculator(stores.contributionStore);
 
   // Load contract for enforcement and mode resolution.
-  // Session-scoped: when GROVE_SESSION_ID is set, load the frozen contract
-  // from the session record to guarantee all agents see the same config.
+  //
+  // Config resolution precedence:
+  //   1. session.config (frozen snapshot from #198) when GROVE_SESSION_ID is set
+  //      and the session has a stored config — use it, skip GROVE.md entirely.
+  //   2. Live GROVE.md — used when no session, or when session exists but
+  //      has no stored config (configless sessions are valid: orchestrator
+  //      calls createSession with config=undefined when GROVE.md is absent;
+  //      legacy pre-#198 sessions also lack config).
+  //   3. No enforcement — neither session config nor GROVE.md available.
+  //
+  // Falling back to GROVE.md on missing session config preserves pre-PR
+  // behavior for configless sessions. This is a compat case, not silent
+  // drift — the only path where drift matters (session with config) takes
+  // precedence and never falls through.
   let contract: Awaited<ReturnType<typeof parseGroveContract>> | undefined;
   const envSessionId = process.env.GROVE_SESSION_ID;
   if (envSessionId) {
-    // Fail closed: if GROVE_SESSION_ID is set, the session's frozen config
-    // is authoritative. Missing config means either the session doesn't
-    // exist, is corrupt, or predates #198. Falling back to live GROVE.md
-    // would cause silent policy drift and is inconsistent with the other
-    // session-scoped paths (grove contribute, local/runtime, server route).
-    const sessionConfig = stores.goalSessionStore.getSessionConfigSync(envSessionId);
-    if (!sessionConfig) {
-      throw new Error(
-        `Session ${envSessionId} has no stored config. ` +
-          `Cannot enforce contract for GROVE_SESSION_ID=${envSessionId}.`,
-      );
-    }
-    contract = sessionConfig;
-  } else {
+    contract = stores.goalSessionStore.getSessionConfigSync(envSessionId);
+  }
+  if (contract === undefined) {
     // Load GROVE.md from the grove root (parent of .grove/).
     //
     // ENOENT is the only acceptable fallthrough. Everything else (parse

--- a/src/cli/commands/discuss.ts
+++ b/src/cli/commands/discuss.ts
@@ -113,14 +113,20 @@ export async function executeDiscuss(options: DiscussOptions): Promise<{ cid: st
   let contract: Awaited<ReturnType<typeof parseGroveContract>> | undefined;
   const envSessionId = process.env.GROVE_SESSION_ID;
   if (envSessionId) {
+    // Fail closed: if GROVE_SESSION_ID is set, the session's frozen config
+    // is authoritative. Missing config means either the session doesn't
+    // exist, is corrupt, or predates #198. Falling back to live GROVE.md
+    // would cause silent policy drift and is inconsistent with the other
+    // session-scoped paths (grove contribute, local/runtime, server route).
     const sessionConfig = stores.goalSessionStore.getSessionConfigSync(envSessionId);
-    if (sessionConfig) {
-      contract = sessionConfig;
+    if (!sessionConfig) {
+      throw new Error(
+        `Session ${envSessionId} has no stored config. ` +
+          `Cannot enforce contract for GROVE_SESSION_ID=${envSessionId}.`,
+      );
     }
-    // Session without a stored config is a valid state (CreateSessionInput.config
-    // is optional). Fall through to GROVE.md instead of hard-failing.
-  }
-  if (contract === undefined) {
+    contract = sessionConfig;
+  } else {
     // Load GROVE.md from the grove root (parent of .grove/).
     //
     // ENOENT is the only acceptable fallthrough. Everything else (parse

--- a/src/cli/commands/discuss.ts
+++ b/src/cli/commands/discuss.ts
@@ -114,21 +114,28 @@ export async function executeDiscuss(options: DiscussOptions): Promise<{ cid: st
   const envSessionId = process.env.GROVE_SESSION_ID;
   if (envSessionId) {
     const sessionConfig = stores.goalSessionStore.getSessionConfigSync(envSessionId);
-    if (!sessionConfig) {
-      throw new Error(
-        `Session ${envSessionId} has no stored config. ` +
-          `Cannot enforce contract for GROVE_SESSION_ID=${envSessionId}.`,
-      );
+    if (sessionConfig) {
+      contract = sessionConfig;
     }
-    contract = sessionConfig;
-  } else {
-    // GROVE.md lives in the parent of .grove/
+    // Session without a stored config is a valid state (CreateSessionInput.config
+    // is optional). Fall through to GROVE.md instead of hard-failing.
+  }
+  if (contract === undefined) {
+    // Load GROVE.md from the grove root (parent of .grove/).
+    //
+    // ENOENT is the only acceptable fallthrough. Everything else (parse
+    // errors, permission denied, schema validation) propagates to the
+    // outer error handler so the operator sees the failure.
     const groveRoot = join(groveDir, "..");
     const grovemdPath = join(groveRoot, "GROVE.md");
     let grovemdContent: string | undefined;
     try {
       grovemdContent = await readFile(grovemdPath, "utf-8");
-    } catch {
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== "ENOENT") {
+        throw err;
+      }
       // GROVE.md does not exist — proceed without enforcement
     }
     if (grovemdContent !== undefined) {

--- a/src/cli/commands/discuss.ts
+++ b/src/cli/commands/discuss.ts
@@ -9,7 +9,6 @@
  *   grove discuss "Topic" --json
  */
 
-import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 
@@ -100,65 +99,20 @@ export async function executeDiscuss(options: DiscussOptions): Promise<{ cid: st
   const { createSqliteStores } = await import("../../local/sqlite-store.js");
   const { FsCas } = await import("../../local/fs-cas.js");
   const { DefaultFrontierCalculator } = await import("../../core/frontier.js");
-  const { parseGroveContract } = await import("../../core/contract.js");
   const { EnforcingContributionStore } = await import("../../core/enforcing-store.js");
+  const { resolveContract } = await import("../utils/resolve-contract.js");
 
   const stores = createSqliteStores(dbPath);
   const cas = new FsCas(join(groveDir, "cas"));
   const frontier = new DefaultFrontierCalculator(stores.contributionStore);
 
-  // Load contract for enforcement and mode resolution.
-  //
-  // Config resolution precedence when GROVE_SESSION_ID is set:
-  //   - ok:          use the frozen session config, skip GROVE.md entirely
-  //   - configless:  session exists without config (orchestrator created
-  //                  session when GROVE.md was absent, or pre-#198 session);
-  //                  fall through to GROVE.md as compat
-  //   - not-found:   bogus/stale session id — fail closed
-  //   - malformed:   corrupted config_json — fail closed
-  //
-  // When GROVE_SESSION_ID is absent, fall through to live GROVE.md.
-  let contract: Awaited<ReturnType<typeof parseGroveContract>> | undefined;
-  const envSessionId = process.env.GROVE_SESSION_ID;
-  if (envSessionId) {
-    const result = stores.goalSessionStore.resolveSessionConfigSync(envSessionId);
-    if (result.kind === "ok") {
-      contract = result.config;
-    } else if (result.kind === "not-found") {
-      throw new Error(
-        `Session ${envSessionId} not found. GROVE_SESSION_ID points at a ` +
-          `session that does not exist in this grove's session store.`,
-      );
-    } else if (result.kind === "malformed") {
-      throw new Error(
-        `Session ${envSessionId} has malformed config_json: ${result.reason}. ` +
-          `Refusing to proceed with unknown enforcement state.`,
-      );
-    }
-    // kind === "configless" — fall through to GROVE.md
-  }
-  if (contract === undefined) {
-    // Load GROVE.md from the grove root (parent of .grove/).
-    //
-    // ENOENT is the only acceptable fallthrough. Everything else (parse
-    // errors, permission denied, schema validation) propagates to the
-    // outer error handler so the operator sees the failure.
-    const groveRoot = join(groveDir, "..");
-    const grovemdPath = join(groveRoot, "GROVE.md");
-    let grovemdContent: string | undefined;
-    try {
-      grovemdContent = await readFile(grovemdPath, "utf-8");
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException)?.code;
-      if (code !== "ENOENT") {
-        throw err;
-      }
-      // GROVE.md does not exist — proceed without enforcement
-    }
-    if (grovemdContent !== undefined) {
-      contract = parseGroveContract(grovemdContent);
-    }
-  }
+  // Shared bootstrap: session.config > GROVE.md > no enforcement.
+  // See src/cli/utils/resolve-contract.ts for the full precedence chain.
+  const contract = await resolveContract({
+    goalSessionStore: stores.goalSessionStore,
+    groveRoot: join(groveDir, ".."),
+    envSessionId: process.env.GROVE_SESSION_ID,
+  });
 
   // Wrap store with enforcement if contract is available
   const store = contract

--- a/src/cli/commands/discuss.ts
+++ b/src/cli/commands/discuss.ts
@@ -107,19 +107,33 @@ export async function executeDiscuss(options: DiscussOptions): Promise<{ cid: st
   const cas = new FsCas(join(groveDir, "cas"));
   const frontier = new DefaultFrontierCalculator(stores.contributionStore);
 
-  // Load GROVE.md contract for enforcement and mode resolution
-  // GROVE.md lives in the parent of .grove/
-  const groveRoot = join(groveDir, "..");
-  const grovemdPath = join(groveRoot, "GROVE.md");
+  // Load contract for enforcement and mode resolution.
+  // Session-scoped: when GROVE_SESSION_ID is set, load the frozen contract
+  // from the session record to guarantee all agents see the same config.
   let contract: Awaited<ReturnType<typeof parseGroveContract>> | undefined;
-  let grovemdContent: string | undefined;
-  try {
-    grovemdContent = await readFile(grovemdPath, "utf-8");
-  } catch {
-    // GROVE.md does not exist — proceed without enforcement
-  }
-  if (grovemdContent !== undefined) {
-    contract = parseGroveContract(grovemdContent);
+  const envSessionId = process.env.GROVE_SESSION_ID;
+  if (envSessionId) {
+    const sessionConfig = stores.goalSessionStore.getSessionConfigSync(envSessionId);
+    if (!sessionConfig) {
+      throw new Error(
+        `Session ${envSessionId} has no stored config. ` +
+          `Cannot enforce contract for GROVE_SESSION_ID=${envSessionId}.`,
+      );
+    }
+    contract = sessionConfig;
+  } else {
+    // GROVE.md lives in the parent of .grove/
+    const groveRoot = join(groveDir, "..");
+    const grovemdPath = join(groveRoot, "GROVE.md");
+    let grovemdContent: string | undefined;
+    try {
+      grovemdContent = await readFile(grovemdPath, "utf-8");
+    } catch {
+      // GROVE.md does not exist — proceed without enforcement
+    }
+    if (grovemdContent !== undefined) {
+      contract = parseGroveContract(grovemdContent);
+    }
   }
 
   // Wrap store with enforcement if contract is available

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -89,14 +89,13 @@ async function handleSend(args: readonly string[], groveOverride?: string): Prom
   const envSessionId = process.env.GROVE_SESSION_ID;
   if (envSessionId) {
     const sessionConfig = stores.goalSessionStore.getSessionConfigSync(envSessionId);
-    if (!sessionConfig) {
-      throw new Error(
-        `Session ${envSessionId} has no stored config. ` +
-          `Cannot enforce contract for GROVE_SESSION_ID=${envSessionId}.`,
-      );
+    if (sessionConfig) {
+      contract = sessionConfig;
     }
-    contract = sessionConfig;
-  } else {
+    // Session without a stored config is a valid state (CreateSessionInput.config
+    // is optional). Fall through to GROVE.md instead of hard-failing.
+  }
+  if (contract === undefined) {
     // Load GROVE.md from the grove root (parent of .grove/).
     //
     // Separate the readFile catch from the parse call so a MALFORMED contract

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -83,25 +83,26 @@ async function handleSend(args: readonly string[], groveOverride?: string): Prom
   const frontier = new DefaultFrontierCalculator(stores.contributionStore);
 
   // Load contract for enforcement.
-  // Session-scoped: when GROVE_SESSION_ID is set, load the frozen contract
-  // from the session record to guarantee all agents see the same config.
+  //
+  // Config resolution precedence:
+  //   1. session.config (frozen snapshot from #198) when GROVE_SESSION_ID is set
+  //      and the session has a stored config — use it, skip GROVE.md entirely.
+  //   2. Live GROVE.md — used when no session, or when session exists but
+  //      has no stored config (configless sessions are valid: orchestrator
+  //      calls createSession with config=undefined when GROVE.md is absent;
+  //      legacy pre-#198 sessions also lack config).
+  //   3. No enforcement — neither session config nor GROVE.md available.
+  //
+  // Falling back to GROVE.md on missing session config preserves pre-PR
+  // behavior for configless sessions. This is a compat case, not silent
+  // drift — the only path where drift matters (session with config) takes
+  // precedence and never falls through.
   let contract: Awaited<ReturnType<typeof parseGroveContract>> | undefined;
   const envSessionId = process.env.GROVE_SESSION_ID;
   if (envSessionId) {
-    // Fail closed: if GROVE_SESSION_ID is set, the session's frozen config
-    // is authoritative. Missing config means either the session doesn't
-    // exist, is corrupt, or predates #198. Falling back to live GROVE.md
-    // would cause silent policy drift and is inconsistent with the other
-    // session-scoped paths (grove contribute, local/runtime, server route).
-    const sessionConfig = stores.goalSessionStore.getSessionConfigSync(envSessionId);
-    if (!sessionConfig) {
-      throw new Error(
-        `Session ${envSessionId} has no stored config. ` +
-          `Cannot enforce contract for GROVE_SESSION_ID=${envSessionId}.`,
-      );
-    }
-    contract = sessionConfig;
-  } else {
+    contract = stores.goalSessionStore.getSessionConfigSync(envSessionId);
+  }
+  if (contract === undefined) {
     // Load GROVE.md from the grove root (parent of .grove/).
     //
     // Separate the readFile catch from the parse call so a MALFORMED contract

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -84,23 +84,33 @@ async function handleSend(args: readonly string[], groveOverride?: string): Prom
 
   // Load contract for enforcement.
   //
-  // Config resolution precedence:
-  //   1. session.config (frozen snapshot from #198) when GROVE_SESSION_ID is set
-  //      and the session has a stored config — use it, skip GROVE.md entirely.
-  //   2. Live GROVE.md — used when no session, or when session exists but
-  //      has no stored config (configless sessions are valid: orchestrator
-  //      calls createSession with config=undefined when GROVE.md is absent;
-  //      legacy pre-#198 sessions also lack config).
-  //   3. No enforcement — neither session config nor GROVE.md available.
+  // Config resolution precedence when GROVE_SESSION_ID is set:
+  //   - ok:          use the frozen session config, skip GROVE.md entirely
+  //   - configless:  session exists without config (orchestrator created
+  //                  session when GROVE.md was absent, or pre-#198 session);
+  //                  fall through to GROVE.md as compat
+  //   - not-found:   bogus/stale session id — fail closed
+  //   - malformed:   corrupted config_json — fail closed
   //
-  // Falling back to GROVE.md on missing session config preserves pre-PR
-  // behavior for configless sessions. This is a compat case, not silent
-  // drift — the only path where drift matters (session with config) takes
-  // precedence and never falls through.
+  // When GROVE_SESSION_ID is absent, fall through to live GROVE.md.
   let contract: Awaited<ReturnType<typeof parseGroveContract>> | undefined;
   const envSessionId = process.env.GROVE_SESSION_ID;
   if (envSessionId) {
-    contract = stores.goalSessionStore.getSessionConfigSync(envSessionId);
+    const result = stores.goalSessionStore.resolveSessionConfigSync(envSessionId);
+    if (result.kind === "ok") {
+      contract = result.config;
+    } else if (result.kind === "not-found") {
+      throw new Error(
+        `Session ${envSessionId} not found. GROVE_SESSION_ID points at a ` +
+          `session that does not exist in this grove's session store.`,
+      );
+    } else if (result.kind === "malformed") {
+      throw new Error(
+        `Session ${envSessionId} has malformed config_json: ${result.reason}. ` +
+          `Refusing to proceed with unknown enforcement state.`,
+      );
+    }
+    // kind === "configless" — fall through to GROVE.md
   }
   if (contract === undefined) {
     // Load GROVE.md from the grove root (parent of .grove/).

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -82,37 +82,52 @@ async function handleSend(args: readonly string[], groveOverride?: string): Prom
   const cas = new FsCas(join(groveDir, "cas"));
   const frontier = new DefaultFrontierCalculator(stores.contributionStore);
 
-  // Load GROVE.md from the grove root (parent of .grove/).
-  //
-  // Separate the readFile catch from the parse call so a MALFORMED contract
-  // fails closed instead of silently falling through to unenforced mode.
-  // The first pass of this patch combined both into one try/catch, which
-  // meant a YAML syntax error would be indistinguishable from "file does
-  // not exist" — any broken contract file reopened the CLI bypass we're
-  // supposed to be closing.
-  //
-  // ENOENT is the only acceptable fallthrough. Everything else (parse
-  // errors, permission denied, schema validation) propagates to the
-  // outer error handler so the operator sees the failure.
-  const groveRoot = join(groveDir, "..");
-  const grovemdPath = join(groveRoot, "GROVE.md");
+  // Load contract for enforcement.
+  // Session-scoped: when GROVE_SESSION_ID is set, load the frozen contract
+  // from the session record to guarantee all agents see the same config.
   let contract: Awaited<ReturnType<typeof parseGroveContract>> | undefined;
-  let grovemdContent: string | undefined;
-  try {
-    grovemdContent = await readFile(grovemdPath, "utf-8");
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException)?.code;
-    if (code !== "ENOENT") {
-      // Permission error, I/O error, etc. — surface loudly.
-      throw err;
+  const envSessionId = process.env.GROVE_SESSION_ID;
+  if (envSessionId) {
+    const sessionConfig = stores.goalSessionStore.getSessionConfigSync(envSessionId);
+    if (!sessionConfig) {
+      throw new Error(
+        `Session ${envSessionId} has no stored config. ` +
+          `Cannot enforce contract for GROVE_SESSION_ID=${envSessionId}.`,
+      );
     }
-    // GROVE.md does not exist — proceed without enforcement, same as
-    // `grove discuss` in a grove without a contract.
-  }
-  if (grovemdContent !== undefined) {
-    // parseGroveContract intentionally runs OUTSIDE the catch: YAML/schema
-    // errors must propagate, not be swallowed as "no contract".
-    contract = parseGroveContract(grovemdContent);
+    contract = sessionConfig;
+  } else {
+    // Load GROVE.md from the grove root (parent of .grove/).
+    //
+    // Separate the readFile catch from the parse call so a MALFORMED contract
+    // fails closed instead of silently falling through to unenforced mode.
+    // The first pass of this patch combined both into one try/catch, which
+    // meant a YAML syntax error would be indistinguishable from "file does
+    // not exist" — any broken contract file reopened the CLI bypass we're
+    // supposed to be closing.
+    //
+    // ENOENT is the only acceptable fallthrough. Everything else (parse
+    // errors, permission denied, schema validation) propagates to the
+    // outer error handler so the operator sees the failure.
+    const groveRoot = join(groveDir, "..");
+    const grovemdPath = join(groveRoot, "GROVE.md");
+    let grovemdContent: string | undefined;
+    try {
+      grovemdContent = await readFile(grovemdPath, "utf-8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== "ENOENT") {
+        // Permission error, I/O error, etc. — surface loudly.
+        throw err;
+      }
+      // GROVE.md does not exist — proceed without enforcement, same as
+      // `grove discuss` in a grove without a contract.
+    }
+    if (grovemdContent !== undefined) {
+      // parseGroveContract intentionally runs OUTSIDE the catch: YAML/schema
+      // errors must propagate, not be swallowed as "no contract".
+      contract = parseGroveContract(grovemdContent);
+    }
   }
 
   // Wrap with EnforcingContributionStore when a contract exists. Without

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -6,7 +6,6 @@
  *   grove inbox read [--from <agent-id>] [--since <iso>] [--limit <n>] [--json]
  */
 
-import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import type { AgentOverrides } from "../../core/operations/agent.js";
@@ -74,77 +73,21 @@ async function handleSend(args: readonly string[], groveOverride?: string): Prom
   const { createSqliteStores } = await import("../../local/sqlite-store.js");
   const { FsCas } = await import("../../local/fs-cas.js");
   const { DefaultFrontierCalculator } = await import("../../core/frontier.js");
-  const { parseGroveContract } = await import("../../core/contract.js");
   const { EnforcingContributionStore } = await import("../../core/enforcing-store.js");
+  const { resolveContract } = await import("../utils/resolve-contract.js");
 
   const { groveDir, dbPath } = resolveGroveDir(groveOverride);
   const stores = createSqliteStores(dbPath);
   const cas = new FsCas(join(groveDir, "cas"));
   const frontier = new DefaultFrontierCalculator(stores.contributionStore);
 
-  // Load contract for enforcement.
-  //
-  // Config resolution precedence when GROVE_SESSION_ID is set:
-  //   - ok:          use the frozen session config, skip GROVE.md entirely
-  //   - configless:  session exists without config (orchestrator created
-  //                  session when GROVE.md was absent, or pre-#198 session);
-  //                  fall through to GROVE.md as compat
-  //   - not-found:   bogus/stale session id — fail closed
-  //   - malformed:   corrupted config_json — fail closed
-  //
-  // When GROVE_SESSION_ID is absent, fall through to live GROVE.md.
-  let contract: Awaited<ReturnType<typeof parseGroveContract>> | undefined;
-  const envSessionId = process.env.GROVE_SESSION_ID;
-  if (envSessionId) {
-    const result = stores.goalSessionStore.resolveSessionConfigSync(envSessionId);
-    if (result.kind === "ok") {
-      contract = result.config;
-    } else if (result.kind === "not-found") {
-      throw new Error(
-        `Session ${envSessionId} not found. GROVE_SESSION_ID points at a ` +
-          `session that does not exist in this grove's session store.`,
-      );
-    } else if (result.kind === "malformed") {
-      throw new Error(
-        `Session ${envSessionId} has malformed config_json: ${result.reason}. ` +
-          `Refusing to proceed with unknown enforcement state.`,
-      );
-    }
-    // kind === "configless" — fall through to GROVE.md
-  }
-  if (contract === undefined) {
-    // Load GROVE.md from the grove root (parent of .grove/).
-    //
-    // Separate the readFile catch from the parse call so a MALFORMED contract
-    // fails closed instead of silently falling through to unenforced mode.
-    // The first pass of this patch combined both into one try/catch, which
-    // meant a YAML syntax error would be indistinguishable from "file does
-    // not exist" — any broken contract file reopened the CLI bypass we're
-    // supposed to be closing.
-    //
-    // ENOENT is the only acceptable fallthrough. Everything else (parse
-    // errors, permission denied, schema validation) propagates to the
-    // outer error handler so the operator sees the failure.
-    const groveRoot = join(groveDir, "..");
-    const grovemdPath = join(groveRoot, "GROVE.md");
-    let grovemdContent: string | undefined;
-    try {
-      grovemdContent = await readFile(grovemdPath, "utf-8");
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException)?.code;
-      if (code !== "ENOENT") {
-        // Permission error, I/O error, etc. — surface loudly.
-        throw err;
-      }
-      // GROVE.md does not exist — proceed without enforcement, same as
-      // `grove discuss` in a grove without a contract.
-    }
-    if (grovemdContent !== undefined) {
-      // parseGroveContract intentionally runs OUTSIDE the catch: YAML/schema
-      // errors must propagate, not be swallowed as "no contract".
-      contract = parseGroveContract(grovemdContent);
-    }
-  }
+  // Shared bootstrap: session.config > GROVE.md > no enforcement.
+  // See src/cli/utils/resolve-contract.ts for the full precedence chain.
+  const contract = await resolveContract({
+    goalSessionStore: stores.goalSessionStore,
+    groveRoot: join(groveDir, ".."),
+    envSessionId: process.env.GROVE_SESSION_ID,
+  });
 
   // Wrap with EnforcingContributionStore when a contract exists. Without
   // this, rate-limits / allowed-kinds / clock-skew checks would not fire

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -88,14 +88,20 @@ async function handleSend(args: readonly string[], groveOverride?: string): Prom
   let contract: Awaited<ReturnType<typeof parseGroveContract>> | undefined;
   const envSessionId = process.env.GROVE_SESSION_ID;
   if (envSessionId) {
+    // Fail closed: if GROVE_SESSION_ID is set, the session's frozen config
+    // is authoritative. Missing config means either the session doesn't
+    // exist, is corrupt, or predates #198. Falling back to live GROVE.md
+    // would cause silent policy drift and is inconsistent with the other
+    // session-scoped paths (grove contribute, local/runtime, server route).
     const sessionConfig = stores.goalSessionStore.getSessionConfigSync(envSessionId);
-    if (sessionConfig) {
-      contract = sessionConfig;
+    if (!sessionConfig) {
+      throw new Error(
+        `Session ${envSessionId} has no stored config. ` +
+          `Cannot enforce contract for GROVE_SESSION_ID=${envSessionId}.`,
+      );
     }
-    // Session without a stored config is a valid state (CreateSessionInput.config
-    // is optional). Fall through to GROVE.md instead of hard-failing.
-  }
-  if (contract === undefined) {
+    contract = sessionConfig;
+  } else {
     // Load GROVE.md from the grove root (parent of .grove/).
     //
     // Separate the readFile catch from the parse call so a MALFORMED contract

--- a/src/cli/utils/resolve-contract.ts
+++ b/src/cli/utils/resolve-contract.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared contract-resolution bootstrap for CLI write paths.
+ *
+ * Resolution precedence:
+ *   1. session.config (frozen snapshot from #198) when GROVE_SESSION_ID is set
+ *      and the session has a stored config — use it, skip GROVE.md entirely.
+ *   2. Live GROVE.md — used when no session is set, or when the session exists
+ *      but has no stored config (configless sessions are valid state:
+ *      orchestrator calls createSession with config=undefined when GROVE.md is
+ *      absent; legacy pre-#198 sessions also lack config).
+ *   3. No enforcement — neither session config nor GROVE.md available.
+ *
+ * Fail-closed cases:
+ *   - GROVE_SESSION_ID points at a session that does not exist (stale env var)
+ *   - Session row has malformed / schema-invalid config_json
+ *   - GROVE.md exists but is unreadable for a non-ENOENT reason (permission,
+ *     I/O error) — the caller must see the failure rather than silently
+ *     dropping to unenforced mode.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { type GroveContract, parseGroveContract } from "../../core/contract.js";
+import type { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
+
+export interface ResolveContractInput {
+  readonly goalSessionStore: SqliteGoalSessionStore;
+  readonly groveRoot: string;
+  readonly envSessionId?: string | undefined;
+}
+
+export async function resolveContract(
+  input: ResolveContractInput,
+): Promise<GroveContract | undefined> {
+  const { goalSessionStore, groveRoot, envSessionId } = input;
+
+  if (envSessionId) {
+    const result = goalSessionStore.resolveSessionConfigSync(envSessionId);
+    if (result.kind === "ok") {
+      return result.config;
+    }
+    if (result.kind === "not-found") {
+      throw new Error(
+        `Session ${envSessionId} not found. GROVE_SESSION_ID points at a ` +
+          `session that does not exist in this grove's session store.`,
+      );
+    }
+    if (result.kind === "malformed") {
+      throw new Error(
+        `Session ${envSessionId} has malformed config_json: ${result.reason}. ` +
+          `Refusing to proceed with unknown enforcement state.`,
+      );
+    }
+    // kind === "configless": fall through to GROVE.md below
+  }
+
+  const grovemdPath = join(groveRoot, "GROVE.md");
+  let grovemdContent: string | undefined;
+  try {
+    grovemdContent = await readFile(grovemdPath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "ENOENT") {
+      throw err;
+    }
+    // GROVE.md does not exist — proceed without enforcement
+    return undefined;
+  }
+  // parseGroveContract intentionally runs OUTSIDE the catch: YAML/schema
+  // errors must propagate, not be swallowed as "no contract".
+  return parseGroveContract(grovemdContent);
+}

--- a/src/core/enforcing-store.ts
+++ b/src/core/enforcing-store.ts
@@ -1,7 +1,7 @@
 /**
  * Enforcement wrappers for ContributionStore and ClaimStore.
  *
- * These decorators compose a raw store with a GroveContract to enforce:
+ * These decorators compose a raw store with a SessionRuntimeConfig to enforce:
  * - Concurrency limits (global, per-agent, per-target)
  * - Rate limits (per-agent, per-grove contributions per hour)
  * - Artifact limits (size, count)

--- a/src/core/enforcing-store.ts
+++ b/src/core/enforcing-store.ts
@@ -15,7 +15,6 @@
  */
 
 import type { ContentStore } from "./cas.js";
-import type { SessionRuntimeConfig } from "./session-config.js";
 import {
   ArtifactLimitError,
   ConcurrencyLimitError,
@@ -23,6 +22,7 @@ import {
   RateLimitError,
 } from "./errors.js";
 import type { Claim, Contribution, ContributionKind, Relation, RelationType } from "./models.js";
+import type { SessionRuntimeConfig } from "./session-config.js";
 import type {
   ActiveClaimFilter,
   ClaimQuery,

--- a/src/core/enforcing-store.ts
+++ b/src/core/enforcing-store.ts
@@ -15,7 +15,7 @@
  */
 
 import type { ContentStore } from "./cas.js";
-import type { GroveContract } from "./contract.js";
+import type { SessionRuntimeConfig } from "./session-config.js";
 import {
   ArtifactLimitError,
   ConcurrencyLimitError,
@@ -134,7 +134,7 @@ function getMutexForStore(store: ContributionStore | ClaimStore): AsyncMutex {
 export class EnforcingContributionStore implements ContributionStore {
   private readonly inner: ContributionStore;
   private readonly cas: ContentStore | undefined;
-  private readonly contract: GroveContract;
+  private readonly config: SessionRuntimeConfig;
   private readonly clock: () => Date;
   private readonly writeMutex: AsyncMutex;
 
@@ -152,14 +152,14 @@ export class EnforcingContributionStore implements ContributionStore {
 
   constructor(
     inner: ContributionStore,
-    contract: GroveContract,
+    config: SessionRuntimeConfig,
     options?: {
       cas?: ContentStore;
       clock?: () => Date;
     },
   ) {
     this.inner = inner;
-    this.contract = contract;
+    this.config = config;
     this.cas = options?.cas;
     this.clock = options?.clock ?? (() => new Date());
     this.writeMutex = getMutexForStore(inner);
@@ -318,7 +318,7 @@ export class EnforcingContributionStore implements ContributionStore {
     _batchIndex: number,
     precedingInBatch: readonly Contribution[],
   ): Promise<void> {
-    const rl = this.contract.rateLimits;
+    const rl = this.config.rateLimits;
 
     // Reject backdated / future-dated contributions to prevent rate-limit bypass.
     // Only enforced when rate limits are configured — without rate limits there is
@@ -493,12 +493,12 @@ export class EnforcingContributionStore implements ContributionStore {
  */
 export class EnforcingClaimStore implements ClaimStore {
   private readonly inner: ClaimStore;
-  private readonly contract: GroveContract;
+  private readonly config: SessionRuntimeConfig;
   private readonly writeMutex: AsyncMutex;
 
-  constructor(inner: ClaimStore, contract: GroveContract) {
+  constructor(inner: ClaimStore, config: SessionRuntimeConfig) {
     this.inner = inner;
-    this.contract = contract;
+    this.config = config;
     this.writeMutex = getMutexForStore(inner);
   }
 
@@ -511,15 +511,15 @@ export class EnforcingClaimStore implements ClaimStore {
   };
 
   heartbeat = async (claimId: string, leaseDurationMs?: number): Promise<Claim> => {
-    // Determine effective lease duration: caller > contract default > store default
+    // Determine effective lease duration: caller > config default > store default
     const contractDefaultMs =
-      this.contract.execution?.defaultLeaseSeconds !== undefined
-        ? this.contract.execution.defaultLeaseSeconds * 1000
+      this.config.execution?.defaultLeaseSeconds !== undefined
+        ? this.config.execution.defaultLeaseSeconds * 1000
         : undefined;
     const effectiveDurationMs = leaseDurationMs ?? contractDefaultMs;
 
     // Enforce max lease if configured
-    const maxLeaseSeconds = this.contract.execution?.maxLeaseSeconds;
+    const maxLeaseSeconds = this.config.execution?.maxLeaseSeconds;
     if (maxLeaseSeconds !== undefined && effectiveDurationMs !== undefined) {
       const effectiveSeconds = effectiveDurationMs / 1000;
       if (effectiveSeconds > maxLeaseSeconds) {
@@ -575,7 +575,7 @@ export class EnforcingClaimStore implements ClaimStore {
   // ========================================================================
 
   private async enforceConcurrencyLimits(claim: Claim): Promise<void> {
-    const concurrency = this.contract.concurrency;
+    const concurrency = this.config.concurrency;
     if (concurrency === undefined) return;
 
     // Check global active claim limit
@@ -620,7 +620,7 @@ export class EnforcingClaimStore implements ClaimStore {
   }
 
   private enforceLeaseLimit(claim: Claim): void {
-    const maxLeaseSeconds = this.contract.execution?.maxLeaseSeconds;
+    const maxLeaseSeconds = this.config.execution?.maxLeaseSeconds;
     if (maxLeaseSeconds === undefined) return;
 
     const leaseMs = new Date(claim.leaseExpiresAt).getTime() - new Date(claim.createdAt).getTime();

--- a/src/core/policy-enforcer.test.ts
+++ b/src/core/policy-enforcer.test.ts
@@ -17,8 +17,9 @@ import { describe, expect, test } from "bun:test";
 import type { GroveContract } from "./contract.js";
 import { PolicyViolationError } from "./errors.js";
 import type { Contribution, Score } from "./models.js";
-import { type ContributionInput, ContributionKind, RelationType } from "./models.js";
+import { type ContributionInput, ContributionKind, ContributionMode, RelationType } from "./models.js";
 import { PolicyEnforcer } from "./policy-enforcer.js";
+import type { SessionRuntimeConfig } from "./session-config.js";
 import type { ContributionStore } from "./store.js";
 import { makeContribution as makeContributionFromHelper } from "./test-helpers.js";
 import { InMemoryContributionStore } from "./testing.js";
@@ -1215,5 +1216,49 @@ describe("PolicyEnforcer: deliberation_limit stop condition", () => {
     const result = await enforcer.enforce(contribution, false);
     expect(result.stopResult).toBeDefined();
     expect(result.stopResult!.stopped).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session config override tests
+// ---------------------------------------------------------------------------
+
+describe("session config override", () => {
+  test("session config with different agentConstraints overrides contract", async () => {
+    // Session config allows only "review" kind
+    const sessionConfig: SessionRuntimeConfig = {
+      mode: ContributionMode.Evaluation,
+      agentConstraints: { allowedKinds: ["review"] },
+    };
+
+    const store = makeStore();
+    const enforcer = new PolicyEnforcer(sessionConfig, store);
+
+    // "work" kind should be rejected by session config
+    const workContribution = makeContribution({ kind: "work", mode: "evaluation" });
+    const result = await enforcer.enforce(workContribution, false);
+    expect(result.passed).toBe(false);
+    expect(result.violations).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "role_kind" })]),
+    );
+
+    // "review" kind should pass the role_kind check
+    const reviewContribution = makeContribution({ kind: "review", mode: "evaluation" });
+    const reviewResult = await enforcer.enforce(reviewContribution, false);
+    expect(reviewResult.violations.filter((v) => v.type === "role_kind")).toHaveLength(0);
+  });
+
+  test("session config with different stopConditions is used", async () => {
+    // Session config with a very low budget
+    const sessionConfig: SessionRuntimeConfig = {
+      stopConditions: { budget: { maxContributions: 1 } },
+    };
+
+    // Store already has 1 contribution → budget should be exhausted
+    const store = makeStore([makeContribution({ kind: "work" })]);
+    const enforcer = new PolicyEnforcer(sessionConfig, store);
+    const contribution = makeContribution({ kind: "work" });
+    const result = await enforcer.enforce(contribution, false);
+    expect(result.stopResult?.stopped).toBe(true);
   });
 });

--- a/src/core/policy-enforcer.test.ts
+++ b/src/core/policy-enforcer.test.ts
@@ -17,7 +17,12 @@ import { describe, expect, test } from "bun:test";
 import type { GroveContract } from "./contract.js";
 import { PolicyViolationError } from "./errors.js";
 import type { Contribution, Score } from "./models.js";
-import { type ContributionInput, ContributionKind, ContributionMode, RelationType } from "./models.js";
+import {
+  type ContributionInput,
+  ContributionKind,
+  ContributionMode,
+  RelationType,
+} from "./models.js";
 import { PolicyEnforcer } from "./policy-enforcer.js";
 import type { SessionRuntimeConfig } from "./session-config.js";
 import type { ContributionStore } from "./store.js";

--- a/src/core/policy-enforcer.ts
+++ b/src/core/policy-enforcer.ts
@@ -131,11 +131,11 @@ export class PolicyEnforcer {
    *   no re-entrant evaluation — outcome derivation and stop checks run
    *   exactly once per enforce() call, never recursively.
    *
-   * - **Contract hot-reload**: Deferred. The contract is parsed once at
+   * - **Config hot-reload**: Deferred. The config is resolved once at
    *   startup (or session init) and passed to the PolicyEnforcer
-   *   constructor. Runtime contract reloading is not supported — callers
+   *   constructor. Runtime config reloading is not supported — callers
    *   must construct a new PolicyEnforcer instance with the updated
-   *   contract.
+   *   config.
    *
    * @param contribution - The contribution to enforce (already created but not yet stored).
    * @param strict - If true, violations throw instead of being returned as flags.

--- a/src/core/policy-enforcer.ts
+++ b/src/core/policy-enforcer.ts
@@ -23,12 +23,12 @@
  */
 
 import type { Gate, MetricDefinition } from "./contract.js";
-import type { SessionRuntimeConfig } from "./session-config.js";
 import { PolicyViolationError } from "./errors.js";
 import type { Contribution } from "./models.js";
 import { ContributionMode } from "./models.js";
 import type { OutcomeRecord, OutcomeStore } from "./outcome.js";
 import { OutcomeStatus } from "./outcome.js";
+import type { SessionRuntimeConfig } from "./session-config.js";
 import { evaluateStopConditions } from "./stop-conditions.js";
 import type { ContributionStore } from "./store.js";
 

--- a/src/core/policy-enforcer.ts
+++ b/src/core/policy-enforcer.ts
@@ -22,7 +22,8 @@
  *   linear, never recursive.
  */
 
-import type { Gate, GroveContract, MetricDefinition } from "./contract.js";
+import type { Gate, MetricDefinition } from "./contract.js";
+import type { SessionRuntimeConfig } from "./session-config.js";
 import { PolicyViolationError } from "./errors.js";
 import type { Contribution } from "./models.js";
 import { ContributionMode } from "./models.js";
@@ -86,7 +87,7 @@ export interface StopCheckResult {
  * Callers are responsible for running this inside a write mutex.
  */
 export class PolicyEnforcer {
-  private readonly contract: GroveContract;
+  private readonly config: SessionRuntimeConfig;
   private readonly contributionStore: ContributionStore;
   private readonly outcomeStore: OutcomeStore | undefined;
 
@@ -101,11 +102,11 @@ export class PolicyEnforcer {
     | undefined;
 
   constructor(
-    contract: GroveContract,
+    config: SessionRuntimeConfig,
     contributionStore: ContributionStore,
     outcomeStore?: OutcomeStore | undefined,
   ) {
-    this.contract = contract;
+    this.config = config;
     this.contributionStore = contributionStore;
     this.outcomeStore = outcomeStore;
   }
@@ -226,7 +227,7 @@ export class PolicyEnforcer {
     }
 
     // 6. Gate checks (evaluation mode only)
-    if (contribution.mode === ContributionMode.Evaluation && this.contract.gates !== undefined) {
+    if (contribution.mode === ContributionMode.Evaluation && this.config.gates !== undefined) {
       const gateViolations = await this.enforceGates(contribution);
       for (const v of gateViolations) {
         if (strict) {
@@ -244,7 +245,7 @@ export class PolicyEnforcer {
     let derivedOutcome: DerivedOutcome | undefined;
     if (
       contribution.mode === ContributionMode.Evaluation &&
-      this.contract.outcomePolicy !== undefined
+      this.config.outcomePolicy !== undefined
     ) {
       derivedOutcome = await this.deriveOutcome(contribution);
     }
@@ -265,9 +266,9 @@ export class PolicyEnforcer {
     //    run inside the write mutex when configured. Thread walks are
     //    parallelized and depth-capped to bound latency (see stop-conditions.ts).
     let stopResult: StopCheckResult | undefined;
-    if (this.contract.stopConditions !== undefined && options?.skipStopConditions !== true) {
+    if (this.config.stopConditions !== undefined && options?.skipStopConditions !== true) {
       try {
-        const evalResult = await evaluateStopConditions(this.contract, this.contributionStore);
+        const evalResult = await evaluateStopConditions(this.config, this.contributionStore);
         stopResult = {
           stopped: evalResult.stopped,
           reason: evalResult.stopped
@@ -312,7 +313,7 @@ export class PolicyEnforcer {
 
   /** Check role-kind constraints from agentConstraints. */
   private enforceRoleKind(contribution: Contribution): PolicyViolation | undefined {
-    const constraints = this.contract.agentConstraints;
+    const constraints = this.config.agentConstraints;
     if (constraints?.allowedKinds === undefined) return undefined;
 
     const allowed = constraints.allowedKinds;
@@ -341,7 +342,7 @@ export class PolicyEnforcer {
    * on every contribution — metrics are optional unless gated.
    */
   private enforceScoreRequirements(contribution: Contribution): PolicyViolation[] {
-    const gates = this.contract.gates;
+    const gates = this.config.gates;
     if (gates === undefined || gates.length === 0) return [];
 
     // Only enforce score requirements for work contributions in evaluation mode
@@ -379,7 +380,7 @@ export class PolicyEnforcer {
 
   /** Check relation requirements per kind from agentConstraints. */
   private enforceRelationRequirements(contribution: Contribution): PolicyViolation[] {
-    const constraints = this.contract.agentConstraints;
+    const constraints = this.config.agentConstraints;
     if (constraints?.requiredRelations === undefined) return [];
 
     const requiredForKind = constraints.requiredRelations[contribution.kind];
@@ -407,7 +408,7 @@ export class PolicyEnforcer {
 
   /** Check artifact requirements per kind from agentConstraints. */
   private enforceArtifactRequirements(contribution: Contribution): PolicyViolation[] {
-    const constraints = this.contract.agentConstraints;
+    const constraints = this.config.agentConstraints;
     if (constraints?.requiredArtifacts === undefined) return [];
 
     const requiredForKind = constraints.requiredArtifacts[contribution.kind];
@@ -435,7 +436,7 @@ export class PolicyEnforcer {
 
   /** Enforce structured evaluation requirements from contract.evaluation. */
   private enforceEvaluation(contribution: Contribution): PolicyViolation[] {
-    const evalConfig = this.contract.evaluation;
+    const evalConfig = this.config.evaluation;
     if (evalConfig === undefined) return [];
 
     const violations: PolicyViolation[] = [];
@@ -498,7 +499,7 @@ export class PolicyEnforcer {
 
   /** Evaluate gate checks against the current store state. */
   private async enforceGates(contribution: Contribution): Promise<PolicyViolation[]> {
-    const gates = this.contract.gates;
+    const gates = this.config.gates;
     if (gates === undefined) return [];
 
     const violations: PolicyViolation[] = [];
@@ -549,7 +550,7 @@ export class PolicyEnforcer {
       return undefined;
     }
 
-    const metricDef = this.contract.metrics?.[metricName];
+    const metricDef = this.config.metrics?.[metricName];
     if (metricDef === undefined) return undefined;
 
     const currentBest = await this.findBestScore(metricName, metricDef);
@@ -662,7 +663,7 @@ export class PolicyEnforcer {
 
   /** Derive an outcome from the contribution's scores and the contract's outcome policy. */
   private async deriveOutcome(contribution: Contribution): Promise<DerivedOutcome | undefined> {
-    const policy = this.contract.outcomePolicy;
+    const policy = this.config.outcomePolicy;
     if (policy === undefined) return undefined;
 
     // Only derive outcomes for work contributions
@@ -673,7 +674,7 @@ export class PolicyEnforcer {
       const metricName = policy.autoAccept.metricImproves;
       const score = contribution.scores?.[metricName];
       if (score !== undefined) {
-        const metricDef = this.contract.metrics?.[metricName];
+        const metricDef = this.config.metrics?.[metricName];
         if (metricDef !== undefined) {
           const currentBest = await this.findBestScore(metricName, metricDef);
           if (currentBest === undefined) {
@@ -705,7 +706,7 @@ export class PolicyEnforcer {
     }
 
     // Check auto-accept: all_gates_pass
-    if (policy.autoAccept?.allGatesPass === true && this.contract.gates !== undefined) {
+    if (policy.autoAccept?.allGatesPass === true && this.config.gates !== undefined) {
       const gateViolations = await this.enforceGates(contribution);
       if (gateViolations.length === 0) {
         return {
@@ -720,7 +721,7 @@ export class PolicyEnforcer {
       const metricName = policy.autoReject.metricRegresses;
       const score = contribution.scores?.[metricName];
       if (score !== undefined) {
-        const metricDef = this.contract.metrics?.[metricName];
+        const metricDef = this.config.metrics?.[metricName];
         if (metricDef !== undefined) {
           const currentBest = await this.findBestScore(metricName, metricDef);
           if (currentBest !== undefined) {
@@ -788,7 +789,7 @@ export class PolicyEnforcer {
   private updateCacheFromContribution(c: Contribution): void {
     if (!c.scores) return;
     for (const [name, score] of Object.entries(c.scores)) {
-      const metricDef = this.contract.metrics?.[name];
+      const metricDef = this.config.metrics?.[name];
       if (!metricDef) continue;
       const existing = this.bestScoreCache?.get(name);
       const isMinimize = metricDef.direction === "minimize";

--- a/src/core/stop-conditions.ts
+++ b/src/core/stop-conditions.ts
@@ -10,8 +10,8 @@
  */
 
 import type { MetricDefinition } from "./contract.js";
-import type { SessionRuntimeConfig } from "./session-config.js";
 import type { Contribution, ContributionMode, JsonValue } from "./models.js";
+import type { SessionRuntimeConfig } from "./session-config.js";
 import type { ContributionStore } from "./store.js";
 
 // ---------------------------------------------------------------------------

--- a/src/core/stop-conditions.ts
+++ b/src/core/stop-conditions.ts
@@ -9,7 +9,8 @@
  * See spec/LIFECYCLE.md for the full specification.
  */
 
-import type { GroveContract, MetricDefinition } from "./contract.js";
+import type { MetricDefinition } from "./contract.js";
+import type { SessionRuntimeConfig } from "./session-config.js";
 import type { Contribution, ContributionMode, JsonValue } from "./models.js";
 import type { ContributionStore } from "./store.js";
 
@@ -57,11 +58,11 @@ export interface DeliberationResult {
  * deliberationLimit if both are configured.
  */
 export async function evaluateStopConditions(
-  contract: GroveContract,
+  config: SessionRuntimeConfig,
   store: ContributionStore,
 ): Promise<StopEvaluationResult> {
   const conditions: Record<string, StopConditionResult> = {};
-  const stopConditions = contract.stopConditions;
+  const stopConditions = config.stopConditions;
 
   if (stopConditions === undefined) {
     return { stopped: false, conditions: {}, evaluatedAt: new Date().toISOString() };
@@ -78,7 +79,7 @@ export async function evaluateStopConditions(
   if (stopConditions.maxRoundsWithoutImprovement !== undefined) {
     conditions.max_rounds_without_improvement = await evaluateMaxRoundsWithoutImprovement(
       stopConditions.maxRoundsWithoutImprovement,
-      contract.metrics ?? {},
+      config.metrics ?? {},
       store,
     );
   }
@@ -87,7 +88,7 @@ export async function evaluateStopConditions(
     conditions.target_metric = await evaluateTargetMetric(
       stopConditions.targetMetric.metric,
       stopConditions.targetMetric.value,
-      contract.metrics ?? {},
+      config.metrics ?? {},
       store,
     );
   }

--- a/src/local/sqlite-goal-session-store.ts
+++ b/src/local/sqlite-goal-session-store.ts
@@ -22,6 +22,13 @@ import { resolveRoleWorkspaceStrategies } from "../core/topology.js";
 import type { GoalData } from "../tui/provider.js";
 
 /**
+ * Supported contractVersion values for stored session configs.
+ * Kept in sync with `parseRawObject` in src/core/contract.ts — adding a new
+ * version there requires extending this list (and the validator below).
+ */
+const SUPPORTED_CONTRACT_VERSIONS = [1, 2, 3] as const;
+
+/**
  * Shape-validate a parsed session config from storage.
  *
  * Returns null on success, or a reason string when validation fails.
@@ -34,11 +41,9 @@ import type { GoalData } from "../tui/provider.js";
  *     `agent_topology` (lossy key-rename).
  *
  * So a stored-form-aware check is the right layer. The check covers the
- * specific nested-field crashes that enforcement code can hit:
- *   - gates[] items missing `type` (switch falls through)
- *   - agentConstraints.allowedKinds not an array (`.includes` crashes)
- *   - rateLimits/concurrency/execution fields with non-numeric values
- *     (silent bypass via optional chaining, or arithmetic errors)
+ * specific nested-field crashes and silent-bypass paths that enforcement
+ * code can hit when the stored snapshot is corrupted or produced by a
+ * version of grove the current binary doesn't understand.
  */
 function validateStoredContractShape(obj: unknown): string | null {
   if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
@@ -47,6 +52,9 @@ function validateStoredContractShape(obj: unknown): string | null {
   const c = obj as Record<string, unknown>;
   if (typeof c.contractVersion !== "number") {
     return "config_json missing numeric contractVersion";
+  }
+  if (!(SUPPORTED_CONTRACT_VERSIONS as readonly number[]).includes(c.contractVersion)) {
+    return `config_json has unsupported contractVersion ${c.contractVersion} (supported: ${SUPPORTED_CONTRACT_VERSIONS.join(", ")})`;
   }
 
   const isPlainObject = (v: unknown): v is Record<string, unknown> =>
@@ -75,9 +83,59 @@ function validateStoredContractShape(obj: unknown): string | null {
     }
   }
 
-  // gates is an array of gate objects, each with a string `type`.
+  // stopConditions nested fields. Each sub-object must be a plain object
+  // (not null) if present — evaluateStopConditions() reads properties
+  // directly and crashes on null / wrong-type. targetMetric must also
+  // carry the fields the enforcement logic reads: `metric` (string),
+  // `value` (number).
+  const sc = c.stopConditions;
+  if (isPlainObject(sc)) {
+    for (const sub of ["targetMetric", "budget", "quorumReviewScore", "deliberationLimit"]) {
+      const v = sc[sub];
+      if (v !== undefined && !isPlainObject(v)) {
+        return `config_json stopConditions.${sub} is not an object`;
+      }
+    }
+    const tm = sc.targetMetric;
+    if (isPlainObject(tm)) {
+      if (typeof tm.metric !== "string") {
+        return "config_json stopConditions.targetMetric.metric is not a string";
+      }
+      if (typeof tm.value !== "number") {
+        return "config_json stopConditions.targetMetric.value is not a number";
+      }
+    }
+    const qrs = sc.quorumReviewScore;
+    if (isPlainObject(qrs)) {
+      if (typeof qrs.minReviews !== "number") {
+        return "config_json stopConditions.quorumReviewScore.minReviews is not a number";
+      }
+      if (typeof qrs.minScore !== "number") {
+        return "config_json stopConditions.quorumReviewScore.minScore is not a number";
+      }
+    }
+    if (
+      sc.maxRoundsWithoutImprovement !== undefined &&
+      typeof sc.maxRoundsWithoutImprovement !== "number"
+    ) {
+      return "config_json stopConditions.maxRoundsWithoutImprovement is not a number";
+    }
+  }
+
+  // gates is an array of gate objects. Each item must be an object with
+  // a recognized string `type`, plus the fields that `type` demands.
+  // Missing-field gates would otherwise become silent no-ops in
+  // PolicyEnforcer.evaluateGate() (e.g. min_score without metric/threshold
+  // short-circuits before checking anything).
   if (c.gates !== undefined) {
     if (!Array.isArray(c.gates)) return "config_json field 'gates' is not an array";
+    const knownGateTypes = new Set([
+      "metric_improves",
+      "has_artifact",
+      "has_relation",
+      "min_reviews",
+      "min_score",
+    ]);
     for (let i = 0; i < c.gates.length; i++) {
       const g = c.gates[i];
       if (!isPlainObject(g)) {
@@ -85,6 +143,32 @@ function validateStoredContractShape(obj: unknown): string | null {
       }
       if (typeof g.type !== "string") {
         return `config_json gates[${i}] missing string 'type'`;
+      }
+      if (!knownGateTypes.has(g.type)) {
+        return `config_json gates[${i}] has unknown type '${g.type}'`;
+      }
+      // Type-specific required fields. Mirrors GateSchema.superRefine in
+      // src/core/contract.ts:53-77 (camelCase here: relationType vs
+      // relation_type).
+      if (g.type === "metric_improves" && typeof g.metric !== "string") {
+        return `config_json gates[${i}] metric_improves requires string 'metric'`;
+      }
+      if (g.type === "has_artifact" && typeof g.name !== "string") {
+        return `config_json gates[${i}] has_artifact requires string 'name'`;
+      }
+      if (g.type === "has_relation" && typeof g.relationType !== "string") {
+        return `config_json gates[${i}] has_relation requires string 'relationType'`;
+      }
+      if (g.type === "min_reviews" && typeof g.count !== "number") {
+        return `config_json gates[${i}] min_reviews requires number 'count'`;
+      }
+      if (g.type === "min_score") {
+        if (typeof g.metric !== "string") {
+          return `config_json gates[${i}] min_score requires string 'metric'`;
+        }
+        if (typeof g.threshold !== "number") {
+          return `config_json gates[${i}] min_score requires number 'threshold'`;
+        }
       }
     }
   }

--- a/src/local/sqlite-goal-session-store.ts
+++ b/src/local/sqlite-goal-session-store.ts
@@ -16,54 +16,122 @@
 
 import type { Database, Statement } from "bun:sqlite";
 import type { GroveContract } from "../core/contract.js";
-import { parseGroveContractObject } from "../core/contract.js";
 import type { CreateSessionInput, Session, SessionQuery } from "../core/session.js";
 import type { AgentTopology } from "../core/topology.js";
 import { resolveRoleWorkspaceStrategies } from "../core/topology.js";
 import type { GoalData } from "../tui/provider.js";
 
 /**
- * Convert camelCase property names to snake_case recursively.
+ * Shape-validate a parsed session config from storage.
  *
- * Session config is stored as the normalized camelCase GroveContract form,
- * but parseGroveContractObject expects the snake_case YAML wire form. This
- * converter lets us round-trip stored snapshots back through the canonical
- * parser for full schema validation at the storage boundary.
+ * Returns null on success, or a reason string when validation fails.
+ *
+ * This is a camelCase-aware shape check, not a full schema validation.
+ * The snake_case zod schemas in contract.ts cannot be reused here:
+ *   - V1 stored form includes auto-migrated `execution`/`concurrency`
+ *     fields that the strict V1 wire schema rejects.
+ *   - V3 stored form uses `topology`; the V3 wire schema uses
+ *     `agent_topology` (lossy key-rename).
+ *
+ * So a stored-form-aware check is the right layer. The check covers the
+ * specific nested-field crashes that enforcement code can hit:
+ *   - gates[] items missing `type` (switch falls through)
+ *   - agentConstraints.allowedKinds not an array (`.includes` crashes)
+ *   - rateLimits/concurrency/execution fields with non-numeric values
+ *     (silent bypass via optional chaining, or arithmetic errors)
  */
-function camelToSnakeKeys(value: unknown): unknown {
-  if (value === null || value === undefined || typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map(camelToSnakeKeys);
-  const out: Record<string, unknown> = {};
-  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
-    const snakeKey = key.replace(/([A-Z])/g, (m) => `_${m.toLowerCase()}`);
-    out[snakeKey] = camelToSnakeKeys(v);
-  }
-  return out;
-}
-
-/**
- * Validate a parsed session config against the full GroveContract schema.
- *
- * Returns the validated contract on success, or a reason string when
- * validation fails. Catches row corruption (manual DB edits, partial
- * writes) before downstream enforcement code silently bypasses checks
- * or crashes late on bad nested fields.
- *
- * Implementation: stored form is normalized camelCase; parseGroveContractObject
- * accepts the snake_case YAML wire form. Round-trip via a key converter so
- * all validation (zod schema + cross-field checks) runs on stored data.
- */
-function validateStoredContract(obj: unknown): { config: GroveContract } | { reason: string } {
+function validateStoredContractShape(obj: unknown): string | null {
   if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
-    return { reason: "config_json is not a plain object" };
+    return "config_json is not a plain object";
   }
-  try {
-    const wire = camelToSnakeKeys(obj);
-    const config = parseGroveContractObject(wire);
-    return { config };
-  } catch (err) {
-    return { reason: err instanceof Error ? err.message : String(err) };
+  const c = obj as Record<string, unknown>;
+  if (typeof c.contractVersion !== "number") {
+    return "config_json missing numeric contractVersion";
   }
+
+  const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+    v !== null && typeof v === "object" && !Array.isArray(v);
+
+  // Top-level object fields must be objects (not null, array, or primitive).
+  const objectFields = [
+    "metrics",
+    "stopConditions",
+    "agentConstraints",
+    "claimPolicy",
+    "concurrency",
+    "execution",
+    "rateLimits",
+    "retry",
+    "gossip",
+    "outcomePolicy",
+    "evaluation",
+    "hooks",
+    "topology",
+  ] as const;
+  for (const field of objectFields) {
+    const v = c[field];
+    if (v !== undefined && !isPlainObject(v)) {
+      return `config_json field '${field}' is not an object`;
+    }
+  }
+
+  // gates is an array of gate objects, each with a string `type`.
+  if (c.gates !== undefined) {
+    if (!Array.isArray(c.gates)) return "config_json field 'gates' is not an array";
+    for (let i = 0; i < c.gates.length; i++) {
+      const g = c.gates[i];
+      if (!isPlainObject(g)) {
+        return `config_json gates[${i}] is not an object`;
+      }
+      if (typeof g.type !== "string") {
+        return `config_json gates[${i}] missing string 'type'`;
+      }
+    }
+  }
+
+  // agentConstraints.allowedKinds must be array of strings if present.
+  const ac = c.agentConstraints;
+  if (isPlainObject(ac)) {
+    if (ac.allowedKinds !== undefined) {
+      if (!Array.isArray(ac.allowedKinds)) {
+        return "config_json agentConstraints.allowedKinds is not an array";
+      }
+      for (let i = 0; i < ac.allowedKinds.length; i++) {
+        if (typeof ac.allowedKinds[i] !== "string") {
+          return `config_json agentConstraints.allowedKinds[${i}] is not a string`;
+        }
+      }
+    }
+    for (const sub of ["requiredRelations", "requiredArtifacts"] as const) {
+      const v = ac[sub];
+      if (v !== undefined && !isPlainObject(v)) {
+        return `config_json agentConstraints.${sub} is not an object`;
+      }
+    }
+  }
+
+  // Numeric sub-fields in rateLimits / concurrency / execution.
+  const numericFields: Record<string, readonly string[]> = {
+    rateLimits: [
+      "maxContributionsPerAgentPerHour",
+      "maxContributionsPerGrovePerHour",
+      "maxArtifactSizeBytes",
+      "maxArtifactsPerContribution",
+    ],
+    concurrency: ["maxActiveClaims", "maxClaimsPerAgent", "maxClaimsPerTarget"],
+    execution: ["defaultLeaseSeconds", "maxLeaseSeconds", "heartbeatIntervalSeconds"],
+  };
+  for (const [section, keys] of Object.entries(numericFields)) {
+    const v = c[section];
+    if (!isPlainObject(v)) continue;
+    for (const key of keys) {
+      if (v[key] !== undefined && typeof v[key] !== "number") {
+        return `config_json ${section}.${key} is not a number`;
+      }
+    }
+  }
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -487,15 +555,16 @@ export class SqliteGoalSessionStore implements GoalSessionStore {
     } catch (err) {
       return { kind: "malformed", reason: err instanceof Error ? err.message : String(err) };
     }
-    // Run full schema validation: round-trip camelCase → snake_case and
-    // reuse parseGroveContractObject so nested bad shapes (e.g. invalid
-    // gate entries, non-array allowedKinds) are rejected at the storage
-    // boundary rather than silently bypassed or crashing enforcement late.
-    const validated = validateStoredContract(parsed);
-    if ("reason" in validated) {
-      return { kind: "malformed", reason: validated.reason };
+    // Shape-validate stored form against the nested fields enforcement
+    // reads. Catches corruption (manual DB edits, partial writes) at the
+    // storage boundary instead of silently bypassing checks or crashing
+    // late. Not a full schema validator — see validateStoredContractShape
+    // doc for why the snake_case schemas in contract.ts cannot be reused.
+    const reason = validateStoredContractShape(parsed);
+    if (reason !== null) {
+      return { kind: "malformed", reason };
     }
-    return { kind: "ok", config: validated.config };
+    return { kind: "ok", config: parsed as GroveContract };
   };
 
   /**

--- a/src/local/sqlite-goal-session-store.ts
+++ b/src/local/sqlite-goal-session-store.ts
@@ -436,11 +436,32 @@ export class SqliteGoalSessionStore implements GoalSessionStore {
       .get(sessionId) as { config_json: string | null } | null;
     if (row === null) return { kind: "not-found" };
     if (!row.config_json || row.config_json === "{}") return { kind: "configless" };
+    let parsed: unknown;
     try {
-      return { kind: "ok", config: JSON.parse(row.config_json) as GroveContract };
+      parsed = JSON.parse(row.config_json);
     } catch (err) {
       return { kind: "malformed", reason: err instanceof Error ? err.message : String(err) };
     }
+    // JSON.parse accepts null, primitives, arrays, and shape-invalid objects.
+    // parseGroveContractObject is YAML-shape (snake_case); session storage is
+    // the normalized camelCase GroveContract from prior parseGroveContract calls.
+    // Validate the minimum invariant that downstream consumers rely on: the
+    // value is a plain object with a numeric contractVersion. Anything else is
+    // treated as malformed (fail closed) rather than trusted as "ok" and
+    // crashing later on missing fields.
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed) ||
+      typeof (parsed as { contractVersion?: unknown }).contractVersion !== "number"
+    ) {
+      return {
+        kind: "malformed",
+        reason:
+          "config_json is not a valid GroveContract (expected object with numeric contractVersion)",
+      };
+    }
+    return { kind: "ok", config: parsed as GroveContract };
   };
 
   /**

--- a/src/local/sqlite-goal-session-store.ts
+++ b/src/local/sqlite-goal-session-store.ts
@@ -16,61 +16,54 @@
 
 import type { Database, Statement } from "bun:sqlite";
 import type { GroveContract } from "../core/contract.js";
+import { parseGroveContractObject } from "../core/contract.js";
 import type { CreateSessionInput, Session, SessionQuery } from "../core/session.js";
 import type { AgentTopology } from "../core/topology.js";
 import { resolveRoleWorkspaceStrategies } from "../core/topology.js";
 import type { GoalData } from "../tui/provider.js";
 
 /**
- * Shape-validate a parsed session config from storage.
+ * Convert camelCase property names to snake_case recursively.
  *
- * Returns null when the object has the expected top-level GroveContract
- * shape, or a reason string when a field has the wrong type.
- *
- * This catches row corruption (manual DB edits) where top-level fields
- * end up as the wrong type, before downstream enforcement code silently
- * bypasses checks via optional chaining.
- *
- * Note: this is a shallow shape check, not a full schema validation.
- * contract.ts hosts snake_case YAML schemas; session storage is the
- * post-parse camelCase form, so we can't reuse those schemas here
- * without building a parallel camelCase schema. The shape check is the
- * minimum defense-in-depth at this boundary.
+ * Session config is stored as the normalized camelCase GroveContract form,
+ * but parseGroveContractObject expects the snake_case YAML wire form. This
+ * converter lets us round-trip stored snapshots back through the canonical
+ * parser for full schema validation at the storage boundary.
  */
-function validateStoredContractShape(obj: unknown): string | null {
+function camelToSnakeKeys(value: unknown): unknown {
+  if (value === null || value === undefined || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(camelToSnakeKeys);
+  const out: Record<string, unknown> = {};
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    const snakeKey = key.replace(/([A-Z])/g, (m) => `_${m.toLowerCase()}`);
+    out[snakeKey] = camelToSnakeKeys(v);
+  }
+  return out;
+}
+
+/**
+ * Validate a parsed session config against the full GroveContract schema.
+ *
+ * Returns the validated contract on success, or a reason string when
+ * validation fails. Catches row corruption (manual DB edits, partial
+ * writes) before downstream enforcement code silently bypasses checks
+ * or crashes late on bad nested fields.
+ *
+ * Implementation: stored form is normalized camelCase; parseGroveContractObject
+ * accepts the snake_case YAML wire form. Round-trip via a key converter so
+ * all validation (zod schema + cross-field checks) runs on stored data.
+ */
+function validateStoredContract(obj: unknown): { config: GroveContract } | { reason: string } {
   if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
-    return "config_json is not a plain object";
+    return { reason: "config_json is not a plain object" };
   }
-  const c = obj as Record<string, unknown>;
-  if (typeof c.contractVersion !== "number") {
-    return "config_json missing numeric contractVersion";
+  try {
+    const wire = camelToSnakeKeys(obj);
+    const config = parseGroveContractObject(wire);
+    return { config };
+  } catch (err) {
+    return { reason: err instanceof Error ? err.message : String(err) };
   }
-  const objectFields = [
-    "metrics",
-    "stopConditions",
-    "agentConstraints",
-    "claimPolicy",
-    "concurrency",
-    "execution",
-    "rateLimits",
-    "retry",
-    "gossip",
-    "outcomePolicy",
-    "evaluation",
-    "hooks",
-    "topology",
-  ] as const;
-  for (const field of objectFields) {
-    const v = c[field];
-    if (v !== undefined && (v === null || typeof v !== "object" || Array.isArray(v))) {
-      return `config_json field '${field}' is not an object`;
-    }
-  }
-  const gates = c.gates;
-  if (gates !== undefined && !Array.isArray(gates)) {
-    return "config_json field 'gates' is not an array";
-  }
-  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -494,18 +487,15 @@ export class SqliteGoalSessionStore implements GoalSessionStore {
     } catch (err) {
       return { kind: "malformed", reason: err instanceof Error ? err.message : String(err) };
     }
-    // Storage is the normalized camelCase GroveContract produced by
-    // parseGroveContract → JSON.stringify. The shape-validation schemas
-    // in contract.ts are YAML-shape (snake_case), so we can't round-trip
-    // them here cheaply. Instead, check the top-level field shape so that
-    // corrupt rows (e.g. `rateLimits: "off"` or `gates: {}` after manual
-    // DB edits) are rejected before downstream enforcement code silently
-    // bypasses checks via optional chaining or throws late.
-    const reason = validateStoredContractShape(parsed);
-    if (reason !== null) {
-      return { kind: "malformed", reason };
+    // Run full schema validation: round-trip camelCase → snake_case and
+    // reuse parseGroveContractObject so nested bad shapes (e.g. invalid
+    // gate entries, non-array allowedKinds) are rejected at the storage
+    // boundary rather than silently bypassed or crashing enforcement late.
+    const validated = validateStoredContract(parsed);
+    if ("reason" in validated) {
+      return { kind: "malformed", reason: validated.reason };
     }
-    return { kind: "ok", config: parsed as GroveContract };
+    return { kind: "ok", config: validated.config };
   };
 
   /**

--- a/src/local/sqlite-goal-session-store.ts
+++ b/src/local/sqlite-goal-session-store.ts
@@ -174,6 +174,9 @@ function validateStoredContractShape(obj: unknown): string | null {
   }
 
   // agentConstraints.allowedKinds must be array of strings if present.
+  // requiredRelations/requiredArtifacts map kind -> array of strings;
+  // PolicyEnforcer iterates `for (const x of requiredForKind)` so a
+  // non-array value would throw a non-iterable TypeError at enforce time.
   const ac = c.agentConstraints;
   if (isPlainObject(ac)) {
     if (ac.allowedKinds !== undefined) {
@@ -188,8 +191,33 @@ function validateStoredContractShape(obj: unknown): string | null {
     }
     for (const sub of ["requiredRelations", "requiredArtifacts"] as const) {
       const v = ac[sub];
-      if (v !== undefined && !isPlainObject(v)) {
+      if (v === undefined) continue;
+      if (!isPlainObject(v)) {
         return `config_json agentConstraints.${sub} is not an object`;
+      }
+      for (const [kind, list] of Object.entries(v)) {
+        if (!Array.isArray(list)) {
+          return `config_json agentConstraints.${sub}.${kind} is not an array`;
+        }
+        for (let i = 0; i < list.length; i++) {
+          if (typeof list[i] !== "string") {
+            return `config_json agentConstraints.${sub}.${kind}[${i}] is not a string`;
+          }
+        }
+      }
+    }
+  }
+
+  // metrics maps name -> MetricDefinition. evaluateTargetMetric reads
+  // `metricDef.direction` directly; null/primitive values crash it.
+  const metrics = c.metrics;
+  if (isPlainObject(metrics)) {
+    for (const [name, def] of Object.entries(metrics)) {
+      if (!isPlainObject(def)) {
+        return `config_json metrics.${name} is not an object`;
+      }
+      if (def.direction !== "minimize" && def.direction !== "maximize") {
+        return `config_json metrics.${name}.direction must be "minimize" or "maximize"`;
       }
     }
   }

--- a/src/local/sqlite-goal-session-store.ts
+++ b/src/local/sqlite-goal-session-store.ts
@@ -408,14 +408,38 @@ export class SqliteGoalSessionStore implements GoalSessionStore {
 
   /** Synchronous variant — used by runtime bootstrap where async is unavailable. */
   getSessionConfigSync = (sessionId: string): GroveContract | undefined => {
+    const result = this.resolveSessionConfigSync(sessionId);
+    return result.kind === "ok" ? result.config : undefined;
+  };
+
+  /**
+   * Detailed session-config lookup for callers that must distinguish
+   * missing session / malformed snapshot / legacy configless session.
+   *
+   * - `not-found`: no session row exists for this id (bogus/stale env var).
+   *   Callers should fail closed.
+   * - `malformed`: config_json exists but does not parse. Callers should
+   *   fail closed — parsing errors indicate corruption, not legacy state.
+   * - `configless`: row exists with empty config (session created without
+   *   a contract, or predates #198). Callers may fall back to live GROVE.md.
+   * - `ok`: row exists with a valid parsed contract. Use it.
+   */
+  resolveSessionConfigSync = (
+    sessionId: string,
+  ):
+    | { kind: "ok"; config: GroveContract }
+    | { kind: "configless" }
+    | { kind: "malformed"; reason: string }
+    | { kind: "not-found" } => {
     const row = this.db
       .prepare("SELECT config_json FROM sessions WHERE session_id = ?")
       .get(sessionId) as { config_json: string | null } | null;
-    if (!row?.config_json || row.config_json === "{}") return undefined;
+    if (row === null) return { kind: "not-found" };
+    if (!row.config_json || row.config_json === "{}") return { kind: "configless" };
     try {
-      return JSON.parse(row.config_json) as GroveContract;
-    } catch {
-      return undefined;
+      return { kind: "ok", config: JSON.parse(row.config_json) as GroveContract };
+    } catch (err) {
+      return { kind: "malformed", reason: err instanceof Error ? err.message : String(err) };
     }
   };
 

--- a/src/local/sqlite-goal-session-store.ts
+++ b/src/local/sqlite-goal-session-store.ts
@@ -21,6 +21,58 @@ import type { AgentTopology } from "../core/topology.js";
 import { resolveRoleWorkspaceStrategies } from "../core/topology.js";
 import type { GoalData } from "../tui/provider.js";
 
+/**
+ * Shape-validate a parsed session config from storage.
+ *
+ * Returns null when the object has the expected top-level GroveContract
+ * shape, or a reason string when a field has the wrong type.
+ *
+ * This catches row corruption (manual DB edits) where top-level fields
+ * end up as the wrong type, before downstream enforcement code silently
+ * bypasses checks via optional chaining.
+ *
+ * Note: this is a shallow shape check, not a full schema validation.
+ * contract.ts hosts snake_case YAML schemas; session storage is the
+ * post-parse camelCase form, so we can't reuse those schemas here
+ * without building a parallel camelCase schema. The shape check is the
+ * minimum defense-in-depth at this boundary.
+ */
+function validateStoredContractShape(obj: unknown): string | null {
+  if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
+    return "config_json is not a plain object";
+  }
+  const c = obj as Record<string, unknown>;
+  if (typeof c.contractVersion !== "number") {
+    return "config_json missing numeric contractVersion";
+  }
+  const objectFields = [
+    "metrics",
+    "stopConditions",
+    "agentConstraints",
+    "claimPolicy",
+    "concurrency",
+    "execution",
+    "rateLimits",
+    "retry",
+    "gossip",
+    "outcomePolicy",
+    "evaluation",
+    "hooks",
+    "topology",
+  ] as const;
+  for (const field of objectFields) {
+    const v = c[field];
+    if (v !== undefined && (v === null || typeof v !== "object" || Array.isArray(v))) {
+      return `config_json field '${field}' is not an object`;
+    }
+  }
+  const gates = c.gates;
+  if (gates !== undefined && !Array.isArray(gates)) {
+    return "config_json field 'gates' is not an array";
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Schema DDL
 // ---------------------------------------------------------------------------
@@ -442,24 +494,16 @@ export class SqliteGoalSessionStore implements GoalSessionStore {
     } catch (err) {
       return { kind: "malformed", reason: err instanceof Error ? err.message : String(err) };
     }
-    // JSON.parse accepts null, primitives, arrays, and shape-invalid objects.
-    // parseGroveContractObject is YAML-shape (snake_case); session storage is
-    // the normalized camelCase GroveContract from prior parseGroveContract calls.
-    // Validate the minimum invariant that downstream consumers rely on: the
-    // value is a plain object with a numeric contractVersion. Anything else is
-    // treated as malformed (fail closed) rather than trusted as "ok" and
-    // crashing later on missing fields.
-    if (
-      parsed === null ||
-      typeof parsed !== "object" ||
-      Array.isArray(parsed) ||
-      typeof (parsed as { contractVersion?: unknown }).contractVersion !== "number"
-    ) {
-      return {
-        kind: "malformed",
-        reason:
-          "config_json is not a valid GroveContract (expected object with numeric contractVersion)",
-      };
+    // Storage is the normalized camelCase GroveContract produced by
+    // parseGroveContract → JSON.stringify. The shape-validation schemas
+    // in contract.ts are YAML-shape (snake_case), so we can't round-trip
+    // them here cheaply. Instead, check the top-level field shape so that
+    // corrupt rows (e.g. `rateLimits: "off"` or `gates: {}` after manual
+    // DB edits) are rejected before downstream enforcement code silently
+    // bypasses checks via optional chaining or throws late.
+    const reason = validateStoredContractShape(parsed);
+    if (reason !== null) {
+      return { kind: "malformed", reason };
     }
     return { kind: "ok", config: parsed as GroveContract };
   };


### PR DESCRIPTION
Closes #199

## Summary
- Narrow `PolicyEnforcer`, `EnforcingContributionStore`, `EnforcingClaimStore`, and `evaluateStopConditions` to accept `SessionRuntimeConfig` instead of `GroveContract`
- Add `GROVE_SESSION_ID` resolution to `grove discuss` and `grove inbox send` (matches existing `grove contribute` pattern)
- `GroveContract` structurally satisfies `SessionRuntimeConfig` (it's a `Pick`), so existing callers compile unchanged

Builds on #198 which stored the frozen config in `session.config`. This PR closes the loop by making all enforcement consumers read from that frozen snapshot rather than the live contract.

## Test plan
- [x] 150 unit tests pass (`bun test src/core/{policy-enforcer,enforcing-store,stop-conditions}.test.ts`)
- [x] 2 new tests prove session config with different `agentConstraints`/`stopConditions` overrides contract
- [x] 14 preset E2E tests pass against live Nexus
- [x] `tsc --noEmit` clean, `biome check` clean
- [x] Shell E2E: created session, frozen `config_json` in DB; tightened GROVE.md mid-run; verified `GROVE_SESSION_ID=... grove contribute --kind work` succeeds (frozen config permits) while bare `grove contribute --kind work` fails with role_kind violation. Same proven for `grove discuss` and `grove inbox send`.
- [x] Full review-loop E2E with real agents: spawned coder + reviewer via acpx in nexus mode, coder wrote fibonacci.py + `grove_submit_work`, handoff routed to reviewer, reviewer reviewed + `grove_submit_review` + `grove_done`, session terminated with `stop_reason: "Agent reviewer signaled done"`. 3 contributions in DAG, all `policy.passed: true`.

## Out of scope
- SessionOrchestrator changes — already done by #198
- `deriveLifecycleState()` — graph-only, doesn't read contract