### PR TITLE
fix(mcp): harden session scoping and plan update semantics

### DIFF
--- a/src/core/operations/plan.ts
+++ b/src/core/operations/plan.ts
@@ -135,6 +135,8 @@ export async function updatePlanOperation(
 
   const previousContext = parsePlanContext(previous.context);
   const title = input.title ?? previousContext?.plan_title ?? "Untitled Plan";
+  // Omitted tags keep the previous plan's tags; explicit tags replace.
+  const tags = [...new Set([...(input.tags ?? previous.tags), "plan"])];
 
   const result = await contributeOperation(
     {
@@ -148,7 +150,7 @@ export async function updatePlanOperation(
           relationType: RelationType.DerivesFrom,
         },
       ],
-      tags: [...(input.tags ?? []), "plan"],
+      tags,
       context: buildPlanContext({ title, tasks: input.tasks }),
       ...(input.agent !== undefined ? { agent: input.agent } : {}),
       ...(input.idempotencyKey !== undefined ? { idempotencyKey: input.idempotencyKey } : {}),

--- a/src/mcp/current-session.test.ts
+++ b/src/mcp/current-session.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseCurrentSessionPayload, SessionStateReadError } from "./current-session.js";
+
+const TEST_FILE = "/tmp/current-session.json";
+
+function expectSessionReadError(run: () => void): SessionStateReadError {
+  try {
+    run();
+  } catch (err) {
+    expect(err).toBeInstanceOf(SessionStateReadError);
+    return err as SessionStateReadError;
+  }
+  throw new Error("Expected SessionStateReadError");
+}
+
+describe("parseCurrentSessionPayload", () => {
+  test("parses valid payload", () => {
+    const sessionId = parseCurrentSessionPayload('{"sessionId":"sess-123"}', TEST_FILE);
+    expect(sessionId).toBe("sess-123");
+  });
+
+  test("throws for invalid JSON", () => {
+    const err = expectSessionReadError(() =>
+      parseCurrentSessionPayload('{"sessionId":', TEST_FILE),
+    );
+    expect(err.message).toContain("read/parse");
+  });
+
+  test("throws for non-object payload", () => {
+    const err = expectSessionReadError(() => parseCurrentSessionPayload('"sess-123"', TEST_FILE));
+    expect(err.message).toContain("expected an object");
+  });
+
+  test("throws for missing sessionId", () => {
+    const err = expectSessionReadError(() => parseCurrentSessionPayload("{}", TEST_FILE));
+    expect(err.message).toContain("non-empty string sessionId");
+  });
+
+  test("throws for non-string sessionId", () => {
+    const err = expectSessionReadError(() =>
+      parseCurrentSessionPayload('{"sessionId":123}', TEST_FILE),
+    );
+    expect(err.message).toContain("non-empty string sessionId");
+  });
+
+  test("throws for blank sessionId", () => {
+    const err = expectSessionReadError(() =>
+      parseCurrentSessionPayload('{"sessionId":"   "}', TEST_FILE),
+    );
+    expect(err.message).toContain("non-empty string sessionId");
+  });
+});

--- a/src/mcp/current-session.ts
+++ b/src/mcp/current-session.ts
@@ -1,0 +1,46 @@
+/**
+ * Helpers for reading and validating `.grove/current-session.json`.
+ */
+
+/**
+ * Error raised when the current-session state file exists but cannot be
+ * parsed or does not match the expected shape.
+ */
+export class SessionStateReadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionStateReadError";
+  }
+}
+
+/**
+ * Parse and validate a current-session payload.
+ *
+ * Expected shape:
+ *   { "sessionId": "<non-empty string>" }
+ */
+export function parseCurrentSessionPayload(rawText: string, sessionFile: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch (err) {
+    throw new SessionStateReadError(
+      `read/parse ${sessionFile} failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new SessionStateReadError(
+      `read/parse ${sessionFile} failed: expected an object with a non-empty string sessionId`,
+    );
+  }
+
+  const sessionId = (parsed as { sessionId?: unknown }).sessionId;
+  if (typeof sessionId !== "string" || sessionId.trim().length === 0) {
+    throw new SessionStateReadError(
+      `read/parse ${sessionFile} failed: expected a non-empty string sessionId`,
+    );
+  }
+
+  return sessionId;
+}

--- a/src/mcp/serve-http.test.ts
+++ b/src/mcp/serve-http.test.ts
@@ -43,6 +43,7 @@ interface TestServerContext {
   baseUrl: string;
   sessions: Map<string, ManagedSession>;
   reapTimer: ReturnType<typeof setInterval> | undefined;
+  reapIntervalMs: number;
   deps: McpDeps;
 }
 
@@ -60,8 +61,8 @@ function buildTestServer(deps: McpDeps, opts: BuildTestServerOptions): TestServe
   const { sessionTtlMs, authToken, maxBodySize = MAX_MCP_BODY_SIZE } = opts;
   const sessions = new Map<string, ManagedSession>();
 
-  // Mirror production: reap interval = min(60s, TTL/3).
-  const reapIntervalMs = Math.min(60_000, Math.floor(sessionTtlMs / 3));
+  // Mirror production: clamp low TTL values to avoid 0ms timer spin loops.
+  const reapIntervalMs = Math.max(50, Math.min(60_000, Math.floor(sessionTtlMs / 3)));
 
   const reapTimer = setInterval(() => {
     const now = Date.now();
@@ -205,7 +206,7 @@ function buildTestServer(deps: McpDeps, opts: BuildTestServerOptions): TestServe
     });
   });
 
-  return { httpServer, baseUrl: "", sessions, reapTimer, deps };
+  return { httpServer, baseUrl: "", sessions, reapTimer, reapIntervalMs, deps };
 }
 
 /** Start server on port 0 (OS picks a free port) and return the base URL. */
@@ -480,6 +481,22 @@ describe("MCP HTTP session management", () => {
     expect(newSessionId).not.toBe("does-not-exist");
     // A new session should have been created
     expect(ctx.sessions.size).toBeGreaterThan(countBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reap interval guardrails
+// ---------------------------------------------------------------------------
+
+describe("MCP HTTP reap interval", () => {
+  test("clamps very low TTL values to avoid zero-ms timer loops", async () => {
+    const testDeps = await createTestMcpDeps();
+    const tinyCtx = buildTestServer(testDeps.deps, { sessionTtlMs: 1 });
+
+    expect(tinyCtx.reapIntervalMs).toBe(50);
+
+    if (tinyCtx.reapTimer) clearInterval(tinyCtx.reapTimer);
+    await testDeps.cleanup();
   });
 });
 

--- a/src/mcp/serve-http.ts
+++ b/src/mcp/serve-http.ts
@@ -18,6 +18,7 @@
  *   DELETE /mcp — Close a session
  */
 
+import { readFileSync, statSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -29,6 +30,7 @@ import { TopologyRouter } from "../core/topology-router.js";
 import { createLocalRuntime } from "../local/runtime.js";
 import { parsePort } from "../shared/env.js";
 import { safeCleanup } from "../shared/safe-cleanup.js";
+import { parseCurrentSessionPayload, SessionStateReadError } from "./current-session.js";
 import type { McpDeps } from "./deps.js";
 import { createMcpServer } from "./server.js";
 
@@ -187,21 +189,9 @@ interface ScopedDeps {
   readonly close: () => void;
 }
 
-/**
- * Error raised when the current-session state file exists but cannot be
- * parsed or read. Distinct from "file absent" (a valid pre-session state)
- * so the caller can fail closed on corrupted state instead of silently
- * falling through to unscoped stores.
- */
-class SessionStateReadError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "SessionStateReadError";
-  }
-}
-
 const depsCache = new Map<string, ScopedDeps>();
 let lastSessionFileMtimeMs = -1;
+let lastSessionFileSize = -1;
 let lastSessionFileId: string | undefined;
 
 /**
@@ -209,49 +199,62 @@ let lastSessionFileId: string | undefined;
  *
  * Returns `undefined` ONLY when no session has been created yet (env var is
  * unset AND the state file does not exist). Throws `SessionStateReadError`
- * when the state file is present but unreadable or unparseable — callers
- * must decide whether to fail closed (Nexus mode) or tolerate the error.
+ * when the state file is present but unreadable, unparseable, or malformed —
+ * callers must decide whether to fail closed (Nexus mode) or tolerate
+ * the error.
  *
- * Caching semantics: we only update the cached mtime/sessionId after a
+ * Caching semantics: we only update the cached stat/sessionId after a
  * SUCCESSFUL parse. A parse failure leaves the cache untouched so that
- * every subsequent call re-runs the read against the current mtime — the
+ * every subsequent call re-runs the read against the current stat — the
  * caller keeps seeing errors until the writer either fixes the file or
- * produces a new mtime with valid JSON.
+ * produces new file metadata with valid JSON.
  */
 function readCurrentSessionId(): string | undefined {
   const fromEnv = process.env.GROVE_SESSION_ID;
   if (fromEnv) return fromEnv;
-  const { existsSync, readFileSync, statSync } = require("node:fs") as typeof import("node:fs");
   const sessionFile = `${groveDir}/current-session.json`;
-  if (!existsSync(sessionFile)) return undefined;
   let stat: ReturnType<typeof statSync>;
   try {
     stat = statSync(sessionFile);
   } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      // Clear cached stat/id when the file disappears so a subsequent recreate
+      // cannot accidentally match stale metadata from the old file.
+      lastSessionFileMtimeMs = -1;
+      lastSessionFileSize = -1;
+      lastSessionFileId = undefined;
+      return undefined;
+    }
     throw new SessionStateReadError(
       `stat ${sessionFile} failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
-  if (stat.mtimeMs === lastSessionFileMtimeMs && lastSessionFileMtimeMs > 0) {
+  if (
+    stat.mtimeMs === lastSessionFileMtimeMs &&
+    stat.size === lastSessionFileSize &&
+    lastSessionFileMtimeMs > 0
+  ) {
     return lastSessionFileId;
   }
-  let raw: { sessionId?: string };
+  let sessionId: string;
   try {
-    raw = JSON.parse(readFileSync(sessionFile, "utf-8")) as { sessionId?: string };
+    sessionId = parseCurrentSessionPayload(readFileSync(sessionFile, "utf-8"), sessionFile);
   } catch (err) {
     // Do NOT update the cache — leave lastSessionFileMtimeMs/lastSessionFileId
     // untouched so the next call re-reads. Otherwise a single torn-write
     // during a concurrent session switch would poison the cache and every
     // subsequent request would read the stale (or undefined) session id
     // without surfacing the error.
+    if (err instanceof SessionStateReadError) throw err;
     throw new SessionStateReadError(
       `read/parse ${sessionFile} failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
   // Success — commit to cache.
   lastSessionFileMtimeMs = stat.mtimeMs;
-  lastSessionFileId = raw.sessionId;
-  return raw.sessionId;
+  lastSessionFileSize = stat.size;
+  lastSessionFileId = sessionId;
+  return sessionId;
 }
 
 async function buildScopedDeps(sessionId: string | undefined): Promise<ScopedDeps> {
@@ -488,7 +491,8 @@ const SESSION_TTL_MS = (() => {
 })();
 
 /** How often the reaper sweeps for stale sessions. Adapts to low TTLs. */
-const REAP_INTERVAL_MS = Math.min(60_000, Math.floor(SESSION_TTL_MS / 3));
+const REAP_INTERVAL_MS = Math.max(50, Math.min(60_000, Math.floor(SESSION_TTL_MS / 3)));
+const KEEPALIVE_INTERVAL_MS = Math.max(25, Math.floor(REAP_INTERVAL_MS / 2));
 
 interface ManagedSession {
   server: McpServer;
@@ -692,7 +696,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
     // client is actively waiting for server-initiated messages.
     const keepAlive = setInterval(() => {
       getSession.lastActivity = Date.now();
-    }, REAP_INTERVAL_MS / 2);
+    }, KEEPALIVE_INTERVAL_MS);
     res.on("close", () => clearInterval(keepAlive));
     await getSession.transport.handleRequest(req, res);
   } else if (req.method === "DELETE") {

--- a/src/mcp/tools/plans.test.ts
+++ b/src/mcp/tools/plans.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpDeps } from "../deps.js";
+import type { TestMcpDeps } from "../test-helpers.js";
+import { createTestMcpDeps } from "../test-helpers.js";
+import { registerPlanTools } from "./plans.js";
+
+async function callTool(
+  server: McpServer,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ isError: boolean | undefined; text: string }> {
+  const registeredTools = (
+    server as unknown as {
+      _registeredTools: Record<string, { handler: (args: unknown) => Promise<unknown> }>;
+    }
+  )._registeredTools;
+  const tool = registeredTools[name];
+  if (!tool) throw new Error(`Tool ${name} not registered`);
+  const result = (await tool.handler(args)) as {
+    isError?: boolean;
+    content: Array<{ type: string; text: string }>;
+  };
+  return {
+    isError: result.isError,
+    text: result.content[0]?.text ?? "",
+  };
+}
+
+describe("grove plan tools", () => {
+  let testDeps: TestMcpDeps;
+  let deps: McpDeps;
+  let server: McpServer;
+
+  beforeEach(async () => {
+    testDeps = await createTestMcpDeps();
+    deps = testDeps.deps;
+    server = new McpServer({ name: "test", version: "0.0.1" }, { capabilities: { tools: {} } });
+    registerPlanTools(server, deps);
+  });
+
+  afterEach(async () => {
+    await testDeps.cleanup();
+  });
+
+  test("grove_update_plan keeps previous tags when tags are omitted", async () => {
+    const createResult = await callTool(server, "grove_create_plan", {
+      title: "Plan A",
+      tasks: [{ id: "t1", title: "Task 1", status: "todo" }],
+      tags: ["alpha"],
+    });
+    expect(createResult.isError).toBeUndefined();
+    const createData = JSON.parse(createResult.text) as { cid: string };
+
+    const updateResult = await callTool(server, "grove_update_plan", {
+      previous_plan_cid: createData.cid,
+      tasks: [{ id: "t1", title: "Task 1", status: "in_progress" }],
+    });
+    expect(updateResult.isError).toBeUndefined();
+    const updateData = JSON.parse(updateResult.text) as { cid: string };
+
+    const updated = await deps.contributionStore.get(updateData.cid);
+    expect(updated).toBeDefined();
+    expect(updated?.tags).toContain("alpha");
+    expect(updated?.tags).toContain("plan");
+    expect(updated?.tags.filter((tag) => tag === "plan")).toHaveLength(1);
+  });
+
+  test("grove_update_plan replaces tags when explicit tags are provided", async () => {
+    const createResult = await callTool(server, "grove_create_plan", {
+      title: "Plan B",
+      tasks: [{ id: "t1", title: "Task 1", status: "todo" }],
+      tags: ["alpha"],
+    });
+    expect(createResult.isError).toBeUndefined();
+    const createData = JSON.parse(createResult.text) as { cid: string };
+
+    const updateResult = await callTool(server, "grove_update_plan", {
+      previous_plan_cid: createData.cid,
+      tasks: [{ id: "t1", title: "Task 1", status: "done" }],
+      tags: ["beta"],
+    });
+    expect(updateResult.isError).toBeUndefined();
+    const updateData = JSON.parse(updateResult.text) as { cid: string };
+
+    const updated = await deps.contributionStore.get(updateData.cid);
+    expect(updated).toBeDefined();
+    expect(updated?.tags).toContain("beta");
+    expect(updated?.tags).toContain("plan");
+    expect(updated?.tags).not.toContain("alpha");
+  });
+});

--- a/src/mcp/tools/plans.ts
+++ b/src/mcp/tools/plans.ts
@@ -41,7 +41,7 @@ const updatePlanInputSchema = z.object({
   tasks: z.array(planTaskSchema).min(1).describe("Updated list of plan tasks"),
   title: z.string().optional().describe("Updated plan title (defaults to previous)"),
   description: z.string().optional().describe("Updated plan description"),
-  tags: z.array(z.string()).optional().default([]).describe("Tags for filtering"),
+  tags: z.array(z.string()).optional().describe("Tags for filtering"),
   agent: agentSchema,
 });
 
@@ -93,7 +93,7 @@ export function registerPlanTools(server: McpServer, deps: McpDeps): void {
           tasks: args.tasks as unknown as readonly PlanTask[],
           ...(args.title !== undefined ? { title: args.title } : {}),
           ...(args.description !== undefined ? { description: args.description } : {}),
-          tags: args.tags,
+          ...(args.tags !== undefined ? { tags: args.tags } : {}),
           agent: args.agent as AgentOverrides,
         },
         opDeps,

--- a/src/mcp/tools/queries.test.ts
+++ b/src/mcp/tools/queries.test.ts
@@ -411,3 +411,91 @@ describe("grove_thread", () => {
     expect(result.text).toContain(McpErrorCode.NotFound);
   });
 });
+
+describe("grove_threads", () => {
+  let testDeps: TestMcpDeps;
+  let deps: McpDeps;
+  let server: McpServer;
+
+  beforeEach(async () => {
+    testDeps = await createTestMcpDeps();
+    deps = testDeps.deps;
+    server = new McpServer({ name: "test", version: "0.0.1" }, { capabilities: { tools: {} } });
+    registerQueryTools(server, deps);
+  });
+
+  afterEach(async () => {
+    await testDeps.cleanup();
+  });
+
+  test("ignores empty and duplicate tags in comma-separated input", async () => {
+    const target = makeContribution({
+      kind: "discussion",
+      summary: "Thread with both tags",
+      tags: ["infra", "urgent"],
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    const targetReply = makeContribution({
+      kind: "discussion",
+      summary: "Reply to target thread",
+      relations: [{ targetCid: target.cid, relationType: "responds_to" }],
+      createdAt: "2026-01-02T00:00:00Z",
+    });
+
+    const nonMatch = makeContribution({
+      kind: "discussion",
+      summary: "Thread with one tag only",
+      tags: ["infra"],
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    const nonMatchReply = makeContribution({
+      kind: "discussion",
+      summary: "Reply to non-match thread",
+      relations: [{ targetCid: nonMatch.cid, relationType: "responds_to" }],
+      createdAt: "2026-01-03T00:00:00Z",
+    });
+
+    await deps.contributionStore.put(target);
+    await deps.contributionStore.put(targetReply);
+    await deps.contributionStore.put(nonMatch);
+    await deps.contributionStore.put(nonMatchReply);
+
+    const result = await callTool(server, "grove_threads", {
+      tags: "infra, , urgent,infra,,",
+      limit: 10,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.text);
+    expect(data.count).toBe(1);
+    expect(data.threads[0].cid).toBe(target.cid);
+  });
+
+  test("treats blank tags input as no filter", async () => {
+    const target = makeContribution({
+      kind: "discussion",
+      summary: "Thread visible without tag filter",
+      tags: ["infra"],
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    const targetReply = makeContribution({
+      kind: "discussion",
+      summary: "Reply",
+      relations: [{ targetCid: target.cid, relationType: "responds_to" }],
+      createdAt: "2026-01-02T00:00:00Z",
+    });
+
+    await deps.contributionStore.put(target);
+    await deps.contributionStore.put(targetReply);
+
+    const result = await callTool(server, "grove_threads", {
+      tags: "   ,  , ",
+      limit: 10,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.text);
+    expect(data.count).toBe(1);
+    expect(data.threads[0].cid).toBe(target.cid);
+  });
+});

--- a/src/mcp/tools/queries.ts
+++ b/src/mcp/tools/queries.ts
@@ -310,7 +310,14 @@ export function registerQueryTools(server: McpServer, deps: McpDeps): void {
       inputSchema: threadsInputSchema,
     },
     async (args) => {
-      const tags = args.tags !== undefined ? args.tags.split(",").map((t) => t.trim()) : undefined;
+      const rawTags =
+        args.tags !== undefined
+          ? args.tags
+              .split(",")
+              .map((tag) => tag.trim())
+              .filter((tag) => tag.length > 0)
+          : undefined;
+      const tags = rawTags !== undefined && rawTags.length > 0 ? [...new Set(rawTags)] : undefined;
       const result = await threadsOperation(
         {
           ...(tags !== undefined ? { tags } : {}),


### PR DESCRIPTION
## Summary
- Fail closed when `.grove/current-session.json` is malformed, and reset stale cache state when the file disappears so HTTP MCP session scoping cannot silently drift.
- Preserve prior plan tags when `grove_update_plan` omits `tags`, while still allowing explicit tag replacement and keeping the canonical `plan` tag deduplicated.
- Add MCP regressions for session payload validation, plan update tag semantics, thread tag sanitization, and low-TTL HTTP reaper interval guardrails.

## Test plan
- [x] `bun test src/mcp`
- [x] `bun test src/mcp/current-session.test.ts src/mcp/tools/plans.test.ts src/mcp/tools/queries.test.ts src/mcp/serve-http.test.ts`
- [x] `bun run typecheck`
- [x] `bunx biome check src/mcp/current-session.ts src/mcp/current-session.test.ts src/mcp/serve-http.ts src/mcp/tools/plans.ts src/mcp/tools/plans.test.ts src/core/operations/plan.ts`

Made with [Cursor](https://cursor.com)