### PR TITLE
fix(acp): preserve replay overflow counters and parser invariants

### DIFF
--- a/src/acp/compact.test.ts
+++ b/src/acp/compact.test.ts
@@ -279,6 +279,64 @@ test("compactTurn status-less update cannot mutate a terminal tool call's payloa
   expect(snap.toolCalls[0]?.error).toBeUndefined();
 });
 
+test("compactTurn status-less update can safely enrich terminal payload when fields are missing", () => {
+  // Terminal-first frame can arrive before payload-rich status-less updates.
+  // Enrichment is allowed only for fields that were still missing.
+  const msgs: Message[] = [
+    {
+      kind: "tool_call",
+      turnId: "t1",
+      toolCall: { id: "tc1", name: "Bash", status: "completed", input: { cmd: "ls" } },
+    },
+    {
+      kind: "tool_call",
+      turnId: "t1",
+      toolCall: { id: "tc1", output: "ok", diff: "stdout", error: "none" },
+    },
+  ];
+  const snap = compactTurn({
+    turnId: "t1",
+    messages: msgs,
+    result: { turnId: "t1", stopReason: "end_turn" },
+  });
+  expect(snap.toolCalls[0]?.status).toBe("completed");
+  expect(snap.toolCalls[0]?.output).toBe("ok");
+  expect(snap.toolCalls[0]?.diff).toBe("stdout");
+  expect(snap.toolCalls[0]?.error).toBe("none");
+});
+
+test("compactTurn terminal status-less mixed conflicting frame is rejected atomically", () => {
+  // Mixed frame: one field conflicts with existing terminal value while a
+  // different field is new. To avoid mixed terminal snapshots from stale
+  // duplicates, the entire frame is rejected.
+  const msgs: Message[] = [
+    {
+      kind: "tool_call",
+      turnId: "t1",
+      toolCall: {
+        id: "tc1",
+        name: "Bash",
+        status: "completed",
+        input: { cmd: "ls" },
+        output: "ok",
+      },
+    },
+    {
+      kind: "tool_call",
+      turnId: "t1",
+      toolCall: { id: "tc1", output: "CONFLICT", error: "late-diagnostic" },
+    },
+  ];
+  const snap = compactTurn({
+    turnId: "t1",
+    messages: msgs,
+    result: { turnId: "t1", stopReason: "end_turn" },
+  });
+  expect(snap.toolCalls[0]?.status).toBe("completed");
+  expect(snap.toolCalls[0]?.output).toBe("ok");
+  expect(snap.toolCalls[0]?.error).toBeUndefined();
+});
+
 test("compactTurn status-less update still enriches a non-terminal tool call", () => {
   // The C5 gate is limited to terminal calls. Pending/in_progress calls
   // still legitimately accept status-less payload enrichment (a later frame

--- a/src/acp/compact.test.ts
+++ b/src/acp/compact.test.ts
@@ -244,6 +244,66 @@ test("compactTurn allows equal-status duplicate updates to enrich terminal paylo
   expect(snap.toolCalls[0]?.output).toBe("ok");
 });
 
+test("compactTurn status-less update cannot mutate a terminal tool call's payload", () => {
+  // Regression for review-finding C5: once a tool call is terminal
+  // (completed/failed), a later frame that carries NO status but mutates
+  // output/diff/error must be rejected. Previously `payloadAccepted` stayed
+  // `true` when incoming.status was undefined, letting stale/duplicate frames
+  // rewrite accepted outcomes — yielding audit records like
+  // {status:"completed", output:"ok", error:"late stale duplicate"}.
+  const msgs: Message[] = [
+    {
+      kind: "tool_call",
+      turnId: "t1",
+      toolCall: {
+        id: "tc1",
+        name: "Bash",
+        status: "completed",
+        input: { cmd: "ls" },
+        output: "ok",
+      },
+    },
+    {
+      kind: "tool_call",
+      turnId: "t1",
+      toolCall: { id: "tc1", output: "LATE-DUPLICATE", error: "stale" },
+    },
+  ];
+  const snap = compactTurn({
+    turnId: "t1",
+    messages: msgs,
+    result: { turnId: "t1", stopReason: "end_turn" },
+  });
+  expect(snap.toolCalls[0]?.status).toBe("completed");
+  expect(snap.toolCalls[0]?.output).toBe("ok");
+  expect(snap.toolCalls[0]?.error).toBeUndefined();
+});
+
+test("compactTurn status-less update still enriches a non-terminal tool call", () => {
+  // The C5 gate is limited to terminal calls. Pending/in_progress calls
+  // still legitimately accept status-less payload enrichment (a later frame
+  // that only adds `diff` during a long-running execution, say).
+  const msgs: Message[] = [
+    {
+      kind: "tool_call",
+      turnId: "t1",
+      toolCall: { id: "tc1", name: "Bash", status: "in_progress", input: { cmd: "sleep 5" } },
+    },
+    {
+      kind: "tool_call",
+      turnId: "t1",
+      toolCall: { id: "tc1", diff: "partial output" },
+    },
+  ];
+  const snap = compactTurn({
+    turnId: "t1",
+    messages: msgs,
+    result: { turnId: "t1", stopReason: "end_turn" },
+  });
+  expect(snap.toolCalls[0]?.status).toBe("in_progress");
+  expect(snap.toolCalls[0]?.diff).toBe("partial output");
+});
+
 test("compactTurn rejected-terminal frames cannot contaminate output/diff/error", () => {
   // A late duplicate terminal update with a conflicting status must not
   // leak its payload into the accepted outcome — otherwise we get audit

--- a/src/acp/compact.ts
+++ b/src/acp/compact.ts
@@ -6,8 +6,9 @@
  * - Tool-call events are merged field-by-field (undefined fields never clobber
  *   previously-known values); status is monotonic (completed/failed are terminal
  *   and won't be reverted by a later "pending"/"in_progress" update).
- * - Canonical usage comes from `result.usage` when present; the last seen
- *   advisory `token_usage` Message is used only as a fallback.
+ * - Canonical usage comes ONLY from `result.usage`; advisory `token_usage`
+ *   frames are preserved separately as `advisoryUsage` and never promoted
+ *   into canonical per-turn accounting.
  */
 
 import type {
@@ -110,13 +111,23 @@ const STATUS_RANK: Record<ToolCallStatus, number> = {
   failed: 2,
 };
 
-/** Finalize a partial accumulator into a fully-populated ToolCall with sensible defaults. */
+/**
+ * Finalize a partial accumulator into a fully-populated ToolCall. The caller
+ * must have verified that `partial.name` and `partial.input` are both set
+ * (`compactTurn` gates this via the `name !== undefined && input !== undefined`
+ * check). Incomplete partials go to `incompleteToolCalls` instead, so the
+ * previous `?? ""` / `?? {}` defaults here were dead code that hid the
+ * invariant.
+ */
 function finalizeToolCall(partial: ToolCallEvent): ToolCall {
+  if (partial.name === undefined || partial.input === undefined) {
+    throw new Error(`finalizeToolCall invariant: name/input required (id=${partial.id})`);
+  }
   const finalized: ToolCall = {
     id: partial.id,
-    name: partial.name ?? "",
+    name: partial.name,
     status: partial.status ?? "pending",
-    input: partial.input ?? {},
+    input: partial.input,
   };
   if (partial.title !== undefined) finalized.title = partial.title;
   if (partial.output !== undefined) finalized.output = partial.output;
@@ -125,11 +136,18 @@ function finalizeToolCall(partial: ToolCallEvent): ToolCall {
   return finalized;
 }
 
-/** Merge an incoming event into the running partial record, preserving known data. */
-function mergeToolCallEvent(existing: ToolCallEvent, incoming: ToolCallEvent): ToolCallEvent {
-  const merged: ToolCallEvent = { ...existing };
-  if (incoming.name !== undefined) merged.name = incoming.name;
-  if (incoming.title !== undefined) merged.title = incoming.title;
+/**
+ * Merge an incoming event into the running partial record, preserving known
+ * data. Mutates `existing` in place — long turns can emit hundreds of updates
+ * against a single tool call, and the old "clone existing on every merge"
+ * pattern was O(M²) field copies. The map holds the only reference, and the
+ * Message's toolCall object is never aliased into the map (compactTurn spreads
+ * `{ ...m.toolCall }` on first insertion), so mutating the accumulator is
+ * safe.
+ */
+function mergeToolCallEvent(existing: ToolCallEvent, incoming: ToolCallEvent): void {
+  if (incoming.name !== undefined) existing.name = incoming.name;
+  if (incoming.title !== undefined) existing.title = incoming.title;
 
   // Gate `status` and its payload (input/output/diff/error) together. Reordered
   // or regressive statuses (e.g. completed→failed duplicate, failed→completed
@@ -139,28 +157,34 @@ function mergeToolCallEvent(existing: ToolCallEvent, incoming: ToolCallEvent): T
   // later frame that repeats the already-seen terminal status.
   let payloadAccepted = true;
   if (incoming.status !== undefined) {
-    if (merged.status === undefined) {
-      merged.status = incoming.status;
+    if (existing.status === undefined) {
+      existing.status = incoming.status;
     } else {
-      const existingStatus = merged.status;
-      const existingRank = STATUS_RANK[existingStatus];
+      const existingRank = STATUS_RANK[existing.status];
       const incomingRank = STATUS_RANK[incoming.status];
       if (incomingRank > existingRank) {
-        merged.status = incoming.status;
-      } else if (incomingRank === existingRank && incoming.status === existingStatus) {
+        existing.status = incoming.status;
+      } else if (incomingRank === existingRank && incoming.status === existing.status) {
         // Duplicate same-status frame: keep status and accept payload.
       } else {
         payloadAccepted = false;
       }
     }
+  } else if (existing.status !== undefined && STATUS_RANK[existing.status] === 2) {
+    // Existing call is terminal and the incoming frame carries no lifecycle
+    // information of its own — a status-less late update. Without this gate,
+    // a stale/duplicate tool_call_update can still mutate `output`, `error`,
+    // or `diff` against an accepted terminal outcome, yielding audit records
+    // like `{status:"completed", output:"ok", error:"stale duplicate"}`.
+    // Reject the payload to preserve the first terminal's finalized state.
+    payloadAccepted = false;
   }
   if (payloadAccepted) {
-    if (incoming.input !== undefined) merged.input = incoming.input;
-    if (incoming.output !== undefined) merged.output = incoming.output;
-    if (incoming.diff !== undefined) merged.diff = incoming.diff;
-    if (incoming.error !== undefined) merged.error = incoming.error;
+    if (incoming.input !== undefined) existing.input = incoming.input;
+    if (incoming.output !== undefined) existing.output = incoming.output;
+    if (incoming.diff !== undefined) existing.diff = incoming.diff;
+    if (incoming.error !== undefined) existing.error = incoming.error;
   }
-  return merged;
 }
 
 export function compactTurn(input: {
@@ -191,10 +215,13 @@ export function compactTurn(input: {
       case "tool_call": {
         const existing = toolCallMap.get(m.toolCall.id);
         if (existing === undefined) {
+          // Spread so the stored accumulator is NOT an alias to the message's
+          // toolCall object — later in-place merges would otherwise leak back
+          // into the original Message sequence (which tests reuse).
           toolCallMap.set(m.toolCall.id, { ...m.toolCall });
           toolCallOrder.push(m.toolCall.id);
         } else {
-          toolCallMap.set(m.toolCall.id, mergeToolCallEvent(existing, m.toolCall));
+          mergeToolCallEvent(existing, m.toolCall);
         }
         break;
       }

--- a/src/acp/compact.ts
+++ b/src/acp/compact.ts
@@ -11,6 +11,7 @@
  *   into canonical per-turn accounting.
  */
 
+import { isDeepStrictEqual } from "node:util";
 import type {
   Message,
   PermissionRequest,
@@ -156,6 +157,7 @@ function mergeToolCallEvent(existing: ToolCallEvent, incoming: ToolCallEvent): v
   // enrich payload fields, because providers may emit final output/error on a
   // later frame that repeats the already-seen terminal status.
   let payloadAccepted = true;
+  let terminalStatusless = false;
   if (incoming.status !== undefined) {
     if (existing.status === undefined) {
       existing.status = incoming.status;
@@ -171,19 +173,50 @@ function mergeToolCallEvent(existing: ToolCallEvent, incoming: ToolCallEvent): v
       }
     }
   } else if (existing.status !== undefined && STATUS_RANK[existing.status] === 2) {
+    terminalStatusless = true;
     // Existing call is terminal and the incoming frame carries no lifecycle
-    // information of its own — a status-less late update. Without this gate,
-    // a stale/duplicate tool_call_update can still mutate `output`, `error`,
-    // or `diff` against an accepted terminal outcome, yielding audit records
-    // like `{status:"completed", output:"ok", error:"stale duplicate"}`.
-    // Reject the payload to preserve the first terminal's finalized state.
-    payloadAccepted = false;
+    // information of its own. Permit safe enrichment (fill missing fields)
+    // and ignore per-field conflicts, preserving first-terminal values while
+    // still accepting new diagnostics on other fields from the same frame.
   }
   if (payloadAccepted) {
-    if (incoming.input !== undefined) existing.input = incoming.input;
-    if (incoming.output !== undefined) existing.output = incoming.output;
-    if (incoming.diff !== undefined) existing.diff = incoming.diff;
-    if (incoming.error !== undefined) existing.error = incoming.error;
+    if (terminalStatusless) {
+      // Terminal + no status: atomic enrichment-only path.
+      // Accept the whole payload only when every provided field is compatible
+      // with the existing terminal record (missing-or-equal). If any field
+      // conflicts, reject the entire frame to avoid mixed terminal snapshots
+      // such as {status:"completed", output:"ok", error:"stale"} from stale
+      // duplicates.
+      const compatible =
+        (incoming.input === undefined ||
+          existing.input === undefined ||
+          isDeepStrictEqual(existing.input, incoming.input)) &&
+        (incoming.output === undefined ||
+          existing.output === undefined ||
+          isDeepStrictEqual(existing.output, incoming.output)) &&
+        (incoming.diff === undefined ||
+          existing.diff === undefined ||
+          isDeepStrictEqual(existing.diff, incoming.diff)) &&
+        (incoming.error === undefined ||
+          existing.error === undefined ||
+          isDeepStrictEqual(existing.error, incoming.error));
+
+      if (compatible) {
+        if (incoming.input !== undefined && existing.input === undefined)
+          existing.input = incoming.input;
+        if (incoming.output !== undefined && existing.output === undefined)
+          existing.output = incoming.output;
+        if (incoming.diff !== undefined && existing.diff === undefined)
+          existing.diff = incoming.diff;
+        if (incoming.error !== undefined && existing.error === undefined)
+          existing.error = incoming.error;
+      }
+    } else {
+      if (incoming.input !== undefined) existing.input = incoming.input;
+      if (incoming.output !== undefined) existing.output = incoming.output;
+      if (incoming.diff !== undefined) existing.diff = incoming.diff;
+      if (incoming.error !== undefined) existing.error = incoming.error;
+    }
   }
 }
 

--- a/src/acp/parser.test.ts
+++ b/src/acp/parser.test.ts
@@ -1001,6 +1001,130 @@ test("AcpParser: only the first subscriber gets replay; later joiners see live-o
   expect(second).toHaveLength(0);
 });
 
+test("AcpParser: multi-byte UTF-8 split across chunks decodes without replacement chars", async () => {
+  // 🔥 is 4 bytes in UTF-8 (0xF0 0x9F 0x94 0xA5). If the parser calls
+  // Buffer.toString("utf8") independently on each chunk, a split at an
+  // interior byte produces U+FFFD (replacement char) silently — which
+  // corrupts assistant text and breaks JSON.parse on tool_call titles /
+  // inputs that contain non-ASCII. Upstream acpx stdout is a raw Buffer
+  // pipe with no setEncoding, so this is a real wire-shape concern.
+  const line = `${JSON.stringify({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId: "s",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "🔥 fire 火" },
+      },
+    },
+  })}\n`;
+  const resultLine = `${JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    result: { stopReason: "end_turn" },
+  })}\n`;
+  const buf = Buffer.from(line + resultLine, "utf8");
+  // Split mid-🔥 and mid-火 — both would corrupt without StringDecoder.
+  const emojiStart = buf.indexOf(0xf0); // first byte of 🔥
+  const hanStart = buf.indexOf(0xe7); // first byte of 火 (0xE7 0x81 0xAB)
+  const chunks: Buffer[] = [
+    buf.subarray(0, emojiStart + 2), // cut mid-emoji (2/4 bytes)
+    buf.subarray(emojiStart + 2, hanStart + 1), // cut mid-han (1/3 bytes)
+    buf.subarray(hanStart + 1),
+  ];
+  const stream = Readable.from(chunks);
+  const parser = new AcpParser({ sessionId: "s", turnId: "t-utf8", stream });
+  const messages: Message[] = [];
+  for await (const m of parser.messages) messages.push(m);
+  const result = await parser.result;
+  expect(result.stopReason).toBe("end_turn");
+  const text = messages.find((m): m is Extract<Message, { kind: "text" }> => m.kind === "text");
+  expect(text?.text).toBe("🔥 fire 火");
+  // No replacement chars leaked through.
+  expect(text?.text).not.toContain("\uFFFD");
+  // And the line didn't get demoted to a parse error either.
+  const parseErrors = messages.filter((m) => m.kind === "raw" && m.acpMethod === "_parseError");
+  expect(parseErrors).toHaveLength(0);
+});
+
+test("AcpParser: overflow marker reports a drop count that grows with actual drops", async () => {
+  // Regression for review-finding C2/C3: the marker previously used a static
+  // `droppedAtLeast: 1` payload regardless of how many messages were actually
+  // dropped, and on the first overflow it replaced the last legitimately
+  // enqueued message (losing one NON-dropped message).
+  const lines: string[] = [];
+  const OVER = 9000; // comfortably > MAX_SUBSCRIBER_BUFFER (8192)
+  for (let i = 0; i < OVER; i += 1) {
+    lines.push(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "s",
+          update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "x" } },
+        },
+      }),
+    );
+  }
+  lines.push(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }));
+  const parser = new AcpParser({
+    sessionId: "s",
+    turnId: "t-overflow-count",
+    stream: readableFromString(`${lines.join("\n")}\n`),
+  });
+  const slow = parser.messages[Symbol.asyncIterator]();
+  await parser.result;
+  let overflowParams: { droppedAtLeast: number } | undefined;
+  while (true) {
+    const { value, done } = await slow.next();
+    if (done) break;
+    if (value.kind === "raw" && value.acpMethod === "_overflow") {
+      overflowParams = value.params as { droppedAtLeast: number };
+    }
+  }
+  expect(overflowParams).toBeDefined();
+  // Count must reflect actual drops, not stay stuck at 1.
+  expect(overflowParams?.droppedAtLeast).toBeGreaterThan(100);
+});
+
+test("AcpParser: delayed first subscriber replay preserves pre-subscription overflow count", async () => {
+  // No subscriber is attached until AFTER the stream settles, so overflow
+  // happens in the parser's pre-subscription buffer. Replay must preserve
+  // that drop count; it must not reset to 1 when copied into the subscriber.
+  const lines: string[] = [];
+  const OVER = 9000; // comfortably > MAX_SUBSCRIBER_BUFFER (8192)
+  for (let i = 0; i < OVER; i += 1) {
+    lines.push(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "s",
+          update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "x" } },
+        },
+      }),
+    );
+  }
+  lines.push(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }));
+  const parser = new AcpParser({
+    sessionId: "s",
+    turnId: "t-overflow-pre-replay",
+    stream: readableFromString(`${lines.join("\n")}\n`),
+  });
+  // Delay first subscription until replay path is required.
+  await parser.result;
+  let overflowParams: { droppedAtLeast: number; pre?: true } | undefined;
+  for await (const value of parser.messages) {
+    if (value.kind === "raw" && value.acpMethod === "_overflow") {
+      overflowParams = value.params as { droppedAtLeast: number; pre?: true };
+    }
+  }
+  expect(overflowParams).toBeDefined();
+  expect(overflowParams?.droppedAtLeast).toBeGreaterThan(100);
+  expect(overflowParams?.pre).toBe(true);
+});
+
 test("AcpParser: foreign-session frames are demoted, not leaked into the iterator", async () => {
   const lines = [
     JSON.stringify({

--- a/src/acp/parser.test.ts
+++ b/src/acp/parser.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { join } from "node:path";
-import { Readable } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
 import { AcpParser, parseAcpLine } from "./parser.js";
 import type { Message, Result } from "./types.js";
 
@@ -1086,6 +1086,54 @@ test("AcpParser: overflow marker reports a drop count that grows with actual dro
   expect(overflowParams).toBeDefined();
   // Count must reflect actual drops, not stay stuck at 1.
   expect(overflowParams?.droppedAtLeast).toBeGreaterThan(100);
+});
+
+test("AcpParser: emitted overflow marker params stay immutable after later drops", async () => {
+  const stream = new PassThrough();
+  const parser = new AcpParser({
+    sessionId: "s",
+    turnId: "t-overflow-immutable",
+    stream,
+  });
+  const iter = parser.messages[Symbol.asyncIterator]();
+  const msgLine = JSON.stringify({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId: "s",
+      update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "x" } },
+    },
+  });
+
+  // First burst: force at least one overflow marker, then read until that
+  // marker is observed by the consumer.
+  const firstBurst = Array.from({ length: 9000 }, () => msgLine).join("\n");
+  stream.write(`${firstBurst}\n`);
+  let observedParams: { droppedAtLeast: number } | undefined;
+  while (observedParams === undefined) {
+    const { value, done } = await iter.next();
+    if (done) throw new Error("unexpected end before overflow marker");
+    if (value.kind === "raw" && value.acpMethod === "_overflow") {
+      observedParams = value.params as { droppedAtLeast: number };
+    }
+  }
+  const firstObserved = observedParams.droppedAtLeast;
+  expect(firstObserved).toBeGreaterThan(0);
+
+  // Stop consuming, then force another overflow wave. Old behavior mutated the
+  // already-emitted marker params object in place, so `observedParams` changed
+  // retroactively as more drops occurred.
+  const secondBurst = Array.from({ length: 9000 }, () => msgLine).join("\n");
+  stream.write(`${secondBurst}\n`);
+  stream.end(`${JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } })}\n`);
+
+  while (true) {
+    const { done } = await iter.next();
+    if (done) break;
+  }
+  const result = await parser.result;
+  expect(result.stopReason).toBe("end_turn");
+  expect(observedParams.droppedAtLeast).toBe(firstObserved);
 });
 
 test("AcpParser: delayed first subscriber replay preserves pre-subscription overflow count", async () => {

--- a/src/acp/parser.ts
+++ b/src/acp/parser.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Readable } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 import type {
   Message,
   Result,
@@ -27,14 +28,6 @@ export type ParsedLine = { kind: "message"; message: Message } | { kind: "result
 // ---------------------------------------------------------------------------
 
 const VALID_STATUSES = new Set<ToolCallStatus>(["pending", "in_progress", "completed", "failed"]);
-
-/** Returns the status if it's a known ToolCallStatus, else undefined (signals "not in this frame"). */
-function normalizeStatus(raw: unknown): ToolCallStatus | undefined {
-  if (typeof raw === "string" && VALID_STATUSES.has(raw as ToolCallStatus)) {
-    return raw as ToolCallStatus;
-  }
-  return undefined;
-}
 
 // ---------------------------------------------------------------------------
 // Helpers: map ACP usage shapes → TokenUsage
@@ -269,14 +262,15 @@ export function parseAcpLine(line: string, turnId: string, sessionId?: string): 
             }
             // Unknown status string → raw (don't silently drop schema-drift info
             // by coercing to "pending" or to "missing"). Absent status is fine.
-            if (
-              u.status !== undefined &&
-              (typeof u.status !== "string" || !VALID_STATUSES.has(u.status as ToolCallStatus))
-            ) {
-              return {
-                kind: "message",
-                message: { kind: "raw", turnId, acpMethod: sessionUpdate, params: update },
-              };
+            let validatedStatus: ToolCallStatus | undefined;
+            if (u.status !== undefined) {
+              if (typeof u.status !== "string" || !VALID_STATUSES.has(u.status as ToolCallStatus)) {
+                return {
+                  kind: "message",
+                  message: { kind: "raw", turnId, acpMethod: sessionUpdate, params: update },
+                };
+              }
+              validatedStatus = u.status as ToolCallStatus;
             }
             const toolCall: ToolCallEvent = { id: u.toolCallId };
             // Canonical identity ONLY: `_meta.claudeCode.toolName` is a
@@ -297,9 +291,8 @@ export function parseAcpLine(line: string, turnId: string, sessionId?: string): 
             if (typeof u.title === "string" && u.title.length > 0) {
               toolCall.title = u.title;
             }
-            const status = normalizeStatus(u.status);
-            if (status !== undefined) {
-              toolCall.status = status;
+            if (validatedStatus !== undefined) {
+              toolCall.status = validatedStatus;
             }
             if (u.rawInput !== undefined) {
               // Claude's initial `tool_call` frame carries `rawInput: {}` as a
@@ -422,16 +415,53 @@ const EOF_RESULT: Omit<Result, "turnId"> = {
 /** Per-subscriber cap before we start dropping messages. */
 const MAX_SUBSCRIBER_BUFFER = 8192;
 
+/**
+ * Head-indexed FIFO. Using `Array.shift()` on a backlog of up to
+ * MAX_SUBSCRIBER_BUFFER messages is O(N) per drain and O(N²) across a full
+ * drain — large enough (8192² ≈ 67M) to show up as latency when an overflow-
+ * class burst is finally read. `head` advances instead of reshifting; the
+ * array periodically compacts when head drifts far from index 0.
+ */
 class AcpSubscriber implements AsyncIterator<Message> {
-  private readonly queue: Message[] = [];
+  private queue: Message[] = [];
+  private head = 0;
   private waiters: Array<(r: IteratorResult<Message>) => void> = [];
   private dropped = 0;
-  private overflowEmitted = false;
+  /**
+   * Live reference to the `_overflow` marker's params object. When the
+   * subscriber overflows a second time we MUTATE this object to keep
+   * `droppedAtLeast` current, rather than re-emitting a new marker (which
+   * would itself require dropping another message). Null until first overflow.
+   */
+  private overflowParams: { droppedAtLeast: number } | null = null;
   private finished = false;
   private readonly onDetach: (() => void) | undefined;
 
   constructor(opts?: { onDetach?: () => void }) {
     this.onDetach = opts?.onDetach;
+  }
+
+  /**
+   * Seed replay/backlog messages into a brand-new subscriber before it is
+   * exposed to callers. This is used for the parser's first-subscriber
+   * start-of-turn replay path; replayed `_overflow` metadata (if present)
+   * is carried over so post-subscription drops continue incrementing the same
+   * counter instead of resetting to 1.
+   */
+  seedReplay(
+    messages: readonly Message[],
+    overflowParams: { droppedAtLeast: number } | null,
+    dropped: number,
+  ): void {
+    if (messages.length === 0) return;
+    this.queue = messages.slice();
+    this.head = 0;
+    this.overflowParams = overflowParams;
+    this.dropped = dropped;
+  }
+
+  private get size(): number {
+    return this.queue.length - this.head;
   }
 
   push(message: Message, turnId: string): void {
@@ -443,25 +473,27 @@ class AcpSubscriber implements AsyncIterator<Message> {
       waiter({ value: message, done: false });
       return;
     }
-    if (this.queue.length >= MAX_SUBSCRIBER_BUFFER) {
+    if (this.size >= MAX_SUBSCRIBER_BUFFER) {
       this.dropped += 1;
       if (this.dropped === 1 || this.dropped % 1000 === 0) {
         process.stderr.write(
           `[acp-parser] subscriber buffer full (${MAX_SUBSCRIBER_BUFFER}); dropped ${this.dropped} messages so far\n`,
         );
       }
-      // Emit one in-band overflow marker so the consumer sees the drop.
-      // Later drops update the counter but don't re-emit (avoid spamming).
-      if (!this.overflowEmitted) {
-        this.overflowEmitted = true;
-        const marker: Message = {
+      if (this.overflowParams === null) {
+        // First overflow: append an in-band marker (queue temporarily holds
+        // MAX+1 items). Unlike the original "replace tail" strategy, no
+        // legitimate message is evicted and the marker's params object is
+        // retained so subsequent drops can keep the count live.
+        this.overflowParams = { droppedAtLeast: this.dropped };
+        this.queue.push({
           kind: "raw",
           turnId,
           acpMethod: "_overflow",
-          params: { droppedAtLeast: 1 },
-        };
-        // Replace the tail so the marker is visible when the consumer eventually drains.
-        this.queue[this.queue.length - 1] = marker;
+          params: this.overflowParams,
+        });
+      } else {
+        this.overflowParams.droppedAtLeast = this.dropped;
       }
       return;
     }
@@ -479,8 +511,23 @@ class AcpSubscriber implements AsyncIterator<Message> {
   }
 
   next(): Promise<IteratorResult<Message>> {
-    const value = this.queue.shift();
-    if (value !== undefined) {
+    if (this.head < this.queue.length) {
+      const value = this.queue[this.head] as Message;
+      // Drop the reference from the backing array so retained messages don't
+      // pin their payloads alive after they've been handed to the consumer.
+      this.queue[this.head] = undefined as unknown as Message;
+      this.head += 1;
+      if (this.head === this.queue.length) {
+        // Fully drained — reset in O(1) so the backing array doesn't grow
+        // unbounded over a long-running subscriber.
+        this.queue.length = 0;
+        this.head = 0;
+      } else if (this.head > 256 && this.head * 2 > this.queue.length) {
+        // Half-drained — periodic compaction keeps the backing array size
+        // proportional to live items without paying O(N) every drain.
+        this.queue = this.queue.slice(this.head);
+        this.head = 0;
+      }
       return Promise.resolve({ value, done: false });
     }
     if (this.finished) {
@@ -497,7 +544,9 @@ class AcpSubscriber implements AsyncIterator<Message> {
     this.onDetach?.();
     // Discard backlog — the consumer has explicitly unsubscribed and must not
     // receive more events, even from what was already in-flight.
-    this.queue.length = 0;
+    this.queue = [];
+    this.head = 0;
+    this.overflowParams = null;
     this.finish();
     return Promise.resolve({ value: undefined, done: true });
   }
@@ -528,6 +577,9 @@ export class AcpParser {
    */
   private readonly preSubscriptionBuffer: Message[] = [];
   private firstSubscriberAttached = false;
+  /** Live-reference marker params for the pre-subscription overflow, mirroring AcpSubscriber.overflowParams. */
+  private preOverflowParams: { droppedAtLeast: number; pre: true } | null = null;
+  private preDropped = 0;
 
   /**
    * True as soon as a terminal result has been produced. Flipped synchronously
@@ -570,10 +622,12 @@ export class AcpParser {
         // empty log — scheduling-dependent audit history.
         if (!this.firstSubscriberAttached) {
           this.firstSubscriberAttached = true;
-          for (const m of this.preSubscriptionBuffer) {
-            sub.push(m, this.turnId);
+          if (this.preSubscriptionBuffer.length > 0) {
+            sub.seedReplay(this.preSubscriptionBuffer, this.preOverflowParams, this.preDropped);
+            this.preSubscriptionBuffer.length = 0;
+            this.preOverflowParams = null;
+            this.preDropped = 0;
           }
-          this.preSubscriptionBuffer.length = 0;
         }
         if (this.streamFinished) {
           sub.finish();
@@ -589,18 +643,28 @@ export class AcpParser {
     if (!this.firstSubscriberAttached) {
       // Buffer until first subscriber attaches (start-of-turn replay).
       // Bounded to prevent OOM if no consumer ever attaches.
-      if (this.preSubscriptionBuffer.length < MAX_SUBSCRIBER_BUFFER) {
-        this.preSubscriptionBuffer.push(message);
-      } else if (this.preSubscriptionBuffer.length === MAX_SUBSCRIBER_BUFFER) {
-        // Replace tail with overflow marker so the replay carries a signal
-        // that events were dropped (same pattern as per-subscriber overflow).
-        this.preSubscriptionBuffer[this.preSubscriptionBuffer.length - 1] = {
+      if (this.preOverflowParams === null) {
+        if (this.preSubscriptionBuffer.length < MAX_SUBSCRIBER_BUFFER) {
+          this.preSubscriptionBuffer.push(message);
+          return;
+        }
+        // First overflow: append an in-band marker (buffer temporarily holds
+        // MAX+1 items) and retain a live reference to its params so later
+        // drops can mutate `droppedAtLeast` in place — the previous "replace
+        // tail" strategy (a) evicted a real message and (b) left the count
+        // stuck at 1 forever.
+        this.preDropped = 1;
+        this.preOverflowParams = { droppedAtLeast: 1, pre: true };
+        this.preSubscriptionBuffer.push({
           kind: "raw",
           turnId: this.turnId,
           acpMethod: "_overflow",
-          params: { droppedAtLeast: 1, pre: true },
-        };
+          params: this.preOverflowParams,
+        });
+        return;
       }
+      this.preDropped += 1;
+      this.preOverflowParams.droppedAtLeast = this.preDropped;
       return;
     }
     for (const sub of this.subscribers) {
@@ -619,16 +683,30 @@ export class AcpParser {
   }
 
   private async _readStream(stream: Readable, turnId: string): Promise<void> {
+    // StringDecoder holds partial multi-byte sequences across chunk
+    // boundaries. Without it, `(chunk as Buffer).toString("utf8")` called
+    // per-chunk silently produces U+FFFD replacement characters whenever a
+    // 2/3/4-byte UTF-8 glyph straddles a chunk — corrupting emoji / CJK /
+    // accented text in assistant output and breaking JSON.parse on tool
+    // call titles or inputs that contain non-ASCII. Pipes on upstream
+    // acpx stdout are raw Buffers (see acpx-runtime), so this is a real
+    // wire-shape concern, not a theoretical one.
+    const decoder = new StringDecoder("utf8");
     let buffer = "";
     let settled = false;
 
     try {
       for await (const chunk of stream) {
-        buffer += typeof chunk === "string" ? chunk : (chunk as Buffer).toString("utf8");
+        buffer += typeof chunk === "string" ? chunk : decoder.write(chunk as Buffer);
 
-        // Split on newlines — emit complete lines
+        // Skip split/pop when no complete line is available yet — avoids
+        // reallocating lines[] every chunk when the stream dribbles in
+        // sub-line fragments.
+        if (buffer.indexOf("\n") === -1) continue;
+
+        // Split on newlines — emit complete lines.
         const lines = buffer.split("\n");
-        // Last element is incomplete (no trailing newline yet) — keep in buffer
+        // Last element is incomplete (no trailing newline yet) — keep in buffer.
         buffer = lines.pop() ?? "";
 
         for (const raw of lines) {
@@ -645,7 +723,9 @@ export class AcpParser {
         }
       }
 
-      // Flush any trailing content without a newline
+      // Flush any trailing bytes the decoder still holds (incomplete
+      // multi-byte sequence at EOF) + any buffered text without a newline.
+      buffer += decoder.end();
       if (buffer.trim().length > 0) {
         const parsed = parseAcpLine(buffer.trim(), turnId, this.sessionId);
         if (parsed.kind === "result") {

--- a/src/acp/parser.ts
+++ b/src/acp/parser.ts
@@ -427,13 +427,6 @@ class AcpSubscriber implements AsyncIterator<Message> {
   private head = 0;
   private waiters: Array<(r: IteratorResult<Message>) => void> = [];
   private dropped = 0;
-  /**
-   * Live reference to the `_overflow` marker's params object. When the
-   * subscriber overflows a second time we MUTATE this object to keep
-   * `droppedAtLeast` current, rather than re-emitting a new marker (which
-   * would itself require dropping another message). Null until first overflow.
-   */
-  private overflowParams: { droppedAtLeast: number } | null = null;
   private finished = false;
   private readonly onDetach: (() => void) | undefined;
 
@@ -444,19 +437,12 @@ class AcpSubscriber implements AsyncIterator<Message> {
   /**
    * Seed replay/backlog messages into a brand-new subscriber before it is
    * exposed to callers. This is used for the parser's first-subscriber
-   * start-of-turn replay path; replayed `_overflow` metadata (if present)
-   * is carried over so post-subscription drops continue incrementing the same
-   * counter instead of resetting to 1.
+   * start-of-turn replay path.
    */
-  seedReplay(
-    messages: readonly Message[],
-    overflowParams: { droppedAtLeast: number } | null,
-    dropped: number,
-  ): void {
+  seedReplay(messages: readonly Message[], dropped: number): void {
     if (messages.length === 0) return;
     this.queue = messages.slice();
     this.head = 0;
-    this.overflowParams = overflowParams;
     this.dropped = dropped;
   }
 
@@ -480,20 +466,22 @@ class AcpSubscriber implements AsyncIterator<Message> {
           `[acp-parser] subscriber buffer full (${MAX_SUBSCRIBER_BUFFER}); dropped ${this.dropped} messages so far\n`,
         );
       }
-      if (this.overflowParams === null) {
-        // First overflow: append an in-band marker (queue temporarily holds
-        // MAX+1 items). Unlike the original "replace tail" strategy, no
-        // legitimate message is evicted and the marker's params object is
-        // retained so subsequent drops can keep the count live.
-        this.overflowParams = { droppedAtLeast: this.dropped };
-        this.queue.push({
-          kind: "raw",
-          turnId,
-          acpMethod: "_overflow",
-          params: this.overflowParams,
-        });
-      } else {
-        this.overflowParams.droppedAtLeast = this.dropped;
+      const marker: Message = {
+        kind: "raw",
+        turnId,
+        acpMethod: "_overflow",
+        params: { droppedAtLeast: this.dropped },
+      };
+      const tail = this.queue[this.queue.length - 1];
+      // Keep emitted messages immutable: never mutate an already-enqueued
+      // marker object in place. If an overflow marker is already the tail,
+      // replace it with a fresh frame carrying the latest drop count.
+      if (tail && tail.kind === "raw" && tail.acpMethod === "_overflow") {
+        this.queue[this.queue.length - 1] = marker;
+      } else if (this.size === MAX_SUBSCRIBER_BUFFER) {
+        // First overflow while at exact capacity: append marker so a
+        // subscriber can observe truncation in-band.
+        this.queue.push(marker);
       }
       return;
     }
@@ -546,7 +534,6 @@ class AcpSubscriber implements AsyncIterator<Message> {
     // receive more events, even from what was already in-flight.
     this.queue = [];
     this.head = 0;
-    this.overflowParams = null;
     this.finish();
     return Promise.resolve({ value: undefined, done: true });
   }
@@ -577,8 +564,6 @@ export class AcpParser {
    */
   private readonly preSubscriptionBuffer: Message[] = [];
   private firstSubscriberAttached = false;
-  /** Live-reference marker params for the pre-subscription overflow, mirroring AcpSubscriber.overflowParams. */
-  private preOverflowParams: { droppedAtLeast: number; pre: true } | null = null;
   private preDropped = 0;
 
   /**
@@ -623,9 +608,8 @@ export class AcpParser {
         if (!this.firstSubscriberAttached) {
           this.firstSubscriberAttached = true;
           if (this.preSubscriptionBuffer.length > 0) {
-            sub.seedReplay(this.preSubscriptionBuffer, this.preOverflowParams, this.preDropped);
+            sub.seedReplay(this.preSubscriptionBuffer, this.preDropped);
             this.preSubscriptionBuffer.length = 0;
-            this.preOverflowParams = null;
             this.preDropped = 0;
           }
         }
@@ -643,28 +627,38 @@ export class AcpParser {
     if (!this.firstSubscriberAttached) {
       // Buffer until first subscriber attaches (start-of-turn replay).
       // Bounded to prevent OOM if no consumer ever attaches.
-      if (this.preOverflowParams === null) {
+      if (this.preDropped === 0) {
         if (this.preSubscriptionBuffer.length < MAX_SUBSCRIBER_BUFFER) {
           this.preSubscriptionBuffer.push(message);
           return;
         }
         // First overflow: append an in-band marker (buffer temporarily holds
-        // MAX+1 items) and retain a live reference to its params so later
-        // drops can mutate `droppedAtLeast` in place — the previous "replace
-        // tail" strategy (a) evicted a real message and (b) left the count
-        // stuck at 1 forever.
+        // MAX+1 items) so delayed first subscribers still receive a clear
+        // truncation signal.
         this.preDropped = 1;
-        this.preOverflowParams = { droppedAtLeast: 1, pre: true };
         this.preSubscriptionBuffer.push({
           kind: "raw",
           turnId: this.turnId,
           acpMethod: "_overflow",
-          params: this.preOverflowParams,
+          params: { droppedAtLeast: this.preDropped, pre: true },
         });
         return;
       }
       this.preDropped += 1;
-      this.preOverflowParams.droppedAtLeast = this.preDropped;
+      const marker: Message = {
+        kind: "raw",
+        turnId: this.turnId,
+        acpMethod: "_overflow",
+        params: { droppedAtLeast: this.preDropped, pre: true },
+      };
+      const tail = this.preSubscriptionBuffer[this.preSubscriptionBuffer.length - 1];
+      // Keep messages immutable: replace the queued marker object rather than
+      // mutating an already-emitted/queued object in place.
+      if (tail && tail.kind === "raw" && tail.acpMethod === "_overflow") {
+        this.preSubscriptionBuffer[this.preSubscriptionBuffer.length - 1] = marker;
+      } else if (this.preSubscriptionBuffer.length === MAX_SUBSCRIBER_BUFFER) {
+        this.preSubscriptionBuffer.push(marker);
+      }
       return;
     }
     for (const sub of this.subscribers) {


### PR DESCRIPTION
## Summary
- preserve delayed first-subscriber replay overflow metadata by seeding replay state directly into the subscriber queue instead of replaying through `push()`, preventing `_overflow.droppedAtLeast` from resetting to `1`
- harden ACP parser/compactor correctness and performance: UTF-8 chunk-safe decoding via `StringDecoder`, O(1)-amortized subscriber queue drains, in-place tool-call merges, and strict terminal-state payload gating
- add ACP regressions for split multi-byte UTF-8 decoding, live overflow counter growth, delayed replay overflow preservation, and status-less terminal update rejection

## Test plan
- [x] `bun test src/acp/parser.test.ts`
- [x] `bun test src/acp`
- [x] `bun run typecheck`
- [x] `bun run check`
- [x] `bun test`

Made with [Cursor](https://cursor.com)