### PR TITLE
fix(core): harden reconciliation and runtime safety paths

### DIFF
--- a/src/core/acpx-runtime.ts
+++ b/src/core/acpx-runtime.ts
@@ -200,6 +200,11 @@ export class AcpxRuntime implements AgentRuntime {
     }
     const mergedEnv = config.env ? { ...baseEnv, ...config.env } : baseEnv;
 
+    // Bind contribution identity to the runtime-issued session id so
+    // SessionOrchestrator polling can authenticate origin metadata.
+    mergedEnv.GROVE_AGENT_ID = id;
+    mergedEnv.GROVE_AGENT_ROLE = role;
+
     // Export platform/model as env vars so agent identity resolution picks them up
     if (config.platform) mergedEnv.GROVE_AGENT_PLATFORM = config.platform;
     if (config.model) mergedEnv.GROVE_AGENT_MODEL = config.model;

--- a/src/core/agent-runtime.ts
+++ b/src/core/agent-runtime.ts
@@ -12,6 +12,10 @@ export interface AgentConfig {
   readonly role: string;
   readonly command: string;
   readonly cwd: string;
+  /**
+   * Environment variables injected into the child agent process.
+   * Runtime implementations MUST pass these through unchanged.
+   */
   readonly env?: Record<string, string> | undefined;
   readonly goal?: string | undefined;
   readonly prompt?: string | undefined;

--- a/src/core/frontier.test.ts
+++ b/src/core/frontier.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { getScore } from "./frontier.js";
+import { DefaultFrontierCalculator, getScore } from "./frontier.js";
+import type { Contribution } from "./models.js";
 import { ScoreDirection } from "./models.js";
 import { makeContribution } from "./test-helpers.js";
+import { InMemoryContributionStore } from "./testing.js";
 
 describe("getScore", () => {
   const contribution = makeContribution({
@@ -26,5 +28,62 @@ describe("getScore", () => {
     const noScores = makeContribution();
     const score = getScore(noScores, "val_bpb");
     expect(score).toBeUndefined();
+  });
+});
+
+describe("DefaultFrontierCalculator", () => {
+  test("uses incomingSources when context-only filters reduce candidate set", async () => {
+    const target = makeContribution({
+      summary: "target",
+      context: { hardware: "H100" },
+    });
+    const other = makeContribution({
+      summary: "other",
+      context: { hardware: "A100" },
+    });
+    const reviewer = makeContribution({
+      kind: "review",
+      summary: "reviewer",
+      relations: [{ relationType: "reviews", targetCid: target.cid }],
+      scores: {
+        quality: { value: 0.9, direction: ScoreDirection.Maximize },
+      },
+    });
+    const store = new InMemoryContributionStore([target, other, reviewer]);
+    const originalIncoming = store.incomingSources;
+    let incomingCalls = 0;
+    let lastTargets: readonly string[] = [];
+    store.incomingSources = async (
+      targetCids: readonly string[],
+    ): Promise<readonly Contribution[]> => {
+      incomingCalls += 1;
+      lastTargets = [...targetCids];
+      return originalIncoming(targetCids);
+    };
+
+    const calculator = new DefaultFrontierCalculator(store);
+    const frontier = await calculator.compute({ context: { hardware: "H100" } });
+
+    expect(incomingCalls).toBe(1);
+    expect(lastTargets).toEqual([target.cid]);
+    expect(frontier.byReviewScore[0]?.cid).toBe(target.cid);
+  });
+
+  test("skips incomingSources when no filters are applied", async () => {
+    const base = makeContribution({ summary: "base" });
+    const store = new InMemoryContributionStore([base]);
+    const originalIncoming = store.incomingSources;
+    let incomingCalls = 0;
+    store.incomingSources = async (
+      targetCids: readonly string[],
+    ): Promise<readonly Contribution[]> => {
+      incomingCalls += 1;
+      return originalIncoming(targetCids);
+    };
+
+    const calculator = new DefaultFrontierCalculator(store);
+    await calculator.compute();
+
+    expect(incomingCalls).toBe(0);
   });
 });

--- a/src/core/frontier.ts
+++ b/src/core/frontier.ts
@@ -159,12 +159,17 @@ export class DefaultFrontierCalculator implements FrontierCalculator {
     const storeContributions = await this.store.list(storeQuery);
     const filtered = storeContributions.filter((c) => !isEphemeral(c) && matchesFilters(c, query));
 
-    // Fetch only contributions with relations targeting the filtered set,
-    // rather than scanning the entire store. When no filters are applied,
+    // Fetch only contributions with relations targeting the filtered set
+    // whenever in-memory filtering reduced the candidate set OR store-level
+    // filters are active. This avoids scanning every stored contribution for
+    // context-only filters while preserving semantics for indexed filters.
+    // When the candidate set is unchanged and no store-level filters exist,
     // storeContributions already contains everything — no second query needed.
     const filteredCids = filtered.map((c) => c.cid);
     let allContributions: readonly Contribution[];
-    if (Object.keys(storeQuery).length > 0) {
+    const hasStoreFilters = Object.keys(storeQuery).length > 0;
+    const filteredSubset = filtered.length !== storeContributions.length;
+    if (hasStoreFilters || filteredSubset) {
       const sources = await this.store.incomingSources(filteredCids);
       if (query?.sessionId !== undefined) {
         // Session-scoped: restrict incoming sources to the same session's

--- a/src/core/operations/contribute.test.ts
+++ b/src/core/operations/contribute.test.ts
@@ -85,50 +85,16 @@ describe("contributeOperation", () => {
     if (result.ok) expect(result.value.mode).toBe("exploration");
   });
 
-  test("rejects forged agent overrides when runtime identity is pinned", async () => {
-    const prevAgentId = process.env.GROVE_AGENT_ID;
-    const prevRole = process.env.GROVE_AGENT_ROLE;
-    process.env.GROVE_AGENT_ID = "runtime-agent";
-    process.env.GROVE_AGENT_ROLE = "coder";
+  test("stamps runtime routing token into contribution context", async () => {
+    const prevRoutingToken = process.env.GROVE_ROUTING_TOKEN;
+    process.env.GROVE_ROUTING_TOKEN = "routing-token-1";
     try {
       const result = await contributeOperation(
         {
           kind: "work",
-          summary: "forged identity",
-          agent: { agentId: "spoofed-agent", role: "reviewer" },
-        },
-        deps,
-      );
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error.code).toBe("VALIDATION_ERROR");
-        expect(result.error.message).toContain("conflicts with runtime identity");
-      }
-    } finally {
-      if (prevAgentId === undefined) {
-        delete process.env.GROVE_AGENT_ID;
-      } else {
-        process.env.GROVE_AGENT_ID = prevAgentId;
-      }
-      if (prevRole === undefined) {
-        delete process.env.GROVE_AGENT_ROLE;
-      } else {
-        process.env.GROVE_AGENT_ROLE = prevRole;
-      }
-    }
-  });
-
-  test("binds contribution identity to runtime agent env", async () => {
-    const prevAgentId = process.env.GROVE_AGENT_ID;
-    const prevRole = process.env.GROVE_AGENT_ROLE;
-    process.env.GROVE_AGENT_ID = "runtime-agent";
-    process.env.GROVE_AGENT_ROLE = "coder";
-    try {
-      const result = await contributeOperation(
-        {
-          kind: "work",
-          summary: "runtime identity",
-          agent: { agentName: "friendly-name" },
+          summary: "runtime routing token",
+          context: { note: "hello" },
+          agent: { agentId: "worker-a" },
         },
         deps,
       );
@@ -136,19 +102,42 @@ describe("contributeOperation", () => {
       if (!result.ok) return;
 
       const stored = await deps.contributionStore.get(result.value.cid);
-      expect(stored?.agent.agentId).toBe("runtime-agent");
-      expect(stored?.agent.role).toBe("coder");
-      expect(stored?.agent.agentName).toBe("friendly-name");
+      const context = stored?.context as Record<string, unknown> | undefined;
+      expect(context?.note).toBe("hello");
+      expect(context?._groveRoutingToken).toBe("routing-token-1");
     } finally {
-      if (prevAgentId === undefined) {
-        delete process.env.GROVE_AGENT_ID;
+      if (prevRoutingToken === undefined) {
+        delete process.env.GROVE_ROUTING_TOKEN;
       } else {
-        process.env.GROVE_AGENT_ID = prevAgentId;
+        process.env.GROVE_ROUTING_TOKEN = prevRoutingToken;
       }
-      if (prevRole === undefined) {
-        delete process.env.GROVE_AGENT_ROLE;
+    }
+  });
+
+  test("runtime routing token overrides caller-supplied reserved context key", async () => {
+    const prevRoutingToken = process.env.GROVE_ROUTING_TOKEN;
+    process.env.GROVE_ROUTING_TOKEN = "runtime-token";
+    try {
+      const result = await contributeOperation(
+        {
+          kind: "work",
+          summary: "reserved context override",
+          context: { _groveRoutingToken: "spoofed-token" },
+          agent: { agentId: "worker-a" },
+        },
+        deps,
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const stored = await deps.contributionStore.get(result.value.cid);
+      const context = stored?.context as Record<string, unknown> | undefined;
+      expect(context?._groveRoutingToken).toBe("runtime-token");
+    } finally {
+      if (prevRoutingToken === undefined) {
+        delete process.env.GROVE_ROUTING_TOKEN;
       } else {
-        process.env.GROVE_AGENT_ROLE = prevRole;
+        process.env.GROVE_ROUTING_TOKEN = prevRoutingToken;
       }
     }
   });

--- a/src/core/operations/contribute.test.ts
+++ b/src/core/operations/contribute.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import { LocalEventBus } from "../local-event-bus.js";
+import { ROUTING_SIGNATURE_CONTEXT_KEY } from "../routing-provenance.js";
 import type { AgentTopology } from "../topology.js";
 import { TopologyRouter } from "../topology-router.js";
 import {
@@ -85,14 +86,14 @@ describe("contributeOperation", () => {
     if (result.ok) expect(result.value.mode).toBe("exploration");
   });
 
-  test("stamps runtime routing token into contribution context", async () => {
+  test("stamps runtime routing signature into contribution context", async () => {
     const prevRoutingToken = process.env.GROVE_ROUTING_TOKEN;
     process.env.GROVE_ROUTING_TOKEN = "routing-token-1";
     try {
       const result = await contributeOperation(
         {
           kind: "work",
-          summary: "runtime routing token",
+          summary: "runtime routing signature",
           context: { note: "hello" },
           agent: { agentId: "worker-a" },
         },
@@ -104,7 +105,8 @@ describe("contributeOperation", () => {
       const stored = await deps.contributionStore.get(result.value.cid);
       const context = stored?.context as Record<string, unknown> | undefined;
       expect(context?.note).toBe("hello");
-      expect(context?._groveRoutingToken).toBe("routing-token-1");
+      expect(context?.[ROUTING_SIGNATURE_CONTEXT_KEY]).toMatch(/^[a-f0-9]{64}$/);
+      expect(context?.[ROUTING_SIGNATURE_CONTEXT_KEY]).not.toBe("routing-token-1");
     } finally {
       if (prevRoutingToken === undefined) {
         delete process.env.GROVE_ROUTING_TOKEN;
@@ -114,7 +116,7 @@ describe("contributeOperation", () => {
     }
   });
 
-  test("runtime routing token overrides caller-supplied reserved context key", async () => {
+  test("runtime routing signature overrides caller-supplied reserved context key", async () => {
     const prevRoutingToken = process.env.GROVE_ROUTING_TOKEN;
     process.env.GROVE_ROUTING_TOKEN = "runtime-token";
     try {
@@ -122,7 +124,7 @@ describe("contributeOperation", () => {
         {
           kind: "work",
           summary: "reserved context override",
-          context: { _groveRoutingToken: "spoofed-token" },
+          context: { [ROUTING_SIGNATURE_CONTEXT_KEY]: "spoofed-token" },
           agent: { agentId: "worker-a" },
         },
         deps,
@@ -132,7 +134,8 @@ describe("contributeOperation", () => {
 
       const stored = await deps.contributionStore.get(result.value.cid);
       const context = stored?.context as Record<string, unknown> | undefined;
-      expect(context?._groveRoutingToken).toBe("runtime-token");
+      expect(context?.[ROUTING_SIGNATURE_CONTEXT_KEY]).toMatch(/^[a-f0-9]{64}$/);
+      expect(context?.[ROUTING_SIGNATURE_CONTEXT_KEY]).not.toBe("spoofed-token");
     } finally {
       if (prevRoutingToken === undefined) {
         delete process.env.GROVE_ROUTING_TOKEN;

--- a/src/core/operations/contribute.test.ts
+++ b/src/core/operations/contribute.test.ts
@@ -85,6 +85,74 @@ describe("contributeOperation", () => {
     if (result.ok) expect(result.value.mode).toBe("exploration");
   });
 
+  test("rejects forged agent overrides when runtime identity is pinned", async () => {
+    const prevAgentId = process.env.GROVE_AGENT_ID;
+    const prevRole = process.env.GROVE_AGENT_ROLE;
+    process.env.GROVE_AGENT_ID = "runtime-agent";
+    process.env.GROVE_AGENT_ROLE = "coder";
+    try {
+      const result = await contributeOperation(
+        {
+          kind: "work",
+          summary: "forged identity",
+          agent: { agentId: "spoofed-agent", role: "reviewer" },
+        },
+        deps,
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("VALIDATION_ERROR");
+        expect(result.error.message).toContain("conflicts with runtime identity");
+      }
+    } finally {
+      if (prevAgentId === undefined) {
+        delete process.env.GROVE_AGENT_ID;
+      } else {
+        process.env.GROVE_AGENT_ID = prevAgentId;
+      }
+      if (prevRole === undefined) {
+        delete process.env.GROVE_AGENT_ROLE;
+      } else {
+        process.env.GROVE_AGENT_ROLE = prevRole;
+      }
+    }
+  });
+
+  test("binds contribution identity to runtime agent env", async () => {
+    const prevAgentId = process.env.GROVE_AGENT_ID;
+    const prevRole = process.env.GROVE_AGENT_ROLE;
+    process.env.GROVE_AGENT_ID = "runtime-agent";
+    process.env.GROVE_AGENT_ROLE = "coder";
+    try {
+      const result = await contributeOperation(
+        {
+          kind: "work",
+          summary: "runtime identity",
+          agent: { agentName: "friendly-name" },
+        },
+        deps,
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const stored = await deps.contributionStore.get(result.value.cid);
+      expect(stored?.agent.agentId).toBe("runtime-agent");
+      expect(stored?.agent.role).toBe("coder");
+      expect(stored?.agent.agentName).toBe("friendly-name");
+    } finally {
+      if (prevAgentId === undefined) {
+        delete process.env.GROVE_AGENT_ID;
+      } else {
+        process.env.GROVE_AGENT_ID = prevAgentId;
+      }
+      if (prevRole === undefined) {
+        delete process.env.GROVE_AGENT_ROLE;
+      } else {
+        process.env.GROVE_AGENT_ROLE = prevRole;
+      }
+    }
+  });
+
   test("validates artifact hashes exist in CAS", async () => {
     const result = await contributeOperation(
       {

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -252,6 +252,47 @@ function resolveMode(
   return CM.Evaluation;
 }
 
+/**
+ * Reject caller-supplied agent overrides that conflict with runtime-issued
+ * identity in orchestrated sessions.
+ */
+function validateRuntimeAgentIdentity(
+  overrides: AgentOverrides | undefined,
+): OperationResult<void> | undefined {
+  const runtimeAgentId = process.env.GROVE_AGENT_ID;
+  const runtimeRole = process.env.GROVE_AGENT_ROLE;
+  if (runtimeAgentId === undefined && runtimeRole === undefined) return undefined;
+
+  if (runtimeAgentId !== undefined && overrides?.agentId !== undefined) {
+    if (overrides.agentId !== runtimeAgentId) {
+      return validationErr(
+        `agent.agentId override '${overrides.agentId}' conflicts with runtime identity '${runtimeAgentId}'`,
+      );
+    }
+  }
+  if (runtimeRole !== undefined && overrides?.role !== undefined) {
+    if (overrides.role !== runtimeRole) {
+      return validationErr(
+        `agent.role override '${overrides.role}' conflicts with runtime identity '${runtimeRole}'`,
+      );
+    }
+  }
+  return undefined;
+}
+
+/** Pin resolved identity to runtime-issued values when present. */
+function bindRuntimeAgentIdentity(
+  agent: ReturnType<typeof resolveAgent>,
+): ReturnType<typeof resolveAgent> {
+  const runtimeAgentId = process.env.GROVE_AGENT_ID;
+  const runtimeRole = process.env.GROVE_AGENT_ROLE;
+  return {
+    ...agent,
+    ...(runtimeAgentId !== undefined ? { agentId: runtimeAgentId } : {}),
+    ...(runtimeRole !== undefined ? { role: runtimeRole } : {}),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Idempotency cache
 // ---------------------------------------------------------------------------
@@ -774,7 +815,11 @@ export async function contributeOperation(
     const relations = input.relations ?? [];
     const tags = input.tags ?? [];
 
-    const agent = resolveAgent(input.agent);
+    const identityErr = validateRuntimeAgentIdentity(input.agent);
+    if (identityErr !== undefined) {
+      return identityErr as OperationResult<ContributeResult>;
+    }
+    const agent = bindRuntimeAgentIdentity(resolveAgent(input.agent));
     const mode = resolveMode(input.mode, deps);
     // Normalize to UTC Z-format so lexicographic ORDER BY works without datetime().
     const createdAt = toUtcIso(input.createdAt ?? new Date().toISOString());

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -25,6 +25,7 @@ import {
 } from "../models.js";
 import type { PolicyEnforcementResult } from "../policy-enforcer.js";
 import { PolicyEnforcer } from "../policy-enforcer.js";
+import { attachRoutingSignatureToInput } from "../routing-provenance.js";
 import type { ContributionStore } from "../store.js";
 import { toUtcIso } from "../time.js";
 import type { AgentOverrides } from "./agent.js";
@@ -252,21 +253,11 @@ function resolveMode(
   return CM.Evaluation;
 }
 
-/**
- * Stamp runtime routing provenance into contribution context when available.
- *
- * `_groveRoutingToken` is reserved for orchestrator ownership verification.
- * Runtime value always wins over caller-supplied context to prevent spoofing.
- */
-function withRuntimeRoutingContext(
-  context: Readonly<Record<string, JsonValue>> | undefined,
-): Readonly<Record<string, JsonValue>> | undefined {
+/** Attach runtime routing signature when orchestrator token is present. */
+function withRuntimeRoutingSignature(input: ContributionInput): ContributionInput {
   const routingToken = process.env.GROVE_ROUTING_TOKEN;
-  if (routingToken === undefined) return context;
-  return {
-    ...(context ?? {}),
-    _groveRoutingToken: routingToken,
-  };
+  if (routingToken === undefined) return input;
+  return attachRoutingSignatureToInput(input, routingToken);
 }
 
 // ---------------------------------------------------------------------------
@@ -793,7 +784,6 @@ export async function contributeOperation(
 
     const agent = resolveAgent(input.agent);
     const mode = resolveMode(input.mode, deps);
-    const runtimeContext = withRuntimeRoutingContext(input.context);
     // Normalize to UTC Z-format so lexicographic ORDER BY works without datetime().
     const createdAt = toUtcIso(input.createdAt ?? new Date().toISOString());
 
@@ -935,7 +925,7 @@ export async function contributeOperation(
       ownsDurableReservation = true;
     }
 
-    const contributionInput: ContributionInput = {
+    const unsignedContributionInput: ContributionInput = {
       kind: input.kind,
       mode,
       summary: input.summary,
@@ -945,10 +935,11 @@ export async function contributeOperation(
       relations,
       ...(input.scores !== undefined ? { scores: input.scores } : {}),
       tags: [...tags],
-      ...(runtimeContext !== undefined ? { context: runtimeContext } : {}),
+      ...(input.context !== undefined ? { context: input.context } : {}),
       agent,
       createdAt,
     };
+    const contributionInput = withRuntimeRoutingSignature(unsignedContributionInput);
 
     const contribution = createContribution(contributionInput);
 

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -253,43 +253,19 @@ function resolveMode(
 }
 
 /**
- * Reject caller-supplied agent overrides that conflict with runtime-issued
- * identity in orchestrated sessions.
+ * Stamp runtime routing provenance into contribution context when available.
+ *
+ * `_groveRoutingToken` is reserved for orchestrator ownership verification.
+ * Runtime value always wins over caller-supplied context to prevent spoofing.
  */
-function validateRuntimeAgentIdentity(
-  overrides: AgentOverrides | undefined,
-): OperationResult<void> | undefined {
-  const runtimeAgentId = process.env.GROVE_AGENT_ID;
-  const runtimeRole = process.env.GROVE_AGENT_ROLE;
-  if (runtimeAgentId === undefined && runtimeRole === undefined) return undefined;
-
-  if (runtimeAgentId !== undefined && overrides?.agentId !== undefined) {
-    if (overrides.agentId !== runtimeAgentId) {
-      return validationErr(
-        `agent.agentId override '${overrides.agentId}' conflicts with runtime identity '${runtimeAgentId}'`,
-      );
-    }
-  }
-  if (runtimeRole !== undefined && overrides?.role !== undefined) {
-    if (overrides.role !== runtimeRole) {
-      return validationErr(
-        `agent.role override '${overrides.role}' conflicts with runtime identity '${runtimeRole}'`,
-      );
-    }
-  }
-  return undefined;
-}
-
-/** Pin resolved identity to runtime-issued values when present. */
-function bindRuntimeAgentIdentity(
-  agent: ReturnType<typeof resolveAgent>,
-): ReturnType<typeof resolveAgent> {
-  const runtimeAgentId = process.env.GROVE_AGENT_ID;
-  const runtimeRole = process.env.GROVE_AGENT_ROLE;
+function withRuntimeRoutingContext(
+  context: Readonly<Record<string, JsonValue>> | undefined,
+): Readonly<Record<string, JsonValue>> | undefined {
+  const routingToken = process.env.GROVE_ROUTING_TOKEN;
+  if (routingToken === undefined) return context;
   return {
-    ...agent,
-    ...(runtimeAgentId !== undefined ? { agentId: runtimeAgentId } : {}),
-    ...(runtimeRole !== undefined ? { role: runtimeRole } : {}),
+    ...(context ?? {}),
+    _groveRoutingToken: routingToken,
   };
 }
 
@@ -815,12 +791,9 @@ export async function contributeOperation(
     const relations = input.relations ?? [];
     const tags = input.tags ?? [];
 
-    const identityErr = validateRuntimeAgentIdentity(input.agent);
-    if (identityErr !== undefined) {
-      return identityErr as OperationResult<ContributeResult>;
-    }
-    const agent = bindRuntimeAgentIdentity(resolveAgent(input.agent));
+    const agent = resolveAgent(input.agent);
     const mode = resolveMode(input.mode, deps);
+    const runtimeContext = withRuntimeRoutingContext(input.context);
     // Normalize to UTC Z-format so lexicographic ORDER BY works without datetime().
     const createdAt = toUtcIso(input.createdAt ?? new Date().toISOString());
 
@@ -972,7 +945,7 @@ export async function contributeOperation(
       relations,
       ...(input.scores !== undefined ? { scores: input.scores } : {}),
       tags: [...tags],
-      ...(input.context !== undefined ? { context: input.context } : {}),
+      ...(runtimeContext !== undefined ? { context: runtimeContext } : {}),
       agent,
       createdAt,
     };

--- a/src/core/reconciler.test.ts
+++ b/src/core/reconciler.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import { ClaimStatus } from "./models.js";
+import { DefaultReconciler } from "./reconciler.js";
+import type { ClaimStore, ExpiredClaim } from "./store.js";
+import { ExpiryReason } from "./store.js";
+import type {
+  CheckoutOptions,
+  WorkspaceInfo,
+  WorkspaceManager,
+  WorkspaceQuery,
+} from "./workspace.js";
+import { WorkspaceStatus } from "./workspace.js";
+
+function makeClaimStore(overrides?: {
+  activeClaims?: () => Promise<readonly import("./models.js").Claim[]>;
+  release?: (claimId: string) => Promise<import("./models.js").Claim>;
+  expireStale?: () => Promise<readonly ExpiredClaim[]>;
+  cleanCompleted?: () => Promise<number>;
+}): ClaimStore {
+  const claimsById = new Map<string, import("./models.js").Claim>();
+  return {
+    createClaim: async (claim) => {
+      claimsById.set(claim.claimId, claim);
+      return claim;
+    },
+    claimOrRenew: async (claim) => claim,
+    getClaim: async (claimId) => claimsById.get(claimId),
+    heartbeat: async (claimId) => {
+      const claim = claimsById.get(claimId);
+      if (!claim) throw new Error("missing claim");
+      return claim;
+    },
+    release:
+      overrides?.release ??
+      (async (claimId) => {
+        const claim = claimsById.get(claimId);
+        if (!claim) throw new Error("missing claim");
+        const released = { ...claim, status: ClaimStatus.Released };
+        claimsById.set(claimId, released);
+        return released;
+      }),
+    complete: async (claimId) => {
+      const claim = claimsById.get(claimId);
+      if (!claim) throw new Error("missing claim");
+      const completed = { ...claim, status: ClaimStatus.Completed };
+      claimsById.set(claimId, completed);
+      return completed;
+    },
+    expireStale: overrides?.expireStale ?? (async () => []),
+    activeClaims: overrides?.activeClaims ?? (async () => []),
+    listClaims: async () => [],
+    cleanCompleted: overrides?.cleanCompleted ?? (async () => 0),
+    countActiveClaims: async () => 0,
+    detectStalled: async () => [],
+    close: () => undefined,
+  };
+}
+
+function makeWorkspaceManager(overrides?: {
+  listWorkspaces?: (query?: WorkspaceQuery) => Promise<readonly WorkspaceInfo[]>;
+  markWorkspaceStale?: (cid: string, agentId: string) => Promise<WorkspaceInfo>;
+}): WorkspaceManager {
+  return {
+    checkout: async (_cid: string, _options: CheckoutOptions) => {
+      throw new Error("not implemented");
+    },
+    getWorkspace: async () => undefined,
+    listWorkspaces: overrides?.listWorkspaces ?? (async () => []),
+    cleanWorkspace: async () => false,
+    markStale: async () => [],
+    markWorkspaceStale:
+      overrides?.markWorkspaceStale ??
+      (async (cid, agentId) => ({
+        cid,
+        workspacePath: `/tmp/${cid}`,
+        agent: { agentId },
+        status: WorkspaceStatus.Stale,
+        createdAt: "2026-01-01T00:00:00Z",
+        lastActivityAt: "2026-01-01T00:00:00Z",
+      })),
+    createBareWorkspace: async (key, options) => ({
+      cid: key,
+      workspacePath: `/tmp/${key}`,
+      agent: options.agent,
+      status: WorkspaceStatus.Active,
+      createdAt: "2026-01-01T00:00:00Z",
+      lastActivityAt: "2026-01-01T00:00:00Z",
+    }),
+    touchWorkspace: async () => {
+      throw new Error("not implemented");
+    },
+    close: () => undefined,
+  };
+}
+
+describe("DefaultReconciler", () => {
+  test("deduplicateActiveClaims keeps newest by actual timestamp, not lexical string", async () => {
+    const releasedIds: string[] = [];
+    const claimStore = makeClaimStore({
+      activeClaims: async () => [
+        {
+          claimId: "old-offset",
+          targetRef: "target-1",
+          agent: { agentId: "agent-1" },
+          status: ClaimStatus.Active,
+          intentSummary: "older absolute time, but lexically larger",
+          createdAt: "2026-01-01T00:00:00+09:00",
+          heartbeatAt: "2026-01-01T00:00:00+09:00",
+          leaseExpiresAt: "2026-01-02T00:00:00+09:00",
+        },
+        {
+          claimId: "newer-z",
+          targetRef: "target-1",
+          agent: { agentId: "agent-1" },
+          status: ClaimStatus.Active,
+          intentSummary: "newer absolute time",
+          createdAt: "2025-12-31T16:00:00Z",
+          heartbeatAt: "2025-12-31T16:00:00Z",
+          leaseExpiresAt: "2026-01-01T16:00:00Z",
+        },
+      ],
+      release: async (claimId) => {
+        releasedIds.push(claimId);
+        return {
+          claimId,
+          targetRef: "target-1",
+          agent: { agentId: "agent-1" },
+          status: ClaimStatus.Released,
+          intentSummary: "released",
+          createdAt: "2026-01-01T00:00:00Z",
+          heartbeatAt: "2026-01-01T00:00:00Z",
+          leaseExpiresAt: "2026-01-01T01:00:00Z",
+        };
+      },
+    });
+
+    const reconciler = new DefaultReconciler(claimStore);
+    const result = await reconciler.reconcile();
+
+    expect(result.deduplicatedClaims).toEqual(["old-offset"]);
+    expect(releasedIds).toEqual(["old-offset"]);
+  });
+
+  test("startupReconcile continues when one orphan workspace fails to mark stale", async () => {
+    const claimStore = makeClaimStore({
+      expireStale: async () => [],
+      activeClaims: async () => [],
+    });
+    const wsA: WorkspaceInfo = {
+      cid: "cid-a",
+      workspacePath: "/tmp/cid-a",
+      agent: { agentId: "agent-a" },
+      status: WorkspaceStatus.Active,
+      createdAt: "2026-01-01T00:00:00Z",
+      lastActivityAt: "2026-01-01T00:00:00Z",
+    };
+    const wsB: WorkspaceInfo = {
+      cid: "cid-b",
+      workspacePath: "/tmp/cid-b",
+      agent: { agentId: "agent-b" },
+      status: WorkspaceStatus.Active,
+      createdAt: "2026-01-01T00:00:00Z",
+      lastActivityAt: "2026-01-01T00:00:00Z",
+    };
+    const workspaceManager = makeWorkspaceManager({
+      listWorkspaces: async () => [wsA, wsB],
+      markWorkspaceStale: async (cid, agentId) => {
+        if (cid === "cid-a") throw new Error("concurrent cleanup");
+        return {
+          cid,
+          workspacePath: `/tmp/${cid}`,
+          agent: { agentId },
+          status: WorkspaceStatus.Stale,
+          createdAt: "2026-01-01T00:00:00Z",
+          lastActivityAt: "2026-01-01T00:00:00Z",
+          context: { reason: ExpiryReason.Stalled },
+        };
+      },
+    });
+
+    const reconciler = new DefaultReconciler(claimStore, workspaceManager);
+    const result = await reconciler.startupReconcile();
+
+    expect(result.expiredClaims).toHaveLength(0);
+    expect(result.orphanedWorkspaces).toHaveLength(1);
+    expect(result.orphanedWorkspaces[0]?.cid).toBe("cid-b");
+    expect(result.orphanedWorkspaces[0]?.status).toBe(WorkspaceStatus.Stale);
+  });
+});

--- a/src/core/reconciler.test.ts
+++ b/src/core/reconciler.test.ts
@@ -141,7 +141,7 @@ describe("DefaultReconciler", () => {
     expect(releasedIds).toEqual(["old-offset"]);
   });
 
-  test("startupReconcile continues when one orphan workspace fails to mark stale", async () => {
+  test("startupReconcile continues when one orphan workspace is concurrently removed", async () => {
     const claimStore = makeClaimStore({
       expireStale: async () => [],
       activeClaims: async () => [],
@@ -165,7 +165,7 @@ describe("DefaultReconciler", () => {
     const workspaceManager = makeWorkspaceManager({
       listWorkspaces: async () => [wsA, wsB],
       markWorkspaceStale: async (cid, agentId) => {
-        if (cid === "cid-a") throw new Error("concurrent cleanup");
+        if (cid === "cid-a") throw new Error("Workspace for 'cid-a' (agent 'agent-a') not found");
         return {
           cid,
           workspacePath: `/tmp/${cid}`,
@@ -185,5 +185,30 @@ describe("DefaultReconciler", () => {
     expect(result.orphanedWorkspaces).toHaveLength(1);
     expect(result.orphanedWorkspaces[0]?.cid).toBe("cid-b");
     expect(result.orphanedWorkspaces[0]?.status).toBe(WorkspaceStatus.Stale);
+  });
+
+  test("startupReconcile surfaces non-benign orphan-mark failures", async () => {
+    const claimStore = makeClaimStore({
+      expireStale: async () => [],
+      activeClaims: async () => [],
+    });
+    const workspaceManager = makeWorkspaceManager({
+      listWorkspaces: async () => [
+        {
+          cid: "cid-x",
+          workspacePath: "/tmp/cid-x",
+          agent: { agentId: "agent-x" },
+          status: WorkspaceStatus.Active,
+          createdAt: "2026-01-01T00:00:00Z",
+          lastActivityAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      markWorkspaceStale: async () => {
+        throw new Error("sqlite write failed");
+      },
+    });
+
+    const reconciler = new DefaultReconciler(claimStore, workspaceManager);
+    await expect(reconciler.startupReconcile()).rejects.toThrow("sqlite write failed");
   });
 });

--- a/src/core/reconciler.test.ts
+++ b/src/core/reconciler.test.ts
@@ -9,7 +9,7 @@ import type {
   WorkspaceManager,
   WorkspaceQuery,
 } from "./workspace.js";
-import { WorkspaceStatus } from "./workspace.js";
+import { WorkspaceNotFoundError, WorkspaceStatus } from "./workspace.js";
 
 function makeClaimStore(overrides?: {
   activeClaims?: () => Promise<readonly import("./models.js").Claim[]>;
@@ -165,7 +165,7 @@ describe("DefaultReconciler", () => {
     const workspaceManager = makeWorkspaceManager({
       listWorkspaces: async () => [wsA, wsB],
       markWorkspaceStale: async (cid, agentId) => {
-        if (cid === "cid-a") throw new Error("Workspace for 'cid-a' (agent 'agent-a') not found");
+        if (cid === "cid-a") throw new WorkspaceNotFoundError(cid, agentId);
         return {
           cid,
           workspacePath: `/tmp/${cid}`,

--- a/src/core/reconciler.ts
+++ b/src/core/reconciler.ts
@@ -175,8 +175,15 @@ export class DefaultReconciler implements Reconciler {
     for (const group of groups.values()) {
       if (group.length <= 1) continue;
 
-      // Sort by createdAt descending — keep first (newest)
-      group.sort((a, b) => (a.createdAt > b.createdAt ? -1 : a.createdAt < b.createdAt ? 1 : 0));
+      // Sort by parsed timestamp descending — keep first (newest).
+      // Use Date.parse rather than lexical string order so timestamps with
+      // timezone offsets compare correctly (e.g. "+09:00" vs "Z").
+      group.sort((a, b) => {
+        const ta = Date.parse(a.createdAt);
+        const tb = Date.parse(b.createdAt);
+        if (Number.isFinite(ta) && Number.isFinite(tb) && ta !== tb) return tb - ta;
+        return a.createdAt > b.createdAt ? -1 : a.createdAt < b.createdAt ? 1 : 0;
+      });
 
       for (let i = 1; i < group.length; i++) {
         const claim = group[i];
@@ -223,9 +230,15 @@ export class DefaultReconciler implements Reconciler {
     for (const ws of activeWorkspaces) {
       const key = `${ws.cid}::${ws.agent.agentId}`;
       if (!activeClaimKeys.has(key)) {
-        // Mark orphaned workspace as stale so it's flagged for cleanup
-        const staleWs = await this.workspaceManager?.markWorkspaceStale(ws.cid, ws.agent.agentId);
-        orphaned.push(staleWs);
+        // Mark orphaned workspace as stale so it's flagged for cleanup.
+        // Best-effort: if one workspace disappeared concurrently, continue
+        // scanning others instead of failing startup reconciliation.
+        try {
+          const staleWs = await this.workspaceManager.markWorkspaceStale(ws.cid, ws.agent.agentId);
+          orphaned.push(staleWs);
+        } catch {
+          // Workspace may have been cleaned concurrently — ignore.
+        }
       }
     }
 

--- a/src/core/reconciler.ts
+++ b/src/core/reconciler.ts
@@ -236,8 +236,15 @@ export class DefaultReconciler implements Reconciler {
         try {
           const staleWs = await this.workspaceManager.markWorkspaceStale(ws.cid, ws.agent.agentId);
           orphaned.push(staleWs);
-        } catch {
-          // Workspace may have been cleaned concurrently — ignore.
+        } catch (err) {
+          // Benign race: workspace disappeared between list() and mark().
+          // Surface all other failures so startup reconciliation doesn't
+          // silently mask storage/cleanup regressions.
+          const message = err instanceof Error ? err.message : String(err);
+          if (message.toLowerCase().includes("not found")) {
+            continue;
+          }
+          throw err;
         }
       }
     }

--- a/src/core/reconciler.ts
+++ b/src/core/reconciler.ts
@@ -13,7 +13,7 @@
 
 import type { ClaimStore, ExpiredClaim } from "./store.js";
 import type { WorkspaceInfo, WorkspaceManager } from "./workspace.js";
-import { WorkspaceStatus } from "./workspace.js";
+import { WorkspaceNotFoundError, WorkspaceStatus } from "./workspace.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -240,8 +240,7 @@ export class DefaultReconciler implements Reconciler {
           // Benign race: workspace disappeared between list() and mark().
           // Surface all other failures so startup reconciliation doesn't
           // silently mask storage/cleanup regressions.
-          const message = err instanceof Error ? err.message : String(err);
-          if (message.toLowerCase().includes("not found")) {
+          if (err instanceof WorkspaceNotFoundError) {
             continue;
           }
           throw err;

--- a/src/core/routing-provenance.ts
+++ b/src/core/routing-provenance.ts
@@ -1,0 +1,117 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { Contribution, ContributionInput, JsonValue, Relation, Score } from "./models.js";
+
+export const ROUTING_SIGNATURE_CONTEXT_KEY = "_groveRoutingSig";
+
+interface RoutingSignaturePayload {
+  readonly kind: ContributionInput["kind"];
+  readonly mode: ContributionInput["mode"];
+  readonly summary: string;
+  readonly description?: string | undefined;
+  readonly artifacts: Readonly<Record<string, string>>;
+  readonly commitHash?: string | undefined;
+  readonly relations: readonly Relation[];
+  readonly scores?: Readonly<Record<string, Score>> | undefined;
+  readonly tags: readonly string[];
+  readonly context?: Readonly<Record<string, JsonValue>> | undefined;
+  readonly agent: {
+    readonly agentId: string;
+    readonly role?: string | undefined;
+  };
+  readonly createdAt: string;
+}
+
+function stripRoutingSignature(
+  context: Readonly<Record<string, JsonValue>> | undefined,
+): Readonly<Record<string, JsonValue>> | undefined {
+  if (context === undefined) return undefined;
+  const next: Record<string, JsonValue> = { ...context };
+  delete next[ROUTING_SIGNATURE_CONTEXT_KEY];
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || value === undefined) return null;
+  if (Array.isArray(value)) return value.map((v) => canonicalize(v));
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = canonicalize((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function payloadFromInput(input: ContributionInput): RoutingSignaturePayload {
+  return {
+    kind: input.kind,
+    mode: input.mode,
+    summary: input.summary,
+    description: input.description,
+    artifacts: input.artifacts,
+    commitHash: input.commitHash,
+    relations: input.relations,
+    scores: input.scores,
+    tags: input.tags,
+    context: stripRoutingSignature(input.context),
+    agent: { agentId: input.agent.agentId, role: input.agent.role },
+    createdAt: input.createdAt,
+  };
+}
+
+function payloadFromContribution(contribution: Contribution): RoutingSignaturePayload {
+  return {
+    kind: contribution.kind,
+    mode: contribution.mode,
+    summary: contribution.summary,
+    description: contribution.description,
+    artifacts: contribution.artifacts,
+    commitHash: contribution.commitHash,
+    relations: contribution.relations,
+    scores: contribution.scores,
+    tags: contribution.tags,
+    context: stripRoutingSignature(contribution.context),
+    agent: { agentId: contribution.agent.agentId, role: contribution.agent.role },
+    createdAt: contribution.createdAt,
+  };
+}
+
+function signPayload(payload: RoutingSignaturePayload, routingToken: string): string {
+  const canonical = JSON.stringify(canonicalize(payload));
+  return createHmac("sha256", routingToken).update(canonical).digest("hex");
+}
+
+export function attachRoutingSignatureToInput(
+  input: ContributionInput,
+  routingToken: string,
+): ContributionInput {
+  const signature = signPayload(payloadFromInput(input), routingToken);
+  return {
+    ...input,
+    context: {
+      ...(stripRoutingSignature(input.context) ?? {}),
+      [ROUTING_SIGNATURE_CONTEXT_KEY]: signature,
+    },
+  };
+}
+
+export function computeRoutingSignatureForContribution(
+  contribution: Contribution,
+  routingToken: string,
+): string {
+  return signPayload(payloadFromContribution(contribution), routingToken);
+}
+
+export function hasValidRoutingSignature(
+  contribution: Contribution,
+  routingToken: string,
+): boolean {
+  const observed = contribution.context?.[ROUTING_SIGNATURE_CONTEXT_KEY];
+  if (typeof observed !== "string") return false;
+  const expected = computeRoutingSignatureForContribution(contribution, routingToken);
+  const observedBuf = Buffer.from(observed, "utf8");
+  const expectedBuf = Buffer.from(expected, "utf8");
+  if (observedBuf.length !== expectedBuf.length) return false;
+  return timingSafeEqual(observedBuf, expectedBuf);
+}

--- a/src/core/session-manager.test.ts
+++ b/src/core/session-manager.test.ts
@@ -63,6 +63,51 @@ describe("SessionManager", () => {
     expect(updated!.status).toBe("cancelled");
   });
 
+  test("startSession throws when session does not exist", async () => {
+    const store = new InMemorySessionStore();
+    const manager = new SessionManager(store);
+
+    await expect(manager.startSession("missing-id")).rejects.toThrow("not found");
+  });
+
+  test("archiveSession throws when session does not exist", async () => {
+    const store = new InMemorySessionStore();
+    const manager = new SessionManager(store);
+
+    await expect(manager.archiveSession("missing-id")).rejects.toThrow("not found");
+  });
+
+  test("archiveSession rejects pending → archived transition", async () => {
+    const store = new InMemorySessionStore();
+    const manager = new SessionManager(store);
+
+    const session = await manager.createSession({
+      goal: "Test",
+      presetName: "review-loop",
+    });
+
+    await expect(manager.archiveSession(session.id)).rejects.toThrow(
+      "Invalid session state transition",
+    );
+  });
+
+  test("archiveSession archives completed session", async () => {
+    const store = new InMemorySessionStore();
+    const manager = new SessionManager(store);
+
+    const session = await manager.createSession({
+      goal: "Test",
+      presetName: "review-loop",
+    });
+    await manager.startSession(session.id);
+    await manager.completeSession(session.id);
+    await manager.archiveSession(session.id);
+
+    const updated = await store.getSession(session.id);
+    expect(updated!.status).toBe("archived");
+    expect(updated!.completedAt).toBeTruthy();
+  });
+
   test("listSessions returns all sessions sorted by recency", async () => {
     const store = new InMemorySessionStore();
     const manager = new SessionManager(store);

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -64,6 +64,16 @@ export class SessionManager {
 
   /** Archive a session. */
   async archiveSession(id: string): Promise<void> {
+    const session = await this.store.getSession(id);
+    if (!session) {
+      throw new Error(`Session '${id}' not found`);
+    }
+    const allowed = SessionManager.VALID_TRANSITIONS[session.status] ?? [];
+    if (!allowed.includes("archived")) {
+      throw new Error(
+        `Invalid session state transition: ${session.status} → archived (allowed: ${allowed.join(", ") || "none"})`,
+      );
+    }
     await this.store.archiveSession(id);
   }
 
@@ -74,13 +84,14 @@ export class SessionManager {
     extraFields?: Record<string, unknown>,
   ): Promise<void> {
     const session = await this.store.getSession(id);
-    if (session) {
-      const allowed = SessionManager.VALID_TRANSITIONS[session.status] ?? [];
-      if (!allowed.includes(newStatus)) {
-        throw new Error(
-          `Invalid session state transition: ${session.status} → ${newStatus} (allowed: ${allowed.join(", ") || "none"})`,
-        );
-      }
+    if (!session) {
+      throw new Error(`Session '${id}' not found`);
+    }
+    const allowed = SessionManager.VALID_TRANSITIONS[session.status] ?? [];
+    if (!allowed.includes(newStatus)) {
+      throw new Error(
+        `Invalid session state transition: ${session.status} → ${newStatus} (allowed: ${allowed.join(", ") || "none"})`,
+      );
     }
     await this.store.updateSession(id, {
       status: newStatus,

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -258,6 +258,51 @@ describe("SessionOrchestrator", () => {
     bus.close();
   });
 
+  test("polling forwards contributions tagged with session-scoped GROVE_AGENT_ID", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    const contract = makeContract();
+    const contributions: ReturnType<typeof makeContribution>[] = [];
+    const contributionStore = {
+      list: async () => contributions,
+    };
+
+    const sessionId = "session-routing-1";
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract,
+      topology: contract.topology!,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+      contributionStore,
+      sessionId,
+    });
+    const internals = orchestrator as unknown as {
+      startContributionPolling: () => void;
+      pollContributions: () => Promise<void>;
+    };
+    // Avoid a real 15s timer in test; invoke poll manually.
+    internals.startContributionPolling = () => undefined;
+
+    await orchestrator.start();
+    contributions.push(
+      makeContribution({
+        summary: "env-derived coder contribution",
+        agent: { agentId: `${sessionId}:coder`, role: "coder" },
+      }),
+    );
+
+    await internals.pollContributions();
+
+    // 2 initial goal sends + 1 routed handoff to reviewer.
+    expect(runtime.sendCalls).toHaveLength(3);
+    expect(runtime.sendCalls[2]!.message).toContain("env-derived coder contribution");
+    bus.close();
+  });
+
   test("stop events are not forwarded to agents", async () => {
     const contract = makeContract();
     const { orchestrator, runtime, bus } = makeOrchestrator(contract);

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -3,6 +3,7 @@ import type { GroveContract } from "./contract.js";
 import { LocalEventBus } from "./local-event-bus.js";
 import { MockRuntime } from "./mock-runtime.js";
 import { SessionOrchestrator } from "./session-orchestrator.js";
+import { makeContribution } from "./test-helpers.js";
 import type { AgentTopology } from "./topology.js";
 
 function makeContract(overrides?: Partial<GroveContract>): GroveContract {
@@ -168,6 +169,92 @@ describe("SessionOrchestrator", () => {
     // 2 goal sends (MockRuntime) + 1 contribution forwarding = 3
     expect(runtime.sendCalls.length).toBe(3);
     expect(runtime.sendCalls[2]!.message).toContain("coder");
+    bus.close();
+  });
+
+  test("polling ignores contributions from same-role agents in other sessions", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    const contract = makeContract();
+    const contributions = [
+      makeContribution({
+        summary: "external coder contribution",
+        agent: { agentId: "external-session-coder", role: "coder" },
+      }),
+    ];
+    const contributionStore = {
+      list: async () => contributions,
+    };
+
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract,
+      topology: contract.topology!,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+      contributionStore,
+    });
+    const internals = orchestrator as unknown as {
+      startContributionPolling: () => void;
+      pollContributions: () => Promise<void>;
+    };
+    // Avoid a real 15s timer in test; invoke poll manually.
+    internals.startContributionPolling = () => undefined;
+
+    await orchestrator.start();
+    await internals.pollContributions();
+
+    // Only initial role-goal sends should be present.
+    expect(runtime.sendCalls).toHaveLength(2);
+    bus.close();
+  });
+
+  test("polling forwards contributions from this session's agentId", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    const contract = makeContract();
+    const contributions: ReturnType<typeof makeContribution>[] = [];
+    const contributionStore = {
+      list: async () => contributions,
+    };
+
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract,
+      topology: contract.topology!,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+      contributionStore,
+    });
+    const internals = orchestrator as unknown as {
+      startContributionPolling: () => void;
+      pollContributions: () => Promise<void>;
+    };
+    // Avoid a real 15s timer in test; invoke poll manually.
+    internals.startContributionPolling = () => undefined;
+
+    const started = await orchestrator.start();
+    const coderSessionId = started.agents.find((a) => a.role === "coder")?.session.id;
+    expect(coderSessionId).toBeDefined();
+
+    contributions.push(
+      makeContribution({
+        summary: "local coder contribution",
+        agent: { agentId: coderSessionId ?? "missing", role: "coder" },
+      }),
+    );
+
+    await internals.pollContributions();
+
+    // 2 initial goal sends + 1 routed handoff to reviewer.
+    expect(runtime.sendCalls).toHaveLength(3);
+    expect(runtime.sendCalls[2]!.message).toContain("local coder contribution");
     bus.close();
   });
 

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -258,7 +258,7 @@ describe("SessionOrchestrator", () => {
     bus.close();
   });
 
-  test("polling forwards contributions tagged with session-scoped GROVE_AGENT_ID", async () => {
+  test("polling ignores contributions with forgeable deterministic agent ids", async () => {
     const runtime = new MockRuntime();
     const bus = new LocalEventBus();
     const contract = makeContract();
@@ -290,16 +290,15 @@ describe("SessionOrchestrator", () => {
     await orchestrator.start();
     contributions.push(
       makeContribution({
-        summary: "env-derived coder contribution",
+        summary: "spoofed deterministic id contribution",
         agent: { agentId: `${sessionId}:coder`, role: "coder" },
       }),
     );
 
     await internals.pollContributions();
 
-    // 2 initial goal sends + 1 routed handoff to reviewer.
-    expect(runtime.sendCalls).toHaveLength(3);
-    expect(runtime.sendCalls[2]!.message).toContain("env-derived coder contribution");
+    // Only initial role-goal sends should be present.
+    expect(runtime.sendCalls).toHaveLength(2);
     bus.close();
   });
 

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test";
 import type { GroveContract } from "./contract.js";
 import { LocalEventBus } from "./local-event-bus.js";
 import { MockRuntime } from "./mock-runtime.js";
+import {
+  computeRoutingSignatureForContribution,
+  ROUTING_SIGNATURE_CONTEXT_KEY,
+} from "./routing-provenance.js";
 import { SessionOrchestrator } from "./session-orchestrator.js";
 import { makeContribution } from "./test-helpers.js";
 import type { AgentTopology } from "./topology.js";
@@ -57,6 +61,20 @@ function makeOrchestrator(
     ...(overrides?.sessionId ? { sessionId: overrides.sessionId } : {}),
   });
   return { orchestrator, runtime, bus };
+}
+
+function signContributionForRouting(
+  contribution: ReturnType<typeof makeContribution>,
+  routingToken: string,
+): ReturnType<typeof makeContribution> {
+  const signature = computeRoutingSignatureForContribution(contribution, routingToken);
+  return {
+    ...contribution,
+    context: {
+      ...(contribution.context ?? {}),
+      [ROUTING_SIGNATURE_CONTEXT_KEY]: signature,
+    },
+  };
 }
 
 describe("SessionOrchestrator", () => {
@@ -247,11 +265,13 @@ describe("SessionOrchestrator", () => {
     expect(coderToken).toBeDefined();
 
     contributions.push(
-      makeContribution({
-        summary: "local coder contribution",
-        context: { _groveRoutingToken: coderToken ?? "missing-token" },
-        agent: { agentId: coderSessionId ?? "missing", role: "coder" },
-      }),
+      signContributionForRouting(
+        makeContribution({
+          summary: "local coder contribution",
+          agent: { agentId: coderSessionId ?? "missing", role: "coder" },
+        }),
+        coderToken ?? "missing-token",
+      ),
     );
 
     await internals.pollContributions();
@@ -306,7 +326,53 @@ describe("SessionOrchestrator", () => {
     bus.close();
   });
 
-  test("polling ignores forged session id when routing token is wrong", async () => {
+  test("polling ignores forged session id when routing signature is invalid", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    const contract = makeContract();
+    const contributions: ReturnType<typeof makeContribution>[] = [];
+    const contributionStore = {
+      list: async () => contributions,
+    };
+
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract,
+      topology: contract.topology!,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+      contributionStore,
+    });
+    const internals = orchestrator as unknown as {
+      startContributionPolling: () => void;
+      pollContributions: () => Promise<void>;
+    };
+    // Avoid a real 15s timer in test; invoke poll manually.
+    internals.startContributionPolling = () => undefined;
+
+    const started = await orchestrator.start();
+    const coderSessionId = started.agents.find((a) => a.role === "coder")?.session.id;
+    expect(coderSessionId).toBeDefined();
+
+    contributions.push({
+      ...makeContribution({
+        summary: "forged signature contribution",
+        agent: { agentId: coderSessionId ?? "missing", role: "coder" },
+      }),
+      context: { [ROUTING_SIGNATURE_CONTEXT_KEY]: "invalid-signature" },
+    });
+
+    await internals.pollContributions();
+
+    // Only initial role-goal sends should be present.
+    expect(runtime.sendCalls).toHaveLength(2);
+    bus.close();
+  });
+
+  test("polling ignores forged session id when routing signature uses wrong token", async () => {
     const runtime = new MockRuntime();
     const bus = new LocalEventBus();
     const contract = makeContract();
@@ -338,11 +404,13 @@ describe("SessionOrchestrator", () => {
     expect(coderSessionId).toBeDefined();
 
     contributions.push(
-      makeContribution({
-        summary: "forged token contribution",
-        context: { _groveRoutingToken: "wrong-token" },
-        agent: { agentId: coderSessionId ?? "missing", role: "coder" },
-      }),
+      signContributionForRouting(
+        makeContribution({
+          summary: "forged token contribution",
+          agent: { agentId: coderSessionId ?? "missing", role: "coder" },
+        }),
+        "wrong-token",
+      ),
     );
 
     await internals.pollContributions();

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -241,11 +241,15 @@ describe("SessionOrchestrator", () => {
 
     const started = await orchestrator.start();
     const coderSessionId = started.agents.find((a) => a.role === "coder")?.session.id;
+    const coderToken = runtime.spawnCalls.find((c) => c.role === "coder")?.config.env
+      ?.GROVE_ROUTING_TOKEN;
     expect(coderSessionId).toBeDefined();
+    expect(coderToken).toBeDefined();
 
     contributions.push(
       makeContribution({
         summary: "local coder contribution",
+        context: { _groveRoutingToken: coderToken ?? "missing-token" },
         agent: { agentId: coderSessionId ?? "missing", role: "coder" },
       }),
     );
@@ -292,6 +296,52 @@ describe("SessionOrchestrator", () => {
       makeContribution({
         summary: "spoofed deterministic id contribution",
         agent: { agentId: `${sessionId}:coder`, role: "coder" },
+      }),
+    );
+
+    await internals.pollContributions();
+
+    // Only initial role-goal sends should be present.
+    expect(runtime.sendCalls).toHaveLength(2);
+    bus.close();
+  });
+
+  test("polling ignores forged session id when routing token is wrong", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    const contract = makeContract();
+    const contributions: ReturnType<typeof makeContribution>[] = [];
+    const contributionStore = {
+      list: async () => contributions,
+    };
+
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract,
+      topology: contract.topology!,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+      contributionStore,
+    });
+    const internals = orchestrator as unknown as {
+      startContributionPolling: () => void;
+      pollContributions: () => Promise<void>;
+    };
+    // Avoid a real 15s timer in test; invoke poll manually.
+    internals.startContributionPolling = () => undefined;
+
+    const started = await orchestrator.start();
+    const coderSessionId = started.agents.find((a) => a.role === "coder")?.session.id;
+    expect(coderSessionId).toBeDefined();
+
+    contributions.push(
+      makeContribution({
+        summary: "forged token contribution",
+        context: { _groveRoutingToken: "wrong-token" },
+        agent: { agentId: coderSessionId ?? "missing", role: "coder" },
       }),
     );
 

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -126,15 +126,6 @@ export class SessionOrchestrator {
   }
 
   /**
-   * Stable agent identity propagated to child processes via GROVE_AGENT_ID.
-   * This is session-scoped and role-scoped, so contribution polling can
-   * attribute writes even when runtime session IDs are transport-specific.
-   */
-  private sessionScopedAgentId(roleName: string): string {
-    return `${this.sessionId}:${roleName}`;
-  }
-
-  /**
    * Observe a fire-and-forget turn's outcome and surface error stop reasons.
    * With the typed-stream runtime, post-spawn failures (malformed frames,
    * provider rejections, cancelled turns) show up as `stopReason: "error"`
@@ -322,14 +313,11 @@ export class SessionOrchestrator {
         if (!sourceRole) continue;
 
         // Only process contributions from agents in THIS session.
-        // Accept both:
-        // - runtime session IDs (legacy/test path), and
-        // - stable session-scoped GROVE_AGENT_ID values propagated at spawn.
+        // Match by runtime-issued session ID + role to avoid same-role
+        // cross-session collisions during polling.
         const agentId = c.agent.agentId;
         const isOurAgent = this.agents.some(
-          (a) =>
-            a.role === sourceRole &&
-            (a.session.id === agentId || this.sessionScopedAgentId(a.role) === agentId),
+          (a) => a.role === sourceRole && a.session.id === agentId,
         );
         if (!isOurAgent) continue;
 
@@ -426,7 +414,6 @@ export class SessionOrchestrator {
         GROVE_SESSION_ID: this.sessionId,
         GROVE_ROLE: role.name,
         GROVE_AGENT_ROLE: role.name,
-        GROVE_AGENT_ID: this.sessionScopedAgentId(role.name),
       },
     };
 

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -14,6 +14,7 @@ import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js
 import type { GroveContract } from "./contract.js";
 import type { EventBus, GroveEvent } from "./event-bus.js";
 import { resolveMcpServePath } from "./resolve-mcp-serve-path.js";
+import { hasValidRoutingSignature } from "./routing-provenance.js";
 import type { AgentPlatformType, AgentRole, AgentTopology } from "./topology.js";
 import { resolveRoleWorkspaceStrategies, topologicalSortRoles } from "./topology.js";
 import { TopologyRouter } from "./topology-router.js";
@@ -86,8 +87,6 @@ export interface AgentSessionInfo {
   /** Describes how this agent's workspace was provisioned. */
   readonly workspaceMode: WorkspaceMode;
 }
-
-const ROUTING_TOKEN_CONTEXT_KEY = "_groveRoutingToken";
 
 /**
  * Merge runtime selection fields from role + profile.
@@ -316,17 +315,13 @@ export class SessionOrchestrator {
         const sourceAgent = this.agents.find((a) => a.role === sourceRole);
         if (!sourceAgent) continue;
 
-        // Trust boundary: require the per-agent routing token issued at spawn.
-        // This prevents caller-supplied `agent` metadata from impersonating
-        // another role/session in the polling router.
+        // Trust boundary: require a valid per-contribution routing signature
+        // and runtime-issued agent session identity.
         const expectedToken = this.routingTokensByRole.get(sourceRole);
-        const context = c.context as Record<string, unknown> | undefined;
-        const observedToken = context?.[ROUTING_TOKEN_CONTEXT_KEY];
-        if (
-          expectedToken === undefined ||
-          typeof observedToken !== "string" ||
-          observedToken !== expectedToken
-        ) {
+        if (expectedToken === undefined || !hasValidRoutingSignature(c, expectedToken)) {
+          continue;
+        }
+        if (c.agent.agentId !== sourceAgent.session.id) {
           continue;
         }
 

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -126,6 +126,15 @@ export class SessionOrchestrator {
   }
 
   /**
+   * Stable agent identity propagated to child processes via GROVE_AGENT_ID.
+   * This is session-scoped and role-scoped, so contribution polling can
+   * attribute writes even when runtime session IDs are transport-specific.
+   */
+  private sessionScopedAgentId(roleName: string): string {
+    return `${this.sessionId}:${roleName}`;
+  }
+
+  /**
    * Observe a fire-and-forget turn's outcome and surface error stop reasons.
    * With the typed-stream runtime, post-spawn failures (malformed frames,
    * provider rejections, cancelled turns) show up as `stopReason: "error"`
@@ -313,10 +322,14 @@ export class SessionOrchestrator {
         if (!sourceRole) continue;
 
         // Only process contributions from agents in THIS session.
-        // Match by agentId (unique per spawn), not just role name (shared across sessions).
+        // Accept both:
+        // - runtime session IDs (legacy/test path), and
+        // - stable session-scoped GROVE_AGENT_ID values propagated at spawn.
         const agentId = c.agent.agentId;
         const isOurAgent = this.agents.some(
-          (a) => a.role === sourceRole && a.session.id === agentId,
+          (a) =>
+            a.role === sourceRole &&
+            (a.session.id === agentId || this.sessionScopedAgentId(a.role) === agentId),
         );
         if (!isOurAgent) continue;
 
@@ -412,6 +425,8 @@ export class SessionOrchestrator {
       env: {
         GROVE_SESSION_ID: this.sessionId,
         GROVE_ROLE: role.name,
+        GROVE_AGENT_ROLE: role.name,
+        GROVE_AGENT_ID: this.sessionScopedAgentId(role.name),
       },
     };
 

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -115,6 +115,7 @@ export class SessionOrchestrator {
   private startedAt = 0;
   private readonly seenCids = new Set<string>();
   private contributionPollTimer: ReturnType<typeof setInterval> | null = null;
+  private contributionPollStartTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(config: SessionConfig) {
     this.config = config;
@@ -245,6 +246,10 @@ export class SessionOrchestrator {
     this.stopReason = reason;
 
     // Stop contribution polling
+    if (this.contributionPollStartTimer) {
+      clearTimeout(this.contributionPollStartTimer);
+      this.contributionPollStartTimer = null;
+    }
     if (this.contributionPollTimer) {
       clearInterval(this.contributionPollTimer);
       this.contributionPollTimer = null;
@@ -281,13 +286,14 @@ export class SessionOrchestrator {
     });
 
     // Start polling after initial delay
-    setTimeout(() => {
+    this.contributionPollStartTimer = setTimeout(() => {
       if (this.stopped) return;
       this.contributionPollTimer = setInterval(() => {
         void this.pollContributions();
       }, POLL_MS);
       // Also poll immediately on first tick
       void this.pollContributions();
+      this.contributionPollStartTimer = null;
     }, INITIAL_DELAY_MS);
   }
 
@@ -310,8 +316,7 @@ export class SessionOrchestrator {
         // Match by agentId (unique per spawn), not just role name (shared across sessions).
         const agentId = c.agent.agentId;
         const isOurAgent = this.agents.some(
-          (a) =>
-            a.role === sourceRole && (a.session.id === agentId || a.session.role === sourceRole),
+          (a) => a.role === sourceRole && a.session.id === agentId,
         );
         if (!isOurAgent) continue;
 

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -5,6 +5,7 @@
  * sends goals, wires event routing, and monitors for stop conditions.
  */
 
+import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import type { AcpxTurn } from "../acp/types.js";
 import { watchTurnError } from "../acp/watch-turn.js";
@@ -86,6 +87,8 @@ export interface AgentSessionInfo {
   readonly workspaceMode: WorkspaceMode;
 }
 
+const ROUTING_TOKEN_CONTEXT_KEY = "_groveRoutingToken";
+
 /**
  * Merge runtime selection fields from role + profile.
  * Precedence: profile > role > default.
@@ -108,6 +111,7 @@ export class SessionOrchestrator {
   private readonly sessionId: string;
   private readonly agents: AgentSessionInfo[] = [];
   private readonly router: TopologyRouter;
+  private readonly routingTokensByRole = new Map<string, string>();
   private eventHandlers?: Map<string, import("./event-bus.js").EventHandler>;
   private stopped = false;
   private stopReason: string | undefined;
@@ -306,24 +310,33 @@ export class SessionOrchestrator {
       const contributions = await this.config.contributionStore.list({ limit: 200 });
       for (const c of contributions) {
         if (this.seenCids.has(c.cid)) continue;
-        this.seenCids.add(c.cid);
-        this.contributionCount++;
 
         const sourceRole = c.agent.role;
         if (!sourceRole) continue;
+        const sourceAgent = this.agents.find((a) => a.role === sourceRole);
+        if (!sourceAgent) continue;
 
-        // Only process contributions from agents in THIS session.
-        // Match by runtime-issued session ID + role to avoid same-role
-        // cross-session collisions during polling.
-        const agentId = c.agent.agentId;
-        const isOurAgent = this.agents.some(
-          (a) => a.role === sourceRole && a.session.id === agentId,
-        );
-        if (!isOurAgent) continue;
+        // Trust boundary: require the per-agent routing token issued at spawn.
+        // This prevents caller-supplied `agent` metadata from impersonating
+        // another role/session in the polling router.
+        const expectedToken = this.routingTokensByRole.get(sourceRole);
+        const context = c.context as Record<string, unknown> | undefined;
+        const observedToken = context?.[ROUTING_TOKEN_CONTEXT_KEY];
+        if (
+          expectedToken === undefined ||
+          typeof observedToken !== "string" ||
+          observedToken !== expectedToken
+        ) {
+          continue;
+        }
+
+        // Mark as seen only after ownership verification so transient identity
+        // skew doesn't permanently suppress routing for this CID.
+        this.seenCids.add(c.cid);
+        this.contributionCount++;
 
         // Find the source agent's workspace path — this is the handoff artifact.
         // The receiving agent reads files directly from this path, no git merge needed.
-        const sourceAgent = this.agents.find((a) => a.role === sourceRole);
         const sourceWorkspace = sourceAgent?.workspaceMode.path ?? "(unknown)";
 
         const action =
@@ -402,6 +415,8 @@ export class SessionOrchestrator {
     // Merge profile overlay (profile > role > default)
     const profile = this.config.profiles?.find((p) => p.role === role.name);
     const resolved = mergeRuntimeConfig(role, profile);
+    const routingToken = randomUUID();
+    this.routingTokensByRole.set(role.name, routingToken);
 
     const agentConfig: AgentConfig = {
       role: role.name,
@@ -414,6 +429,7 @@ export class SessionOrchestrator {
         GROVE_SESSION_ID: this.sessionId,
         GROVE_ROLE: role.name,
         GROVE_AGENT_ROLE: role.name,
+        GROVE_ROUTING_TOKEN: routingToken,
       },
     };
 

--- a/src/core/subprocess-runtime.test.ts
+++ b/src/core/subprocess-runtime.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { parseSessionId } from "./session-id.js";
 import { SubprocessRuntime } from "./subprocess-runtime.js";
 
 test("SubprocessRuntime.send returns error turn when the child has already exited", async () => {
@@ -28,6 +29,37 @@ test("SubprocessRuntime.send returns end_turn for a live child", async () => {
   const session = await rt.spawn("smoke", { role: "smoke", command: "cat", cwd: "/tmp" });
   try {
     const turn = await rt.send(session, "hello");
+    const result = await turn.result;
+    expect(result.stopReason).toBe("end_turn");
+  } finally {
+    await rt.close(session);
+  }
+});
+
+test("SubprocessRuntime.spawn uses canonical session IDs", async () => {
+  const rt = new SubprocessRuntime();
+  const session = await rt.spawn("smoke", { role: "smoke", command: "cat", cwd: "/tmp" });
+  try {
+    const parsed = parseSessionId(session.id);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.role).toBe("smoke");
+  } finally {
+    await rt.close(session);
+  }
+});
+
+test("SubprocessRuntime.spawn preserves quoted command arguments", async () => {
+  const rt = new SubprocessRuntime();
+  const session = await rt.spawn("quoted", {
+    role: "quoted",
+    // Needs proper quote-aware argv splitting so the whole script stays one arg.
+    command: 'bun -e "setInterval(() => {}, 1000)"',
+    cwd: "/tmp",
+  });
+  try {
+    // Give the child a moment to fail fast if argv parsing was broken.
+    await new Promise((r) => setTimeout(r, 50));
+    const turn = await rt.send(session, "ping");
     const result = await turn.result;
     expect(result.stopReason).toBe("end_turn");
   } finally {

--- a/src/core/subprocess-runtime.test.ts
+++ b/src/core/subprocess-runtime.test.ts
@@ -66,3 +66,39 @@ test("SubprocessRuntime.spawn preserves quoted command arguments", async () => {
     await rt.close(session);
   }
 });
+
+test("SubprocessRuntime.spawn preserves literal backslashes in double-quoted args", async () => {
+  const rt = new SubprocessRuntime();
+  const session = await rt.spawn("quoted-backslash", {
+    role: "quoted-backslash",
+    command:
+      "bun -e \"if (!/\\d+/.test('123') || !/\\w+/.test('abc')) process.exit(42); setInterval(() => {}, 1000)\"",
+    cwd: "/tmp",
+  });
+  try {
+    await new Promise((r) => setTimeout(r, 50));
+    const turn = await rt.send(session, "ping");
+    const result = await turn.result;
+    expect(result.stopReason).toBe("end_turn");
+  } finally {
+    await rt.close(session);
+  }
+});
+
+test("SubprocessRuntime.spawn injects runtime-issued GROVE_AGENT_ID", async () => {
+  const rt = new SubprocessRuntime();
+  const session = await rt.spawn("identity", {
+    role: "identity",
+    command:
+      "bun -e \"if (!/^grove-identity-/.test(process.env.GROVE_AGENT_ID ?? '')) process.exit(42); if (process.env.GROVE_AGENT_ROLE !== 'identity') process.exit(43); setInterval(() => {}, 1000)\"",
+    cwd: "/tmp",
+  });
+  try {
+    await new Promise((r) => setTimeout(r, 50));
+    const turn = await rt.send(session, "ping");
+    const result = await turn.result;
+    expect(result.stopReason).toBe("end_turn");
+  } finally {
+    await rt.close(session);
+  }
+});

--- a/src/core/subprocess-runtime.ts
+++ b/src/core/subprocess-runtime.ts
@@ -5,6 +5,7 @@
 
 import type { AcpxTurn } from "../acp/types.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
+import { buildSessionId } from "./session-id.js";
 
 /**
  * SubprocessRuntime does not produce ACP output. Return an already-settled
@@ -59,13 +60,83 @@ interface SessionEntry {
   exited: boolean;
 }
 
+/**
+ * Split a shell-like command string into argv tokens.
+ *
+ * Supports single/double quotes and backslash escaping so profiles can pass
+ * quoted `-e` / `-c` scripts without being corrupted by naive whitespace split.
+ */
+function splitCommand(command: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaping = false;
+  let tokenStarted = false;
+
+  for (const ch of command) {
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (quote === null) {
+      if (ch === " " || ch === "\t" || ch === "\n") {
+        if (tokenStarted) {
+          args.push(current);
+          current = "";
+          tokenStarted = false;
+        }
+        continue;
+      }
+      if (ch === "'" || ch === '"') {
+        quote = ch;
+        tokenStarted = true;
+        continue;
+      }
+      if (ch === "\\") {
+        escaping = true;
+        tokenStarted = true;
+        continue;
+      }
+      current += ch;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (ch === quote) {
+      quote = null;
+      continue;
+    }
+    if (quote === '"' && ch === "\\") {
+      escaping = true;
+      continue;
+    }
+    current += ch;
+    tokenStarted = true;
+  }
+
+  if (quote !== null) {
+    throw new Error(`Unterminated quote in command: ${command}`);
+  }
+  if (escaping) {
+    current += "\\";
+    tokenStarted = true;
+  }
+  if (tokenStarted) {
+    args.push(current);
+  }
+  return args;
+}
+
 export class SubprocessRuntime implements AgentRuntime {
   private sessions = new Map<string, SessionEntry>();
   private nextId = 0;
 
   async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
-    const id = `subprocess-${role}-${this.nextId++}`;
-    const [cmd, ...args] = config.command.split(/\s+/);
+    const id = buildSessionId(role, this.nextId++);
+    const [cmd, ...args] = splitCommand(config.command);
 
     if (!cmd) {
       throw new Error(`Empty command for role "${role}"`);

--- a/src/core/subprocess-runtime.ts
+++ b/src/core/subprocess-runtime.ts
@@ -73,8 +73,12 @@ function splitCommand(command: string): string[] {
   let escaping = false;
   let tokenStarted = false;
 
-  for (const ch of command) {
-    if (escaping) {
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (ch === undefined) break;
+
+    // Outside quotes, backslash escapes the next character verbatim.
+    if (quote === null && escaping) {
       current += ch;
       escaping = false;
       tokenStarted = true;
@@ -105,12 +109,32 @@ function splitCommand(command: string): string[] {
       continue;
     }
 
-    if (ch === quote) {
+    if (quote === "'") {
+      if (ch === "'") {
+        quote = null;
+      } else {
+        current += ch;
+        tokenStarted = true;
+      }
+      continue;
+    }
+
+    // Double-quoted mode: backslash only escapes a shell-defined subset.
+    if (ch === '"') {
       quote = null;
       continue;
     }
-    if (quote === '"' && ch === "\\") {
-      escaping = true;
+    if (ch === "\\") {
+      const next = command[i + 1];
+      if (next === '"' || next === "\\" || next === "$" || next === "`" || next === "\n") {
+        current += next;
+        tokenStarted = true;
+        i += 1;
+      } else {
+        // Keep the backslash literal for non-escapable characters (\d, \w, paths).
+        current += "\\";
+        tokenStarted = true;
+      }
       continue;
     }
     current += ch;
@@ -146,6 +170,10 @@ export class SubprocessRuntime implements AgentRuntime {
       ...process.env,
       ...config.env,
     } as Record<string, string>;
+    // Bind contribution identity to the runtime-issued session id so
+    // SessionOrchestrator polling can verify origin without role-only matching.
+    spawnEnv.GROVE_AGENT_ID = id;
+    spawnEnv.GROVE_AGENT_ROLE = role;
     if (config.platform) spawnEnv.GROVE_AGENT_PLATFORM = config.platform;
     if (config.model) spawnEnv.GROVE_AGENT_MODEL = config.model;
 

--- a/src/core/subprocess.test.ts
+++ b/src/core/subprocess.test.ts
@@ -46,6 +46,22 @@ describe("spawnCommand", () => {
     expect(result.exitCode).toBe(127);
     expect(result.stderr).toBeTruthy();
   });
+
+  test("throws when stdout exceeds maxBufferBytes", async () => {
+    await expect(
+      spawnCommand(["bun", "-e", "process.stdout.write('a'.repeat(2048))"], {
+        maxBufferBytes: 1024,
+      }),
+    ).rejects.toThrow(/stdout exceeded max buffer/i);
+  });
+
+  test("throws when stderr exceeds maxBufferBytes", async () => {
+    await expect(
+      spawnCommand(["bun", "-e", "process.stderr.write('e'.repeat(2048))"], {
+        maxBufferBytes: 1024,
+      }),
+    ).rejects.toThrow(/stderr exceeded max buffer/i);
+  });
 });
 
 describe("spawnOrThrow", () => {

--- a/src/core/subprocess.ts
+++ b/src/core/subprocess.ts
@@ -19,7 +19,7 @@ export interface SpawnOptions {
   readonly cwd?: string;
   /** Timeout in milliseconds. Defaults to 30_000 (30s). */
   readonly timeoutMs?: number;
-  /** Maximum stdout buffer size in bytes. Defaults to 10MB. */
+  /** Maximum buffered output size per stream in bytes. Defaults to 10MB. */
   readonly maxBufferBytes?: number;
 }
 
@@ -28,6 +28,43 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 
 /** Default max buffer: 10 MB. */
 const DEFAULT_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+async function readStreamWithLimit(
+  stream: ReadableStream<Uint8Array> | null,
+  maxBufferBytes: number,
+  label: "stdout" | "stderr",
+  onOverflow: () => void,
+): Promise<string> {
+  if (stream === null) return "";
+
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value === undefined) continue;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBufferBytes) {
+        onOverflow();
+        throw new Error(`${label} exceeded max buffer of ${maxBufferBytes} bytes`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const decoder = new TextDecoder();
+  let text = "";
+  for (const chunk of chunks) {
+    text += decoder.decode(chunk, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
+}
 
 /**
  * Spawn a command and collect its output.
@@ -43,7 +80,7 @@ export async function spawnCommand(
 ): Promise<SpawnResult> {
   const cwd = options?.cwd ?? process.cwd();
   const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const _maxBufferBytes = options?.maxBufferBytes ?? DEFAULT_MAX_BUFFER_BYTES;
+  const maxBufferBytes = options?.maxBufferBytes ?? DEFAULT_MAX_BUFFER_BYTES;
 
   let proc: import("bun").Subprocess<"pipe", "pipe", "pipe">;
   try {
@@ -72,9 +109,15 @@ export async function spawnCommand(
   });
 
   const collectPromise = async (): Promise<SpawnResult> => {
+    let overflowed = false;
+    const killForOverflow = (): void => {
+      if (overflowed) return;
+      overflowed = true;
+      proc.kill();
+    };
     const [stdout, stderr] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
+      readStreamWithLimit(proc.stdout, maxBufferBytes, "stdout", killForOverflow),
+      readStreamWithLimit(proc.stderr, maxBufferBytes, "stderr", killForOverflow),
     ]);
     const exitCode = await proc.exited;
     return { stdout, stderr, exitCode };

--- a/src/core/tmux-runtime.ts
+++ b/src/core/tmux-runtime.ts
@@ -98,6 +98,10 @@ export class TmuxRuntime implements AgentRuntime {
       ...process.env,
       ...config.env,
     } as Record<string, string>;
+    // Bind contribution identity to the runtime-issued session id so
+    // polling can authenticate in-session writes.
+    spawnEnv.GROVE_AGENT_ID = id;
+    spawnEnv.GROVE_AGENT_ROLE = role;
     if (config.platform) spawnEnv.GROVE_AGENT_PLATFORM = config.platform;
     if (config.model) spawnEnv.GROVE_AGENT_MODEL = config.model;
 

--- a/src/core/tmux-runtime.ts
+++ b/src/core/tmux-runtime.ts
@@ -243,13 +243,16 @@ export class TmuxRuntime implements AgentRuntime {
       });
 
       if (output === entry.lastOutput && entry.lastOutput !== "") {
-        // Output hasn't changed — fire idle callbacks
-        entry.session = { ...entry.session, status: "idle" };
-        for (const cb of entry.idleCallbacks) {
-          try {
-            cb();
-          } catch {
-            // Don't let callback errors kill the poll loop
+        // Output hasn't changed. Fire callbacks only on transition to idle
+        // to avoid repeated callback storms on every poll tick.
+        if (entry.session.status !== "idle") {
+          entry.session = { ...entry.session, status: "idle" };
+          for (const cb of entry.idleCallbacks) {
+            try {
+              cb();
+            } catch {
+              // Don't let callback errors kill the poll loop
+            }
           }
         }
       } else {

--- a/src/core/workspace-validator.test.ts
+++ b/src/core/workspace-validator.test.ts
@@ -146,6 +146,25 @@ describe("validateWorkspaceMutations", () => {
     expect(result.violations[0]!.type).toBe("immutable_path");
   });
 
+  test("rename from immutable path is still treated as immutable mutation", () => {
+    writeFile(dir, ".grove/config.yaml", "locked");
+    commitAll(dir, "add immutable config");
+    mkdirSync(join(dir, "src"), { recursive: true });
+
+    // Rename out of immutable directory; both old/new paths are reported by
+    // porcelain -z and old immutable path must still be flagged.
+    execSync('git mv ".grove/config.yaml" "src/config.yaml"', { cwd: dir, stdio: "pipe" });
+
+    const result = validateWorkspaceMutations(dir, {
+      immutablePaths: [".grove/"],
+      mutablePaths: ["src/"],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v) => v.type === "immutable_path")).toBe(true);
+    expect(result.violations.some((v) => v.path === ".grove/config.yaml")).toBe(true);
+  });
+
   // -------------------------------------------------------------------------
   // Mutable path constraints
   // -------------------------------------------------------------------------

--- a/src/core/workspace-validator.ts
+++ b/src/core/workspace-validator.ts
@@ -6,7 +6,7 @@
  * stashes the offending changes.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { statSync } from "node:fs";
 import { join } from "node:path";
 
@@ -49,8 +49,8 @@ export interface WorkspaceViolation {
  * Run a git command in the workspace directory.
  * Returns trimmed stdout. Throws on non-zero exit.
  */
-function git(workspacePath: string, args: string): string {
-  return execSync(`git ${args}`, {
+function git(workspacePath: string, args: readonly string[]): string {
+  return execFileSync("git", [...args], {
     cwd: workspacePath,
     encoding: "utf-8",
     stdio: ["pipe", "pipe", "pipe"],
@@ -84,9 +84,9 @@ function matchesAnyPattern(filePath: string, patterns: readonly string[]): boole
 function getChangedFiles(workspacePath: string): string[] {
   let output: string;
   try {
-    // Do NOT use the git() helper here — it trims the output, which strips
-    // the leading space from porcelain status indicators like " M file.txt".
-    output = execSync("git status --porcelain", {
+    // Use -z so file names are NUL-delimited and unescaped (safe for spaces,
+    // quotes, and other special characters).
+    output = execFileSync("git", ["status", "--porcelain", "-z"], {
       cwd: workspacePath,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
@@ -96,25 +96,31 @@ function getChangedFiles(workspacePath: string): string[] {
     return [];
   }
 
-  // Remove only trailing whitespace/newlines, preserving leading spaces
-  // that are part of the porcelain status format.
-  const trimmed = output.replace(/\s+$/, "");
-  if (trimmed.length === 0) return [];
+  if (output.length === 0) return [];
 
-  const files: string[] = [];
-  for (const line of trimmed.split("\n")) {
-    // porcelain format: XY <path> or XY <path> -> <newpath> (for renames)
-    // XY is exactly 2 characters, followed by a space, then the path.
-    if (line.length < 4) continue;
-    const rest = line.slice(3);
-    // Handle renames: "R  old -> new" — we care about the new path
-    const arrowIndex = rest.indexOf(" -> ");
-    const filePath = arrowIndex >= 0 ? rest.slice(arrowIndex + 4) : rest;
-    if (filePath.length > 0) {
-      files.push(filePath);
+  const files = new Set<string>();
+  const entries = output.split("\0");
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!entry || entry.length < 4) continue;
+
+    // Porcelain -z first token: "XY <path>".
+    const status = entry.slice(0, 2);
+    const path = entry.slice(3);
+    if (path.length > 0) {
+      files.add(path);
+    }
+
+    // For rename/copy, git emits a second NUL-delimited path token.
+    if (status[0] === "R" || status[0] === "C" || status[1] === "R" || status[1] === "C") {
+      const oldPath = entries[i + 1];
+      if (oldPath && oldPath.length > 0) {
+        files.add(oldPath);
+      }
+      i += 1;
     }
   }
-  return files;
+  return [...files];
 }
 
 // ---------------------------------------------------------------------------
@@ -153,7 +159,7 @@ export function validateWorkspaceMutations(
 
   // Check each file against constraints
   const violations: WorkspaceViolation[] = [];
-  const violatingFiles: string[] = [];
+  const violatingFiles = new Set<string>();
 
   for (const filePath of changedFiles) {
     // 1. Immutable path check (takes precedence)
@@ -163,9 +169,7 @@ export function validateWorkspaceMutations(
         path: filePath,
         message: `File '${filePath}' is in an immutable path`,
       });
-      if (!violatingFiles.includes(filePath)) {
-        violatingFiles.push(filePath);
-      }
+      violatingFiles.add(filePath);
       continue; // Skip further checks for this file
     }
 
@@ -176,9 +180,7 @@ export function validateWorkspaceMutations(
         path: filePath,
         message: `File '${filePath}' is outside allowed mutable paths`,
       });
-      if (!violatingFiles.includes(filePath)) {
-        violatingFiles.push(filePath);
-      }
+      violatingFiles.add(filePath);
       continue;
     }
 
@@ -193,9 +195,7 @@ export function validateWorkspaceMutations(
             path: filePath,
             message: `File '${filePath}' is ${stat.size} bytes, exceeds max ${maxFileSize} bytes`,
           });
-          if (!violatingFiles.includes(filePath)) {
-            violatingFiles.push(filePath);
-          }
+          violatingFiles.add(filePath);
         }
       } catch {
         // File may have been deleted — skip size check
@@ -209,16 +209,22 @@ export function validateWorkspaceMutations(
   let stashed = false;
   let stashRef: string | undefined;
 
-  if (!valid && stashOnViolation && violatingFiles.length > 0) {
+  if (!valid && stashOnViolation && violatingFiles.size > 0) {
     try {
       // Stash only the violating files
-      const fileArgs = violatingFiles.map((f) => `"${f}"`).join(" ");
-      git(workspacePath, `stash push -m "grove: workspace constraint violation" -- ${fileArgs}`);
+      git(workspacePath, [
+        "stash",
+        "push",
+        "-m",
+        "grove: workspace constraint violation",
+        "--",
+        ...violatingFiles,
+      ]);
       stashed = true;
 
       // Get the stash ref
       try {
-        stashRef = git(workspacePath, "stash list -1 --format=%H");
+        stashRef = git(workspacePath, ["stash", "list", "-1", "--format=%H"]);
       } catch {
         // stash ref is optional — failing to get it is not critical
         stashRef = "stash@{0}";

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -29,6 +29,19 @@ export const WorkspaceStatus = {
 } as const;
 export type WorkspaceStatus = (typeof WorkspaceStatus)[keyof typeof WorkspaceStatus];
 
+/** Error thrown when a workspace lookup by (cid, agentId) fails. */
+export class WorkspaceNotFoundError extends Error {
+  readonly cid: string;
+  readonly agentId: string;
+
+  constructor(cid: string, agentId: string) {
+    super(`Workspace for '${cid}' (agent '${agentId}') not found`);
+    this.name = "WorkspaceNotFoundError";
+    this.cid = cid;
+    this.agentId = agentId;
+  }
+}
+
 /** Information about a workspace. */
 export interface WorkspaceInfo {
   /** The contribution CID that was checked out into this workspace. */

--- a/src/local/workspace.ts
+++ b/src/local/workspace.ts
@@ -35,7 +35,7 @@ import type {
   WorkspaceManager,
   WorkspaceQuery,
 } from "../core/workspace.js";
-import { WorkspaceStatus } from "../core/workspace.js";
+import { WorkspaceNotFoundError, WorkspaceStatus } from "../core/workspace.js";
 import { safeCleanup } from "../shared/safe-cleanup.js";
 import type { FsCas } from "./fs-cas.js";
 
@@ -328,7 +328,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
   async markWorkspaceStale(cid: string, agentId: string): Promise<WorkspaceInfo> {
     const workspace = await this.getWorkspace(cid, agentId);
     if (workspace === undefined) {
-      throw new Error(`Workspace for '${cid}' (agent '${agentId}') not found`);
+      throw new WorkspaceNotFoundError(cid, agentId);
     }
 
     // Only transition active workspaces — already stale/cleaned is a no-op in terms of effect
@@ -397,7 +397,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
 
     const workspace = await this.getWorkspace(cid, agentId);
     if (workspace === undefined) {
-      throw new Error(`Workspace for '${cid}' not found`);
+      throw new WorkspaceNotFoundError(cid, agentId);
     }
     return workspace;
   }


### PR DESCRIPTION
## Summary
- Harden core runtime correctness paths in `src/core` by fixing shell command parsing/session ID generation, enforcing per-stream subprocess buffer limits, and tightening session-orchestrator contribution routing + idle transition behavior.
- Improve reconciliation and lifecycle safety by validating session transition/not-found handling in `SessionManager`, making claim dedup timestamp-ordering timezone-safe, and making orphan-workspace marking best-effort under concurrent cleanup.
- Close workspace/frontier edge cases by parsing rename/copy mutations from `git status --porcelain -z` (including old paths), using safer `execFileSync` git invocation, and reducing unnecessary frontier source scans when filters are not active.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test src/core/session-manager.test.ts`
- [x] `bun test src/core/reconciler.test.ts`
- [x] `bun test src/core/policy-enforcer.test.ts`
- [ ] `bun test src/core/*.test.ts` (CI)

