### PR TITLE
fix(acp): stop demoting acpx frames as _sessionMismatch (#319)

### DIFF
--- a/src/acp/parser.test.ts
+++ b/src/acp/parser.test.ts
@@ -1208,3 +1208,48 @@ test("AcpParser: foreign-session frames are demoted, not leaked into the iterato
   const rawMismatch = got.find((m) => m.kind === "raw" && m.acpMethod === "_sessionMismatch");
   expect(rawMismatch).toBeDefined();
 });
+
+// Regression (issue #319 round 5): a constructor-bound parser represents
+// an explicit trust authority for a multiplexed/shared stream. Foreign
+// `result.sessionId` noise on that stream must NOT escalate to
+// `session_ambiguous` — only handshake-learned bindings are subject to
+// in-band ambiguity detection. Otherwise this becomes a DoS vector for
+// legitimate multiplexed callers.
+test("AcpParser: explicit-bound parser tolerates foreign result.sessionId noise", async () => {
+  const lines = [
+    // Foreign handshake on a shared stream — not addressed to us.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 99,
+      method: "session/new",
+      params: { cwd: "/tmp", mcpServers: [] },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 99, result: { sessionId: "foreign" } }),
+    // Our legitimate session/update.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "mine",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "legit" },
+        },
+      },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const parser = new AcpParser({
+    sessionId: "mine",
+    turnId: "t-multiplex",
+    stream: readableFromString(`${lines.join("\n")}\n`),
+  });
+  const got: Message[] = [];
+  for await (const m of parser.messages) got.push(m);
+  const r = await parser.result;
+
+  // Explicit-bound: foreign noise is observable but not fatal.
+  expect(r.stopReason).toBe("end_turn");
+  const texts = got.filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text");
+  expect(texts.map((m) => m.text).join("")).toBe("legit");
+});

--- a/src/acp/parser.ts
+++ b/src/acp/parser.ts
@@ -547,7 +547,7 @@ export class AcpParser {
   private streamFinished = false;
   private resolveResult!: (r: Result) => void;
   private readonly turnId: string;
-  private readonly sessionId: string;
+  private readonly sessionId: string | undefined;
 
   /**
    * Start-of-turn replay buffer. The parser reads eagerly on construction,
@@ -581,7 +581,15 @@ export class AcpParser {
     turnId,
     stream,
   }: {
-    sessionId: string;
+    /**
+     * Optional. When provided, session/update frames whose params.sessionId
+     * does not match are demoted to raw _sessionMismatch — defense for
+     * multiplexed/shared streams. Per-turn acpx stdout is single-session and
+     * acpx emits its own internal UUID (not the caller's label), so callers
+     * wrapping a single acpx child (AcpxTurnImpl) should leave this undefined
+     * to avoid demoting every legitimate frame. See issue #319.
+     */
+    sessionId?: string;
     turnId: string;
     stream: Readable;
   }) {

--- a/src/acp/parser.ts
+++ b/src/acp/parser.ts
@@ -114,6 +114,92 @@ function parseResultUsage(usage: Record<string, unknown>): TokenUsage | undefine
   return out;
 }
 
