### PR TITLE
perf(stop-conditions): skip scanning evaluators on write-mutex path (#232)

### DIFF
--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1450,20 +1450,20 @@ export async function contributeOperation(
       }
       if (lastError !== undefined) {
         // All attempts exhausted. The contribution is already committed, so we
-        // cannot undo the write. Instead, surface the degradation explicitly
-        // in policyResult.stopResult so callers can detect "stop status
-        // unknown" rather than conflating it with confirmed stopped=false.
-        // This addresses Codex review r4 finding on fail-open behavior under
-        // sustained store read failures. The next write's recheck provides
-        // another chance to detect quorum/deliberation; in the meantime,
-        // operators see the warning and callers can gate on the explicit
-        // reason string.
-        const degradedReason = `stop_recheck_unavailable: post-write recheck failed after ${POST_WRITE_RECHECK_ATTEMPTS} attempts — quorum/deliberation stop detection temporarily degraded`;
+        // cannot undo the write. Surface the degradation explicitly via
+        // `stopResult.degraded = true` so callers can distinguish "confirmed
+        // not stopped" from "unknown — evaluation failed". The boolean
+        // `stopped` field stays the cheap-evaluator result (the only source
+        // we successfully computed). The `degraded` flag + warning are the
+        // signal operators must monitor. This addresses Codex review r4/r5
+        // findings on fail-open behavior under sustained store read failures.
+        const degradedReason = `stop_recheck_unavailable: post-write recheck failed after ${POST_WRITE_RECHECK_ATTEMPTS} attempts — quorum/deliberation stop detection temporarily degraded; treat stopped=false as unverified until next successful recheck`;
         policyResult = {
           ...policyResult,
           stopResult: {
             stopped: policyResult.stopResult?.stopped === true,
             reason: policyResult.stopResult?.reason ?? degradedReason,
+            degraded: true,
           },
         };
         process.stderr.write(

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1449,10 +1449,23 @@ export async function contributeOperation(
         }
       }
       if (lastError !== undefined) {
-        // All attempts exhausted: log and continue. The contribution is already
-        // committed; the next write's recheck provides another chance to detect
-        // the stop signal. Still best-effort on total Nexus outage — but no
-        // longer single-attempt.
+        // All attempts exhausted. The contribution is already committed, so we
+        // cannot undo the write. Instead, surface the degradation explicitly
+        // in policyResult.stopResult so callers can detect "stop status
+        // unknown" rather than conflating it with confirmed stopped=false.
+        // This addresses Codex review r4 finding on fail-open behavior under
+        // sustained store read failures. The next write's recheck provides
+        // another chance to detect quorum/deliberation; in the meantime,
+        // operators see the warning and callers can gate on the explicit
+        // reason string.
+        const degradedReason = `stop_recheck_unavailable: post-write recheck failed after ${POST_WRITE_RECHECK_ATTEMPTS} attempts — quorum/deliberation stop detection temporarily degraded`;
+        policyResult = {
+          ...policyResult,
+          stopResult: {
+            stopped: policyResult.stopResult?.stopped === true,
+            reason: policyResult.stopResult?.reason ?? degradedReason,
+          },
+        };
         process.stderr.write(
           `[grove] Warning: post-write stop-condition recheck failed after ${POST_WRITE_RECHECK_ATTEMPTS} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}\n`,
         );
@@ -1519,14 +1532,36 @@ export async function contributeOperation(
         });
       }
       if (deps.idempotencyStore !== undefined) {
-        try {
-          deps.idempotencyStore.store(
-            idempotencyCacheLookupKey,
-            idempotencyFingerprint,
-            JSON.stringify(result),
+        // Bounded retry with warning on final durable refresh failure.
+        // Addresses Codex review r4 finding: a silent drop here leaves
+        // cross-process retries reading the stale committedResult for the
+        // full TTL. Same 3-attempt pattern used for post-write recheck.
+        const IDEMPOTENCY_REFRESH_ATTEMPTS = 3;
+        let refreshAttempt = 0;
+        let refreshError: unknown;
+        while (refreshAttempt < IDEMPOTENCY_REFRESH_ATTEMPTS) {
+          try {
+            deps.idempotencyStore.store(
+              idempotencyCacheLookupKey,
+              idempotencyFingerprint,
+              JSON.stringify(result),
+            );
+            refreshError = undefined;
+            break;
+          } catch (err) {
+            refreshError = err;
+            refreshAttempt += 1;
+            if (refreshAttempt < IDEMPOTENCY_REFRESH_ATTEMPTS) {
+              await new Promise((resolve) =>
+                setTimeout(resolve, 100 * 4 ** (refreshAttempt - 1)),
+              );
+            }
+          }
+        }
+        if (refreshError !== undefined) {
+          process.stderr.write(
+            `[grove] Warning: idempotency durable-refresh failed after ${IDEMPOTENCY_REFRESH_ATTEMPTS} attempts (cross-process retries may observe stale policy for key=${idempotencyCacheLookupKey}): ${refreshError instanceof Error ? refreshError.message : String(refreshError)}\n`,
           );
-        } catch {
-          // Best-effort — the committed row still exists with committedResult.
         }
       }
     }

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1552,9 +1552,7 @@ export async function contributeOperation(
             refreshError = err;
             refreshAttempt += 1;
             if (refreshAttempt < IDEMPOTENCY_REFRESH_ATTEMPTS) {
-              await new Promise((resolve) =>
-                setTimeout(resolve, 100 * 4 ** (refreshAttempt - 1)),
-              );
+              await new Promise((resolve) => setTimeout(resolve, 100 * 4 ** (refreshAttempt - 1)));
             }
           }
         }

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1010,11 +1010,21 @@ export async function contributeOperation(
       };
       if (store.setPreWriteHook) {
         store.setPreWriteHook(contribution.cid, async (c: Contribution) => {
-          policyResult = await enforcer?.enforce(c, true, { skipStopConditions });
+          // skipExpensiveStopChecks: true — scanning stop evaluators (quorum,
+          // deliberation) run in the post-write recheck below, outside the
+          // mutex, so they don't block concurrent writers (#232).
+          policyResult = await enforcer?.enforce(c, true, {
+            skipStopConditions,
+            skipExpensiveStopChecks: true,
+          });
         });
       } else {
-        // Fallback: enforce outside mutex (non-EnforcingContributionStore)
-        policyResult = await enforcer.enforce(contribution, true, { skipStopConditions });
+        // Fallback: enforce outside mutex (non-EnforcingContributionStore).
+        // Same skipExpensiveStopChecks opt-in — post-write recheck still runs.
+        policyResult = await enforcer.enforce(contribution, true, {
+          skipStopConditions,
+          skipExpensiveStopChecks: true,
+        });
       }
     }
 

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1410,27 +1410,51 @@ export async function contributeOperation(
       deps.contract?.stopConditions !== undefined &&
       deps.contributionStore !== undefined
     ) {
-      try {
-        const { evaluateStopConditions } = await import("../stop-conditions.js");
-        const postWriteResult = await evaluateStopConditions(deps.contract, deps.contributionStore);
-        if (postWriteResult.stopped) {
-          policyResult = {
-            ...policyResult,
-            stopResult: {
-              stopped: true,
-              reason: Object.entries(postWriteResult.conditions)
-                .filter(([, c]) => c.met)
-                .map(([name, c]) => `${name}: ${c.reason}`)
-                .join("; "),
-            },
-          };
+      // Bounded retry with exponential backoff — addresses Codex review r3:
+      // the scanning stop evaluators are the ONLY detector for
+      // quorum/deliberation on the mutex-hook path, so a transient
+      // store read failure must not silently drop a stop signal.
+      // 3 attempts × (100ms, 400ms) backoff caps at ~500ms added latency
+      // in the worst case; success on attempt 1 adds zero latency.
+      const { evaluateStopConditions } = await import("../stop-conditions.js");
+      const POST_WRITE_RECHECK_ATTEMPTS = 3;
+      let attempt = 0;
+      let lastError: unknown;
+      while (attempt < POST_WRITE_RECHECK_ATTEMPTS) {
+        try {
+          const postWriteResult = await evaluateStopConditions(
+            deps.contract,
+            deps.contributionStore,
+          );
+          if (postWriteResult.stopped) {
+            policyResult = {
+              ...policyResult,
+              stopResult: {
+                stopped: true,
+                reason: Object.entries(postWriteResult.conditions)
+                  .filter(([, c]) => c.met)
+                  .map(([name, c]) => `${name}: ${c.reason}`)
+                  .join("; "),
+              },
+            };
+          }
+          lastError = undefined;
+          break;
+        } catch (err) {
+          lastError = err;
+          attempt += 1;
+          if (attempt < POST_WRITE_RECHECK_ATTEMPTS) {
+            await new Promise((resolve) => setTimeout(resolve, 100 * 4 ** (attempt - 1)));
+          }
         }
-      } catch (err) {
-        // Best-effort: the contribution is already committed. A stop-condition
-        // recheck failure does not invalidate the write, but log it so operators
-        // can detect cases where a threshold-crossing stop signal was lost.
+      }
+      if (lastError !== undefined) {
+        // All attempts exhausted: log and continue. The contribution is already
+        // committed; the next write's recheck provides another chance to detect
+        // the stop signal. Still best-effort on total Nexus outage — but no
+        // longer single-attempt.
         process.stderr.write(
-          `[grove] Warning: post-write stop-condition recheck failed: ${err instanceof Error ? err.message : String(err)}\n`,
+          `[grove] Warning: post-write stop-condition recheck failed after ${POST_WRITE_RECHECK_ATTEMPTS} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}\n`,
         );
       }
     }
@@ -1473,30 +1497,37 @@ export async function contributeOperation(
       ...(policyResult !== undefined ? { policy: policyResult } : {}),
     };
 
-    // Refresh the durable idempotency row with the final result. The earlier
-    // write at the DURABLE COMMIT BOUNDARY stored `committedResult`, which
-    // reflects only the pre-write policyResult. Without this refresh, a retry
-    // (or a concurrent same-key caller reading the durable row after a
-    // process restart) would observe stopped=false for quorum/deliberation
-    // threshold-crossing writes, while the direct caller saw stopped=true.
-    // See Codex finding on #312 round 2.
+    // Refresh BOTH the in-memory idempotency cache AND the durable row with
+    // the final result so same-process retries and cross-process lookups
+    // return the same payload as the direct caller. Without this, the
+    // committedResult snapshot (pre-recheck) would persist in the in-memory
+    // cache for up to IDEMPOTENCY_TTL_MS, and same-process retries would see
+    // stopped=false while the direct caller saw stopped=true. See Codex
+    // findings on #312 rounds 2–3.
     //
-    // In-flight concurrent retries that already awaited the in-memory
-    // idempotency slot still receive committedResult — that's a pre-existing
-    // narrow window documented at the DURABLE COMMIT BOUNDARY.
-    if (
-      deps.idempotencyStore !== undefined &&
-      idempotencyCacheLookupKey !== undefined &&
-      idempotencyFingerprint !== undefined
-    ) {
-      try {
-        deps.idempotencyStore.store(
-          idempotencyCacheLookupKey,
-          idempotencyFingerprint,
-          JSON.stringify(result),
-        );
-      } catch {
-        // Best-effort — the committed row still exists with committedResult.
+    // In-flight concurrent retries that already awaited the in-memory slot's
+    // pending promise still receive committedResult — that's a pre-existing
+    // narrow window documented at the DURABLE COMMIT BOUNDARY. New retries
+    // (key lookup after the slot resolves) get the final result.
+    if (idempotencyCacheLookupKey !== undefined && idempotencyFingerprint !== undefined) {
+      const existing = idempotencyCache.get(idempotencyCacheLookupKey);
+      if (existing !== undefined && existing.fingerprint === idempotencyFingerprint) {
+        idempotencyCache.set(idempotencyCacheLookupKey, {
+          fingerprint: idempotencyFingerprint,
+          storedAt: existing.storedAt,
+          value: result,
+        });
+      }
+      if (deps.idempotencyStore !== undefined) {
+        try {
+          deps.idempotencyStore.store(
+            idempotencyCacheLookupKey,
+            idempotencyFingerprint,
+            JSON.stringify(result),
+          );
+        } catch {
+          // Best-effort — the committed row still exists with committedResult.
+        }
       }
     }
 

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1012,7 +1012,9 @@ export async function contributeOperation(
         store.setPreWriteHook(contribution.cid, async (c: Contribution) => {
           // skipExpensiveStopChecks: true — scanning stop evaluators (quorum,
           // deliberation) run in the post-write recheck below, outside the
-          // mutex, so they don't block concurrent writers (#232).
+          // mutex, so they don't block concurrent writers (#232). This opt-in
+          // is ONLY for the mutex-hook path — the fallback branch below uses
+          // the default full evaluation since it isn't holding the mutex.
           policyResult = await enforcer?.enforce(c, true, {
             skipStopConditions,
             skipExpensiveStopChecks: true,
@@ -1020,11 +1022,10 @@ export async function contributeOperation(
         });
       } else {
         // Fallback: enforce outside mutex (non-EnforcingContributionStore).
-        // Same skipExpensiveStopChecks opt-in — post-write recheck still runs.
-        policyResult = await enforcer.enforce(contribution, true, {
-          skipStopConditions,
-          skipExpensiveStopChecks: true,
-        });
+        // Not the write-mutex hot path that motivated skipExpensiveStopChecks,
+        // so keep full evaluation — the post-write recheck is best-effort and
+        // should not be the sole detector here.
+        policyResult = await enforcer.enforce(contribution, true, { skipStopConditions });
       }
     }
 
@@ -1458,9 +1459,7 @@ export async function contributeOperation(
 
     // Build the final result returned to the DIRECT caller. This includes
     // any post-write updates to policyResult (e.g., stop-condition recheck
-    // detecting a threshold crossing). Cached retries get the narrower
-    // `committedResult` built above — that's intentional, see the
-    // DURABLE COMMIT BOUNDARY comment.
+    // detecting a threshold crossing).
     const result: ContributeResult = {
       cid: contribution.cid,
       kind: contribution.kind,
@@ -1473,6 +1472,33 @@ export async function contributeOperation(
       ...(handoffIds.length > 0 ? { handoffIds } : {}),
       ...(policyResult !== undefined ? { policy: policyResult } : {}),
     };
+
+    // Refresh the durable idempotency row with the final result. The earlier
+    // write at the DURABLE COMMIT BOUNDARY stored `committedResult`, which
+    // reflects only the pre-write policyResult. Without this refresh, a retry
+    // (or a concurrent same-key caller reading the durable row after a
+    // process restart) would observe stopped=false for quorum/deliberation
+    // threshold-crossing writes, while the direct caller saw stopped=true.
+    // See Codex finding on #312 round 2.
+    //
+    // In-flight concurrent retries that already awaited the in-memory
+    // idempotency slot still receive committedResult — that's a pre-existing
+    // narrow window documented at the DURABLE COMMIT BOUNDARY.
+    if (
+      deps.idempotencyStore !== undefined &&
+      idempotencyCacheLookupKey !== undefined &&
+      idempotencyFingerprint !== undefined
+    ) {
+      try {
+        deps.idempotencyStore.store(
+          idempotencyCacheLookupKey,
+          idempotencyFingerprint,
+          JSON.stringify(result),
+        );
+      } catch {
+        // Best-effort — the committed row still exists with committedResult.
+      }
+    }
 
     return ok(result);
   } catch (error) {

--- a/src/core/policy-enforcer.test.ts
+++ b/src/core/policy-enforcer.test.ts
@@ -1098,10 +1098,7 @@ function makeFullContribution(overrides?: Partial<ContributionInput>): Contribut
 }
 
 describe("PolicyEnforcer: quorum_review_score stop condition", () => {
-  // Pre-write enforcement skips the scanning quorum evaluator (#232) to keep
-  // the write mutex cheap. Threshold-crossing writes are detected by the
-  // post-write recheck in contributeOperation, not by enforce() directly.
-  test("skipped on pre-write path even when quorum is met", async () => {
+  test("stopped when quorum is met", async () => {
     const target = makeFullContribution({ summary: "Work to review" });
     const review1 = makeFullContribution({
       kind: ContributionKind.Review,
@@ -1137,8 +1134,38 @@ describe("PolicyEnforcer: quorum_review_score stop condition", () => {
 
     const result = await enforcer.enforce(contribution, false);
     expect(result.stopResult).toBeDefined();
+    expect(result.stopResult!.stopped).toBe(true);
+    expect(result.stopResult!.reason).toContain("quorum_review_score");
+  });
+
+  test("skipExpensiveStopChecks=true omits quorum even when met", async () => {
+    const target = makeFullContribution({ summary: "Work" });
+    const r1 = makeFullContribution({
+      kind: ContributionKind.Review,
+      summary: "Review 1",
+      relations: [
+        { targetCid: target.cid, relationType: RelationType.Reviews, metadata: { score: 0.9 } },
+      ],
+    });
+    const r2 = makeFullContribution({
+      kind: ContributionKind.Review,
+      summary: "Review 2",
+      relations: [
+        { targetCid: target.cid, relationType: RelationType.Reviews, metadata: { score: 0.95 } },
+      ],
+    });
+    const contract: GroveContract = {
+      contractVersion: 2,
+      name: "test",
+      stopConditions: { quorumReviewScore: { minReviews: 2, minScore: 0.8 } },
+    };
+    const store = new InMemoryContributionStore([target, r1, r2]);
+    const enforcer = new PolicyEnforcer(contract, store);
+    const contribution = makeContribution();
+
+    const result = await enforcer.enforce(contribution, false, { skipExpensiveStopChecks: true });
+    expect(result.stopResult).toBeDefined();
     expect(result.stopResult!.stopped).toBe(false);
-    expect(result.stopResult!.reason).toBeUndefined();
   });
 
   test("not stopped when quorum is not met", async () => {
@@ -1171,10 +1198,7 @@ describe("PolicyEnforcer: quorum_review_score stop condition", () => {
 });
 
 describe("PolicyEnforcer: deliberation_limit stop condition", () => {
-  // Pre-write enforcement skips the scanning deliberation evaluator (#232)
-  // to keep the write mutex cheap. Post-write recheck in contributeOperation
-  // catches threshold crossings.
-  test("skipped on pre-write path even when thread depth exceeds limit", async () => {
+  test("stopped when thread depth exceeds limit", async () => {
     const root = makeFullContribution({ summary: "Topic root" });
     const reply1 = makeFullContribution({
       kind: ContributionKind.Discussion,
@@ -1203,8 +1227,36 @@ describe("PolicyEnforcer: deliberation_limit stop condition", () => {
 
     const result = await enforcer.enforce(contribution, false);
     expect(result.stopResult).toBeDefined();
+    expect(result.stopResult!.stopped).toBe(true);
+    expect(result.stopResult!.reason).toContain("deliberation_limit");
+  });
+
+  test("skipExpensiveStopChecks=true omits deliberation even when exceeded", async () => {
+    const root = makeFullContribution({ summary: "Topic root" });
+    const r1 = makeFullContribution({
+      kind: ContributionKind.Discussion,
+      relations: [{ targetCid: root.cid, relationType: RelationType.RespondsTo }],
+    });
+    const r2 = makeFullContribution({
+      kind: ContributionKind.Discussion,
+      relations: [{ targetCid: r1.cid, relationType: RelationType.RespondsTo }],
+    });
+    const r3 = makeFullContribution({
+      kind: ContributionKind.Discussion,
+      relations: [{ targetCid: r2.cid, relationType: RelationType.RespondsTo }],
+    });
+    const contract: GroveContract = {
+      contractVersion: 2,
+      name: "test",
+      stopConditions: { deliberationLimit: { maxRounds: 3 } },
+    };
+    const store = new InMemoryContributionStore([root, r1, r2, r3]);
+    const enforcer = new PolicyEnforcer(contract, store);
+    const contribution = makeContribution();
+
+    const result = await enforcer.enforce(contribution, false, { skipExpensiveStopChecks: true });
+    expect(result.stopResult).toBeDefined();
     expect(result.stopResult!.stopped).toBe(false);
-    expect(result.stopResult!.reason).toBeUndefined();
   });
 
   test("not stopped when thread is below limit", async () => {

--- a/src/core/policy-enforcer.test.ts
+++ b/src/core/policy-enforcer.test.ts
@@ -1098,7 +1098,10 @@ function makeFullContribution(overrides?: Partial<ContributionInput>): Contribut
 }
 
 describe("PolicyEnforcer: quorum_review_score stop condition", () => {
-  test("stopped when quorum is met", async () => {
+  // Pre-write enforcement skips the scanning quorum evaluator (#232) to keep
+  // the write mutex cheap. Threshold-crossing writes are detected by the
+  // post-write recheck in contributeOperation, not by enforce() directly.
+  test("skipped on pre-write path even when quorum is met", async () => {
     const target = makeFullContribution({ summary: "Work to review" });
     const review1 = makeFullContribution({
       kind: ContributionKind.Review,
@@ -1134,8 +1137,8 @@ describe("PolicyEnforcer: quorum_review_score stop condition", () => {
 
     const result = await enforcer.enforce(contribution, false);
     expect(result.stopResult).toBeDefined();
-    expect(result.stopResult!.stopped).toBe(true);
-    expect(result.stopResult!.reason).toContain("quorum_review_score");
+    expect(result.stopResult!.stopped).toBe(false);
+    expect(result.stopResult!.reason).toBeUndefined();
   });
 
   test("not stopped when quorum is not met", async () => {
@@ -1168,7 +1171,10 @@ describe("PolicyEnforcer: quorum_review_score stop condition", () => {
 });
 
 describe("PolicyEnforcer: deliberation_limit stop condition", () => {
-  test("stopped when thread depth exceeds limit", async () => {
+  // Pre-write enforcement skips the scanning deliberation evaluator (#232)
+  // to keep the write mutex cheap. Post-write recheck in contributeOperation
+  // catches threshold crossings.
+  test("skipped on pre-write path even when thread depth exceeds limit", async () => {
     const root = makeFullContribution({ summary: "Topic root" });
     const reply1 = makeFullContribution({
       kind: ContributionKind.Discussion,
@@ -1197,8 +1203,8 @@ describe("PolicyEnforcer: deliberation_limit stop condition", () => {
 
     const result = await enforcer.enforce(contribution, false);
     expect(result.stopResult).toBeDefined();
-    expect(result.stopResult!.stopped).toBe(true);
-    expect(result.stopResult!.reason).toContain("deliberation_limit");
+    expect(result.stopResult!.stopped).toBe(false);
+    expect(result.stopResult!.reason).toBeUndefined();
   });
 
   test("not stopped when thread is below limit", async () => {

--- a/src/core/policy-enforcer.ts
+++ b/src/core/policy-enforcer.ts
@@ -251,24 +251,28 @@ export class PolicyEnforcer {
     }
 
     // 8. Stop condition check — delegates to the canonical evaluator in
-    //    stop-conditions.ts so all five conditions use the same algorithm as
+    //    stop-conditions.ts so the cheap conditions use the same algorithm as
     //    grove_check_stop (lifecycle path).
     //
     //    Timing note: this runs pre-write, so the contribution being enforced
     //    is NOT yet in the store. A contribution that crosses a threshold
     //    (e.g., the Nth review satisfying quorum) reports stopped=false here;
-    //    the next check will detect it. This is the existing accept-then-flag
-    //    design — the same pre-write timing applied to the old budget/target/
-    //    maxRounds checks and is unchanged by this refactor.
+    //    the post-write recheck in contributeOperation will detect it. This is
+    //    the existing accept-then-flag design.
     //
-    //    Cost note: quorum_review_score requires a full store.list() and
-    //    deliberation_limit requires per-root store.thread() calls. These
-    //    run inside the write mutex when configured. Thread walks are
-    //    parallelized and depth-capped to bound latency (see stop-conditions.ts).
+    //    Cost note (#232): the scanning evaluators (quorum_review_score via
+    //    full store.list(), deliberation_limit via per-root store.thread())
+    //    are skipped here via `skipExpensive: true` so they cannot block
+    //    concurrent writers on the write mutex. The post-write recheck in
+    //    contributeOperation runs these evaluators outside the mutex, so
+    //    threshold-crossing stop signals are still detected — they simply
+    //    arrive on the post-write path instead of the pre-write path.
     let stopResult: StopCheckResult | undefined;
     if (this.config.stopConditions !== undefined && options?.skipStopConditions !== true) {
       try {
-        const evalResult = await evaluateStopConditions(this.config, this.contributionStore);
+        const evalResult = await evaluateStopConditions(this.config, this.contributionStore, {
+          skipExpensive: true,
+        });
         stopResult = {
           stopped: evalResult.stopped,
           reason: evalResult.stopped

--- a/src/core/policy-enforcer.ts
+++ b/src/core/policy-enforcer.ts
@@ -74,6 +74,15 @@ export interface DerivedOutcome {
 export interface StopCheckResult {
   readonly stopped: boolean;
   readonly reason?: string | undefined;
+  /**
+   * When `true`, stop evaluation did not complete with confidence — the
+   * scanning evaluators (`quorum_review_score`, `deliberation_limit`) could
+   * not be run (e.g., sustained store read failures on the post-write
+   * recheck path). Callers must NOT treat `stopped=false` as authoritative
+   * in this state; they should gate on `degraded === true` and surface
+   * alerts or conservative behavior to operators. See Codex review r5.
+   */
+  readonly degraded?: boolean | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/policy-enforcer.ts
+++ b/src/core/policy-enforcer.ts
@@ -144,11 +144,21 @@ export class PolicyEnforcer {
    *   (plans, ephemeral messages) through the enforcement pipeline for the
    *   role-kind check but don't want their coordination traffic to count
    *   toward progress-driven stop conditions or pay the O(n) scan cost.
+   * @param options.skipExpensiveStopChecks - When true, omit the scanning
+   *   stop evaluators (`quorumReviewScore`, `deliberationLimit`) that require
+   *   a full `store.list()` scan. Intended for the write-mutex hot path in
+   *   `contributeOperation`, where the post-write recheck (outside the mutex)
+   *   evaluates these conditions without blocking concurrent writers (#232).
+   *   Default is `false` so direct `enforce()` callers keep full parity with
+   *   `evaluateStopConditions` on quorum/deliberation.
    */
   async enforce(
     contribution: Contribution,
     strict = false,
-    options?: { readonly skipStopConditions?: boolean },
+    options?: {
+      readonly skipStopConditions?: boolean;
+      readonly skipExpensiveStopChecks?: boolean;
+    },
   ): Promise<PolicyEnforcementResult> {
     // Reset best-score cache so each enforce() call gets a fresh view of the store.
     // The cache is repopulated lazily on the first findBestScore() call within
@@ -260,18 +270,18 @@ export class PolicyEnforcer {
     //    the post-write recheck in contributeOperation will detect it. This is
     //    the existing accept-then-flag design.
     //
-    //    Cost note (#232): the scanning evaluators (quorum_review_score via
-    //    full store.list(), deliberation_limit via per-root store.thread())
-    //    are skipped here via `skipExpensive: true` so they cannot block
-    //    concurrent writers on the write mutex. The post-write recheck in
-    //    contributeOperation runs these evaluators outside the mutex, so
-    //    threshold-crossing stop signals are still detected — they simply
-    //    arrive on the post-write path instead of the pre-write path.
+    //    Cost note (#232): callers on the write-mutex hot path can pass
+    //    `skipExpensiveStopChecks: true` to omit the scanning evaluators
+    //    (quorum_review_score via full store.list(), deliberation_limit via
+    //    per-root store.thread()) and avoid blocking concurrent writers. The
+    //    default is `false` so direct callers keep full parity with
+    //    `evaluateStopConditions` — only contributeOperation opts in, and its
+    //    post-write recheck runs the full evaluator outside the mutex.
     let stopResult: StopCheckResult | undefined;
     if (this.config.stopConditions !== undefined && options?.skipStopConditions !== true) {
       try {
         const evalResult = await evaluateStopConditions(this.config, this.contributionStore, {
-          skipExpensive: true,
+          skipExpensive: options?.skipExpensiveStopChecks === true,
         });
         stopResult = {
           stopped: evalResult.stopped,

--- a/src/core/stop-conditions.test.ts
+++ b/src/core/stop-conditions.test.ts
@@ -1049,7 +1049,7 @@ describe("cross-path agreement: evaluateStopConditions vs PolicyEnforcer.enforce
     expect(enforceResult.stopResult?.stopped).toBe(true);
   });
 
-  test("quorum divergence: enforcer skips quorum on pre-write path (#232)", async () => {
+  test("quorum agreement: default enforce() evaluates quorum in parity with canonical", async () => {
     const target = makeUniqueContribution({ summary: "Quorum target" });
     const review1 = makeUniqueContribution({
       kind: ContributionKind.Review,
@@ -1083,19 +1083,26 @@ describe("cross-path agreement: evaluateStopConditions vs PolicyEnforcer.enforce
     };
     const store = new InMemoryContributionStore([target, review1, review2]);
 
-    // Canonical path (full) still detects quorum
+    // Canonical path detects quorum
     const canonical = await evaluateStopConditions(contract, store);
     expect(canonical.stopped).toBe(true);
 
-    // PolicyEnforcer path — pre-write skips scanning evaluators (quorum/
-    // deliberation) for mutex-cost reasons (#232). Post-write recheck in
-    // contributeOperation catches these; enforcer alone reports not stopped.
+    // PolicyEnforcer (default) also detects quorum — full parity. Only callers
+    // on the write-mutex hot path (contributeOperation) opt into
+    // skipExpensiveStopChecks: true; direct enforce() usage stays full.
     const enforcer = new PolicyEnforcer(contract, store);
     const enforceResult = await enforcer.enforce(makeEnforceContribution());
-    expect(enforceResult.stopResult?.stopped).toBe(false);
+    expect(enforceResult.stopResult?.stopped).toBe(true);
+
+    // With skipExpensiveStopChecks=true the enforcer diverges intentionally
+    // (post-write recheck in contributeOperation closes the gap).
+    const cheapResult = await enforcer.enforce(makeEnforceContribution(), false, {
+      skipExpensiveStopChecks: true,
+    });
+    expect(cheapResult.stopResult?.stopped).toBe(false);
   });
 
-  test("deliberation divergence: enforcer skips deliberation on pre-write path (#232)", async () => {
+  test("deliberation agreement: default enforce() evaluates deliberation in parity with canonical", async () => {
     // root → reply1 → reply2 → reply3 (depth=3), maxRounds=3
     const root = makeUniqueContribution({ summary: "Deliberation root" });
     const reply1 = makeUniqueContribution({
@@ -1127,12 +1134,16 @@ describe("cross-path agreement: evaluateStopConditions vs PolicyEnforcer.enforce
     const canonical = await evaluateStopConditions(contract, store);
     expect(canonical.stopped).toBe(true);
 
-    // PolicyEnforcer path — pre-write skips scanning evaluators (quorum/
-    // deliberation) for mutex-cost reasons (#232). Post-write recheck in
-    // contributeOperation catches these; enforcer alone reports not stopped.
+    // PolicyEnforcer (default) also detects deliberation — full parity.
     const enforcer = new PolicyEnforcer(contract, store);
     const enforceResult = await enforcer.enforce(makeEnforceContribution());
-    expect(enforceResult.stopResult?.stopped).toBe(false);
+    expect(enforceResult.stopResult?.stopped).toBe(true);
+
+    // With skipExpensiveStopChecks=true the enforcer diverges intentionally.
+    const cheapResult = await enforcer.enforce(makeEnforceContribution(), false, {
+      skipExpensiveStopChecks: true,
+    });
+    expect(cheapResult.stopResult?.stopped).toBe(false);
   });
 });
 

--- a/src/core/stop-conditions.test.ts
+++ b/src/core/stop-conditions.test.ts
@@ -1049,7 +1049,7 @@ describe("cross-path agreement: evaluateStopConditions vs PolicyEnforcer.enforce
     expect(enforceResult.stopResult?.stopped).toBe(true);
   });
 
-  test("quorum agreement: enforcer now evaluates quorum (was missing before)", async () => {
+  test("quorum divergence: enforcer skips quorum on pre-write path (#232)", async () => {
     const target = makeUniqueContribution({ summary: "Quorum target" });
     const review1 = makeUniqueContribution({
       kind: ContributionKind.Review,
@@ -1083,17 +1083,19 @@ describe("cross-path agreement: evaluateStopConditions vs PolicyEnforcer.enforce
     };
     const store = new InMemoryContributionStore([target, review1, review2]);
 
-    // Canonical path
+    // Canonical path (full) still detects quorum
     const canonical = await evaluateStopConditions(contract, store);
     expect(canonical.stopped).toBe(true);
 
-    // PolicyEnforcer path — should ALSO say stopped now
+    // PolicyEnforcer path — pre-write skips scanning evaluators (quorum/
+    // deliberation) for mutex-cost reasons (#232). Post-write recheck in
+    // contributeOperation catches these; enforcer alone reports not stopped.
     const enforcer = new PolicyEnforcer(contract, store);
     const enforceResult = await enforcer.enforce(makeEnforceContribution());
-    expect(enforceResult.stopResult?.stopped).toBe(true);
+    expect(enforceResult.stopResult?.stopped).toBe(false);
   });
 
-  test("deliberation agreement: enforcer now evaluates deliberation limits", async () => {
+  test("deliberation divergence: enforcer skips deliberation on pre-write path (#232)", async () => {
     // root → reply1 → reply2 → reply3 (depth=3), maxRounds=3
     const root = makeUniqueContribution({ summary: "Deliberation root" });
     const reply1 = makeUniqueContribution({
@@ -1125,9 +1127,118 @@ describe("cross-path agreement: evaluateStopConditions vs PolicyEnforcer.enforce
     const canonical = await evaluateStopConditions(contract, store);
     expect(canonical.stopped).toBe(true);
 
-    // PolicyEnforcer path — should ALSO say stopped now
+    // PolicyEnforcer path — pre-write skips scanning evaluators (quorum/
+    // deliberation) for mutex-cost reasons (#232). Post-write recheck in
+    // contributeOperation catches these; enforcer alone reports not stopped.
     const enforcer = new PolicyEnforcer(contract, store);
     const enforceResult = await enforcer.enforce(makeEnforceContribution());
-    expect(enforceResult.stopResult?.stopped).toBe(true);
+    expect(enforceResult.stopResult?.stopped).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section 11: Issue #232 — skipExpensive option for pre-write pipeline
+// ---------------------------------------------------------------------------
+
+describe("skipExpensive option", () => {
+  test("omits quorum_review_score when skipExpensive=true", async () => {
+    const target = makeUniqueContribution({ summary: "target" });
+    const review1 = makeUniqueContribution({
+      kind: ContributionKind.Review,
+      relations: [
+        { targetCid: target.cid, relationType: RelationType.Reviews, metadata: { score: 0.9 } },
+      ],
+    });
+    const review2 = makeUniqueContribution({
+      kind: ContributionKind.Review,
+      relations: [
+        { targetCid: target.cid, relationType: RelationType.Reviews, metadata: { score: 0.95 } },
+      ],
+    });
+    const contract: GroveContract = {
+      contractVersion: 1,
+      name: "test-grove",
+      stopConditions: { quorumReviewScore: { minReviews: 2, minScore: 0.8 } },
+    };
+    const store = new InMemoryContributionStore([target, review1, review2]);
+
+    const full = await evaluateStopConditions(contract, store);
+    expect(full.stopped).toBe(true);
+    expect(full.conditions.quorum_review_score).toBeDefined();
+
+    const cheap = await evaluateStopConditions(contract, store, { skipExpensive: true });
+    expect(cheap.stopped).toBe(false);
+    expect(cheap.conditions.quorum_review_score).toBeUndefined();
+  });
+
+  test("omits deliberation_limit when skipExpensive=true", async () => {
+    const root = makeUniqueContribution({ summary: "root" });
+    const r1 = makeUniqueContribution({
+      kind: ContributionKind.Discussion,
+      relations: [{ targetCid: root.cid, relationType: RelationType.RespondsTo }],
+    });
+    const r2 = makeUniqueContribution({
+      kind: ContributionKind.Discussion,
+      relations: [{ targetCid: r1.cid, relationType: RelationType.RespondsTo }],
+    });
+    const r3 = makeUniqueContribution({
+      kind: ContributionKind.Discussion,
+      relations: [{ targetCid: r2.cid, relationType: RelationType.RespondsTo }],
+    });
+    const contract: GroveContract = {
+      contractVersion: 1,
+      name: "test-grove",
+      stopConditions: { deliberationLimit: { maxRounds: 3 } },
+    };
+    const store = new InMemoryContributionStore([root, r1, r2, r3]);
+
+    const full = await evaluateStopConditions(contract, store);
+    expect(full.stopped).toBe(true);
+    expect(full.conditions.deliberation_limit).toBeDefined();
+
+    const cheap = await evaluateStopConditions(contract, store, { skipExpensive: true });
+    expect(cheap.stopped).toBe(false);
+    expect(cheap.conditions.deliberation_limit).toBeUndefined();
+  });
+
+  test("skipExpensive still evaluates cheap conditions", async () => {
+    const contributions = Array.from({ length: 10 }, () => makeUniqueContribution());
+    const contract: GroveContract = {
+      contractVersion: 1,
+      name: "test-grove",
+      stopConditions: {
+        budget: { maxContributions: 10 },
+        quorumReviewScore: { minReviews: 2, minScore: 0.8 },
+      },
+    };
+    const store = new InMemoryContributionStore(contributions);
+
+    const cheap = await evaluateStopConditions(contract, store, { skipExpensive: true });
+    expect(cheap.stopped).toBe(true);
+    expect(cheap.conditions.budget?.met).toBe(true);
+    expect(cheap.conditions.quorum_review_score).toBeUndefined();
+  });
+
+  test("skipExpensive avoids store.list() when only expensive conditions configured", async () => {
+    const contract: GroveContract = {
+      contractVersion: 1,
+      name: "test-grove",
+      stopConditions: { quorumReviewScore: { minReviews: 2, minScore: 0.8 } },
+    };
+    let listCalls = 0;
+    const base = new InMemoryContributionStore([]);
+    const tracking: typeof base = {
+      ...base,
+      list: async (...args: Parameters<typeof base.list>) => {
+        listCalls += 1;
+        return base.list(...args);
+      },
+      thread: base.thread.bind(base),
+      count: base.count.bind(base),
+    } as unknown as typeof base;
+
+    const result = await evaluateStopConditions(contract, tracking, { skipExpensive: true });
+    expect(result.stopped).toBe(false);
+    expect(listCalls).toBe(0);
   });
 });

--- a/src/core/stop-conditions.ts
+++ b/src/core/stop-conditions.ts
@@ -45,6 +45,21 @@ export interface DeliberationResult {
 // Canonical evaluator
 // ---------------------------------------------------------------------------
 
+/** Options for {@link evaluateStopConditions}. */
+export interface EvaluateStopConditionsOptions {
+  /**
+   * Skip the "expensive" evaluators — `quorumReviewScore` and
+   * `deliberationLimit` — which require a full `store.list()` scan and
+   * per-root `store.thread()` traversals. Callers on the pre-write hot
+   * path (PolicyEnforcer.enforce inside the write mutex) pass this to
+   * avoid blocking concurrent writers on large groves (#232). The
+   * post-write recheck in contributeOperation runs with this option
+   * disabled so threshold-crossing stops are still detected outside the
+   * mutex.
+   */
+  readonly skipExpensive?: boolean;
+}
+
 /**
  * Evaluate all stop conditions defined in a grove contract.
  *
@@ -56,10 +71,15 @@ export interface DeliberationResult {
  * contributions into memory up front. The full contribution list is
  * loaded at most once — shared between quorumReviewScore and
  * deliberationLimit if both are configured.
+ *
+ * When `options.skipExpensive` is true, the quorumReviewScore and
+ * deliberationLimit evaluators are omitted entirely and the full
+ * contribution list is not loaded.
  */
 export async function evaluateStopConditions(
   config: SessionRuntimeConfig,
   store: ContributionStore,
+  options?: EvaluateStopConditionsOptions,
 ): Promise<StopEvaluationResult> {
   const conditions: Record<string, StopConditionResult> = {};
   const stopConditions = config.stopConditions;
@@ -68,12 +88,16 @@ export async function evaluateStopConditions(
     return { stopped: false, conditions: {}, evaluatedAt: new Date().toISOString() };
   }
 
+  const evaluateQuorum =
+    stopConditions.quorumReviewScore !== undefined && options?.skipExpensive !== true;
+  const evaluateDeliberation =
+    stopConditions.deliberationLimit !== undefined && options?.skipExpensive !== true;
+
   // Load the full contribution list at most once, shared by evaluators that need it.
   // The targeted evaluators (maxRoundsWithoutImprovement, targetMetric, budget) do
-  // their own focused queries and do not use this list.
-  const needsFullList =
-    stopConditions.quorumReviewScore !== undefined ||
-    stopConditions.deliberationLimit !== undefined;
+  // their own focused queries and do not use this list. When skipExpensive=true
+  // the list is never loaded since neither expensive evaluator will run.
+  const needsFullList = evaluateQuorum || evaluateDeliberation;
   const allContributions: readonly Contribution[] = needsFullList ? await store.list() : [];
 
   if (stopConditions.maxRoundsWithoutImprovement !== undefined) {
@@ -97,7 +121,7 @@ export async function evaluateStopConditions(
     conditions.budget = await evaluateBudget(stopConditions.budget, store);
   }
 
-  if (stopConditions.quorumReviewScore !== undefined) {
+  if (evaluateQuorum && stopConditions.quorumReviewScore !== undefined) {
     conditions.quorum_review_score = evaluateQuorumReviewScore(
       stopConditions.quorumReviewScore.minReviews,
       stopConditions.quorumReviewScore.minScore,
@@ -105,7 +129,7 @@ export async function evaluateStopConditions(
     );
   }
 
-  if (stopConditions.deliberationLimit !== undefined) {
+  if (evaluateDeliberation && stopConditions.deliberationLimit !== undefined) {
     conditions.deliberation_limit = await evaluateDeliberationLimit(
       stopConditions.deliberationLimit,
       allContributions,


### PR DESCRIPTION
## Summary

- `PolicyEnforcer.enforce()` (the pre-write, inside-mutex hot path) now passes `skipExpensive: true` to `evaluateStopConditions`, omitting `quorumReviewScore` and `deliberationLimit`
- Eliminates the full `store.list()` + per-root `store.thread()` scans that blocked concurrent writers on large groves
- Threshold crossings are still detected by the existing post-write recheck in `contributeOperation` (runs outside the mutex, no `skipExpensive`)
- `grove_check_stop` (lifecycle path) unchanged — still evaluates all 5 conditions

## Approach

Option 3 from the issue (simplest change). Pre-write evaluator now only runs the O(1)-ish conditions (`budget` via `count()`, `targetMetric` via filtered list, `maxRoundsWithoutImprovement`). The expensive scanning evaluators run exactly once per write, outside the mutex, on the post-write recheck that was already added in #233.

## Files changed

| File | Change |
|---|---|
| `src/core/stop-conditions.ts` | New `EvaluateStopConditionsOptions` with `skipExpensive`; evaluators gated, `store.list()` no longer loaded when skipped |
| `src/core/policy-enforcer.ts` | `enforce()` passes `skipExpensive: true`; comments updated |
| `src/core/stop-conditions.test.ts` | +4 tests for `skipExpensive` (incl. spy confirming `store.list()` is never called); cross-path agreement tests inverted for quorum/deliberation (divergence by design) |
| `src/core/policy-enforcer.test.ts` | 2 quorum/deliberation tests inverted — pre-write now returns `stopped=false` |

## Test plan

- [x] 5481/5481 tests pass (full suite, 278 files)
- [x] Typecheck clean
- [x] New spy test confirms `store.list()` is not called from the pre-write evaluation path when only expensive conditions are configured
- [x] Cross-path tests document the intentional divergence between canonical (full) and pre-write (cheap-only) evaluators
- [ ] Manual verification with a large-grove session configured for `quorumReviewScore` / `deliberationLimit` to confirm the mutex-hold latency drop

Closes #232