### PR TITLE
feat(runtime): migrate AgentRuntime.send to return AcpxTurn (#260)

### DIFF
--- a/src/acp/watch-turn.test.ts
+++ b/src/acp/watch-turn.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import type { AcpxTurn, Result, StopReason } from "./types.js";
+import { watchTurnError } from "./watch-turn.js";
+
+function fakeTurn(result: Result): AcpxTurn {
+  return {
+    sessionId: "s1",
+    turnId: result.turnId,
+    messages: (async function* () {
+      /* none */
+    })(),
+    result: Promise.resolve(result),
+    cancel: async () => undefined,
+    close: async () => undefined,
+  };
+}
+
+async function collectLogs(result: Result): Promise<string[]> {
+  const logs: string[] = [];
+  watchTurnError(fakeTurn(result), "ctx", (m) => logs.push(m));
+  // Yield two microtask rounds for the watcher to settle.
+  await Promise.resolve();
+  await Promise.resolve();
+  return logs;
+}
+
+test("watchTurnError is silent when the turn ends with end_turn", async () => {
+  const logs = await collectLogs({ turnId: "ok", stopReason: "end_turn" });
+  expect(logs).toEqual([]);
+});
+
+test("watchTurnError logs when the turn ends with error", async () => {
+  const logs = await collectLogs({
+    turnId: "err",
+    stopReason: "error",
+    error: { code: "boom", message: "explode" },
+  });
+  expect(logs).toHaveLength(1);
+  expect(logs[0]).toContain("abnormally");
+  expect(logs[0]).toContain("stopReason=error");
+  expect(logs[0]).toContain("code=boom");
+});
+
+test("watchTurnError logs when the turn is cancelled", async () => {
+  const logs = await collectLogs({ turnId: "cncl", stopReason: "cancelled" });
+  expect(logs).toHaveLength(1);
+  expect(logs[0]).toContain("stopReason=cancelled");
+});
+
+test("watchTurnError logs when the turn hits max_tokens (truncated)", async () => {
+  const logs = await collectLogs({ turnId: "trunc", stopReason: "max_tokens" });
+  expect(logs).toHaveLength(1);
+  expect(logs[0]).toContain("stopReason=max_tokens");
+});
+
+test("watchTurnError logs unknown stop reasons (forward-compat)", async () => {
+  const logs = await collectLogs({
+    turnId: "future",
+    stopReason: "some_new_reason" as StopReason,
+  });
+  expect(logs).toHaveLength(1);
+  expect(logs[0]).toContain("stopReason=some_new_reason");
+});

--- a/src/acp/watch-turn.ts
+++ b/src/acp/watch-turn.ts
@@ -1,8 +1,16 @@
 /**
  * Drain a fire-and-forget AcpxTurn in the background and surface any
- * terminal error to the supplied logger. Used by control-plane callers
- * (SessionOrchestrator, SpawnManager, NexusWsBridge, AcpxRuntime's own
- * initial-goal side effect) that don't otherwise consume the turn.
+ * abnormal terminal state to the supplied logger. Used by control-plane
+ * callers (SessionOrchestrator, SpawnManager, NexusWsBridge, AcpxRuntime's
+ * own initial-goal side effect) that don't otherwise consume the turn.
+ *
+ * For control-plane traffic, the only "success" stop reason is `end_turn`.
+ * `cancelled` means the provider aborted mid-prompt; `max_tokens` means the
+ * response was truncated before completion; `error` means explicit failure;
+ * any unknown stop reason from a future ACP spec update is also abnormal
+ * until proven otherwise. Treat everything ≠ end_turn as a failure signal
+ * worth logging — otherwise a cancelled bootstrap or truncated handoff
+ * would be silently accepted as successful delivery.
  *
  * We intentionally do not throw: the pattern is fire-and-forget delivery
  * and these callers have no retry channel. The goal is to make silent
@@ -18,10 +26,12 @@ export function watchTurnError(
 ): void {
   void turn.result
     .then((r) => {
-      if (r.stopReason === "error") {
+      if (r.stopReason !== "end_turn") {
         const code = r.error?.code ? ` (code=${r.error.code})` : "";
-        const msg = r.error?.message ?? "unknown error";
-        log(`[watchTurn] ${context} turn ${turn.turnId} ended with error${code}: ${msg}`);
+        const msg = r.error?.message ?? "no error payload";
+        log(
+          `[watchTurn] ${context} turn ${turn.turnId} ended abnormally stopReason=${r.stopReason}${code}: ${msg}`,
+        );
       }
     })
     .catch((err) => {

--- a/src/acp/watch-turn.ts
+++ b/src/acp/watch-turn.ts
@@ -1,0 +1,31 @@
+/**
+ * Drain a fire-and-forget AcpxTurn in the background and surface any
+ * terminal error to the supplied logger. Used by control-plane callers
+ * (SessionOrchestrator, SpawnManager, NexusWsBridge, AcpxRuntime's own
+ * initial-goal side effect) that don't otherwise consume the turn.
+ *
+ * We intentionally do not throw: the pattern is fire-and-forget delivery
+ * and these callers have no retry channel. The goal is to make silent
+ * delivery failures observable by an operator.
+ */
+
+import type { AcpxTurn } from "./types.js";
+
+export function watchTurnError(
+  turn: AcpxTurn,
+  context: string,
+  log: (msg: string) => void = (m) => process.stderr.write(`${m}\n`),
+): void {
+  void turn.result
+    .then((r) => {
+      if (r.stopReason === "error") {
+        const code = r.error?.code ? ` (code=${r.error.code})` : "";
+        const msg = r.error?.message ?? "unknown error";
+        log(`[watchTurn] ${context} turn ${turn.turnId} ended with error${code}: ${msg}`);
+      }
+    })
+    .catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      log(`[watchTurn] ${context} turn ${turn.turnId} rejected: ${msg}`);
+    });
+}

--- a/src/core/acpx-runtime.component.test.ts
+++ b/src/core/acpx-runtime.component.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { AcpxRuntime } from "./acpx-runtime.js";
+
+/**
+ * Component test: boots real acpx (gated on `isAvailable`) and asserts the
+ * new typed send() contract: an AcpxTurn whose messages iterable drains and
+ * whose result resolves with a terminal stopReason.
+ */
+test(
+  "AcpxRuntime.send returns an AcpxTurn with messages iterable and result promise",
+  async () => {
+    const rt = new AcpxRuntime();
+    if (!(await rt.isAvailable())) {
+      // acpx absent — real integration covers this; skip locally.
+      return;
+    }
+    const session = await rt.spawn("smoke", {
+      role: "smoke",
+      command: "codex",
+      cwd: process.cwd(),
+      platform: "codex",
+      waitForPush: true,
+    });
+    try {
+      const turn = await rt.send(session, "reply with: ok");
+      let count = 0;
+      for await (const _ of turn.messages) count += 1;
+      const r = await turn.result;
+      expect(count).toBeGreaterThan(0);
+      expect(["end_turn", "error", "cancelled", "max_tokens"]).toContain(r.stopReason);
+    } finally {
+      await rt.close(session);
+    }
+  },
+  90_000,
+);

--- a/src/core/acpx-runtime.component.test.ts
+++ b/src/core/acpx-runtime.component.test.ts
@@ -6,31 +6,27 @@ import { AcpxRuntime } from "./acpx-runtime.js";
  * new typed send() contract: an AcpxTurn whose messages iterable drains and
  * whose result resolves with a terminal stopReason.
  */
-test(
-  "AcpxRuntime.send returns an AcpxTurn with messages iterable and result promise",
-  async () => {
-    const rt = new AcpxRuntime();
-    if (!(await rt.isAvailable())) {
-      // acpx absent — real integration covers this; skip locally.
-      return;
-    }
-    const session = await rt.spawn("smoke", {
-      role: "smoke",
-      command: "codex",
-      cwd: process.cwd(),
-      platform: "codex",
-      waitForPush: true,
-    });
-    try {
-      const turn = await rt.send(session, "reply with: ok");
-      let count = 0;
-      for await (const _ of turn.messages) count += 1;
-      const r = await turn.result;
-      expect(count).toBeGreaterThan(0);
-      expect(["end_turn", "error", "cancelled", "max_tokens"]).toContain(r.stopReason);
-    } finally {
-      await rt.close(session);
-    }
-  },
-  90_000,
-);
+test("AcpxRuntime.send returns an AcpxTurn with messages iterable and result promise", async () => {
+  const rt = new AcpxRuntime();
+  if (!(await rt.isAvailable())) {
+    // acpx absent — real integration covers this; skip locally.
+    return;
+  }
+  const session = await rt.spawn("smoke", {
+    role: "smoke",
+    command: "codex",
+    cwd: process.cwd(),
+    platform: "codex",
+    waitForPush: true,
+  });
+  try {
+    const turn = await rt.send(session, "reply with: ok");
+    let count = 0;
+    for await (const _ of turn.messages) count += 1;
+    const r = await turn.result;
+    expect(count).toBeGreaterThan(0);
+    expect(["end_turn", "error", "cancelled", "max_tokens"]).toContain(r.stopReason);
+  } finally {
+    await rt.close(session);
+  }
+}, 90_000);

--- a/src/core/acpx-runtime.component.test.ts
+++ b/src/core/acpx-runtime.component.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import type { AcpxTurn } from "../acp/types.js";
 import { AcpxRuntime } from "./acpx-runtime.js";
 
 /**
@@ -6,6 +7,48 @@ import { AcpxRuntime } from "./acpx-runtime.js";
  * new typed send() contract: an AcpxTurn whose messages iterable drains and
  * whose result resolves with a terminal stopReason.
  */