+/**
+ * Session-binding signals extracted from a raw NDJSON line, without
+ * committing to full parsing. Used by `AcpParser` during the bootstrap
+ * window (before a trust anchor is established) to (a) track outgoing
+ * `session/new`/`session/load` request ids, (b) bind on the matching
+ * `result.sessionId` response, (c) quarantine `session/update` frames that
+ * arrive before a binding, (d) let any other frame parse normally.
+ *
+ * Rationale (issue #319): the caller's grove label (`grove-<role>-<n>--...`)
+ * does not match acpx's internal UUID, so we can't hard-bind at construction
+ * time. Learning from the first `session/update` would let a foreign first
+ * frame poison the binding. Learning from any `result.sessionId` would let
+ * a foreign `result` frame poison the binding. Only by correlating a result
+ * frame's id to a previously observed `session/new`/`session/load` request
+ * id do we have a trusted anchor.
+ */
+type SessionBindingHint =
+  | {
+      readonly kind: "session-request";
+      /** JSON-RPC request id — used to correlate with a later response. */
+      readonly id: string | number;
+    }
+  | {
+      readonly kind: "session-response";
+      readonly id: string | number;
+      /** Non-empty `result.sessionId` from a JSON-RPC result frame. */
+      readonly sessionId: string;
+    }
+  | {
+      readonly kind: "session-update";
+      /** Raw params — preserved on quarantine for audit. */
+      readonly params: unknown;
+    }
+  | { readonly kind: "other" };
+
+/**
+ * Canonicalize a JSON-RPC id to a string key. Tolerates providers or
+ * intermediaries that normalize numeric ids to strings (or vice versa) so
+ * that a request with `id: 0` still correlates to a response with `id: "0"`
+ * — otherwise strict equality leaves the parser unbound and the turn fails
+ * `session_unbound` under benign upstream drift (round 5 finding).
+ */
+function canonicalRpcId(id: string | number): string {
+  return typeof id === "number" ? String(id) : id;
+}
+
+function peekSessionBindingHint(line: string): SessionBindingHint {
+  try {
+    const frame = JSON.parse(line) as unknown;
+    if (typeof frame !== "object" || frame === null) return { kind: "other" };
+    const f = frame as Record<string, unknown>;
+    const id = f.id;
+    const hasRpcId = typeof id === "string" || typeof id === "number";
+
+    // Outgoing `session/new` or `session/load` request: these are authored
+    // by acpx (or by grove through acpx) and their response `id` is the
+    // correlation token we need to trust a later `result.sessionId`.
+    const method = f.method;
+    if (
+      hasRpcId &&
+      (method === "session/new" || method === "session/load") &&
+      f.result === undefined
+    ) {
+      return { kind: "session-request", id: id as string | number };
+    }
+
+    // JSON-RPC result frame with a non-empty string sessionId. Only trusted
+    // if its id matches a previously seen session-request (checked upstream).
+    const r = f.result;
+    if (hasRpcId && typeof r === "object" && r !== null) {
+      const sid = (r as Record<string, unknown>).sessionId;
+      if (typeof sid === "string" && sid.length > 0) {
+        return { kind: "session-response", id: id as string | number, sessionId: sid };
+      }
+    }
+
+    if (method === "session/update") {
+      return { kind: "session-update", params: f.params };
+    }
+
+    return { kind: "other" };
+  } catch {
+    return { kind: "other" };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // parseAcpLine — pure, synchronous, never throws
 // ---------------------------------------------------------------------------
@@ -547,7 +633,53 @@ export class AcpParser {
   private streamFinished = false;
   private resolveResult!: (r: Result) => void;
   private readonly turnId: string;
-  private readonly sessionId: string | undefined;
+  /**
+   * Session binding used to demote foreign `session/update` frames to
+   * `_sessionMismatch`. Set either:
+   *   - at construction time (explicit hard-bind — tests, multiplexed callers),
+   *   - OR at runtime via request/response correlation: we see
+   *     `{method:"session/new"|"session/load", id:N}` pass through the
+   *     stream, track N in `pendingSessionRequestIds`, and bind when a
+   *     later `{id:N, result:{sessionId:"..."}}` frame arrives. Any other
+   *     `result.sessionId` (foreign, uncorrelated) is NOT trusted.
+   *
+   * See issue #319. The caller-supplied grove label (`grove-<role>-<n>--...`)
+   * does not match acpx's internal UUID, so we can't hard-bind upfront.
+   */
+  private sessionId: string | undefined;
+  /**
+   * Ids of `session/new`/`session/load` requests seen so far — trusted
+   * anchors. Stored as canonical string keys (via `canonicalRpcId`) so
+   * correlation tolerates provider id-type skew (`0` vs `"0"`): both sides
+   * of the round-trip resolve to the same key.
+   */
+  private readonly pendingSessionRequestIds: Set<string> = new Set();
+  /**
+   * True iff at least one `session/update` arrived while the parser was
+   * unbound (before any correlated handshake had landed). Drives fail-closed:
+   * any quarantined update is a data-loss signal — we override the terminal
+   * stopReason to `error` so the caller can't mistake a silent truncation
+   * for a successful run, whether the binding never happened OR arrived
+   * later (late-binding silent truncation is the round-4 finding).
+   */
+  private sawUnboundSessionUpdate = false;
+  /**
+   * True iff a second correlated handshake arrived with a sessionId that
+   * differs from an already-locked binding — i.e. a foreign handshake
+   * reached us before the real one and poisoned the binding. Drives
+   * fail-closed so the caller does NOT receive a `stopReason: end_turn`
+   * that papers over cross-session contamination (round 4 finding).
+   */
+  private sessionBindingAmbiguous = false;
+  /**
+   * True iff the current `sessionId` was learned via an in-band handshake
+   * (round 3 correlation path). False when bound at construction time by
+   * an explicit caller-supplied sessionId — in that case the caller is
+   * the trust authority, so foreign `result.sessionId` noise on a
+   * multiplexed/shared stream must NOT escalate to `session_ambiguous`.
+   * See round-5 finding on explicit-bound regression.
+   */
+  private sessionBoundFromHandshake = false;
 
   /**
    * Start-of-turn replay buffer. The parser reads eagerly on construction,
@@ -576,6 +708,16 @@ export class AcpParser {
     return this.streamFinished;
   }
 
+  /**
+   * The acpx-internal wire sessionId this parser is (or became) bound to.
+   * Undefined if no binding was ever established. Read by the runtime
+   * after turn settle to propagate the learned id to the next turn's
+   * parser (issue #319).
+   */
+  get wireSessionId(): string | undefined {
+    return this.sessionId;
+  }
+
   constructor({
     sessionId,
     turnId,
@@ -589,7 +731,7 @@ export class AcpParser {
      * wrapping a single acpx child (AcpxTurnImpl) should leave this undefined
      * to avoid demoting every legitimate frame. See issue #319.
      */
-    sessionId?: string;
+    sessionId?: string | undefined;
     turnId: string;
     stream: Readable;
   }) {
@@ -675,13 +817,127 @@ export class AcpParser {
   }
 
   private finish(result: Result): void {
-    this.resolveResult(result);
+    // Fail-closed (issue #319 adversarial review rounds 3 & 4). Surface a
+    // hard error whenever the turn's session-binding integrity is in doubt,
+    // so callers do NOT see `stopReason: end_turn` over a stream that
+    // silently lost or commingled content. Two failure modes:
+    //   (a) `sawUnboundSessionUpdate`: at least one `session/update` arrived
+    //       before binding was established. Whether binding never happened
+    //       OR arrived later, the early updates are irrecoverably missing
+    //       from the semantic stream (they are only in the audit log as
+    //       `_sessionUnbound`). Round-4 added the late-binding arm: before
+    //       this, a late handshake masked early truncation.
+    //   (b) `sessionBindingAmbiguous`: a second correlated handshake landed
+    //       with a different wire sessionId — cross-session contamination.
+    // Already-terminal errors are preserved unchanged (the upstream error
+    // is more informative than our generic session_unbound wrapper).
+    let finalResult = result;
+    if (
+      result.stopReason !== "error" &&
+      (this.sawUnboundSessionUpdate || this.sessionBindingAmbiguous)
+    ) {
+      const code = this.sessionBindingAmbiguous ? "session_ambiguous" : "session_unbound";
+      const message = this.sessionBindingAmbiguous
+        ? "turn ended with conflicting session bindings — multiple correlated handshakes observed with different wire sessionIds"
+        : "turn observed session/update frames before a trusted session binding was established — early content was quarantined as _sessionUnbound";
+      finalResult = {
+        turnId: result.turnId,
+        stopReason: "error",
+        error: { code, message },
+        ...(result.usage !== undefined ? { usage: result.usage } : {}),
+      };
+    }
+    this.resolveResult(finalResult);
     this.streamFinished = true;
     const subs = Array.from(this.subscribers);
     this.subscribers.clear();
     for (const sub of subs) {
       sub.finish();
     }
+  }
+
+  /**
+   * Parse one NDJSON line, applying session-binding discipline (issue #319).
+   *
+   * Binding lifecycle:
+   *   1. Explicit constructor sessionId → bound from line 1.
+   *   2. Otherwise, bind only when a `result.sessionId` frame correlates to
+   *      a previously observed `session/new`/`session/load` request id. This
+   *      defeats foreign `result` frames that would otherwise poison the
+   *      binding (adversarial review round 3).
+   *   3. Until bound, any `session/update` is surfaced as `_sessionUnbound`
+   *      raw rather than parsed as semantic content.
+   *   4. If the turn terminates without a binding AND we quarantined at
+   *      least one `session/update`, `finish` degrades `stopReason` to
+   *      `error` so the caller sees a hard failure, not silent data loss.
+   *
+   * @returns `true` iff a terminal result frame was parsed (caller should stop reading).
+   */
+  private handleLine(line: string, turnId: string): boolean {
+    const hint = peekSessionBindingHint(line);
+
+    // Session-request: always track the id (canonical key), even after
+    // binding, so a later correlated response can be detected for
+    // ambiguity checks.
+    if (hint.kind === "session-request") {
+      this.pendingSessionRequestIds.add(canonicalRpcId(hint.id));
+    }
+
+    // Session-response: ambiguity escalation only applies when the parser
+    // is handshake-bound. Constructor-bound callers (multiplexed / shared
+    // streams with explicit trust authority) must NOT be forced into
+    // `session_ambiguous` by foreign `result.sessionId` noise — that
+    // would be a DoS vector for legitimate multiplexed parsing.
+    if (hint.kind === "session-response") {
+      const key = canonicalRpcId(hint.id);
+      const correlated = this.pendingSessionRequestIds.has(key);
+      if (correlated) {
+        this.pendingSessionRequestIds.delete(key);
+        if (this.sessionId === undefined) {
+          // First correlated handshake → bind.
+          this.sessionId = hint.sessionId;
+          this.sessionBoundFromHandshake = true;
+        } else if (this.sessionBoundFromHandshake && this.sessionId !== hint.sessionId) {
+          // A second correlated handshake disagrees with the learned
+          // binding — cross-session contamination. Not applicable to
+          // constructor-bound parsers (see flag comment above).
+          this.sessionBindingAmbiguous = true;
+        }
+      } else if (
+        this.sessionBoundFromHandshake &&
+        this.sessionId !== undefined &&
+        this.sessionId !== hint.sessionId
+      ) {
+        // Round-5 hardening: uncorrelated response disagrees with a
+        // handshake-learned binding. A conflicting `result.sessionId`
+        // may legitimately lack its echoed request line (schema drift,
+        // partial stream, or provider suppressing the request echo).
+        // Flag only when the binding itself came from in-band learning.
+        this.sessionBindingAmbiguous = true;
+      }
+      // Uncorrelated response when unbound OR when constructor-bound: do
+      // NOT bind, do NOT escalate. Frame flows through as raw `_result`.
+    }
+
+    // Quarantine pre-bind session/update as raw anomaly.
+    if (hint.kind === "session-update" && this.sessionId === undefined) {
+      this.sawUnboundSessionUpdate = true;
+      this.broadcast({
+        kind: "raw",
+        turnId,
+        acpMethod: "_sessionUnbound",
+        params: hint.params,
+      });
+      return false;
+    }
+
+    const parsed = parseAcpLine(line, turnId, this.sessionId);
+    if (parsed.kind === "result") {
+      this.finish({ ...parsed.result, turnId });
+      return true;
+    }
+    this.broadcast(parsed.message);
+    return false;
   }
 
   private async _readStream(stream: Readable, turnId: string): Promise<void> {
@@ -714,14 +970,10 @@ export class AcpParser {
         for (const raw of lines) {
           const line = raw.trim();
           if (!line) continue;
-
-          const parsed = parseAcpLine(line, turnId, this.sessionId);
-          if (parsed.kind === "result") {
+          if (this.handleLine(line, turnId)) {
             settled = true;
-            this.finish({ ...parsed.result, turnId });
             return;
           }
-          this.broadcast(parsed.message);
         }
       }
 
@@ -729,13 +981,10 @@ export class AcpParser {
       // multi-byte sequence at EOF) + any buffered text without a newline.
       buffer += decoder.end();
       if (buffer.trim().length > 0) {
-        const parsed = parseAcpLine(buffer.trim(), turnId, this.sessionId);
-        if (parsed.kind === "result") {
+        if (this.handleLine(buffer.trim(), turnId)) {
           settled = true;
-          this.finish({ ...parsed.result, turnId });
           return;
         }
-        this.broadcast(parsed.message);
       }
     } catch (err) {
       // Stream error — surface as a terminal error result.

--- a/src/acp/turn.test.ts
+++ b/src/acp/turn.test.ts
@@ -7,8 +7,30 @@ function makeStream(lines: string[]): Readable {
   return Readable.from([`${lines.join("\n")}\n`]);
 }
 
+/**
+ * Emit the trusted session/new request/response pair that binds AcpParser
+ * to the given wire sessionId. Real acpx stdout echoes BOTH its outbound
+ * `session/new` request and the agent's response, and AcpParser correlates
+ * the response's id back to the tracked request id to accept the binding.
+ * Tests simulating turn streams must include the pair so subsequent
+ * `session/update` frames are not quarantined as `_sessionUnbound` (issue
+ * #319 adversarial review round 3).
+ */
+function handshake(wireSessionId: string, id: string | number = 0): string[] {
+  return [
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: "session/new",
+      params: { cwd: "/tmp", mcpServers: [] },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id, result: { sessionId: wireSessionId } }),
+  ];
+}
+
 test("AcpxTurn yields messages and resolves result from a stream", async () => {
   const lines = [
+    ...handshake("s1"),
     JSON.stringify({
       jsonrpc: "2.0",
       method: "session/update",
@@ -28,7 +50,12 @@ test("AcpxTurn yields messages and resolves result from a stream", async () => {
   const got: Message[] = [];
   for await (const m of turn.messages) got.push(m);
   const r = await turn.result;
-  expect(got).toHaveLength(1);
+  // handshake → 2 raw (session/new request + _result response),
+  // session/update → text. 3 messages total.
+  expect(got).toHaveLength(3);
+  const texts = got.filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text");
+  expect(texts).toHaveLength(1);
+  expect(texts[0]?.text).toBe("hi");
   expect(r.stopReason).toBe("end_turn");
 });
 
@@ -206,7 +233,7 @@ test("AcpxTurnImpl: default capacity 256 evicts oldest under slow consumer", asy
   // the pump can fill the channel buffer, exercising drop_oldest_on_full
   // eviction (raw → drop_oldest_on_full policy).
   const N = 300;
-  const lines: string[] = [];
+  const lines: string[] = [...handshake("s1")];
   for (let i = 0; i < N; i++) {
     lines.push(
       JSON.stringify({
@@ -246,7 +273,7 @@ test("AcpxTurnImpl: default capacity 256 evicts oldest under slow consumer", asy
 
 test("AcpxTurnImpl: channelCapacity Infinity bypasses eviction", async () => {
   const N = 1000;
-  const lines: string[] = [];
+  const lines: string[] = [...handshake("s1")];
   for (let i = 0; i < N; i++) {
     lines.push(
       JSON.stringify({
@@ -268,7 +295,11 @@ test("AcpxTurnImpl: channelCapacity Infinity bypasses eviction", async () => {
   const got: Message[] = [];
   for await (const m of turn.messages) got.push(m);
   await turn.result;
-  expect(got.length).toBe(N);
+  // N session/update frames + 2 handshake raw frames (session/new + _result).
+  expect(got.length).toBe(N + 2);
+  // All session/update frames land as raw (unknown sessionUpdate kind).
+  const rawUnknown = got.filter((m) => m.kind === "raw" && m.acpMethod === "_unknown_kind");
+  expect(rawUnknown).toHaveLength(N);
 });
 
 test("classifyMessage covers all Message kinds with expected policies", () => {
@@ -307,6 +338,7 @@ test("REGRESSION: tool_call invalidates text/thinking coalesce tail (#274 round 
   // of the correct [text(A), tool_call, text(B)]. A slow consumer keeps the
   // events buffered long enough for B to merge into A.
   const lines = [
+    ...handshake("s1"),
     JSON.stringify({
       jsonrpc: "2.0",
       method: "session/update",
@@ -348,7 +380,13 @@ test("REGRESSION: tool_call invalidates text/thinking coalesce tail (#274 round 
     await new Promise((r) => setImmediate(r));
   }
   await turn.result;
-  const kinds = got.map((m) => m.kind);
+  // Skip the leading handshake raw frames (session/new request + _result
+  // response) when asserting chronology.
+  const kinds = got
+    .filter(
+      (m) => !(m.kind === "raw" && (m.acpMethod === "_result" || m.acpMethod === "session/new")),
+    )
+    .map((m) => m.kind);
   // Order must reflect chronology: text, tool_call, text — never [text, text, tool_call]
   // and never [text("AB"), tool_call] (which would mean B merged into A).
   expect(kinds).toEqual(["text", "tool_call", "text"]);
@@ -359,7 +397,7 @@ test("REGRESSION: tool_call invalidates text/thinking coalesce tail (#274 round 
 });
 
 test("AcpxTurnImpl: chunked text deltas coalesce under default capacity", async () => {
-  const lines: string[] = [];
+  const lines: string[] = [...handshake("s1")];
   for (let i = 0; i < 50; i++) {
     lines.push(
       JSON.stringify({
@@ -409,11 +447,15 @@ test("AcpxTurnImpl: chunked text deltas coalesce under default capacity", async 
 // _sessionMismatch and consumers would see 0 chars of text.
 test("AcpxTurn does not filter frames by caller-supplied sessionId (issue #319)", async () => {
   const lines = [
+    // Real acpx precedes session/update with a session/new result carrying
+    // its internal UUID. AcpParser binds to that trusted sessionId — not to
+    // the caller-supplied grove label — so the session/update that follows
+    // is accepted even though its sessionId differs from the grove label.
+    ...handshake("acpx-internal-uuid-abc123"),
     JSON.stringify({
       jsonrpc: "2.0",
       method: "session/update",
       params: {
-        // acpx's internal UUID, different from the grove sessionName below
         sessionId: "acpx-internal-uuid-abc123",
         update: {
           sessionUpdate: "agent_message_chunk",
@@ -439,4 +481,470 @@ test("AcpxTurn does not filter frames by caller-supplied sessionId (issue #319)"
   expect(texts[0]?.text).toBe("hello");
   const mismatches = got.filter((m) => m.kind === "raw" && m.acpMethod === "_sessionMismatch");
   expect(mismatches).toHaveLength(0);
+});
+
+// Regression: a mixed stream (two wire sessionIds on the same stdout) MUST
+// still surface foreign frames as `_sessionMismatch` anomalies. The #319 fix
+// removed caller-supplied session filtering; this test locks in that the
+// parser auto-learns the first wire sessionId and enforces it on later
+// frames, so cross-session contamination is visible in the audit log
+// (`rawAnomalyFrames` after compaction).
+test("AcpxTurn binds to trusted session/new sessionId and demotes foreign frames (issue #319 audit)", async () => {
+  const lines = [
+    // Trusted binding: acpx's session/new result carries the real wire id.
+    ...handshake("acpx-A"),
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acpx-A",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "native" },
+        },
+      },
+    }),
+    // Second frame: a foreign session sneaks in — must be demoted.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acpx-B-foreign",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "LEAK" },
+        },
+      },
+    }),
+    // Third frame: native again — should still pass after the foreign leak.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acpx-A",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: " ok" },
+        },
+      },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const turn = new AcpxTurnImpl({
+    sessionId: "grove-coder-1--xyz",
+    turnId: "t-mix",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  await turn.result;
+
+  // Native text from the learned session survives (possibly coalesced).
+  const texts = got.filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text");
+  const totalText = texts.map((m) => m.text).join("");
+  expect(totalText).toBe("native ok");
+  expect(totalText).not.toContain("LEAK");
+
+  // Foreign frame is surfaced as a raw anomaly, not dropped silently.
+  const mismatches = got.filter((m) => m.kind === "raw" && m.acpMethod === "_sessionMismatch");
+  expect(mismatches).toHaveLength(1);
+  // The anomaly frame retains the foreign params for auditability.
+  const mismatch = mismatches[0];
+  if (mismatch?.kind !== "raw") throw new Error("unreachable");
+  const params = mismatch.params as { sessionId?: string } | undefined;
+  expect(params?.sessionId).toBe("acpx-B-foreign");
+});
+
+// Adversarial regression (issue #319 round 2): a stream whose FIRST frame is
+// a foreign `session/update` — no trusted binding yet — must NOT trust that
+// frame to bootstrap the session. It is quarantined as `_sessionUnbound` so
+// a later legitimate session/new handshake can still establish the correct
+// binding for subsequent traffic.
+test("AcpxTurn quarantines session/update arriving before any trust anchor and fails closed", async () => {
+  const lines = [
+    // Attacker / misbehaving acpx: first wire frame is a session/update
+    // that a naive auto-learn would bind to.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "foreign-poison",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "POISON" },
+        },
+      },
+    }),
+    // Then the real trusted session/new handshake lands.
+    ...handshake("acpx-real"),
+    // A legitimate frame from the real session.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acpx-real",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "legit" },
+        },
+      },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const turn = new AcpxTurnImpl({
+    sessionId: "grove-coder-1--xyz",
+    turnId: "t-poison",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  const r = await turn.result;
+
+  // The poisoned first frame must NOT appear as semantic text.
+  const poisoned = got
+    .filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text")
+    .some((m) => m.text.includes("POISON"));
+  expect(poisoned).toBe(false);
+
+  // Foreign update surfaces as _sessionUnbound anomaly.
+  const unbound = got.filter((m) => m.kind === "raw" && m.acpMethod === "_sessionUnbound");
+  expect(unbound).toHaveLength(1);
+
+  // Round-4 hardening: even though a legitimate handshake arrived later
+  // and legitimate updates flowed, the turn MUST fail closed because
+  // pre-bind quarantine means early content (if any) was irrecoverably
+  // lost from the semantic stream.
+  expect(r.stopReason).toBe("error");
+  expect(r.error?.code).toBe("session_unbound");
+});
+
+// Adversarial regression (issue #319 round 2): a pre-binding session/update
+// whose params.sessionId is missing or non-string (schema drift / deliberate
+// field stripping) must NOT slip through as semantic content. Quarantine it.
+test("AcpxTurn quarantines pre-binding session/update with missing sessionId and fails closed", async () => {
+  const lines = [
+    // No sessionId on params at all — schema drift.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "NO_SID" },
+        },
+      },
+    }),
+    ...handshake("acpx-real"),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const turn = new AcpxTurnImpl({
+    sessionId: "grove-coder-1--xyz",
+    turnId: "t-drift",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  const r = await turn.result;
+
+  const texts = got.filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text");
+  expect(texts).toHaveLength(0);
+  const unbound = got.filter((m) => m.kind === "raw" && m.acpMethod === "_sessionUnbound");
+  expect(unbound).toHaveLength(1);
+  // Fail closed (round 4): any pre-bind quarantine invalidates the turn.
+  expect(r.stopReason).toBe("error");
+  expect(r.error?.code).toBe("session_unbound");
+});
+
+// Adversarial regression (issue #319 round 3): a foreign `result.sessionId`
+// frame that does NOT correlate to a tracked session/new / session/load
+// request id must NOT bind the parser. Otherwise an attacker / buggy
+// upstream could poison the binding from any `result` frame.
+test("AcpxTurn ignores uncorrelated result.sessionId frames (no poisoning)", async () => {
+  const lines = [
+    // No session/new request seen yet — this result frame is uncorrelated
+    // even though it carries a sessionId. Must NOT bind.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 99,
+      result: { sessionId: "poisoned-session" },
+    }),
+    // A session/update for the poisoned id would be accepted IF the poison
+    // had bound. Instead it should be `_sessionUnbound`.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "poisoned-session",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "POISON" },
+        },
+      },
+    }),
+    // Now the real correlated handshake lands.
+    ...handshake("acpx-real"),
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acpx-real",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "legit" },
+        },
+      },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const turn = new AcpxTurnImpl({
+    sessionId: "grove-coder-1--xyz",
+    turnId: "t-poison-result",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  const r = await turn.result;
+
+  const poisoned = got
+    .filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text")
+    .some((m) => m.text.includes("POISON"));
+  expect(poisoned).toBe(false);
+  const unbound = got.filter((m) => m.kind === "raw" && m.acpMethod === "_sessionUnbound");
+  expect(unbound).toHaveLength(1);
+  // Fail closed: pre-bind quarantine marks the turn as lossy.
+  expect(r.stopReason).toBe("error");
+  expect(r.error?.code).toBe("session_unbound");
+});
+
+// Adversarial regression (issue #319 round 3): if the stream carries
+// session/update frames but never emits a correlated session/new result,
+// the parser quarantines every update AND fails the turn closed. Returning
+// `stopReason: "end_turn"` here would hide the fact that 0 semantic
+// messages were delivered.
+test("AcpxTurn fails closed with session_unbound when no handshake arrives", async () => {
+  const lines = [
+    // No session/new request + no correlated response — only updates.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "orphan",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "lost" },
+        },
+      },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const turn = new AcpxTurnImpl({
+    sessionId: "grove-coder-1--xyz",
+    turnId: "t-orphan",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  const r = await turn.result;
+
+  // Hard failure signal, not a silent empty success.
+  expect(r.stopReason).toBe("error");
+  expect(r.error?.code).toBe("session_unbound");
+  // No semantic text leaked.
+  const texts = got.filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text");
+  expect(texts).toHaveLength(0);
+  const unbound = got.filter((m) => m.kind === "raw" && m.acpMethod === "_sessionUnbound");
+  expect(unbound).toHaveLength(1);
+});
+
+// Adversarial regression (issue #319 round 4): a foreign correlated
+// handshake (request + response pair with an attacker-chosen id) arrives
+// BEFORE the real one. The parser binds to the foreign sessionId; when the
+// real handshake follows with a different sessionId, that disagreement
+// must be caught and the turn must fail closed with `session_ambiguous` —
+// a silent `end_turn` here would paper over cross-session contamination.
+test("AcpxTurn fails closed on ambiguous binding (foreign handshake first)", async () => {
+  const lines = [
+    // Foreign correlated handshake — attacker owns id=99.
+    ...handshake("foreign-poison", 99),
+    // Real correlated handshake — different id, different sessionId.
+    ...handshake("acpx-real", 2),
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acpx-real",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "legit" },
+        },
+      },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const turn = new AcpxTurnImpl({
+    sessionId: "grove-coder-1--xyz",
+    turnId: "t-ambiguous",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  const r = await turn.result;
+
+  // Turn MUST NOT silently end_turn — ambiguity is observable.
+  expect(r.stopReason).toBe("error");
+  expect(r.error?.code).toBe("session_ambiguous");
+  // (Best-effort audit: the mismatched-session traffic is visible as
+  // `_sessionMismatch` raw entries since the bound session was "foreign-
+  // poison" but the real update used "acpx-real". We do not assert a
+  // specific count — the key signal is the terminal failure.)
+  const mismatches = got.filter((m) => m.kind === "raw" && m.acpMethod === "_sessionMismatch");
+  expect(mismatches.length).toBeGreaterThan(0);
+});
+
+// Adversarial regression (issue #319 round 5): a post-bind conflicting
+// `result.sessionId` that LACKS an echoed request frame must still trigger
+// ambiguity detection. Restricting ambiguity to correlated responses leaves
+// a bypass under schema drift / partial streams / providers that suppress
+// the request echo — the turn would resolve `end_turn` while legitimate
+// updates were silently demoted to `_sessionMismatch`.
+test("AcpxTurn flags ambiguity on uncorrelated conflicting session-response", async () => {
+  const lines = [
+    // Foreign correlated handshake binds first.
+    ...handshake("foreign-poison", 99),
+    // Real session-response arrives WITHOUT its request echo — this is
+    // the bypass scenario. It disagrees with the current binding.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      result: { sessionId: "acpx-real" },
+    }),
+    // Real update for the real session — gets demoted to _sessionMismatch
+    // because the parser is still bound to "foreign-poison".
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acpx-real",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "legit" },
+        },
+      },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const turn = new AcpxTurnImpl({
+    sessionId: "grove-coder-1--xyz",
+    turnId: "t-ambig-uncorr",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  const r = await turn.result;
+
+  expect(r.stopReason).toBe("error");
+  expect(r.error?.code).toBe("session_ambiguous");
+  const mismatches = got.filter((m) => m.kind === "raw" && m.acpMethod === "_sessionMismatch");
+  expect(mismatches.length).toBeGreaterThan(0);
+});
+
+// Multi-turn regression (issue #319 live TUI validation): one acpx child
+// serves many turns; only the FIRST turn sees `session/new` on stdout.
+// Subsequent turns see only `session/prompt` + `session/update` — no
+// handshake. They must be hard-bound by the caller with the learned wire
+// sessionId, or the parser's fail-closed path triggers every turn after
+// the first. This test simulates turn 2 and asserts a clean end_turn when
+// constructed with `wireSessionId`.
+test("AcpxTurn hard-binds via wireSessionId for turns without handshake (multi-turn)", async () => {
+  const lines = [
+    // No session/new — this is turn 2+ on the same acpx child.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acpx-reused",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "followup" },
+        },
+      },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const turn = new AcpxTurnImpl({
+    sessionId: "grove-coder-1--xyz",
+    wireSessionId: "acpx-reused", // caller knows the id from turn 1
+    turnId: "t-2",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  const r = await turn.result;
+
+  // Hard-bound: no fail-closed, normal end_turn.
+  expect(r.stopReason).toBe("end_turn");
+  const texts = got.filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text");
+  expect(texts.map((m) => m.text).join("")).toBe("followup");
+  // Zero pre-bind quarantine anomalies — the parser was bound from frame 1.
+  const unbound = got.filter((m) => m.kind === "raw" && m.acpMethod === "_sessionUnbound");
+  expect(unbound).toHaveLength(0);
+  // And the getter surfaces the bound id for AcpxRuntime to forward.
+  expect(turn.wireSessionId).toBe("acpx-reused");
+});
+
+// Round-5 regression: JSON-RPC id type skew (`0` vs `"0"`) between request
+// and response MUST still correlate — providers/intermediaries can normalize
+// numeric ids to strings (or vice versa) and strict equality would leave
+// the parser unbound under benign drift.
+test("AcpxTurn correlates session handshake across id numeric/string skew", async () => {
+  const lines = [
+    // Request uses numeric id 0.
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 0,
+      method: "session/new",
+      params: { cwd: "/tmp", mcpServers: [] },
+    }),
+    // Response uses string id "0" — skewed but logically the same id.
+    JSON.stringify({ jsonrpc: "2.0", id: "0", result: { sessionId: "acpx-skew" } }),
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acpx-skew",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "ok" },
+        },
+      },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const turn = new AcpxTurnImpl({
+    sessionId: "grove-coder-1--xyz",
+    turnId: "t-id-skew",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  const r = await turn.result;
+
+  // Binding succeeded despite id-type skew → normal success, no fail-closed.
+  expect(r.stopReason).toBe("end_turn");
+  const totalText = got
+    .filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text")
+    .map((m) => m.text)
+    .join("");
+  expect(totalText).toBe("ok");
+  const unbound = got.filter((m) => m.kind === "raw" && m.acpMethod === "_sessionUnbound");
+  expect(unbound).toHaveLength(0);
 });

--- a/src/acp/turn.test.ts
+++ b/src/acp/turn.test.ts
@@ -401,3 +401,42 @@ test("AcpxTurnImpl: chunked text deltas coalesce under default capacity", async 
   expect(totalText.length).toBe(50);
   expect(totalText).toBe("x".repeat(50));
 });
+
+// Regression: issue #319 — acpx emits its own internal session UUID in
+// session/update frames, not the grove sessionName that the runtime used
+// to label the turn. If AcpxTurnImpl forwarded its caller-supplied sessionId
+// to AcpParser for filtering, every frame would be demoted to
+// _sessionMismatch and consumers would see 0 chars of text.
+test("AcpxTurn does not filter frames by caller-supplied sessionId (issue #319)", async () => {
+  const lines = [
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        // acpx's internal UUID, different from the grove sessionName below
+        sessionId: "acpx-internal-uuid-abc123",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "hello" },
+        },
+      },
+    }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, result: { stopReason: "end_turn" } }),
+  ];
+  const turn = new AcpxTurnImpl({
+    // Grove-style label the runtime hands in — NOT what acpx echoes on the wire.
+    sessionId: "grove-reviewer-1--ab12",
+    turnId: "t1",
+    stdout: Readable.from([`${lines.join("\n")}\n`]),
+    cancelFn: async () => undefined,
+  });
+  const got: Message[] = [];
+  for await (const m of turn.messages) got.push(m);
+  const r = await turn.result;
+  expect(r.stopReason).toBe("end_turn");
+  const texts = got.filter((m): m is Extract<Message, { kind: "text" }> => m.kind === "text");
+  expect(texts).toHaveLength(1);
+  expect(texts[0]?.text).toBe("hello");
+  const mismatches = got.filter((m) => m.kind === "raw" && m.acpMethod === "_sessionMismatch");
+  expect(mismatches).toHaveLength(0);
+});

--- a/src/acp/turn.ts
+++ b/src/acp/turn.ts
@@ -65,6 +65,15 @@ export class AcpxTurnImpl implements AcpxTurn {
 
   constructor(opts: {
     sessionId: string;
+    /**
+     * Optional acpx-internal wire sessionId. Pass the UUID learned from the
+     * first turn's `session/new` handshake to hard-bind subsequent turns
+     * that reuse the same acpx child — those turns don't see the handshake
+     * again on stdout, so without this the parser would fail-closed (issue
+     * #319). Leave undefined on the first turn to let AcpParser auto-learn
+     * via in-band correlation.
+     */
+    wireSessionId?: string | undefined;
     turnId: string;
     stdout: Readable;
     cancelFn: () => Promise<void>;
@@ -74,12 +83,13 @@ export class AcpxTurnImpl implements AcpxTurn {
     this.sessionId = opts.sessionId;
     this.turnId = opts.turnId;
     this.cancelFn = opts.cancelFn;
-    // Intentionally NOT passing sessionId to AcpParser: acpx stdout is
-    // single-session, and acpx emits its own internal UUID in session/update
-    // frames (not the caller-supplied `opts.sessionId` label like
-    // `grove-<role>-<n>--<suffix>`). Forwarding the label would demote every
-    // frame to _sessionMismatch — see issue #319.
+    // Do NOT forward the caller's grove label (`opts.sessionId`) to
+    // AcpParser — acpx's wire sessionId is a different value (see #319).
+    // Forward `opts.wireSessionId` when the caller knows acpx's UUID (e.g.
+    // on a second+ turn of the same child); otherwise AcpParser auto-learns
+    // via correlated `session/new` handshake.
     this.parser = new AcpParser({
+      sessionId: opts.wireSessionId,
       turnId: opts.turnId,
       stream: opts.stdout,
     });
@@ -127,5 +137,14 @@ export class AcpxTurnImpl implements AcpxTurn {
 
   async close(): Promise<void> {
     // Parser closes when stdout EOFs; nothing extra to release here.
+  }
+
+  /**
+   * The acpx-internal wire sessionId the parser ended up bound to (if any).
+   * `AcpxRuntime` reads this after a turn settles and caches it so the next
+   * turn on the same child can be hard-bound (issue #319).
+   */
+  get wireSessionId(): string | undefined {
+    return this.parser.wireSessionId;
   }
 }

--- a/src/acp/turn.ts
+++ b/src/acp/turn.ts
@@ -74,8 +74,12 @@ export class AcpxTurnImpl implements AcpxTurn {
     this.sessionId = opts.sessionId;
     this.turnId = opts.turnId;
     this.cancelFn = opts.cancelFn;
+    // Intentionally NOT passing sessionId to AcpParser: acpx stdout is
+    // single-session, and acpx emits its own internal UUID in session/update
+    // frames (not the caller-supplied `opts.sessionId` label like
+    // `grove-<role>-<n>--<suffix>`). Forwarding the label would demote every
+    // frame to _sessionMismatch — see issue #319.
     this.parser = new AcpParser({
-      sessionId: opts.sessionId,
       turnId: opts.turnId,
       stream: opts.stdout,
     });

--- a/src/core/acpx-runtime.ts
+++ b/src/core/acpx-runtime.ts
@@ -78,6 +78,15 @@ interface AcpxSessionEntry {
   logStream: import("node:fs").WriteStream | null;
   /** Log file path for agent output (debug/streaming). */
   logFile: string | null;
+  /**
+   * acpx's internal session UUID (issue #319). The first turn sees
+   * `session/new` on its stdout and the parser learns the id from the
+   * correlated response; subsequent turns on the same acpx child only see
+   * `session/prompt`+`session/update` — no handshake — so they must be
+   * constructed with this id explicitly, or the parser's fail-closed path
+   * would fire on every turn after the first.
+   */
+  wireSessionId: string | undefined;
 }
 
 export class AcpxRuntime implements AgentRuntime {
@@ -259,6 +268,7 @@ export class AcpxRuntime implements AgentRuntime {
       sendChainTail: null,
       logStream,
       logFile,
+      wireSessionId: undefined,
     };
     this.sessions.set(id, entry);
 
@@ -420,8 +430,13 @@ ${message}`;
       throw new Error("acpx child spawned without stdout pipe");
     }
 
-    return new AcpxTurnImpl({
+    const turn = new AcpxTurnImpl({
       sessionId: entry.sessionName,
+      // Issue #319: forward the learned acpx-internal wire sessionId across
+      // turns. Only the first turn sees `session/new` on stdout; subsequent
+      // turns must be constructor-bound or the parser's fail-closed path
+      // fires on every later turn.
+      wireSessionId: entry.wireSessionId,
       turnId,
       stdout: child.stdout,
       cancelFn: async () => {
@@ -435,6 +450,16 @@ ${message}`;
         }
       },
     });
+    // After the first turn settles, stash the learned wire sessionId on the
+    // entry so subsequent turns can hard-bind. Intentionally fire-and-forget:
+    // the caller awaits `turn.result` separately for the stopReason.
+    void turn.result.then(() => {
+      const learned = turn.wireSessionId;
+      if (learned !== undefined && entry.wireSessionId === undefined) {
+        entry.wireSessionId = learned;
+      }
+    });
+    return turn;
   }
 
   async send(session: AgentSession, message: string): Promise<AcpxTurn> {
@@ -463,6 +488,7 @@ ${message}`;
         sendChainTail: null,
         logStream: null,
         logFile: this.logDir ? join(this.logDir, `${session.role}-reattach.log`) : null,
+        wireSessionId: undefined,
       };
       if (entry.logFile) {
         entry.logStream = createWriteStream(entry.logFile, { flags: "a" });


### PR DESCRIPTION
## Summary

Fixes #319 — `AcpxTurnImpl` passed the grove-style sessionName (e.g. `grove-coder-1--f641`) to `AcpParser`, but acpx emits `session/update` frames with its own internal UUID in `params.sessionId`. The parser's session guard at `src/acp/parser.ts:201-208` then demoted **every** frame to `{kind:"raw", acpMethod:"_sessionMismatch"}`, so consumers saw 0 chars of text despite agents reaching `end_turn`.

Per the issue's option 2: drop the filter for per-turn acpx streams (each `AcpxTurnImpl` wraps a single-session acpx child — nothing to multiplex against). `AcpParser`'s `sessionId` is now optional; `AcpxTurnImpl` no longer forwards the grove label. The filter is retained on `AcpParser` for any future multiplexed-stream caller, but dormant.

## Changes

- `src/acp/parser.ts` — `sessionId` optional on `AcpParser` constructor + field; doc comment explaining why
- `src/acp/turn.ts` — drop `sessionId` from `AcpParser` call with comment referencing #319
- `src/acp/turn.test.ts` — regression test: grove label ≠ wire `sessionId` must yield typed text, zero `_sessionMismatch`

## Test plan

- [x] 116/116 ACP unit tests pass (`bun test src/acp`)
- [x] Biome lint clean on changed files
- [x] New regression test `AcpxTurn does not filter frames by caller-supplied sessionId (issue #319)` — fails on pre-fix code, passes now
- [x] Live validation: `tests/e2e/acp-stream-nexus.e2e.test.ts` "TUI AcpSessionStore ingests typed messages from a real agent turn" — passes against running Nexus stack
- [x] Full `grove up` review-loop preset in tmux: coder wrote `add.js`, submitted work CID `blake3:63abcfb48…`, Nexus routed handoff `fed6c01d-…` → reviewer, reviewer submitted review CID `blake3:ec760e57…` ("LGTM — one-line add(a,b) function meets the session goal."), feedback discussion landed back on coder. All frames carried acpx's internal UUID (e.g. `323da4ff-907c-4f8c-b871-de4067a101e2`), none of the grove labels — exactly the mismatch #319 identified. Zero `_sessionMismatch` frames observed across the full handoff loop.