### PR TITLE
feat: bounded channel backpressure (#274) + grove-dir worktree fence (#315)

### DIFF
--- a/docs/superpowers/plans/2026-04-18-bounded-channel-backpressure.md
+++ b/docs/superpowers/plans/2026-04-18-bounded-channel-backpressure.md
@@ -1,0 +1,1207 @@
+# Bounded Channel Backpressure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Insert a bounded, per-event-kind drop-policy channel between `AcpParser` and `AcpxTurn.messages` consumers so a slow consumer never stalls the parser nor causes unbounded memory growth.
+
+**Architecture:** A generic `BoundedEventChannel<T>` ring buffer with a parallel `policyAt: Policy[]` ring (records each slot's classification at push time). Push is synchronous and never blocks: chunked text/thinking deltas coalesce into the most recent same-kind buffered event via a per-kind tail-index map; semantic events (`tool_call`, `permission_request`, terminal text) evict the oldest drop-eligible slot to fit; cosmetic events (`token_usage`, `raw`) evict the oldest. Single consumer per channel. `AcpxTurnImpl` constructs one channel per turn, drains the existing `parser.messages` subscriber into it, and exposes the channel as its `messages` iterable.
+
+**Tech Stack:** TypeScript, Bun test runner (`bun:test`), Node `Readable` streams. No new runtime deps.
+
+**Design spec:** `docs/superpowers/specs/2026-04-18-bounded-channel-backpressure-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/acp/bounded-channel.ts` | **create** | Generic `BoundedEventChannel<T>`: ring buffer, policy resolver, async iterator, stats. Zero ACP coupling. |
+| `src/acp/bounded-channel.test.ts` | **create** | Unit tests for the generic primitive. Uses a synthetic `TestEvent` type. |
+| `src/acp/turn.ts` | **modify** | `AcpxTurnImpl` constructs channel with ACP-specific `classify`/`coalesceKey`/`coalesce`/`invalidatesCoalesceKey` callbacks. Exposes channel as `this.messages`. |
+| `src/acp/turn.test.ts` | **modify** | Add 4 integration tests: default capacity 256, Infinity bypass, kind classification, slow-consumer simulation. Existing 8 tests stay green. |
+
+---
+
+## Task 1: Scaffold BoundedEventChannel module + first failing test
+
+**Files:**
+- Create: `src/acp/bounded-channel.ts`
+- Create: `src/acp/bounded-channel.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/acp/bounded-channel.test.ts
+import { expect, test } from "bun:test";
+import { BoundedEventChannel, type Policy } from "./bounded-channel.js";
+
+interface TestEvent {
+  kind: "drop" | "keep" | "delta_a" | "delta_b" | "terminal_a";
+  text?: string;
+  id: number;
+}
+
+function classify(e: TestEvent): Policy {
+  if (e.kind === "keep" || e.kind === "terminal_a") return "never";
+  if (e.kind === "delta_a" || e.kind === "delta_b") return "coalesce_text_deltas";
+  return "drop_oldest_on_full";
+}
+
+function coalesceKey(e: TestEvent): string | null {
+  if (e.kind === "delta_a" || e.kind === "delta_b") return e.kind;
+  return null;
+}
+
+function coalesce(existing: TestEvent, incoming: TestEvent): TestEvent {
+  return { ...existing, text: (existing.text ?? "") + (incoming.text ?? "") };
+}
+
+function invalidatesCoalesceKey(e: TestEvent): string | null {
+  if (e.kind === "terminal_a") return "delta_a";
+  return null;
+}
+
+function makeChannel(capacity = 4) {
+  return new BoundedEventChannel<TestEvent>({
+    capacity,
+    classify,
+    coalesceKey,
+    coalesce,
+    invalidatesCoalesceKey,
+  });
+}
+
+test("push 3 then drain returns 3 in FIFO order", async () => {
+  const ch = makeChannel();
+  ch.push({ kind: "drop", id: 1 });
+  ch.push({ kind: "drop", id: 2 });
+  ch.push({ kind: "drop", id: 3 });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got.map((e) => e.id)).toEqual([1, 2, 3]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/acp/bounded-channel.test.ts -t "push 3 then drain"`
+Expected: FAIL with module not found / `BoundedEventChannel` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/acp/bounded-channel.ts
+export type Policy = "never" | "coalesce_text_deltas" | "drop_oldest_on_full";
+
+export interface ChannelOptions<T> {
+  capacity: number;
+  classify: (event: T) => Policy;
+  coalesceKey?: (event: T) => string | null;
+  coalesce?: (existing: T, incoming: T) => T;
+  invalidatesCoalesceKey?: (event: T) => string | null;
+  onDrop?: (event: T, reason: "evicted" | "coalesced" | "no_capacity") => void;
+}
+
+export interface ChannelStats {
+  pushed: number;
+  coalesced: number;
+  evicted: number;
+  droppedByPolicy: Map<Policy, number>;
+}
+
+export class BoundedEventChannel<T> {
+  private readonly opts: ChannelOptions<T>;
+  private readonly buffer: (T | undefined)[];
+  private readonly policyAt: (Policy | undefined)[];
+  private head = 0;
+  private tail = 0;
+  private size = 0;
+  private readonly coalesceTails = new Map<string, number>();
+  private pendingResolver: ((value: IteratorResult<T>) => void) | null = null;
+  private closed = false;
+  private readonly _stats: ChannelStats = {
+    pushed: 0,
+    coalesced: 0,
+    evicted: 0,
+    droppedByPolicy: new Map(),
+  };
+  private readonly unbounded: boolean;
+
+  constructor(opts: ChannelOptions<T>) {
+    this.opts = opts;
+    this.unbounded = !Number.isFinite(opts.capacity);
+    // For unbounded, allocate a small initial array and grow on push.
+    const initial = this.unbounded ? 16 : opts.capacity;
+    this.buffer = new Array(initial);
+    this.policyAt = new Array(initial);
+  }
+
+  push(event: T): void {
+    if (this.closed) {
+      this.opts.onDrop?.(event, "no_capacity");
+      return;
+    }
+    this._stats.pushed++;
+    // Minimal: append-only. Policy logic added in later tasks.
+    this._appendTail(event, this.opts.classify(event));
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.pendingResolver && this.size === 0) {
+      const r = this.pendingResolver;
+      this.pendingResolver = null;
+      r({ value: undefined as unknown as T, done: true });
+    }
+  }
+
+  stats(): ChannelStats {
+    return {
+      pushed: this._stats.pushed,
+      coalesced: this._stats.coalesced,
+      evicted: this._stats.evicted,
+      droppedByPolicy: new Map(this._stats.droppedByPolicy),
+    };
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    const self = this;
+    return {
+      async next(): Promise<IteratorResult<T>> {
+        if (self.size > 0) {
+          const ev = self.buffer[self.head] as T;
+          self.buffer[self.head] = undefined;
+          self.policyAt[self.head] = undefined;
+          // Clear coalesce tail if this index was a tail.
+          for (const [k, idx] of self.coalesceTails) {
+            if (idx === self.head) self.coalesceTails.delete(k);
+          }
+          self.head = (self.head + 1) % self.buffer.length;
+          self.size--;
+          return { value: ev, done: false };
+        }
+        if (self.closed) return { value: undefined as unknown as T, done: true };
+        return new Promise<IteratorResult<T>>((resolve) => {
+          self.pendingResolver = resolve;
+        });
+      },
+      async return(): Promise<IteratorResult<T>> {
+        self.closed = true;
+        return { value: undefined as unknown as T, done: true };
+      },
+    };
+  }
+
+  private _appendTail(event: T, policy: Policy): void {
+    if (this.pendingResolver) {
+      const r = this.pendingResolver;
+      this.pendingResolver = null;
+      r({ value: event, done: false });
+      return;
+    }
+    if (this.unbounded && this.size === this.buffer.length) {
+      this._grow();
+    }
+    this.buffer[this.tail] = event;
+    this.policyAt[this.tail] = policy;
+    this.tail = (this.tail + 1) % this.buffer.length;
+    this.size++;
+  }
+
+  private _grow(): void {
+    const oldCap = this.buffer.length;
+    const newCap = oldCap * 2;
+    const newBuf: (T | undefined)[] = new Array(newCap);
+    const newPol: (Policy | undefined)[] = new Array(newCap);
+    for (let i = 0; i < this.size; i++) {
+      const idx = (this.head + i) % oldCap;
+      newBuf[i] = this.buffer[idx];
+      newPol[i] = this.policyAt[idx];
+    }
+    // Replace via index assignment to preserve readonly-ish array refs.
+    this.buffer.length = 0;
+    this.policyAt.length = 0;
+    for (let i = 0; i < newCap; i++) {
+      this.buffer.push(newBuf[i]);
+      this.policyAt.push(newPol[i]);
+    }
+    this.head = 0;
+    this.tail = this.size;
+    this.coalesceTails.clear(); // indices invalid after rehome — safe-loss
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/acp/bounded-channel.test.ts -t "push 3 then drain"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/acp/bounded-channel.ts src/acp/bounded-channel.test.ts
+git commit -m "feat(acp): scaffold BoundedEventChannel with FIFO drain (#274)"
+```
+
+---
+
+## Task 2: drop_oldest_on_full evicts oldest when buffer full
+
+**Files:**
+- Modify: `src/acp/bounded-channel.ts`
+- Modify: `src/acp/bounded-channel.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/acp/bounded-channel.test.ts`:
+
+```ts
+test("drop_oldest_on_full: cap+10 pushes, drain returns last `cap` in order", async () => {
+  const cap = 4;
+  const evicted: TestEvent[] = [];
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: cap,
+    classify,
+    onDrop: (e, reason) => {
+      if (reason === "evicted") evicted.push(e);
+    },
+  });
+  for (let i = 1; i <= cap + 10; i++) ch.push({ kind: "drop", id: i });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got.map((e) => e.id)).toEqual([11, 12, 13, 14]);
+  expect(evicted.map((e) => e.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  expect(ch.stats().evicted).toBe(10);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/acp/bounded-channel.test.ts -t "drop_oldest_on_full"`
+Expected: FAIL — buffer overruns or ordering wrong because eviction is unimplemented.
+
+- [ ] **Step 3: Implement eviction in push for drop_oldest_on_full**
+
+Replace the body of `push()` in `src/acp/bounded-channel.ts`:
+
+```ts
+push(event: T): void {
+  if (this.closed) {
+    this.opts.onDrop?.(event, "no_capacity");
+    return;
+  }
+  this._stats.pushed++;
+  const policy = this.opts.classify(event);
+
+  if (policy === "drop_oldest_on_full") {
+    if (!this.unbounded && this.size === this.buffer.length) {
+      const victim = this.buffer[this.head] as T;
+      this._evictAt(this.head);
+      this._stats.evicted++;
+      this.opts.onDrop?.(victim, "evicted");
+    }
+    this._appendTail(event, policy);
+    return;
+  }
+
+  // never + coalesce policies handled in later tasks; for now, append.
+  this._appendTail(event, policy);
+}
+```
+
+Add `_evictAt` helper to the class:
+
+```ts
+private _evictAt(idx: number): void {
+  this.buffer[idx] = undefined;
+  this.policyAt[idx] = undefined;
+  for (const [k, i] of this.coalesceTails) {
+    if (i === idx) this.coalesceTails.delete(k);
+  }
+  if (idx === this.head) {
+    this.head = (this.head + 1) % this.buffer.length;
+    this.size--;
+    return;
+  }
+  // Mid-ring eviction: shift tail-side elements one slot toward head to keep
+  // the ring contiguous. Cheap because cap is small (256).
+  const cap = this.buffer.length;
+  let cur = idx;
+  while (true) {
+    const next = (cur + 1) % cap;
+    if (next === this.tail) break;
+    this.buffer[cur] = this.buffer[next];
+    this.policyAt[cur] = this.policyAt[next];
+    // Update coalesceTails entries that pointed at `next` → now `cur`.
+    for (const [k, i] of this.coalesceTails) {
+      if (i === next) this.coalesceTails.set(k, cur);
+    }
+    cur = next;
+  }
+  this.tail = (this.tail - 1 + cap) % cap;
+  this.buffer[this.tail] = undefined;
+  this.policyAt[this.tail] = undefined;
+  this.size--;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/acp/bounded-channel.test.ts -t "drop_oldest_on_full"`
+Expected: PASS. Also re-run prior test:
+Run: `bun test src/acp/bounded-channel.test.ts`
+Expected: 2/2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/acp/bounded-channel.ts src/acp/bounded-channel.test.ts
+git commit -m "feat(acp): drop_oldest_on_full eviction in BoundedEventChannel (#274)"
+```
+
+---
+
+## Task 3: coalesce_text_deltas merges into per-kind tail
+
+**Files:**
+- Modify: `src/acp/bounded-channel.ts`
+- Modify: `src/acp/bounded-channel.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append:
+
+```ts
+test("coalesce hot path: 100 deltas merge into one buffered event", async () => {
+  const ch = makeChannel(8);
+  for (let i = 0; i < 100; i++) ch.push({ kind: "delta_a", id: i, text: "x" });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got).toHaveLength(1);
+  expect(got[0]?.text).toBe("x".repeat(100));
+  expect(ch.stats().coalesced).toBe(99);
+});
+
+test("coalesce key isolation: delta_a and delta_b coalesce independently", async () => {
+  const ch = makeChannel(8);
+  for (let i = 0; i < 5; i++) {
+    ch.push({ kind: "delta_a", id: i, text: "a" });
+    ch.push({ kind: "delta_b", id: i, text: "b" });
+  }
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got).toHaveLength(2);
+  const byKind = Object.fromEntries(got.map((e) => [e.kind, e.text]));
+  expect(byKind["delta_a"]).toBe("aaaaa");
+  expect(byKind["delta_b"]).toBe("bbbbb");
+});
+
+test("coalesce tail invalidated on consume: next delta starts new entry", async () => {
+  const ch = makeChannel(8);
+  ch.push({ kind: "delta_a", id: 1, text: "a" });
+  ch.push({ kind: "delta_a", id: 2, text: "b" }); // coalesces → "ab"
+  // Drain manually so we control timing; iterator drains both as one event "ab".
+  const it = ch[Symbol.asyncIterator]();
+  const first = await it.next();
+  expect(first.value.text).toBe("ab");
+  // Tail consumed → next delta must NOT merge into it.
+  ch.push({ kind: "delta_a", id: 3, text: "c" });
+  ch.close();
+  const second = await it.next();
+  expect(second.value.text).toBe("c");
+  const third = await it.next();
+  expect(third.done).toBe(true);
+});
+
+test("coalesce tail invalidated by terminal: next delta starts new entry", async () => {
+  const ch = makeChannel(8);
+  ch.push({ kind: "delta_a", id: 1, text: "a" });
+  ch.push({ kind: "delta_a", id: 2, text: "b" });
+  ch.push({ kind: "terminal_a", id: 3 }); // invalidates delta_a tail
+  ch.push({ kind: "delta_a", id: 4, text: "c" }); // must NOT merge into id=1/2
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got).toHaveLength(3);
+  expect(got[0]?.text).toBe("ab");
+  expect(got[1]?.kind).toBe("terminal_a");
+  expect(got[2]?.text).toBe("c");
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/acp/bounded-channel.test.ts -t "coalesce"`
+Expected: FAIL — coalesce not implemented; events accumulate without merging.
+
+- [ ] **Step 3: Implement coalesce in push**
+
+Update `push()` in `src/acp/bounded-channel.ts` to handle `coalesce_text_deltas` and the terminal-invalidation case for `never`:
+
+```ts
+push(event: T): void {
+  if (this.closed) {
+    this.opts.onDrop?.(event, "no_capacity");
+    return;
+  }
+  this._stats.pushed++;
+  const policy = this.opts.classify(event);
+
+  if (policy === "coalesce_text_deltas") {
+    const key = this.opts.coalesceKey?.(event) ?? null;
+    if (key !== null && this.coalesceTails.has(key) && this.opts.coalesce) {
+      const idx = this.coalesceTails.get(key) as number;
+      this.buffer[idx] = this.opts.coalesce(this.buffer[idx] as T, event);
+      this._stats.coalesced++;
+      this.opts.onDrop?.(event, "coalesced");
+      return;
+    }
+    // Fall through to append; record tail after.
+    const tailIdxBefore = this.tail;
+    this._appendTail(event, policy);
+    // Only record tail if event was actually buffered (not fast-pathed).
+    if (this.size > 0 && this.policyAt[tailIdxBefore] === policy && key !== null) {
+      this.coalesceTails.set(key, tailIdxBefore);
+    }
+    return;
+  }
+
+  if (policy === "never") {
+    const invKey = this.opts.invalidatesCoalesceKey?.(event) ?? null;
+    if (invKey !== null) this.coalesceTails.delete(invKey);
+    // Eviction-to-fit handled in Task 4. For now, just append.
+    this._appendTail(event, policy);
+    return;
+  }
+
+  if (policy === "drop_oldest_on_full") {
+    if (!this.unbounded && this.size === this.buffer.length) {
+      const victim = this.buffer[this.head] as T;
+      this._evictAt(this.head);
+      this._stats.evicted++;
+      this.opts.onDrop?.(victim, "evicted");
+    }
+    this._appendTail(event, policy);
+    return;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/acp/bounded-channel.test.ts`
+Expected: 6/6 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/acp/bounded-channel.ts src/acp/bounded-channel.test.ts
+git commit -m "feat(acp): coalesce_text_deltas with per-kind tail invalidation (#274)"
+```
+
+---
+
+## Task 4: never policy evicts drop-eligible to fit
+
+**Files:**
+- Modify: `src/acp/bounded-channel.ts`
+- Modify: `src/acp/bounded-channel.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append:
+
+```ts
+test("never policy evicts oldest drop-eligible to make room", async () => {
+  const cap = 4;
+  const ch = new BoundedEventChannel<TestEvent>({ capacity: cap, classify });
+  // Fill with drop-eligible.
+  for (let i = 1; i <= cap; i++) ch.push({ kind: "drop", id: i });
+  // Push semantic event — must evict the OLDEST drop-eligible (id=1).
+  ch.push({ kind: "keep", id: 99 });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got.map((e) => e.id)).toEqual([2, 3, 4, 99]);
+  expect(ch.stats().evicted).toBe(1);
+});
+
+test("never policy with no drop-eligible: incoming dropped, counter increments", async () => {
+  const cap = 3;
+  const dropped: TestEvent[] = [];
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: cap,
+    classify,
+    onDrop: (e, reason) => {
+      if (reason === "no_capacity") dropped.push(e);
+    },
+  });
+  // Fill with never-policy events.
+  for (let i = 1; i <= cap; i++) ch.push({ kind: "keep", id: i });
+  // Push another never-policy → no drop-eligible victim → drop incoming.
+  ch.push({ kind: "keep", id: 99 });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got.map((e) => e.id)).toEqual([1, 2, 3]);
+  expect(dropped.map((e) => e.id)).toEqual([99]);
+  expect(ch.stats().droppedByPolicy.get("never")).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/acp/bounded-channel.test.ts -t "never policy"`
+Expected: FAIL — `never` branch in push currently calls `_appendTail` which lacks bounded-eviction support, so semantic events overflow or wedge silently.
+
+- [ ] **Step 3: Implement evict-to-fit in never branch**
+
+Add helper to the class:
+
+```ts
+private _findOldestDropEligibleIdx(): number {
+  // Walk head → tail in ring order; return first slot whose policy is drop_oldest_on_full.
+  const cap = this.buffer.length;
+  for (let i = 0; i < this.size; i++) {
+    const idx = (this.head + i) % cap;
+    if (this.policyAt[idx] === "drop_oldest_on_full") return idx;
+  }
+  return -1;
+}
+```
+
+Replace the `never` branch of `push()`:
+
+```ts
+if (policy === "never") {
+  const invKey = this.opts.invalidatesCoalesceKey?.(event) ?? null;
+  if (invKey !== null) this.coalesceTails.delete(invKey);
+
+  if (!this.unbounded && this.size === this.buffer.length) {
+    const victimIdx = this._findOldestDropEligibleIdx();
+    if (victimIdx === -1) {
+      // All slots are never-policy → preserve bounded mem; drop incoming.
+      const prev = this._stats.droppedByPolicy.get("never") ?? 0;
+      this._stats.droppedByPolicy.set("never", prev + 1);
+      this.opts.onDrop?.(event, "no_capacity");
+      return;
+    }
+    const victim = this.buffer[victimIdx] as T;
+    this._evictAt(victimIdx);
+    this._stats.evicted++;
+    this.opts.onDrop?.(victim, "evicted");
+  }
+  this._appendTail(event, policy);
+  return;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/acp/bounded-channel.test.ts`
+Expected: 8/8 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/acp/bounded-channel.ts src/acp/bounded-channel.test.ts
+git commit -m "feat(acp): never-policy evicts drop-eligible victim, drops incoming if none (#274)"
+```
+
+---
+
+## Task 5: Iterator awaiting empty + close drains then EOFs
+
+**Files:**
+- Modify: `src/acp/bounded-channel.test.ts`
+- (No source changes needed — fast-path resolver already implemented in Task 1; this task verifies it.)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append:
+
+```ts
+test("iterator awaiting empty: push resolves directly without buffering", async () => {
+  const ch = makeChannel(4);
+  const it = ch[Symbol.asyncIterator]();
+  // Start consuming before any push — iterator is now pending.
+  const nextP = it.next();
+  ch.push({ kind: "drop", id: 1 });
+  const r = await nextP;
+  expect(r.value.id).toBe(1);
+  // Verify the event did NOT pass through the ring (size never grew).
+  // Indirect check: stats.pushed === 1, but no eviction needed even at cap=1.
+  // Construct a cap=1 channel and push twice with consumer awaiting:
+  const ch2 = new BoundedEventChannel<TestEvent>({ capacity: 1, classify });
+  const it2 = ch2[Symbol.asyncIterator]();
+  const p1 = it2.next();
+  ch2.push({ kind: "drop", id: 1 });
+  expect((await p1).value.id).toBe(1);
+  const p2 = it2.next();
+  ch2.push({ kind: "drop", id: 2 });
+  expect((await p2).value.id).toBe(2);
+  expect(ch2.stats().evicted).toBe(0); // never buffered, never evicted
+});
+
+test("close drains buffered then signals done", async () => {
+  const ch = makeChannel(8);
+  ch.push({ kind: "drop", id: 1 });
+  ch.push({ kind: "drop", id: 2 });
+  ch.push({ kind: "drop", id: 3 });
+  ch.close();
+  const it = ch[Symbol.asyncIterator]();
+  expect((await it.next()).value.id).toBe(1);
+  expect((await it.next()).value.id).toBe(2);
+  expect((await it.next()).value.id).toBe(3);
+  expect((await it.next()).done).toBe(true);
+});
+
+test("close while iterator pending resolves it as done", async () => {
+  const ch = makeChannel(8);
+  const it = ch[Symbol.asyncIterator]();
+  const nextP = it.next();
+  ch.close();
+  const r = await nextP;
+  expect(r.done).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test src/acp/bounded-channel.test.ts -t "iterator awaiting empty|close drains|close while iterator pending"`
+Expected: FAIL on "close while iterator pending" — current `close()` only resolves pending if `size === 0` AND `closed` is checked correctly, but the existing implementation does this. Verify behavior; if pass, move on.
+
+If any test fails, the most likely fix is in `close()`. Ensure:
+
+```ts
+close(): void {
+  this.closed = true;
+  if (this.pendingResolver) {
+    const r = this.pendingResolver;
+    this.pendingResolver = null;
+    r({ value: undefined as unknown as T, done: true });
+  }
+}
+```
+
+(Drop the `size === 0` guard from Task 1's stub — pending only exists when size was 0 anyway.)
+
+- [ ] **Step 3: Re-run all tests**
+
+Run: `bun test src/acp/bounded-channel.test.ts`
+Expected: 11/11 PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/acp/bounded-channel.ts src/acp/bounded-channel.test.ts
+git commit -m "test(acp): cover fast-path resolver + close-while-pending (#274)"
+```
+
+---
+
+## Task 6: Consumer break cleanup + post-close push drops silently
+
+**Files:**
+- Modify: `src/acp/bounded-channel.test.ts`
+- Possibly modify: `src/acp/bounded-channel.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+test("consumer break: subsequent pushes drop silently and channel marks closed", async () => {
+  const dropped: TestEvent[] = [];
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: 4,
+    classify,
+    onDrop: (e, reason) => {
+      if (reason === "no_capacity") dropped.push(e);
+    },
+  });
+  ch.push({ kind: "drop", id: 1 });
+  ch.push({ kind: "drop", id: 2 });
+  for await (const e of ch) {
+    expect(e.id).toBe(1);
+    break; // triggers iterator.return() → channel marks closed
+  }
+  ch.push({ kind: "drop", id: 3 });
+  ch.push({ kind: "keep", id: 4 });
+  expect(dropped.map((e) => e.id)).toEqual([3, 4]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `bun test src/acp/bounded-channel.test.ts -t "consumer break"`
+Expected: PASS — `return()` already sets `closed = true` (Task 1). If it fails, check the iterator's `return()`:
+
+```ts
+async return(): Promise<IteratorResult<T>> {
+  self.closed = true;
+  // Drop any pending resolver (no consumer to wake).
+  self.pendingResolver = null;
+  return { value: undefined as unknown as T, done: true };
+},
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `bun test src/acp/bounded-channel.test.ts`
+Expected: 12/12 PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/acp/bounded-channel.ts src/acp/bounded-channel.test.ts
+git commit -m "test(acp): consumer break closes channel and drops further pushes (#274)"
+```
+
+---
+
+## Task 7: Stats accuracy + onDrop reasons under mixed push
+
+**Files:**
+- Modify: `src/acp/bounded-channel.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+test("stats accuracy under mixed push: pushed/coalesced/evicted/droppedByPolicy", async () => {
+  const cap = 3;
+  const reasons: Array<{ id: number; reason: string }> = [];
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: cap,
+    classify,
+    coalesceKey,
+    coalesce,
+    invalidatesCoalesceKey,
+    onDrop: (e, reason) => reasons.push({ id: e.id, reason }),
+  });
+
+  // 3 deltas → 1 buffered, 2 coalesced
+  ch.push({ kind: "delta_a", id: 1, text: "a" });
+  ch.push({ kind: "delta_a", id: 2, text: "b" });
+  ch.push({ kind: "delta_a", id: 3, text: "c" });
+  // 2 drop-eligible (cap reached: 1 delta + 2 drop = 3)
+  ch.push({ kind: "drop", id: 4 });
+  ch.push({ kind: "drop", id: 5 });
+  // never → evicts oldest drop-eligible (id=4)
+  ch.push({ kind: "keep", id: 6 });
+  // another never with no drop-eligible left? buffer = [delta_a-merged, drop-5, keep-6]
+  // → drop-5 is the only drop-eligible → evicted
+  ch.push({ kind: "keep", id: 7 });
+  // now buffer = [delta_a-merged, keep-6, keep-7] → all never-policy
+  // next never → no drop-eligible → drop incoming
+  ch.push({ kind: "keep", id: 8 });
+
+  const s = ch.stats();
+  expect(s.pushed).toBe(8);
+  expect(s.coalesced).toBe(2);
+  expect(s.evicted).toBe(2); // id=4 and id=5
+  expect(s.droppedByPolicy.get("never")).toBe(1); // id=8
+
+  expect(reasons).toEqual([
+    { id: 2, reason: "coalesced" },
+    { id: 3, reason: "coalesced" },
+    { id: 4, reason: "evicted" },
+    { id: 5, reason: "evicted" },
+    { id: 8, reason: "no_capacity" },
+  ]);
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `bun test src/acp/bounded-channel.test.ts -t "stats accuracy"`
+Expected: PASS (counters wired in Tasks 2/3/4). If it fails, the failure message identifies which counter is off.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `bun test src/acp/bounded-channel.test.ts`
+Expected: 13/13 PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/acp/bounded-channel.test.ts
+git commit -m "test(acp): stats and onDrop reasons under mixed push (#274)"
+```
+
+---
+
+## Task 8: Wire AcpxTurnImpl through BoundedEventChannel
+
+**Files:**
+- Modify: `src/acp/turn.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/acp/turn.test.ts`:
+
+```ts
+test("AcpxTurnImpl: default capacity 256, 257th drop_oldest evicts oldest", async () => {
+  // Build a stream of 257 raw frames (raw → drop_oldest_on_full policy).
+  const lines: string[] = [];
+  for (let i = 0; i < 257; i++) {
+    lines.push(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: { sessionId: "s1", update: { sessionUpdate: "_unknown_kind", n: i } },
+      }),
+    );
+  }
+  // Terminal result so result resolves and parser closes channel.
+  lines.push(JSON.stringify({ jsonrpc: "2.0", id: "req-1", result: { stopReason: "end_turn" } }));
+
+  const turn = new AcpxTurnImpl({
+    sessionId: "s1",
+    turnId: "t1",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  await turn.result;
+
+  // 256 raw events delivered (oldest evicted).
+  expect(got.length).toBe(256);
+  expect(got[0]?.kind).toBe("raw");
+  // First retained should be n=1 (n=0 was evicted).
+  const firstParams = (got[0] as { kind: "raw"; params: { n: number } }).params;
+  expect(firstParams.n).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `bun test src/acp/turn.test.ts -t "default capacity 256"`
+Expected: FAIL — without the channel, all 257 events flow through unbuffered (the consumer holds them via the for-await), so `got.length === 257`. The test's assertion of 256 confirms the channel must be wired.
+
+- [ ] **Step 3: Modify AcpxTurnImpl to use BoundedEventChannel**
+
+Replace `src/acp/turn.ts` body:
+
+```ts
+/**
+ * AcpxTurn — owns a single prompt's message stream and final result.
+ * Constructed by AcpxRuntime from the acpx child's stdout Readable.
+ */
+
+import type { Readable } from "node:stream";
+import { BoundedEventChannel, type Policy } from "./bounded-channel.js";
+import { AcpParser } from "./parser.js";
+import type { AcpxTurn, Message, Result } from "./types.js";
+
+const DEFAULT_CHANNEL_CAPACITY = 256;
+
+function classifyMessage(m: Message): Policy {
+  switch (m.kind) {
+    case "tool_call":
+    case "permission_request":
+      return "never";
+    case "text":
+    case "thinking":
+      return m.chunk ? "coalesce_text_deltas" : "never";
+    case "token_usage":
+    case "raw":
+      return "drop_oldest_on_full";
+    default:
+      return "drop_oldest_on_full";
+  }
+}
+
+function coalesceKeyFor(m: Message): string | null {
+  if ((m.kind === "text" || m.kind === "thinking") && m.chunk) return m.kind;
+  return null;
+}
+
+function coalesceMessage(existing: Message, incoming: Message): Message {
+  // Both are guaranteed same-kind chunked text/thinking by classify+key contract.
+  if (
+    (existing.kind === "text" && incoming.kind === "text") ||
+    (existing.kind === "thinking" && incoming.kind === "thinking")
+  ) {
+    return { ...existing, text: existing.text + incoming.text };
+  }
+  return existing;
+}
+
+function invalidatesCoalesceKeyFor(m: Message): string | null {
+  if ((m.kind === "text" || m.kind === "thinking") && !m.chunk) return m.kind;
+  return null;
+}
+
+export class AcpxTurnImpl implements AcpxTurn {
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly messages: AsyncIterable<Message>;
+  readonly result: Promise<Result>;
+  private readonly cancelFn: () => Promise<void>;
+  private readonly parser: AcpParser;
+  private readonly channel: BoundedEventChannel<Message>;
+  private pendingCancel: Promise<void> | null = null;
+
+  constructor(opts: {
+    sessionId: string;
+    turnId: string;
+    stdout: Readable;
+    cancelFn: () => Promise<void>;
+    /** Override the default 256-event channel capacity. Pass `Infinity` to bypass eviction. */
+    channelCapacity?: number;
+  }) {
+    this.sessionId = opts.sessionId;
+    this.turnId = opts.turnId;
+    this.cancelFn = opts.cancelFn;
+    this.parser = new AcpParser({
+      sessionId: opts.sessionId,
+      turnId: opts.turnId,
+      stream: opts.stdout,
+    });
+    this.channel = new BoundedEventChannel<Message>({
+      capacity: opts.channelCapacity ?? DEFAULT_CHANNEL_CAPACITY,
+      classify: classifyMessage,
+      coalesceKey: coalesceKeyFor,
+      coalesce: coalesceMessage,
+      invalidatesCoalesceKey: invalidatesCoalesceKeyFor,
+    });
+    this.result = this.parser.result;
+    this.messages = this.channel;
+
+    // Pump parser messages into the channel; close channel when result settles.
+    void (async () => {
+      try {
+        for await (const m of this.parser.messages) {
+          this.channel.push(m);
+        }
+      } finally {
+        this.channel.close();
+      }
+    })();
+  }
+
+  async cancel(): Promise<void> {
+    if (this.parser.settled) return;
+    if (this.pendingCancel !== null) return this.pendingCancel;
+    const attempt = (async () => {
+      try {
+        await this.cancelFn();
+      } finally {
+        this.pendingCancel = null;
+      }
+    })();
+    this.pendingCancel = attempt;
+    return attempt;
+  }
+
+  async close(): Promise<void> {
+    // Parser closes when stdout EOFs; nothing extra to release here.
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/acp/turn.test.ts`
+Expected: previously-passing 8 tests still PASS, new "default capacity 256" PASS = 9/9 PASS.
+
+If "EOF without result yields acpx_exit error Result" fails: the channel pump still works (parser EOF → for-await exits → channel.close()), and `result` is `parser.result` directly so `acpx_exit` flows through unchanged. If it fails anyway, inspect the test output.
+
+- [ ] **Step 5: Run full acp suite to catch regressions**
+
+Run: `bun test src/acp/`
+Expected: all green (channel + turn + parser + compact + types + watch-turn).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/acp/turn.ts src/acp/turn.test.ts
+git commit -m "feat(acp): wire AcpxTurnImpl through BoundedEventChannel (#274)"
+```
+
+---
+
+## Task 9: AcpxTurnImpl integration tests — Infinity bypass + slow consumer
+
+**Files:**
+- Modify: `src/acp/turn.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+test("AcpxTurnImpl: channelCapacity Infinity bypasses eviction", async () => {
+  const N = 1000;
+  const lines: string[] = [];
+  for (let i = 0; i < N; i++) {
+    lines.push(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: { sessionId: "s1", update: { sessionUpdate: "_unknown_kind", n: i } },
+      }),
+    );
+  }
+  lines.push(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }));
+
+  const turn = new AcpxTurnImpl({
+    sessionId: "s1",
+    turnId: "t1",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+    channelCapacity: Infinity,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  await turn.result;
+  expect(got.length).toBe(N);
+});
+
+test("AcpxTurnImpl: chunked text deltas coalesce under default capacity", async () => {
+  // 50 chunked agent_message_chunk frames + final result.
+  const lines: string[] = [];
+  for (let i = 0; i < 50; i++) {
+    lines.push(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "s1",
+          update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "x" } },
+        },
+      }),
+    );
+  }
+  lines.push(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }));
+
+  const turn = new AcpxTurnImpl({
+    sessionId: "s1",
+    turnId: "t1",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+    channelCapacity: 4, // small cap forces coalescing under contention
+  });
+
+  // Slow consumer: yield control between reads so producer fills the buffer.
+  const got: Message[] = [];
+  for await (const m of turn.messages) {
+    got.push(m);
+    await new Promise((r) => setImmediate(r));
+  }
+  await turn.result;
+
+  // With cap=4 and a slow consumer, all 50 chunked text deltas must merge into
+  // a small number of buffered events. Cannot assert exact length (depends on
+  // scheduling), but must be far fewer than 50 and the concatenated text length
+  // must equal 50 (no character loss).
+  expect(got.length).toBeLessThan(50);
+  const totalText = got
+    .filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text")
+    .map((m) => m.text)
+    .join("");
+  expect(totalText.length).toBe(50);
+  expect(totalText).toBe("x".repeat(50));
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test src/acp/turn.test.ts -t "Infinity bypasses|chunked text deltas coalesce"`
+Expected: PASS — wiring from Task 8 already supports both paths. If "chunked text deltas coalesce" fails because all 50 events come through individually, check that the parser is emitting `chunk: true` for `agent_message_chunk` (it is — see `src/acp/parser.ts`).
+
+- [ ] **Step 3: Run full acp suite**
+
+Run: `bun test src/acp/`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/acp/turn.test.ts
+git commit -m "test(acp): AcpxTurnImpl Infinity bypass + slow-consumer coalesce (#274)"
+```
+
+---
+
+## Task 10: Run full repo test suite + tsc
+
+**Files:** none modified.
+
+- [ ] **Step 1: TypeScript check**
+
+Run: `bun run tsc --noEmit`
+Expected: clean (no errors).
+
+If errors surface, they are most likely in:
+- `src/acp/turn.ts` — the constructor option type changed (added `channelCapacity?`). Existing callers (`src/core/acpx-runtime.ts:423-437`) pass an object literal; the new field is optional, so no change required. Verify.
+- `src/acp/bounded-channel.ts` — fix any strict-mode complaints inline.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `bun test`
+Expected: all green. The new channel is invisible to existing callers; the only behavioral change is upstream-bounded memory and per-policy drops under sustained pressure.
+
+If any non-acp test fails, investigate. Most likely culprits:
+- Tests that asserted exact event counts on long sessions — now bounded to 256 per turn.
+- Tests that asserted exact ordering of `token_usage` interleaved with text — `token_usage` is now `drop_oldest_on_full` and may be evicted under pressure. Update assertion to allow drop, or pass `channelCapacity: Infinity` in the test.
+
+- [ ] **Step 3: Commit any test fixes (if needed)**
+
+```bash
+git add <files>
+git commit -m "test: adjust assertions for bounded channel semantics (#274)"
+```
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push -u origin HEAD
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec section | Implementing task |
+|---|---|
+| Architecture (channel between parser + consumer) | Task 1, Task 8 |
+| `BoundedEventChannel<T>` interface (push/close/stats/iterator) | Task 1 |
+| `policyAt: Policy[]` parallel ring | Task 1 |
+| `coalesceTails: Map<string, number>` | Task 3 |
+| ACP policy table (kind → Policy) | Task 8 |
+| `coalesce` for text concat | Task 8 |
+| `invalidatesCoalesceKey` for chunk:false terminal | Task 3 (test) + Task 8 (wiring) |
+| Push: drop_oldest_on_full | Task 2 |
+| Push: coalesce_text_deltas | Task 3 |
+| Push: never w/ evict-to-fit | Task 4 |
+| Push: never w/ no drop-eligible → drop incoming | Task 4 |
+| Fast-path: pending resolver | Task 1 + Task 5 (test) |
+| Consume: clear coalesce tail on consume | Task 1 + Task 3 (test) |
+| Close drains then EOFs | Task 5 |
+| Consumer break → channel marks closed | Task 6 |
+| Stats accuracy | Task 7 |
+| `onDrop` callback firing | Task 2/3/4/7 (tests) |
+| AcpxTurnImpl integration (default 256) | Task 8 |
+| AcpxTurnImpl integration (Infinity bypass) | Task 9 |
+| Slow consumer simulation | Task 9 |
+| Existing turn.test.ts stays green | Task 8 |
+| Full repo regression | Task 10 |
+
+All spec sections covered.
+
+**Placeholder scan:** No "TBD", "TODO", "implement later" strings in this plan. Every step contains exact file paths, exact code, exact commands, and expected output.
+
+**Type consistency:** `Policy`, `ChannelOptions`, `ChannelStats`, `BoundedEventChannel` names consistent across tasks. ACP callbacks (`classifyMessage`, `coalesceKeyFor`, `coalesceMessage`, `invalidatesCoalesceKeyFor`) defined once in Task 8 and reused. `channelCapacity` option spelled consistently in Tasks 8 and 9.

--- a/docs/superpowers/plans/2026-04-19-grove-dir-fence.md
+++ b/docs/superpowers/plans/2026-04-19-grove-dir-fence.md
@@ -1,0 +1,118 @@
+# Grove Dir Fence — Unify findGroveDir Implementations (#315)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans for inline execution.
+
+**Goal:** Eliminate three divergent `findGroveDir` impls by promoting one shared implementation that fences walk-up at the first `.grove/` directory (not grove.json). Fix the TUI's silent-walk-past-worktree bug.
+
+**Architecture:** Single `findGroveDir(startDir): string | undefined` in `src/cli/utils/grove-dir.ts`. Walk-up returns the first ancestor containing `.grove/`. Callers that need `grove.json` check it AFTER and treat "found .grove/ but no grove.json" as "not initialized at this level" — they do NOT silently walk past to find a parent grove.json.
+
+**Tech Stack:** TypeScript, Bun test runner. No new dependencies.
+
+**Issue:** [#315](https://github.com/windoliver/grove/issues/315)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/cli/utils/grove-dir.ts` | modify | Export new shared `findGroveDir(startDir)`; refactor `resolveGroveDir` to use it. |
+| `src/cli/utils/grove-dir.test.ts` | modify | Add tests for shared findGroveDir + the "found .grove/ but incomplete, do not walk past" semantics. |
+| `src/cli/context.ts` | modify | Delete local `findGroveDir`; import from utils. |
+| `src/tui/main.ts` | modify | Delete local `findGroveDir`; build a thin wrapper around the shared one that adds the grove.json existence check WITHOUT walking past. |
+
+---
+
+## Task 1: Promote `findGroveDir` to shared util
+
+- [ ] Edit `src/cli/utils/grove-dir.ts`:
+  - Add new export `findGroveDir(startDir: string): string | undefined`
+  - Refactor `resolveGroveDir` to use it
+  - Behavior: walk up from `resolve(startDir)` returning the first ancestor containing `.grove/` (subdirectory existence). Return undefined if reach FS root with no match.
+
+- [ ] Add tests to `src/cli/utils/grove-dir.test.ts`:
+  - `findGroveDir`: returns undefined for tmpdir with no .grove
+  - `findGroveDir`: finds .grove in startDir directly
+  - `findGroveDir`: walks up to ancestor .grove
+  - `findGroveDir`: when both ancestor and child have .grove → returns child (fence semantics)
+
+- [ ] Run: `bun test src/cli/utils/grove-dir.test.ts` — all green
+
+- [ ] Commit:
+```
+git add src/cli/utils/grove-dir.ts src/cli/utils/grove-dir.test.ts
+git commit -m "feat(cli): promote findGroveDir to shared util with fence semantics (#315)"
+```
+
+---
+
+## Task 2: Replace cli/context.ts duplicate with import
+
+- [ ] Edit `src/cli/context.ts`:
+  - Remove the local `function findGroveDir(startDir)` (lines ~36-60)
+  - Remove the unused `existsSync`, `dirname`, `join` imports if they become unused
+  - Import the shared one: `import { findGroveDir } from "./utils/grove-dir.js";`
+  - Verify `initCliDeps` callsite still compiles unchanged
+
+- [ ] Run: `bun run tsc --noEmit` — clean
+- [ ] Run: `bun test src/cli/` — green
+
+- [ ] Commit:
+```
+git add src/cli/context.ts
+git commit -m "refactor(cli): use shared findGroveDir (#315)"
+```
+
+---
+
+## Task 3: Fix TUI to fence + require grove.json without walking past
+
+- [ ] Edit `src/tui/main.ts`:
+  - Replace local `findGroveDir(groveOverride)` with a thin wrapper
+  - New behavior:
+    1. If `groveOverride` provided: check `<override>/grove.json` exists → return override or undefined
+    2. If `process.env.GROVE_DIR`: same check
+    3. Otherwise: call shared `findGroveDir(process.cwd())`. If result undefined → return undefined. Else: check `<result>/grove.json` exists. If yes → return result. **If no → return undefined (do NOT walk past).**
+  - Import: `import { findGroveDir as findGroveRoot } from "../cli/utils/grove-dir.js";`
+  - Keep the function `findGroveDir` name in main.ts to avoid touching all call sites (267, 451)
+
+- [ ] Run: `bun run tsc --noEmit` — clean
+- [ ] Run: `bun test src/tui/` — green (any failures: investigate; may need test fixture updates)
+- [ ] Run: `bun test` (full repo) — green
+
+- [ ] Commit:
+```
+git add src/tui/main.ts
+git commit -m "fix(tui): fence findGroveDir at .grove/ dir, do not walk past incomplete grove (#315)"
+```
+
+---
+
+## Task 4: Add regression test for the bug
+
+- [ ] Add a test fixture in `src/tui/main.test.ts` (or new file `src/tui/find-grove-dir.test.ts` if main.ts is hard to test):
+  - Create temp parent dir with `.grove/grove.json`
+  - Create child dir with `.grove/` (no grove.json)
+  - chdir to child
+  - Call the TUI's findGroveDir
+  - Expect: `undefined` (not parent's path)
+
+- [ ] If `findGroveDir` is not exported from main.ts, export it (private-by-convention but exported for testing)
+
+- [ ] Run: `bun test` — all green
+
+- [ ] Commit:
+```
+git add src/tui/main.ts <test file>
+git commit -m "test(tui): regression test for worktree fence (#315)"
+```
+
+---
+
+## Self-Review
+
+- [ ] All 3 callsites of `findGroveDir` (TUI + 2 CLI) point at one source of truth (or use the shared one + a thin wrapper)
+- [ ] No callsite walks past a `.grove/` directory silently
+- [ ] Error messages tell user exactly what to do
+- [ ] tsc clean
+- [ ] Full repo test suite green

--- a/docs/superpowers/specs/2026-04-18-bounded-channel-backpressure-design.md
+++ b/docs/superpowers/specs/2026-04-18-bounded-channel-backpressure-design.md
@@ -1,0 +1,257 @@
+# Bounded Channel Backpressure (Issue #274)
+
+**Status:** Draft
+**Date:** 2026-04-18
+**Issue:** [#274](https://github.com/windoliver/grove/issues/274)
+**Related:** #188 (event-driven TUI updates), #259/#260/#261 (typed ACP message streams)
+
+## Problem
+
+`AcpxRuntime` returns an `AcpxTurn` whose `messages: AsyncIterable<Message>` is fed directly by `AcpParser` reading the acpx child's stdout. Producer rate (agent tokens) can far exceed consumer rate (Nexus IPC publisher, TUI redraw, remote subscribers). Today there is no buffer between them.
+
+Two failure modes follow:
+
+1. **Unbounded buffering** — if the consumer is wrapped in something that buffers (e.g., a `for await` body that awaits HTTP), event objects pile up in V8 closures and memory grows without bound.
+2. **Stalled iterator** — if backpressure is added naively (block the parser until consumer drains), the parser stops reading from the acpx pipe, the OS pipe buffer fills, the acpx child blocks on `write()`, and the agent stalls mid-turn.
+
+A naive bounded queue with drop-oldest eviction loses semantically important events (`tool_call`, `permission_request`) — those are state changes the consumer cannot reconstruct from later events.
+
+## Goal
+
+Insert a bounded channel between `AcpParser` and the `AcpxTurn.messages` consumer with a per-event-kind drop policy that:
+
+- Preserves semantic events (tool calls, permission requests, terminal text, errors).
+- Coalesces cosmetic deltas (chunked `text` / `thinking`) so a slow consumer sees one merged delta per kind, not a queue of fragments.
+- Drops the lowest-value events (`token_usage`, `raw`) before harming the higher-priority categories.
+- Never blocks the parser. The acpx child must always be free to write its next frame.
+
+## Non-goals
+
+- Not redesigning SSE transport — purely the in-process channel.
+- Not solving cross-process backpressure (server → remote SSE subscriber).
+- Not a generic pub/sub primitive — single consumer per channel.
+- Not multi-turn coalescing — channel is per `AcpxTurn` instance.
+
+## Architecture
+
+```
+acpx stdout → AcpParser → channel.push() → ring buffer → channel[Symbol.asyncIterator] → consumer
+                                          ↑
+                                  policy resolver
+                                  (coalesce | evict | append)
+```
+
+- **Module**: `src/acp/bounded-channel.ts` — generic `BoundedEventChannel<T>`, no ACP coupling.
+- **Wiring**: `AcpxTurnImpl` constructs one channel instance, replaces parser-direct `messages` with `channel[Symbol.asyncIterator]()`.
+- **Lifetime**: one channel per `AcpxTurn`. Closes when parser EOFs (existing `parser.result` resolution path).
+- **Capacity**: 256 default, override via `AcpxTurnImpl({channelCapacity})`. Tests pass `Infinity` to bypass eviction code paths.
+
+## Components
+
+### `src/acp/bounded-channel.ts`
+
+```ts
+export type Policy = "never" | "coalesce_text_deltas" | "drop_oldest_on_full";
+
+export interface ChannelOptions<T> {
+  capacity: number;
+  classify: (event: T) => Policy;
+  coalesceKey?: (event: T) => string | null;       // returns key if event coalesces, null otherwise
+  coalesce?: (existing: T, incoming: T) => T;      // merge fn for same-key chunked events
+  invalidatesCoalesceKey?: (event: T) => string | null; // chunk:false terminal that clears tail
+  onDrop?: (event: T, reason: "evicted" | "coalesced" | "no_capacity") => void;
+}
+
+export interface ChannelStats {
+  pushed: number;
+  coalesced: number;
+  evicted: number;
+  droppedByPolicy: Map<Policy, number>;
+}
+
+export class BoundedEventChannel<T> {
+  constructor(opts: ChannelOptions<T>);
+  push(event: T): void;        // never throws, never blocks
+  close(): void;               // signals consumer EOF after buffer drains
+  stats(): ChannelStats;
+  [Symbol.asyncIterator](): AsyncIterator<T>;  // single consumer
+}
+```
+
+**Internal state**:
+
+- `buffer: (T | undefined)[]` of size `capacity` (ring).
+- `policyAt: Policy[]` of size `capacity` — policy classification recorded at push time. Lets eviction find the oldest drop-eligible slot without re-classifying stored events.
+- `head, tail, size` indices.
+- `coalesceTails: Map<string, number>` — coalesce key → buffer index of the most recent un-consumed chunked event of that kind.
+- `pendingResolver: ((value: IteratorResult<T>) => void) | null` — set when iterator is awaiting an empty buffer.
+- `closed: boolean` — set by `close()`; iterator returns `{done:true}` once buffer drains.
+- `stats` counters.
+
+### `src/acp/turn.ts` (modified)
+
+`AcpxTurnImpl` constructor accepts optional `channelCapacity?: number` (default 256). It builds a `BoundedEventChannel<Message>` with ACP-specific policy callbacks and pumps the existing parser-message stream into it. `this.messages` exposes `channel[Symbol.asyncIterator]()`.
+
+Policy callbacks (live in `turn.ts`, not in the generic channel):
+
+| `Message.kind` | Condition | Policy |
+|---|---|---|
+| `tool_call` | always | `never` |
+| `permission_request` | always | `never` |
+| `text`, `thinking` | `chunk: true` | `coalesce_text_deltas` (key = `kind`) |
+| `text`, `thinking` | `chunk: false` | `never` (terminal — invalidates coalesce tail of same kind) |
+| `token_usage` | always | `drop_oldest_on_full` |
+| `raw` | always | `drop_oldest_on_full` |
+
+`coalesce` for ACP merges by appending the incoming event's `text` to the existing event's `text`, preserving `chunk: true`.
+
+## Push algorithm
+
+Synchronous, never blocks. Pseudocode:
+
+```
+push(event):
+  if closed:
+    onDrop(event, "no_capacity"); return
+  stats.pushed++
+
+  policy = classify(event)
+
+  if policy == coalesce_text_deltas:
+    key = coalesceKey(event)
+    if key && coalesceTails.has(key):
+      idx = coalesceTails.get(key)
+      buffer[idx] = coalesce(buffer[idx], event)
+      stats.coalesced++
+      onDrop(event, "coalesced")
+      return
+    # fall through to append; record tail after
+
+  if policy == never:
+    # 1. Invalidate same-kind coalesce tail if this event is a terminal
+    invKey = invalidatesCoalesceKey(event)
+    if invKey: coalesceTails.delete(invKey)
+
+    # 2. Evict-to-fit: prefer "drop-eligible" victim over rejecting.
+    #    Drop-eligible = any buffer slot whose stored event was classified
+    #    as drop_oldest_on_full at push time. To know this without re-classifying,
+    #    a parallel ring of "policy at push time" is kept (`policyAt: Policy[]`).
+    if size == capacity:
+      victimIdx = findOldestDropEligible()  # walk head→tail seeking policyAt[i] == drop_oldest_on_full
+      if victimIdx == -1:
+        # all slots are never-policy → bounded mem must win; drop incoming
+        stats.droppedByPolicy[never]++
+        onDrop(event, "no_capacity")
+        return
+      evictAt(victimIdx)
+      stats.evicted++
+    appendTail(event)
+    return
+
+  if policy == drop_oldest_on_full:
+    if size == capacity:
+      victim = buffer[head]
+      evictAt(head)
+      stats.evicted++
+      onDrop(victim, "evicted")
+    appendTail(event)
+    return
+
+# helpers
+appendTail(event):
+  if pendingResolver:
+    # consumer is waiting on empty buffer — fast path: resolve directly,
+    # do NOT buffer, do NOT record coalesce tail (event has already left).
+    r = pendingResolver; pendingResolver = null
+    r({value: event, done: false})
+    return
+  prevTailIdx = tail
+  buffer[tail] = event; policyAt[tail] = policy
+  tail = (tail+1) % capacity; size++
+  if policy == coalesce_text_deltas: coalesceTails.set(key, prevTailIdx)
+
+evictAt(idx):
+  ev = buffer[idx]
+  # if this index was a coalesce tail for any key, clear it
+  for [k, i] of coalesceTails: if i == idx: coalesceTails.delete(k)
+  # remove from ring (compact via head/tail tracking)
+  ...
+```
+
+**Edge case — all slots are never-policy**: documented above. Drop incoming with counter increment. This signals serious downstream stall: 256 priority events accumulated without any drop-eligible to evict. Operationally observable via `stats.droppedByPolicy["never"] > 0`; alarmable.
+
+## Consume algorithm
+
+```
+asyncIterator.next():
+  if size > 0:
+    ev = buffer[head]
+    if head was a coalesce tail key, clear that key (consumed → no longer valid merge target)
+    advance head; size--
+    return {value: ev, done: false}
+  if closed:
+    return {value: undefined, done: true}
+  # buffer empty, not closed → wait
+  return new Promise(resolve => pendingResolver = resolve)
+```
+
+Push that finds non-null `pendingResolver` resolves it directly without going through the buffer (fast path). For coalesce events on the fast path: no tail recorded, since the event left the channel synchronously.
+
+## Error handling & edge cases
+
+**Producer errors**: parser already emits malformed lines as `{kind:"raw", acpMethod:"_parseError"}`. These flow through the channel as `drop_oldest_on_full` policy — no special handling.
+
+**Parser EOF**: existing `parser.result` resolution path calls `channel.close()`. Buffered events drain to consumer first, then iterator returns `{done:true}`.
+
+**Consumer breaks early** (`for await ... of` with `break`): iterator's `return()` invoked → channel marks `closed`. Subsequent pushes are silently dropped via `onDrop(event, "no_capacity")` with policy counter increment for diagnostics.
+
+**Cancel during turn**: `AcpxTurn.cancel()` → child SIGINT → parser EOFs → channel closes naturally. Already-buffered events still drain (consumer chooses to read or break).
+
+**Concurrency**: single-threaded JS; push and consumer share the event loop — no locking. `pendingResolver` invariant: nulled before resolve to prevent re-resolve.
+
+**Memory bound**: `O(capacity)` event slots. Coalesce-merged text strings can grow but represent one un-consumed delta run; bounded by `consumer slowness × producer text rate`. If this becomes a concern, future work can cap the merged string length.
+
+**Backwards compat**: `AcpxTurn.messages` consumers see no API change. `AcpxTurnImpl` constructor adds optional `channelCapacity?: number`; unset = 256 default.
+
+**Test bypass**: `AcpxTurnImpl({channelCapacity: Infinity})` → channel uses unbounded array; eviction code paths skipped (coalesce + stats still work). Useful for tests that need exact event ordering without policy interference.
+
+## Observability
+
+- `channel.stats()` returns `{pushed, coalesced, evicted, droppedByPolicy}`. Pull-based — operators or tests scrape on demand.
+- `onDrop(event, reason)` optional callback fires per event drop. Wires to logs, EventBus, or test assertions.
+
+Future work (out of scope here): expose stats via Nexus EventBus emission so operator dashboards can render `dropped_events_total{kind, slot_id}` over time.
+
+## Testing
+
+**`src/acp/bounded-channel.test.ts`** (unit, generic — no ACP coupling):
+
+1. Basic push/consume — push 3, consume 3, verify order.
+2. Capacity bound — push `capacity+10` drop_oldest events, consumer reads `capacity` newest.
+3. Coalesce hot path — push 100 chunked text, buffer holds 1, `stats.coalesced == 99`.
+4. Coalesce key isolation — interleave text + thinking chunked deltas, verify each kind coalesces independently.
+5. Coalesce tail invalidation on consume — coalesce builds tail; consumer pulls it; next chunked text becomes a new entry (not merged into consumed event).
+6. Coalesce tail invalidation on terminal — chunked text run, then chunk:false text → tail cleared, next chunked text is new entry.
+7. Never-policy evicts drop-eligible — fill with drop_oldest events; push tool_call → evicts oldest, tool_call appended.
+8. Never-policy with no drop-eligible — fill with never-policy; push tool_call → dropped, `droppedByPolicy["never"]` increments.
+9. `onDrop` callback fires per coalesce + eviction with correct reason.
+10. `stats` accuracy under mixed push.
+11. Iterator awaits empty — consumer iter pending; push resolves it without going through buffer (fast path).
+12. Close drains then EOFs — push 3, close, consumer reads 3 then `{done:true}`.
+13. Consumer break cleanup — `for await` with `break` after 1; subsequent push silently dropped, channel marked closed.
+
+**`src/acp/turn.test.ts`** (integration with `AcpxTurnImpl`):
+
+14. Default capacity 256 — construct without opts, push 257 drop_oldest, oldest evicted.
+15. `channelCapacity: Infinity` bypasses eviction — push 1000, consumer reads all in order.
+16. Real ACP message classification — push one of each `Message` kind, verify policy applied (via stats inspection).
+17. Slow consumer simulation — push 500 chunked text via parser stub at high rate, consumer reads at low rate; verify final coalesced count and no memory blow-up.
+
+Existing coverage retained:
+
+- Cross-turn behavior covered by `src/core/acpx-runtime.test.ts`.
+- Real `acpx --format json --json-strict` E2E covered by `src/core/acpx-runtime.component.test.ts`. No new E2E required.
+
+## Open questions
+
+None at design time. The channel is a self-contained primitive; the consumer side (#261 publisher) integrates by simply iterating `turn.messages` as it does today.

--- a/octopus-camouflage-essay.md
+++ b/octopus-camouflage-essay.md
@@ -1,0 +1,47 @@
+# How Octopuses Use Camouflage
+
+## Camouflage as a Core Survival Tool
+
+Camouflage is central to octopus survival. Unlike shelled mollusks, octopuses are soft-bodied and exposed, with no hard armor to absorb attacks. They live in habitats packed with visual predators. In that environment, being difficult to detect is often better than being fast. Camouflage lets an octopus avoid risky chases and reduces how often predators even attempt an attack.
+
+This ability also helps with hunting. Octopuses stalk prey such as crabs, shrimp, and small fish that are highly sensitive to motion and contrast. If an octopus can match its surroundings before moving in, it can close distance without triggering an escape response.
+
+## The Skin Machinery Behind the Effect
+
+Octopus camouflage begins with chromatophores, tiny pigment organs in the skin. Each chromatophore is controlled by muscles connected to the nervous system. When muscles contract, pigment sacs expand and become visible; when they relax, the sacs shrink. Coordinating thousands at once allows rapid pattern shifts, often in less than a second.
+
+Chromatophores are only one layer. Iridophores beneath them reflect light in structured ways, and leucophores scatter ambient light to support brightness matching. Together, these layers let octopuses tune contrast, reflectivity, and visual texture rather than simply toggling between colors.
+
+## Texture and Body Shape Matching
+
+A convincing disguise requires more than color. Octopuses also control skin texture using papillae, muscular projections that can be raised or flattened. On smooth sand, a low-profile surface helps them disappear. On rubble, coral, or algae-covered rock, raised papillae create a rougher appearance that better matches local substrate.
+
+They also manipulate body posture. An octopus can flatten its mantle, curl or extend arms, and align its body with cracks, ledges, or shadow boundaries. These adjustments reduce recognizable outlines, which is important because predators often detect shape edges before subtle color mismatches.
+
+## Neural Control and Pattern Selection
+
+The speed of octopus camouflage reflects advanced neural control. Visual information is processed rapidly, and skin output is adjusted in near real time. Researchers often describe a few broad pattern modes: uniform patterns for simple backgrounds, mottled patterns for patchy terrain, and disruptive patterns that break up body boundaries with stronger contrast.
+
+In nature, octopuses switch among these modes continuously. A single foraging path can cross sand, shell fragments, and rock within minutes. As terrain changes, the octopus updates color, contrast, and texture accordingly.
+
+## Concrete Field Examples
+
+The day octopus (*Octopus cyanea*) is a strong example of active camouflage. On tropical reefs, it often shifts appearance multiple times during one hunt. Over bright sand it may appear pale with minimal texture. Crossing into broken coral, it becomes darker and mottled while raising papillae.
+
+The common octopus (*Octopus vulgaris*) shows similar flexibility in Mediterranean and Atlantic coastal habitats. Individuals leaving rocky dens are often darker at first, then gradually lighten as they move over sediment. Some pause, change pattern, then continue forward. This stop-adjust-move behavior suggests ongoing visual evaluation rather than a fixed, automatic response.
+
+The mimic octopus (*Thaumoctopus mimicus*) demonstrates how camouflage can combine with behavioral deception. It can blend with soft-bottom sediments, but under threat it may shift posture and movement to resemble other animals, including sea snakes or flatfish-like forms. The key point is that camouflage is part of a broader strategy: concealment when possible, and strategic misdirection when needed.
+
+## Limits and Tradeoffs
+
+Even this sophisticated system has limits. Artificial lighting, suspended sediment, and abrupt background changes can reduce matching quality. Habitat degradation can remove the textures and contrast patterns that octopuses rely on, making concealment less reliable.
+
+There are behavioral tradeoffs too. Octopuses sometimes need to signal to others during courtship, competition, or warning displays. In those moments, they may use high-contrast patterns that increase visibility. They are effectively choosing communication over concealment, accepting short-term exposure for social or defensive reasons.
+
+Camouflage also carries biological cost. Fine control of chromatophores, papillae, and posture requires constant neuromuscular activity and attention to surroundings. Still, the payoff is substantial: fewer predator encounters, better ambush success, and greater freedom to exploit varied habitats.
+
+## Conclusion
+
+Octopus camouflage stands out because it is integrated and dynamic. It combines rapid skin patterning, reflective control, texture modulation, posture changes, and context-aware behavior into one continuous process. Instead of relying on a fixed disguise, octopuses run a live concealment system that updates as they move through changing terrain.
+
+That sophistication is why octopuses continue to shape research in marine biology, robotics, and adaptive materials. Scientists study their camouflage to understand fast perception-action loops, while engineers explore ways to build surfaces that alter appearance on demand. For the octopus, however, the function is immediate and practical: effective camouflage means staying alive long enough to hunt, reproduce, and avoid becoming someone else’s meal.

--- a/src/acp/bounded-channel.test.ts
+++ b/src/acp/bounded-channel.test.ts
@@ -215,3 +215,39 @@ test("consumer break: subsequent pushes drop silently and channel marks closed",
   ch.push({ kind: "keep", id: 4 });
   expect(dropped.map((e) => e.id)).toEqual([3, 4]);
 });
+
+test("stats accuracy under mixed push: pushed/coalesced/evicted/droppedByPolicy", async () => {
+  const cap = 3;
+  const reasons: Array<{ id: number; reason: string }> = [];
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: cap,
+    classify,
+    coalesceKey,
+    coalesce,
+    invalidatesCoalesceKey,
+    onDrop: (e, reason) => reasons.push({ id: e.id, reason }),
+  });
+
+  ch.push({ kind: "delta_a", id: 1, text: "a" });
+  ch.push({ kind: "delta_a", id: 2, text: "b" });
+  ch.push({ kind: "delta_a", id: 3, text: "c" });
+  ch.push({ kind: "drop", id: 4 });
+  ch.push({ kind: "drop", id: 5 });
+  ch.push({ kind: "keep", id: 6 });
+  ch.push({ kind: "keep", id: 7 });
+  ch.push({ kind: "keep", id: 8 });
+
+  const s = ch.stats();
+  expect(s.pushed).toBe(8);
+  expect(s.coalesced).toBe(2);
+  expect(s.evicted).toBe(2);
+  expect(s.droppedByPolicy.get("never")).toBe(1);
+
+  expect(reasons).toEqual([
+    { id: 2, reason: "coalesced" },
+    { id: 3, reason: "coalesced" },
+    { id: 4, reason: "evicted" },
+    { id: 5, reason: "evicted" },
+    { id: 8, reason: "no_capacity" },
+  ]);
+});

--- a/src/acp/bounded-channel.test.ts
+++ b/src/acp/bounded-channel.test.ts
@@ -195,3 +195,23 @@ test("close while iterator pending resolves it as done", async () => {
   const r = await nextP;
   expect(r.done).toBe(true);
 });
+
+test("consumer break: subsequent pushes drop silently and channel marks closed", async () => {
+  const dropped: TestEvent[] = [];
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: 4,
+    classify,
+    onDrop: (e, reason) => {
+      if (reason === "no_capacity") dropped.push(e);
+    },
+  });
+  ch.push({ kind: "drop", id: 1 });
+  ch.push({ kind: "drop", id: 2 });
+  for await (const e of ch) {
+    expect(e.id).toBe(1);
+    break;
+  }
+  ch.push({ kind: "drop", id: 3 });
+  ch.push({ kind: "keep", id: 4 });
+  expect(dropped.map((e) => e.id)).toEqual([3, 4]);
+});

--- a/src/acp/bounded-channel.test.ts
+++ b/src/acp/bounded-channel.test.ts
@@ -47,3 +47,22 @@ test("push 3 then drain returns 3 in FIFO order", async () => {
   for await (const e of ch) got.push(e);
   expect(got.map((e) => e.id)).toEqual([1, 2, 3]);
 });
+
+test("drop_oldest_on_full: cap+10 pushes, drain returns last `cap` in order", async () => {
+  const cap = 4;
+  const evicted: TestEvent[] = [];
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: cap,
+    classify,
+    onDrop: (e, reason) => {
+      if (reason === "evicted") evicted.push(e);
+    },
+  });
+  for (let i = 1; i <= cap + 10; i++) ch.push({ kind: "drop", id: i });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got.map((e) => e.id)).toEqual([11, 12, 13, 14]);
+  expect(evicted.map((e) => e.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  expect(ch.stats().evicted).toBe(10);
+});

--- a/src/acp/bounded-channel.test.ts
+++ b/src/acp/bounded-channel.test.ts
@@ -261,3 +261,96 @@ test("stats accuracy under mixed push: pushed/coalesced/evicted/droppedByPolicy"
     { id: 8, reason: "no_capacity" },
   ]);
 });
+
+// --- Codex adversarial-review regressions (#274 round 1) ---
+
+test("REGRESSION: coalesce-new-key on full buffer must not overflow ring", async () => {
+  // Cap=2. Fill with two drop_oldest events. Push a coalesce-new-key delta.
+  // Without the bounded-full guard, _appendTail would write past tail and
+  // size would exceed capacity, leaving an undefined slot.
+  const cap = 2;
+  const ch = makeChannel(cap);
+  ch.push({ kind: "drop", id: 1 });
+  ch.push({ kind: "drop", id: 2 });
+  // New coalesce key with no existing tail. Must evict drop-eligible (id=1).
+  ch.push({ kind: "delta_a", id: 3, text: "x" });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  // Ring must remain bounded: exactly cap=2 events delivered, no undefineds.
+  expect(got.length).toBe(2);
+  for (const e of got) expect(e).toBeDefined();
+  expect(got.map((e) => e.id)).toEqual([2, 3]);
+});
+
+test("REGRESSION: coalesce-new-key when no drop-eligible victim drops incoming", async () => {
+  // Cap=2. Fill with two never-policy events. Push a coalesce-new-key delta.
+  // No drop-eligible victim exists → incoming must be dropped, not buffered.
+  const cap = 2;
+  const dropped: TestEvent[] = [];
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: cap,
+    classify,
+    coalesceKey,
+    coalesce,
+    invalidatesCoalesceKey,
+    onDrop: (e, reason) => {
+      if (reason === "no_capacity") dropped.push(e);
+    },
+  });
+  ch.push({ kind: "keep", id: 1 });
+  ch.push({ kind: "keep", id: 2 });
+  ch.push({ kind: "delta_a", id: 99, text: "x" });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got.map((e) => e.id)).toEqual([1, 2]);
+  expect(dropped.map((e) => e.id)).toEqual([99]);
+  expect(ch.stats().droppedByPolicy.get("coalesce_text_deltas")).toBe(1);
+});
+
+test("REGRESSION: drop_oldest_on_full must not evict a never-policy event at head", async () => {
+  // Cap=2. keep (never) + drop (drop_oldest_on_full). Push another drop.
+  // Naive head-eviction would drop `keep`. Policy-aware logic must evict
+  // the drop-eligible slot (id=2) and preserve the never event (id=1).
+  const cap = 2;
+  const evicted: TestEvent[] = [];
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: cap,
+    classify,
+    onDrop: (e, reason) => {
+      if (reason === "evicted") evicted.push(e);
+    },
+  });
+  ch.push({ kind: "keep", id: 1 });
+  ch.push({ kind: "drop", id: 2 });
+  ch.push({ kind: "drop", id: 3 });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got.map((e) => e.id)).toEqual([1, 3]);
+  expect(evicted.map((e) => e.id)).toEqual([2]);
+});
+
+test("REGRESSION: drop_oldest_on_full with no drop-eligible victim drops incoming", async () => {
+  // Cap=2. Two never events. Incoming drop event has nothing eligible to
+  // evict — must drop incoming, never the never events.
+  const cap = 2;
+  const dropped: TestEvent[] = [];
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: cap,
+    classify,
+    onDrop: (e, reason) => {
+      if (reason === "no_capacity") dropped.push(e);
+    },
+  });
+  ch.push({ kind: "keep", id: 1 });
+  ch.push({ kind: "keep", id: 2 });
+  ch.push({ kind: "drop", id: 99 });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got.map((e) => e.id)).toEqual([1, 2]);
+  expect(dropped.map((e) => e.id)).toEqual([99]);
+  expect(ch.stats().droppedByPolicy.get("drop_oldest_on_full")).toBe(1);
+});

