### PR TITLE
feat(nexus): publish typed AcpxTurn messages + E2E (#261)

### DIFF
--- a/src/core/acpx-runtime.integration.test.ts
+++ b/src/core/acpx-runtime.integration.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Integration test: AcpxRuntime end-to-end against a real `acpx` + agent CLI.
+ *
+ * Gated on `AcpxRuntime.isAvailable()` so the suite passes on machines
+ * without acpx installed. Complements `acpx-runtime.component.test.ts`
+ * (which covers send serialization and basic reply) by asserting the
+ * typed-message contract — Message unions, terminal Result stopReason,
+ * and that the stream is an async iterable rather than a raw string.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Message, StopReason } from "../acp/types.js";
+import { AcpxRuntime } from "./acpx-runtime.js";
+
+const TERMINAL_STOP_REASONS: StopReason[] = ["end_turn", "max_tokens", "cancelled", "error"];
+
+describe("AcpxRuntime integration (real acpx)", () => {
+  test("send yields typed Messages and a terminal Result", async () => {
+    const rt = new AcpxRuntime();
+    if (!(await rt.isAvailable())) {
+      console.warn("[skip] acpx not installed — integration test skipped");
+      return;
+    }
+
+    const session = await rt.spawn("smoke", {
+      role: "smoke",
+      command: "codex",
+      cwd: process.cwd(),
+      platform: "codex",
+      waitForPush: true,
+    });
+
+    try {
+      const turn = await rt.send(session, "reply with: pong");
+      expect(turn.sessionId).toBe(session.id);
+      expect(typeof turn.turnId).toBe("string");
+
+      const collected: Message[] = [];
+      for await (const m of turn.messages) {
+        // Every Message must have a turnId string (discriminated union invariant).
+        expect(typeof m.turnId).toBe("string");
+        collected.push(m);
+      }
+
+      expect(collected.length).toBeGreaterThan(0);
+
+      // At least one kind should be a real provider output — text, thinking,
+      // tool_call, token_usage, permission_request, or raw (future-compat).
+      const knownKinds = new Set([
+        "text",
+        "thinking",
+        "tool_call",
+        "token_usage",
+        "permission_request",
+        "raw",
+      ]);
+      for (const m of collected) {
+        expect(knownKinds.has(m.kind)).toBe(true);
+      }
+
+      const r = await turn.result;
+      expect(r.turnId).toBe(turn.turnId);
+      // Accept any known canonical stopReason (non-canonical strings are
+      // allowed by the StopReason type via the `(string & {})` escape but a
+      // real codex turn should land in the canonical set).
+      const canonical = new Set<string>(TERMINAL_STOP_REASONS);
+      expect(canonical.has(r.stopReason as string)).toBe(true);
+    } finally {
+      await rt.close(session);
+    }
+  }, 120_000);
+});