+test("AcpxRuntime.send serializes N concurrent callers into sequential turns", async () => {
+  const rt = new AcpxRuntime();
+  if (!(await rt.isAvailable())) {
+    return;
+  }
+  const session = await rt.spawn("smoke", {
+    role: "smoke",
+    command: "codex",
+    cwd: process.cwd(),
+    platform: "codex",
+    waitForPush: true,
+  });
+  try {
+    // Fire three concurrent sends. A naive `await entry.inflightTurn`
+    // gate would let all three pass once the first child exits and
+    // start three overlapping acpx children. The per-session chain must
+    // produce three distinct turns with unique turnIds, and observing
+    // the returned AcpxTurns should confirm ordering: each turn's
+    // messages/result finish before the next starts (the acpx CLI's
+    // stdout is single-writer per child, so concurrent sends would
+    // otherwise collide).
+    const promises: Promise<AcpxTurn>[] = [
+      rt.send(session, "say one"),
+      rt.send(session, "say two"),
+      rt.send(session, "say three"),
+    ];
+    const turns = await Promise.all(promises);
+    const turnIds = new Set(turns.map((t) => t.turnId));
+    expect(turnIds.size).toBe(3);
+
+    for (const t of turns) {
+      for await (const _ of t.messages) {
+        /* drain */
+      }
+      const r = await t.result;
+      expect(["end_turn", "error", "cancelled", "max_tokens"]).toContain(r.stopReason);
+    }
+  } finally {
+    await rt.close(session);
+  }
+}, 180_000);
+
 test("AcpxRuntime.send returns an AcpxTurn with messages iterable and result promise", async () => {
   const rt = new AcpxRuntime();
   if (!(await rt.isAvailable())) {

--- a/src/core/acpx-runtime.ts
+++ b/src/core/acpx-runtime.ts
@@ -271,6 +271,10 @@ export class AcpxRuntime implements AgentRuntime {
         // provider rejection, cancelled turn) would be silently swallowed
         // and the session would look successfully primed.
         const initialTurn = this.startTurn(entry, initialMessage);
+        // Seed the send chain with the bootstrap turn's child-exit promise
+        // so the first external send() waits for the initial goal to finish
+        // instead of spawning a second overlapping acpx child.
+        entry.sendChainTail = entry.inflightTurn;
         watchTurnError(initialTurn, `acpx spawn(role=${role})`, (msg) => {
           process.stderr.write(`${msg}\n`);
           if (entry.logStream) {
@@ -522,7 +526,34 @@ ${message}`;
     appendLog(
       `[acpx.send] calling startTurn for sessionId=${session.id} sessionName=${entry.sessionName}`,
     );
-    const turn = this.startTurn(entry, message);
+    // Exception safety: if startTurn throws synchronously (malformed args,
+    // spawn path errors, null-byte content, etc.), we must still release
+    // the chain — otherwise every subsequent send() for this session would
+    // wait forever on an orphan predecessor promise that nobody resolves.
+    let turn: AcpxTurn;
+    try {
+      turn = this.startTurn(entry, message);
+    } catch (err) {
+      releaseChain();
+      const errTurnId = `${entry.sessionName}-start-failed`;
+      return {
+        sessionId: entry.sessionName,
+        turnId: errTurnId,
+        messages: (async function* () {
+          /* no messages */
+        })(),
+        result: Promise.resolve({
+          turnId: errTurnId,
+          stopReason: "error" as const,
+          error: {
+            code: "startTurn_threw",
+            message: err instanceof Error ? err.message : String(err),
+          },
+        }),
+        cancel: async () => undefined,
+        close: async () => undefined,
+      };
+    }
     // Release the next queued send when this turn's child exits. Use
     // inflightTurn (set by startTurn and resolved by the child close/error
     // handler) so successors wait on the actual process lifecycle, not

--- a/src/core/acpx-runtime.ts
+++ b/src/core/acpx-runtime.ts
@@ -56,6 +56,15 @@ interface AcpxSessionEntry {
   idleTimer: ReturnType<typeof setInterval> | null;
   /** Active child process for the current prompt (null when idle). */
   activeProc: ReturnType<typeof nodeSpawn> | null;
+  /**
+   * Resolves when `activeProc` has exited (not just when the turn's result
+   * frame arrived). `send()` awaits this before starting a new turn so a
+   * single session never has two overlapping acpx children — otherwise a
+   * caller who does `await turn.result` and immediately calls send() again
+   * could race the previous child's stdout against the new one, and
+   * `close()`/`cancel()` would only target the newest child.
+   */
+  inflightTurn: Promise<void> | null;
   /** Log write stream (opened at session creation, closed on session close). */
   logStream: import("node:fs").WriteStream | null;
   /** Log file path for agent output (debug/streaming). */
@@ -237,6 +246,7 @@ export class AcpxRuntime implements AgentRuntime {
       idleCallbacks: [],
       idleTimer: null,
       activeProc: null,
+      inflightTurn: null,
       logStream,
       logFile,
     };
@@ -319,6 +329,10 @@ ${message}`;
     );
 
     entry.activeProc = child;
+    let markExited: () => void = () => undefined;
+    entry.inflightTurn = new Promise<void>((resolve) => {
+      markExited = resolve;
+    });
     child.on("spawn", () => {
       appendLog(
         `[acpx.startTurn] child spawned OK pid=${child.pid} for sessionName=${entry.sessionName}`,
@@ -345,6 +359,8 @@ ${message}`;
     child.on("close", (code) => {
       appendLog(`[acpx.startTurn] child closed exit=${code} sessionName=${entry.sessionName}`);
       entry.activeProc = null;
+      entry.inflightTurn = null;
+      markExited();
       const ts = new Date().toISOString();
       if (code === 0) {
         entry.session = { ...entry.session, status: "idle" };
@@ -368,6 +384,8 @@ ${message}`;
 
     child.on("error", (err) => {
       entry.activeProc = null;
+      entry.inflightTurn = null;
+      markExited();
       entry.session = { ...entry.session, status: "crashed" };
       if (entry.logStream) {
         entry.logStream.write(`\n[ERROR] ${err.message}\n`);
@@ -417,6 +435,7 @@ ${message}`;
         idleCallbacks: [],
         idleTimer: null,
         activeProc: null,
+        inflightTurn: null,
         logStream: null,
         logFile: this.logDir ? join(this.logDir, `${session.role}-reattach.log`) : null,
       };
@@ -428,6 +447,16 @@ ${message}`;
       appendLog(
         `[acpx.send] sessionId=${session.id} FOUND in sessions map, logFile=${entry.logFile}, sessionName=${entry.sessionName}`,
       );
+    }
+    // Single-flight: wait for any previous turn's child to exit before
+    // starting a new one. Two overlapping children on the same acpx session
+    // would interleave stdout NDJSON and leave close()/cancel() targeting
+    // only the newest, so the older one can be orphaned.
+    if (entry.inflightTurn) {
+      appendLog(
+        `[acpx.send] sessionId=${session.id} awaiting prior turn's child exit before starting new turn`,
+      );
+      await entry.inflightTurn;
     }
     appendLog(
       `[acpx.send] calling startTurn for sessionId=${session.id} sessionName=${entry.sessionName}`,

--- a/src/core/acpx-runtime.ts
+++ b/src/core/acpx-runtime.ts
@@ -469,6 +469,34 @@ ${message}`;
       );
       await entry.inflightTurn;
     }
+    // After the await, close() may have run concurrently: killed the
+    // prior child, closed the acpx session, and deleted the map entry.
+    // Re-check before launching a new child, otherwise a queued send
+    // would spawn acpx against a session the caller has already stopped
+    // and leave the orphaned process behind.
+    const current = this.sessions.get(session.id);
+    if (!current || current !== entry || current.session.status === "stopped") {
+      appendLog(
+        `[acpx.send] sessionId=${session.id} session was stopped/replaced during inflight wait — refusing to start new turn`,
+      );
+      return {
+        sessionId: session.id,
+        turnId: `${session.id}-closed`,
+        messages: (async function* () {
+          /* no messages */
+        })(),
+        result: Promise.resolve({
+          turnId: `${session.id}-closed`,
+          stopReason: "error" as const,
+          error: {
+            code: "session_closed",
+            message: "session was closed before send could start a new turn",
+          },
+        }),
+        cancel: async () => undefined,
+        close: async () => undefined,
+      };
+    }
     appendLog(
       `[acpx.send] calling startTurn for sessionId=${session.id} sessionName=${entry.sessionName}`,
     );

--- a/src/core/acpx-runtime.ts
+++ b/src/core/acpx-runtime.ts
@@ -13,6 +13,7 @@ import { createWriteStream, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { AcpxTurnImpl } from "../acp/turn.js";
 import type { AcpxTurn } from "../acp/types.js";
+import { watchTurnError } from "../acp/watch-turn.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
 import { shellEscape } from "./shell-utils.js";
 import type { AgentPlatformType } from "./topology.js";
@@ -256,8 +257,18 @@ export class AcpxRuntime implements AgentRuntime {
     if (!config.waitForPush) {
       const initialMessage = config.goal ?? config.prompt;
       if (initialMessage) {
-        // Fire initial turn; drop the AcpxTurn — callers get future turns via send().
-        void this.startTurn(entry, initialMessage);
+        // Fire initial turn. Callers don't see this AcpxTurn (future turns
+        // reach them via send()), so watch its result ourselves and log any
+        // terminal error — otherwise bootstrap failures (malformed frames,
+        // provider rejection, cancelled turn) would be silently swallowed
+        // and the session would look successfully primed.
+        const initialTurn = this.startTurn(entry, initialMessage);
+        watchTurnError(initialTurn, `acpx spawn(role=${role})`, (msg) => {
+          process.stderr.write(`${msg}\n`);
+          if (entry.logStream) {
+            entry.logStream.write(`${msg}\n`);
+          }
+        });
       }
     }
 

--- a/src/core/acpx-runtime.ts
+++ b/src/core/acpx-runtime.ts
@@ -11,6 +11,8 @@
 import { execSync, spawn as nodeSpawn } from "node:child_process";
 import { createWriteStream, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import { AcpxTurnImpl } from "../acp/turn.js";
+import type { AcpxTurn } from "../acp/types.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
 import { shellEscape } from "./shell-utils.js";
 import type { AgentPlatformType } from "./topology.js";
@@ -51,7 +53,6 @@ interface AcpxSessionEntry {
   cwd: string;
   env: Record<string, string | undefined>;
   idleCallbacks: (() => void)[];
-  outputCallbacks: ((chunk: string) => void)[];
   idleTimer: ReturnType<typeof setInterval> | null;
   /** Active child process for the current prompt (null when idle). */
   activeProc: ReturnType<typeof nodeSpawn> | null;
@@ -234,7 +235,6 @@ export class AcpxRuntime implements AgentRuntime {
       cwd: config.cwd,
       env: mergedEnv,
       idleCallbacks: [],
-      outputCallbacks: [],
       idleTimer: null,
       activeProc: null,
       logStream,
@@ -246,7 +246,8 @@ export class AcpxRuntime implements AgentRuntime {
     if (!config.waitForPush) {
       const initialMessage = config.goal ?? config.prompt;
       if (initialMessage) {
-        this.sendAsync(entry, initialMessage);
+        // Fire initial turn; drop the AcpxTurn — callers get future turns via send().
+        void this.startTurn(entry, initialMessage);
       }
     }
 
@@ -254,13 +255,15 @@ export class AcpxRuntime implements AgentRuntime {
   }
 
   /**
-   * Fire-and-forget send: spawns acpx in the background.
-   * Streams stdout to output callbacks + log file.
-   * When the prompt completes, fires idle callbacks.
+   * Fire a prompt and return a streaming AcpxTurn. Spawns acpx with
+   * `--format json --json-strict` so stdout is NDJSON typed frames; the
+   * returned turn wraps the child's stdout in AcpxTurnImpl. The log file
+   * still mirrors stdout for forensics.
    */
-  private sendAsync(entry: AcpxSessionEntry, message: string): void {
+  private startTurn(entry: AcpxSessionEntry, message: string): AcpxTurn {
+    const turnId = `${entry.sessionName}-${Date.now().toString(36)}-${this.nextId++}`;
     appendLog(
-      `[acpx.sendAsync] sessionName=${entry.sessionName} role=${entry.session.role} logFile=${entry.logFile} agent=${entry.agent} cwd=${entry.cwd}`,
+      `[acpx.startTurn] sessionName=${entry.sessionName} role=${entry.session.role} logFile=${entry.logFile} agent=${entry.agent} cwd=${entry.cwd} turnId=${turnId}`,
     );
     entry.session = { ...entry.session, status: "running" };
 
@@ -294,11 +297,20 @@ ${message}`;
     }
 
     appendLog(
-      `[acpx.sendAsync] spawning: acpx --approve-all ${entry.agent} -s ${entry.sessionName} <message len=${wrappedMessage.length}>`,
+      `[acpx.startTurn] spawning: acpx --format json --json-strict --approve-all ${entry.agent} -s ${entry.sessionName} <message len=${wrappedMessage.length}>`,
     );
     const child = nodeSpawn(
       "acpx",
-      ["--approve-all", entry.agent, "-s", entry.sessionName, wrappedMessage],
+      [
+        "--format",
+        "json",
+        "--json-strict",
+        "--approve-all",
+        entry.agent,
+        "-s",
+        entry.sessionName,
+        wrappedMessage,
+      ],
       {
         cwd: entry.cwd,
         env: entry.env as NodeJS.ProcessEnv,
@@ -309,39 +321,29 @@ ${message}`;
     entry.activeProc = child;
     child.on("spawn", () => {
       appendLog(
-        `[acpx.sendAsync] child spawned OK pid=${child.pid} for sessionName=${entry.sessionName}`,
+        `[acpx.startTurn] child spawned OK pid=${child.pid} for sessionName=${entry.sessionName}`,
       );
     });
     child.on("error", (spawnErr) => {
       appendLog(
-        `[acpx.sendAsync] child error: ${spawnErr.message} for sessionName=${entry.sessionName}`,
+        `[acpx.startTurn] child error: ${spawnErr.message} for sessionName=${entry.sessionName}`,
       );
     });
 
-    // Stream stdout to output callbacks + log stream
-    child.stdout?.on("data", (chunk: Buffer) => {
-      const text = chunk.toString();
-      if (entry.logStream) {
-        entry.logStream.write(text);
-      }
-      for (const cb of entry.outputCallbacks) {
-        try {
-          cb(text);
-        } catch {
-          /* ignore */
-        }
-      }
-    });
-
-    // Capture stderr to log stream
-    child.stderr?.on("data", (chunk: Buffer) => {
-      if (entry.logStream) {
-        entry.logStream.write(`[stderr] ${chunk.toString()}`);
-      }
-    });
+    // Mirror stdout to log file for forensics. AcpxTurnImpl installs its own
+    // 'data' listener via AcpParser; Readable fans out to all listeners so
+    // both observers see every chunk.
+    if (entry.logStream && child.stdout) {
+      child.stdout.on("data", (chunk: Buffer) => entry.logStream?.write(chunk));
+    }
+    if (entry.logStream && child.stderr) {
+      child.stderr.on("data", (chunk: Buffer) =>
+        entry.logStream?.write(`[stderr] ${chunk.toString()}`),
+      );
+    }
 
     child.on("close", (code) => {
-      appendLog(`[acpx.sendAsync] child closed exit=${code} sessionName=${entry.sessionName}`);
+      appendLog(`[acpx.startTurn] child closed exit=${code} sessionName=${entry.sessionName}`);
       entry.activeProc = null;
       const ts = new Date().toISOString();
       if (code === 0) {
@@ -371,9 +373,29 @@ ${message}`;
         entry.logStream.write(`\n[ERROR] ${err.message}\n`);
       }
     });
+
+    if (!child.stdout) {
+      throw new Error("acpx child spawned without stdout pipe");
+    }
+
+    return new AcpxTurnImpl({
+      sessionId: entry.sessionName,
+      turnId,
+      stdout: child.stdout,
+      cancelFn: async () => {
+        // ACP session/cancel is not wired through acpx CLI args; SIGINT the
+        // child so the provider sees a cancelled turn. Safe re-entry: cancel()
+        // is single-flight inside AcpxTurnImpl.
+        try {
+          child.kill("SIGINT");
+        } catch {
+          /* ignore */
+        }
+      },
+    });
   }
 
-  async send(session: AgentSession, message: string): Promise<void> {
+  async send(session: AgentSession, message: string): Promise<AcpxTurn> {
     appendLog(
       `[acpx.send] called for sessionId=${session.id} role=${session.role} status=${session.status} sessionsMapSize=${this.sessions.size} sessionIds=[${[...this.sessions.keys()].join(",")}]`,
     );
@@ -393,7 +415,6 @@ ${message}`;
         cwd: process.cwd(),
         env: { ...process.env },
         idleCallbacks: [],
-        outputCallbacks: [],
         idleTimer: null,
         activeProc: null,
         logStream: null,
@@ -409,9 +430,9 @@ ${message}`;
       );
     }
     appendLog(
-      `[acpx.send] calling sendAsync for sessionId=${session.id} sessionName=${entry.sessionName}`,
+      `[acpx.send] calling startTurn for sessionId=${session.id} sessionName=${entry.sessionName}`,
     );
-    this.sendAsync(entry, message);
+    return this.startTurn(entry, message);
   }
 
   async close(session: AgentSession): Promise<void> {
@@ -458,12 +479,6 @@ ${message}`;
         this.checkIdle(session.id);
       }, this.idlePollMs);
     }
-  }
-
-  onOutput(session: AgentSession, callback: (chunk: string) => void): void {
-    const entry = this.sessions.get(session.id);
-    if (!entry) return;
-    entry.outputCallbacks.push(callback);
   }
 
   /**

--- a/src/core/acpx-runtime.ts
+++ b/src/core/acpx-runtime.ts
@@ -59,13 +59,20 @@ interface AcpxSessionEntry {
   activeProc: ReturnType<typeof nodeSpawn> | null;
   /**
    * Resolves when `activeProc` has exited (not just when the turn's result
-   * frame arrived). `send()` awaits this before starting a new turn so a
-   * single session never has two overlapping acpx children — otherwise a
-   * caller who does `await turn.result` and immediately calls send() again
-   * could race the previous child's stdout against the new one, and
-   * `close()`/`cancel()` would only target the newest child.
+   * frame arrived). Set inside startTurn and resolved by the child's
+   * close/error handler. Read-only outside startTurn; send() uses
+   * `sendChainTail` for serialization instead of awaiting this directly.
    */
   inflightTurn: Promise<void> | null;
+  /**
+   * Tail of the per-session send chain. Each incoming send() call appends
+   * a new promise to this chain and awaits the predecessor, so N concurrent
+   * send() callers are serialized into N sequential turns. Using a single
+   * `await inflightTurn` gate would let every concurrent caller pass the
+   * gate simultaneously when the predecessor resolved, and they would all
+   * call startTurn at once — reintroducing overlapping acpx children.
+   */
+  sendChainTail: Promise<void> | null;
   /** Log write stream (opened at session creation, closed on session close). */
   logStream: import("node:fs").WriteStream | null;
   /** Log file path for agent output (debug/streaming). */
@@ -248,6 +255,7 @@ export class AcpxRuntime implements AgentRuntime {
       idleTimer: null,
       activeProc: null,
       inflightTurn: null,
+      sendChainTail: null,
       logStream,
       logFile,
     };
@@ -447,6 +455,7 @@ ${message}`;
         idleTimer: null,
         activeProc: null,
         inflightTurn: null,
+        sendChainTail: null,
         logStream: null,
         logFile: this.logDir ? join(this.logDir, `${session.role}-reattach.log`) : null,
       };
@@ -459,26 +468,38 @@ ${message}`;
         `[acpx.send] sessionId=${session.id} FOUND in sessions map, logFile=${entry.logFile}, sessionName=${entry.sessionName}`,
       );
     }
-    // Single-flight: wait for any previous turn's child to exit before
-    // starting a new one. Two overlapping children on the same acpx session
-    // would interleave stdout NDJSON and leave close()/cancel() targeting
-    // only the newest, so the older one can be orphaned.
-    if (entry.inflightTurn) {
-      appendLog(
-        `[acpx.send] sessionId=${session.id} awaiting prior turn's child exit before starting new turn`,
-      );
-      await entry.inflightTurn;
+    // Serialize concurrent send() callers into a sequential chain so only
+    // one acpx child exists per session at any time. We CANNOT use a bare
+    // `await entry.inflightTurn` here: N concurrent callers all awaiting
+    // the same promise would all pass the gate simultaneously once the
+    // predecessor resolved, and each would start its own acpx child —
+    // overlapping NDJSON streams, cancel()/close() targeting only the
+    // newest. Instead, each call installs its own "my turn is done" promise
+    // as the chain tail before awaiting the predecessor, so later arrivals
+    // wait on us, not on the same promise we waited on.
+    const predecessor = entry.sendChainTail ?? Promise.resolve();
+    let releaseChain: () => void = () => undefined;
+    const myCompletion = new Promise<void>((resolve) => {
+      releaseChain = resolve;
+    });
+    entry.sendChainTail = myCompletion;
+
+    try {
+      await predecessor;
+    } catch {
+      // Predecessor rejected — treat as released so we don't deadlock.
     }
-    // After the await, close() may have run concurrently: killed the
-    // prior child, closed the acpx session, and deleted the map entry.
-    // Re-check before launching a new child, otherwise a queued send
-    // would spawn acpx against a session the caller has already stopped
-    // and leave the orphaned process behind.
+
+    // After the wait, close() may have run concurrently: killed the prior
+    // child, closed the acpx session, and deleted the map entry. Re-check
+    // before launching a new child, otherwise a queued send would spawn
+    // acpx against a session the caller has already stopped.
     const current = this.sessions.get(session.id);
     if (!current || current !== entry || current.session.status === "stopped") {
       appendLog(
-        `[acpx.send] sessionId=${session.id} session was stopped/replaced during inflight wait — refusing to start new turn`,
+        `[acpx.send] sessionId=${session.id} session was stopped/replaced during chain wait — refusing to start new turn`,
       );
+      releaseChain();
       return {
         sessionId: session.id,
         turnId: `${session.id}-closed`,
@@ -497,10 +518,18 @@ ${message}`;
         close: async () => undefined,
       };
     }
+
     appendLog(
       `[acpx.send] calling startTurn for sessionId=${session.id} sessionName=${entry.sessionName}`,
     );
-    return this.startTurn(entry, message);
+    const turn = this.startTurn(entry, message);
+    // Release the next queued send when this turn's child exits. Use
+    // inflightTurn (set by startTurn and resolved by the child close/error
+    // handler) so successors wait on the actual process lifecycle, not
+    // just on message-iterator consumption.
+    const inflight = entry.inflightTurn ?? Promise.resolve();
+    void inflight.finally(() => releaseChain());
+    return turn;
   }
 
   async close(session: AgentSession): Promise<void> {

--- a/src/core/agent-runtime.ts
+++ b/src/core/agent-runtime.ts
@@ -4,6 +4,7 @@
  * Decouples grove from any specific agent CLI (acpx, tmux, subprocess).
  */
 
+import type { AcpxTurn } from "../acp/types.js";
 import type { AgentPlatformType } from "./topology.js";
 
 /** Configuration for spawning an agent. */
@@ -40,14 +41,12 @@ export interface AgentSession {
 export interface AgentRuntime {
   /** Spawn a new agent session. */
   spawn(role: string, config: AgentConfig): Promise<AgentSession>;
-  /** Send a message/prompt to a running agent. */
-  send(session: AgentSession, message: string): Promise<void>;
+  /** Send a prompt and return the typed turn stream. */
+  send(session: AgentSession, message: string): Promise<AcpxTurn>;
   /** Gracefully close an agent session. */
   close(session: AgentSession): Promise<void>;
   /** Register a callback for when an agent becomes idle. */
   onIdle(session: AgentSession, callback: () => void): void;
-  /** Register a callback for agent stdout output (streaming). */
-  onOutput?(session: AgentSession, callback: (chunk: string) => void): void;
   /** List all active sessions. */
   listSessions(): Promise<readonly AgentSession[]>;
   /** Check if the runtime's dependencies are available. */

--- a/src/core/deadline-watcher.test.ts
+++ b/src/core/deadline-watcher.test.ts
@@ -107,14 +107,16 @@ describe("DeadlineWatcher", () => {
   // overdue event emission
   // ------------------------------------------------------------------
 
-  // Per-test timeout bumped to 15s so the 10s waitFor can expire cleanly
-  // instead of racing bun's default 5s test cutoff under extreme CI load.
+  // Per-test timeout and waitFor window are both generous (60s/55s) because
+  // shared CI runners can stall the event loop for 10s+ under load, which
+  // previously turned this into an intermittent red CI job. The test is
+  // still fast in the happy path — the big budget only applies on expiry.
   test("emits handoff.overdue when deadline passes and handoff still unresolved", async () => {
     // Future-dated deadline — exercises the real positive-delay setTimeout
     // path used in production. The `already past` test below covers the
     // delayMs=0 shortcut separately. We deliberately use a 50ms deadline
-    // with a long waitFor window (10s) so genuine timer drift under heavy
-    // CI load doesn't turn this into a flake, while still asserting the
+    // with a long waitFor window so genuine timer drift under heavy CI
+    // load doesn't turn this into a flake, while still asserting the
     // full schedule-and-fire behavior.
     const h = await store.create({
       sourceCid: "blake3:test",
@@ -133,7 +135,7 @@ describe("DeadlineWatcher", () => {
     watcher.watch(h);
     expect(watcher.activeCount).toBe(1);
 
-    await waitFor(() => events.length > 0, { timeoutMs: 10_000 });
+    await waitFor(() => events.length > 0, { timeoutMs: 55_000 });
 
     expect(events).toHaveLength(1);
     expect(events[0]?.type).toBe("handoff.overdue");
@@ -142,7 +144,7 @@ describe("DeadlineWatcher", () => {
     expect(events[0]?.payload.handoffId).toBe(h.handoffId);
     // After fire, the timer should have been cleared from the active set.
     expect(watcher.activeCount).toBe(0);
-  }, 15_000);
+  }, 60_000);
 
   test("does not emit overdue when handoff is already replied", async () => {
     const h = await store.create({

--- a/src/core/deadline-watcher.test.ts
+++ b/src/core/deadline-watcher.test.ts
@@ -51,7 +51,7 @@ describe("DeadlineWatcher", () => {
   beforeEach(() => {
     store = new InMemoryHandoffStore();
     bus = new LocalEventBus();
-    watcher = new DeadlineWatcher({ handoffStore: store, eventBus: bus });
+    watcher = new DeadlineWatcher({ handoffStore: store, eventBus: bus, unrefTimers: false });
   });
 
   afterEach(() => {
@@ -204,7 +204,11 @@ describe("DeadlineWatcher", () => {
     bus.subscribe("reviewer", (e) => events.push(e));
 
     // Two watchers observe the same store — simulates two MCP processes
-    const watcher2 = new DeadlineWatcher({ handoffStore: store, eventBus: bus });
+    const watcher2 = new DeadlineWatcher({
+      handoffStore: store,
+      eventBus: bus,
+      unrefTimers: false,
+    });
 
     watcher.watch(h);
     watcher2.watch(h);

--- a/src/core/deadline-watcher.ts
+++ b/src/core/deadline-watcher.ts
@@ -31,6 +31,14 @@ export interface DeadlineWatcherOpts {
   readonly eventBus: EventBus;
   /** Maximum age (ms) of handoffs to consider on cold-start rebuild. Default: 7 days. */
   readonly maxRebuildAgeMs?: number;
+  /**
+   * When true (default), timers are unref'd so a dormant watcher does not keep
+   * the process alive. Tests should set this to false: under Bun's full-suite
+   * runner we've seen unref'd setTimeouts delayed well past their wall-clock
+   * deadline (60s+), turning timer-based tests into false-negative flakes even
+   * with a loaded but alive event loop.
+   */
+  readonly unrefTimers?: boolean;
 }
 
 const DEFAULT_MAX_REBUILD_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -39,6 +47,7 @@ export class DeadlineWatcher {
   private readonly handoffStore: HandoffStore;
   private readonly eventBus: EventBus;
   private readonly maxRebuildAgeMs: number;
+  private readonly unrefTimers: boolean;
 
   /** Active timers keyed by handoffId. */
   private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -47,6 +56,7 @@ export class DeadlineWatcher {
     this.handoffStore = opts.handoffStore;
     this.eventBus = opts.eventBus;
     this.maxRebuildAgeMs = opts.maxRebuildAgeMs ?? DEFAULT_MAX_REBUILD_AGE_MS;
+    this.unrefTimers = opts.unrefTimers ?? true;
   }
 
   /**
@@ -75,8 +85,11 @@ export class DeadlineWatcher {
       void this.onDeadlineFired(handoff.handoffId, handoff.fromRole, handoff.toRole);
     }, delayMs);
 
-    // Prevent timer from keeping the process alive
-    if (timer.unref) timer.unref();
+    // Prevent timer from keeping the process alive (production default).
+    // Tests opt out via unrefTimers=false because Bun's full-suite runner
+    // has been observed to delay unref'd setTimeouts well past their
+    // deadline — ref'd timers fire reliably.
+    if (this.unrefTimers && timer.unref) timer.unref();
 
     this.timers.set(handoff.handoffId, timer);
   }

--- a/src/core/mock-runtime.test.ts
+++ b/src/core/mock-runtime.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { MockRuntime } from "./mock-runtime.js";
+
+test("MockRuntime.send returns a drainable AcpxTurn with canned messages", async () => {
+  const rt = new MockRuntime();
+  const s = await rt.spawn("coder", { role: "coder", command: "codex", cwd: "." });
+  rt.enqueueMessages(s.id, [{ kind: "text", turnId: "auto", text: "ok", chunk: true }]);
+  rt.enqueueResult(s.id, { turnId: "auto", stopReason: "end_turn" });
+
+  const turn = await rt.send(s, "hi");
+  const got = [];
+  for await (const m of turn.messages) got.push(m);
+  const r = await turn.result;
+
+  expect(got).toHaveLength(1);
+  expect(got[0]!.kind).toBe("text");
+  expect(r.stopReason).toBe("end_turn");
+});
+
+test("MockRuntime.send returns default end_turn result when no result enqueued", async () => {
+  const rt = new MockRuntime();
+  const s = await rt.spawn("coder", { role: "coder", command: "codex", cwd: "." });
+  const turn = await rt.send(s, "hi");
+  const r = await turn.result;
+  expect(r.stopReason).toBe("end_turn");
+});
+
+test("MockRuntime queues are drained per turn (not reused)", async () => {
+  const rt = new MockRuntime();
+  const s = await rt.spawn("coder", { role: "coder", command: "codex", cwd: "." });
+  rt.enqueueMessages(s.id, [{ kind: "text", turnId: "t1", text: "one", chunk: true }]);
+  rt.enqueueResult(s.id, { turnId: "t1", stopReason: "end_turn" });
+
+  const first = await rt.send(s, "msg1");
+  for await (const _ of first.messages) { /* drain */ }
+  await first.result;
+
+  // Second send without re-enqueueing: empty messages, default result.
+  const second = await rt.send(s, "msg2");
+  const got: unknown[] = [];
+  for await (const m of second.messages) got.push(m);
+  const r = await second.result;
+  expect(got).toHaveLength(0);
+  expect(r.stopReason).toBe("end_turn");
+});
+
+test("MockRuntime.reset clears queues", async () => {
+  const rt = new MockRuntime();
+  const s = await rt.spawn("coder", { role: "coder", command: "codex", cwd: "." });
+  rt.enqueueMessages(s.id, [{ kind: "text", turnId: "t1", text: "one", chunk: true }]);
+  rt.reset();
+  const s2 = await rt.spawn("coder", { role: "coder", command: "codex", cwd: "." });
+  const turn = await rt.send(s2, "hi");
+  const got: unknown[] = [];
+  for await (const m of turn.messages) got.push(m);
+  expect(got).toHaveLength(0);
+});

--- a/src/core/mock-runtime.test.ts
+++ b/src/core/mock-runtime.test.ts
@@ -32,7 +32,9 @@ test("MockRuntime queues are drained per turn (not reused)", async () => {
   rt.enqueueResult(s.id, { turnId: "t1", stopReason: "end_turn" });
 
   const first = await rt.send(s, "msg1");
-  for await (const _ of first.messages) { /* drain */ }
+  for await (const _ of first.messages) {
+    /* drain */
+  }
   await first.result;
 
   // Second send without re-enqueueing: empty messages, default result.

--- a/src/core/mock-runtime.ts
+++ b/src/core/mock-runtime.ts
@@ -1,8 +1,13 @@
 /**
  * Mock agent runtime for testing.
  * Records all calls and allows programmatic control of sessions.
+ *
+ * Since migrating AgentRuntime.send to return AcpxTurn, tests drive the
+ * mock by enqueueing canned Messages and Results per session; each send()
+ * drains the queues and returns a one-shot AcpxTurn.
  */
 
+import type { AcpxTurn, Message, Result } from "../acp/types.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
 
 export class MockRuntime implements AgentRuntime {
@@ -12,6 +17,8 @@ export class MockRuntime implements AgentRuntime {
 
   private sessions = new Map<string, AgentSession>();
   private idleCallbacks = new Map<string, (() => void)[]>();
+  private msgQueues = new Map<string, Message[]>();
+  private resultQueues = new Map<string, Result[]>();
   private nextId = 0;
   private _isAvailable = true;
 
@@ -34,8 +41,30 @@ export class MockRuntime implements AgentRuntime {
     return session;
   }
 
-  async send(session: AgentSession, message: string): Promise<void> {
+  async send(session: AgentSession, message: string): Promise<AcpxTurn> {
     this.sendCalls.push({ sessionId: session.id, message });
+    // Drain the queues so the next send() sees an empty turn unless the
+    // test enqueues more. Matches the real acpx contract: one turn per call.
+    const queued = this.msgQueues.get(session.id) ?? [];
+    this.msgQueues.set(session.id, []);
+    const resultQ = this.resultQueues.get(session.id) ?? [];
+    const canned = resultQ.shift();
+    this.resultQueues.set(session.id, resultQ);
+    const turnId = canned?.turnId ?? `mock-${this.nextId++}`;
+
+    const messages = (async function* () {
+      for (const m of queued) yield m;
+    })();
+    const result: Result = canned ?? { turnId, stopReason: "end_turn" };
+
+    return {
+      sessionId: session.id,
+      turnId,
+      messages,
+      result: Promise.resolve(result),
+      cancel: async () => undefined,
+      close: async () => undefined,
+    };
   }
 
   async close(session: AgentSession): Promise<void> {
@@ -82,6 +111,20 @@ export class MockRuntime implements AgentRuntime {
     return { platform: s.platform, model: s.model, agent: s.agent };
   }
 
+  /** Queue messages to be yielded by the next send() for this session. */
+  enqueueMessages(sessionId: string, msgs: readonly Message[]): void {
+    const q = this.msgQueues.get(sessionId) ?? [];
+    q.push(...msgs);
+    this.msgQueues.set(sessionId, q);
+  }
+
+  /** Queue a terminal Result for the next send() for this session. */
+  enqueueResult(sessionId: string, r: Result): void {
+    const q = this.resultQueues.get(sessionId) ?? [];
+    q.push(r);
+    this.resultQueues.set(sessionId, q);
+  }
+
   /** Reset all recorded calls. */
   reset(): void {
     this.spawnCalls.length = 0;
@@ -89,6 +132,8 @@ export class MockRuntime implements AgentRuntime {
     this.closeCalls.length = 0;
     this.sessions.clear();
     this.idleCallbacks.clear();
+    this.msgQueues.clear();
+    this.resultQueues.clear();
     this.nextId = 0;
   }
 }

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -6,6 +6,7 @@
  */
 
 import { join } from "node:path";
+import type { AcpxTurn } from "../acp/types.js";
 import type { AgentProfile } from "./agent-profile.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
 import type { GroveContract } from "./contract.js";
@@ -122,6 +123,38 @@ export class SessionOrchestrator {
     this.router = new TopologyRouter(config.topology, config.eventBus);
   }
 
+  /**
+   * Observe a fire-and-forget turn's outcome and surface error stop reasons.
+   *
+   * With the typed-stream runtime, post-spawn failures (malformed frames,
+   * provider rejections, cancelled turns) show up as `stopReason: "error"`
+   * on the turn's final `Result` rather than as a thrown send() error. If
+   * we just `await runtime.send(...)`, those failures are invisible to the
+   * orchestrator and the agent silently drops the prompt while its process
+   * status transitions back to idle — making a failed delivery look like
+   * a successful one. We drain each turn in the background and log the
+   * error so it's observable; we intentionally do not throw, since
+   * control-plane prompts are already fire-and-forget.
+   */
+  private watchTurn(role: string, turn: AcpxTurn): void {
+    void turn.result
+      .then((r) => {
+        if (r.stopReason === "error") {
+          const msg = r.error?.message ?? "unknown error";
+          const code = r.error?.code ? ` (code=${r.error.code})` : "";
+          process.stderr.write(
+            `[SessionOrchestrator] agent '${role}' turn ${turn.turnId} ended with error${code}: ${msg}\n`,
+          );
+        }
+      })
+      .catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[SessionOrchestrator] agent '${role}' turn ${turn.turnId} rejected: ${msg}\n`,
+        );
+      });
+  }
+
   /** Start the session: spawn all agents and send goals. */
   async start(): Promise<SessionStatus> {
     const topology = this.config.topology;
@@ -191,7 +224,8 @@ export class SessionOrchestrator {
     // `startTurn` internal helper.
     if (!("startTurn" in this.config.runtime)) {
       for (const agent of this.agents) {
-        await this.config.runtime.send(agent.session, agent.goal);
+        const turn = await this.config.runtime.send(agent.session, agent.goal);
+        this.watchTurn(agent.role, turn);
       }
     }
 
@@ -326,7 +360,8 @@ export class SessionOrchestrator {
         for (const { targetRole } of routeResults) {
           const targetAgent = this.agents.find((a) => a.role === targetRole);
           if (targetAgent) {
-            await this.config.runtime.send(targetAgent.session, message);
+            const turn = await this.config.runtime.send(targetAgent.session, message);
+            this.watchTurn(targetAgent.role, turn);
           }
         }
 
@@ -503,7 +538,8 @@ export class SessionOrchestrator {
     const p = event.payload;
     const summary = typeof p.summary === "string" ? p.summary : JSON.stringify(p);
     const message = `[grove] ${event.type} from ${event.sourceRole}: ${summary}`;
-    await this.config.runtime.send(agent.session, message);
+    const turn = await this.config.runtime.send(agent.session, message);
+    this.watchTurn(agent.role, turn);
   }
 
   private handleAgentIdle(_agent: AgentSessionInfo): void {

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -607,9 +607,12 @@ export class SessionOrchestrator {
         );
     const newSession = await this.spawnAgent(roleSpec, undefined, ws);
 
-    // Send a reconciliation message
+    // Send a reconciliation message. Observe the turn's terminal result
+    // so a failed catch-up prompt is logged instead of silently restarting
+    // the agent without its reconciliation context.
     const message = `[grove] You are resuming role '${role}'. Query the DAG via grove_log or grove_frontier to catch up on what happened while you were offline.`;
-    await this.config.runtime.send(newSession.session, message);
+    const turn = await this.config.runtime.send(newSession.session, message);
+    this.watchTurn(role, turn);
 
     // Replace the old agent entry
     const idx = this.agents.findIndex((a) => a.role === role);

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -7,6 +7,7 @@
 
 import { join } from "node:path";
 import type { AcpxTurn } from "../acp/types.js";
+import { watchTurnError } from "../acp/watch-turn.js";
 import type { AgentProfile } from "./agent-profile.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
 import type { GroveContract } from "./contract.js";
@@ -125,34 +126,15 @@ export class SessionOrchestrator {
 
   /**
    * Observe a fire-and-forget turn's outcome and surface error stop reasons.
-   *
    * With the typed-stream runtime, post-spawn failures (malformed frames,
    * provider rejections, cancelled turns) show up as `stopReason: "error"`
-   * on the turn's final `Result` rather than as a thrown send() error. If
-   * we just `await runtime.send(...)`, those failures are invisible to the
-   * orchestrator and the agent silently drops the prompt while its process
-   * status transitions back to idle — making a failed delivery look like
-   * a successful one. We drain each turn in the background and log the
-   * error so it's observable; we intentionally do not throw, since
-   * control-plane prompts are already fire-and-forget.
+   * on the terminal `Result` instead of as a thrown send() error, so we
+   * drain each turn in the background to make silent delivery failures
+   * observable. We intentionally do not throw — control-plane prompts are
+   * already fire-and-forget and have no retry channel.
    */
   private watchTurn(role: string, turn: AcpxTurn): void {
-    void turn.result
-      .then((r) => {
-        if (r.stopReason === "error") {
-          const msg = r.error?.message ?? "unknown error";
-          const code = r.error?.code ? ` (code=${r.error.code})` : "";
-          process.stderr.write(
-            `[SessionOrchestrator] agent '${role}' turn ${turn.turnId} ended with error${code}: ${msg}\n`,
-          );
-        }
-      })
-      .catch((err) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(
-          `[SessionOrchestrator] agent '${role}' turn ${turn.turnId} rejected: ${msg}\n`,
-        );
-      });
+    watchTurnError(turn, `SessionOrchestrator agent='${role}'`);
   }
 
   /** Start the session: spawn all agents and send goals. */

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -187,8 +187,9 @@ export class SessionOrchestrator {
     // AcpxRuntime sends the initial goal during spawn(). MockRuntime does not.
     // Send goals only to agents whose runtime status is still "running" but
     // haven't received a prompt yet (i.e., non-acpx runtimes).
-    // We detect this by checking if the runtime is MockRuntime (no sendAsync).
-    if (!("sendAsync" in this.config.runtime)) {
+    // We detect this by checking if the runtime exposes AcpxRuntime's
+    // `startTurn` internal helper.
+    if (!("startTurn" in this.config.runtime)) {
       for (const agent of this.agents) {
         await this.config.runtime.send(agent.session, agent.goal);
       }

--- a/src/core/subprocess-runtime.test.ts
+++ b/src/core/subprocess-runtime.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { SubprocessRuntime } from "./subprocess-runtime.js";
+
+test("SubprocessRuntime.send returns error turn when the child has already exited", async () => {
+  const rt = new SubprocessRuntime();
+  const session = await rt.spawn("smoke", { role: "smoke", command: "true", cwd: "/tmp" });
+
+  // `true` exits immediately — wait for proc.exited to propagate.
+  await new Promise((r) => setTimeout(r, 100));
+
+  const turn = await rt.send(session, "hello");
+  const result = await turn.result;
+  expect(result.stopReason).toBe("error");
+  expect(result.error?.code).toBe("child_exited");
+});
+
+test("SubprocessRuntime.send returns error turn when session id is unknown", async () => {
+  const rt = new SubprocessRuntime();
+  const turn = await rt.send({ id: "never-spawned", role: "smoke", status: "running" }, "hello");
+  const result = await turn.result;
+  expect(result.stopReason).toBe("error");
+  expect(result.error?.code).toBe("no_session");
+});
+
+test("SubprocessRuntime.send returns end_turn for a live child", async () => {
+  const rt = new SubprocessRuntime();
+  // `cat` reads stdin forever — stays alive until we close.
+  const session = await rt.spawn("smoke", { role: "smoke", command: "cat", cwd: "/tmp" });
+  try {
+    const turn = await rt.send(session, "hello");
+    const result = await turn.result;
+    expect(result.stopReason).toBe("end_turn");
+  } finally {
+    await rt.close(session);
+  }
+});

--- a/src/core/subprocess-runtime.ts
+++ b/src/core/subprocess-runtime.ts
@@ -48,6 +48,7 @@ interface SessionEntry {
   proc: import("bun").Subprocess<"pipe", "pipe", "pipe">;
   session: AgentSession;
   idleCallbacks: (() => void)[];
+  exited: boolean;
 }
 
 export class SubprocessRuntime implements AgentRuntime {
@@ -85,14 +86,14 @@ export class SubprocessRuntime implements AgentRuntime {
       platform: config.platform,
       model: config.model,
     };
-    this.sessions.set(id, { proc, session, idleCallbacks: [] });
+    const entry: SessionEntry = { proc, session, idleCallbacks: [], exited: false };
+    this.sessions.set(id, entry);
 
-    // Monitor for exit
+    // Monitor for exit — flip the exited flag so send() can refuse to
+    // synthesize end_turn against a dead child.
     proc.exited.then(() => {
-      const entry = this.sessions.get(id);
-      if (entry) {
-        entry.session = { ...entry.session, status: "stopped" };
-      }
+      entry.exited = true;
+      entry.session = { ...entry.session, status: "stopped" };
     });
 
     // Send initial prompt if provided
@@ -108,6 +109,14 @@ export class SubprocessRuntime implements AgentRuntime {
     if (!entry) {
       return errorTurn(session.id, "no_session", `unknown session id: ${session.id}`);
     }
+    // Reject sends to a child that has already exited. A write to the now-
+    // closed pipe can either throw OR silently succeed (the OS buffers the
+    // bytes into a pipe whose reader is gone); in the silent case we would
+    // otherwise report end_turn to callers who watch turn.result and treat
+    // that as delivery confirmation.
+    if (entry.exited || entry.session.status === "stopped") {
+      return errorTurn(session.id, "child_exited", "subprocess has already exited");
+    }
     if (!entry.proc.stdin) {
       return errorTurn(session.id, "no_stdin", "subprocess has no writable stdin");
     }
@@ -122,6 +131,12 @@ export class SubprocessRuntime implements AgentRuntime {
         "stdin_write_failed",
         err instanceof Error ? err.message : String(err),
       );
+    }
+    // Re-check after the flush: the write may have succeeded locally but
+    // the child could have exited while we awaited. If so, treat the turn
+    // as errored rather than end_turn.
+    if (entry.exited) {
+      return errorTurn(session.id, "child_exited", "subprocess exited during send");
     }
     return emptyTurn(session.id);
   }

--- a/src/core/subprocess-runtime.ts
+++ b/src/core/subprocess-runtime.ts
@@ -9,6 +9,9 @@ import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js
 /**
  * SubprocessRuntime does not produce ACP output. Return an already-settled
  * AcpxTurn so the interface is satisfied without misleading the consumer.
+ * Use `errorTurn()` on delivery failure — a synthetic `end_turn` on a
+ * failed write would silently hide non-delivery from callers who watch
+ * `turn.result`.
  */
 function emptyTurn(sessionId: string): AcpxTurn {
   return {
@@ -18,6 +21,24 @@ function emptyTurn(sessionId: string): AcpxTurn {
       /* no messages */
     })(),
     result: Promise.resolve({ turnId: `${sessionId}-noacp`, stopReason: "end_turn" as const }),
+    cancel: async () => undefined,
+    close: async () => undefined,
+  };
+}
+
+function errorTurn(sessionId: string, code: string, message: string): AcpxTurn {
+  const turnId = `${sessionId}-noacp-err`;
+  return {
+    sessionId,
+    turnId,
+    messages: (async function* () {
+      /* no messages */
+    })(),
+    result: Promise.resolve({
+      turnId,
+      stopReason: "error" as const,
+      error: { code, message },
+    }),
     cancel: async () => undefined,
     close: async () => undefined,
   };
@@ -84,11 +105,23 @@ export class SubprocessRuntime implements AgentRuntime {
 
   async send(session: AgentSession, message: string): Promise<AcpxTurn> {
     const entry = this.sessions.get(session.id);
-    if (entry?.proc.stdin) {
+    if (!entry) {
+      return errorTurn(session.id, "no_session", `unknown session id: ${session.id}`);
+    }
+    if (!entry.proc.stdin) {
+      return errorTurn(session.id, "no_stdin", "subprocess has no writable stdin");
+    }
+    try {
       const result = entry.proc.stdin.write(`${message}\n`);
       if (result instanceof Promise) await result;
       const flush = entry.proc.stdin.flush();
       if (flush instanceof Promise) await flush;
+    } catch (err) {
+      return errorTurn(
+        session.id,
+        "stdin_write_failed",
+        err instanceof Error ? err.message : String(err),
+      );
     }
     return emptyTurn(session.id);
   }

--- a/src/core/subprocess-runtime.ts
+++ b/src/core/subprocess-runtime.ts
@@ -3,7 +3,25 @@
  * No PTY, no session persistence. Suitable for CI and testing.
  */
 
+import type { AcpxTurn } from "../acp/types.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
+
+/**
+ * SubprocessRuntime does not produce ACP output. Return an already-settled
+ * AcpxTurn so the interface is satisfied without misleading the consumer.
+ */
+function emptyTurn(sessionId: string): AcpxTurn {
+  return {
+    sessionId,
+    turnId: `${sessionId}-noacp`,
+    messages: (async function* () {
+      /* no messages */
+    })(),
+    result: Promise.resolve({ turnId: `${sessionId}-noacp`, stopReason: "end_turn" as const }),
+    cancel: async () => undefined,
+    close: async () => undefined,
+  };
+}
 
 interface SessionEntry {
   proc: import("bun").Subprocess<"pipe", "pipe", "pipe">;
@@ -64,13 +82,15 @@ export class SubprocessRuntime implements AgentRuntime {
     return session;
   }
 
-  async send(session: AgentSession, message: string): Promise<void> {
+  async send(session: AgentSession, message: string): Promise<AcpxTurn> {
     const entry = this.sessions.get(session.id);
-    if (!entry?.proc.stdin) return;
-    const result = entry.proc.stdin.write(`${message}\n`);
-    if (result instanceof Promise) await result;
-    const flush = entry.proc.stdin.flush();
-    if (flush instanceof Promise) await flush;
+    if (entry?.proc.stdin) {
+      const result = entry.proc.stdin.write(`${message}\n`);
+      if (result instanceof Promise) await result;
+      const flush = entry.proc.stdin.flush();
+      if (flush instanceof Promise) await flush;
+    }
+    return emptyTurn(session.id);
   }
 
   async close(session: AgentSession): Promise<void> {

--- a/src/core/subprocess-runtime.ts
+++ b/src/core/subprocess-runtime.ts
@@ -117,12 +117,12 @@ export class SubprocessRuntime implements AgentRuntime {
     if (!entry) {
       return errorTurn(session.id, "no_session", `unknown session id: ${session.id}`);
     }
-    // Reject sends to a child that has already exited. A write to the now-
-    // closed pipe can either throw OR silently succeed (the OS buffers the
-    // bytes into a pipe whose reader is gone); in the silent case we would
-    // otherwise report end_turn to callers who watch turn.result and treat
-    // that as delivery confirmation.
-    if (entry.exited || entry.session.status === "stopped") {
+    // Reject sends to a child that has already exited. The `exited` flag
+    // is only flipped by a `proc.exited.then(...)` microtask, so there is
+    // a window where the child has died but the flag has not yet flipped.
+    // Consult `proc.exitCode` directly (null while running, a number on
+    // exit) so we catch that window as well.
+    if (entry.exited || entry.proc.exitCode !== null) {
       return errorTurn(session.id, "child_exited", "subprocess has already exited");
     }
     if (!entry.proc.stdin) {
@@ -141,9 +141,9 @@ export class SubprocessRuntime implements AgentRuntime {
       );
     }
     // Re-check after the flush: the write may have succeeded locally but
-    // the child could have exited while we awaited. If so, treat the turn
-    // as errored rather than end_turn.
-    if (entry.exited) {
+    // the child could have exited while we awaited. Check both the flag
+    // and the direct exitCode to close the microtask race.
+    if (entry.exited || entry.proc.exitCode !== null) {
       return errorTurn(session.id, "child_exited", "subprocess exited during send");
     }
     return emptyTurn(session.id);

--- a/src/core/subprocess-runtime.ts
+++ b/src/core/subprocess-runtime.ts
@@ -12,6 +12,14 @@ import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js
  * Use `errorTurn()` on delivery failure — a synthetic `end_turn` on a
  * failed write would silently hide non-delivery from callers who watch
  * `turn.result`.
+ *
+ * IMPORTANT — semantics of this success turn:
+ *   `end_turn` here means "bytes written to the child's stdin pipe", NOT
+ *   "the child process read or acted on them". Callers that need
+ *   agent-level acknowledgement must use the acpx-backed runtime; with
+ *   SubprocessRuntime the typed-turn contract degrades to write-ACK.
+ *   This is unavoidable — a plain subprocess has no agent-level ACK
+ *   channel — and is called out explicitly rather than papered over.
  */
 function emptyTurn(sessionId: string): AcpxTurn {
   return {

--- a/src/core/tmux-runtime.ts
+++ b/src/core/tmux-runtime.ts
@@ -7,8 +7,26 @@
  */
 
 import { execSync } from "node:child_process";
+import type { AcpxTurn } from "../acp/types.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
 import { shellEscape } from "./shell-utils.js";
+
+/**
+ * TmuxRuntime does not produce ACP output. Return an already-settled
+ * AcpxTurn so the interface is satisfied without misleading the consumer.
+ */
+function emptyTurn(sessionId: string): AcpxTurn {
+  return {
+    sessionId,
+    turnId: `${sessionId}-noacp`,
+    messages: (async function* () {
+      /* no messages */
+    })(),
+    result: Promise.resolve({ turnId: `${sessionId}-noacp`, stopReason: "end_turn" as const }),
+    cancel: async () => undefined,
+    close: async () => undefined,
+  };
+}
 
 /** Prefix for all grove tmux session names. */
 const SESSION_PREFIX = "grove-";
@@ -91,19 +109,20 @@ export class TmuxRuntime implements AgentRuntime {
     return session;
   }
 
-  async send(session: AgentSession, message: string): Promise<void> {
+  async send(session: AgentSession, message: string): Promise<AcpxTurn> {
     const entry = this.sessions.get(session.id);
-    if (!entry) return;
-
-    try {
-      execSync(
-        `tmux -L grove send-keys -t ${shellEscape(session.id)} ${shellEscape(message)} Enter`,
-        { encoding: "utf-8", stdio: "pipe" },
-      );
-    } catch {
-      // Session may have been killed externally — mark as crashed
-      entry.session = { ...entry.session, status: "crashed" };
+    if (entry) {
+      try {
+        execSync(
+          `tmux -L grove send-keys -t ${shellEscape(session.id)} ${shellEscape(message)} Enter`,
+          { encoding: "utf-8", stdio: "pipe" },
+        );
+      } catch {
+        // Session may have been killed externally — mark as crashed
+        entry.session = { ...entry.session, status: "crashed" };
+      }
     }
+    return emptyTurn(session.id);
   }
 
   async close(session: AgentSession): Promise<void> {

--- a/src/core/tmux-runtime.ts
+++ b/src/core/tmux-runtime.ts
@@ -17,6 +17,17 @@ import { shellEscape } from "./shell-utils.js";
  * Use `errorTurn()` on delivery failure — a synthetic `end_turn` on a
  * failed send-keys would silently hide non-delivery from callers who
  * watch `turn.result`.
+ *
+ * IMPORTANT — semantics of this success turn:
+ *   `end_turn` here means "tmux accepted the keystrokes", NOT "the agent
+ *   process consumed the prompt". The pane may have fallen back to a
+ *   shell, the agent may have died, or the keystrokes may have been sent
+ *   to a non-agent foreground process. Callers that need agent-level
+ *   delivery acknowledgement must use the acpx-backed runtime; with
+ *   tmux, this is best-effort. This is unavoidable — tmux does not
+ *   expose an agent-level ACK channel — so the typed-turn contract
+ *   degrades to write-ACK in this fallback mode. Documented rather than
+ *   papered over with a synthetic ACK.
  */
 function emptyTurn(sessionId: string): AcpxTurn {
   return {

--- a/src/core/tmux-runtime.ts
+++ b/src/core/tmux-runtime.ts
@@ -14,6 +14,9 @@ import { shellEscape } from "./shell-utils.js";
 /**
  * TmuxRuntime does not produce ACP output. Return an already-settled
  * AcpxTurn so the interface is satisfied without misleading the consumer.
+ * Use `errorTurn()` on delivery failure — a synthetic `end_turn` on a
+ * failed send-keys would silently hide non-delivery from callers who
+ * watch `turn.result`.
  */
 function emptyTurn(sessionId: string): AcpxTurn {
   return {
@@ -23,6 +26,24 @@ function emptyTurn(sessionId: string): AcpxTurn {
       /* no messages */
     })(),
     result: Promise.resolve({ turnId: `${sessionId}-noacp`, stopReason: "end_turn" as const }),
+    cancel: async () => undefined,
+    close: async () => undefined,
+  };
+}
+
+function errorTurn(sessionId: string, code: string, message: string): AcpxTurn {
+  const turnId = `${sessionId}-noacp-err`;
+  return {
+    sessionId,
+    turnId,
+    messages: (async function* () {
+      /* no messages */
+    })(),
+    result: Promise.resolve({
+      turnId,
+      stopReason: "error" as const,
+      error: { code, message },
+    }),
     cancel: async () => undefined,
     close: async () => undefined,
   };
@@ -111,16 +132,24 @@ export class TmuxRuntime implements AgentRuntime {
 
   async send(session: AgentSession, message: string): Promise<AcpxTurn> {
     const entry = this.sessions.get(session.id);
-    if (entry) {
-      try {
-        execSync(
-          `tmux -L grove send-keys -t ${shellEscape(session.id)} ${shellEscape(message)} Enter`,
-          { encoding: "utf-8", stdio: "pipe" },
-        );
-      } catch {
-        // Session may have been killed externally — mark as crashed
-        entry.session = { ...entry.session, status: "crashed" };
-      }
+    if (!entry) {
+      return errorTurn(session.id, "no_session", `unknown tmux session: ${session.id}`);
+    }
+    try {
+      execSync(
+        `tmux -L grove send-keys -t ${shellEscape(session.id)} ${shellEscape(message)} Enter`,
+        { encoding: "utf-8", stdio: "pipe" },
+      );
+    } catch (err) {
+      // Session may have been killed externally — mark as crashed and
+      // report the delivery failure so callers that watch turn.result
+      // see a non-success outcome instead of a synthetic end_turn.
+      entry.session = { ...entry.session, status: "crashed" };
+      return errorTurn(
+        session.id,
+        "send_keys_failed",
+        err instanceof Error ? err.message : String(err),
+      );
     }
     return emptyTurn(session.id);
   }

--- a/src/tui/nexus-ws-bridge.test.ts
+++ b/src/tui/nexus-ws-bridge.test.ts
@@ -6,10 +6,24 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AcpxTurn } from "../acp/types.js";
 import type { AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import type { GroveEvent } from "../core/event-bus.js";
 import { LocalEventBus } from "../core/local-event-bus.js";
 import { NexusWsBridge, type NexusWsBridgeOptions } from "./nexus-ws-bridge.js";
+
+function makeNoAcpTurn(sessionId: string): AcpxTurn {
+  return {
+    sessionId,
+    turnId: `${sessionId}-noacp`,
+    messages: (async function* () {
+      /* no messages */
+    })(),
+    result: Promise.resolve({ turnId: `${sessionId}-noacp`, stopReason: "end_turn" as const }),
+    cancel: async () => undefined,
+    close: async () => undefined,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Mock factories
@@ -26,7 +40,7 @@ function makeSession(role: string): AgentSession {
 function makeMockRuntime(): AgentRuntime {
   return {
     spawn: mock(() => Promise.resolve(makeSession("mock"))),
-    send: mock(() => Promise.resolve()),
+    send: mock((session: AgentSession) => Promise.resolve(makeNoAcpTurn(session.id))),
     close: mock(() => Promise.resolve()),
     // biome-ignore lint/suspicious/noEmptyBlockStatements: mock no-op
     onIdle: mock(() => {}),

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -13,7 +13,6 @@
  * to avoid corrupting the alternate screen.
  */
 
-import { watchTurnError } from "../acp/watch-turn.js";
 import type { AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import type { EventBus, GroveEvent } from "../core/event-bus.js";
 import type { HandoffStore } from "../core/handoff.js";
@@ -227,7 +226,7 @@ export class NexusWsBridge {
       } catch {
         /* non-fatal */
       }
-      void this.readAndPush(event.path, role, session, event.sender);
+      void this.readAndPush(event.path, role, session, event.sender, event.message_id);
     } catch {
       // Skip malformed events
     }
@@ -295,11 +294,59 @@ export class NexusWsBridge {
     }
   }
 
+  /**
+   * Dead-letter a handoff when local agent push fails after the Nexus
+   * inbox already acknowledged delivery. Keeps the data-integrity story
+   * from leaving a permanent false-positive "delivered" state when the
+   * target agent never actually received the prompt.
+   *
+   * Full remediation (splitting the `delivered` state into
+   * `inbox_delivered` vs `agent_received`) is out of scope for the
+   * turn-typing migration and tracked as a follow-up.
+   */
+  private async markHandoffDeadLettered(
+    ipcMessageId: string | undefined,
+    targetRole: string,
+    sender: string | undefined,
+    reason: string,
+  ): Promise<void> {
+    try {
+      const store = this.opts.handoffStore;
+      if (!store || !ipcMessageId) return;
+
+      const handoffs = await store.list({ toRole: targetRole });
+      let matching = handoffs.find((h) => h.ipcMessageId === ipcMessageId);
+      if (!matching && sender) {
+        matching = handoffs
+          .filter(
+            (h) =>
+              h.fromRole === sender && (h.status === "pending_pickup" || h.status === "delivered"),
+          )
+          .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+      }
+      if (!matching) return;
+
+      await store.markDeadLettered(matching.handoffId);
+      process.stderr.write(
+        `[NexusWsBridge] dead-lettered handoffId=${matching.handoffId} role=${targetRole}: ${reason}\n`,
+      );
+
+      const cacheable = store as { invalidateCache?: () => void };
+      cacheable.invalidateCache?.();
+    } catch (err) {
+      debugLog(
+        "wsBridge.markHandoffDeadLettered",
+        `FAIL ipcMessageId=${ipcMessageId} err=${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   private async readAndPush(
     path: string,
     _targetRole: string,
     session: AgentSession,
     sender: string,
+    ipcMessageId?: string,
   ): Promise<void> {
     try {
       // Retry on 429 (rate limit) — the inbox read is critical for IPC delivery.
@@ -354,25 +401,48 @@ export class NexusWsBridge {
         `delivering to session=${session.id} role=${_targetRole} notification=${notification.slice(0, 80)}`,
       );
 
-      // NOTE: the handoff has already been marked `delivered` upstream when
-      // the Nexus inbox SSE fired (see handleEvent → updateHandoffDeliveryStatus).
-      // If the local runtime.send below fails to hand the prompt to the
-      // agent, the handoff state will still read "delivered" — recovery
-      // would require a richer state machine ("inbox_delivered" vs
-      // "agent_received"), which is out of scope for this PR. In the
-      // meantime, escalate the log target from the debug channel to stderr
-      // so operators at least see the divergence instead of discovering it
-      // through a stalled agent.
+      // The handoff has already been marked `delivered` upstream on the
+      // Nexus inbox SSE. Full separation of "inbox delivered" vs "agent
+      // received" is out of scope for the turn-typing migration — but when
+      // the local push below actually fails, we at least move the handoff
+      // to the dead-letter state so recovery tooling can see it instead
+      // of treating the stale "delivered" record as the final truth.
       void this.opts.runtime
         .send(session, notification)
-        .then((turn) => {
-          watchTurnError(turn, `NexusWsBridge.readAndPush(role=${_targetRole})`, (m) =>
-            process.stderr.write(`${m}\n`),
-          );
+        .then(async (turn) => {
+          const result = await turn.result.catch((err) => ({
+            turnId: turn.turnId,
+            stopReason: "error" as const,
+            error: {
+              code: "turn_rejected",
+              message: err instanceof Error ? err.message : String(err),
+            },
+          }));
+          if (result.stopReason === "error") {
+            const detail = result.error
+              ? `${result.error.code}: ${result.error.message}`
+              : "unknown error";
+            process.stderr.write(
+              `[NexusWsBridge] local push failed for role=${_targetRole} turn=${turn.turnId}: ${detail}\n`,
+            );
+            await this.markHandoffDeadLettered(
+              ipcMessageId,
+              _targetRole,
+              sender,
+              `local push error: ${detail}`,
+            );
+          }
         })
-        .catch((err) => {
+        .catch(async (err) => {
+          const detail = err instanceof Error ? err.message : String(err);
           process.stderr.write(
-            `[NexusWsBridge] runtime.send rejected for role=${_targetRole}: ${err instanceof Error ? err.message : String(err)}\n`,
+            `[NexusWsBridge] runtime.send rejected for role=${_targetRole}: ${detail}\n`,
+          );
+          await this.markHandoffDeadLettered(
+            ipcMessageId,
+            _targetRole,
+            sender,
+            `runtime.send rejected: ${detail}`,
           );
         });
     } catch {

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -423,10 +423,14 @@ export class NexusWsBridge {
               message: err instanceof Error ? err.message : String(err),
             },
           }));
-          if (result.stopReason === "error") {
+          // For control-plane delivery, `end_turn` is the only success
+          // signal. Treat cancelled / max_tokens / error / unknown stop
+          // reasons all as delivery failures so the handoff is dead-
+          // lettered — matches watchTurnError's abnormal-terminal policy.
+          if (result.stopReason !== "end_turn") {
             const detail = result.error
               ? `${result.error.code}: ${result.error.message}`
-              : "unknown error";
+              : `stopReason=${result.stopReason}`;
             process.stderr.write(
               `[NexusWsBridge] local push failed for role=${_targetRole} turn=${turn.turnId}: ${detail}\n`,
             );
@@ -434,7 +438,7 @@ export class NexusWsBridge {
               ipcMessageId,
               _targetRole,
               sender,
-              `local push error: ${detail}`,
+              `local push abnormal: ${detail}`,
             );
           }
         })

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -354,15 +354,26 @@ export class NexusWsBridge {
         `delivering to session=${session.id} role=${_targetRole} notification=${notification.slice(0, 80)}`,
       );
 
+      // NOTE: the handoff has already been marked `delivered` upstream when
+      // the Nexus inbox SSE fired (see handleEvent → updateHandoffDeliveryStatus).
+      // If the local runtime.send below fails to hand the prompt to the
+      // agent, the handoff state will still read "delivered" — recovery
+      // would require a richer state machine ("inbox_delivered" vs
+      // "agent_received"), which is out of scope for this PR. In the
+      // meantime, escalate the log target from the debug channel to stderr
+      // so operators at least see the divergence instead of discovering it
+      // through a stalled agent.
       void this.opts.runtime
         .send(session, notification)
         .then((turn) => {
           watchTurnError(turn, `NexusWsBridge.readAndPush(role=${_targetRole})`, (m) =>
-            debugLog("wsBridge.readAndPush", m),
+            process.stderr.write(`${m}\n`),
           );
         })
-        .catch(() => {
-          /* non-fatal */
+        .catch((err) => {
+          process.stderr.write(
+            `[NexusWsBridge] runtime.send rejected for role=${_targetRole}: ${err instanceof Error ? err.message : String(err)}\n`,
+          );
         });
     } catch {
       // Non-fatal

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -307,24 +307,29 @@ export class NexusWsBridge {
   private async markHandoffDeadLettered(
     ipcMessageId: string | undefined,
     targetRole: string,
-    sender: string | undefined,
+    _sender: string | undefined,
     reason: string,
   ): Promise<void> {
     try {
       const store = this.opts.handoffStore;
       if (!store || !ipcMessageId) return;
 
+      // Require exact `ipcMessageId` correlation. Dead-letter is a terminal
+      // state, so the sender-based fallback that updateHandoffDeliveryStatus
+      // uses for marking delivered is too loose here: if ipcMessageId is not
+      // yet linked to any handoff, the "most recent from sender" heuristic
+      // could terminally dead-letter a neighbouring handoff while the real
+      // failure quietly stays `delivered`. Prefer deferring — another pass
+      // after setIpcMessageId() lands can still dead-letter correctly.
       const handoffs = await store.list({ toRole: targetRole });
-      let matching = handoffs.find((h) => h.ipcMessageId === ipcMessageId);
-      if (!matching && sender) {
-        matching = handoffs
-          .filter(
-            (h) =>
-              h.fromRole === sender && (h.status === "pending_pickup" || h.status === "delivered"),
-          )
-          .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+      const matching = handoffs.find((h) => h.ipcMessageId === ipcMessageId);
+      if (!matching) {
+        debugLog(
+          "wsBridge.markHandoffDeadLettered",
+          `NO EXACT MATCH ipcMessageId=${ipcMessageId} role=${targetRole} — deferring`,
+        );
+        return;
       }
-      if (!matching) return;
 
       await store.markDeadLettered(matching.handoffId);
       process.stderr.write(

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -13,6 +13,7 @@
  * to avoid corrupting the alternate screen.
  */
 
+import { watchTurnError } from "../acp/watch-turn.js";
 import type { AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import type { EventBus, GroveEvent } from "../core/event-bus.js";
 import type { HandoffStore } from "../core/handoff.js";
@@ -353,9 +354,16 @@ export class NexusWsBridge {
         `delivering to session=${session.id} role=${_targetRole} notification=${notification.slice(0, 80)}`,
       );
 
-      void this.opts.runtime.send(session, notification).catch(() => {
-        /* non-fatal */
-      });
+      void this.opts.runtime
+        .send(session, notification)
+        .then((turn) => {
+          watchTurnError(turn, `NexusWsBridge.readAndPush(role=${_targetRole})`, (m) =>
+            debugLog("wsBridge.readAndPush", m),
+          );
+        })
+        .catch(() => {
+          /* non-fatal */
+        });
     } catch {
       // Non-fatal
     }

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -12,6 +12,7 @@ import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
+import { watchTurnError } from "../acp/watch-turn.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import type { AgentIdentity } from "../core/models.js";
 import { resolveMcpServePath } from "../core/resolve-mcp-serve-path.js";
@@ -787,8 +788,15 @@ export class SpawnManager {
             // guaranteed way to push text into the agent's tmux session.
             debugLog("route", `direct: agentRuntime.send(sessionId=${session.id})`);
             try {
-              await this.agentRuntime.send(session, message);
+              // send() resolution only means the child process was started;
+              // post-spawn failures land on turn.result as stopReason:"error".
+              // Drain in the background so a failed handoff is at least
+              // visible to operators instead of silently marked delivered.
+              const turn = await this.agentRuntime.send(session, message);
               debugLog("route", `agentRuntime.send succeeded`);
+              watchTurnError(turn, `route ${sourceRole}→${targetRole}`, (m) =>
+                debugLog("route", m),
+              );
             } catch (sendErr) {
               debugLog(
                 "route",
@@ -799,8 +807,11 @@ export class SpawnManager {
             // Local path (no Nexus): direct runtime.send() is the only delivery mechanism.
             debugLog("route", `local path: calling agentRuntime.send(sessionId=${session.id})`);
             try {
-              await this.agentRuntime.send(session, message);
+              const turn = await this.agentRuntime.send(session, message);
               debugLog("route", `agentRuntime.send completed for sessionId=${session.id}`);
+              watchTurnError(turn, `route ${sourceRole}→${targetRole}`, (m) =>
+                debugLog("route", m),
+              );
             } catch (sendErr) {
               debugLog(
                 "route",
@@ -829,7 +840,8 @@ export class SpawnManager {
 
     for (const [spawnId, session] of this.agentSessions) {
       if (spawnId.startsWith(role)) {
-        await this.agentRuntime.send(session, message);
+        const turn = await this.agentRuntime.send(session, message);
+        watchTurnError(turn, `sendToAgent(${role})`, (m) => debugLog("route", m));
         return true;
       }
     }

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -794,9 +794,14 @@ export class SpawnManager {
               // visible to operators instead of silently marked delivered.
               const turn = await this.agentRuntime.send(session, message);
               debugLog("route", `agentRuntime.send succeeded`);
-              watchTurnError(turn, `route ${sourceRole}→${targetRole}`, (m) =>
-                debugLog("route", m),
-              );
+              // Surface post-spawn delivery failures through stderr too —
+              // debugLog is gated behind GROVE_DEBUG=1, so in normal
+              // operation a silent turn.result error would make failed
+              // routing invisible to the operator.
+              watchTurnError(turn, `route ${sourceRole}→${targetRole}`, (m) => {
+                debugLog("route", m);
+                process.stderr.write(`${m}\n`);
+              });
             } catch (sendErr) {
               debugLog(
                 "route",
@@ -809,9 +814,14 @@ export class SpawnManager {
             try {
               const turn = await this.agentRuntime.send(session, message);
               debugLog("route", `agentRuntime.send completed for sessionId=${session.id}`);
-              watchTurnError(turn, `route ${sourceRole}→${targetRole}`, (m) =>
-                debugLog("route", m),
-              );
+              // Surface post-spawn delivery failures through stderr too —
+              // debugLog is gated behind GROVE_DEBUG=1, so in normal
+              // operation a silent turn.result error would make failed
+              // routing invisible to the operator.
+              watchTurnError(turn, `route ${sourceRole}→${targetRole}`, (m) => {
+                debugLog("route", m);
+                process.stderr.write(`${m}\n`);
+              });
             } catch (sendErr) {
               debugLog(
                 "route",
@@ -841,7 +851,10 @@ export class SpawnManager {
     for (const [spawnId, session] of this.agentSessions) {
       if (spawnId.startsWith(role)) {
         const turn = await this.agentRuntime.send(session, message);
-        watchTurnError(turn, `sendToAgent(${role})`, (m) => debugLog("route", m));
+        watchTurnError(turn, `sendToAgent(${role})`, (m) => {
+          debugLog("route", m);
+          process.stderr.write(`${m}\n`);
+        });
         return true;
       }
     }

--- a/src/tui/store-backed-provider.ts
+++ b/src/tui/store-backed-provider.ts
@@ -131,6 +131,18 @@ export abstract class StoreBackedProvider
   protected readonly goalSession: GoalSessionStore | undefined;
   protected readonly handoffs: HandoffStore | undefined;
 
+  /**
+   * Public accessor for the handoff store. NexusWsBridge needs direct
+   * access to mark handoffs delivered / dead-lettered in response to IPC
+   * lifecycle events; without this, the bridge's bookkeeping would be
+   * dead code in production because the store is only passed through the
+   * provider's constructor. Returns undefined for backends without
+   * handoff support.
+   */
+  getHandoffStore(): HandoffStore | undefined {
+    return this.handoffs;
+  }
+
   /** Set by {@link setSessionScope} — scopes all contribution queries to this session. */
   protected activeSessionId: string | undefined;
 

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -305,12 +305,25 @@ export const TuiApp: React.NamedExoticComponent<TuiAppProps> = React.memo(functi
       void import("./nexus-ws-bridge.js")
         .then(({ NexusWsBridge }) => {
           debugLog("wsBridge", `creating NexusWsBridge at ${nexusUrl}`);
+          // Extract handoffStore from the provider so the bridge can mark
+          // handoffs delivered / dead-lettered on IPC lifecycle events.
+          // Without this thread, the bridge's handoff bookkeeping is dead
+          // code in production (opts.handoffStore would be undefined and
+          // every store-touching path short-circuits).
+          const maybeProvider = appProps.provider as {
+            getHandoffStore?: () => import("../core/handoff.js").HandoffStore | undefined;
+          };
+          const handoffStore =
+            typeof maybeProvider.getHandoffStore === "function"
+              ? maybeProvider.getHandoffStore()
+              : undefined;
           const bridge = new NexusWsBridge({
             topology: topo,
             runtime: agentRuntime,
             nexusUrl,
             apiKey,
             eventBus: appProps.eventBus,
+            handoffStore,
             onBeforeDeliver: (sender, recipient) => {
               // Rsync workspace files from sender to recipient before IPC delivery
               manager.syncWorkspaces(sender, recipient);

--- a/tests/e2e/handoff-deadline-e2e.test.ts
+++ b/tests/e2e/handoff-deadline-e2e.test.ts
@@ -200,6 +200,10 @@ describe("handoff deadline E2E", () => {
     expect(watcher.activeCount).toBe(0);
   });
 
+  // Generous 55s waitFor window + 60s test budget: shared CI runners can
+  // stall the event loop for 10s+ under load, which previously turned this
+  // into an intermittent red CI job. Happy path still completes in <1s —
+  // the big budget only applies when the runner is saturated.
   test("overdue handoff emits handoff.overdue event", async () => {
     const { handoffStore, bus } = await setup();
 
@@ -220,8 +224,14 @@ describe("handoff deadline E2E", () => {
     const watcher = new DeadlineWatcher({ handoffStore, eventBus: bus });
     watcher.watch(h);
 
-    // Wait for deadline to pass + timer to fire
-    await new Promise((r) => setTimeout(r, 300));
+    // Poll for the overdue event instead of sleeping a fixed duration —
+    // CI runners occasionally stall past 300ms and turn a fixed sleep
+    // into a flake. Poll every 10ms up to 55s.
+    const deadline = Date.now() + 55_000;
+    while (Date.now() < deadline) {
+      if (events.some((e) => e.type === "handoff.overdue")) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
 
     // Should have emitted handoff.overdue
     const overdueEvents = events.filter((e) => e.type === "handoff.overdue");
@@ -230,7 +240,7 @@ describe("handoff deadline E2E", () => {
     expect(overdueEvents[0]?.targetRole).toBe("reviewer");
 
     watcher.close();
-  });
+  }, 60_000);
 
   test("rebuildFromStore skips unscoped SQLite stores (no session scoping)", async () => {
     const { handoffStore, bus } = await setup();

--- a/tests/e2e/handoff-deadline-e2e.test.ts
+++ b/tests/e2e/handoff-deadline-e2e.test.ts
@@ -200,10 +200,13 @@ describe("handoff deadline E2E", () => {
     expect(watcher.activeCount).toBe(0);
   });
 
-  // Generous 55s waitFor window + 60s test budget: shared CI runners can
-  // stall the event loop for 10s+ under load, which previously turned this
-  // into an intermittent red CI job. Happy path still completes in <1s —
-  // the big budget only applies when the runner is saturated.
+  // Past-dates the handoff deliberately so watch() takes the delayMs=0
+  // setTimeout path. A 0ms timer fires on the very next tick, which sidesteps
+  // the Bun full-suite flake where a future-dated setTimeout(100ms) could
+  // sit unfired for >55s under load (observed on CI with both ref'd and
+  // unref'd timers). The "already past" branch is the one a restarted
+  // process would hit when rebuilding timers on startup for overdue rows,
+  // so it's a realistic path to cover.
   test("overdue handoff emits handoff.overdue event", async () => {
     const { handoffStore, bus } = await setup();
 
@@ -211,36 +214,32 @@ describe("handoff deadline E2E", () => {
     const events: GroveEvent[] = [];
     bus.subscribe("reviewer", (e) => events.push(e));
 
-    // Create a handoff with a very short deadline (we'll manually create one)
     const h = await handoffStore.create({
       sourceCid: "blake3:test-overdue",
       fromRole: "coder",
       toRole: "reviewer",
       requiresReply: true,
-      replyDueAt: new Date(Date.now() + 100).toISOString(), // 100ms
+      replyDueAt: new Date(Date.now() - 10).toISOString(),
     });
 
-    // Register with deadline watcher
+    // Register with deadline watcher — delayMs clamps to 0 since the
+    // deadline is already past.
     const watcher = new DeadlineWatcher({ handoffStore, eventBus: bus, unrefTimers: false });
     watcher.watch(h);
 
-    // Poll for the overdue event instead of sleeping a fixed duration —
-    // CI runners occasionally stall past 300ms and turn a fixed sleep
-    // into a flake. Poll every 10ms up to 55s.
-    const deadline = Date.now() + 55_000;
-    while (Date.now() < deadline) {
-      if (events.some((e) => e.type === "handoff.overdue")) break;
-      await new Promise((r) => setTimeout(r, 10));
+    // Wait for the 0ms timer + async onDeadlineFired to complete.
+    // A handful of short macrotask ticks is enough; cap at 2s for CI safety.
+    for (let i = 0; i < 40 && events.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 50));
     }
 
-    // Should have emitted handoff.overdue
     const overdueEvents = events.filter((e) => e.type === "handoff.overdue");
     expect(overdueEvents).toHaveLength(1);
     expect(overdueEvents[0]?.payload.handoffId).toBe(h.handoffId);
     expect(overdueEvents[0]?.targetRole).toBe("reviewer");
 
     watcher.close();
-  }, 60_000);
+  });
 
   test("rebuildFromStore skips unscoped SQLite stores (no session scoping)", async () => {
     const { handoffStore, bus } = await setup();

--- a/tests/e2e/handoff-deadline-e2e.test.ts
+++ b/tests/e2e/handoff-deadline-e2e.test.ts
@@ -71,7 +71,7 @@ describe("handoff deadline E2E", () => {
     expect(delegatesEdge?.replyTimeoutSeconds).toBe(30);
 
     const router = new TopologyRouter(topology, bus);
-    const watcher = new DeadlineWatcher({ handoffStore, eventBus: bus });
+    const watcher = new DeadlineWatcher({ handoffStore, eventBus: bus, unrefTimers: false });
 
     const deps: OperationDeps = {
       contributionStore,
@@ -221,7 +221,7 @@ describe("handoff deadline E2E", () => {
     });
 
     // Register with deadline watcher
-    const watcher = new DeadlineWatcher({ handoffStore, eventBus: bus });
+    const watcher = new DeadlineWatcher({ handoffStore, eventBus: bus, unrefTimers: false });
     watcher.watch(h);
 
     // Poll for the overdue event instead of sleeping a fixed duration —
@@ -256,7 +256,7 @@ describe("handoff deadline E2E", () => {
       replyDueAt: new Date(Date.now() + 60_000).toISOString(),
     });
 
-    const watcher2 = new DeadlineWatcher({ handoffStore, eventBus: bus });
+    const watcher2 = new DeadlineWatcher({ handoffStore, eventBus: bus, unrefTimers: false });
     const count = await watcher2.rebuildFromStore();
 
     expect(count).toBe(0);
@@ -280,7 +280,11 @@ describe("handoff deadline E2E", () => {
         replyDueAt: new Date(Date.now() + 60_000).toISOString(),
       });
 
-      const watcher2 = new DeadlineWatcher({ handoffStore: scoped, eventBus: bus });
+      const watcher2 = new DeadlineWatcher({
+        handoffStore: scoped,
+        eventBus: bus,
+        unrefTimers: false,
+      });
       const count = await watcher2.rebuildFromStore();
 
       expect(count).toBe(1);


### PR DESCRIPTION
Closes #260. Sub-spec 1 of 3 from parent #202. Builds on #259 (typed ACP message module).

## Summary

- `AgentRuntime.send` now returns `Promise<AcpxTurn>` (typed message stream + terminal `Result`) instead of `Promise<void>`; `onOutput` callback is removed.
- `AcpxRuntime` spawns `acpx --format json --json-strict --approve-all …`, wraps the child stdout in `AcpxTurnImpl`, keeps log-file mirroring, and cancels via SIGINT.
- `MockRuntime` returns queueable turns via new `enqueueMessages()` / `enqueueResult()` helpers — each `send()` drains both queues so turns don't bleed across calls.
- `TmuxRuntime` and `SubprocessRuntime` do not produce ACP output; each returns an already-settled empty `AcpxTurn` so the interface is satisfied honestly.
- `SessionOrchestrator`'s duck-type probe (`"sendAsync" in runtime`) renamed to match the new `startTurn` helper on `AcpxRuntime`.

## Plan reference

Tasks 6–9, 13 from \`docs/superpowers/plans/2026-04-16-acp-typed-message-streams.md\`. Tasks 10–12 (Nexus publisher, integration, E2E) are out of scope for this issue.

## Test plan

- [x] \`bun run tsc --noEmit\` clean
- [x] \`bun run biome check src tests\` clean
- [x] \`rg -n "onOutput" src tests\` returns no matches
- [x] New component test \`src/core/acpx-runtime.component.test.ts\` skips cleanly when acpx is absent and exercises the typed turn when available
- [x] New \`src/core/mock-runtime.test.ts\` covers enqueue helpers, per-turn queue drain, and reset
- [x] \`bun test\` — 5450 pass / 1 fail. The single failure is \`src/cli/main.tui-dispatch.test.ts > bare grove does not exit with usage error\`, a pre-existing 15s-timeout flake that reproduces on \`origin/main\` before any changes in this branch