### PR TITLE
fix(grove-dir): unify findGroveDir, fence on .grove/ directory not grove.json (#315)

### DIFF
--- a/docs/superpowers/plans/2026-04-19-grove-dir-fence.md
+++ b/docs/superpowers/plans/2026-04-19-grove-dir-fence.md
@@ -1,0 +1,118 @@
+# Grove Dir Fence — Unify findGroveDir Implementations (#315)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans for inline execution.
+
+**Goal:** Eliminate three divergent `findGroveDir` impls by promoting one shared implementation that fences walk-up at the first `.grove/` directory (not grove.json). Fix the TUI's silent-walk-past-worktree bug.
+
+**Architecture:** Single `findGroveDir(startDir): string | undefined` in `src/cli/utils/grove-dir.ts`. Walk-up returns the first ancestor containing `.grove/`. Callers that need `grove.json` check it AFTER and treat "found .grove/ but no grove.json" as "not initialized at this level" — they do NOT silently walk past to find a parent grove.json.
+
+**Tech Stack:** TypeScript, Bun test runner. No new dependencies.
+
+**Issue:** [#315](https://github.com/windoliver/grove/issues/315)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/cli/utils/grove-dir.ts` | modify | Export new shared `findGroveDir(startDir)`; refactor `resolveGroveDir` to use it. |
+| `src/cli/utils/grove-dir.test.ts` | modify | Add tests for shared findGroveDir + the "found .grove/ but incomplete, do not walk past" semantics. |
+| `src/cli/context.ts` | modify | Delete local `findGroveDir`; import from utils. |
+| `src/tui/main.ts` | modify | Delete local `findGroveDir`; build a thin wrapper around the shared one that adds the grove.json existence check WITHOUT walking past. |
+
+---
+
+## Task 1: Promote `findGroveDir` to shared util
+
+- [ ] Edit `src/cli/utils/grove-dir.ts`:
+  - Add new export `findGroveDir(startDir: string): string | undefined`
+  - Refactor `resolveGroveDir` to use it
+  - Behavior: walk up from `resolve(startDir)` returning the first ancestor containing `.grove/` (subdirectory existence). Return undefined if reach FS root with no match.
+
+- [ ] Add tests to `src/cli/utils/grove-dir.test.ts`:
+  - `findGroveDir`: returns undefined for tmpdir with no .grove
+  - `findGroveDir`: finds .grove in startDir directly
+  - `findGroveDir`: walks up to ancestor .grove
+  - `findGroveDir`: when both ancestor and child have .grove → returns child (fence semantics)
+
+- [ ] Run: `bun test src/cli/utils/grove-dir.test.ts` — all green
+
+- [ ] Commit:
+```
+git add src/cli/utils/grove-dir.ts src/cli/utils/grove-dir.test.ts
+git commit -m "feat(cli): promote findGroveDir to shared util with fence semantics (#315)"
+```
+
+---
+
+## Task 2: Replace cli/context.ts duplicate with import
+
+- [ ] Edit `src/cli/context.ts`:
+  - Remove the local `function findGroveDir(startDir)` (lines ~36-60)
+  - Remove the unused `existsSync`, `dirname`, `join` imports if they become unused
+  - Import the shared one: `import { findGroveDir } from "./utils/grove-dir.js";`
+  - Verify `initCliDeps` callsite still compiles unchanged
+
+- [ ] Run: `bun run tsc --noEmit` — clean
+- [ ] Run: `bun test src/cli/` — green
+
+- [ ] Commit:
+```
+git add src/cli/context.ts
+git commit -m "refactor(cli): use shared findGroveDir (#315)"
+```
+
+---
+
+## Task 3: Fix TUI to fence + require grove.json without walking past
+
+- [ ] Edit `src/tui/main.ts`:
+  - Replace local `findGroveDir(groveOverride)` with a thin wrapper
+  - New behavior:
+    1. If `groveOverride` provided: check `<override>/grove.json` exists → return override or undefined
+    2. If `process.env.GROVE_DIR`: same check
+    3. Otherwise: call shared `findGroveDir(process.cwd())`. If result undefined → return undefined. Else: check `<result>/grove.json` exists. If yes → return result. **If no → return undefined (do NOT walk past).**
+  - Import: `import { findGroveDir as findGroveRoot } from "../cli/utils/grove-dir.js";`
+  - Keep the function `findGroveDir` name in main.ts to avoid touching all call sites (267, 451)
+
+- [ ] Run: `bun run tsc --noEmit` — clean
+- [ ] Run: `bun test src/tui/` — green (any failures: investigate; may need test fixture updates)
+- [ ] Run: `bun test` (full repo) — green
+
+- [ ] Commit:
+```
+git add src/tui/main.ts
+git commit -m "fix(tui): fence findGroveDir at .grove/ dir, do not walk past incomplete grove (#315)"
+```
+
+---
+
+## Task 4: Add regression test for the bug
+
+- [ ] Add a test fixture in `src/tui/main.test.ts` (or new file `src/tui/find-grove-dir.test.ts` if main.ts is hard to test):
+  - Create temp parent dir with `.grove/grove.json`
+  - Create child dir with `.grove/` (no grove.json)
+  - chdir to child
+  - Call the TUI's findGroveDir
+  - Expect: `undefined` (not parent's path)
+
+- [ ] If `findGroveDir` is not exported from main.ts, export it (private-by-convention but exported for testing)
+
+- [ ] Run: `bun test` — all green
+
+- [ ] Commit:
+```
+git add src/tui/main.ts <test file>
+git commit -m "test(tui): regression test for worktree fence (#315)"
+```
+
+---
+
+## Self-Review
+
+- [ ] All 3 callsites of `findGroveDir` (TUI + 2 CLI) point at one source of truth (or use the shared one + a thin wrapper)
+- [ ] No callsite walks past a `.grove/` directory silently
+- [ ] Error messages tell user exactly what to do
+- [ ] tsc clean
+- [ ] Full repo test suite green

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -6,16 +6,16 @@
  * CLI commands.
  */
 
-import { existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { resolve } from "node:path";
 import type { FrontierCalculator } from "../core/frontier.js";
 import type { OutcomeStore } from "../core/outcome.js";
 import type { ClaimStore, ContributionStore } from "../core/store.js";
 import type { WorkspaceManager } from "../core/workspace.js";
 import type { FsCas } from "../local/fs-cas.js";
 import { createLocalRuntime } from "../local/runtime.js";
+import { findGroveDir } from "./utils/grove-dir.js";
 
-const GROVE_DIR = ".grove";
+export { findGroveDir };
 
 /** All dependencies a CLI command needs. */
 export interface CliDeps {
@@ -31,33 +31,6 @@ export interface CliDeps {
 
 /** Writer function for testable output. */
 export type Writer = (text: string) => void;
-
-/**
- * Walk up from `startDir` to find the nearest directory containing `.grove/`.
- * Returns the absolute path to the `.grove` directory, or undefined.
- */
-export function findGroveDir(startDir: string): string | undefined {
-  let dir = resolve(startDir);
-  const root = dirname(dir) === dir ? dir : undefined;
-
-  while (true) {
-    const candidate = join(dir, GROVE_DIR);
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break; // filesystem root
-    dir = parent;
-  }
-
-  // Check filesystem root
-  if (root !== undefined) {
-    const candidate = join(root, GROVE_DIR);
-    if (existsSync(candidate)) return candidate;
-  }
-
-  return undefined;
-}
 
 /**
  * Discover the grove and initialize all stores.

--- a/src/cli/utils/grove-dir.test.ts
+++ b/src/cli/utils/grove-dir.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { resolveAgentId, resolveGroveDir } from "./grove-dir.js";
+import { findGroveDir, resolveAgentId, resolveGroveDir } from "./grove-dir.js";
 
 describe("resolveGroveDir", () => {
   let tempDir: string;
@@ -69,6 +69,61 @@ describe("resolveGroveDir", () => {
     } finally {
       process.chdir(originalCwd);
     }
+  });
+});
+
+describe("findGroveDir", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await realpath(await mkdtemp(join(tmpdir(), "grove-find-test-")));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("returns undefined when no .grove anywhere up to FS root", () => {
+    expect(findGroveDir(tempDir)).toBeUndefined();
+  });
+
+  test("returns startDir's .grove when it exists directly", async () => {
+    const groveDir = join(tempDir, ".grove");
+    await mkdir(groveDir);
+    expect(findGroveDir(tempDir)).toBe(groveDir);
+  });
+
+  test("walks up to find ancestor .grove", async () => {
+    const groveDir = join(tempDir, ".grove");
+    await mkdir(groveDir);
+    const subDir = join(tempDir, "a", "b", "c");
+    await mkdir(subDir, { recursive: true });
+    expect(findGroveDir(subDir)).toBe(groveDir);
+  });
+
+  test("fence semantics: child .grove wins over ancestor .grove", async () => {
+    // parent .grove at tempDir
+    await mkdir(join(tempDir, ".grove"));
+    // child .grove at tempDir/wt
+    const wt = join(tempDir, "wt");
+    await mkdir(wt);
+    const wtGrove = join(wt, ".grove");
+    await mkdir(wtGrove);
+    expect(findGroveDir(wt)).toBe(wtGrove);
+  });
+
+  test("fence semantics: child .grove wins even when incomplete (no grove.json)", async () => {
+    // Parent has full grove
+    const parentGrove = join(tempDir, ".grove");
+    await mkdir(parentGrove);
+    await Bun.write(join(parentGrove, "grove.json"), "{}");
+    // Child has bare .grove (no grove.json)
+    const wt = join(tempDir, "wt");
+    await mkdir(wt);
+    const wtGrove = join(wt, ".grove");
+    await mkdir(wtGrove);
+    // findGroveDir is artifact-agnostic — child wins regardless of grove.json
+    expect(findGroveDir(wt)).toBe(wtGrove);
   });
 });
 

--- a/src/cli/utils/grove-dir.ts
+++ b/src/cli/utils/grove-dir.ts
@@ -19,6 +19,29 @@ export interface GroveLocation {
 }
 
 /**
+ * Walk up from `startDir` looking for the nearest ancestor (or startDir itself)
+ * containing a `.grove/` subdirectory. Returns the absolute path to the
+ * `.grove/` directory, or undefined if none is found before the FS root.
+ *
+ * Fence semantics: this function ONLY checks `.grove/` directory existence.
+ * Callers that require additional artifacts (grove.json, grove.db, etc.)
+ * MUST validate them after resolution and treat "found .grove/ but missing
+ * artifact" as "not initialized at this level" — they MUST NOT silently walk
+ * past an incomplete grove to find a more-complete parent. That behavior
+ * causes git worktrees to inherit stale parent state (#315).
+ */
+export function findGroveDir(startDir: string): string | undefined {
+  let current = resolve(startDir);
+  while (true) {
+    const candidate = join(current, GROVE_DIR_NAME);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+/**
  * Resolve the grove directory path.
  *
  * Priority: overridePath > GROVE_DIR env > walk-up from cwd().
@@ -31,18 +54,8 @@ export function resolveGroveDir(overridePath?: string): GroveLocation {
     return { groveDir: resolved, dbPath: join(resolved, DB_FILENAME) };
   }
 
-  let current = resolve(process.cwd());
-
-  while (true) {
-    const candidate = join(current, GROVE_DIR_NAME);
-    if (existsSync(candidate)) {
-      return { groveDir: candidate, dbPath: join(candidate, DB_FILENAME) };
-    }
-
-    const parent = dirname(current);
-    if (parent === current) break;
-    current = parent;
-  }
+  const found = findGroveDir(process.cwd());
+  if (found) return { groveDir: found, dbPath: join(found, DB_FILENAME) };
 
   throw new Error("No grove found. Run 'grove init' to create one, or set GROVE_DIR.");
 }

--- a/src/tui/find-grove-dir.test.ts
+++ b/src/tui/find-grove-dir.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression test for #315: TUI's findGroveDir must NOT walk past a worktree's
+ * own incomplete .grove/ to find a parent's grove.json.
+ */
+
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { findGroveDir } from "./main.js";
+
+let tempDir: string;
+let originalCwd: string;
+
+beforeEach(async () => {
+  tempDir = await realpath(await mkdtemp(join(tmpdir(), "grove-tui-fence-test-")));
+  originalCwd = process.cwd();
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await rm(tempDir, { recursive: true, force: true });
+  delete process.env.GROVE_DIR;
+});
+
+test("worktree with .grove/ but no grove.json returns undefined (does NOT inherit parent grove.json)", async () => {
+  // Parent: full grove
+  const parentGrove = join(tempDir, ".grove");
+  await mkdir(parentGrove);
+  await writeFile(join(parentGrove, "grove.json"), "{}");
+
+  // Worktree: .grove/ exists but no grove.json
+  const wt = join(tempDir, "wt");
+  await mkdir(wt);
+  await mkdir(join(wt, ".grove"));
+
+  process.chdir(wt);
+
+  // findGroveDir must NOT return parent's .grove/ — that would inherit stale state.
+  expect(findGroveDir()).toBeUndefined();
+});
+
+test("worktree with .grove/grove.json returns its own .grove/", async () => {
+  const parentGrove = join(tempDir, ".grove");
+  await mkdir(parentGrove);
+  await writeFile(join(parentGrove, "grove.json"), "{}");
+
+  const wt = join(tempDir, "wt");
+  await mkdir(wt);
+  const wtGrove = join(wt, ".grove");
+  await mkdir(wtGrove);
+  await writeFile(join(wtGrove, "grove.json"), "{}");
+
+  process.chdir(wt);
+
+  expect(findGroveDir()).toBe(wtGrove);
+});
+
+test("plain subdirectory walks up to ancestor's full grove (no fence in the way)", async () => {
+  const groveDir = join(tempDir, ".grove");
+  await mkdir(groveDir);
+  await writeFile(join(groveDir, "grove.json"), "{}");
+
+  const sub = join(tempDir, "src", "deep");
+  await mkdir(sub, { recursive: true });
+
+  process.chdir(sub);
+
+  expect(findGroveDir()).toBe(groveDir);
+});
+
+test("explicit override with no grove.json returns undefined", async () => {
+  const dir = join(tempDir, "bare");
+  await mkdir(dir);
+  expect(findGroveDir(dir)).toBeUndefined();
+});
+
+test("explicit override with grove.json returns it", async () => {
+  const dir = join(tempDir, "real");
+  await mkdir(dir);
+  await writeFile(join(dir, "grove.json"), "{}");
+  expect(findGroveDir(dir)).toBe(dir);
+});

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -8,8 +8,9 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { join } from "node:path";
 import { parseArgs } from "node:util";
+import { findGroveDir as findNearestGroveDir } from "../cli/utils/grove-dir.js";
 import type { RunningServices } from "../shared/service-lifecycle.js";
 import type { SessionRecord, TuiDataProvider } from "./provider.js";
 import {
@@ -105,45 +106,33 @@ async function createProviderForTui(
 // ---------------------------------------------------------------------------
 
 /**
- * Check whether a .grove/grove.json file exists in the current working tree.
+ * Resolve a fully-initialized grove (.grove/ + grove.json) for the TUI.
  *
- * Walks up from cwd (or the explicit groveOverride path) looking for the
- * directory. Returns the resolved groveDir path if found, undefined otherwise.
+ * Fence semantics (#315): walk-up stops at the first ancestor containing a
+ * `.grove/` directory. If that .grove/ lacks grove.json, returns undefined —
+ * we do NOT silently walk past to find a parent's grove.json. This prevents
+ * git worktrees from inheriting the parent repo's grove state when their
+ * own .grove/ is incomplete.
+ *
+ * Exported for regression testing.
  */
-function findGroveDir(groveOverride?: string): string | undefined {
-  // If an explicit override was provided, check it directly
+export function findGroveDir(groveOverride?: string): string | undefined {
   if (groveOverride) {
     const configPath = join(groveOverride, "grove.json");
     return existsSync(configPath) ? groveOverride : undefined;
   }
 
-  // Check GROVE_DIR env
   const envDir = process.env.GROVE_DIR;
   if (envDir) {
     const configPath = join(envDir, "grove.json");
     return existsSync(configPath) ? envDir : undefined;
   }
 
-  // Check CWD first — each project/worktree should use its OWN .grove/, not a parent's.
-  const cwd = resolve(process.cwd());
-  const cwdCandidate = join(cwd, ".grove");
-  if (existsSync(join(cwdCandidate, "grove.json"))) {
-    return cwdCandidate;
-  }
-
-  // Walk up only if CWD has no .grove/ — supports nested repos
-  let current = dirname(cwd);
-  while (true) {
-    const candidate = join(current, ".grove");
-    const configPath = join(candidate, "grove.json");
-    if (existsSync(configPath)) {
-      return candidate;
-    }
-    const parent = dirname(current);
-    if (parent === current) break;
-    current = parent;
-  }
-
+  const nearest = findNearestGroveDir(process.cwd());
+  if (nearest === undefined) return undefined;
+  if (existsSync(join(nearest, "grove.json"))) return nearest;
+  // Found .grove/ but no grove.json — caller will route to setup screen.
+  // Do NOT walk past: that would silently use a parent's grove state.
   return undefined;
 }
 


### PR DESCRIPTION
## Summary

Closes #315. Three divergent `findGroveDir` impls had inconsistent fence rules — one (`src/tui/main.ts`) silently walked past a worktree's incomplete `.grove/` to find a parent's `grove.json`, causing agents to inherit stale parent state.

This PR:
- Promotes a single artifact-agnostic `findGroveDir(startDir): string | undefined` into `src/cli/utils/grove-dir.ts` (fence: walk-up stops at first `.grove/` directory).
- Refactors `src/cli/context.ts` and `src/cli/utils/grove-dir.ts:resolveGroveDir` to use it.
- Rewrites `src/tui/main.ts:findGroveDir` so a worktree with `.grove/` but no `grove.json` returns `undefined` (TUI shows setup screen pointing at the worktree) instead of silently inheriting the parent's grove.

## Test plan

- [x] New unit tests in `src/cli/utils/grove-dir.test.ts` — fence semantics, empty tmpdir, ancestor walk, child-wins-over-parent, child-wins-when-incomplete (5 added).
- [x] New regression tests in `src/tui/find-grove-dir.test.ts` — worktree-with-incomplete-grove returns undefined, worktree-with-grove.json wins, plain subdir walks up, override paths (5 added).
- [x] `bun test src/cli/` — 569 pass.
- [x] `bun test src/tui/` — 763 pass.
- [x] `bun test` (full repo) — 5502 pass, 0 unrelated fail (one flaky `DeadlineWatcher` timing test consistent with prior runs on main).
- [x] `bun run tsc --noEmit` — clean.

## User-visible behavior change

Before: `grove tui` from a worktree with bare `.grove/` would silently use the parent repo's grove state. 401s on `grove_contribute`, stale API keys, mixed agent identity.

After: same scenario shows the setup screen pointing at the worktree's `.grove/`. User runs `grove init` here, gets isolated state.