--- a/src/nexus/nexus-agent-publisher.test.ts
+++ b/src/nexus/nexus-agent-publisher.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for publishTurnToNexus — drains an AcpxTurn and emits one
+ * GroveEvent per Message plus one final acp.result event.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Message, Result } from "../acp/types.js";
+import type { GroveEvent } from "../core/event-bus.js";
+import { publishTurnToNexus } from "./nexus-agent-publisher.js";
+import { NexusEventBus } from "./nexus-event-bus.js";
+
+function asyncIter<T>(items: T[]): AsyncIterable<T> {
+  return (async function* () {
+    for (const item of items) yield item;
+  })();
+}
+
+describe("publishTurnToNexus", () => {
+  test("emits one event per Message plus a final acp.result event", async () => {
+    const bus = new NexusEventBus(undefined);
+    const received: GroveEvent[] = [];
+    bus.subscribe("orchestrator", (e) => received.push(e));
+
+    const messages: Message[] = [
+      { kind: "text", turnId: "t1", text: "hi", chunk: true },
+      { kind: "tool_call", turnId: "t1", toolCall: { id: "tc1", name: "bash" } },
+    ];
+    const result: Result = { turnId: "t1", stopReason: "end_turn" };
+
+    await publishTurnToNexus({
+      bus,
+      sourceRole: "coder",
+      targetRole: "orchestrator",
+      sessionId: "s1",
+      turnId: "t1",
+      messages: asyncIter(messages),
+      result: Promise.resolve(result),
+    });
+
+    expect(received).toHaveLength(3);
+    expect(received[0]!.type).toBe("acp.message");
+    expect(received[1]!.type).toBe("acp.message");
+    expect(received[2]!.type).toBe("acp.result");
+    bus.close();
+  });
+
+  test("every event carries sessionId + turnId in payload for correlation", async () => {
+    const bus = new NexusEventBus(undefined);
+    const received: GroveEvent[] = [];
+    bus.subscribe("orchestrator", (e) => received.push(e));
+
+    const messages: Message[] = [{ kind: "text", turnId: "t1", text: "a", chunk: true }];
+    const result: Result = { turnId: "t1", stopReason: "end_turn" };
+
+    await publishTurnToNexus({
+      bus,
+      sourceRole: "coder",
+      targetRole: "orchestrator",
+      sessionId: "s-abc",
+      turnId: "t-xyz",
+      messages: asyncIter(messages),
+      result: Promise.resolve(result),
+    });
+
+    for (const event of received) {
+      expect(event.payload.sessionId).toBe("s-abc");
+      expect(event.payload.turnId).toBe("t-xyz");
+      expect(event.sourceRole).toBe("coder");
+      expect(event.targetRole).toBe("orchestrator");
+    }
+    bus.close();
+  });
+
+  test("acp.message payload round-trips the typed Message shape", async () => {
+    const bus = new NexusEventBus(undefined);
+    const received: GroveEvent[] = [];
+    bus.subscribe("orchestrator", (e) => received.push(e));
+
+    const toolCallMsg: Message = {
+      kind: "tool_call",
+      turnId: "t1",
+      toolCall: {
+        id: "tc-1",
+        name: "bash",
+        status: "completed",
+        input: { command: "echo hi" },
+        output: "hi",
+      },
+    };
+    await publishTurnToNexus({
+      bus,
+      sourceRole: "coder",
+      targetRole: "orchestrator",
+      sessionId: "s1",
+      turnId: "t1",
+      messages: asyncIter([toolCallMsg]),
+      result: Promise.resolve({ turnId: "t1", stopReason: "end_turn" }),
+    });
+
+    expect(received[0]!.payload.message).toEqual(toolCallMsg);
+  });
+
+  test("acp.result payload carries the terminal Result including error", async () => {
+    const bus = new NexusEventBus(undefined);
+    const received: GroveEvent[] = [];
+    bus.subscribe("orchestrator", (e) => received.push(e));
+
+    const result: Result = {
+      turnId: "t1",
+      stopReason: "error",
+      error: { code: "provider", message: "rate limit" },
+    };
+    await publishTurnToNexus({
+      bus,
+      sourceRole: "coder",
+      targetRole: "orchestrator",
+      sessionId: "s1",
+      turnId: "t1",
+      messages: asyncIter([]),
+      result: Promise.resolve(result),
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]!.type).toBe("acp.result");
+    expect(received[0]!.payload.result).toEqual(result);
+  });
+
+  test("events carry ISO timestamps", async () => {
+    const bus = new NexusEventBus(undefined);
+    const received: GroveEvent[] = [];
+    bus.subscribe("orchestrator", (e) => received.push(e));
+
+    await publishTurnToNexus({
+      bus,
+      sourceRole: "coder",
+      targetRole: "orchestrator",
+      sessionId: "s1",
+      turnId: "t1",
+      messages: asyncIter([{ kind: "text", turnId: "t1", text: "x", chunk: true }]),
+      result: Promise.resolve({ turnId: "t1", stopReason: "end_turn" }),
+    });
+
+    for (const e of received) {
+      expect(typeof e.timestamp).toBe("string");
+      expect(Number.isNaN(Date.parse(e.timestamp))).toBe(false);
+    }
+  });
+
+  test("returns one PublishResult per emitted event", async () => {
+    const bus = new NexusEventBus(undefined);
+    const results = await publishTurnToNexus({
+      bus,
+      sourceRole: "coder",
+      targetRole: "orchestrator",
+      sessionId: "s1",
+      turnId: "t1",
+      messages: asyncIter([
+        { kind: "text", turnId: "t1", text: "a", chunk: true },
+        { kind: "text", turnId: "t1", text: "b", chunk: true },
+      ]),
+      result: Promise.resolve({ turnId: "t1", stopReason: "end_turn" }),
+    });
+    // 2 messages + 1 terminal result = 3 PublishResults
+    expect(results).toHaveLength(3);
+    for (const r of results) expect(r.ok).toBe(true);
+  });
+
+  test("streams messages in iteration order without buffering the whole stream", async () => {
+    const bus = new NexusEventBus(undefined);
+    const received: GroveEvent[] = [];
+    bus.subscribe("orchestrator", (e) => received.push({ ...e }));
+
+    // Build a stream that observes publish progress as iteration advances.
+    const observed: number[] = [];
+    const messages: AsyncIterable<Message> = (async function* () {
+      for (let i = 0; i < 3; i++) {
+        observed.push(received.length);
+        yield { kind: "text", turnId: "t1", text: String(i), chunk: true };
+      }
+    })();
+
+    await publishTurnToNexus({
+      bus,
+      sourceRole: "coder",
+      targetRole: "orchestrator",
+      sessionId: "s1",
+      turnId: "t1",
+      messages,
+      result: Promise.resolve({ turnId: "t1", stopReason: "end_turn" }),
+    });
+
+    // Each iteration step observes the running count before yielding, so the
+    // first yield sees 0 published, second sees 1, third sees 2 — proving the
+    // publisher does not drain the iterator before publishing.
+    expect(observed).toEqual([0, 1, 2]);
+    expect(received).toHaveLength(4);
+  });
+});