--- a/src/acp/bounded-channel.test.ts
+++ b/src/acp/bounded-channel.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { BoundedEventChannel, type Policy } from "./bounded-channel.js";
+
+interface TestEvent {
+  kind: "drop" | "keep" | "delta_a" | "delta_b" | "terminal_a";
+  text?: string;
+  id: number;
+}
+
+function classify(e: TestEvent): Policy {
+  if (e.kind === "keep" || e.kind === "terminal_a") return "never";
+  if (e.kind === "delta_a" || e.kind === "delta_b") return "coalesce_text_deltas";
+  return "drop_oldest_on_full";
+}
+
+function coalesceKey(e: TestEvent): string | null {
+  if (e.kind === "delta_a" || e.kind === "delta_b") return e.kind;
+  return null;
+}
+
+function coalesce(existing: TestEvent, incoming: TestEvent): TestEvent {
+  return { ...existing, text: (existing.text ?? "") + (incoming.text ?? "") };
+}
+
+function invalidatesCoalesceKey(e: TestEvent): string | null {
+  if (e.kind === "terminal_a") return "delta_a";
+  return null;
+}
+
+function makeChannel(capacity = 4) {
+  return new BoundedEventChannel<TestEvent>({
+    capacity,
+    classify,
+    coalesceKey,
+    coalesce,
+    invalidatesCoalesceKey,
+  });
+}
+
+test("push 3 then drain returns 3 in FIFO order", async () => {
+  const ch = makeChannel();
+  ch.push({ kind: "drop", id: 1 });
+  ch.push({ kind: "drop", id: 2 });
+  ch.push({ kind: "drop", id: 3 });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got.map((e) => e.id)).toEqual([1, 2, 3]);
+});

