### PR TITLE
fix(local/sqlite-store): backfill handoffs columns before HANDOFF_DDL indexes

### DIFF
--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -220,6 +220,28 @@ export function initSqliteDb(dbPath: string): Database {
   const initSchema = db.transaction(() => {
     db.exec(SCHEMA_DDL);
     db.exec(FTS_DDL);
+
+    // Pre-HANDOFF_DDL column-safe migration: legacy handoffs tables (pre-#164)
+    // lack session_id/seen_at/acked_at/ipc_message_id. HANDOFF_DDL now includes
+    // `CREATE INDEX idx_handoffs_session_id ON handoffs(session_id)`, which
+    // fails on those older tables because CREATE TABLE IF NOT EXISTS leaves the
+    // existing schema alone. Add the missing columns here so the index
+    // statement in HANDOFF_DDL succeeds. Fresh DBs are no-ops — the table
+    // doesn't exist yet, so the PRAGMA returns empty and nothing runs.
+    {
+      const handoffCols = db.prepare("PRAGMA table_info(handoffs)").all() as readonly {
+        name: string;
+      }[];
+      if (handoffCols.length > 0) {
+        const names = new Set(handoffCols.map((c) => c.name));
+        for (const col of ["seen_at", "acked_at", "session_id", "ipc_message_id"]) {
+          if (!names.has(col)) {
+            db.run(`ALTER TABLE handoffs ADD COLUMN ${col} TEXT`);
+          }
+        }
+      }
+    }
+
     db.exec(HANDOFF_DDL);
 
     // Check current schema version for migrations


### PR DESCRIPTION
## Summary

Fixes `no such column: session_id` during TUI startup against pre-#164 databases (typically `~/.grove/nexus-workspaces/nexus.db`). The legacy table has the 9-column handoffs schema; HANDOFF_DDL's `CREATE INDEX idx_handoffs_session_id ON handoffs(session_id)` now fails inside the schema-init transaction and rolls back everything. Adds a pre-DDL column-safe `ALTER TABLE` migration so the index statement can run.

## Root cause

- `initSqliteDb` runs `SCHEMA_DDL` + `FTS_DDL` + `HANDOFF_DDL` inside one transaction.
- `HANDOFF_DDL` uses `CREATE TABLE IF NOT EXISTS`, so legacy tables keep their old column set.
- `HANDOFF_DDL` then creates `idx_handoffs_session_id` → throws on missing column → transaction rolls back → every call site of `initSqliteDb` fails.
- `SqliteHandoffStore.safeAddColumn` runs *later* (constructor) and can't help because the transaction already failed.

## What it enables

- `grove up` TUI path works end-to-end against legacy installs.
- Verified via full cycle: coder submits work → reviewer approves → `[DONE]` discussion → 3 contributions land in Nexus (work/review/discussion).

## Test plan

- [x] `bun test src/local` — 532 pass
- [x] Direct repro: `createProvider({mode: "nexus"})` against legacy nexus.db — succeeds, backfills 4 columns
- [x] Full TUI e2e: `grove init` → `grove up` → New session → goal → launch → coder+reviewer complete