### PR TITLE
fix(operations): harden correctness and response parity

### DIFF
--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -355,7 +355,7 @@ export function createContribution(input: ContributionInput): Contribution {
     kind: input.kind,
     mode: input.mode,
     summary: input.summary,
-    ...stripUndefined({ description: input.description }),
+    ...stripUndefined({ description: input.description, commitHash: input.commitHash }),
     artifacts: { ...input.artifacts },
     relations: input.relations.map((r) =>
       stripUndefined({

--- a/src/core/operations/ask-user-bus.test.ts
+++ b/src/core/operations/ask-user-bus.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { Contribution, ContributionInput } from "../models.js";
 import { ContributionKind, ContributionMode, RelationType } from "../models.js";
 import { InMemoryContributionStore } from "../testing.js";
-import { answerQuestion, listPendingQuestions, submitQuestion } from "./ask-user-bus.js";
+import { answerQuestion, getAnswer, listPendingQuestions, submitQuestion } from "./ask-user-bus.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -136,6 +136,29 @@ describe("answerQuestion", () => {
       ),
     ).rejects.toThrow(/not a question/);
   });
+
+  test("rejects second answer for the same question", async () => {
+    const store = new InMemoryContributionStore();
+    const question = await submitQuestion(
+      store,
+      { agent: AGENT_CODER, question: "Can I merge now?" },
+      mockComputeCid,
+    );
+
+    await answerQuestion(
+      store,
+      { questionCid: question.cid, answer: "Yes", operator: OPERATOR },
+      mockComputeCid,
+    );
+
+    await expect(
+      answerQuestion(
+        store,
+        { questionCid: question.cid, answer: "No", operator: OPERATOR },
+        mockComputeCid,
+      ),
+    ).rejects.toThrow(/already answered/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -261,5 +284,90 @@ describe("listPendingQuestions", () => {
     expect(cids).toContain(q1.cid);
     expect(cids).toContain(q2.cid);
     expect(cids).toContain(q3.cid);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAnswer
+// ---------------------------------------------------------------------------
+
+describe("getAnswer", () => {
+  test("returns the latest answer text when multiple answers exist", async () => {
+    const store = new InMemoryContributionStore();
+    const question = await submitQuestion(
+      store,
+      { agent: AGENT_CODER, question: "Ship now?" },
+      mockComputeCid,
+    );
+
+    // Bypass answerQuestion's single-answer guard to simulate historical
+    // data containing multiple answers for one question.
+    const oldAnswer: Contribution = {
+      cid: mockComputeCid({
+        kind: ContributionKind.Discussion,
+        mode: ContributionMode.Exploration,
+        summary: "old answer",
+        description: "old answer",
+        artifacts: {},
+        relations: [{ targetCid: question.cid, relationType: RelationType.RespondsTo }],
+        tags: ["ask-user", "answer"],
+        context: { ephemeral: true, ask_user_answer: true, answer_text: "old answer" },
+        agent: OPERATOR,
+        createdAt: "2026-01-01T00:00:00Z",
+      }),
+      manifestVersion: 1,
+      kind: ContributionKind.Discussion,
+      mode: ContributionMode.Exploration,
+      summary: "old answer",
+      description: "old answer",
+      artifacts: {},
+      relations: [{ targetCid: question.cid, relationType: RelationType.RespondsTo }],
+      tags: ["ask-user", "answer"],
+      context: { ephemeral: true, ask_user_answer: true, answer_text: "old answer" },
+      agent: OPERATOR,
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+    const newAnswer: Contribution = {
+      cid: mockComputeCid({
+        kind: ContributionKind.Discussion,
+        mode: ContributionMode.Exploration,
+        summary: "new answer",
+        description: "new answer",
+        artifacts: {},
+        relations: [{ targetCid: question.cid, relationType: RelationType.RespondsTo }],
+        tags: ["ask-user", "answer"],
+        context: { ephemeral: true, ask_user_answer: true, answer_text: "new answer" },
+        agent: OPERATOR,
+        createdAt: "2026-01-02T00:00:00Z",
+      }),
+      manifestVersion: 1,
+      kind: ContributionKind.Discussion,
+      mode: ContributionMode.Exploration,
+      summary: "new answer",
+      description: "new answer",
+      artifacts: {},
+      relations: [{ targetCid: question.cid, relationType: RelationType.RespondsTo }],
+      tags: ["ask-user", "answer"],
+      context: { ephemeral: true, ask_user_answer: true, answer_text: "new answer" },
+      agent: OPERATOR,
+      createdAt: "2026-01-02T00:00:00Z",
+    };
+    await store.put(oldAnswer);
+    await store.put(newAnswer);
+
+    const answer = await getAnswer(store, question.cid);
+    expect(answer).toBe("new answer");
+  });
+
+  test("returns undefined when question has no answer", async () => {
+    const store = new InMemoryContributionStore();
+    const question = await submitQuestion(
+      store,
+      { agent: AGENT_CODER, question: "Any blockers?" },
+      mockComputeCid,
+    );
+
+    const answer = await getAnswer(store, question.cid);
+    expect(answer).toBeUndefined();
   });
 });

--- a/src/core/operations/ask-user-bus.ts
+++ b/src/core/operations/ask-user-bus.ts
@@ -139,6 +139,15 @@ export async function answerQuestion(
     throw new Error(`Contribution ${input.questionCid} is not a question`);
   }
 
+  // Prevent ambiguous state: a question can have at most one answer.
+  const existingAnswers = await store.relatedTo(input.questionCid, RelationType.RespondsTo);
+  const alreadyAnswered = existingAnswers.some(
+    (c) => c.context?.ephemeral === true && c.context?.ask_user_answer === true,
+  );
+  if (alreadyAnswered) {
+    throw new Error(`Question already answered: ${input.questionCid}`);
+  }
+
   const contributionInput: ContributionInput = {
     kind: ContributionKind.Discussion,
     mode: ContributionMode.Exploration,
@@ -179,18 +188,22 @@ export async function listPendingQuestions(
   store: ContributionStore,
   options?: { readonly sessionId?: string | undefined },
 ): Promise<readonly PendingQuestion[]> {
-  const contributions = await store.list({
+  const baseQuery = {
     kind: ContributionKind.Discussion,
     ...(options?.sessionId !== undefined ? { sessionId: options.sessionId } : {}),
-  });
+  };
+  const [questionCandidates, answerCandidates] = await Promise.all([
+    store.list({ ...baseQuery, tags: ["ask-user", "question"] }),
+    store.list({ ...baseQuery, tags: ["ask-user", "answer"] }),
+  ]);
 
-  const questions = contributions.filter(
+  const questions = questionCandidates.filter(
     (c) => c.context?.ephemeral === true && c.context?.ask_user_question === true,
   );
 
   // Find answered question CIDs
   const answeredCids = new Set<string>();
-  const answers = contributions.filter(
+  const answers = answerCandidates.filter(
     (c) => c.context?.ephemeral === true && c.context?.ask_user_answer === true,
   );
   for (const a of answers) {
@@ -232,9 +245,10 @@ export async function getAnswer(
   questionCid: string,
 ): Promise<string | undefined> {
   const children = await store.relatedTo(questionCid, RelationType.RespondsTo);
-  const answer = children.find(
-    (c) => c.context?.ephemeral === true && c.context?.ask_user_answer === true,
-  );
+  const answers = children
+    .filter((c) => c.context?.ephemeral === true && c.context?.ask_user_answer === true)
+    .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+  const answer = answers[0];
   return answer !== undefined
     ? ((answer.context?.answer_text as string) ?? answer.description ?? answer.summary)
     : undefined;

--- a/src/core/operations/contribute.test.ts
+++ b/src/core/operations/contribute.test.ts
@@ -513,6 +513,35 @@ describe("contributeOperation: idempotencyKey", () => {
     expect(second.error.code).toBe("STATE_CONFLICT");
   });
 
+  test("fingerprint rejects same key + different commitHash", async () => {
+    const first = await contributeOperation(
+      {
+        kind: "work",
+        summary: "commit submission",
+        commitHash: "abc123",
+        agent: { agentId: "a1" },
+        idempotencyKey: "commit-hash-key",
+      },
+      deps,
+    );
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+
+    const second = await contributeOperation(
+      {
+        kind: "work",
+        summary: "commit submission",
+        commitHash: "def456",
+        agent: { agentId: "a1" },
+        idempotencyKey: "commit-hash-key",
+      },
+      deps,
+    );
+    expect(second.ok).toBe(false);
+    if (second.ok) return;
+    expect(second.error.code).toBe("STATE_CONFLICT");
+  });
+
   test("fingerprint rejects same key + renamed artifact (same hash)", async () => {
     // Store a single blob in CAS, reference it under two different names.
     const hash = await storeTestContent(deps.cas, "hello world");

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -346,7 +346,7 @@ function canonicalizeForFingerprint(value: unknown): unknown {
  * could produce a different stored contribution is reflected in the
  * hash:
  *
- *   - kind, mode, summary, description
+ *   - kind, mode, summary, description, commitHash
  *   - `context` (deep-canonicalized so key order doesn't matter) —
  *     plans store their task list here, messages store recipients +
  *     body, grove_done stores the ephemeral flag + reason
@@ -379,6 +379,7 @@ function computeIdempotencyFingerprint(
     mode: input.mode ?? null,
     summary: input.summary,
     description: input.description ?? null,
+    commitHash: input.commitHash ?? null,
     // Sort artifacts by name and keep name→hash pairs so a rename
     // (same hash, different filename) produces a different fingerprint.
     artifacts: input.artifacts

--- a/src/core/operations/cost-tracking.test.ts
+++ b/src/core/operations/cost-tracking.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ContributionInput } from "../models.js";
+import type { Contribution, ContributionInput } from "../models.js";
 import { ContributionKind } from "../models.js";
 import { InMemoryContributionStore } from "../testing.js";
 import { getSessionCosts, reportUsage } from "./cost-tracking.js";
@@ -148,5 +148,44 @@ describe("getSessionCosts", () => {
     expect(summary.totalOutputTokens).toBe(0);
     expect(summary.totalCostUsd).toBe(0);
     expect(summary.byAgent).toHaveLength(0);
+  });
+
+  test("ignores malformed usage_report payloads when aggregating", async () => {
+    const store = new InMemoryContributionStore();
+
+    await reportUsage(
+      store,
+      AGENT_ALICE,
+      { inputTokens: 1000, outputTokens: 500, costUsd: 0.01 },
+      mockComputeCid,
+    );
+
+    const malformed: Contribution = {
+      cid: "blake3:9999999999999999999999999999999999999999999999999999999999999999",
+      manifestVersion: 1,
+      kind: ContributionKind.Discussion,
+      mode: "exploration",
+      summary: "Malformed usage report",
+      artifacts: {},
+      relations: [],
+      tags: ["usage-report"],
+      context: {
+        ephemeral: true,
+        usage_report: {
+          input_tokens: "not-a-number",
+          output_tokens: 123,
+        } as unknown as Record<string, unknown>,
+      },
+      agent: AGENT_BOB,
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+    await store.put(malformed);
+
+    const summary = await getSessionCosts(store);
+    expect(summary.totalInputTokens).toBe(1000);
+    expect(summary.totalOutputTokens).toBe(500);
+    expect(summary.totalCostUsd).toBeCloseTo(0.01);
+    expect(summary.byAgent).toHaveLength(1);
+    expect(summary.byAgent[0]?.agentId).toBe("alice");
   });
 });

--- a/src/core/operations/cost-tracking.test.ts
+++ b/src/core/operations/cost-tracking.test.ts
@@ -174,7 +174,7 @@ describe("getSessionCosts", () => {
         usage_report: {
           input_tokens: "not-a-number",
           output_tokens: 123,
-        } as unknown as Record<string, unknown>,
+        },
       },
       agent: AGENT_BOB,
       createdAt: "2026-01-01T00:00:00Z",

--- a/src/core/operations/cost-tracking.ts
+++ b/src/core/operations/cost-tracking.ts
@@ -145,22 +145,23 @@ export async function getSessionCosts(
 ): Promise<SessionCostSummary> {
   const contributions = await store.list({
     kind: ContributionKind.Discussion,
+    tags: ["usage-report"],
     ...(options?.sessionId !== undefined ? { sessionId: options.sessionId } : {}),
   });
 
-  const usageContributions = contributions.filter(
-    (c) => c.context?.ephemeral === true && c.context?.usage_report !== undefined,
-  );
-
   const agentMap = new Map<string, AgentCostSummary>();
 
-  for (const c of usageContributions) {
-    const report = c.context?.usage_report as Record<string, unknown>;
-    const inputTokens = (report.input_tokens as number) ?? 0;
-    const outputTokens = (report.output_tokens as number) ?? 0;
-    const costUsd = (report.cost_usd as number) ?? 0;
-    const contextPercent = report.context_window_percent as number | undefined;
-    const model = report.model as string | undefined;
+  for (const c of contributions) {
+    if (c.context?.ephemeral !== true || c.context?.usage_report === undefined) continue;
+    const parsed = UsageReportSchema.safeParse(c.context.usage_report);
+    if (!parsed.success) continue;
+
+    const report = parsed.data;
+    const inputTokens = report.input_tokens;
+    const outputTokens = report.output_tokens;
+    const costUsd = report.cost_usd ?? 0;
+    const contextPercent = report.context_window_percent;
+    const model = report.model;
 
     const existing = agentMap.get(c.agent.agentId);
     if (existing) {

--- a/src/core/operations/messaging.test.ts
+++ b/src/core/operations/messaging.test.ts
@@ -405,6 +405,28 @@ describe("readInbox", () => {
     expect(bodies).not.toContain("to-dave");
   });
 
+  test("multi-recipient query also includes @all broadcasts", async () => {
+    const store = new InMemoryContributionStore();
+    await seedMessages(store, [
+      {
+        from: AGENT_ALICE,
+        body: "broadcast",
+        recipients: ["@all"],
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+      {
+        from: AGENT_ALICE,
+        body: "to-charlie",
+        recipients: ["@charlie"],
+        createdAt: "2026-01-01T01:00:00Z",
+      },
+    ]);
+
+    const inbox = await readInbox(store, { recipients: ["@bob", "@dave"] });
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0]?.body).toBe("broadcast");
+  });
+
   test("empty inbox returns empty array", async () => {
     const store = new InMemoryContributionStore();
     const inbox = await readInbox(store, { recipient: "@bob" });

--- a/src/core/operations/messaging.ts
+++ b/src/core/operations/messaging.ts
@@ -150,6 +150,7 @@ export async function readInbox(
 
   const contributions = await store.list({
     kind: ContributionKind.Discussion,
+    tags: ["message"],
     ...(storeLimit !== undefined ? { limit: storeLimit } : {}),
     ...(query?.sessionId !== undefined ? { sessionId: query.sessionId } : {}),
   });
@@ -173,7 +174,10 @@ export async function readInbox(
   // Filter by multiple recipients (matches if any handle appears in the message)
   if (query?.recipients !== undefined && query.recipients.length > 0) {
     const handles = new Set(query.recipients);
-    messages = messages.filter(({ context }) => context.recipients.some((r) => handles.has(r)));
+    messages = messages.filter(
+      ({ context }) =>
+        context.recipients.includes("@all") || context.recipients.some((r) => handles.has(r)),
+    );
   }
 
   // Filter by sender

--- a/src/core/operations/query.test.ts
+++ b/src/core/operations/query.test.ts
@@ -203,7 +203,12 @@ describe("logOperation", () => {
   test("respects limit and offset", async () => {
     for (let i = 0; i < 5; i++) {
       await contributeOperation(
-        { kind: "work", summary: `entry ${i}`, agent: { agentId: "a1" } },
+        {
+          kind: "work",
+          summary: `entry ${i}`,
+          createdAt: `2026-01-01T00:00:0${i}.000Z`,
+          agent: { agentId: "a1" },
+        },
         deps,
       );
     }
@@ -213,6 +218,15 @@ describe("logOperation", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.count).toBe(2);
+    expect(result.value.results[0]?.summary).toBe("entry 4");
+    expect(result.value.results[1]?.summary).toBe("entry 3");
+
+    const paged = await logOperation({ limit: 2, offset: 1 }, deps);
+    expect(paged.ok).toBe(true);
+    if (!paged.ok) return;
+    expect(paged.value.count).toBe(2);
+    expect(paged.value.results[0]?.summary).toBe("entry 3");
+    expect(paged.value.results[1]?.summary).toBe("entry 2");
   });
 });
 

--- a/src/core/operations/query.ts
+++ b/src/core/operations/query.ts
@@ -296,17 +296,43 @@ export async function logOperation(
       return validationErr("Query operations not available (missing contributionStore)");
     }
 
-    const results = await deps.contributionStore.list({
+    const baseQuery = {
       kind: input.kind,
       mode: input.mode,
       tags: input.tags,
       agentId: input.agentId,
-      limit: input.limit,
-      offset: input.offset,
+    };
+
+    // Fast path: no pagination requested.
+    if (input.limit === undefined && (input.offset === undefined || input.offset === 0)) {
+      const results = await deps.contributionStore.list(baseQuery);
+      // Store returns oldest-first; reverse for newest-first.
+      const summaries = results.map(toContributionSummary).reverse();
+      return ok({ results: summaries, count: summaries.length });
+    }
+
+    // Pagination requested in newest-first order. The underlying store paginates
+    // oldest-first, so translate the requested descending window into an
+    // equivalent ascending offset/limit window.
+    const total = await deps.contributionStore.count(baseQuery);
+    const descOffset = Math.max(0, input.offset ?? 0);
+    const descLimit = input.limit !== undefined ? Math.max(0, input.limit) : undefined;
+
+    if (total === 0 || descOffset >= total || descLimit === 0) {
+      return ok({ results: [], count: 0 });
+    }
+
+    const ascWindowEnd = total - descOffset;
+    const ascWindowStart = descLimit !== undefined ? Math.max(0, ascWindowEnd - descLimit) : 0;
+    const ascWindowSize = ascWindowEnd - ascWindowStart;
+
+    const pagedResults = await deps.contributionStore.list({
+      ...baseQuery,
+      offset: ascWindowStart,
+      limit: ascWindowSize,
     });
 
-    // Store returns oldest-first; reverse for newest-first
-    const summaries = results.map(toContributionSummary).reverse();
+    const summaries = pagedResults.map(toContributionSummary).reverse();
     return ok({ results: summaries, count: summaries.length });
   } catch (error) {
     return fromGroveError(error);

--- a/src/core/operations/schemas.test.ts
+++ b/src/core/operations/schemas.test.ts
@@ -6,8 +6,10 @@
  */
 
 import { describe, expect, test } from "bun:test";
-
+import { BountyStatus } from "../bounty.js";
+import { OperationErrorCode } from "./result.js";
 import {
+  BountyStatusSchema,
   CheckoutResultSchema,
   CheckStopResultSchema,
   ClaimBountyResultSchema,
@@ -21,6 +23,7 @@ import {
   ListBountiesResultSchema,
   ListClaimsResultSchema,
   LogResultSchema,
+  OperationErrorCodeSchema,
   OperationErrorSchema,
   OperationErrSchema,
   OperationResultSchema,
@@ -60,6 +63,12 @@ function expectInvalid(schema: { parse: (v: unknown) => unknown }, value: unknow
 // ---------------------------------------------------------------------------
 
 describe("OperationErrorSchema", () => {
+  test("accepts all OperationErrorCode values", () => {
+    for (const code of Object.values(OperationErrorCode)) {
+      expectValid(OperationErrorCodeSchema, code);
+    }
+  });
+
   test("accepts valid error", () => {
     expectValid(OperationErrorSchema, {
       code: "NOT_FOUND",
@@ -554,6 +563,14 @@ describe("CheckStopResultSchema", () => {
 // ---------------------------------------------------------------------------
 // Bounty results
 // ---------------------------------------------------------------------------
+
+describe("BountyStatusSchema", () => {
+  test("accepts all BountyStatus values", () => {
+    for (const status of Object.values(BountyStatus)) {
+      expectValid(BountyStatusSchema, status);
+    }
+  });
+});
 
 describe("CreateBountyResultSchema", () => {
   test("accepts valid result with reservation", () => {

--- a/src/core/operations/schemas.ts
+++ b/src/core/operations/schemas.ts
@@ -10,22 +10,16 @@
 
 import { z } from "zod";
 
+import { BountyStatus } from "../bounty.js";
+import { OperationErrorCode } from "./result.js";
+
 // ---------------------------------------------------------------------------
 // Shared building blocks
 // ---------------------------------------------------------------------------
 
 /** Error codes shared across all surfaces. */
-export const OperationErrorCodeSchema: z.ZodType = z.enum([
-  "CLAIM_CONFLICT",
-  "CONCURRENCY_LIMIT",
-  "RATE_LIMIT",
-  "ARTIFACT_LIMIT",
-  "RETRY_EXHAUSTED",
-  "LEASE_VIOLATION",
-  "NOT_FOUND",
-  "VALIDATION_ERROR",
-  "INTERNAL_ERROR",
-]);
+const OPERATION_ERROR_CODES = Object.values(OperationErrorCode) as [string, ...string[]];
+export const OperationErrorCodeSchema: z.ZodType = z.enum(OPERATION_ERROR_CODES);
 
 /** Structured error from an operation. */
 export const OperationErrorSchema: z.ZodType = z.object({
@@ -272,15 +266,8 @@ export const CheckStopResultSchema: z.ZodType = z.object({
 // ---------------------------------------------------------------------------
 
 /** Schema for BountyStatus enum values. */
-export const BountyStatusSchema: z.ZodType = z.enum([
-  "draft",
-  "open",
-  "claimed",
-  "completed",
-  "settled",
-  "expired",
-  "cancelled",
-]);
+const BOUNTY_STATUSES = Object.values(BountyStatus) as [string, ...string[]];
+export const BountyStatusSchema: z.ZodType = z.enum(BOUNTY_STATUSES);
 
 /** Schema for CreateBountyResult. */
 export const CreateBountyResultSchema: z.ZodType = z.object({


### PR DESCRIPTION
## Summary
- Fix newest-first log pagination semantics in `logOperation` by translating descending `limit/offset` into the correct ascending store window, and add regression assertions for paged content.
- Include `commitHash` in idempotency fingerprinting and preserve `commitHash` in `createContribution()` output to close CID-integrity + dedupe correctness gaps.
- Remove schema enum drift by deriving operation/bounty status schemas from source constants, and harden ask-user/messaging/cost-tracking read paths (single-answer enforcement, deterministic answer resolution, `@all` recipient parity, tag-scoped scans, and safe usage-report parsing).

## Test plan
- [x] `bun test src/core/operations/query.test.ts src/core/operations/contribute.test.ts src/core/operations/schemas.test.ts src/core/operations/cost-tracking.test.ts src/core/operations/messaging.test.ts src/core/operations/ask-user-bus.test.ts` (all tests pass; command exits non-zero in this repo due global coverage threshold settings in `bunfig.toml`)
- [x] Pre-commit hook (`biome-check`) passes
- [x] Pre-push hooks (`typecheck`, `build`) pass

Made with [Cursor](https://cursor.com)