### PR TITLE
fix(runtime): centralize agent session ID contract (#210)

### DIFF
--- a/src/cli/main.tui-dispatch.test.ts
+++ b/src/cli/main.tui-dispatch.test.ts
@@ -16,8 +16,13 @@ describe("bare grove → TUI dispatch", () => {
     // render. The key assertion: it should NOT exit with code 2
     // ("unknown command"). We give it 5s then kill it — if it hasn't
     // exited with code 2 by then, it successfully reached the TUI path.
+    //
+    // stdout is "ignore" because the TUI emits a continuous stream of
+    // ANSI escape codes; if we piped it without draining, the child's
+    // stdout buffer would fill in <1s, the TUI would block on write,
+    // and SIGTERM cleanup would hang past the outer test timeout.
     const proc = Bun.spawn(["bun", "run", CLI_PATH], {
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
       env: { ...process.env, TERM: "dumb" },
     });
@@ -37,9 +42,12 @@ describe("bare grove → TUI dispatch", () => {
     if (result.kind === "timeout") {
       // Process is still running (TUI is blocking) — this means it
       // successfully dispatched to handleTuiDirect and didn't exit with
-      // "unknown command"
+      // "unknown command". SIGTERM first; SIGKILL after a grace period
+      // in case the TUI traps the signal and stalls in cleanup.
       proc.kill();
+      const killTimer = setTimeout(() => proc.kill("SIGKILL"), 2000);
       await proc.exited;
+      clearTimeout(killTimer);
     } else {
       // Process exited — verify it wasn't a usage error
       const stderr = await new Response(proc.stderr).text();

--- a/src/core/acpx-runtime.test.ts
+++ b/src/core/acpx-runtime.test.ts
@@ -120,9 +120,9 @@ describe("AcpxRuntime", () => {
 
     const rt = new AcpxRuntime();
     // Session names now carry a per-spawn counter and a base36 timestamp:
-    // grove-<role>-<counter>-<timestamp>
+    // grove-<role>-<counter>--<timestamp> (double dash separator).
     const session = await rt.spawn("test", config);
-    expect(session.id).toMatch(/^grove-test-\d+-[a-z0-9]+$/);
+    expect(session.id).toMatch(/^grove-test-\d+--[a-z0-9]+$/);
     expect(session.role).toBe("test");
     expect(session.status).toBe("running");
 

--- a/src/core/acpx-runtime.ts
+++ b/src/core/acpx-runtime.ts
@@ -12,6 +12,7 @@ import { execSync, spawn as nodeSpawn } from "node:child_process";
 import { createWriteStream, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
+import { buildSessionId, parseSessionId, SESSION_ID_PREFIX } from "./session-id.js";
 import { shellEscape } from "./shell-utils.js";
 import type { AgentPlatformType } from "./topology.js";
 
@@ -155,7 +156,7 @@ export class AcpxRuntime implements AgentRuntime {
     }
 
     const counter = this.nextId++;
-    const sessionName = `grove-${role}-${counter}-${Date.now().toString(36)}`;
+    const sessionName = buildSessionId(role, counter);
     const id = sessionName;
 
     // Strip Claude Code harness env vars before spawning the subagent.
@@ -514,9 +515,10 @@ ${message}`;
           const fields = line.split("\t");
           const name = (fields[1] ?? line).trim();
           const isClosed = line.includes("[closed]");
-          if (name.startsWith("grove-") && !seenIds.has(name) && !isClosed) {
-            const role = name.replace(/^grove-/, "").replace(/-\d+-.*$/, "");
-            result.push({ id: name, role, status: "idle", agent: agentName });
+          if (name.startsWith(SESSION_ID_PREFIX) && !seenIds.has(name) && !isClosed) {
+            const parsed = parseSessionId(name);
+            if (!parsed) continue;
+            result.push({ id: name, role: parsed.role, status: "idle", agent: agentName });
             seenIds.add(name);
           }
         }

--- a/src/core/acpx-runtime.ts
+++ b/src/core/acpx-runtime.ts
@@ -12,7 +12,7 @@ import { execSync, spawn as nodeSpawn } from "node:child_process";
 import { createWriteStream, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
-import { buildSessionId, parseSessionId, SESSION_ID_PREFIX } from "./session-id.js";
+import { buildSessionId, parseAcpxSessionId, SESSION_ID_PREFIX } from "./session-id.js";
 import { shellEscape } from "./shell-utils.js";
 import type { AgentPlatformType } from "./topology.js";
 
@@ -516,7 +516,11 @@ ${message}`;
           const name = (fields[1] ?? line).trim();
           const isClosed = line.includes("[closed]");
           if (name.startsWith(SESSION_ID_PREFIX) && !seenIds.has(name) && !isClosed) {
-            const parsed = parseSessionId(name);
+            // parseAcpxSessionId accepts the prior single-dash acpx contract
+            // so an upgrade still rediscovers agents created on the previous
+            // grove version. Source-narrow: safe here because acpx never
+            // returns TUI-shaped names.
+            const parsed = parseAcpxSessionId(name);
             if (!parsed) continue;
             result.push({ id: name, role: parsed.role, status: "idle", agent: agentName });
             seenIds.add(name);

--- a/src/core/agent-runtime.ts
+++ b/src/core/agent-runtime.ts
@@ -22,7 +22,16 @@ export interface AgentConfig {
   readonly model?: string | undefined;
 }
 
-/** A running agent session. */
+/**
+ * A running agent session.
+ *
+ * `id` follows the canonical contract documented in `./session-id.ts`:
+ * `grove-<role>-<counter>-<base36-timestamp>`. Implementations MUST construct
+ * IDs via `buildSessionId()` and consumers MUST parse them via
+ * `parseSessionId()` rather than open-coding regexes — this is what keeps
+ * `listSessions()` rediscovery and reattach/resume paths consistent across
+ * runtimes.
+ */
 export interface AgentSession {
   readonly id: string;
   readonly role: string;
@@ -38,7 +47,13 @@ export interface AgentSession {
 
 /** Runtime for managing agent lifecycle. */
 export interface AgentRuntime {
-  /** Spawn a new agent session. */
+  /**
+   * Spawn a new agent session.
+   *
+   * The returned `session.id` MUST be produced via `buildSessionId(role, n)`
+   * (see `./session-id.ts`). `listSessions()` MUST be able to rediscover any
+   * id this method returned for the lifetime of the underlying session.
+   */
   spawn(role: string, config: AgentConfig): Promise<AgentSession>;
   /** Send a message/prompt to a running agent. */
   send(session: AgentSession, message: string): Promise<void>;

--- a/src/core/session-id.test.ts
+++ b/src/core/session-id.test.ts
@@ -40,6 +40,23 @@ describe("session-id", () => {
     expect(parseSessionId("grove-")).toBeNull();
     expect(parseSessionId("grove-onlyrole")).toBeNull();
     expect(parseSessionId("grove-role-notanumber-suffix")).toBeNull();
-    expect(parseSessionId("grove-role-1")).toBeNull(); // missing suffix
+  });
+
+  test("parseSessionId accepts legacy grove-<role>-<counter> shape", () => {
+    // Pre-#210 tmux IDs lacked the base36 suffix. Rediscovery after upgrade
+    // must still find these sessions or live agents get marked dead.
+    const parsed = parseSessionId("grove-coder-3");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.role).toBe("coder");
+    expect(parsed!.counter).toBe(3);
+    expect(parsed!.suffix).toBeNull();
+  });
+
+  test("parseSessionId legacy shape supports hyphenated roles", () => {
+    const parsed = parseSessionId("grove-code-reviewer-12");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.role).toBe("code-reviewer");
+    expect(parsed!.counter).toBe(12);
+    expect(parsed!.suffix).toBeNull();
   });
 });

--- a/src/core/session-id.test.ts
+++ b/src/core/session-id.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { buildSessionId, parseSessionId, SESSION_ID_PREFIX } from "./session-id.js";
+import {
+  buildSessionId,
+  parseAcpxSessionId,
+  parseSessionId,
+  SESSION_ID_PREFIX,
+} from "./session-id.js";
 
 describe("session-id", () => {
   test("buildSessionId emits grove-<role>-<counter>--<base36>", () => {
@@ -77,5 +82,37 @@ describe("session-id", () => {
     // contract surface clean for use-permission-detection.
     expect(parseSessionId("grove-worker-1-mo3i3zh6")).toBeNull();
     expect(parseSessionId("grove-coder-mo3i3zh6")).toBeNull();
+  });
+});
+
+describe("parseAcpxSessionId", () => {
+  test("accepts canonical IDs", () => {
+    const id = buildSessionId("coder", 0);
+    const parsed = parseAcpxSessionId(id);
+    expect(parsed?.role).toBe("coder");
+    expect(parsed?.counter).toBe(0);
+    expect(parsed?.suffix).toMatch(/^[a-z0-9]+$/);
+  });
+
+  test("accepts pre-double-dash acpx shape (upgrade compatibility)", () => {
+    // Live agents created on the previous grove version have IDs shaped
+    // `grove-<role>-<counter>-<base36>` (single dashes). Rediscovery must
+    // still find them post-upgrade or claims/spawnRecords get cleaned up.
+    const parsed = parseAcpxSessionId("grove-coder-0-mo3i3zh6");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.role).toBe("coder");
+    expect(parsed!.counter).toBe(0);
+    expect(parsed!.suffix).toBe("mo3i3zh6");
+  });
+
+  test("accepts legacy <role>-<counter> shape", () => {
+    const parsed = parseAcpxSessionId("grove-worker-3");
+    expect(parsed?.role).toBe("worker");
+    expect(parsed?.counter).toBe(3);
+    expect(parsed?.suffix).toBeNull();
+  });
+
+  test("rejects non-grove names", () => {
+    expect(parseAcpxSessionId("foo-bar-0-abc")).toBeNull();
   });
 });

--- a/src/core/session-id.test.ts
+++ b/src/core/session-id.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { buildSessionId, parseSessionId, SESSION_ID_PREFIX } from "./session-id.js";
 
 describe("session-id", () => {
-  test("buildSessionId emits grove-<role>-<counter>-<base36>", () => {
+  test("buildSessionId emits grove-<role>-<counter>--<base36>", () => {
     const id = buildSessionId("coder", 0);
-    expect(id).toMatch(/^grove-coder-0-[a-z0-9]+$/);
+    expect(id).toMatch(/^grove-coder-0--[a-z0-9]+$/);
     expect(id.startsWith(SESSION_ID_PREFIX)).toBe(true);
   });
 
@@ -61,9 +61,9 @@ describe("session-id", () => {
   });
 
   test("legacy ID with role ending in digit segment is not misparsed as canonical", () => {
-    // Regression: `grove-worker-1-0` was being parsed as canonical
-    // (role=worker, counter=1, suffix=0) because the canonical regex matched
-    // greedily. The suffix-length gate forces this down the legacy branch.
+    // Regression: legacy `grove-worker-1-0` (role=worker-1, counter=0) was
+    // matching the old single-dash canonical regex as role=worker. Canonical
+    // now uses `--`, so single-dash names always go to the legacy branch.
     const parsed = parseSessionId("grove-worker-1-0");
     expect(parsed).not.toBeNull();
     expect(parsed!.role).toBe("worker-1");
@@ -71,13 +71,11 @@ describe("session-id", () => {
     expect(parsed!.suffix).toBeNull();
   });
 
-  test("canonical IDs with short or numeric-looking suffixes still parse legacy-style", () => {
-    // A 6-char numeric suffix could be legacy counter; only ≥7 chars qualify
-    // as canonical timestamp. This protects upgrade paths.
-    const parsed = parseSessionId("grove-coder-3-123456");
-    expect(parsed).not.toBeNull();
-    expect(parsed!.role).toBe("coder-3");
-    expect(parsed!.counter).toBe(123456);
-    expect(parsed!.suffix).toBeNull();
+  test("TUI-style names (single dash, no counter) return null", () => {
+    // The TUI's tmuxSessionName(agentId) shape `grove-<roleId>-<base36>` is
+    // not a runtime session — parser must NOT claim it. Keeps the runtime
+    // contract surface clean for use-permission-detection.
+    expect(parseSessionId("grove-worker-1-mo3i3zh6")).toBeNull();
+    expect(parseSessionId("grove-coder-mo3i3zh6")).toBeNull();
   });
 });

--- a/src/core/session-id.test.ts
+++ b/src/core/session-id.test.ts
@@ -59,4 +59,25 @@ describe("session-id", () => {
     expect(parsed!.counter).toBe(12);
     expect(parsed!.suffix).toBeNull();
   });
+
+  test("legacy ID with role ending in digit segment is not misparsed as canonical", () => {
+    // Regression: `grove-worker-1-0` was being parsed as canonical
+    // (role=worker, counter=1, suffix=0) because the canonical regex matched
+    // greedily. The suffix-length gate forces this down the legacy branch.
+    const parsed = parseSessionId("grove-worker-1-0");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.role).toBe("worker-1");
+    expect(parsed!.counter).toBe(0);
+    expect(parsed!.suffix).toBeNull();
+  });
+
+  test("canonical IDs with short or numeric-looking suffixes still parse legacy-style", () => {
+    // A 6-char numeric suffix could be legacy counter; only ≥7 chars qualify
+    // as canonical timestamp. This protects upgrade paths.
+    const parsed = parseSessionId("grove-coder-3-123456");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.role).toBe("coder-3");
+    expect(parsed!.counter).toBe(123456);
+    expect(parsed!.suffix).toBeNull();
+  });
 });

--- a/src/core/session-id.test.ts
+++ b/src/core/session-id.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { buildSessionId, parseSessionId, SESSION_ID_PREFIX } from "./session-id.js";
+
+describe("session-id", () => {
+  test("buildSessionId emits grove-<role>-<counter>-<base36>", () => {
+    const id = buildSessionId("coder", 0);
+    expect(id).toMatch(/^grove-coder-0-[a-z0-9]+$/);
+    expect(id.startsWith(SESSION_ID_PREFIX)).toBe(true);
+  });
+
+  test("buildSessionId produces distinct ids for sequential counters", () => {
+    const a = buildSessionId("test", 0);
+    const b = buildSessionId("test", 1);
+    expect(a).not.toBe(b);
+  });
+
+  test("parseSessionId round-trips builder output", () => {
+    const id = buildSessionId("reviewer", 42);
+    const parsed = parseSessionId(id);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.role).toBe("reviewer");
+    expect(parsed!.counter).toBe(42);
+    expect(parsed!.suffix).toMatch(/^[a-z0-9]+$/);
+  });
+
+  test("parseSessionId handles roles containing hyphens", () => {
+    const id = buildSessionId("send-test", 3);
+    const parsed = parseSessionId(id);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.role).toBe("send-test");
+    expect(parsed!.counter).toBe(3);
+  });
+
+  test("parseSessionId returns null for non-grove names", () => {
+    expect(parseSessionId("foo-bar-0-abc")).toBeNull();
+    expect(parseSessionId("")).toBeNull();
+  });
+
+  test("parseSessionId returns null when shape is malformed", () => {
+    expect(parseSessionId("grove-")).toBeNull();
+    expect(parseSessionId("grove-onlyrole")).toBeNull();
+    expect(parseSessionId("grove-role-notanumber-suffix")).toBeNull();
+    expect(parseSessionId("grove-role-1")).toBeNull(); // missing suffix
+  });
+});

--- a/src/core/session-id.ts
+++ b/src/core/session-id.ts
@@ -1,0 +1,51 @@
+/**
+ * Canonical contract for grove agent session IDs.
+ *
+ * Every {@link AgentRuntime} implementation MUST construct session IDs via
+ * {@link buildSessionId} and parse them via {@link parseSessionId}. This is
+ * the single source of truth for the on-disk / on-tmux / on-acpx name shape:
+ *
+ *     grove-<role>-<counter>-<base36-timestamp>
+ *
+ * - `role` is the orchestration role passed to `spawn()` (may contain hyphens).
+ * - `counter` is a monotonically increasing per-runtime integer used to
+ *   distinguish sessions spawned in the same millisecond.
+ * - `<base36-timestamp>` is `Date.now().toString(36)` and provides
+ *   cross-process / cross-restart uniqueness so that `listSessions()` can
+ *   safely rediscover sessions that outlive the runtime instance.
+ *
+ * Consumers should treat the full ID as opaque and use {@link parseSessionId}
+ * to recover `role`/`counter` rather than open-coding their own regex.
+ */
+
+export const SESSION_ID_PREFIX = "grove-";
+
+export interface ParsedSessionId {
+  readonly role: string;
+  readonly counter: number;
+  readonly suffix: string;
+}
+
+export function buildSessionId(role: string, counter: number): string {
+  return `${SESSION_ID_PREFIX}${role}-${counter}-${Date.now().toString(36)}`;
+}
+
+/**
+ * Parse a grove session ID emitted by {@link buildSessionId}.
+ *
+ * Returns `null` for any name that doesn't follow the canonical shape, which
+ * lets callers safely filter foreign tmux/acpx sessions out of discovery.
+ */
+export function parseSessionId(name: string): ParsedSessionId | null {
+  if (!name.startsWith(SESSION_ID_PREFIX)) return null;
+  const body = name.slice(SESSION_ID_PREFIX.length);
+  // Anchor on the last two `-`-separated segments: counter + suffix.
+  // Everything before is the role (which may itself contain hyphens).
+  const match = body.match(/^(.+)-(\d+)-([a-z0-9]+)$/);
+  if (!match) return null;
+  const [, role, counterStr, suffix] = match;
+  if (!role || !counterStr || !suffix) return null;
+  const counter = Number.parseInt(counterStr, 10);
+  if (!Number.isFinite(counter)) return null;
+  return { role, counter, suffix };
+}

--- a/src/core/session-id.ts
+++ b/src/core/session-id.ts
@@ -23,7 +23,12 @@ export const SESSION_ID_PREFIX = "grove-";
 export interface ParsedSessionId {
   readonly role: string;
   readonly counter: number;
-  readonly suffix: string;
+  /**
+   * Base36 timestamp suffix from {@link buildSessionId}. `null` when parsing
+   * a legacy ID (`grove-<role>-<counter>`) emitted by the older tmux contract,
+   * preserved here so post-upgrade rediscovery doesn't drop live sessions.
+   */
+  readonly suffix: string | null;
 }
 
 export function buildSessionId(role: string, counter: number): string {
@@ -31,21 +36,33 @@ export function buildSessionId(role: string, counter: number): string {
 }
 
 /**
- * Parse a grove session ID emitted by {@link buildSessionId}.
+ * Parse a grove session ID.
  *
- * Returns `null` for any name that doesn't follow the canonical shape, which
- * lets callers safely filter foreign tmux/acpx sessions out of discovery.
+ * Accepts both the canonical shape (`grove-<role>-<counter>-<base36>`) emitted
+ * by {@link buildSessionId} and the legacy pre-#210 shape
+ * (`grove-<role>-<counter>`). Returns `null` for anything else so callers can
+ * safely filter foreign tmux/acpx sessions out of discovery.
  */
 export function parseSessionId(name: string): ParsedSessionId | null {
   if (!name.startsWith(SESSION_ID_PREFIX)) return null;
   const body = name.slice(SESSION_ID_PREFIX.length);
-  // Anchor on the last two `-`-separated segments: counter + suffix.
-  // Everything before is the role (which may itself contain hyphens).
-  const match = body.match(/^(.+)-(\d+)-([a-z0-9]+)$/);
-  if (!match) return null;
-  const [, role, counterStr, suffix] = match;
-  if (!role || !counterStr || !suffix) return null;
-  const counter = Number.parseInt(counterStr, 10);
-  if (!Number.isFinite(counter)) return null;
-  return { role, counter, suffix };
+  // Try canonical first: <role>-<counter>-<base36-suffix>
+  const canonical = body.match(/^(.+)-(\d+)-([a-z0-9]+)$/);
+  if (canonical) {
+    const [, role, counterStr, suffix] = canonical;
+    if (role && counterStr && suffix) {
+      const counter = Number.parseInt(counterStr, 10);
+      if (Number.isFinite(counter)) return { role, counter, suffix };
+    }
+  }
+  // Legacy fallback: <role>-<counter> (no suffix).
+  const legacy = body.match(/^(.+)-(\d+)$/);
+  if (legacy) {
+    const [, role, counterStr] = legacy;
+    if (role && counterStr) {
+      const counter = Number.parseInt(counterStr, 10);
+      if (Number.isFinite(counter)) return { role, counter, suffix: null };
+    }
+  }
+  return null;
 }

--- a/src/core/session-id.ts
+++ b/src/core/session-id.ts
@@ -5,7 +5,7 @@
  * {@link buildSessionId} and parse them via {@link parseSessionId}. This is
  * the single source of truth for the on-disk / on-tmux / on-acpx name shape:
  *
- *     grove-<role>-<counter>-<base36-timestamp>
+ *     grove-<role>-<counter>--<base36-timestamp>
  *
  * - `role` is the orchestration role passed to `spawn()` (may contain hyphens).
  * - `counter` is a monotonically increasing per-runtime integer used to
@@ -14,11 +14,18 @@
  *   cross-process / cross-restart uniqueness so that `listSessions()` can
  *   safely rediscover sessions that outlive the runtime instance.
  *
+ * The `--` (double dash) between counter and timestamp is intentional: it
+ * disambiguates canonical IDs from the TUI's `grove-${agentId}` tmux session
+ * names (single dashes) and from legacy pre-#210 IDs (`grove-<role>-<counter>`,
+ * also single dashes), so a name like `grove-worker-1-mo3i3zh6` (TUI agent
+ * with role `worker-1`) is never misparsed as canonical role `worker`.
+ *
  * Consumers should treat the full ID as opaque and use {@link parseSessionId}
  * to recover `role`/`counter` rather than open-coding their own regex.
  */
 
 export const SESSION_ID_PREFIX = "grove-";
+const CANONICAL_SEPARATOR = "--";
 
 export interface ParsedSessionId {
   readonly role: string;
@@ -32,27 +39,24 @@ export interface ParsedSessionId {
 }
 
 export function buildSessionId(role: string, counter: number): string {
-  return `${SESSION_ID_PREFIX}${role}-${counter}-${Date.now().toString(36)}`;
+  return `${SESSION_ID_PREFIX}${role}-${counter}${CANONICAL_SEPARATOR}${Date.now().toString(36)}`;
 }
 
 /**
  * Parse a grove session ID.
  *
- * Accepts both the canonical shape (`grove-<role>-<counter>-<base36>`) emitted
- * by {@link buildSessionId} and the legacy pre-#210 shape
- * (`grove-<role>-<counter>`). Returns `null` for anything else so callers can
- * safely filter foreign tmux/acpx sessions out of discovery.
+ * Accepts both the canonical shape (`grove-<role>-<counter>--<base36>`)
+ * emitted by {@link buildSessionId} and the legacy pre-#210 shape
+ * (`grove-<role>-<counter>`). Returns `null` for anything else (notably the
+ * TUI's `grove-${agentId}` tmux convention) so callers can safely filter
+ * non-runtime sessions out of discovery.
  */
 export function parseSessionId(name: string): ParsedSessionId | null {
   if (!name.startsWith(SESSION_ID_PREFIX)) return null;
   const body = name.slice(SESSION_ID_PREFIX.length);
-  // Canonical: <role>-<counter>-<base36-suffix>.
-  // Suffix length is gated at 7 to disambiguate from legacy IDs whose role
-  // ends in a digit segment (e.g. `worker-1`). `Date.now().toString(36)` is
-  // 8 chars today and won't drop below 7 until well after year 5000, so
-  // every real builder output passes this gate while legacy counter tails
-  // (typically 1–4 digits) are forced down the legacy branch below.
-  const canonical = body.match(/^(.+)-(\d+)-([a-z0-9]{7,})$/);
+  // Canonical: <role>-<counter>--<base36-suffix>. The double-dash separator
+  // is what makes parsing unambiguous against single-dash conventions.
+  const canonical = body.match(/^(.+)-(\d+)--([a-z0-9]+)$/);
   if (canonical) {
     const [, role, counterStr, suffix] = canonical;
     if (role && counterStr && suffix) {
@@ -60,7 +64,9 @@ export function parseSessionId(name: string): ParsedSessionId | null {
       if (Number.isFinite(counter)) return { role, counter, suffix };
     }
   }
-  // Legacy fallback: <role>-<counter> (no suffix).
+  // Legacy fallback: <role>-<counter> (no suffix). Only matches when there
+  // is no `--` in the body so we don't falsely accept canonical-shaped names.
+  if (body.includes(CANONICAL_SEPARATOR)) return null;
   const legacy = body.match(/^(.+)-(\d+)$/);
   if (legacy) {
     const [, role, counterStr] = legacy;

--- a/src/core/session-id.ts
+++ b/src/core/session-id.ts
@@ -77,3 +77,32 @@ export function parseSessionId(name: string): ParsedSessionId | null {
   }
   return null;
 }
+
+/**
+ * Parse a session ID known to originate from acpx (e.g. the output of
+ * `acpx sessions list` or `AcpxRuntime.discoverSessions()`).
+ *
+ * Extends {@link parseSessionId} with a transitional branch for the
+ * pre-double-dash acpx shape `grove-<role>-<counter>-<base36>` so an
+ * upgrade doesn't strand already-running agents that were created on the
+ * older contract. Do NOT use this on tmux pane lookups — single-dash names
+ * there can also be TUI sessions (`grove-${agentId}`) whose `agentId`
+ * happens to look like `<role>-<counter>-<suffix>`, leading to misparse.
+ */
+export function parseAcpxSessionId(name: string): ParsedSessionId | null {
+  const standard = parseSessionId(name);
+  if (standard) return standard;
+  if (!name.startsWith(SESSION_ID_PREFIX)) return null;
+  const body = name.slice(SESSION_ID_PREFIX.length);
+  if (body.includes(CANONICAL_SEPARATOR)) return null;
+  // Prior-PR acpx shape: <role>-<counter>-<base36-suffix>, all single dashes.
+  const priorAcpx = body.match(/^(.+)-(\d+)-([a-z0-9]+)$/);
+  if (priorAcpx) {
+    const [, role, counterStr, suffix] = priorAcpx;
+    if (role && counterStr && suffix) {
+      const counter = Number.parseInt(counterStr, 10);
+      if (Number.isFinite(counter)) return { role, counter, suffix };
+    }
+  }
+  return null;
+}

--- a/src/core/session-id.ts
+++ b/src/core/session-id.ts
@@ -46,8 +46,13 @@ export function buildSessionId(role: string, counter: number): string {
 export function parseSessionId(name: string): ParsedSessionId | null {
   if (!name.startsWith(SESSION_ID_PREFIX)) return null;
   const body = name.slice(SESSION_ID_PREFIX.length);
-  // Try canonical first: <role>-<counter>-<base36-suffix>
-  const canonical = body.match(/^(.+)-(\d+)-([a-z0-9]+)$/);
+  // Canonical: <role>-<counter>-<base36-suffix>.
+  // Suffix length is gated at 7 to disambiguate from legacy IDs whose role
+  // ends in a digit segment (e.g. `worker-1`). `Date.now().toString(36)` is
+  // 8 chars today and won't drop below 7 until well after year 5000, so
+  // every real builder output passes this gate while legacy counter tails
+  // (typically 1–4 digits) are forced down the legacy branch below.
+  const canonical = body.match(/^(.+)-(\d+)-([a-z0-9]{7,})$/);
   if (canonical) {
     const [, role, counterStr, suffix] = canonical;
     if (role && counterStr && suffix) {

--- a/src/core/tmux-runtime.test.ts
+++ b/src/core/tmux-runtime.test.ts
@@ -39,7 +39,7 @@ describe("TmuxRuntime", () => {
     if (skip) return;
 
     const session = await rt.spawn("test", config);
-    expect(session.id).toMatch(/^grove-test-\d+$/);
+    expect(session.id).toMatch(/^grove-test-\d+-[a-z0-9]+$/);
     expect(session.role).toBe("test");
     expect(session.status).toBe("running");
 

--- a/src/core/tmux-runtime.test.ts
+++ b/src/core/tmux-runtime.test.ts
@@ -39,7 +39,7 @@ describe("TmuxRuntime", () => {
     if (skip) return;
 
     const session = await rt.spawn("test", config);
-    expect(session.id).toMatch(/^grove-test-\d+-[a-z0-9]+$/);
+    expect(session.id).toMatch(/^grove-test-\d+--[a-z0-9]+$/);
     expect(session.role).toBe("test");
     expect(session.status).toBe("running");
 

--- a/src/core/tmux-runtime.ts
+++ b/src/core/tmux-runtime.ts
@@ -8,10 +8,8 @@
 
 import { execSync } from "node:child_process";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
+import { buildSessionId, parseSessionId, SESSION_ID_PREFIX } from "./session-id.js";
 import { shellEscape } from "./shell-utils.js";
-
-/** Prefix for all grove tmux session names. */
-const SESSION_PREFIX = "grove-";
 
 interface TmuxSessionEntry {
   session: AgentSession;
@@ -42,7 +40,7 @@ export class TmuxRuntime implements AgentRuntime {
 
   async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
     const counter = this.nextId++;
-    const sessionName = `${SESSION_PREFIX}${role}-${counter}`;
+    const sessionName = buildSessionId(role, counter);
     const id = sessionName;
 
     // Pass platform/model as env vars so the agent process can read them
@@ -152,7 +150,7 @@ export class TmuxRuntime implements AgentRuntime {
       const names = output
         .trim()
         .split("\n")
-        .filter((n) => n.startsWith(SESSION_PREFIX));
+        .filter((n) => n.startsWith(SESSION_ID_PREFIX));
 
       // Reconcile tracked sessions with tmux reality
       const result: AgentSession[] = [];
@@ -162,8 +160,9 @@ export class TmuxRuntime implements AgentRuntime {
           result.push(tracked.session);
         } else {
           // External grove session — report it as running
-          const role = name.slice(SESSION_PREFIX.length).replace(/-\d+$/, "");
-          result.push({ id: name, role, status: "running" });
+          const parsed = parseSessionId(name);
+          if (!parsed) continue;
+          result.push({ id: name, role: parsed.role, status: "running" });
         }
       }
       return result;

--- a/src/tui/hooks/use-agent-monitor.test.ts
+++ b/src/tui/hooks/use-agent-monitor.test.ts
@@ -114,8 +114,10 @@ describe("roleFromSessionName", () => {
   });
 
   test("parses canonical session-id contract (role-counter-base36)", () => {
-    expect(roleFromSessionName("grove-coder-0-l8x9pq2")).toBe("coder");
-    expect(roleFromSessionName("grove-code-reviewer-12-abc1z")).toBe("code-reviewer");
+    // Suffixes here are 8 chars to match the real `Date.now().toString(36)`
+    // length and clear the parser's length gate.
+    expect(roleFromSessionName("grove-coder-0-mo3i3zh6")).toBe("coder");
+    expect(roleFromSessionName("grove-code-reviewer-12-mo3i3zz6")).toBe("code-reviewer");
   });
 });
 

--- a/src/tui/hooks/use-agent-monitor.test.ts
+++ b/src/tui/hooks/use-agent-monitor.test.ts
@@ -113,11 +113,18 @@ describe("roleFromSessionName", () => {
     expect(roleFromSessionName("grove-coder-AbC123")).toBe("coder");
   });
 
-  test("parses canonical session-id contract (role-counter-base36)", () => {
-    // Suffixes here are 8 chars to match the real `Date.now().toString(36)`
-    // length and clear the parser's length gate.
-    expect(roleFromSessionName("grove-coder-0-mo3i3zh6")).toBe("coder");
-    expect(roleFromSessionName("grove-code-reviewer-12-mo3i3zz6")).toBe("code-reviewer");
+  test("parses canonical session-id contract (role-counter--base36)", () => {
+    // Canonical IDs use `--` between counter and base36 timestamp so they
+    // never collide with the TUI's `grove-${agentId}` single-dash convention.
+    expect(roleFromSessionName("grove-coder-0--mo3i3zh6")).toBe("coder");
+    expect(roleFromSessionName("grove-code-reviewer-12--mo3i3zz6")).toBe("code-reviewer");
+  });
+
+  test("TUI single-dash names with role ending in digit fall through to legacy strip", () => {
+    // `grove-worker-1-mo3i3zh6` is a TUI agent, not a runtime session.
+    // parseSessionId rejects it; the legacy fallback strip recovers
+    // `worker-1` (the actual TUI agentId), preserving correct attribution.
+    expect(roleFromSessionName("grove-worker-1-mo3i3zh6")).toBe("worker-1");
   });
 });
 

--- a/src/tui/hooks/use-agent-monitor.test.ts
+++ b/src/tui/hooks/use-agent-monitor.test.ts
@@ -112,6 +112,11 @@ describe("roleFromSessionName", () => {
   test("handles uppercase in trailing ID", () => {
     expect(roleFromSessionName("grove-coder-AbC123")).toBe("coder");
   });
+
+  test("parses canonical session-id contract (role-counter-base36)", () => {
+    expect(roleFromSessionName("grove-coder-0-l8x9pq2")).toBe("coder");
+    expect(roleFromSessionName("grove-code-reviewer-12-abc1z")).toBe("code-reviewer");
+  });
 });
 
 // ===========================================================================

--- a/src/tui/hooks/use-agent-monitor.ts
+++ b/src/tui/hooks/use-agent-monitor.ts
@@ -7,6 +7,7 @@
 
 import { useEffect, useState } from "react";
 import type { EventBus, GroveEvent } from "../../core/event-bus.js";
+import { parseSessionId } from "../../core/session-id.js";
 import type { AgentTopology } from "../../core/topology.js";
 import { stripAnsi } from "../../shared/format.js";
 import { BRAILLE_SPINNER } from "../theme.js";
@@ -89,8 +90,16 @@ export function roleFromLogFilename(filename: string): string {
   return filename.replace(/\.log$/, "").replace(/-\d+$/, "");
 }
 
-/** Extract role name from a tmux session name (e.g. "grove-coder-abc123" → "coder"). */
+/**
+ * Extract role name from a grove session name.
+ *
+ * Prefers the canonical {@link parseSessionId} contract
+ * (`grove-<role>-<counter>-<base36>`). Falls back to a legacy single-suffix
+ * strip for sessions named via the older TUI `tmuxSessionName(agentId)` path.
+ */
 export function roleFromSessionName(sessionName: string): string {
+  const parsed = parseSessionId(sessionName);
+  if (parsed) return parsed.role;
   return sessionName.replace("grove-", "").replace(/-[a-z0-9]+$/i, "");
 }
 

--- a/src/tui/hooks/use-permission-detection.ts
+++ b/src/tui/hooks/use-permission-detection.ts
@@ -6,6 +6,7 @@
 
 import { useKeyboard } from "@opentui/react";
 import { useCallback, useEffect, useState } from "react";
+import { parseSessionId } from "../../core/session-id.js";
 import type { TmuxManager } from "../agents/tmux-manager.js";
 
 /** A detected permission prompt from a tmux agent session. */
@@ -59,7 +60,8 @@ export function usePermissionDetection(
                 cmd = t;
               }
             }
-            const role = sess.replace("grove-", "").replace(/-[a-z0-9]+$/i, "");
+            const parsed = parseSessionId(sess);
+            const role = parsed?.role ?? sess.replace("grove-", "").replace(/-[a-z0-9]+$/i, "");
             prompts.push({ sessionName: sess, agentRole: role, command: cmd.slice(0, 80) });
           }
         }

--- a/src/tui/spawn-manager.test.ts
+++ b/src/tui/spawn-manager.test.ts
@@ -757,4 +757,42 @@ describe("SpawnManager — reconciliation", () => {
     expect(result.reattached).toBe(0);
     expect(result.released).toBe(0);
   });
+
+  test("setWsBridge late-registers hyphenated roles by full role name", async () => {
+    // Regression: setWsBridge used to derive role via spawnId.split("-")[0],
+    // which truncates `code-reviewer-mo3i3zh6` to `code` and drops inbound
+    // IPC because NexusWsBridge does an exact role lookup downstream.
+    const provider = makeMockProvider();
+    const tmux = makeMockTmux();
+    const errors: string[] = [];
+    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg));
+
+    const seedSession = {
+      id: "grove-code-reviewer-0--mo3i3zh6",
+      role: "code-reviewer",
+      status: "running" as const,
+    };
+    // Seed agentSessions directly — we're testing setWsBridge in isolation,
+    // not the full spawn pipeline.
+    (manager as unknown as { agentSessions: Map<string, typeof seedSession> }).agentSessions.set(
+      "code-reviewer-mo3i3zh6",
+      seedSession,
+    );
+
+    const registered: { role: string; sessionId: string }[] = [];
+    const stubBridge = {
+      registerSession(role: string, session: { id: string }) {
+        registered.push({ role, sessionId: session.id });
+      },
+      close() {
+        /* destroy() calls this on teardown */
+      },
+    } as unknown as Parameters<typeof manager.setWsBridge>[0];
+
+    manager.setWsBridge(stubBridge);
+
+    expect(registered).toHaveLength(1);
+    expect(registered[0]!.role).toBe("code-reviewer");
+    expect(registered[0]!.sessionId).toBe("grove-code-reviewer-0--mo3i3zh6");
+  });
 });

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -15,7 +15,7 @@ import { join, resolve } from "node:path";
 import type { AgentConfig, AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import type { AgentIdentity } from "../core/models.js";
 import { resolveMcpServePath } from "../core/resolve-mcp-serve-path.js";
-import { parseSessionId } from "../core/session-id.js";
+import { parseAcpxSessionId } from "../core/session-id.js";
 import type { AgentTopology } from "../core/topology.js";
 import { resolveRoleWorkspaceStrategies } from "../core/topology.js";
 import type { WorkspaceIsolationPolicy, WorkspaceMode } from "../core/workspace-provisioner.js";
@@ -125,8 +125,14 @@ export class SpawnManager {
     this.wsBridge = bridge;
     // Register any sessions that were spawned before the bridge was ready.
     // The bridge is created async (dynamic import) so agents may already be running.
+    //
+    // Use `session.role` (the orchestration role from spawn config) rather
+    // than splitting the map key on `-`: the split would truncate hyphenated
+    // roles like `code-reviewer` to `code` and drop inbound IPC. NexusWsBridge
+    // does an exact role lookup downstream, so the registration key must match
+    // the topology role exactly.
     for (const [spawnId, session] of this.agentSessions) {
-      const role = spawnId.split("-")[0]; // "coder-abc123" → "coder"
+      const role = session.role;
       if (role) {
         bridge.registerSession(role, session);
         debugLog("wsBridge", `late-registered ${role} (spawnId=${spawnId})`);
@@ -621,11 +627,10 @@ export class SpawnManager {
           if (!cwd.startsWith(workspacesPrefix) && !cwd.startsWith(`/private${workspacesPrefix}`))
             continue;
 
-          // acpx session names follow the canonical runtime contract
-          // (`grove-<role>-<counter>--<base36>`); parseSessionId is the
-          // single source of truth so role attribution stays consistent
-          // with rediscovery in TmuxRuntime/AcpxRuntime/use-agent-monitor.
-          const parsed = parseSessionId(name);
+          // Acpx names follow the canonical runtime contract; the acpx-aware
+          // parser also accepts the prior single-dash shape so rediscovery
+          // still works for live agents created on the previous grove version.
+          const parsed = parseAcpxSessionId(name);
           if (!parsed) continue;
           const role = parsed.role;
           if (role && !this.agentSessions.has(role)) {

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -15,6 +15,7 @@ import { join, resolve } from "node:path";
 import type { AgentConfig, AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import type { AgentIdentity } from "../core/models.js";
 import { resolveMcpServePath } from "../core/resolve-mcp-serve-path.js";
+import { parseSessionId } from "../core/session-id.js";
 import type { AgentTopology } from "../core/topology.js";
 import { resolveRoleWorkspaceStrategies } from "../core/topology.js";
 import type { WorkspaceIsolationPolicy, WorkspaceMode } from "../core/workspace-provisioner.js";
@@ -620,7 +621,13 @@ export class SpawnManager {
           if (!cwd.startsWith(workspacesPrefix) && !cwd.startsWith(`/private${workspacesPrefix}`))
             continue;
 
-          const role = name.replace(/^grove-/, "").replace(/-\d+-.*$/, "");
+          // acpx session names follow the canonical runtime contract
+          // (`grove-<role>-<counter>--<base36>`); parseSessionId is the
+          // single source of truth so role attribution stays consistent
+          // with rediscovery in TmuxRuntime/AcpxRuntime/use-agent-monitor.
+          const parsed = parseSessionId(name);
+          if (!parsed) continue;
+          const role = parsed.role;
           if (role && !this.agentSessions.has(role)) {
             const session = liveSessionMap.get(name);
             if (session) {


### PR DESCRIPTION
## Summary

- New `src/core/session-id.ts` is the single source of truth for grove session IDs. Canonical shape: `grove-<role>-<counter>-<base36-timestamp>`. Both `AcpxRuntime` and `TmuxRuntime` now build IDs via `buildSessionId()` and parse them via `parseSessionId()` instead of open-coding regexes — fixing the drift called out in #210.
- `AgentRuntime`/`AgentSession` JSDoc documents the contract so reattach/discovery/TUI role extraction all reference one place. `roleFromSessionName` in `use-agent-monitor` now prefers the canonical parser and only falls back to the legacy single-suffix regex for sessions named via the older TUI `tmuxSessionName(agentId)` path.
- Unrelated but blocking: `main.tui-dispatch.test.ts` was timing out at 15s because `Bun.spawn` piped stdout was never drained — the TUI's ANSI stream filled the buffer in <1s and SIGTERM cleanup stalled. Switched stdout to `"ignore"` and added a SIGKILL grace timer.

## Test plan

- [x] `bun test src/core/session-id.test.ts` — 6/6 (100% line coverage on helper)
- [x] `bun test src/core/acpx-runtime.test.ts` — 13/13
- [x] `bun test src/core/tmux-runtime.test.ts` — 8/8
- [x] `bun test src/tui/hooks/use-agent-monitor.test.ts` — 28/28 (added canonical-shape assertion)
- [x] `bun test src/cli/main.tui-dispatch.test.ts` — 3/3, 7s (was timing out at 15s)
- [x] `bun test` (full suite) — 5453/5453 pass

Closes #210