--- a/src/acp/bounded-channel.test.ts
+++ b/src/acp/bounded-channel.test.ts
@@ -382,6 +382,25 @@ test("REGRESSION: concurrent next() calls all resolve in FIFO order (no lost wak
   expect(r3.value.id).toBe(3);
 });
 
+test("REGRESSION: return() is an abort fence — discards backlog (no replay via next() or new iterator)", async () => {
+  const ch = makeChannel(8);
+  ch.push({ kind: "drop", id: 1 });
+  ch.push({ kind: "drop", id: 2 });
+  ch.push({ kind: "drop", id: 3 });
+  // Consume one event, then abort via return().
+  const it = ch[Symbol.asyncIterator]();
+  const first = await it.next();
+  expect(first.value.id).toBe(1);
+  await it.return?.();
+  // Same iterator: subsequent next() must NOT yield events 2 or 3.
+  const after = await it.next();
+  expect(after.done).toBe(true);
+  // Fresh iterator: must also see channel as drained + closed.
+  const it2 = ch[Symbol.asyncIterator]();
+  const fresh = await it2.next();
+  expect(fresh.done).toBe(true);
+});
+
 test("REGRESSION: close() resolves ALL pending next() callers as done", async () => {
   const ch = makeChannel(8);
   const it = ch[Symbol.asyncIterator]();

--- a/src/acp/bounded-channel.test.ts
+++ b/src/acp/bounded-channel.test.ts
@@ -66,3 +66,59 @@ test("drop_oldest_on_full: cap+10 pushes, drain returns last `cap` in order", as
   expect(evicted.map((e) => e.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   expect(ch.stats().evicted).toBe(10);
 });
+
+test("coalesce hot path: 100 deltas merge into one buffered event", async () => {
+  const ch = makeChannel(8);
+  for (let i = 0; i < 100; i++) ch.push({ kind: "delta_a", id: i, text: "x" });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got).toHaveLength(1);
+  expect(got[0]?.text).toBe("x".repeat(100));
+  expect(ch.stats().coalesced).toBe(99);
+});
+
+test("coalesce key isolation: delta_a and delta_b coalesce independently", async () => {
+  const ch = makeChannel(8);
+  for (let i = 0; i < 5; i++) {
+    ch.push({ kind: "delta_a", id: i, text: "a" });
+    ch.push({ kind: "delta_b", id: i, text: "b" });
+  }
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got).toHaveLength(2);
+  const byKind = Object.fromEntries(got.map((e) => [e.kind, e.text]));
+  expect(byKind["delta_a"]).toBe("aaaaa");
+  expect(byKind["delta_b"]).toBe("bbbbb");
+});
+
+test("coalesce tail invalidated on consume: next delta starts new entry", async () => {
+  const ch = makeChannel(8);
+  ch.push({ kind: "delta_a", id: 1, text: "a" });
+  ch.push({ kind: "delta_a", id: 2, text: "b" });
+  const it = ch[Symbol.asyncIterator]();
+  const first = await it.next();
+  expect(first.value.text).toBe("ab");
+  ch.push({ kind: "delta_a", id: 3, text: "c" });
+  ch.close();
+  const second = await it.next();
+  expect(second.value.text).toBe("c");
+  const third = await it.next();
+  expect(third.done).toBe(true);
+});
+
+test("coalesce tail invalidated by terminal: next delta starts new entry", async () => {
+  const ch = makeChannel(8);
+  ch.push({ kind: "delta_a", id: 1, text: "a" });
+  ch.push({ kind: "delta_a", id: 2, text: "b" });
+  ch.push({ kind: "terminal_a", id: 3 });
+  ch.push({ kind: "delta_a", id: 4, text: "c" });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got).toHaveLength(3);
+  expect(got[0]?.text).toBe("ab");
+  expect(got[1]?.kind).toBe("terminal_a");
+  expect(got[2]?.text).toBe("c");
+});

