### PR TITLE
fix(cli): harden parsing and traversal behavior

### DIFF
--- a/src/cli/commands/checkout.ts
+++ b/src/cli/commands/checkout.ts
@@ -11,8 +11,7 @@
  */
 
 import { mkdir, rename, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { frontierOperation } from "../../core/operations/index.js";
 import {
@@ -130,14 +129,18 @@ export async function runCheckout(
     throw new Error(errMsg);
   }
 
-  // Stage artifacts into a temp directory, then atomically swap into --to.
-  // This prevents two failure modes:
+  // Stage artifacts into a sibling directory of the final destination, then
+  // atomically swap into --to. Staging next to destDir keeps the rename within
+  // a single filesystem so `rename` cannot fail with EXDEV after we've already
+  // torn down the destination. This prevents two failure modes:
   //   1. Stale files left behind when re-checking out into the same directory
   //   2. Partial snapshots when a later artifact is missing from CAS
   const destDir = resolve(options.to);
+  const destParent = dirname(destDir);
+  await mkdir(destParent, { recursive: true });
   const stagingDir = join(
-    tmpdir(),
-    `grove-checkout-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    destParent,
+    `.grove-checkout-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
   await mkdir(stagingDir, { recursive: true });
 
@@ -157,7 +160,6 @@ export async function runCheckout(
     // All artifacts staged successfully — swap into destination.
     // Remove existing destination first to prevent stale files.
     await rm(destDir, { recursive: true, force: true });
-    await mkdir(join(destDir, ".."), { recursive: true });
     await rename(stagingDir, destDir);
   } catch (err) {
     // Clean up staging dir on failure — destination is untouched

--- a/src/cli/commands/claims.ts
+++ b/src/cli/commands/claims.ts
@@ -39,35 +39,28 @@ export async function runClaims(args: readonly string[], deps: ClaimsDeps): Prom
   const json = values.json ?? false;
 
   if (values.expired) {
-    // Terminal claims: use listClaimsOperation with status filter
-    const opDeps: OperationDeps = {
-      claimStore: deps.claimStore,
-    };
+    const terminalStatuses = [ClaimStatus.Expired, ClaimStatus.Released, ClaimStatus.Completed];
 
-    const result = await listClaimsOperation(
-      {
-        status: [ClaimStatus.Expired, ClaimStatus.Released, ClaimStatus.Completed],
-        agentId: values.agent,
-      },
-      opDeps,
-    );
+    if (json) {
+      // JSON path goes through the operation layer for structured envelopes
+      const opDeps: OperationDeps = { claimStore: deps.claimStore };
+      const result = await listClaimsOperation(
+        { status: terminalStatuses, agentId: values.agent },
+        opDeps,
+      );
 
-    if (!result.ok) {
-      if (json) {
+      if (!result.ok) {
         outputJsonError(result.error);
         return;
       }
-      throw new Error(result.error.message);
-    }
 
-    if (json) {
       outputJson(result.value);
       return;
     }
 
-    // Fetch full Claim objects for table formatting (operation returns summaries)
+    // Human path fetches full Claim objects directly — operation returns summaries
     const claims = await deps.claimStore.listClaims({
-      status: [ClaimStatus.Expired, ClaimStatus.Released, ClaimStatus.Completed],
+      status: terminalStatuses,
       agentId: values.agent,
     });
     deps.stdout(formatClaimsTable(claims));

--- a/src/cli/commands/completions.ts
+++ b/src/cli/commands/completions.ts
@@ -48,6 +48,23 @@ export function generateCompletions(shell: Shell, commands?: readonly CommandMet
   }
 }
 
+/**
+ * Escape a string for inclusion in a single-quoted shell literal.
+ * Also flattens newlines so the quoted value stays on one line.
+ */
+function escapeSingleQuoted(s: string): string {
+  return s.replace(/\n/g, " ").replace(/'/g, "'\\''");
+}
+
+/**
+ * Escape a description for the zsh `name:description` completion tuple.
+ * Zsh treats unescaped `:` as a separator and `'` closes the literal, so
+ * both must be neutralized; also strip newlines that would break the list.
+ */
+function escapeZshDescription(s: string): string {
+  return s.replace(/\n/g, " ").replace(/:/g, "\\:").replace(/'/g, "'\\''");
+}
+
 // ---------------------------------------------------------------------------
 // Bash
 // ---------------------------------------------------------------------------
@@ -125,7 +142,7 @@ complete -F _grove_completions grove
 
 function generateZsh(commands: readonly CommandMeta[]): string {
   const cmdDescriptions = commands
-    .map((cmd) => `    '${cmd.name}:${cmd.description}'`)
+    .map((cmd) => `    '${cmd.name}:${escapeZshDescription(cmd.description)}'`)
     .join(" \\\n");
 
   // Generate per-command helper functions for commands with subcommands
@@ -137,7 +154,7 @@ function generateZsh(commands: readonly CommandMeta[]): string {
       if (subcmds.length > 0) {
         // Commands with subcommands get a dedicated helper function
         const subDescriptions = subcmds
-          .map((s) => `      '${s.name}:${s.description}'`)
+          .map((s) => `      '${s.name}:${escapeZshDescription(s.description)}'`)
           .join(" \\\n");
 
         const subCaseArms = subcmds
@@ -221,7 +238,7 @@ function generateFish(commands: readonly CommandMeta[]): string {
 
   for (const cmd of commands) {
     lines.push(
-      `complete -c grove -n '__fish_use_subcommand' -a '${cmd.name}' -d '${cmd.description}'`,
+      `complete -c grove -n '__fish_use_subcommand' -a '${cmd.name}' -d '${escapeSingleQuoted(cmd.description)}'`,
     );
   }
 
@@ -236,7 +253,7 @@ function generateFish(commands: readonly CommandMeta[]): string {
     if (cmd.subcommands) {
       for (const sub of cmd.subcommands) {
         lines.push(
-          `complete -c grove -n '__fish_seen_subcommand_from ${cmd.name}' -a '${sub.name}' -d '${sub.description}'`,
+          `complete -c grove -n '__fish_seen_subcommand_from ${cmd.name}' -a '${sub.name}' -d '${escapeSingleQuoted(sub.description)}'`,
         );
         // Subcommand-specific flags — scope by both parent AND sub to avoid
         // name collisions (e.g. bounty list vs outcome list)

--- a/src/cli/commands/contribute.ts
+++ b/src/cli/commands/contribute.ts
@@ -334,27 +334,29 @@ export async function executeContribute(options: ContributeOptions): Promise<{ c
   const dbPath = join(grovePath, "grove.db");
   const casPath = join(grovePath, "cas");
   const db = initSqliteDb(dbPath);
-  const rawStore = new SqliteContributionStore(db);
-  const claimStore = new SqliteClaimStore(db);
-  const idempotencyStore = new SqliteIdempotencyStore(db);
-  const cas = new FsCas(casPath);
-  const frontier = new DefaultFrontierCalculator(rawStore);
-
-  // 3. Load contract for enforcement, default mode, and metric directions.
-  //    Shared bootstrap: session.config > GROVE.md > no enforcement.
-  //    See src/cli/utils/resolve-contract.ts for the full precedence chain.
-  const { SqliteGoalSessionStore } = await import("../../local/sqlite-goal-session-store.js");
-  const { resolveContract } = await import("../utils/resolve-contract.js");
-  const contract = await resolveContract({
-    goalSessionStore: new SqliteGoalSessionStore(db),
-    groveRoot: options.cwd,
-    envSessionId: process.env.GROVE_SESSION_ID,
-  });
-
-  // Wrap store with enforcement if contract is available
-  const store = contract ? new EnforcingContributionStore(rawStore, contract, { cas }) : rawStore;
-
+  // Guarantee close() even when bootstrap (contract resolution, schema checks)
+  // throws before we reach the main work. Without this, a bad GROVE.md or a
+  // missing session row leaks the DB handle.
   try {
+    const rawStore = new SqliteContributionStore(db);
+    const claimStore = new SqliteClaimStore(db);
+    const idempotencyStore = new SqliteIdempotencyStore(db);
+    const cas = new FsCas(casPath);
+    const frontier = new DefaultFrontierCalculator(rawStore);
+
+    // 3. Load contract for enforcement, default mode, and metric directions.
+    //    Shared bootstrap: session.config > GROVE.md > no enforcement.
+    //    See src/cli/utils/resolve-contract.ts for the full precedence chain.
+    const { SqliteGoalSessionStore } = await import("../../local/sqlite-goal-session-store.js");
+    const { resolveContract } = await import("../utils/resolve-contract.js");
+    const contract = await resolveContract({
+      goalSessionStore: new SqliteGoalSessionStore(db),
+      groveRoot: options.cwd,
+      envSessionId: process.env.GROVE_SESSION_ID,
+    });
+
+    // Wrap store with enforcement if contract is available
+    const store = contract ? new EnforcingContributionStore(rawStore, contract, { cas }) : rawStore;
     // 4. Validate parent CID exists (CLI-specific: early user-friendly error)
     if (options.parent) {
       const parent = await store.get(options.parent);

--- a/src/cli/commands/discuss.test.ts
+++ b/src/cli/commands/discuss.test.ts
@@ -14,6 +14,8 @@ import { executeDiscuss, handleDiscuss, parseDiscussArgs } from "./discuss.js";
 import type { InitOptions } from "./init.js";
 import { executeInit } from "./init.js";
 
+const VALID_CID = `blake3:${"a".repeat(64)}`;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -51,8 +53,8 @@ describe("parseDiscussArgs", () => {
   });
 
   test("parses reply (CID + message)", () => {
-    const opts = parseDiscussArgs(["blake3:abc123", "I think push is better"]);
-    expect(opts.respondsTo).toBe("blake3:abc123");
+    const opts = parseDiscussArgs([VALID_CID, "I think push is better"]);
+    expect(opts.respondsTo).toBe(VALID_CID);
     expect(opts.message).toBe("I think push is better");
   });
 
@@ -101,13 +103,59 @@ describe("parseDiscussArgs", () => {
   });
 
   test("joins extra positionals into reply message", () => {
-    const opts = parseDiscussArgs(["blake3:abc123", "this", "needs", "work"]);
-    expect(opts.respondsTo).toBe("blake3:abc123");
+    const opts = parseDiscussArgs([VALID_CID, "this", "needs", "work"]);
+    expect(opts.respondsTo).toBe(VALID_CID);
     expect(opts.message).toBe("this needs work");
   });
 
   test("throws on CID with no message", () => {
-    expect(() => parseDiscussArgs(["blake3:abc123"])).toThrow("empty");
+    expect(() => parseDiscussArgs([VALID_CID])).toThrow("empty");
+  });
+
+  test("does not misclassify root messages that look like algo:hex", () => {
+    const opts = parseDiscussArgs(["fix:deadbeef", "works"]);
+    expect(opts.respondsTo).toBeUndefined();
+    expect(opts.message).toBe("fix:deadbeef works");
+  });
+
+  test("rejects truncated blake3 CID intent", () => {
+    expect(() => parseDiscussArgs(["blake3:abc123", "reply"])).toThrow("Invalid CID");
+  });
+
+  test("rejects mixed-hex blake3 CID intent", () => {
+    expect(() => parseDiscussArgs(["blake3:abc123g", "reply"])).toThrow("Invalid CID");
+  });
+
+  test("rejects bare blake3 prefix intent", () => {
+    expect(() => parseDiscussArgs(["blake3:", "reply"])).toThrow("Invalid CID");
+  });
+
+  test("rejects uppercase blake3 CID intent", () => {
+    const uppercase = `blake3:${"A".repeat(64)}`;
+    expect(() => parseDiscussArgs([uppercase, "reply"])).toThrow("Invalid CID");
+  });
+
+  test("rejects uppercase BLAKE3 prefix intent", () => {
+    const uppercasePrefix = `BLAKE3:${"a".repeat(64)}`;
+    expect(() => parseDiscussArgs([uppercasePrefix, "reply"])).toThrow("Invalid CID");
+  });
+
+  test("allows non-CID hash-prefixed root messages", () => {
+    const opts = parseDiscussArgs(["sha256:collision", "risk"]);
+    expect(opts.respondsTo).toBeUndefined();
+    expect(opts.message).toBe("sha256:collision risk");
+  });
+
+  test("allows non-hex blake3-prefixed root messages with --root", () => {
+    const opts = parseDiscussArgs(["--root", "blake3:algorithm", "notes"]);
+    expect(opts.respondsTo).toBeUndefined();
+    expect(opts.message).toBe("blake3:algorithm notes");
+  });
+
+  test("forces root parsing for canonical CID prefix when --root is set", () => {
+    const opts = parseDiscussArgs(["--root", VALID_CID, "literal"]);
+    expect(opts.respondsTo).toBeUndefined();
+    expect(opts.message).toBe(`${VALID_CID} literal`);
   });
 });
 

--- a/src/cli/commands/discuss.ts
+++ b/src/cli/commands/discuss.ts
@@ -3,15 +3,17 @@
  *
  * Usage:
  *   grove discuss "Should we use polling or push?"           # root discussion
- *   grove discuss blake3:abc123 "I think push is better"    # reply to thread
- *   grove discuss blake3:abc123 "Push wins" --tag arch      # reply with tags
+ *   grove discuss blake3:<64-hex> "I think push is better"  # reply to thread
+ *   grove discuss blake3:<64-hex> "Push wins" --tag arch    # reply with tags
  *   grove discuss "New topic" --tag design --mode exploration
+ *   grove discuss --root blake3:algorithm "notes"           # literal root message
  *   grove discuss "Topic" --json
  */
 
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 
+import { CID_PATTERN } from "../../core/manifest.js";
 import type { ContributionMode } from "../../core/models.js";
 import { RelationType } from "../../core/models.js";
 import type { OperationDeps } from "../../core/operations/index.js";
@@ -36,7 +38,7 @@ export interface DiscussOptions {
  * Positional args: [cid] <message>
  *   - If one positional: it's the message (root discussion)
  *   - If two positionals: first is CID, second is message (reply)
- * Flags: --tag, --mode, --description, --json
+ * Flags: --tag, --mode, --description, --json, --root
  */
 export function parseDiscussArgs(args: readonly string[]): DiscussOptions {
   const { values, positionals } = parseArgs({
@@ -46,6 +48,7 @@ export function parseDiscussArgs(args: readonly string[]): DiscussOptions {
       mode: { type: "string" },
       description: { type: "string" },
       json: { type: "boolean", default: false },
+      root: { type: "boolean", default: false },
     },
     strict: true,
     allowPositionals: true,
@@ -55,23 +58,28 @@ export function parseDiscussArgs(args: readonly string[]): DiscussOptions {
     throw new Error(
       "Usage: grove discuss [<cid>] <message>\n" +
         '  grove discuss "Topic question"                  # root discussion\n' +
-        '  grove discuss blake3:abc.. "Reply message"      # reply to thread',
+        '  grove discuss blake3:<64-hex> "Reply message"   # reply to thread\n' +
+        '  grove discuss --root blake3:topic "Message"     # literal root message',
     );
   }
 
   let respondsTo: string | undefined;
   let message: string;
 
-  // First positional is a CID when it looks like "<algo>:<hex>" — a single
-  // token with a hash prefix and only hex chars after the colon. Previously
-  // this was `startsWith("blake3:")` which mis-parsed sentences that happened
-  // to begin with the literal prefix and couldn't tolerate other hash algos.
-  // We stay permissive on the digest length so CLI shorthand still works.
+  // Reply mode is entered for canonical CIDs only. `--root` always forces
+  // literal root parsing. Non-canonical `blake3:` prefixes fail closed by
+  // default so malformed reply intent is not silently downgraded to root mode.
   const first = positionals[0];
-  if (first !== undefined && /^[a-z][a-z0-9]*:[0-9a-f]+$/i.test(first)) {
-    // Reply mode: first positional is the CID, rest is the message.
+  if (values.root ?? false) {
+    message = positionals.join(" ");
+  } else if (first !== undefined && CID_PATTERN.test(first)) {
     respondsTo = first;
     message = positionals.slice(1).join(" ");
+  } else if (first !== undefined && first.toLowerCase().startsWith("blake3:")) {
+    throw new Error(
+      `Invalid CID '${first}'. Expected format: blake3:<64 lowercase hex characters> ` +
+        "(or pass --root to treat it as literal message text).",
+    );
   } else {
     // Root discussion — all positionals form the message.
     message = positionals.join(" ");

--- a/src/cli/commands/discuss.ts
+++ b/src/cli/commands/discuss.ts
@@ -16,6 +16,7 @@ import type { ContributionMode } from "../../core/models.js";
 import { RelationType } from "../../core/models.js";
 import type { OperationDeps } from "../../core/operations/index.js";
 import { contributeOperation } from "../../core/operations/index.js";
+import { resolveAgent } from "../agent.js";
 import { outputJson } from "../format.js";
 import { resolveGroveDir } from "../utils/grove-dir.js";
 
@@ -61,9 +62,15 @@ export function parseDiscussArgs(args: readonly string[]): DiscussOptions {
   let respondsTo: string | undefined;
   let message: string;
 
-  if (positionals[0]?.startsWith("blake3:")) {
-    // First positional is a CID — reply mode. Rest is the message.
-    respondsTo = positionals[0];
+  // First positional is a CID when it looks like "<algo>:<hex>" — a single
+  // token with a hash prefix and only hex chars after the colon. Previously
+  // this was `startsWith("blake3:")` which mis-parsed sentences that happened
+  // to begin with the literal prefix and couldn't tolerate other hash algos.
+  // We stay permissive on the digest length so CLI shorthand still works.
+  const first = positionals[0];
+  if (first !== undefined && /^[a-z][a-z0-9]*:[0-9a-f]+$/i.test(first)) {
+    // Reply mode: first positional is the CID, rest is the message.
+    respondsTo = first;
     message = positionals.slice(1).join(" ");
   } else {
     // Root discussion — all positionals form the message.
@@ -134,6 +141,11 @@ export async function executeDiscuss(options: DiscussOptions): Promise<{ cid: st
         ? [{ targetCid: options.respondsTo, relationType: RelationType.RespondsTo }]
         : [];
 
+    // Explicitly pass the resolved agent identity so discussions are
+    // attributed consistently with contribute/review/reproduce/inbox (all of
+    // which pass `agent` rather than relying on operation-layer fallback).
+    const agent = resolveAgent();
+
     const result = await contributeOperation(
       {
         kind: "discussion",
@@ -142,6 +154,10 @@ export async function executeDiscuss(options: DiscussOptions): Promise<{ cid: st
         description: options.description,
         relations,
         tags: [...options.tags],
+        agent: {
+          agentId: agent.agentId,
+          ...(agent.agentName ? { agentName: agent.agentName } : {}),
+        },
       },
       opDeps,
     );

--- a/src/cli/commands/export-dag.ts
+++ b/src/cli/commands/export-dag.ts
@@ -92,7 +92,7 @@ async function collectSubgraph(
   let frontier: readonly { cid: string; depth: number }[] = [{ cid: fromCid, depth: 0 }];
 
   while (frontier.length > 0) {
-    const current = frontier.filter((f) => !visited.has(f.cid) && f.depth <= maxDepth);
+    const current = dedupeByCid(frontier).filter((f) => !visited.has(f.cid) && f.depth <= maxDepth);
     const toFetch = current.map((f) => f.cid);
     const fetched =
       toFetch.length > 0 ? await deps.store.getMany(toFetch) : new Map<string, Contribution>();
@@ -107,14 +107,21 @@ async function collectSubgraph(
       }
     }
 
-    const nextFrontier: { cid: string; depth: number }[] = [];
+    const nextFrontier = new Map<string, number>();
+    const enqueue = (cid: string, depth: number): void => {
+      if (visited.has(cid)) return;
+      const prev = nextFrontier.get(cid);
+      if (prev === undefined || depth < prev) {
+        nextFrontier.set(cid, depth);
+      }
+    };
     for (const { depth, contribution } of expandable) {
       for (const rel of contribution.relations) {
         if (
           (rel.relationType === "derives_from" || rel.relationType === "adopts") &&
           !visited.has(rel.targetCid)
         ) {
-          nextFrontier.push({ cid: rel.targetCid, depth: depth + 1 });
+          enqueue(rel.targetCid, depth + 1);
         }
       }
     }
@@ -133,15 +140,29 @@ async function collectSubgraph(
               rel.relationType === RelationType.Adopts),
         );
         if (hasEdge) {
-          nextFrontier.push({ cid: child.cid, depth: node.depth + 1 });
+          enqueue(child.cid, node.depth + 1);
         }
       }
     }
 
-    frontier = nextFrontier;
+    frontier = [...nextFrontier.entries()].map(([cid, depth]) => ({ cid, depth }));
   }
 
   return [...visited.values()];
+}
+
+function dedupeByCid(nodes: readonly { cid: string; depth: number }[]): readonly {
+  cid: string;
+  depth: number;
+}[] {
+  const byCid = new Map<string, number>();
+  for (const node of nodes) {
+    const prev = byCid.get(node.cid);
+    if (prev === undefined || node.depth < prev) {
+      byCid.set(node.cid, node.depth);
+    }
+  }
+  return [...byCid.entries()].map(([cid, depth]) => ({ cid, depth }));
 }
 
 export async function runExportDag(

--- a/src/cli/commands/export-dag.ts
+++ b/src/cli/commands/export-dag.ts
@@ -80,7 +80,8 @@ export function parseExportDagArgs(argv: string[]): ExportDagOptions {
 
 /**
  * Collect contributions reachable from a starting CID within a depth limit.
- * BFS over derives_from and adopts relations in both directions.
+ * Level-wise BFS over derives_from and adopts edges in both directions,
+ * batching `store.getMany` and merging per-node `relatedTo` calls.
  */
 async function collectSubgraph(
   deps: CliDeps,
@@ -88,36 +89,56 @@ async function collectSubgraph(
   maxDepth: number,
 ): Promise<readonly Contribution[]> {
   const visited = new Map<string, Contribution>();
-  const queue: { cid: string; depth: number }[] = [{ cid: fromCid, depth: 0 }];
+  let frontier: readonly { cid: string; depth: number }[] = [{ cid: fromCid, depth: 0 }];
 
-  while (queue.length > 0) {
-    const item = queue.shift();
-    if (item === undefined) break;
-    if (visited.has(item.cid) || item.depth > maxDepth) continue;
+  while (frontier.length > 0) {
+    const current = frontier.filter((f) => !visited.has(f.cid) && f.depth <= maxDepth);
+    const toFetch = current.map((f) => f.cid);
+    const fetched =
+      toFetch.length > 0 ? await deps.store.getMany(toFetch) : new Map<string, Contribution>();
 
-    const contribution = await deps.store.get(item.cid);
-    if (contribution === undefined) continue;
-
-    visited.set(item.cid, contribution);
-
-    // Follow outgoing derives_from and adopts edges (ancestors)
-    for (const rel of contribution.relations) {
-      if (
-        (rel.relationType === "derives_from" || rel.relationType === "adopts") &&
-        !visited.has(rel.targetCid)
-      ) {
-        queue.push({ cid: rel.targetCid, depth: item.depth + 1 });
+    const expandable: Array<{ cid: string; depth: number; contribution: Contribution }> = [];
+    for (const { cid, depth } of current) {
+      const contribution = fetched.get(cid);
+      if (contribution === undefined) continue;
+      visited.set(cid, contribution);
+      if (depth < maxDepth) {
+        expandable.push({ cid, depth, contribution });
       }
     }
 
-    // Follow incoming derives_from and adopts edges (children)
-    const derivesChildren = await deps.store.relatedTo(item.cid, RelationType.DerivesFrom);
-    const adoptsChildren = await deps.store.relatedTo(item.cid, RelationType.Adopts);
-    for (const child of [...derivesChildren, ...adoptsChildren]) {
-      if (!visited.has(child.cid)) {
-        queue.push({ cid: child.cid, depth: item.depth + 1 });
+    const nextFrontier: { cid: string; depth: number }[] = [];
+    for (const { depth, contribution } of expandable) {
+      for (const rel of contribution.relations) {
+        if (
+          (rel.relationType === "derives_from" || rel.relationType === "adopts") &&
+          !visited.has(rel.targetCid)
+        ) {
+          nextFrontier.push({ cid: rel.targetCid, depth: depth + 1 });
+        }
       }
     }
+
+    const incomingLists = await Promise.all(expandable.map((n) => deps.store.relatedTo(n.cid)));
+    for (let i = 0; i < expandable.length; i++) {
+      const node = expandable[i];
+      if (node === undefined) continue;
+      const incoming = incomingLists[i] ?? [];
+      for (const child of incoming) {
+        if (visited.has(child.cid)) continue;
+        const hasEdge = child.relations.some(
+          (rel) =>
+            rel.targetCid === node.cid &&
+            (rel.relationType === RelationType.DerivesFrom ||
+              rel.relationType === RelationType.Adopts),
+        );
+        if (hasEdge) {
+          nextFrontier.push({ cid: child.cid, depth: node.depth + 1 });
+        }
+      }
+    }
+
+    frontier = nextFrontier;
   }
 
   return [...visited.values()];

--- a/src/cli/commands/gossip.ts
+++ b/src/cli/commands/gossip.ts
@@ -498,46 +498,86 @@ async function handleDaemon(
     initialFrontier: persistedFrontier,
   });
 
-  // Register event listener for console output and state persistence
+  // Debounce state persistence: gossip events fire on every shuffle/exchange
+  // (often multiple per second). fsyncing the full peer/frontier state on each
+  // one burns I/O and can starve the gossip loop. We coalesce into a single
+  // write per PERSIST_INTERVAL_MS window, plus one final write on shutdown.
+  const PERSIST_INTERVAL_MS = 5_000;
+  let pendingPersist: ReturnType<typeof setTimeout> | undefined;
+  const flushPersistence = (): void => {
+    try {
+      gossipStore.savePeers(gossipService.peers());
+      gossipStore.saveFrontier(gossipService.mergedFrontier());
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      writer(`[gossip] state persistence failed: ${msg}`);
+    }
+  };
+  const schedulePersist = (): void => {
+    if (pendingPersist !== undefined) return;
+    pendingPersist = setTimeout(() => {
+      pendingPersist = undefined;
+      flushPersistence();
+    }, PERSIST_INTERVAL_MS);
+  };
+
   gossipService.on((event: GossipEvent) => {
     writer(`[gossip] ${event.type}: peer=${event.peerId} at ${event.timestamp}`);
-
-    // Persist state after each event
-    gossipStore.savePeers(gossipService.peers());
-    gossipStore.saveFrontier(gossipService.mergedFrontier());
+    schedulePersist();
   });
 
   // Start HTTP server for incoming gossip requests
   const server = Bun.serve({
     port,
     async fetch(req) {
-      const url = new URL(req.url);
-      const path = url.pathname;
+      // Malformed or buggy peers must not crash the daemon. Wrap the whole
+      // dispatch in try/catch, bounce JSON parse errors back as 400 with a
+      // minimal body, and log unexpected failures to stderr for the operator.
+      try {
+        const url = new URL(req.url);
+        const path = url.pathname;
 
-      if (req.method === "POST" && path === "/api/gossip/exchange") {
-        const body = (await req.json()) as GossipMessage;
-        const response = await gossipService.handleExchange(body);
-        return Response.json(response);
+        if (req.method === "POST" && path === "/api/gossip/exchange") {
+          let body: GossipMessage;
+          try {
+            body = (await req.json()) as GossipMessage;
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return Response.json({ error: `invalid JSON: ${msg}` }, { status: 400 });
+          }
+          const response = await gossipService.handleExchange(body);
+          return Response.json(response);
+        }
+
+        if (req.method === "POST" && path === "/api/gossip/shuffle") {
+          let body: ShuffleRequest;
+          try {
+            body = (await req.json()) as ShuffleRequest;
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return Response.json({ error: `invalid JSON: ${msg}` }, { status: 400 });
+          }
+          const response = gossipService.handleShuffle(body);
+          return Response.json(response);
+        }
+
+        if (req.method === "GET" && path === "/api/gossip/peers") {
+          return Response.json({
+            peers: gossipService.peers(),
+            liveness: gossipService.liveness(),
+          });
+        }
+
+        if (req.method === "GET" && path === "/api/gossip/frontier") {
+          return Response.json({ entries: gossipService.mergedFrontier() });
+        }
+
+        return new Response("Not found", { status: 404 });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[gossip] request handler failed: ${msg}\n`);
+        return Response.json({ error: "internal error" }, { status: 500 });
       }
-
-      if (req.method === "POST" && path === "/api/gossip/shuffle") {
-        const body = (await req.json()) as ShuffleRequest;
-        const response = gossipService.handleShuffle(body);
-        return Response.json(response);
-      }
-
-      if (req.method === "GET" && path === "/api/gossip/peers") {
-        return Response.json({
-          peers: gossipService.peers(),
-          liveness: gossipService.liveness(),
-        });
-      }
-
-      if (req.method === "GET" && path === "/api/gossip/frontier") {
-        return Response.json({ entries: gossipService.mergedFrontier() });
-      }
-
-      return new Response("Not found", { status: 404 });
     },
   });
 
@@ -555,17 +595,34 @@ async function handleDaemon(
   // Start the gossip loop
   gossipService.start();
 
-  // Wait for SIGINT/SIGTERM
+  // Wait for SIGINT/SIGTERM. Shutdown is idempotent because signal handlers
+  // can fire twice (e.g. Ctrl-C in a pipeline) and each would otherwise race
+  // on `server.stop` / `gossipStore.close`.
   await new Promise<void>((resolve) => {
+    let shuttingDown = false;
     const shutdown = async () => {
+      if (shuttingDown) return;
+      shuttingDown = true;
       writer("\nShutting down gossip daemon...");
-      await gossipService.stop();
+      try {
+        await gossipService.stop();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        writer(`[gossip] stop() failed: ${msg}`);
+      }
       server.stop(true);
 
-      // Persist final state
-      gossipStore.savePeers(gossipService.peers());
-      gossipStore.saveFrontier(gossipService.mergedFrontier());
-      gossipStore.close();
+      // Cancel any pending debounced write and persist final state once.
+      if (pendingPersist !== undefined) {
+        clearTimeout(pendingPersist);
+        pendingPersist = undefined;
+      }
+      flushPersistence();
+      try {
+        gossipStore.close();
+      } catch {
+        /* already closed */
+      }
 
       writer("State persisted. Goodbye.");
       resolve();
@@ -602,7 +659,7 @@ async function handleWatch(args: readonly string[], writer: Writer): Promise<voi
 
   // Track previous state to detect changes
   let previousPeers = new Map<string, string>(); // peerId -> status
-  let previousFrontierSize = 0;
+  let previousFrontierCids = new Set<string>();
   let running = true;
 
   const shutdown = () => {
@@ -656,12 +713,22 @@ async function handleWatch(args: readonly string[], writer: Writer): Promise<voi
         }
       }
 
-      // Frontier changes
-      if (frontierData.entries.length !== previousFrontierSize) {
+      // Frontier changes — compare the CID set, not just cardinality,
+      // because equal-size churn (one CID replaced by another) must register.
+      const currentFrontierCids = new Set<string>(frontierData.entries.map((e) => e.cid));
+      const added: string[] = [];
+      const removed: string[] = [];
+      for (const cid of currentFrontierCids) {
+        if (!previousFrontierCids.has(cid)) added.push(cid);
+      }
+      for (const cid of previousFrontierCids) {
+        if (!currentFrontierCids.has(cid)) removed.push(cid);
+      }
+      if (added.length > 0 || removed.length > 0) {
         events.push({
           type: "frontier_updated",
           peerId: "local",
-          detail: `${previousFrontierSize} -> ${frontierData.entries.length} entries`,
+          detail: `+${added.length}/-${removed.length} cid(s), total=${currentFrontierCids.size}`,
         });
       }
 
@@ -677,7 +744,7 @@ async function handleWatch(args: readonly string[], writer: Writer): Promise<voi
       }
 
       previousPeers = currentPeers;
-      previousFrontierSize = frontierData.entries.length;
+      previousFrontierCids = currentFrontierCids;
     } catch (err) {
       writer(`[error] ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -135,7 +135,7 @@ async function handleSend(args: readonly string[], groveOverride?: string): Prom
       console.log(`  to: ${recipients.join(", ")}`);
     }
   } finally {
-    stores.contributionStore.close();
+    stores.close();
   }
 }
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -6,8 +6,7 @@
  * writes grove.json configuration, and optionally ingests seed data.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { access, mkdir, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { parseArgs } from "node:util";
 
@@ -185,161 +184,169 @@ export async function executeInit(
   const dbPath = join(grovePath, "grove.db");
   const { initSqliteDb } = await import("../../local/sqlite-store.js");
   const db = initSqliteDb(dbPath);
+  // Everything below runs under try/finally so db.close() always fires — a
+  // failure writing GROVE.md, grove.json, or seeding must not leak the DB.
+  try {
+    // 5. Generate GROVE.md
+    progress(3, "Generating GROVE.md contract");
+    const grovemdPath = join(options.cwd, "GROVE.md");
+    const mdConfig = preset
+      ? presetToGroveMdConfig(preset, options)
+      : defaultGroveMdConfig(options);
+    const grovemdContent = buildGroveMd(mdConfig);
+    await writeFile(grovemdPath, grovemdContent, "utf-8");
 
-  // 5. Generate GROVE.md
-  progress(3, "Generating GROVE.md contract");
-  const grovemdPath = join(options.cwd, "GROVE.md");
-  const mdConfig = preset ? presetToGroveMdConfig(preset, options) : defaultGroveMdConfig(options);
-  const grovemdContent = buildGroveMd(mdConfig);
-  await writeFile(grovemdPath, grovemdContent, "utf-8");
-
-  // 6. Write grove.json
-  progress(4, "Writing configuration");
-  // Resolve backend mode: if preset prefers nexus, use it.
-  // - With explicit --nexus-url: external (unmanaged) Nexus
-  // - Without --nexus-url: grove-managed Nexus (grove up handles lifecycle)
-  //   The actual Nexus URL is discovered at `grove up` time via nexus.yaml,
-  //   so we don't write nexusUrl here — this avoids stale port references
-  //   when Nexus resolves port conflicts (nexus#2918).
-  const { writeGroveConfig } = await import("../../core/config.js");
-  const groveJsonPath = join(grovePath, "grove.json");
-  const preferredBackend = preset?.backend ?? "local";
-  let resolvedMode: "local" | "nexus" = "local";
-  let nexusManaged = false;
-  // Preserve existing nexusUrl from current grove.json when reinitializing.
-  // Without this, each "New session" drops the URL → startServices runs ensureNexusRunning
-  // (slow, may create duplicate compose projects) instead of reusing the existing Nexus.
-  let nexusUrl = options.nexusUrl;
-  if (!nexusUrl && existsSync(groveJsonPath)) {
-    try {
-      const existing = JSON.parse(readFileSync(groveJsonPath, "utf-8")) as { nexusUrl?: string };
-      if (existing.nexusUrl) nexusUrl = existing.nexusUrl;
-    } catch {
-      /* best-effort */
-    }
-  }
-  if (preferredBackend === "nexus") {
-    resolvedMode = "nexus";
+    // 6. Write grove.json
+    progress(4, "Writing configuration");
+    // Resolve backend mode: if preset prefers nexus, use it.
+    // - With explicit --nexus-url: external (unmanaged) Nexus
+    // - Without --nexus-url: grove-managed Nexus (grove up handles lifecycle)
+    //   The actual Nexus URL is discovered at `grove up` time via nexus.yaml,
+    //   so we don't write nexusUrl here — this avoids stale port references
+    //   when Nexus resolves port conflicts (nexus#2918).
+    const { writeGroveConfig } = await import("../../core/config.js");
+    const groveJsonPath = join(grovePath, "grove.json");
+    const preferredBackend = preset?.backend ?? "local";
+    let resolvedMode: "local" | "nexus" = "local";
+    let nexusManaged = false;
+    // Preserve existing nexusUrl from current grove.json when reinitializing.
+    // Without this, each "New session" drops the URL → startServices runs ensureNexusRunning
+    // (slow, may create duplicate compose projects) instead of reusing the existing Nexus.
+    let nexusUrl = options.nexusUrl;
     if (!nexusUrl) {
-      // No explicit URL — grove will manage Nexus lifecycle
-      nexusManaged = true;
+      try {
+        const existing = JSON.parse(await readFile(groveJsonPath, "utf-8")) as {
+          nexusUrl?: string;
+        };
+        if (existing.nexusUrl) nexusUrl = existing.nexusUrl;
+      } catch {
+        /* best-effort */
+      }
     }
-  }
-  writeGroveConfig(
-    {
-      name: options.name,
-      mode: resolvedMode,
-      preset: options.preset,
-      ...(nexusUrl ? { nexusUrl } : {}),
-      ...(nexusManaged ? { nexusManaged: true } : {}),
-      ...(nexusManaged && options.nexusChannel ? { nexusChannel: options.nexusChannel } : {}),
-      services: preset?.services ?? { server: false, mcp: false },
-    },
-    groveJsonPath,
-  );
+    if (preferredBackend === "nexus") {
+      resolvedMode = "nexus";
+      if (!nexusUrl) {
+        // No explicit URL — grove will manage Nexus lifecycle
+        nexusManaged = true;
+      }
+    }
+    writeGroveConfig(
+      {
+        name: options.name,
+        mode: resolvedMode,
+        preset: options.preset,
+        ...(nexusUrl ? { nexusUrl } : {}),
+        ...(nexusManaged ? { nexusManaged: true } : {}),
+        ...(nexusManaged && options.nexusChannel ? { nexusChannel: options.nexusChannel } : {}),
+        services: preset?.services ?? { server: false, mcp: false },
+      },
+      groveJsonPath,
+    );
 
-  // 6b. Initialize Nexus if grove-managed — but skip if one is already running
-  if (nexusManaged) {
-    try {
-      const { generateNexusYaml, inferNexusPreset, discoverRunningNexus } = await import(
-        "../nexus-lifecycle.js"
+    // 6b. Initialize Nexus if grove-managed — but skip if one is already running
+    if (nexusManaged) {
+      try {
+        const { generateNexusYaml, inferNexusPreset, discoverRunningNexus } = await import(
+          "../nexus-lifecycle.js"
+        );
+
+        // Reuse existing Nexus if any stack is running (avoid creating duplicate stacks).
+        // API key is read from .state.json (authoritative) via readNexusApiKey.
+        // Respect explicit GROVE_NEXUS_URL if already set (e.g., by user or parent process).
+        const existingUrl =
+          process.env.GROVE_NEXUS_URL ?? (await discoverRunningNexus(options.cwd));
+        if (existingUrl) {
+          if (!process.env.GROVE_NEXUS_URL) {
+            process.env.GROVE_NEXUS_URL = existingUrl;
+          }
+          const { readNexusApiKey } = await import("../nexus-lifecycle.js");
+          const key = readNexusApiKey(options.cwd);
+          if (key && !process.env.NEXUS_API_KEY) process.env.NEXUS_API_KEY = key;
+          console.log(`Reusing existing Nexus at ${existingUrl}`);
+        } else {
+          // Generate nexus.yaml directly — no nexus CLI required for initialization.
+          // `grove up` will shell out to `nexus up` to start the Docker stack.
+          const nexusPreset = inferNexusPreset({
+            name: options.name,
+            mode: resolvedMode,
+            preset: options.preset,
+          });
+          generateNexusYaml(options.cwd, {
+            preset: nexusPreset,
+            channel: options.nexusChannel,
+          });
+          const channel = options.nexusChannel ?? "edge";
+          console.log(`Initialized Nexus config (preset: ${nexusPreset}, channel: ${channel}).`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(`Warning: Nexus init failed (${msg}). 'grove up' will retry.`);
+      }
+    }
+
+    // 7. Seed demo contributions if preset defines them
+    progress(5, "Seeding data");
+    if (preset?.seedContributions && preset.seedContributions.length > 0) {
+      const { createContribution } = await import("../../core/manifest.js");
+      const { SqliteContributionStore } = await import("../../local/sqlite-store.js");
+
+      const store = new SqliteContributionStore(db);
+      const contributions = preset.seedContributions.map((seed) =>
+        createContribution({
+          kind: seed.kind,
+          mode: seed.mode,
+          summary: seed.summary,
+          artifacts: {},
+          relations: [],
+          tags: [...(seed.tags ?? [])],
+          agent: {
+            agentId: seed.agentId ?? "seed-agent",
+            // role is tracked via agentName for seed data (AgentIdentity
+            // schema in manifest.ts doesn't include role)
+            ...(seed.role ? { agentName: seed.role } : {}),
+          },
+          createdAt: new Date().toISOString(),
+        }),
       );
 
-      // Reuse existing Nexus if any stack is running (avoid creating duplicate stacks).
-      // API key is read from .state.json (authoritative) via readNexusApiKey.
-      // Respect explicit GROVE_NEXUS_URL if already set (e.g., by user or parent process).
-      const existingUrl = process.env.GROVE_NEXUS_URL ?? (await discoverRunningNexus(options.cwd));
-      if (existingUrl) {
-        if (!process.env.GROVE_NEXUS_URL) {
-          process.env.GROVE_NEXUS_URL = existingUrl;
-        }
-        const { readNexusApiKey } = await import("../nexus-lifecycle.js");
-        const key = readNexusApiKey(options.cwd);
-        if (key && !process.env.NEXUS_API_KEY) process.env.NEXUS_API_KEY = key;
-        console.log(`Reusing existing Nexus at ${existingUrl}`);
-      } else {
-        // Generate nexus.yaml directly — no nexus CLI required for initialization.
-        // `grove up` will shell out to `nexus up` to start the Docker stack.
-        const nexusPreset = inferNexusPreset({
-          name: options.name,
-          mode: resolvedMode,
-          preset: options.preset,
+      await store.putMany(contributions);
+      console.log(
+        `Seeded ${contributions.length} demo contribution(s) from preset '${options.preset}'`,
+      );
+    }
+
+    // 8. Ingest seed artifacts if provided
+    if (options.seed.length > 0) {
+      const { FsCas } = await import("../../local/fs-cas.js");
+      const { ingestFiles } = await import("../../local/ingest/files.js");
+      const { createContribution } = await import("../../core/manifest.js");
+      const { SqliteContributionStore } = await import("../../local/sqlite-store.js");
+
+      const cas = new FsCas(casPath);
+      const store = new SqliteContributionStore(db);
+      const agent = resolveAgent(options.agentOverrides);
+
+      const artifacts = await ingestFiles(cas, options.seed);
+
+      if (Object.keys(artifacts).length > 0) {
+        const contribution = createContribution({
+          kind: "work",
+          mode: options.mode,
+          summary: `Seed artifacts for ${options.name}`,
+          artifacts,
+          relations: [],
+          tags: ["seed"],
+          agent,
+          createdAt: new Date().toISOString(),
         });
-        generateNexusYaml(options.cwd, {
-          preset: nexusPreset,
-          channel: options.nexusChannel,
-        });
-        const channel = options.nexusChannel ?? "edge";
-        console.log(`Initialized Nexus config (preset: ${nexusPreset}, channel: ${channel}).`);
+
+        await store.put(contribution);
+        console.log(`Seeded ${Object.keys(artifacts).length} artifact(s) as ${contribution.cid}`);
       }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.log(`Warning: Nexus init failed (${msg}). 'grove up' will retry.`);
     }
+  } finally {
+    db.close();
   }
-
-  // 7. Seed demo contributions if preset defines them
-  progress(5, "Seeding data");
-  if (preset?.seedContributions && preset.seedContributions.length > 0) {
-    const { createContribution } = await import("../../core/manifest.js");
-    const { SqliteContributionStore } = await import("../../local/sqlite-store.js");
-
-    const store = new SqliteContributionStore(db);
-    const contributions = preset.seedContributions.map((seed) =>
-      createContribution({
-        kind: seed.kind,
-        mode: seed.mode,
-        summary: seed.summary,
-        artifacts: {},
-        relations: [],
-        tags: [...(seed.tags ?? [])],
-        agent: {
-          agentId: seed.agentId ?? "seed-agent",
-          // role is tracked via agentName for seed data (AgentIdentity
-          // schema in manifest.ts doesn't include role)
-          ...(seed.role ? { agentName: seed.role } : {}),
-        },
-        createdAt: new Date().toISOString(),
-      }),
-    );
-
-    await store.putMany(contributions);
-    console.log(
-      `Seeded ${contributions.length} demo contribution(s) from preset '${options.preset}'`,
-    );
-  }
-
-  // 8. Ingest seed artifacts if provided
-  if (options.seed.length > 0) {
-    const { FsCas } = await import("../../local/fs-cas.js");
-    const { ingestFiles } = await import("../../local/ingest/files.js");
-    const { createContribution } = await import("../../core/manifest.js");
-    const { SqliteContributionStore } = await import("../../local/sqlite-store.js");
-
-    const cas = new FsCas(casPath);
-    const store = new SqliteContributionStore(db);
-    const agent = resolveAgent(options.agentOverrides);
-
-    const artifacts = await ingestFiles(cas, options.seed);
-
-    if (Object.keys(artifacts).length > 0) {
-      const contribution = createContribution({
-        kind: "work",
-        mode: options.mode,
-        summary: `Seed artifacts for ${options.name}`,
-        artifacts,
-        relations: [],
-        tags: ["seed"],
-        agent,
-        createdAt: new Date().toISOString(),
-      });
-
-      await store.put(contribution);
-      console.log(`Seeded ${Object.keys(artifacts).length} artifact(s) as ${contribution.cid}`);
-    }
-  }
-
-  db.close();
 
   console.log(`Initialized grove '${options.name}' at ${grovePath}`);
   if (preset) {

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -76,26 +76,40 @@ export async function runLog(
       throw new Error("Outcome store is not available. Cannot filter by outcome.");
     }
 
-    // Fetch all matching contributions, filter by outcome, then sort and slice
+    // Fetch matching contributions, then evaluate outcomes in date-sorted
+    // chunks so we can stop once we have `limit` matches. This avoids loading
+    // and materializing outcomes for the entire history on every call.
     const contributions = await deps.store.list({
       kind: options.kind as ContributionKind | undefined,
       mode: options.mode as ContributionMode | undefined,
     });
 
-    const cids = contributions.map((c) => c.cid);
-    const outcomes = await deps.outcomeStore.getBatch(cids);
     const targetStatus = options.outcome as OutcomeStatus;
-    const filtered = contributions.filter((c) => {
-      const record = outcomes.get(c.cid);
-      return record !== undefined && record.status === targetStatus;
-    });
+    const sortedByRecency = [...contributions].sort(
+      (a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt),
+    );
 
-    const sorted = [...filtered]
-      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
-      .slice(0, options.limit);
+    const CHUNK_SIZE = 200;
+    const filtered: import("../../core/models.js").Contribution[] = [];
+    for (
+      let i = 0;
+      i < sortedByRecency.length && filtered.length < options.limit;
+      i += CHUNK_SIZE
+    ) {
+      const chunk = sortedByRecency.slice(i, i + CHUNK_SIZE);
+      const outcomes = await deps.outcomeStore.getBatch(chunk.map((c) => c.cid));
+      for (const contribution of chunk) {
+        const record = outcomes.get(contribution.cid);
+        if (record !== undefined && record.status === targetStatus) {
+          filtered.push(contribution);
+          if (filtered.length >= options.limit) break;
+        }
+      }
+    }
+    const limited = filtered.slice(0, options.limit);
 
     if (options.json) {
-      const summaries: ContributionSummary[] = sorted.map((c) => ({
+      const summaries: ContributionSummary[] = limited.map((c) => ({
         cid: c.cid,
         summary: c.summary,
         kind: c.kind,
@@ -108,7 +122,7 @@ export async function runLog(
       outputJson({ results: summaries, count: summaries.length });
       return;
     }
-    writer(formatContributions(sorted, { wide: options.wide }));
+    writer(formatContributions(limited, { wide: options.wide }));
     return;
   }
 

--- a/src/cli/commands/outcome.ts
+++ b/src/cli/commands/outcome.ts
@@ -322,6 +322,14 @@ async function runGet(args: OutcomeGetArgs, deps: OutcomeDeps): Promise<void> {
 }
 
 async function runList(args: OutcomeListArgs, deps: OutcomeDeps): Promise<void> {
+  if (args.status !== undefined && !OUTCOME_STATUSES.has(args.status)) {
+    deps.stderr(
+      `Error: invalid status '${args.status}'. Must be one of: ${[...OUTCOME_STATUSES].join(", ")}`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+
   const result = await listOutcomesOperation(
     {
       ...(args.status !== undefined ? { status: args.status as OutcomeRecord["status"] } : {}),
@@ -331,8 +339,7 @@ async function runList(args: OutcomeListArgs, deps: OutcomeDeps): Promise<void> 
   );
 
   if (!result.ok) {
-    deps.stderr(`Error: ${result.error.message}`);
-    process.exitCode = 1;
+    handleOperationError(result.error, args.json);
     return;
   }
 
@@ -350,8 +357,7 @@ async function runStats(args: OutcomeStatsArgs, deps: OutcomeDeps): Promise<void
   const result = await outcomeStatsOperation(toOpDeps(deps));
 
   if (!result.ok) {
-    deps.stderr(`Error: ${result.error.message}`);
-    process.exitCode = 1;
+    handleOperationError(result.error, args.json);
     return;
   }
 

--- a/src/cli/commands/reproduce.ts
+++ b/src/cli/commands/reproduce.ts
@@ -7,9 +7,12 @@
  *   grove reproduce blake3:abc123 --summary "Partial" --result partial --json
  */
 
+import { join } from "node:path";
 import { parseArgs } from "node:util";
+import { EnforcingContributionStore } from "../../core/enforcing-store.js";
 import { DefaultFrontierCalculator } from "../../core/frontier.js";
 import type { Score } from "../../core/models.js";
+import { ScoreDirection } from "../../core/models.js";
 import type { OperationDeps } from "../../core/operations/deps.js";
 import { reproduceOperation } from "../../core/operations/index.js";
 import { FsCas } from "../../local/fs-cas.js";
@@ -17,13 +20,18 @@ import { createSqliteStores } from "../../local/sqlite-store.js";
 import { resolveAgent } from "../agent.js";
 import { outputJson, outputJsonError } from "../format.js";
 import { resolveGroveDir } from "../utils/grove-dir.js";
+import { resolveContract } from "../utils/resolve-contract.js";
 
 export interface ReproduceOptions {
   readonly targetCid: string;
   readonly summary: string;
   readonly description?: string | undefined;
   readonly result: "confirmed" | "challenged" | "partial";
-  readonly scores: Readonly<Record<string, Score>>;
+  /**
+   * Raw parsed scores as name→value. Direction is deferred to `runReproduce`
+   * so we can honor the GROVE.md contract's metric direction when available.
+   */
+  readonly scores: Readonly<Record<string, number>>;
   readonly tags: readonly string[];
   readonly json: boolean;
 }
@@ -69,8 +77,10 @@ export function parseReproduceArgs(args: readonly string[]): ReproduceOptions {
     );
   }
 
-  // Parse scores from "name=value" format
-  const scores: Record<string, Score> = {};
+  // Parse scores from "name=value" format. Direction is resolved later
+  // against the contract (see runReproduce) so a metric configured as
+  // `minimize` in GROVE.md is not silently recorded as maximize.
+  const scores: Record<string, number> = {};
   for (const s of values.score as string[]) {
     const eq = s.indexOf("=");
     if (eq === -1) {
@@ -81,7 +91,7 @@ export function parseReproduceArgs(args: readonly string[]): ReproduceOptions {
     if (Number.isNaN(value)) {
       throw new Error(`Invalid score value for '${name}': not a number`);
     }
-    scores[name] = { value, direction: "maximize" };
+    scores[name] = value;
   }
 
   return {
@@ -102,17 +112,38 @@ export async function runReproduce(
 ): Promise<void> {
   const { dbPath, groveDir } = resolveGroveDir(groveOverride);
   const stores = createSqliteStores(dbPath);
-  const cas = new FsCas(`${groveDir}/cas`);
+  const cas = new FsCas(join(groveDir, "cas"));
   const frontier = new DefaultFrontierCalculator(stores.contributionStore);
 
   try {
+    // Resolve the contract so reproductions go through the same enforcement
+    // pipeline as contribute/discuss/review/inbox.
+    const contract = await resolveContract({
+      goalSessionStore: stores.goalSessionStore,
+      groveRoot: join(groveDir, ".."),
+      envSessionId: process.env.GROVE_SESSION_ID,
+    });
+
+    const contributionStore = contract
+      ? new EnforcingContributionStore(stores.contributionStore, contract, { cas })
+      : stores.contributionStore;
+
     const agent = resolveAgent();
     const opDeps: OperationDeps = {
-      contributionStore: stores.contributionStore,
+      contributionStore,
       claimStore: stores.claimStore,
       cas,
       frontier,
+      ...(contract !== undefined ? { contract } : {}),
     };
+
+    // Resolve score directions from the contract (defaults to maximize
+    // when unknown) so minimize-metrics aren't inverted.
+    const resolvedScores: Record<string, Score> = {};
+    for (const [name, value] of Object.entries(options.scores)) {
+      const direction = contract?.metrics?.[name]?.direction ?? ScoreDirection.Maximize;
+      resolvedScores[name] = { value, direction };
+    }
 
     const result = await reproduceOperation(
       {
@@ -120,7 +151,7 @@ export async function runReproduce(
         summary: options.summary,
         ...(options.description !== undefined ? { description: options.description } : {}),
         result: options.result,
-        ...(Object.keys(options.scores).length > 0 ? { scores: options.scores } : {}),
+        ...(Object.keys(resolvedScores).length > 0 ? { scores: resolvedScores } : {}),
         ...(options.tags.length > 0 ? { tags: options.tags } : {}),
         agent: { agentId: agent.agentId },
       },

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -7,9 +7,12 @@
  *   grove review blake3:abc123 --summary "Needs work" --score quality=0.3 --json
  */
 
+import { join } from "node:path";
 import { parseArgs } from "node:util";
+import { EnforcingContributionStore } from "../../core/enforcing-store.js";
 import { DefaultFrontierCalculator } from "../../core/frontier.js";
 import type { Score } from "../../core/models.js";
+import { ScoreDirection } from "../../core/models.js";
 import type { OperationDeps } from "../../core/operations/deps.js";
 import { reviewOperation } from "../../core/operations/index.js";
 import { FsCas } from "../../local/fs-cas.js";
@@ -17,12 +20,18 @@ import { createSqliteStores } from "../../local/sqlite-store.js";
 import { resolveAgent } from "../agent.js";
 import { outputJson, outputJsonError } from "../format.js";
 import { resolveGroveDir } from "../utils/grove-dir.js";
+import { resolveContract } from "../utils/resolve-contract.js";
 
 export interface ReviewOptions {
   readonly targetCid: string;
   readonly summary: string;
   readonly description?: string | undefined;
-  readonly scores: Readonly<Record<string, Score>>;
+  /**
+   * Raw parsed scores as name→value. Direction is deferred to `runReview`
+   * so we can honor the GROVE.md contract's metric direction when available,
+   * rather than blindly defaulting to maximize.
+   */
+  readonly scores: Readonly<Record<string, number>>;
   readonly tags: readonly string[];
   readonly json: boolean;
 }
@@ -60,8 +69,10 @@ export function parseReviewArgs(args: readonly string[]): ReviewOptions {
     throw new Error("--summary is required for grove review");
   }
 
-  // Parse scores from "name=value" format
-  const scores: Record<string, Score> = {};
+  // Parse scores from "name=value" format. Direction is resolved later
+  // against the contract (see runReview) so a metric configured as
+  // `minimize` in GROVE.md is not silently recorded as maximize.
+  const scores: Record<string, number> = {};
   for (const s of values.score as string[]) {
     const eq = s.indexOf("=");
     if (eq === -1) {
@@ -72,7 +83,7 @@ export function parseReviewArgs(args: readonly string[]): ReviewOptions {
     if (Number.isNaN(value)) {
       throw new Error(`Invalid score value for '${name}': not a number`);
     }
-    scores[name] = { value, direction: "maximize" };
+    scores[name] = value;
   }
 
   return {
@@ -89,24 +100,46 @@ export function parseReviewArgs(args: readonly string[]): ReviewOptions {
 export async function runReview(options: ReviewOptions, groveOverride?: string): Promise<void> {
   const { dbPath, groveDir } = resolveGroveDir(groveOverride);
   const stores = createSqliteStores(dbPath);
-  const cas = new FsCas(`${groveDir}/cas`);
+  const cas = new FsCas(join(groveDir, "cas"));
   const frontier = new DefaultFrontierCalculator(stores.contributionStore);
 
   try {
+    // Resolve the contract so reviews go through the same enforcement
+    // pipeline as contribute/discuss/inbox. Without this, GROVE.md rate
+    // limits and role-kind rules silently don't apply to reviews.
+    const contract = await resolveContract({
+      goalSessionStore: stores.goalSessionStore,
+      groveRoot: join(groveDir, ".."),
+      envSessionId: process.env.GROVE_SESSION_ID,
+    });
+
+    const contributionStore = contract
+      ? new EnforcingContributionStore(stores.contributionStore, contract, { cas })
+      : stores.contributionStore;
+
     const agent = resolveAgent();
     const opDeps: OperationDeps = {
-      contributionStore: stores.contributionStore,
+      contributionStore,
       claimStore: stores.claimStore,
       cas,
       frontier,
+      ...(contract !== undefined ? { contract } : {}),
     };
+
+    // Resolve score directions from the contract (defaults to maximize
+    // when unknown) so minimize-metrics aren't inverted.
+    const resolvedScores: Record<string, Score> = {};
+    for (const [name, value] of Object.entries(options.scores)) {
+      const direction = contract?.metrics?.[name]?.direction ?? ScoreDirection.Maximize;
+      resolvedScores[name] = { value, direction };
+    }
 
     const result = await reviewOperation(
       {
         targetCid: options.targetCid,
         summary: options.summary,
         ...(options.description !== undefined ? { description: options.description } : {}),
-        ...(Object.keys(options.scores).length > 0 ? { scores: options.scores } : {}),
+        ...(Object.keys(resolvedScores).length > 0 ? { scores: resolvedScores } : {}),
         ...(options.tags.length > 0 ? { tags: options.tags } : {}),
         agent: { agentId: agent.agentId },
       },

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -111,17 +111,18 @@ export async function runSearch(
       return;
     }
 
-    // Fetch full Contribution objects for display formatting
-    const cids = result.value.results.map((r) => r.cid);
+    // Fetch only the top-N recency-sorted CIDs we will actually display.
+    // The operation already returns summaries that include createdAt, so we can
+    // sort/slice at summary level and avoid loading all full rows.
+    const cids = [...result.value.results]
+      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
+      .slice(0, options.limit)
+      .map((r) => r.cid);
     const fullMap = await deps.store.getMany(cids);
     const full = cids
       .map((cid) => fullMap.get(cid))
       .filter((c): c is import("../../core/models.js").Contribution => c !== undefined);
-    const sorted = [...full]
-      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
-      .slice(0, options.limit);
-
-    writer(formatContributions(sorted, { wide: options.wide }));
+    writer(formatContributions(full, { wide: options.wide }));
     return;
   }
 
@@ -136,21 +137,27 @@ export async function runSearch(
       .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
       .slice(0, options.limit);
   } else if (options.sort === "adoption") {
-    // Count adoption + derives_from relations pointing at each result
-    const allContributions = await deps.store.list();
+    // Count adoption + derives_from edges pointing at each result without
+    // scanning the entire DAG. We query incoming relations per candidate.
     const adoptionCounts = new Map<string, number>();
     for (const r of results) {
       adoptionCounts.set(r.cid, 0);
     }
-    for (const c of allContributions) {
-      for (const rel of c.relations) {
-        if (
-          (rel.relationType === "adopts" || rel.relationType === "derives_from") &&
-          adoptionCounts.has(rel.targetCid)
-        ) {
-          adoptionCounts.set(rel.targetCid, (adoptionCounts.get(rel.targetCid) ?? 0) + 1);
-        }
+    const incomingLists = await Promise.all(results.map((r) => deps.store.relatedTo(r.cid)));
+    for (let i = 0; i < results.length; i++) {
+      const resultItem = results[i];
+      if (resultItem === undefined) continue;
+      const incoming = incomingLists[i] ?? [];
+      let count = 0;
+      for (const child of incoming) {
+        const relevant = child.relations.some(
+          (rel) =>
+            rel.targetCid === resultItem.cid &&
+            (rel.relationType === "adopts" || rel.relationType === "derives_from"),
+        );
+        if (relevant) count += 1;
       }
+      adoptionCounts.set(resultItem.cid, count);
     }
     results = [...results]
       .sort((a, b) => (adoptionCounts.get(b.cid) ?? 0) - (adoptionCounts.get(a.cid) ?? 0))

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -153,86 +153,109 @@ async function sessionStart(args: readonly string[]): Promise<void> {
   // Open SQLite database and create session
   const { initSqliteDb } = await import("../../local/sqlite-store.js");
   const db = initSqliteDb(join(groveDir, "grove.db"));
+
+  // Everything below must run under try/finally so db.close() always fires.
+  // Signal handlers are installed early (before orchestrator.start) so a
+  // Ctrl-C during startup still records a stopReason.
+  let shuttingDown = false;
+  const sigintHandler = () => void handleSignal(130, "User interrupted (SIGINT)");
+  const sigtermHandler = () => void handleSignal(143, "Terminated (SIGTERM)");
+  let sessionId: string | undefined;
   const goalSessionStore = new SqliteGoalSessionStore(db);
 
-  const session = await goalSessionStore.createSession({
-    goal,
-    presetName: presetName ?? contract?.name,
-    topology: resolution.topology,
-    config: contract,
-  });
-
-  // Create contribution store for polling-based routing (MCP runs in child processes)
-  const { SqliteContributionStore } = await import("../../local/sqlite-store.js");
-  const contributionStore = new SqliteContributionStore(db);
-
-  const orchestrator = new SessionOrchestrator({
-    goal,
-    contract: contract ?? { contractVersion: 3, name: presetName ?? "default" },
-    topology: resolution.topology,
-    runtime,
-    eventBus,
-    projectRoot: groveRoot,
-    workspaceBaseDir: join(groveDir, "workspaces"),
-    sessionId: session.id,
-    contributionStore,
-  });
-
-  let status: import("../../core/session-orchestrator.js").SessionStatus;
-  try {
-    status = await orchestrator.start();
-  } catch (err) {
-    // Mark session as cancelled on spawn failure
-    await goalSessionStore.archiveSession(session.id);
-    db.close();
-    throw err;
-  }
-
-  // Register cleanup: mark session completed/cancelled on exit
-  const markDone = async (reason: string) => {
+  const markDone = async (reason: string): Promise<void> => {
+    if (sessionId === undefined) return;
     try {
-      await goalSessionStore.updateSession(session.id, {
+      await goalSessionStore.updateSession(sessionId, {
         status: "completed",
         completedAt: new Date().toISOString(),
         stopReason: reason,
       });
     } catch {
-      // Best-effort — DB may already be closed
+      // Best-effort — DB may already be closed or session archived.
     }
   };
 
-  process.on("SIGINT", () => {
-    void markDone("User interrupted (SIGINT)").then(() => {
-      db.close();
-      process.exit(130);
-    });
-  });
-  process.on("SIGTERM", () => {
-    void markDone("Terminated (SIGTERM)").then(() => {
-      db.close();
-      process.exit(143);
-    });
-  });
+  const handleSignal = async (exitCode: number, reason: string): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    try {
+      await markDone(reason);
+    } finally {
+      try {
+        db.close();
+      } catch {
+        /* already closed */
+      }
+      process.exit(exitCode);
+    }
+  };
 
-  // Output initial status
-  outputJson({
-    sessionId: session.id,
-    goal,
-    preset: presetName ?? contract?.name,
-    agents: status.agents.map((a) => ({
-      role: a.role,
-      sessionId: a.session.id,
-      status: a.session.status,
-    })),
-    message: `Session started with ${status.agents.length} agents`,
-  });
+  process.on("SIGINT", sigintHandler);
+  process.on("SIGTERM", sigtermHandler);
 
-  // Wait for session to complete — agents need time to work, submit, review, and call grove_done.
-  // Without this, the CLI exits immediately and the reviewer never gets routed events.
-  const SESSION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-  const stopReason = await orchestrator.waitForCompletion(SESSION_TIMEOUT_MS);
-  await markDone(stopReason);
-  db.close();
+  try {
+    const session = await goalSessionStore.createSession({
+      goal,
+      presetName: presetName ?? contract?.name,
+      topology: resolution.topology,
+      config: contract,
+    });
+    sessionId = session.id;
+
+    // Create contribution store for polling-based routing (MCP runs in child processes)
+    const { SqliteContributionStore } = await import("../../local/sqlite-store.js");
+    const contributionStore = new SqliteContributionStore(db);
+
+    const orchestrator = new SessionOrchestrator({
+      goal,
+      contract: contract ?? { contractVersion: 3, name: presetName ?? "default" },
+      topology: resolution.topology,
+      runtime,
+      eventBus,
+      projectRoot: groveRoot,
+      workspaceBaseDir: join(groveDir, "workspaces"),
+      sessionId: session.id,
+      contributionStore,
+    });
+
+    let status: import("../../core/session-orchestrator.js").SessionStatus;
+    try {
+      status = await orchestrator.start();
+    } catch (err) {
+      // Mark session as cancelled on spawn failure. The outer finally still
+      // closes db and removes signal listeners.
+      await goalSessionStore.archiveSession(session.id);
+      throw err;
+    }
+
+    // Output initial status
+    outputJson({
+      sessionId: session.id,
+      goal,
+      preset: presetName ?? contract?.name,
+      agents: status.agents.map((a) => ({
+        role: a.role,
+        sessionId: a.session.id,
+        status: a.session.status,
+      })),
+      message: `Session started with ${status.agents.length} agents`,
+    });
+
+    // Wait for session to complete — agents need time to work, submit, review, and call grove_done.
+    // Without this, the CLI exits immediately and the reviewer never gets routed events.
+    const SESSION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+    const stopReason = await orchestrator.waitForCompletion(SESSION_TIMEOUT_MS);
+    await markDone(stopReason);
+  } finally {
+    process.removeListener("SIGINT", sigintHandler);
+    process.removeListener("SIGTERM", sigtermHandler);
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -338,12 +361,6 @@ async function sessionStop(args: readonly string[]): Promise<void> {
 
     // Find the latest active session and archive it
     const sessions = await store.listSessions({ status: "active" });
-    if (sessions.length === 0) {
-      outputJson({ message: "No active session to stop" });
-      db.close();
-      return;
-    }
-
     const latest = sessions[0];
     if (!latest) {
       outputJson({ message: "No active session to stop" });

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -99,14 +99,20 @@ export async function handleSkillInstall(args: SkillInstallArgs): Promise<void> 
 
   const content = renderSkillTemplate({ serverUrl, mcpUrl });
 
-  const written: string[] = [];
-  for (const target of targets) {
-    const dir = resolvePath(target.path);
-    await mkdir(dir, { recursive: true });
-    const filePath = join(dir, "SKILL.md");
-    await writeFile(filePath, content, "utf-8");
-    written.push(filePath);
-    console.log(`  ${target.platform}: ${filePath}`);
+  // Installs are independent across targets — parallelize the mkdir/write
+  // so the common case of 2-3 targets doesn't serialize fs round-trips.
+  const written = await Promise.all(
+    targets.map(async (target) => {
+      const dir = resolvePath(target.path);
+      await mkdir(dir, { recursive: true });
+      const filePath = join(dir, "SKILL.md");
+      await writeFile(filePath, content, "utf-8");
+      return { platform: target.platform, filePath };
+    }),
+  );
+
+  for (const { platform, filePath } of written) {
+    console.log(`  ${platform}: ${filePath}`);
   }
 
   console.log(`\nInstalled SKILL.md to ${written.length} target(s).`);

--- a/src/cli/commands/tree.ts
+++ b/src/cli/commands/tree.ts
@@ -65,7 +65,7 @@ async function collectSubgraph(
 
   while (frontier.length > 0) {
     // Batch-fetch all nodes in the current frontier that we haven't seen yet.
-    const current = frontier.filter((f) => !visited.has(f.cid) && f.depth <= maxDepth);
+    const current = dedupeByCid(frontier).filter((f) => !visited.has(f.cid) && f.depth <= maxDepth);
     const toFetch = current.map((f) => f.cid);
     const fetched =
       toFetch.length > 0 ? await deps.store.getMany(toFetch) : new Map<string, Contribution>();
@@ -80,7 +80,14 @@ async function collectSubgraph(
       }
     }
 
-    const nextFrontier: { cid: string; depth: number }[] = [];
+    const nextFrontier = new Map<string, number>();
+    const enqueue = (cid: string, depth: number): void => {
+      if (visited.has(cid)) return;
+      const prev = nextFrontier.get(cid);
+      if (prev === undefined || depth < prev) {
+        nextFrontier.set(cid, depth);
+      }
+    };
 
     // Outgoing edges live on the contribution — no DB call needed.
     for (const { depth, contribution } of expandable) {
@@ -89,7 +96,7 @@ async function collectSubgraph(
           (rel.relationType === "derives_from" || rel.relationType === "adopts") &&
           !visited.has(rel.targetCid)
         ) {
-          nextFrontier.push({ cid: rel.targetCid, depth: depth + 1 });
+          enqueue(rel.targetCid, depth + 1);
         }
       }
     }
@@ -110,15 +117,29 @@ async function collectSubgraph(
               rel.relationType === RelationType.Adopts),
         );
         if (hasEdge) {
-          nextFrontier.push({ cid: child.cid, depth: node.depth + 1 });
+          enqueue(child.cid, node.depth + 1);
         }
       }
     }
 
-    frontier = nextFrontier;
+    frontier = [...nextFrontier.entries()].map(([cid, depth]) => ({ cid, depth }));
   }
 
   return [...visited.values()];
+}
+
+function dedupeByCid(nodes: readonly { cid: string; depth: number }[]): readonly {
+  cid: string;
+  depth: number;
+}[] {
+  const byCid = new Map<string, number>();
+  for (const node of nodes) {
+    const prev = byCid.get(node.cid);
+    if (prev === undefined || node.depth < prev) {
+      byCid.set(node.cid, node.depth);
+    }
+  }
+  return [...byCid.entries()].map(([cid, depth]) => ({ cid, depth }));
 }
 
 export async function runTree(

--- a/src/cli/commands/tree.ts
+++ b/src/cli/commands/tree.ts
@@ -12,10 +12,8 @@ import { parseArgs } from "node:util";
 
 import type { Contribution } from "../../core/models.js";
 import { RelationType } from "../../core/models.js";
-import { treeOperation } from "../../core/operations/index.js";
 import type { CliDeps, Writer } from "../context.js";
 import { contributionsToDagNodes, formatDag, renderDag } from "../format-dag.js";
-import { toOperationDeps } from "../operation-adapter.js";
 
 const DEFAULT_DEPTH = 10;
 
@@ -51,7 +49,11 @@ export function parseTreeArgs(argv: string[]): TreeOptions {
 
 /**
  * Collect contributions reachable from a starting CID within a depth limit.
- * Performs a BFS over derives_from and adopts relations (outgoing edges).
+ * Performs a level-wise BFS over derives_from and adopts edges, batching
+ * `store.get` / `store.relatedTo` to avoid N+1 round-trips on deep graphs.
+ *
+ * For each visited node we already have the outgoing relations in memory
+ * (on the fetched Contribution), so only incoming edges need a DB call.
  */
 async function collectSubgraph(
   deps: CliDeps,
@@ -59,36 +61,61 @@ async function collectSubgraph(
   maxDepth: number,
 ): Promise<readonly Contribution[]> {
   const visited = new Map<string, Contribution>();
-  const queue: { cid: string; depth: number }[] = [{ cid: fromCid, depth: 0 }];
+  let frontier: readonly { cid: string; depth: number }[] = [{ cid: fromCid, depth: 0 }];
 
-  while (queue.length > 0) {
-    const item = queue.shift();
-    if (item === undefined) break;
-    if (visited.has(item.cid) || item.depth > maxDepth) continue;
+  while (frontier.length > 0) {
+    // Batch-fetch all nodes in the current frontier that we haven't seen yet.
+    const current = frontier.filter((f) => !visited.has(f.cid) && f.depth <= maxDepth);
+    const toFetch = current.map((f) => f.cid);
+    const fetched =
+      toFetch.length > 0 ? await deps.store.getMany(toFetch) : new Map<string, Contribution>();
 
-    const contribution = await deps.store.get(item.cid);
-    if (contribution === undefined) continue;
-
-    visited.set(item.cid, contribution);
-
-    // Follow derives_from and adopts edges (ancestors)
-    for (const rel of contribution.relations) {
-      if (
-        (rel.relationType === "derives_from" || rel.relationType === "adopts") &&
-        !visited.has(rel.targetCid)
-      ) {
-        queue.push({ cid: rel.targetCid, depth: item.depth + 1 });
+    const expandable: Array<{ cid: string; depth: number; contribution: Contribution }> = [];
+    for (const { cid, depth } of current) {
+      const contribution = fetched.get(cid);
+      if (contribution === undefined) continue;
+      visited.set(cid, contribution);
+      if (depth < maxDepth) {
+        expandable.push({ cid, depth, contribution });
       }
     }
 
-    // Follow incoming derives_from and adopts edges (children of this node)
-    const derivesChildren = await deps.store.relatedTo(item.cid, RelationType.DerivesFrom);
-    const adoptsChildren = await deps.store.relatedTo(item.cid, RelationType.Adopts);
-    for (const child of [...derivesChildren, ...adoptsChildren]) {
-      if (!visited.has(child.cid)) {
-        queue.push({ cid: child.cid, depth: item.depth + 1 });
+    const nextFrontier: { cid: string; depth: number }[] = [];
+
+    // Outgoing edges live on the contribution — no DB call needed.
+    for (const { depth, contribution } of expandable) {
+      for (const rel of contribution.relations) {
+        if (
+          (rel.relationType === "derives_from" || rel.relationType === "adopts") &&
+          !visited.has(rel.targetCid)
+        ) {
+          nextFrontier.push({ cid: rel.targetCid, depth: depth + 1 });
+        }
       }
     }
+
+    // Incoming edges: fetch all current frontier nodes in parallel, then
+    // filter for derives_from/adopts in memory.
+    const incomingLists = await Promise.all(expandable.map((n) => deps.store.relatedTo(n.cid)));
+    for (let i = 0; i < expandable.length; i++) {
+      const node = expandable[i];
+      if (node === undefined) continue;
+      const incoming = incomingLists[i] ?? [];
+      for (const child of incoming) {
+        if (visited.has(child.cid)) continue;
+        const hasEdge = child.relations.some(
+          (rel) =>
+            rel.targetCid === node.cid &&
+            (rel.relationType === RelationType.DerivesFrom ||
+              rel.relationType === RelationType.Adopts),
+        );
+        if (hasEdge) {
+          nextFrontier.push({ cid: child.cid, depth: node.depth + 1 });
+        }
+      }
+    }
+
+    frontier = nextFrontier;
   }
 
   return [...visited.values()];
@@ -102,18 +129,12 @@ export async function runTree(
   let contributions: readonly Contribution[];
 
   if (options.from !== undefined) {
-    // Use the treeOperation to validate the CID exists, then collect full subgraph
-    // for DAG rendering (the operation only returns summaries, but we need full
-    // Contribution objects for the DAG renderer).
-    const result = await treeOperation(
-      { cid: options.from, direction: "both" },
-      toOperationDeps(deps),
-    );
-
-    if (!result.ok) {
+    // Validate the CID exists before walking. Previously this double-walked:
+    // one traversal via treeOperation, then another in collectSubgraph.
+    const root = await deps.store.get(options.from);
+    if (root === undefined) {
       throw new Error(`Contribution '${options.from}' not found.`);
     }
-
     contributions = await collectSubgraph(deps, options.from, options.depth);
   } else {
     // Full graph

--- a/src/cli/commands/up.ts
+++ b/src/cli/commands/up.ts
@@ -136,9 +136,10 @@ export async function handleUp(args: readonly string[], groveOverride?: string):
           `[cleanup] expired ${result.expiredClaims} stale claim(s), cleaned ${result.cleanedClaims} old claim(s)\n`,
         );
       }
-    } catch {
-      // Cleanup errors are non-fatal — log and continue
-      process.stderr.write("[cleanup] claim cleanup failed\n");
+    } catch (err) {
+      // Cleanup errors are non-fatal — log the cause so operators can debug
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[cleanup] claim cleanup failed: ${msg}\n`);
     }
   }, CLAIM_CLEANUP_INTERVAL_MS);
 
@@ -153,25 +154,40 @@ export async function handleUp(args: readonly string[], groveOverride?: string):
           `[cleanup] garbage-collected ${result.deletedBlobs} unreferenced blob(s)\n`,
         );
       }
-    } catch {
-      // GC errors are non-fatal — log and continue
-      process.stderr.write("[cleanup] artifact GC failed\n");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[cleanup] artifact GC failed: ${msg}\n`);
     }
   }, ARTIFACT_GC_INTERVAL_MS);
 
-  const shutdown = async () => {
-    process.stderr.write("\nShutting down...\n");
-    clearInterval(claimCleanupTimer);
-    clearInterval(artifactGcTimer);
-    runtime.close();
-    await stopServices(services);
+  // shutdown() is idempotent: concurrent signal and child-exit paths race for
+  // teardown, and both should converge on a single clean stop. Without the
+  // guard, stopServices runs twice (once per caller) and can double-kill.
+  let shutdownPromise: Promise<void> | undefined;
+  const shutdown = (): Promise<void> => {
+    if (shutdownPromise) return shutdownPromise;
+    shutdownPromise = (async () => {
+      process.stderr.write("\nShutting down...\n");
+      clearInterval(claimCleanupTimer);
+      clearInterval(artifactGcTimer);
+      runtime.close();
+      await stopServices(services);
+    })();
+    return shutdownPromise;
   };
-  process.on("SIGINT", () => {
-    shutdown().then(() => process.exit(0));
-  });
-  process.on("SIGTERM", () => {
-    shutdown().then(() => process.exit(0));
-  });
+
+  const runShutdownAndExit = (code: number): void => {
+    shutdown().then(
+      () => process.exit(code),
+      (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[shutdown] failed: ${msg}\n`);
+        process.exit(1);
+      },
+    );
+  };
+  process.on("SIGINT", () => runShutdownAndExit(0));
+  process.on("SIGTERM", () => runShutdownAndExit(0));
 
   try {
     if (services.children.length > 0) {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -36,6 +36,7 @@ import { parseSearchArgs, runSearch } from "./commands/search.js";
 import { parseThreadArgs, runThread } from "./commands/thread.js";
 import { parseThreadsArgs, runThreads } from "./commands/threads.js";
 import { parseTreeArgs, runTree } from "./commands/tree.js";
+import { handleVersion } from "./commands/version.js";
 import { initCliDeps } from "./context.js";
 import { UsageError } from "./errors.js";
 import { resolveGroveDir } from "./utils/grove-dir.js";
@@ -283,6 +284,17 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "export-dag",
+      description: "Export contribution DAG as JSON",
+      needsStore: false,
+      handler: async (args) => {
+        const { parseExportDagArgs, runExportDag } = await import("./commands/export-dag.js");
+        await withCliDeps(async (a, deps) => {
+          await runExportDag(parseExportDagArgs([...a]), deps);
+        }, args);
+      },
+    },
+    {
       name: "gossip",
       description: "Gossip protocol commands",
       needsStore: false,
@@ -420,11 +432,22 @@ async function main(): Promise<void> {
   let groveOverride: string | undefined;
   const args: string[] = [];
   for (let i = 0; i < rawArgs.length; i++) {
-    if (rawArgs[i] === "--grove" && i + 1 < rawArgs.length) {
-      groveOverride = rawArgs[i + 1];
-      i++; // skip value
+    const token = rawArgs[i] ?? "";
+    if (token === "--grove") {
+      const value = rawArgs[i + 1];
+      if (!value) {
+        throw new UsageError("--grove requires a path value");
+      }
+      groveOverride = value;
+      i++; // skip consumed value
+    } else if (token.startsWith("--grove=")) {
+      const value = token.slice("--grove=".length);
+      if (!value) {
+        throw new UsageError("--grove requires a non-empty path value");
+      }
+      groveOverride = value;
     } else {
-      args.push(rawArgs[i] ?? "");
+      args.push(token);
     }
   }
 
@@ -444,7 +467,7 @@ async function main(): Promise<void> {
   }
 
   if (first === "--version" || first === "-v") {
-    console.log("grove 0.1.0");
+    handleVersion();
     return;
   }
 
@@ -509,6 +532,7 @@ Navigation:
   grove log [-n <count>]               Recent contributions
   grove frontier [--metric <name>]     Show current frontier
   grove tree [--from <cid>]            DAG visualization
+  grove export-dag [options]           Export contribution DAG as JSON
   grove search [--query <text>]        Search contributions
   grove checkout <cid> --to <dir>      Materialize contribution artifacts
   grove thread <cid>                   View a discussion thread

--- a/src/cli/presets/index.ts
+++ b/src/cli/presets/index.ts
@@ -14,6 +14,12 @@ import type {
   MetricEntry,
   StopConditionsConfig,
 } from "../grove-md-builder.js";
+import { explorationPreset } from "./exploration.js";
+import { federatedSwarmPreset } from "./federated-swarm.js";
+import { prReviewPreset } from "./pr-review.js";
+import { researchLoopPreset } from "./research-loop.js";
+import { reviewLoopPreset } from "./review-loop.js";
+import { swarmOpsPreset } from "./swarm-ops.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,28 +70,20 @@ export interface PresetConfig extends CorePresetConfig {
 // Registry
 // ---------------------------------------------------------------------------
 
-export { explorationPreset } from "./exploration.js";
-export { federatedSwarmPreset } from "./federated-swarm.js";
-export { prReviewPreset } from "./pr-review.js";
-export { researchLoopPreset } from "./research-loop.js";
-export { reviewLoopPreset } from "./review-loop.js";
-export { swarmOpsPreset } from "./swarm-ops.js";
+export {
+  explorationPreset,
+  federatedSwarmPreset,
+  prReviewPreset,
+  researchLoopPreset,
+  reviewLoopPreset,
+  swarmOpsPreset,
+};
 
 let _registry: Readonly<Record<string, PresetConfig>> | undefined;
 
 /** All available presets indexed by name (memoized after first call). */
 export function getPresetRegistry(): Readonly<Record<string, PresetConfig>> {
   if (_registry) return _registry;
-
-  // Lazy import to avoid circular deps and keep startup fast
-  const { reviewLoopPreset } = require("./review-loop.js") as typeof import("./review-loop.js");
-  const { explorationPreset } = require("./exploration.js") as typeof import("./exploration.js");
-  const { swarmOpsPreset } = require("./swarm-ops.js") as typeof import("./swarm-ops.js");
-  const { researchLoopPreset } =
-    require("./research-loop.js") as typeof import("./research-loop.js");
-  const { prReviewPreset } = require("./pr-review.js") as typeof import("./pr-review.js");
-  const { federatedSwarmPreset } =
-    require("./federated-swarm.js") as typeof import("./federated-swarm.js");
 
   _registry = {
     "review-loop": reviewLoopPreset,

--- a/src/cli/utils/grove-dir.test.ts
+++ b/src/cli/utils/grove-dir.test.ts
@@ -35,13 +35,28 @@ describe("resolveGroveDir", () => {
   });
 
   test("explicit override takes priority over GROVE_DIR", async () => {
-    const dir1 = join(tempDir, "one");
-    const dir2 = join(tempDir, "two");
-    await mkdir(dir1);
-    await mkdir(dir2);
+    const dir1 = join(tempDir, "one", ".grove");
+    const dir2 = join(tempDir, "two", ".grove");
+    await mkdir(dir1, { recursive: true });
+    await mkdir(dir2, { recursive: true });
     process.env.GROVE_DIR = dir2;
     const result = resolveGroveDir(dir1);
     expect(result.groveDir).toBe(dir1);
+  });
+
+  test("accepts override pointing at repo root and resolves nested .grove", async () => {
+    const repoRoot = join(tempDir, "repo");
+    const groveDir = join(repoRoot, ".grove");
+    await mkdir(groveDir, { recursive: true });
+    const result = resolveGroveDir(repoRoot);
+    expect(result.groveDir).toBe(groveDir);
+    expect(result.dbPath).toBe(join(groveDir, "grove.db"));
+  });
+
+  test("throws when override path does not resolve to a grove", async () => {
+    const invalid = join(tempDir, "invalid-dir");
+    await mkdir(invalid);
+    expect(() => resolveGroveDir(invalid)).toThrow(/No grove found at/);
   });
 
   test("throws when no .grove found", () => {

--- a/src/cli/utils/grove-dir.ts
+++ b/src/cli/utils/grove-dir.ts
@@ -8,7 +8,7 @@
 
 import { statSync } from "node:fs";
 import { hostname, userInfo } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 
 const GROVE_DIR_NAME = ".grove";
 const DB_FILENAME = "grove.db";
@@ -64,7 +64,16 @@ export function resolveGroveDir(overridePath?: string): GroveLocation {
   const target = overridePath ?? process.env.GROVE_DIR;
   if (target) {
     const resolved = resolve(target);
-    return { groveDir: resolved, dbPath: join(resolved, DB_FILENAME) };
+    if (isDirectory(resolved) && basename(resolved) === GROVE_DIR_NAME) {
+      return { groveDir: resolved, dbPath: join(resolved, DB_FILENAME) };
+    }
+    const nested = join(resolved, GROVE_DIR_NAME);
+    if (isDirectory(nested)) {
+      return { groveDir: nested, dbPath: join(nested, DB_FILENAME) };
+    }
+    throw new Error(
+      `No grove found at '${resolved}'. Pass a .grove directory or a parent containing .grove.`,
+    );
   }
 
   const found = findGroveDir(process.cwd());

--- a/src/cli/utils/parse-helpers.test.ts
+++ b/src/cli/utils/parse-helpers.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { UsageError } from "../errors.js";
+import { parseLimit, parseOffset, requirePositional } from "./parse-helpers.js";
+
+describe("parseLimit", () => {
+  test("returns default when omitted", () => {
+    expect(parseLimit(undefined, 25)).toBe(25);
+  });
+
+  test("parses a valid positive integer", () => {
+    expect(parseLimit("42", 10)).toBe(42);
+  });
+
+  test("rejects non-integer text", () => {
+    expect(() => parseLimit("abc", 10)).toThrow(UsageError);
+  });
+
+  test("rejects partially numeric text", () => {
+    expect(() => parseLimit("10abc", 10)).toThrow(UsageError);
+  });
+
+  test("rejects scientific notation", () => {
+    expect(() => parseLimit("1e3", 10)).toThrow(UsageError);
+  });
+
+  test("rejects zero", () => {
+    expect(() => parseLimit("0", 10)).toThrow(UsageError);
+  });
+});
+
+describe("parseOffset", () => {
+  test("defaults to zero when omitted", () => {
+    expect(parseOffset(undefined)).toBe(0);
+  });
+
+  test("parses a valid non-negative integer", () => {
+    expect(parseOffset("12")).toBe(12);
+  });
+
+  test("rejects negative values", () => {
+    expect(() => parseOffset("-1")).toThrow(UsageError);
+  });
+
+  test("rejects partially numeric text", () => {
+    expect(() => parseOffset("7days")).toThrow(UsageError);
+  });
+
+  test("rejects scientific notation", () => {
+    expect(() => parseOffset("2e2")).toThrow(UsageError);
+  });
+});
+
+describe("requirePositional", () => {
+  test("returns positional value when present", () => {
+    expect(requirePositional(["cid-123"], 0, "cid")).toBe("cid-123");
+  });
+
+  test("throws when positional value is missing", () => {
+    expect(() => requirePositional([], 0, "cid")).toThrow(UsageError);
+  });
+});

--- a/src/cli/utils/parse-helpers.ts
+++ b/src/cli/utils/parse-helpers.ts
@@ -8,11 +8,18 @@
 
 import { UsageError } from "../errors.js";
 
+function parseStrictInteger(raw: string): number | undefined {
+  if (!/^\d+$/.test(raw)) return undefined;
+  const n = Number(raw);
+  if (!Number.isSafeInteger(n)) return undefined;
+  return n;
+}
+
 /** Parse a positive integer limit from a CLI flag value. */
 export function parseLimit(raw: string | undefined, defaultLimit: number): number {
   if (raw === undefined) return defaultLimit;
-  const n = Number.parseInt(raw, 10);
-  if (Number.isNaN(n) || n <= 0) {
+  const n = parseStrictInteger(raw);
+  if (n === undefined || n <= 0) {
     throw new UsageError(`Invalid limit: '${raw}'. Must be a positive integer.`);
   }
   return n;
@@ -21,8 +28,8 @@ export function parseLimit(raw: string | undefined, defaultLimit: number): numbe
 /** Parse a non-negative integer offset from a CLI flag value. */
 export function parseOffset(raw: string | undefined): number {
   if (raw === undefined) return 0;
-  const n = Number.parseInt(raw, 10);
-  if (Number.isNaN(n) || n < 0) {
+  const n = parseStrictInteger(raw);
+  if (n === undefined || n < 0) {
     throw new UsageError(`Invalid offset: '${raw}'. Must be a non-negative integer.`);
   }
   return n;

--- a/src/cli/utils/string.test.ts
+++ b/src/cli/utils/string.test.ts
@@ -59,4 +59,14 @@ describe("suggestCommand", () => {
   test("handles empty command list", () => {
     expect(suggestCommand("anything", [])).toBeUndefined();
   });
+
+  test("short-circuits huge input when maxDistance cannot be met by length", () => {
+    const huge = "x".repeat(1_000_000);
+    const started = performance.now();
+    const result = suggestCommand(huge, commands, 2);
+    const elapsed = performance.now() - started;
+
+    expect(result).toBeUndefined();
+    expect(elapsed).toBeLessThan(100);
+  });
 });

--- a/src/cli/utils/string.ts
+++ b/src/cli/utils/string.ts
@@ -7,30 +7,66 @@
  * Used for typo suggestions when an unknown command is entered.
  */
 export function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
   if (a.length === 0) return b.length;
   if (b.length === 0) return a.length;
 
-  const matrix: number[][] = [];
+  // Keep only two rows to avoid O(n*m) matrix allocation.
+  let previous = Array.from({ length: b.length + 1 }, (_, j) => j);
+  let current = new Array<number>(b.length + 1);
 
-  for (let i = 0; i <= b.length; i++) {
-    matrix[i] = [i];
-  }
-  for (let j = 0; j <= a.length; j++) {
-    (matrix[0] as number[])[j] = j;
-  }
-
-  for (let i = 1; i <= b.length; i++) {
-    for (let j = 1; j <= a.length; j++) {
-      const cost = a[j - 1] === b[i - 1] ? 0 : 1;
-      (matrix[i] as number[])[j] = Math.min(
-        ((matrix[i - 1] as number[])[j] ?? 0) + 1, // deletion
-        ((matrix[i] as number[])[j - 1] ?? 0) + 1, // insertion
-        ((matrix[i - 1] as number[])[j - 1] ?? 0) + cost, // substitution
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(
+        (previous[j] as number) + 1, // deletion
+        (current[j - 1] as number) + 1, // insertion
+        (previous[j - 1] as number) + cost, // substitution
       );
     }
+    [previous, current] = [current, previous];
   }
 
-  return (matrix[b.length] as number[])[a.length] ?? 0;
+  return (previous[b.length] as number) ?? 0;
+}
+
+function boundedLevenshteinDistance(a: string, b: string, maxDistance: number): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  if (Math.abs(a.length - b.length) > maxDistance) return maxDistance + 1;
+
+  const sentinel = maxDistance + 1;
+  let previous = Array.from({ length: b.length + 1 }, (_, j) => j);
+  let current = new Array<number>(b.length + 1).fill(sentinel);
+
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i;
+    const jStart = Math.max(1, i - maxDistance);
+    const jEnd = Math.min(b.length, i + maxDistance);
+    let rowMin = sentinel;
+
+    for (let j = 1; j < jStart; j++) current[j] = sentinel;
+
+    for (let j = jStart; j <= jEnd; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      const value = Math.min(
+        (previous[j] as number) + 1,
+        (current[j - 1] as number) + 1,
+        (previous[j - 1] as number) + cost,
+      );
+      current[j] = value;
+      if (value < rowMin) rowMin = value;
+    }
+
+    for (let j = jEnd + 1; j <= b.length; j++) current[j] = sentinel;
+
+    if (rowMin > maxDistance) return sentinel;
+    [previous, current] = [current, previous];
+  }
+
+  return previous[b.length] as number;
 }
 
 /**
@@ -42,14 +78,18 @@ export function suggestCommand(
   commandNames: readonly string[],
   maxDistance = 3,
 ): string | undefined {
+  if (maxDistance < 0) return undefined;
+
   let best: string | undefined;
   let bestDist = maxDistance + 1;
 
   for (const name of commandNames) {
-    const dist = levenshteinDistance(input, name);
+    if (Math.abs(input.length - name.length) > maxDistance) continue;
+    const dist = boundedLevenshteinDistance(input, name, bestDist - 1);
     if (dist < bestDist) {
       bestDist = dist;
       best = name;
+      if (bestDist === 0) break;
     }
   }
 

--- a/src/core/presets.test.ts
+++ b/src/core/presets.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+import { getPreset } from "../cli/presets/index.js";
+import { listPresetNames, lookupPresetTopology } from "./presets.js";
+
+describe("core preset topology registry", () => {
+  test("review-loop topology matches CLI preset topology", () => {
+    const cliTopology = getPreset("review-loop")?.topology;
+    const coreTopology = lookupPresetTopology("review-loop");
+
+    expect(cliTopology).toBeDefined();
+    expect(coreTopology).toEqual(cliTopology);
+  });
+
+  test("lists known preset names", () => {
+    expect(listPresetNames()).toContain("review-loop");
+  });
+});

--- a/src/core/presets.ts
+++ b/src/core/presets.ts
@@ -40,33 +40,36 @@ export function getPresetTopologyRegistry(): Readonly<Record<string, CorePresetC
             name: "coder",
             description: "Writes and iterates on code",
             maxInstances: 1,
-            edges: [{ target: "reviewer", edgeType: "delegates" }],
+            mode: "broadcast",
             platform: "claude-code",
             prompt:
               "You are a software engineer. Your workflow:\n" +
               "1. Read the codebase and understand the goal\n" +
               "2. Edit files to implement the solution\n" +
-              "3. Call grove_submit_work to submit your work:\n" +
-              '   grove_submit_work({ summary: "Implemented landing page", artifacts: {"index.html": "blake3:..."}, agent: { role: "coder" } })\n' +
-              "4. Reviewer feedback arrives automatically — when it does, iterate and grove_submit_work again\n" +
-              "5. NEVER call grove_done yourself. Only the reviewer ends the session.\n" +
+              "3. Commit your changes: git add -A && git commit -m 'description'\n" +
+              "4. Get the commit hash: run git rev-parse HEAD\n" +
+              "5. Submit your work:\n" +
+              '   grove_submit_work({ summary: "what you did", commitHash: "<hash from step 4>", agent: { role: "coder" } })\n' +
+              "6. Reviewer feedback arrives automatically — when it does, iterate and submit again\n" +
+              "7. NEVER call grove_done yourself. Only the reviewer ends the session.\n" +
               "You MUST call grove_submit_work after editing files — without it, nobody sees your work.",
           },
           {
             name: "reviewer",
             description: "Reviews code and provides feedback",
             maxInstances: 1,
-            edges: [{ target: "coder", edgeType: "feedback" }],
+            mode: "broadcast",
             platform: "claude-code",
             prompt:
               "You are a code reviewer. Your workflow:\n" +
-              "1. Coder contributions arrive automatically — wait for the first one\n" +
-              "2. Read the files in your workspace and review for bugs, security, edge cases, quality\n" +
-              "3. Submit your review via grove_submit_review:\n" +
-              '   grove_submit_review({ targetCid: "blake3:...", summary: "LGTM — clean implementation", scores: {"correctness": {"value": 0.9, "direction": "maximize"}}, agent: { role: "reviewer" } })\n' +
-              "4. If changes needed, your review is sent to the coder automatically\n" +
-              '5. When code meets standards, call grove_done({ summary: "Approved — code meets standards", agent: { role: "reviewer" } })\n' +
-              "You MUST call grove_submit_review for every review — without it, the coder gets no feedback.",
+              "1. You will receive a notification with the coder's Workspace path\n" +
+              "2. Read the actual source files at that path (e.g., cat /path/to/coder-workspace/app.js)\n" +
+              "3. Review for bugs, correctness, security, edge cases, code quality\n" +
+              "4. Submit your review:\n" +
+              '   grove_submit_review({ targetCid: "<CID from notification>", summary: "your review", scores: {"correctness": {"value": 0.9, "direction": "maximize"}}, agent: { role: "reviewer" } })\n' +
+              "5. If changes needed, your review is sent to the coder automatically\n" +
+              '6. When code meets standards, call grove_done({ summary: "Approved", agent: { role: "reviewer" } })\n' +
+              "You MUST read the actual files at the Workspace path — do NOT review based on summary alone.",
           },
         ],
         spawning: { dynamic: true, maxDepth: 2 },

--- a/src/tui/resolve-backend.test.ts
+++ b/src/tui/resolve-backend.test.ts
@@ -149,7 +149,7 @@ describe("resolveBackend", () => {
     }
   });
 
-  test("grove.json not found when --grove points at repo root (not .grove)", async () => {
+  test("finds grove.json when --grove points at repo root (parent of .grove)", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "grove-resolve-test-"));
     const groveDir = join(tempDir, ".grove");
     mkdirSync(groveDir, { recursive: true });
@@ -159,13 +159,14 @@ describe("resolveBackend", () => {
     );
 
     try {
-      // --grove points at the repo root (parent of .grove) — config won't be found
-      // because resolveGroveDir treats the override as the final directory
       const result = await resolveBackend({ groveOverride: tempDir });
-      // Should fall through to local since grove.json is at tempDir/.grove/grove.json
-      // but resolveGroveDir(tempDir) returns groveDir=tempDir, so we look for
-      // tempDir/grove.json which doesn't exist
-      expect(result.mode).toBe("local");
+      expect(result.mode).toBe("nexus");
+      expect(result.source).toBe("grove.json");
+      if (result.mode === "nexus") {
+        expect(result.url).toBe("http://json-nexus:7070");
+        // Preserve the user-provided override path.
+        expect(result.groveOverride).toBe(tempDir);
+      }
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/tui/resolve-backend.ts
+++ b/src/tui/resolve-backend.ts
@@ -166,8 +166,7 @@ async function readNexusUrlFromConfig(
       // This handles standalone `grove tui` on a managed-Nexus grove where
       // `grove up` already started Nexus but didn't set GROVE_NEXUS_URL.
       if (config.nexusManaged && config.mode === "nexus") {
-        const { readNexusUrl } = await import("../cli/nexus-lifecycle.js");
-        const yamlUrl = readNexusUrl(join(groveDir, ".."));
+        const yamlUrl = readNexusUrlFromYaml(join(groveDir, ".."));
         if (yamlUrl) return { url: yamlUrl, fromExplicit: false };
       }
 
@@ -183,18 +182,29 @@ async function readNexusUrlFromConfig(
 
       // Managed Nexus fallback: discover from nexus.yaml
       if (parsed.nexusManaged && parsed.mode === "nexus") {
-        try {
-          const { readNexusUrl } = await import("../cli/nexus-lifecycle.js");
-          const yamlUrl = readNexusUrl(join(groveDir, ".."));
-          if (yamlUrl) return { url: yamlUrl, fromExplicit: false };
-        } catch {
-          // nexus-lifecycle not available
-        }
+        const yamlUrl = readNexusUrlFromYaml(join(groveDir, ".."));
+        if (yamlUrl) return { url: yamlUrl, fromExplicit: false };
       }
       return none;
     }
   } catch {
     return none;
+  }
+}
+
+/** Parse managed Nexus URL from project-local nexus.yaml (ports.http). */
+function readNexusUrlFromYaml(projectRoot: string): string | undefined {
+  const yamlPath = join(projectRoot, "nexus.yaml");
+  if (!existsSync(yamlPath)) return undefined;
+  try {
+    const raw = readFileSync(yamlPath, "utf-8");
+    const match = raw.match(/^\s*http:\s*(\d{1,5})\s*$/m);
+    if (!match?.[1]) return undefined;
+    const port = Number(match[1]);
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) return undefined;
+    return `http://localhost:${port}`;
+  } catch {
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Summary
- align CLI/core preset behavior and registry loading, including review-loop topology parity and safer grove path resolution for `--grove` / `GROVE_DIR`
- harden CLI parsing (`limit`/`offset` strict integers, discuss CID intent handling with explicit `--root` escape hatch) and expand parser regression coverage
- dedupe level-wise BFS expansion in `tree` and `export-dag` so shared-node DAGs are expanded once per level instead of repeatedly
- optimize command suggestion edit-distance logic for large invalid inputs while preserving existing suggestion behavior

## Test plan
- [x] `bun test src/cli/utils`
- [x] `bun test src/tui/resolve-backend.test.ts src/cli/utils/grove-dir.test.ts`
- [x] `bun test src/cli/utils/parse-helpers.test.ts src/cli/utils/string.test.ts src/core/presets.test.ts src/tui/resolve-backend.test.ts src/cli/utils/grove-dir.test.ts`
- [x] adversarial review/fix loop run repeatedly until `approve` (last successful verdict approved)
- [ ] `bun test src/cli/commands/discuss.test.ts src/cli/commands/tree.test.ts` (blocked in this environment by missing `blake3` package resolution)

Made with [Cursor](https://cursor.com)