--- a/src/nexus/nexus-agent-publisher.ts
+++ b/src/nexus/nexus-agent-publisher.ts
@@ -1,0 +1,65 @@
+/**
+ * Drain an AcpxTurn and publish typed records through an EventBus.
+ *
+ * For every Message the publisher emits one `acp.message` GroveEvent. When
+ * the turn resolves, it emits a terminal `acp.result` event. sessionId +
+ * turnId are carried in the payload so consumers can correlate events per
+ * turn without depending on delivery order.
+ *
+ * Iteration-ordered: publish happens as each message is pulled from the
+ * async iterator, not after the whole stream is buffered. This keeps
+ * downstream subscribers live with the agent's output.
+ */
+
+import type { Message, Result } from "../acp/types.js";
+import type { EventBus, GroveEvent, PublishResult } from "../core/event-bus.js";
+
+export interface PublishTurnOptions {
+  readonly bus: EventBus;
+  readonly sourceRole: string;
+  readonly targetRole: string;
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly messages: AsyncIterable<Message>;
+  readonly result: Promise<Result>;
+}
+
+/**
+ * Returns one PublishResult per event emitted (N messages + 1 terminal
+ * result). Callers can inspect `ok` / `messageId` to confirm real delivery
+ * or detect transport failure — the publisher never throws on bus errors.
+ */
+export async function publishTurnToNexus(opts: PublishTurnOptions): Promise<PublishResult[]> {
+  const results: PublishResult[] = [];
+
+  for await (const message of opts.messages) {
+    const event: GroveEvent = {
+      type: "acp.message",
+      sourceRole: opts.sourceRole,
+      targetRole: opts.targetRole,
+      payload: {
+        sessionId: opts.sessionId,
+        turnId: opts.turnId,
+        message,
+      },
+      timestamp: new Date().toISOString(),
+    };
+    results.push(await opts.bus.publish(event));
+  }
+
+  const result = await opts.result;
+  const terminal: GroveEvent = {
+    type: "acp.result",
+    sourceRole: opts.sourceRole,
+    targetRole: opts.targetRole,
+    payload: {
+      sessionId: opts.sessionId,
+      turnId: opts.turnId,
+      result,
+    },
+    timestamp: new Date().toISOString(),
+  };
+  results.push(await opts.bus.publish(terminal));
+
+  return results;
+}