--- a/src/acp/bounded-channel.test.ts
+++ b/src/acp/bounded-channel.test.ts
@@ -154,3 +154,44 @@ test("never policy with no drop-eligible: incoming dropped, counter increments",
   expect(dropped.map((e) => e.id)).toEqual([99]);
   expect(ch.stats().droppedByPolicy.get("never")).toBe(1);
 });
+
+test("iterator awaiting empty: push resolves directly without buffering", async () => {
+  const ch = makeChannel(4);
+  const it = ch[Symbol.asyncIterator]();
+  const nextP = it.next();
+  ch.push({ kind: "drop", id: 1 });
+  const r = await nextP;
+  expect(r.value.id).toBe(1);
+  // Verify fast-path: cap=1 channel can sustain push-while-pending without eviction.
+  const ch2 = new BoundedEventChannel<TestEvent>({ capacity: 1, classify });
+  const it2 = ch2[Symbol.asyncIterator]();
+  const p1 = it2.next();
+  ch2.push({ kind: "drop", id: 1 });
+  expect((await p1).value.id).toBe(1);
+  const p2 = it2.next();
+  ch2.push({ kind: "drop", id: 2 });
+  expect((await p2).value.id).toBe(2);
+  expect(ch2.stats().evicted).toBe(0);
+});
+
+test("close drains buffered then signals done", async () => {
+  const ch = makeChannel(8);
+  ch.push({ kind: "drop", id: 1 });
+  ch.push({ kind: "drop", id: 2 });
+  ch.push({ kind: "drop", id: 3 });
+  ch.close();
+  const it = ch[Symbol.asyncIterator]();
+  expect((await it.next()).value.id).toBe(1);
+  expect((await it.next()).value.id).toBe(2);
+  expect((await it.next()).value.id).toBe(3);
+  expect((await it.next()).done).toBe(true);
+});
+
+test("close while iterator pending resolves it as done", async () => {
+  const ch = makeChannel(8);
+  const it = ch[Symbol.asyncIterator]();
+  const nextP = it.next();
+  ch.close();
+  const r = await nextP;
+  expect(r.done).toBe(true);
+});

--- a/src/acp/bounded-channel.test.ts
+++ b/src/acp/bounded-channel.test.ts
@@ -122,3 +122,35 @@ test("coalesce tail invalidated by terminal: next delta starts new entry", async
   expect(got[1]?.kind).toBe("terminal_a");
   expect(got[2]?.text).toBe("c");
 });
+
+test("never policy evicts oldest drop-eligible to make room", async () => {
+  const cap = 4;
+  const ch = new BoundedEventChannel<TestEvent>({ capacity: cap, classify });
+  for (let i = 1; i <= cap; i++) ch.push({ kind: "drop", id: i });
+  ch.push({ kind: "keep", id: 99 });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got.map((e) => e.id)).toEqual([2, 3, 4, 99]);
+  expect(ch.stats().evicted).toBe(1);
+});
+
+test("never policy with no drop-eligible: incoming dropped, counter increments", async () => {
+  const cap = 3;
+  const dropped: TestEvent[] = [];
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: cap,
+    classify,
+    onDrop: (e, reason) => {
+      if (reason === "no_capacity") dropped.push(e);
+    },
+  });
+  for (let i = 1; i <= cap; i++) ch.push({ kind: "keep", id: i });
+  ch.push({ kind: "keep", id: 99 });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  expect(got.map((e) => e.id)).toEqual([1, 2, 3]);
+  expect(dropped.map((e) => e.id)).toEqual([99]);
+  expect(ch.stats().droppedByPolicy.get("never")).toBe(1);
+});

--- a/src/acp/bounded-channel.test.ts
+++ b/src/acp/bounded-channel.test.ts
@@ -332,6 +332,68 @@ test("REGRESSION: drop_oldest_on_full must not evict a never-policy event at hea
   expect(evicted.map((e) => e.id)).toEqual([2]);
 });
 