--- a/tests/e2e/acp-stream-nexus.e2e.test.ts
+++ b/tests/e2e/acp-stream-nexus.e2e.test.ts
@@ -1,0 +1,96 @@
+/**
+ * E2E: spawn a real acpx agent, publish its typed turn stream through a
+ * real Nexus instance, and verify delivery via Nexus HTTP.
+ *
+ * Skipped unless both NEXUS_URL and NEXUS_API_KEY are set so `bun test`
+ * stays green on machines without a running Nexus stack. Also gated on
+ * AcpxRuntime.isAvailable() (no mock fallback — acpx absence is a skip).
+ *
+ * Requires a Nexus agent whose inbox already exists. Configure via
+ * NEXUS_TEST_AGENT_ID; the test uses that agent as both sender and
+ * recipient so the single API-key auth context matches on both
+ * `_check_agent_access` boundaries.
+ *
+ * Run with the `nexus-stack` skill:
+ *   1. Start stack, export NEXUS_URL + NEXUS_API_KEY + NEXUS_TEST_AGENT_ID.
+ *   2. bun test tests/e2e/acp-stream-nexus.e2e.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AcpxRuntime } from "../../src/core/acpx-runtime.js";
+import { publishTurnToNexus } from "../../src/nexus/nexus-agent-publisher.js";
+import { NexusEventBus } from "../../src/nexus/nexus-event-bus.js";
+import { NexusIpcClient } from "../../src/nexus/nexus-ipc-client.js";
+
+const NEXUS_URL = process.env.NEXUS_URL;
+const NEXUS_API_KEY = process.env.NEXUS_API_KEY;
+const NEXUS_TEST_AGENT_ID = process.env.NEXUS_TEST_AGENT_ID ?? "grove-e2e";
+
+const gated = Boolean(NEXUS_URL && NEXUS_API_KEY);
+
+async function inboxCount(agentId: string): Promise<number> {
+  const resp = await fetch(`${NEXUS_URL}/api/v2/ipc/inbox/${encodeURIComponent(agentId)}/count`, {
+    headers: { Authorization: `Bearer ${NEXUS_API_KEY}` },
+  });
+  if (!resp.ok) throw new Error(`inbox count failed: HTTP ${resp.status}`);
+  const body = (await resp.json()) as { count: number };
+  return body.count;
+}
+
+describe.skipIf(!gated)("acp stream → Nexus E2E", () => {
+  test("published turn events land in the recipient's Nexus inbox", async () => {
+    const rt = new AcpxRuntime();
+    if (!(await rt.isAvailable())) {
+      console.warn("[skip] acpx not installed");
+      return;
+    }
+
+    const ipc = new NexusIpcClient({
+      nexusUrl: NEXUS_URL as string,
+      apiKey: NEXUS_API_KEY as string,
+    });
+    const bus = new NexusEventBus(ipc);
+
+    const session = await rt.spawn("smoke", {
+      role: "smoke",
+      command: "codex",
+      cwd: process.cwd(),
+      platform: "codex",
+      waitForPush: true,
+    });
+
+    try {
+      const before = await inboxCount(NEXUS_TEST_AGENT_ID);
+
+      const turn = await rt.send(session, "reply with: pong");
+      const results = await publishTurnToNexus({
+        bus,
+        sourceRole: NEXUS_TEST_AGENT_ID,
+        targetRole: NEXUS_TEST_AGENT_ID,
+        sessionId: session.id,
+        turnId: turn.turnId,
+        messages: turn.messages,
+        result: turn.result,
+      });
+
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      const terminal = results.at(-1);
+      expect(terminal?.ok).toBe(true);
+      expect(typeof terminal?.messageId).toBe("string");
+
+      // Every emitted event should carry an IPC message ID from the real
+      // Nexus — proves the payload survived the HTTP round-trip, not just
+      // that the local handler saw it.
+      for (const r of results) {
+        expect(r.ok).toBe(true);
+        expect(r.messageId).toBeDefined();
+      }
+
+      const after = await inboxCount(NEXUS_TEST_AGENT_ID);
+      expect(after - before).toBeGreaterThanOrEqual(results.length);
+    } finally {
+      await rt.close(session);
+      bus.close();
+    }
+  }, 180_000);
+});

--- a/tests/e2e/acp-stream-nexus.e2e.test.ts
+++ b/tests/e2e/acp-stream-nexus.e2e.test.ts
@@ -25,6 +25,10 @@ import { NexusIpcClient } from "../../src/nexus/nexus-ipc-client.js";
 const NEXUS_URL = process.env.NEXUS_URL;
 const NEXUS_API_KEY = process.env.NEXUS_API_KEY;
 const NEXUS_TEST_AGENT_ID = process.env.NEXUS_TEST_AGENT_ID ?? "grove-e2e";
+// Nexus rejects self-send (sender==recipient envelope check). Sender must
+// differ from NEXUS_TEST_AGENT_ID and must match the API key's agent scope
+// — default to "admin" since `nexus init` provisions that as the key owner.
+const NEXUS_SENDER_AGENT_ID = process.env.NEXUS_SENDER_AGENT_ID ?? "admin";
 
 const gated = Boolean(NEXUS_URL && NEXUS_API_KEY);
 
@@ -65,7 +69,7 @@ describe.skipIf(!gated)("acp stream → Nexus E2E", () => {
       const turn = await rt.send(session, "reply with: pong");
       const results = await publishTurnToNexus({
         bus,
-        sourceRole: NEXUS_TEST_AGENT_ID,
+        sourceRole: NEXUS_SENDER_AGENT_ID,
         targetRole: NEXUS_TEST_AGENT_ID,
         sessionId: session.id,
         turnId: turn.turnId,


### PR DESCRIPTION
Closes #261 (sub-spec 1 of 3, Tasks 10–12 from the plan).

## Summary

- `src/nexus/nexus-agent-publisher.ts` — `publishTurnToNexus` drains an `AcpxTurn`, emits one `acp.message` GroveEvent per `Message` + a terminal `acp.result`. Returns `PublishResult[]` so callers can detect IPC failures.
- Unit tests cover drain order, payload shape (sessionId/turnId correlation), PublishResult fan-out, ISO timestamps, and iteration-ordered streaming (no pre-buffer).
- `src/core/acpx-runtime.integration.test.ts` — real-acpx smoke gated on `isAvailable`. Asserts `Message` union kinds and terminal `Result.stopReason` from an actual codex turn.
- `tests/e2e/acp-stream-nexus.e2e.test.ts` — spawns acpx, publishes through a real Nexus instance via `NexusIpcClient`, verifies every event got a `messageId` and the recipient inbox count grew. Skipped unless `NEXUS_URL` + `NEXUS_API_KEY` are set (`NEXUS_TEST_AGENT_ID` configurable, default `grove-e2e`).

## Open-question resolution

Plan flagged: opaque JSON payload vs indexed `turnId` / `toolCallId` columns. Answer: Nexus IPC send is payload-opaque — `routers/ipc.py:87` accepts `payload: dict[str, Any]` and stores envelopes as JSON. No schema migration needed; `sessionId` / `turnId` travel inside the payload for consumer correlation.

## Acceptance

- [x] `bun test src/nexus/nexus-agent-publisher.test.ts` green (7 tests, 26 expects)
- [x] Integration test passes with acpx + codex installed (1 test, 27 expects, ~24s)
- [x] E2E skips cleanly without Nexus; ready to run against stack per `nexus-stack` skill
- [x] No mocked Nexus in E2E — uses real `NexusIpcClient` → real HTTP
- [x] Full `bun test`: 5485 pass / 1 skip / 0 fail
- [x] `bun run tsc --noEmit` clean
- [x] `bun run biome check src tests` clean

## Test plan

- [x] Publisher unit tests
- [x] AcpxRuntime integration smoke
- [ ] E2E against running Nexus (needs `nexus-stack` skill + env vars — validated on reviewer's machine)