+test("REGRESSION: dropped never-event must NOT invalidate coalesce tail", async () => {
+  // cap=2. delta_a + drop. Then push a terminal_a (never-policy) — buffer
+  // is full and drop-eligible victim exists, so terminal_a evicts the drop
+  // event and IS buffered. That's the happy path. Now contrast: cap=2,
+  // delta_a + keep (both never-policy + coalesce-buffered). Push terminal_a:
+  // no drop-eligible victim → terminal_a is dropped. The delta_a tail must
+  // remain valid so subsequent delta_a chunks coalesce into it.
+  const cap = 2;
+  const ch = new BoundedEventChannel<TestEvent>({
+    capacity: cap,
+    classify,
+    coalesceKey,
+    coalesce,
+    invalidatesCoalesceKey,
+  });
+  ch.push({ kind: "delta_a", id: 1, text: "a" });
+  ch.push({ kind: "keep", id: 2 });
+  // Buffer = [delta_a-tail, keep]. No drop-eligible. terminal_a is dropped.
+  ch.push({ kind: "terminal_a", id: 99 });
+  // Subsequent delta_a chunk MUST coalesce into the prior tail (id=1).
+  ch.push({ kind: "delta_a", id: 3, text: "b" });
+  ch.close();
+  const got: TestEvent[] = [];
+  for await (const e of ch) got.push(e);
+  // 2 events: the merged delta_a "ab" + the keep event.
+  expect(got.length).toBe(2);
+  const deltaEvent = got.find((e) => e.kind === "delta_a");
+  expect(deltaEvent?.text).toBe("ab");
+  expect(ch.stats().coalesced).toBe(1);
+  expect(ch.stats().droppedByPolicy.get("never")).toBe(1);
+});
+
+test("REGRESSION: concurrent next() calls all resolve in FIFO order (no lost wakeups)", async () => {
+  const ch = makeChannel(8);
+  const it = ch[Symbol.asyncIterator]();
+  // Issue 3 next() calls before any push — all must enqueue.
+  const p1 = it.next();
+  const p2 = it.next();
+  const p3 = it.next();
+  ch.push({ kind: "drop", id: 1 });
+  ch.push({ kind: "drop", id: 2 });
+  ch.push({ kind: "drop", id: 3 });
+  const r1 = await p1;
+  const r2 = await p2;
+  const r3 = await p3;
+  expect(r1.value.id).toBe(1);
+  expect(r2.value.id).toBe(2);
+  expect(r3.value.id).toBe(3);
+});
+
+test("REGRESSION: close() resolves ALL pending next() callers as done", async () => {
+  const ch = makeChannel(8);
+  const it = ch[Symbol.asyncIterator]();
+  const p1 = it.next();
+  const p2 = it.next();
+  ch.close();
+  const r1 = await p1;
+  const r2 = await p2;
+  expect(r1.done).toBe(true);
+  expect(r2.done).toBe(true);
+});
+
 test("REGRESSION: drop_oldest_on_full with no drop-eligible victim drops incoming", async () => {
   // Cap=2. Two never events. Incoming drop event has nothing eligible to
   // evict — must drop incoming, never the never events.

--- a/src/acp/bounded-channel.test.ts
+++ b/src/acp/bounded-channel.test.ts
@@ -202,7 +202,7 @@ test("consumer break: subsequent pushes drop silently and channel marks closed",
     capacity: 4,
     classify,
     onDrop: (e, reason) => {
-      if (reason === "no_capacity") dropped.push(e);
+      if (reason === "closed") dropped.push(e);
     },
   });
   ch.push({ kind: "drop", id: 1 });
@@ -214,6 +214,16 @@ test("consumer break: subsequent pushes drop silently and channel marks closed",
   ch.push({ kind: "drop", id: 3 });
   ch.push({ kind: "keep", id: 4 });
   expect(dropped.map((e) => e.id)).toEqual([3, 4]);
+});
+
+test("iterator return() while next() pending resolves the pending promise", async () => {
+  const ch = makeChannel(4);
+  const it = ch[Symbol.asyncIterator]();
+  const nextP = it.next();
+  // Trigger return() while next() is pending.
+  await it.return?.();
+  const r = await nextP;
+  expect(r.done).toBe(true);
 });
 
 test("stats accuracy under mixed push: pushed/coalesced/evicted/droppedByPolicy", async () => {

--- a/src/acp/bounded-channel.ts
+++ b/src/acp/bounded-channel.ts
@@ -54,7 +54,7 @@ export class BoundedEventChannel<T> {
 
   close(): void {
     this.closed = true;
-    if (this.pendingResolver && this.size === 0) {
+    if (this.pendingResolver) {
       const r = this.pendingResolver;
       this.pendingResolver = null;
       r({ value: undefined as unknown as T, done: true });
@@ -92,6 +92,7 @@ export class BoundedEventChannel<T> {
       },
       async return(): Promise<IteratorResult<T>> {
         self.closed = true;
+        self.pendingResolver = null;
         return { value: undefined as unknown as T, done: true };
       },
     };

--- a/src/acp/bounded-channel.ts
+++ b/src/acp/bounded-channel.ts
@@ -48,8 +48,21 @@ export class BoundedEventChannel<T> {
       return;
     }
     this._stats.pushed++;
-    // Minimal: append-only. Policy logic added in later tasks.
-    this._appendTail(event, this.opts.classify(event));
+    const policy = this.opts.classify(event);
+
+    if (policy === "drop_oldest_on_full") {
+      if (!this.unbounded && this.size === this.buffer.length) {
+        const victim = this.buffer[this.head] as T;
+        this._evictAt(this.head);
+        this._stats.evicted++;
+        this.opts.onDrop?.(victim, "evicted");
+      }
+      this._appendTail(event, policy);
+      return;
+    }
+
+    // never + coalesce policies handled in later tasks; for now, append.
+    this._appendTail(event, policy);
   }
 
   close(): void {
@@ -112,6 +125,35 @@ export class BoundedEventChannel<T> {
     this.policyAt[this.tail] = policy;
     this.tail = (this.tail + 1) % this.buffer.length;
     this.size++;
+  }
+
+  private _evictAt(idx: number): void {
+    this.buffer[idx] = undefined;
+    this.policyAt[idx] = undefined;
+    for (const [k, i] of this.coalesceTails) {
+      if (i === idx) this.coalesceTails.delete(k);
+    }
+    if (idx === this.head) {
+      this.head = (this.head + 1) % this.buffer.length;
+      this.size--;
+      return;
+    }
+    const cap = this.buffer.length;
+    let cur = idx;
+    while (true) {
+      const next = (cur + 1) % cap;
+      if (next === this.tail) break;
+      this.buffer[cur] = this.buffer[next];
+      this.policyAt[cur] = this.policyAt[next];
+      for (const [k, i] of this.coalesceTails) {
+        if (i === next) this.coalesceTails.set(k, cur);
+      }
+      cur = next;
+    }
+    this.tail = (this.tail - 1 + cap) % cap;
+    this.buffer[this.tail] = undefined;
+    this.policyAt[this.tail] = undefined;
+    this.size--;
   }
 
   private _grow(): void {

--- a/src/acp/bounded-channel.ts
+++ b/src/acp/bounded-channel.ts
@@ -59,7 +59,25 @@ export class BoundedEventChannel<T> {
         this.opts.onDrop?.(event, "coalesced");
         return;
       }
-      // Fall through to append; record tail after.
+      // No existing tail for this key → buffer as a new entry. A new chunked
+      // delta is the *start* of a text run; losing it would drop the opening
+      // of a sentence. Treat like never-policy when full: evict oldest
+      // drop-eligible victim, or drop incoming if no victim exists. Without
+      // this guard, _appendTail would overflow the bounded ring (size grows
+      // past capacity, head/tail wrap mid-buffer, undefined emissions).
+      if (!this.unbounded && this.size === this.buffer.length) {
+        const victimIdx = this._findOldestDropEligibleIdx();
+        if (victimIdx === -1) {
+          const prev = this._stats.droppedByPolicy.get("coalesce_text_deltas") ?? 0;
+          this._stats.droppedByPolicy.set("coalesce_text_deltas", prev + 1);
+          this.opts.onDrop?.(event, "no_capacity");
+          return;
+        }
+        const victim = this.buffer[victimIdx] as T;
+        this._evictAt(victimIdx);
+        this._stats.evicted++;
+        this.opts.onDrop?.(victim, "evicted");
+      }
       const tailIdxBefore = this.tail;
       this._appendTail(event, policy);
       // Only record tail if event was actually buffered (not fast-pathed).
@@ -92,8 +110,21 @@ export class BoundedEventChannel<T> {
 
     if (policy === "drop_oldest_on_full") {
       if (!this.unbounded && this.size === this.buffer.length) {
-        const victim = this.buffer[this.head] as T;
-        this._evictAt(this.head);
+        // Policy-aware victim selection: head may be a `never` event (e.g.
+        // tool_call buffered earlier). Evicting it to make room for a low-
+        // priority `raw`/`token_usage` would lose a semantic event. Walk
+        // for an oldest drop-eligible slot instead. If none exists (every
+        // slot is `never` or `coalesce`), drop the incoming low-priority
+        // event to preserve bounded memory + semantic events.
+        const victimIdx = this._findOldestDropEligibleIdx();
+        if (victimIdx === -1) {
+          const prev = this._stats.droppedByPolicy.get("drop_oldest_on_full") ?? 0;
+          this._stats.droppedByPolicy.set("drop_oldest_on_full", prev + 1);
+          this.opts.onDrop?.(event, "no_capacity");
+          return;
+        }
+        const victim = this.buffer[victimIdx] as T;
+        this._evictAt(victimIdx);
         this._stats.evicted++;
         this.opts.onDrop?.(victim, "evicted");
       }

--- a/src/acp/bounded-channel.ts
+++ b/src/acp/bounded-channel.ts
@@ -72,7 +72,20 @@ export class BoundedEventChannel<T> {
     if (policy === "never") {
       const invKey = this.opts.invalidatesCoalesceKey?.(event) ?? null;
       if (invKey !== null) this.coalesceTails.delete(invKey);
-      // Eviction-to-fit handled in Task 4. For now, just append.
+
+      if (!this.unbounded && this.size === this.buffer.length) {
+        const victimIdx = this._findOldestDropEligibleIdx();
+        if (victimIdx === -1) {
+          const prev = this._stats.droppedByPolicy.get("never") ?? 0;
+          this._stats.droppedByPolicy.set("never", prev + 1);
+          this.opts.onDrop?.(event, "no_capacity");
+          return;
+        }
+        const victim = this.buffer[victimIdx] as T;
+        this._evictAt(victimIdx);
+        this._stats.evicted++;
+        this.opts.onDrop?.(victim, "evicted");
+      }
       this._appendTail(event, policy);
       return;
     }
@@ -149,6 +162,15 @@ export class BoundedEventChannel<T> {
     this.policyAt[this.tail] = policy;
     this.tail = (this.tail + 1) % this.buffer.length;
     this.size++;
+  }
+
+  private _findOldestDropEligibleIdx(): number {
+    const cap = this.buffer.length;
+    for (let i = 0; i < this.size; i++) {
+      const idx = (this.head + i) % cap;
+      if (this.policyAt[idx] === "drop_oldest_on_full") return idx;
+    }
+    return -1;
   }
 
   private _evictAt(idx: number): void {

--- a/src/acp/bounded-channel.ts
+++ b/src/acp/bounded-channel.ts
@@ -24,7 +24,14 @@ export class BoundedEventChannel<T> {
   private tail = 0;
   private size = 0;
   private readonly coalesceTails = new Map<string, number>();
-  private pendingResolver: ((value: IteratorResult<T>) => void) | null = null;
+  /**
+   * FIFO queue of pending `next()` resolvers. Although the channel is
+   * documented as single-consumer, defensive consumers may issue concurrent
+   * `next()` calls (e.g. a wrapper that prefetches one ahead). A single
+   * resolver slot would silently overwrite earlier waiters and hang their
+   * promises. The queue resolves in arrival order on push fast-path / close.
+   */
+  private readonly waitQueue: Array<(value: IteratorResult<T>) => void> = [];
   private closed = false;
   private readonly _stats: ChannelStats = {
     pushed: 0,
@@ -89,11 +96,15 @@ export class BoundedEventChannel<T> {
 
     if (policy === "never") {
       const invKey = this.opts.invalidatesCoalesceKey?.(event) ?? null;
-      if (invKey !== null) this.coalesceTails.delete(invKey);
 
       if (!this.unbounded && this.size === this.buffer.length) {
         const victimIdx = this._findOldestDropEligibleIdx();
         if (victimIdx === -1) {
+          // Incoming dropped — do NOT invalidate the coalesce tail. The
+          // prior chunk is still in the buffer, and consumers will see it
+          // continue to coalesce with subsequent chunks. Invalidating here
+          // would orphan that tail and force every following chunk to seek
+          // a fresh slot, multiplying text loss under sustained pressure.
           const prev = this._stats.droppedByPolicy.get("never") ?? 0;
           this._stats.droppedByPolicy.set("never", prev + 1);
           this.opts.onDrop?.(event, "no_capacity");
@@ -105,6 +116,9 @@ export class BoundedEventChannel<T> {
         this.opts.onDrop?.(victim, "evicted");
       }
       this._appendTail(event, policy);
+      // Event was either buffered or fast-path delivered — consumer will see
+      // the terminal, so any prior coalesce tail is now semantically stale.
+      if (invKey !== null) this.coalesceTails.delete(invKey);
       return;
     }
 
@@ -135,9 +149,8 @@ export class BoundedEventChannel<T> {
 
   close(): void {
     this.closed = true;
-    if (this.pendingResolver) {
-      const r = this.pendingResolver;
-      this.pendingResolver = null;
+    while (this.waitQueue.length > 0) {
+      const r = this.waitQueue.shift() as (value: IteratorResult<T>) => void;
       r({ value: undefined as unknown as T, done: true });
     }
   }
@@ -168,14 +181,13 @@ export class BoundedEventChannel<T> {
         }
         if (self.closed) return { value: undefined as unknown as T, done: true };
         return new Promise<IteratorResult<T>>((resolve) => {
-          self.pendingResolver = resolve;
+          self.waitQueue.push(resolve);
         });
       },
       async return(): Promise<IteratorResult<T>> {
         self.closed = true;
-        if (self.pendingResolver) {
-          const r = self.pendingResolver;
-          self.pendingResolver = null;
+        while (self.waitQueue.length > 0) {
+          const r = self.waitQueue.shift() as (value: IteratorResult<T>) => void;
           r({ value: undefined as unknown as T, done: true });
         }
         return { value: undefined as unknown as T, done: true };
@@ -184,9 +196,8 @@ export class BoundedEventChannel<T> {
   }
 
   private _appendTail(event: T, policy: Policy): void {
-    if (this.pendingResolver) {
-      const r = this.pendingResolver;
-      this.pendingResolver = null;
+    if (this.waitQueue.length > 0) {
+      const r = this.waitQueue.shift() as (value: IteratorResult<T>) => void;
       r({ value: event, done: false });
       return;
     }

--- a/src/acp/bounded-channel.ts
+++ b/src/acp/bounded-channel.ts
@@ -5,7 +5,7 @@ export interface ChannelOptions<T> {
   classify: (event: T) => Policy;
   coalesceKey?: (event: T) => string | null;
   coalesce?: (existing: T, incoming: T) => T;
-  invalidatesCoalesceKey?: (event: T) => string | null;
+  invalidatesCoalesceKey?: (event: T) => string | readonly string[] | null;
   onDrop?: (event: T, reason: "evicted" | "coalesced" | "no_capacity" | "closed") => void;
 }
 
@@ -95,7 +95,7 @@ export class BoundedEventChannel<T> {
     }
 
     if (policy === "never") {
-      const invKey = this.opts.invalidatesCoalesceKey?.(event) ?? null;
+      const invRaw = this.opts.invalidatesCoalesceKey?.(event) ?? null;
 
       if (!this.unbounded && this.size === this.buffer.length) {
         const victimIdx = this._findOldestDropEligibleIdx();
@@ -117,8 +117,17 @@ export class BoundedEventChannel<T> {
       }
       this._appendTail(event, policy);
       // Event was either buffered or fast-path delivered — consumer will see
-      // the terminal, so any prior coalesce tail is now semantically stale.
-      if (invKey !== null) this.coalesceTails.delete(invKey);
+      // it, so any prior coalesce tail is now semantically stale. A semantic
+      // boundary event (e.g. tool_call) MUST invalidate text/thinking tails
+      // even when it does not share a key with them: otherwise a later text
+      // chunk would coalesce into a slot that lives BEFORE this event in
+      // the ring, reordering chronology (text after tool_call appears as
+      // text before tool_call). Callers signal this by returning all keys
+      // whose chronological order this event terminates.
+      if (invRaw !== null) {
+        if (typeof invRaw === "string") this.coalesceTails.delete(invRaw);
+        else for (const k of invRaw) this.coalesceTails.delete(k);
+      }
       return;
     }
 

--- a/src/acp/bounded-channel.ts
+++ b/src/acp/bounded-channel.ts
@@ -6,7 +6,7 @@ export interface ChannelOptions<T> {
   coalesceKey?: (event: T) => string | null;
   coalesce?: (existing: T, incoming: T) => T;
   invalidatesCoalesceKey?: (event: T) => string | null;
-  onDrop?: (event: T, reason: "evicted" | "coalesced" | "no_capacity") => void;
+  onDrop?: (event: T, reason: "evicted" | "coalesced" | "no_capacity" | "closed") => void;
 }
 
 export interface ChannelStats {
@@ -44,7 +44,7 @@ export class BoundedEventChannel<T> {
 
   push(event: T): void {
     if (this.closed) {
-      this.opts.onDrop?.(event, "no_capacity");
+      this.opts.onDrop?.(event, "closed");
       return;
     }
     this._stats.pushed++;
@@ -142,7 +142,11 @@ export class BoundedEventChannel<T> {
       },
       async return(): Promise<IteratorResult<T>> {
         self.closed = true;
-        self.pendingResolver = null;
+        if (self.pendingResolver) {
+          const r = self.pendingResolver;
+          self.pendingResolver = null;
+          r({ value: undefined as unknown as T, done: true });
+        }
         return { value: undefined as unknown as T, done: true };
       },
     };

--- a/src/acp/bounded-channel.ts
+++ b/src/acp/bounded-channel.ts
@@ -50,6 +50,33 @@ export class BoundedEventChannel<T> {
     this._stats.pushed++;
     const policy = this.opts.classify(event);
 
+    if (policy === "coalesce_text_deltas") {
+      const key = this.opts.coalesceKey?.(event) ?? null;
+      if (key !== null && this.coalesceTails.has(key) && this.opts.coalesce) {
+        const idx = this.coalesceTails.get(key) as number;
+        this.buffer[idx] = this.opts.coalesce(this.buffer[idx] as T, event);
+        this._stats.coalesced++;
+        this.opts.onDrop?.(event, "coalesced");
+        return;
+      }
+      // Fall through to append; record tail after.
+      const tailIdxBefore = this.tail;
+      this._appendTail(event, policy);
+      // Only record tail if event was actually buffered (not fast-pathed).
+      if (this.size > 0 && this.policyAt[tailIdxBefore] === policy && key !== null) {
+        this.coalesceTails.set(key, tailIdxBefore);
+      }
+      return;
+    }
+
+    if (policy === "never") {
+      const invKey = this.opts.invalidatesCoalesceKey?.(event) ?? null;
+      if (invKey !== null) this.coalesceTails.delete(invKey);
+      // Eviction-to-fit handled in Task 4. For now, just append.
+      this._appendTail(event, policy);
+      return;
+    }
+
     if (policy === "drop_oldest_on_full") {
       if (!this.unbounded && this.size === this.buffer.length) {
         const victim = this.buffer[this.head] as T;
@@ -60,9 +87,6 @@ export class BoundedEventChannel<T> {
       this._appendTail(event, policy);
       return;
     }
-
-    // never + coalesce policies handled in later tasks; for now, append.
-    this._appendTail(event, policy);
   }
 
   close(): void {

--- a/src/acp/bounded-channel.ts
+++ b/src/acp/bounded-channel.ts
@@ -185,7 +185,21 @@ export class BoundedEventChannel<T> {
         });
       },
       async return(): Promise<IteratorResult<T>> {
+        // return() is an abort signal (e.g. for-await break). Unlike close(),
+        // which says "no more pushes, drain what's buffered", return() says
+        // "consumer is gone, discard everything." Without this, a subsequent
+        // next() (same iterator) or a fresh iterator on the same channel
+        // would still see stale buffered events because next() checks
+        // size > 0 before checking closed.
         self.closed = true;
+        for (let i = 0; i < self.buffer.length; i++) {
+          self.buffer[i] = undefined;
+          self.policyAt[i] = undefined;
+        }
+        self.head = 0;
+        self.tail = 0;
+        self.size = 0;
+        self.coalesceTails.clear();
         while (self.waitQueue.length > 0) {
           const r = self.waitQueue.shift() as (value: IteratorResult<T>) => void;
           r({ value: undefined as unknown as T, done: true });

--- a/src/acp/bounded-channel.ts
+++ b/src/acp/bounded-channel.ts
@@ -1,0 +1,136 @@
+export type Policy = "never" | "coalesce_text_deltas" | "drop_oldest_on_full";
+
+export interface ChannelOptions<T> {
+  capacity: number;
+  classify: (event: T) => Policy;
+  coalesceKey?: (event: T) => string | null;
+  coalesce?: (existing: T, incoming: T) => T;
+  invalidatesCoalesceKey?: (event: T) => string | null;
+  onDrop?: (event: T, reason: "evicted" | "coalesced" | "no_capacity") => void;
+}
+
+export interface ChannelStats {
+  pushed: number;
+  coalesced: number;
+  evicted: number;
+  droppedByPolicy: Map<Policy, number>;
+}
+
+export class BoundedEventChannel<T> {
+  private readonly opts: ChannelOptions<T>;
+  private readonly buffer: (T | undefined)[];
+  private readonly policyAt: (Policy | undefined)[];
+  private head = 0;
+  private tail = 0;
+  private size = 0;
+  private readonly coalesceTails = new Map<string, number>();
+  private pendingResolver: ((value: IteratorResult<T>) => void) | null = null;
+  private closed = false;
+  private readonly _stats: ChannelStats = {
+    pushed: 0,
+    coalesced: 0,
+    evicted: 0,
+    droppedByPolicy: new Map(),
+  };
+  private readonly unbounded: boolean;
+
+  constructor(opts: ChannelOptions<T>) {
+    this.opts = opts;
+    this.unbounded = !Number.isFinite(opts.capacity);
+    const initial = this.unbounded ? 16 : opts.capacity;
+    this.buffer = new Array(initial);
+    this.policyAt = new Array(initial);
+  }
+
+  push(event: T): void {
+    if (this.closed) {
+      this.opts.onDrop?.(event, "no_capacity");
+      return;
+    }
+    this._stats.pushed++;
+    // Minimal: append-only. Policy logic added in later tasks.
+    this._appendTail(event, this.opts.classify(event));
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.pendingResolver && this.size === 0) {
+      const r = this.pendingResolver;
+      this.pendingResolver = null;
+      r({ value: undefined as unknown as T, done: true });
+    }
+  }
+
+  stats(): ChannelStats {
+    return {
+      pushed: this._stats.pushed,
+      coalesced: this._stats.coalesced,
+      evicted: this._stats.evicted,
+      droppedByPolicy: new Map(this._stats.droppedByPolicy),
+    };
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    const self = this;
+    return {
+      async next(): Promise<IteratorResult<T>> {
+        if (self.size > 0) {
+          const ev = self.buffer[self.head] as T;
+          self.buffer[self.head] = undefined;
+          self.policyAt[self.head] = undefined;
+          for (const [k, idx] of self.coalesceTails) {
+            if (idx === self.head) self.coalesceTails.delete(k);
+          }
+          self.head = (self.head + 1) % self.buffer.length;
+          self.size--;
+          return { value: ev, done: false };
+        }
+        if (self.closed) return { value: undefined as unknown as T, done: true };
+        return new Promise<IteratorResult<T>>((resolve) => {
+          self.pendingResolver = resolve;
+        });
+      },
+      async return(): Promise<IteratorResult<T>> {
+        self.closed = true;
+        return { value: undefined as unknown as T, done: true };
+      },
+    };
+  }
+
+  private _appendTail(event: T, policy: Policy): void {
+    if (this.pendingResolver) {
+      const r = this.pendingResolver;
+      this.pendingResolver = null;
+      r({ value: event, done: false });
+      return;
+    }
+    if (this.unbounded && this.size === this.buffer.length) {
+      this._grow();
+    }
+    this.buffer[this.tail] = event;
+    this.policyAt[this.tail] = policy;
+    this.tail = (this.tail + 1) % this.buffer.length;
+    this.size++;
+  }
+
+  private _grow(): void {
+    const oldCap = this.buffer.length;
+    const newCap = oldCap * 2;
+    const newBuf: (T | undefined)[] = new Array(newCap);
+    const newPol: (Policy | undefined)[] = new Array(newCap);
+    for (let i = 0; i < this.size; i++) {
+      const idx = (this.head + i) % oldCap;
+      newBuf[i] = this.buffer[idx];
+      newPol[i] = this.policyAt[idx];
+    }
+    this.buffer.length = 0;
+    this.policyAt.length = 0;
+    for (let i = 0; i < newCap; i++) {
+      this.buffer.push(newBuf[i]);
+      this.policyAt.push(newPol[i]);
+    }
+    this.head = 0;
+    this.tail = this.size;
+    this.coalesceTails.clear();
+  }
+}

--- a/src/acp/turn.test.ts
+++ b/src/acp/turn.test.ts
@@ -200,3 +200,46 @@ test("EOF without result yields acpx_exit error Result", async () => {
   expect(r.stopReason).toBe("error");
   expect(r.error?.code).toBe("acpx_exit");
 });
+
+test("AcpxTurnImpl: default capacity 256 evicts oldest under slow consumer", async () => {
+  // 300 raw events + terminal result. Slow consumer yields between reads so
+  // the pump can fill the channel buffer, exercising drop_oldest_on_full
+  // eviction (raw → drop_oldest_on_full policy).
+  const N = 300;
+  const lines: string[] = [];
+  for (let i = 0; i < N; i++) {
+    lines.push(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: { sessionId: "s1", update: { sessionUpdate: "_unknown_kind", n: i } },
+      }),
+    );
+  }
+  lines.push(JSON.stringify({ jsonrpc: "2.0", id: "req-1", result: { stopReason: "end_turn" } }));
+
+  const turn = new AcpxTurnImpl({
+    sessionId: "s1",
+    turnId: "t1",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+
+  // Slow consumer: yield to the event loop between reads so the pump runs
+  // ahead and the buffer reaches its 256 cap, forcing eviction of the oldest
+  // raw events.
+  const got: Message[] = [];
+  for await (const m of turn.messages) {
+    got.push(m);
+    await new Promise((r) => setImmediate(r));
+  }
+  await turn.result;
+
+  // Cannot assert exact count (depends on scheduling), but the buffer cap is
+  // 256, so we MUST observe fewer than N=300 messages — eviction fired.
+  expect(got.length).toBeLessThan(N);
+  expect(got.length).toBeGreaterThan(0);
+  // All received messages should be `raw` kind (no terminal frame goes
+  // through `messages` — it lands in `result`).
+  for (const m of got) expect(m.kind).toBe("raw");
+});

--- a/src/acp/turn.test.ts
+++ b/src/acp/turn.test.ts
@@ -243,3 +243,74 @@ test("AcpxTurnImpl: default capacity 256 evicts oldest under slow consumer", asy
   // through `messages` — it lands in `result`).
   for (const m of got) expect(m.kind).toBe("raw");
 });
+
+test("AcpxTurnImpl: channelCapacity Infinity bypasses eviction", async () => {
+  const N = 1000;
+  const lines: string[] = [];
+  for (let i = 0; i < N; i++) {
+    lines.push(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: { sessionId: "s1", update: { sessionUpdate: "_unknown_kind", n: i } },
+      }),
+    );
+  }
+  lines.push(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }));
+
+  const turn = new AcpxTurnImpl({
+    sessionId: "s1",
+    turnId: "t1",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+    channelCapacity: Infinity,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  await turn.result;
+  expect(got.length).toBe(N);
+});
+
+test("AcpxTurnImpl: chunked text deltas coalesce under default capacity", async () => {
+  const lines: string[] = [];
+  for (let i = 0; i < 50; i++) {
+    lines.push(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "s1",
+          update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "x" } },
+        },
+      }),
+    );
+  }
+  lines.push(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }));
+
+  const turn = new AcpxTurnImpl({
+    sessionId: "s1",
+    turnId: "t1",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+    channelCapacity: 4,
+  });
+
+  const got: Message[] = [];
+  for await (const m of turn.messages) {
+    got.push(m);
+    await new Promise((r) => setImmediate(r));
+  }
+  await turn.result;
+
+  // With cap=4 and a slow consumer, chunked text deltas must coalesce. The
+  // exact buffered count depends on scheduling, but the concatenated text
+  // must total exactly 50 characters (no character loss) — coalescing
+  // preserves text by appending, never dropping.
+  expect(got.length).toBeLessThanOrEqual(50); // not stricter — could be 1..50 depending on timing
+  const totalText = got
+    .filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text")
+    .map((m) => m.text)
+    .join("");
+  expect(totalText.length).toBe(50);
+  expect(totalText).toBe("x".repeat(50));
+});

--- a/src/acp/turn.test.ts
+++ b/src/acp/turn.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { PassThrough, Readable } from "node:stream";
-import { AcpxTurnImpl } from "./turn.js";
+import { AcpxTurnImpl, classifyMessage } from "./turn.js";
 import type { Message } from "./types.js";
 
 function makeStream(lines: string[]): Readable {
@@ -269,6 +269,37 @@ test("AcpxTurnImpl: channelCapacity Infinity bypasses eviction", async () => {
   for await (const m of turn.messages) got.push(m);
   await turn.result;
   expect(got.length).toBe(N);
+});
+
+test("classifyMessage covers all Message kinds with expected policies", () => {
+  expect(
+    classifyMessage({ kind: "tool_call", turnId: "t", toolCall: { id: "x" } }),
+  ).toBe("never");
+  expect(
+    classifyMessage({
+      kind: "permission_request",
+      turnId: "t",
+      request: { id: "x", tool: "y", input: {} },
+    }),
+  ).toBe("never");
+  expect(classifyMessage({ kind: "text", turnId: "t", text: "x", chunk: true })).toBe(
+    "coalesce_text_deltas",
+  );
+  expect(classifyMessage({ kind: "text", turnId: "t", text: "x", chunk: false })).toBe(
+    "never",
+  );
+  expect(classifyMessage({ kind: "thinking", turnId: "t", text: "x", chunk: true })).toBe(
+    "coalesce_text_deltas",
+  );
+  expect(classifyMessage({ kind: "thinking", turnId: "t", text: "x", chunk: false })).toBe(
+    "never",
+  );
+  expect(
+    classifyMessage({ kind: "token_usage", turnId: "t", usage: { inputTokens: 0, outputTokens: 0 } }),
+  ).toBe("drop_oldest_on_full");
+  expect(classifyMessage({ kind: "raw", turnId: "t", acpMethod: "any", params: {} })).toBe(
+    "drop_oldest_on_full",
+  );
 });
 
 test("AcpxTurnImpl: chunked text deltas coalesce under default capacity", async () => {

--- a/src/acp/turn.test.ts
+++ b/src/acp/turn.test.ts
@@ -272,9 +272,7 @@ test("AcpxTurnImpl: channelCapacity Infinity bypasses eviction", async () => {
 });
 
 test("classifyMessage covers all Message kinds with expected policies", () => {
-  expect(
-    classifyMessage({ kind: "tool_call", turnId: "t", toolCall: { id: "x" } }),
-  ).toBe("never");
+  expect(classifyMessage({ kind: "tool_call", turnId: "t", toolCall: { id: "x" } })).toBe("never");
   expect(
     classifyMessage({
       kind: "permission_request",
@@ -285,21 +283,79 @@ test("classifyMessage covers all Message kinds with expected policies", () => {
   expect(classifyMessage({ kind: "text", turnId: "t", text: "x", chunk: true })).toBe(
     "coalesce_text_deltas",
   );
-  expect(classifyMessage({ kind: "text", turnId: "t", text: "x", chunk: false })).toBe(
-    "never",
-  );
+  expect(classifyMessage({ kind: "text", turnId: "t", text: "x", chunk: false })).toBe("never");
   expect(classifyMessage({ kind: "thinking", turnId: "t", text: "x", chunk: true })).toBe(
     "coalesce_text_deltas",
   );
-  expect(classifyMessage({ kind: "thinking", turnId: "t", text: "x", chunk: false })).toBe(
-    "never",
-  );
+  expect(classifyMessage({ kind: "thinking", turnId: "t", text: "x", chunk: false })).toBe("never");
   expect(
-    classifyMessage({ kind: "token_usage", turnId: "t", usage: { inputTokens: 0, outputTokens: 0 } }),
+    classifyMessage({
+      kind: "token_usage",
+      turnId: "t",
+      usage: { inputTokens: 0, outputTokens: 0 },
+    }),
   ).toBe("drop_oldest_on_full");
   expect(classifyMessage({ kind: "raw", turnId: "t", acpMethod: "any", params: {} })).toBe(
     "drop_oldest_on_full",
   );
+});
+
+test("REGRESSION: tool_call invalidates text/thinking coalesce tail (#274 round 4)", async () => {
+  // Stream: text chunk A → tool_call → text chunk B. Without the boundary
+  // invalidation, B coalesces into A's slot which lives BEFORE tool_call in
+  // the ring, reordering the visible stream to [text(AB), tool_call] instead
+  // of the correct [text(A), tool_call, text(B)]. A slow consumer keeps the
+  // events buffered long enough for B to merge into A.
+  const lines = [
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "s1",
+        update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "A" } },
+      },
+    }),
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "s1",
+        update: { sessionUpdate: "tool_call", toolCallId: "tc-1", title: "do work" },
+      },
+    }),
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "s1",
+        update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "B" } },
+      },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const turn = new AcpxTurnImpl({
+    sessionId: "s1",
+    turnId: "t1",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) {
+    got.push(m);
+    // Slow consumer: hold every event for one tick so the pump pushes all
+    // three before the consumer has drained even one — the only condition
+    // under which the reorder bug surfaces.
+    await new Promise((r) => setImmediate(r));
+  }
+  await turn.result;
+  const kinds = got.map((m) => m.kind);
+  // Order must reflect chronology: text, tool_call, text — never [text, text, tool_call]
+  // and never [text("AB"), tool_call] (which would mean B merged into A).
+  expect(kinds).toEqual(["text", "tool_call", "text"]);
+  const texts = got
+    .filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text")
+    .map((m) => m.text);
+  expect(texts).toEqual(["A", "B"]);
 });
 
 test("AcpxTurnImpl: chunked text deltas coalesce under default capacity", async () => {

--- a/src/acp/turn.ts
+++ b/src/acp/turn.ts
@@ -41,8 +41,15 @@ function coalesceMessage(existing: Message, incoming: Message): Message {
   return existing;
 }
 
-function invalidatesCoalesceKeyFor(m: Message): string | null {
+const TEXT_THINKING_KEYS: readonly string[] = ["text", "thinking"];
+
+function invalidatesCoalesceKeyFor(m: Message): string | readonly string[] | null {
   if ((m.kind === "text" || m.kind === "thinking") && !m.chunk) return m.kind;
+  // tool_call / permission_request are chronological boundaries between
+  // text/thinking runs. Without invalidation, a later text chunk would
+  // coalesce into the pre-tool_call slot and visibly reorder the stream
+  // (text-after-tool would surface as text-before-tool to the consumer).
+  if (m.kind === "tool_call" || m.kind === "permission_request") return TEXT_THINKING_KEYS;
   return null;
 }
 
@@ -93,9 +100,7 @@ export class AcpxTurnImpl implements AcpxTurn {
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(
-          `[acpx-turn] pump error for session=${sid} turn=${tid}: ${msg}\n`,
-        );
+        process.stderr.write(`[acpx-turn] pump error for session=${sid} turn=${tid}: ${msg}\n`);
       } finally {
         channel.close();
       }

--- a/src/acp/turn.ts
+++ b/src/acp/turn.ts
@@ -4,8 +4,47 @@
  */
 
 import type { Readable } from "node:stream";
+import { BoundedEventChannel, type Policy } from "./bounded-channel.js";
 import { AcpParser } from "./parser.js";
 import type { AcpxTurn, Message, Result } from "./types.js";
+
+const DEFAULT_CHANNEL_CAPACITY = 256;
+
+function classifyMessage(m: Message): Policy {
+  switch (m.kind) {
+    case "tool_call":
+    case "permission_request":
+      return "never";
+    case "text":
+    case "thinking":
+      return m.chunk ? "coalesce_text_deltas" : "never";
+    case "token_usage":
+    case "raw":
+      return "drop_oldest_on_full";
+    default:
+      return "drop_oldest_on_full";
+  }
+}
+
+function coalesceKeyFor(m: Message): string | null {
+  if ((m.kind === "text" || m.kind === "thinking") && m.chunk) return m.kind;
+  return null;
+}
+
+function coalesceMessage(existing: Message, incoming: Message): Message {
+  if (
+    (existing.kind === "text" && incoming.kind === "text") ||
+    (existing.kind === "thinking" && incoming.kind === "thinking")
+  ) {
+    return { ...existing, text: existing.text + incoming.text };
+  }
+  return existing;
+}
+
+function invalidatesCoalesceKeyFor(m: Message): string | null {
+  if ((m.kind === "text" || m.kind === "thinking") && !m.chunk) return m.kind;
+  return null;
+}
 
 export class AcpxTurnImpl implements AcpxTurn {
   readonly sessionId: string;
@@ -14,6 +53,7 @@ export class AcpxTurnImpl implements AcpxTurn {
   readonly result: Promise<Result>;
   private readonly cancelFn: () => Promise<void>;
   private readonly parser: AcpParser;
+  private readonly channel: BoundedEventChannel<Message>;
   private pendingCancel: Promise<void> | null = null;
 
   constructor(opts: {
@@ -21,6 +61,8 @@ export class AcpxTurnImpl implements AcpxTurn {
     turnId: string;
     stdout: Readable;
     cancelFn: () => Promise<void>;
+    /** Override the default 256-event channel capacity. Pass `Infinity` to bypass eviction. */
+    channelCapacity?: number;
   }) {
     this.sessionId = opts.sessionId;
     this.turnId = opts.turnId;
@@ -30,34 +72,32 @@ export class AcpxTurnImpl implements AcpxTurn {
       turnId: opts.turnId,
       stream: opts.stdout,
     });
-    this.messages = this.parser.messages;
+    this.channel = new BoundedEventChannel<Message>({
+      capacity: opts.channelCapacity ?? DEFAULT_CHANNEL_CAPACITY,
+      classify: classifyMessage,
+      coalesceKey: coalesceKeyFor,
+      coalesce: coalesceMessage,
+      invalidatesCoalesceKey: invalidatesCoalesceKeyFor,
+    });
     this.result = this.parser.result;
+    this.messages = this.channel;
+
+    const parser = this.parser;
+    const channel = this.channel;
+    void (async () => {
+      try {
+        for await (const m of parser.messages) {
+          channel.push(m);
+        }
+      } finally {
+        channel.close();
+      }
+    })();
   }
 
-  /**
-   * Cancel the in-flight turn.
-   *
-   * Single-flight: concurrent callers share the same in-flight cancellation
-   * attempt so we never double-send cancel to the underlying transport during
-   * a single call "wave".
-   *
-   * Retryable until the turn settles: a successful `cancelFn()` resolution is
-   * only a "cancel requested", not a guaranteed "cancel confirmed" — the
-   * provider may ignore it. Callers can re-invoke `cancel()` to re-send until
-   * the turn's result arrives (at which point this becomes a no-op). If
-   * `cancelFn` rejects, the rejection propagates and the next caller still
-   * gets a fresh attempt.
-   */
   async cancel(): Promise<void> {
-    // Gate synchronously on the parser's own settled flag (flipped inside
-    // finish()) rather than a .then() latch on `this.result`. A microtask
-    // latch would still read `false` when a caller invokes cancel() in the
-    // same tick as resolution — and ACP sessions are persistent, so a
-    // stray cancel sent after the turn ended could hit the NEXT prompt or
-    // produce spurious cancelled telemetry for an already-finished turn.
     if (this.parser.settled) return;
     if (this.pendingCancel !== null) return this.pendingCancel;
-
     const attempt = (async () => {
       try {
         await this.cancelFn();

--- a/src/acp/turn.ts
+++ b/src/acp/turn.ts
@@ -10,7 +10,7 @@ import type { AcpxTurn, Message, Result } from "./types.js";
 
 const DEFAULT_CHANNEL_CAPACITY = 256;
 
-function classifyMessage(m: Message): Policy {
+export function classifyMessage(m: Message): Policy {
   switch (m.kind) {
     case "tool_call":
     case "permission_request":
@@ -84,11 +84,18 @@ export class AcpxTurnImpl implements AcpxTurn {
 
     const parser = this.parser;
     const channel = this.channel;
+    const sid = this.sessionId;
+    const tid = this.turnId;
     void (async () => {
       try {
         for await (const m of parser.messages) {
           channel.push(m);
         }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[acpx-turn] pump error for session=${sid} turn=${tid}: ${msg}\n`,
+        );
       } finally {
         channel.close();
       }

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -6,16 +6,16 @@
  * CLI commands.
  */
 
-import { existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { resolve } from "node:path";
 import type { FrontierCalculator } from "../core/frontier.js";
 import type { OutcomeStore } from "../core/outcome.js";
 import type { ClaimStore, ContributionStore } from "../core/store.js";
 import type { WorkspaceManager } from "../core/workspace.js";
 import type { FsCas } from "../local/fs-cas.js";
 import { createLocalRuntime } from "../local/runtime.js";
+import { findGroveDir } from "./utils/grove-dir.js";
 
-const GROVE_DIR = ".grove";
+export { findGroveDir };
 
 /** All dependencies a CLI command needs. */
 export interface CliDeps {
@@ -31,33 +31,6 @@ export interface CliDeps {
 
 /** Writer function for testable output. */
 export type Writer = (text: string) => void;
-
-/**
- * Walk up from `startDir` to find the nearest directory containing `.grove/`.
- * Returns the absolute path to the `.grove` directory, or undefined.
- */
-export function findGroveDir(startDir: string): string | undefined {
-  let dir = resolve(startDir);
-  const root = dirname(dir) === dir ? dir : undefined;
-
-  while (true) {
-    const candidate = join(dir, GROVE_DIR);
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break; // filesystem root
-    dir = parent;
-  }
-
-  // Check filesystem root
-  if (root !== undefined) {
-    const candidate = join(root, GROVE_DIR);
-    if (existsSync(candidate)) return candidate;
-  }
-
-  return undefined;
-}
 
 /**
  * Discover the grove and initialize all stores.

--- a/src/cli/utils/grove-dir.test.ts
+++ b/src/cli/utils/grove-dir.test.ts
@@ -125,6 +125,42 @@ describe("findGroveDir", () => {
     // findGroveDir is artifact-agnostic — child wins regardless of grove.json
     expect(findGroveDir(wt)).toBe(wtGrove);
   });
+
+  test("REGRESSION: walks past a regular FILE named .grove (not a fence)", async () => {
+    // Parent has real grove
+    const parentGrove = join(tempDir, ".grove");
+    await mkdir(parentGrove);
+    // Child has a regular file named .grove — should NOT fence
+    const wt = join(tempDir, "wt");
+    await mkdir(wt);
+    await Bun.write(join(wt, ".grove"), "not a directory");
+    // Walk-up must skip past the file and reach parent
+    expect(findGroveDir(wt)).toBe(parentGrove);
+  });
+
+  test("REGRESSION: walks past a broken symlink named .grove (not a fence)", async () => {
+    const parentGrove = join(tempDir, ".grove");
+    await mkdir(parentGrove);
+    const wt = join(tempDir, "wt");
+    await mkdir(wt);
+    // Create a broken symlink (target does not exist)
+    const { symlink } = await import("node:fs/promises");
+    await symlink(join(tempDir, "nonexistent-target"), join(wt, ".grove"));
+    expect(findGroveDir(wt)).toBe(parentGrove);
+  });
+
+  test("REGRESSION: follows a symlink that resolves to a directory (fence)", async () => {
+    // Real directory elsewhere
+    const realGrove = join(tempDir, "real-grove-dir");
+    await mkdir(realGrove);
+    const wt = join(tempDir, "wt");
+    await mkdir(wt);
+    // .grove in wt is a symlink to the real directory
+    const { symlink } = await import("node:fs/promises");
+    await symlink(realGrove, join(wt, ".grove"));
+    // Symlink resolves to a dir → fence applies, returns the symlink path
+    expect(findGroveDir(wt)).toBe(join(wt, ".grove"));
+  });
 });
 
 describe("resolveAgentId", () => {

--- a/src/cli/utils/grove-dir.test.ts
+++ b/src/cli/utils/grove-dir.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { resolveAgentId, resolveGroveDir } from "./grove-dir.js";
+import { findGroveDir, resolveAgentId, resolveGroveDir } from "./grove-dir.js";
 
 describe("resolveGroveDir", () => {
   let tempDir: string;
@@ -69,6 +69,61 @@ describe("resolveGroveDir", () => {
     } finally {
       process.chdir(originalCwd);
     }
+  });
+});
+
+describe("findGroveDir", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await realpath(await mkdtemp(join(tmpdir(), "grove-find-test-")));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("returns undefined when no .grove anywhere up to FS root", () => {
+    expect(findGroveDir(tempDir)).toBeUndefined();
+  });
+
+  test("returns startDir's .grove when it exists directly", async () => {
+    const groveDir = join(tempDir, ".grove");
+    await mkdir(groveDir);
+    expect(findGroveDir(tempDir)).toBe(groveDir);
+  });
+
+  test("walks up to find ancestor .grove", async () => {
+    const groveDir = join(tempDir, ".grove");
+    await mkdir(groveDir);
+    const subDir = join(tempDir, "a", "b", "c");
+    await mkdir(subDir, { recursive: true });
+    expect(findGroveDir(subDir)).toBe(groveDir);
+  });
+
+  test("fence semantics: child .grove wins over ancestor .grove", async () => {
+    // parent .grove at tempDir
+    await mkdir(join(tempDir, ".grove"));
+    // child .grove at tempDir/wt
+    const wt = join(tempDir, "wt");
+    await mkdir(wt);
+    const wtGrove = join(wt, ".grove");
+    await mkdir(wtGrove);
+    expect(findGroveDir(wt)).toBe(wtGrove);
+  });
+
+  test("fence semantics: child .grove wins even when incomplete (no grove.json)", async () => {
+    // Parent has full grove
+    const parentGrove = join(tempDir, ".grove");
+    await mkdir(parentGrove);
+    await Bun.write(join(parentGrove, "grove.json"), "{}");
+    // Child has bare .grove (no grove.json)
+    const wt = join(tempDir, "wt");
+    await mkdir(wt);
+    const wtGrove = join(wt, ".grove");
+    await mkdir(wtGrove);
+    // findGroveDir is artifact-agnostic — child wins regardless of grove.json
+    expect(findGroveDir(wt)).toBe(wtGrove);
   });
 });
 

--- a/src/cli/utils/grove-dir.ts
+++ b/src/cli/utils/grove-dir.ts
@@ -6,7 +6,7 @@
  * or GROVE_DIR environment variable.
  */
 
-import { existsSync } from "node:fs";
+import { statSync } from "node:fs";
 import { hostname, userInfo } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -18,10 +18,23 @@ export interface GroveLocation {
   readonly dbPath: string;
 }
 
+/** True iff `path` is an actual directory (resolves through symlinks). */
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Walk up from `startDir` looking for the nearest ancestor (or startDir itself)
  * containing a `.grove/` subdirectory. Returns the absolute path to the
  * `.grove/` directory, or undefined if none is found before the FS root.
+ *
+ * The fence requires `.grove` to be an actual directory (or a symlink that
+ * resolves to one). Stray regular files or broken symlinks named `.grove`
+ * are NOT fences — walk-up continues past them.
  *
  * Fence semantics: this function ONLY checks `.grove/` directory existence.
  * Callers that require additional artifacts (grove.json, grove.db, etc.)
@@ -34,7 +47,7 @@ export function findGroveDir(startDir: string): string | undefined {
   let current = resolve(startDir);
   while (true) {
     const candidate = join(current, GROVE_DIR_NAME);
-    if (existsSync(candidate)) return candidate;
+    if (isDirectory(candidate)) return candidate;
     const parent = dirname(current);
     if (parent === current) return undefined;
     current = parent;

--- a/src/cli/utils/grove-dir.ts
+++ b/src/cli/utils/grove-dir.ts
@@ -19,6 +19,29 @@ export interface GroveLocation {
 }
 
 /**
+ * Walk up from `startDir` looking for the nearest ancestor (or startDir itself)
+ * containing a `.grove/` subdirectory. Returns the absolute path to the
+ * `.grove/` directory, or undefined if none is found before the FS root.
+ *
+ * Fence semantics: this function ONLY checks `.grove/` directory existence.
+ * Callers that require additional artifacts (grove.json, grove.db, etc.)
+ * MUST validate them after resolution and treat "found .grove/ but missing
+ * artifact" as "not initialized at this level" — they MUST NOT silently walk
+ * past an incomplete grove to find a more-complete parent. That behavior
+ * causes git worktrees to inherit stale parent state (#315).
+ */
+export function findGroveDir(startDir: string): string | undefined {
+  let current = resolve(startDir);
+  while (true) {
+    const candidate = join(current, GROVE_DIR_NAME);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+/**
  * Resolve the grove directory path.
  *
  * Priority: overridePath > GROVE_DIR env > walk-up from cwd().
@@ -31,18 +54,8 @@ export function resolveGroveDir(overridePath?: string): GroveLocation {
     return { groveDir: resolved, dbPath: join(resolved, DB_FILENAME) };
   }
 
-  let current = resolve(process.cwd());
-
-  while (true) {
-    const candidate = join(current, GROVE_DIR_NAME);
-    if (existsSync(candidate)) {
-      return { groveDir: candidate, dbPath: join(candidate, DB_FILENAME) };
-    }
-
-    const parent = dirname(current);
-    if (parent === current) break;
-    current = parent;
-  }
+  const found = findGroveDir(process.cwd());
+  if (found) return { groveDir: found, dbPath: join(found, DB_FILENAME) };
 
   throw new Error("No grove found. Run 'grove init' to create one, or set GROVE_DIR.");
 }

--- a/src/tui/find-grove-dir.test.ts
+++ b/src/tui/find-grove-dir.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression test for #315: TUI's findGroveDir must NOT walk past a worktree's
+ * own incomplete .grove/ to find a parent's grove.json.
+ */
+
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { findGroveDir } from "./main.js";
+
+let tempDir: string;
+let originalCwd: string;
+
+beforeEach(async () => {
+  tempDir = await realpath(await mkdtemp(join(tmpdir(), "grove-tui-fence-test-")));
+  originalCwd = process.cwd();
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await rm(tempDir, { recursive: true, force: true });
+  delete process.env.GROVE_DIR;
+});
+
+test("worktree with .grove/ but no grove.json returns undefined (does NOT inherit parent grove.json)", async () => {
+  // Parent: full grove
+  const parentGrove = join(tempDir, ".grove");
+  await mkdir(parentGrove);
+  await writeFile(join(parentGrove, "grove.json"), "{}");
+
+  // Worktree: .grove/ exists but no grove.json
+  const wt = join(tempDir, "wt");
+  await mkdir(wt);
+  await mkdir(join(wt, ".grove"));
+
+  process.chdir(wt);
+
+  // findGroveDir must NOT return parent's .grove/ — that would inherit stale state.
+  expect(findGroveDir()).toBeUndefined();
+});
+
+test("worktree with .grove/grove.json returns its own .grove/", async () => {
+  const parentGrove = join(tempDir, ".grove");
+  await mkdir(parentGrove);
+  await writeFile(join(parentGrove, "grove.json"), "{}");
+
+  const wt = join(tempDir, "wt");
+  await mkdir(wt);
+  const wtGrove = join(wt, ".grove");
+  await mkdir(wtGrove);
+  await writeFile(join(wtGrove, "grove.json"), "{}");
+
+  process.chdir(wt);
+
+  expect(findGroveDir()).toBe(wtGrove);
+});
+
+test("plain subdirectory walks up to ancestor's full grove (no fence in the way)", async () => {
+  const groveDir = join(tempDir, ".grove");
+  await mkdir(groveDir);
+  await writeFile(join(groveDir, "grove.json"), "{}");
+
+  const sub = join(tempDir, "src", "deep");
+  await mkdir(sub, { recursive: true });
+
+  process.chdir(sub);
+
+  expect(findGroveDir()).toBe(groveDir);
+});
+
+test("explicit override with no grove.json returns undefined", async () => {
+  const dir = join(tempDir, "bare");
+  await mkdir(dir);
+  expect(findGroveDir(dir)).toBeUndefined();
+});
+
+test("explicit override with grove.json returns it", async () => {
+  const dir = join(tempDir, "real");
+  await mkdir(dir);
+  await writeFile(join(dir, "grove.json"), "{}");
+  expect(findGroveDir(dir)).toBe(dir);
+});

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -8,8 +8,9 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { join } from "node:path";
 import { parseArgs } from "node:util";
+import { findGroveDir as findNearestGroveDir } from "../cli/utils/grove-dir.js";
 import type { RunningServices } from "../shared/service-lifecycle.js";
 import type { SessionRecord, TuiDataProvider } from "./provider.js";
 import {
@@ -105,45 +106,33 @@ async function createProviderForTui(
 // ---------------------------------------------------------------------------
 
 /**
- * Check whether a .grove/grove.json file exists in the current working tree.
+ * Resolve a fully-initialized grove (.grove/ + grove.json) for the TUI.
  *
- * Walks up from cwd (or the explicit groveOverride path) looking for the
- * directory. Returns the resolved groveDir path if found, undefined otherwise.
+ * Fence semantics (#315): walk-up stops at the first ancestor containing a
+ * `.grove/` directory. If that .grove/ lacks grove.json, returns undefined —
+ * we do NOT silently walk past to find a parent's grove.json. This prevents
+ * git worktrees from inheriting the parent repo's grove state when their
+ * own .grove/ is incomplete.
+ *
+ * Exported for regression testing.
  */
-function findGroveDir(groveOverride?: string): string | undefined {
-  // If an explicit override was provided, check it directly
+export function findGroveDir(groveOverride?: string): string | undefined {
   if (groveOverride) {
     const configPath = join(groveOverride, "grove.json");
     return existsSync(configPath) ? groveOverride : undefined;
   }
 
-  // Check GROVE_DIR env
   const envDir = process.env.GROVE_DIR;
   if (envDir) {
     const configPath = join(envDir, "grove.json");
     return existsSync(configPath) ? envDir : undefined;
   }
 
-  // Check CWD first — each project/worktree should use its OWN .grove/, not a parent's.
-  const cwd = resolve(process.cwd());
-  const cwdCandidate = join(cwd, ".grove");
-  if (existsSync(join(cwdCandidate, "grove.json"))) {
-    return cwdCandidate;
-  }
-
-  // Walk up only if CWD has no .grove/ — supports nested repos
-  let current = dirname(cwd);
-  while (true) {
-    const candidate = join(current, ".grove");
-    const configPath = join(candidate, "grove.json");
-    if (existsSync(configPath)) {
-      return candidate;
-    }
-    const parent = dirname(current);
-    if (parent === current) break;
-    current = parent;
-  }
-
+  const nearest = findNearestGroveDir(process.cwd());
+  if (nearest === undefined) return undefined;
+  if (existsSync(join(nearest, "grove.json"))) return nearest;
+  // Found .grove/ but no grove.json — caller will route to setup screen.
+  // Do NOT walk past: that would silently use a parent's grove state.
   return undefined;
 }
 


### PR DESCRIPTION
## Summary

Two coupled fixes — bundled because real E2E validation needs both:

### 1. Bounded channel backpressure (closes #274)
- Inserts generic `BoundedEventChannel<T>` between `AcpParser` and `AcpxTurn.messages` consumers.
- Per-event-kind drop policy: `tool_call`/`permission_request`/terminal text → never (evict drop-eligible to fit); `text`/`thinking` chunked deltas → coalesce; `token_usage`/`raw` → drop oldest on full.
- Wired into `AcpxTurnImpl` with default capacity 256, override via `channelCapacity?` (`Infinity` for tests).

### 2. Grove-dir fence unification (closes #315)
- Three divergent `findGroveDir` impls had inconsistent fence rules. TUI's silently walked past a worktree's incomplete `.grove/` to find a parent's `grove.json`, causing agents to inherit stale parent state.
- Promoted single shared `findGroveDir(startDir)` into `src/cli/utils/grove-dir.ts` (artifact-agnostic — fences on `.grove/` directory existence).
- Refactored `src/cli/context.ts` and `resolveGroveDir` to use it.
- Rewrote TUI's `findGroveDir` so a worktree with `.grove/` but no `grove.json` returns `undefined` (TUI shows setup screen here) instead of inheriting parent.

## Why bundled

The grove-dir fix is required to run a real E2E of the bounded channel from a worktree — without it, agents in the worktree would register against parent's grove state, polluting the test signal.

## Design docs

- Spec: `docs/superpowers/specs/2026-04-18-bounded-channel-backpressure-design.md`
- Plan: `docs/superpowers/plans/2026-04-18-bounded-channel-backpressure.md`
- Plan: `docs/superpowers/plans/2026-04-19-grove-dir-fence.md`

## Codex adversarial review (5 rounds, converged)

Ran `superpowers:codex adversarial-review` until verdict=`approve`. Each round produced a separate fix commit with regression tests:

| Round | Severity | Finding | Fix commit |
|-------|----------|---------|------------|
| 1 | critical | `coalesce_text_deltas` on full buffer overflowed ring (size > capacity, undefined slots) | `d460de0` |
| 1 | critical | `drop_oldest_on_full` could evict a `never` event at head | `d460de0` |
| 1 | medium | `findGroveDir` treated regular file/broken symlink named `.grove` as a fence | `d460de0` |
| 2 | high | dropped `never` event still invalidated coalesce tail (orphaned tail, multiplied text loss) | `7cd9bdd` |
| 2 | medium | concurrent `next()` calls overwrote single resolver slot (lost wakeups) | `7cd9bdd` |
| 3 | high | `iter.return()` did not clear buffer (post-return replay possible via fresh iterator) | `7f6ea11` |
| 4 | high | `tool_call`/`permission_request` did not invalidate `text`/`thinking` coalesce tails — later text chunks coalesced into pre-tool slot, reordering the visible stream | `6b7b584` |
| 5 | — | `approve`, no material findings | — |

One round-4 finding (fail-closed on broken `.grove` sentinels) was deferred — it directly contradicts the round-1 fix that requires `.grove` to be a real directory, and resolving the design tension is out of scope for #274/#315.

## Test plan

### Unit + integration
- [x] `bun test src/acp/` — 107 pass (channel + turn + parser + compact)
- [x] `bun test src/cli/utils/grove-dir.test.ts` — 14 pass (fence semantics)
- [x] `bun test src/tui/find-grove-dir.test.ts` — 5 pass (worktree regression)
- [x] `bun test` (full repo) — 5500+ pass, 0 unrelated fail
- [x] `bun run tsc --noEmit` — clean

### Channel correctness (regression-tested)
- [x] Default cap 256 evicts oldest under slow consumer
- [x] `Infinity` bypass delivers all events
- [x] Chunked text deltas coalesce with no character loss
- [x] Classification table locked: all 8 `Message.kind`/`chunk` combinations
- [x] Pump errors surfaced via stderr (no silent swallowing)
- [x] `iter.return()` while `next()` pending resolves the pending promise
- [x] Coalesce-on-full does not overflow ring (round 1)
- [x] `drop_oldest_on_full` skips `never`-policy slots (round 1)
- [x] Dropped `never` does not invalidate coalesce tail (round 2)
- [x] Concurrent `next()` calls all wake in FIFO order (round 2)
- [x] `iter.return()` is an abort fence — discards backlog from same + fresh iterator (round 3)
- [x] `close()` resolves all pending `next()` callers (round 3)
- [x] `tool_call` invalidates text/thinking coalesce tail — preserves chronology (round 4)

### Focused E2E
- [x] `scripts/e2e-bounded-channel.ts` — spawns real `codex` agent, slow consumer (50ms/read), reports `pushed=1005 / coalesced=0 / evicted=397 / dropped[never]=0` — channel under pressure, no priority loss

## Replaces

- Closes #316 (now bundled)