### PR TITLE
fix(core): harden orchestrator routing and enforcement hooks

### DIFF
--- a/src/core/enforcing-store.test.ts
+++ b/src/core/enforcing-store.test.ts
@@ -460,6 +460,54 @@ describe("EnforcingContributionStore", () => {
         await cleanup(dir, db);
       }
     });
+
+    test("clears pre-write hook when enforcement rejects before hook runs", async () => {
+      const { dir, db, contributionStore } = await setupStores();
+      try {
+        const contract = makeContract({
+          rateLimits: { maxContributionsPerAgentPerHour: 1 },
+        });
+        const store = new EnforcingContributionStore(contributionStore, contract);
+        const hooks = (
+          store as unknown as { preWriteHooks: Map<string, (c: unknown) => Promise<void>> }
+        ).preWriteHooks;
+
+        await store.put(makeRecentContribution({ summary: "at-limit" }));
+        const blocked = makeRecentContribution({ summary: "blocked" });
+
+        let hookRan = false;
+        store.setPreWriteHook(blocked.cid, async () => {
+          hookRan = true;
+        });
+
+        await expect(store.put(blocked)).rejects.toThrow(RateLimitError);
+        expect(hookRan).toBe(false);
+        expect(hooks.has(blocked.cid)).toBe(false);
+      } finally {
+        await cleanup(dir, db);
+      }
+    });
+
+    test("clears pre-write hook when hook throws", async () => {
+      const { dir, db, contributionStore } = await setupStores();
+      try {
+        const store = new EnforcingContributionStore(contributionStore, makeContract());
+        const hooks = (
+          store as unknown as { preWriteHooks: Map<string, (c: unknown) => Promise<void>> }
+        ).preWriteHooks;
+        const c = makeRecentContribution({ summary: "hook-throws" });
+
+        store.setPreWriteHook(c.cid, async () => {
+          throw new Error("hook boom");
+        });
+
+        await expect(store.put(c)).rejects.toThrow("hook boom");
+        expect(hooks.has(c.cid)).toBe(false);
+        expect(await store.count()).toBe(0);
+      } finally {
+        await cleanup(dir, db);
+      }
+    });
   });
 
   describe("clock skew rejection", () => {
@@ -1555,6 +1603,42 @@ describe("EnforcingContributionStore: putWithCowrite preservation", () => {
       // Confirm the second was never written.
       const stored = await contributionStore.get(c2.cid);
       expect(stored).toBeUndefined();
+    } finally {
+      await cleanup(dir, db);
+    }
+  });
+
+  test("putWithCowrite clears pre-write hook when enforcement rejects", async () => {
+    const { dir, db, contributionStore } = await setupStores();
+    try {
+      const contract = makeContract({
+        rateLimits: { maxContributionsPerAgentPerHour: 1 },
+      });
+      const store = new EnforcingContributionStore(contributionStore, contract);
+      const hooks = (
+        store as unknown as { preWriteHooks: Map<string, (c: unknown) => Promise<void>> }
+      ).preWriteHooks;
+      const cowriteFn = (): void => {
+        /* no handoffs in this test */
+      };
+      type CowriteStore = { putWithCowrite: (c: unknown, fn: () => void) => Promise<void> };
+
+      await (store as unknown as CowriteStore).putWithCowrite(
+        makeRecentContribution({ summary: "first", agent: { agentId: "agent-y" } }),
+        cowriteFn,
+      );
+
+      const blocked = makeRecentContribution({ summary: "blocked", agent: { agentId: "agent-y" } });
+      let hookRan = false;
+      store.setPreWriteHook(blocked.cid, async () => {
+        hookRan = true;
+      });
+
+      await expect(
+        (store as unknown as CowriteStore).putWithCowrite(blocked, cowriteFn),
+      ).rejects.toThrow(RateLimitError);
+      expect(hookRan).toBe(false);
+      expect(hooks.has(blocked.cid)).toBe(false);
     } finally {
       await cleanup(dir, db);
     }

--- a/src/core/enforcing-store.ts
+++ b/src/core/enforcing-store.ts
@@ -167,20 +167,28 @@ export class EnforcingContributionStore implements ContributionStore {
 
   put = async (contribution: Contribution): Promise<void> => {
     return this.writeMutex.runExclusive(async () => {
-      // Idempotent: if CID already exists, skip enforcement and delegate (no-op)
-      const existing = await this.inner.get(contribution.cid);
-      if (existing !== undefined) {
-        return this.inner.put(contribution);
-      }
-
-      await this.enforceContributionLimits(contribution, 0, []);
-      // Run per-CID policy enforcement inside mutex (TOCTOU-safe, no shared state race)
       const hook = this.preWriteHooks.get(contribution.cid);
-      if (hook) {
-        this.preWriteHooks.delete(contribution.cid);
-        await hook(contribution);
+      try {
+        // Idempotent: if CID already exists, skip enforcement and delegate (no-op)
+        const existing = await this.inner.get(contribution.cid);
+        if (existing !== undefined) {
+          return this.inner.put(contribution);
+        }
+
+        await this.enforceContributionLimits(contribution, 0, []);
+        // Run per-CID policy enforcement inside mutex (TOCTOU-safe, no shared state race)
+        if (hook) {
+          await hook(contribution);
+        }
+        return await this.inner.put(contribution);
+      } finally {
+        // One-shot hook lifecycle: clear stale registrations even when
+        // enforcement/write fails. Only remove if unchanged to avoid racing
+        // with a newer registration for the same CID.
+        if (hook !== undefined && this.preWriteHooks.get(contribution.cid) === hook) {
+          this.preWriteHooks.delete(contribution.cid);
+        }
       }
-      return await this.inner.put(contribution);
     });
   };
 
@@ -209,33 +217,38 @@ export class EnforcingContributionStore implements ContributionStore {
    */
   putWithCowrite = async (contribution: Contribution, cowriteFn: () => void): Promise<void> => {
     return this.writeMutex.runExclusive(async () => {
-      const existing = await this.inner.get(contribution.cid);
-      if (existing !== undefined) {
-        // Idempotent: contribution already present, skip enforcement and
-        // the cowrite (no handoffs to insert for an existing row).
-        return;
-      }
-
-      await this.enforceContributionLimits(contribution, 0, []);
       const hook = this.preWriteHooks.get(contribution.cid);
-      if (hook) {
-        this.preWriteHooks.delete(contribution.cid);
-        await hook(contribution);
-      }
-
-      const innerCowrite = (
-        this.inner as unknown as {
-          putWithCowrite?: (c: Contribution, fn: () => void) => void;
+      try {
+        const existing = await this.inner.get(contribution.cid);
+        if (existing !== undefined) {
+          // Idempotent: contribution already present, skip enforcement and
+          // the cowrite (no handoffs to insert for an existing row).
+          return;
         }
-      ).putWithCowrite;
-      if (innerCowrite !== undefined) {
-        innerCowrite.call(this.inner, contribution, cowriteFn);
-      } else {
-        // Defensive fallback — inner store does not support atomic cowrite.
-        // Do the best we can: put the contribution, then run the cowrite fn
-        // serially. This loses atomicity but matches the serial write path.
-        await this.inner.put(contribution);
-        cowriteFn();
+
+        await this.enforceContributionLimits(contribution, 0, []);
+        if (hook) {
+          await hook(contribution);
+        }
+
+        const innerCowrite = (
+          this.inner as unknown as {
+            putWithCowrite?: (c: Contribution, fn: () => void) => void;
+          }
+        ).putWithCowrite;
+        if (innerCowrite !== undefined) {
+          innerCowrite.call(this.inner, contribution, cowriteFn);
+        } else {
+          // Defensive fallback — inner store does not support atomic cowrite.
+          // Do the best we can: put the contribution, then run the cowrite fn
+          // serially. This loses atomicity but matches the serial write path.
+          await this.inner.put(contribution);
+          cowriteFn();
+        }
+      } finally {
+        if (hook !== undefined && this.preWriteHooks.get(contribution.cid) === hook) {
+          this.preWriteHooks.delete(contribution.cid);
+        }
       }
     });
   };
@@ -465,17 +478,25 @@ export class EnforcingContributionStore implements ContributionStore {
    * Finds the oldest in-window contribution and calculates when it rolls out.
    */
   private computeRetryAfterMs(contributions: readonly Contribution[], windowStart: Date): number {
-    const now = this.clock();
-    const inWindow = contributions
-      .filter((c) => new Date(c.createdAt).getTime() >= windowStart.getTime())
-      .sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
+    const nowMs = this.clock().getTime();
+    const windowStartMs = windowStart.getTime();
+    let oldestInWindowMs: number | undefined;
 
-    const oldest = inWindow[0];
-    if (oldest === undefined) return 0;
+    // Single-pass scan avoids an O(n log n) sort while preserving behavior.
+    for (const contribution of contributions) {
+      const createdAtMs = Date.parse(contribution.createdAt);
+      if (!Number.isFinite(createdAtMs) || createdAtMs < windowStartMs) {
+        continue;
+      }
+      if (oldestInWindowMs === undefined || createdAtMs < oldestInWindowMs) {
+        oldestInWindowMs = createdAtMs;
+      }
+    }
 
-    const oldestTime = new Date(oldest.createdAt).getTime();
-    const rolloutTime = oldestTime + RATE_LIMIT_WINDOW_SECONDS * 1000;
-    return Math.max(0, rolloutTime - now.getTime());
+    if (oldestInWindowMs === undefined) return 0;
+
+    const rolloutTime = oldestInWindowMs + RATE_LIMIT_WINDOW_SECONDS * 1000;
+    return Math.max(0, rolloutTime - nowMs);
   }
 }
 

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { GroveContract } from "./contract.js";
 import { LocalEventBus } from "./local-event-bus.js";
 import { MockRuntime } from "./mock-runtime.js";
+import { type Contribution, ContributionKind, ContributionMode } from "./models.js";
 import { SessionOrchestrator } from "./session-orchestrator.js";
 import type { AgentTopology } from "./topology.js";
 
@@ -38,6 +39,9 @@ function makeOrchestrator(
     bus?: InstanceType<typeof LocalEventBus>;
     goal?: string;
     sessionId?: string;
+    contributionStore?:
+      | { list(query?: { limit?: number }): Promise<readonly Contribution[]> }
+      | undefined;
   },
 ) {
   const runtime = overrides?.runtime ?? new MockRuntime();
@@ -54,6 +58,7 @@ function makeOrchestrator(
     // allow-fallback lets agents start despite that.
     workspaceIsolationPolicy: "allow-fallback",
     ...(overrides?.sessionId ? { sessionId: overrides.sessionId } : {}),
+    ...(overrides?.contributionStore ? { contributionStore: overrides.contributionStore } : {}),
   });
   return { orchestrator, runtime, bus };
 }
@@ -171,6 +176,109 @@ describe("SessionOrchestrator", () => {
     bus.close();
   });
 
+  test("polling forwards only contributions from this session's agent IDs", async () => {
+    const contract = makeContract();
+    const contributions: Contribution[] = [];
+    const contributionStore = {
+      list: async (_query?: { limit?: number }): Promise<readonly Contribution[]> => contributions,
+    };
+    const { orchestrator, runtime, bus } = makeOrchestrator(contract, { contributionStore });
+
+    const status = await orchestrator.start();
+    const coderSession = status.agents.find((a) => a.role === "coder")?.session.id;
+    expect(coderSession).toBeDefined();
+    if (coderSession === undefined) {
+      throw new Error("Expected coder session to be defined");
+    }
+
+    contributions.push(
+      {
+        cid: `blake3:${"a".repeat(64)}`,
+        manifestVersion: 1,
+        kind: ContributionKind.Work,
+        mode: ContributionMode.Exploration,
+        summary: "Foreign coder contribution",
+        artifacts: {},
+        relations: [],
+        tags: ["work"],
+        agent: { agentId: "mock-coder-other", role: "coder" },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        cid: `blake3:${"b".repeat(64)}`,
+        manifestVersion: 1,
+        kind: ContributionKind.Work,
+        mode: ContributionMode.Exploration,
+        summary: "Local coder contribution",
+        artifacts: {},
+        relations: [],
+        tags: ["work"],
+        agent: { agentId: coderSession, role: "coder" },
+        createdAt: "2026-01-01T00:00:01.000Z",
+      },
+    );
+
+    const before = runtime.sendCalls.length;
+    await (
+      orchestrator as unknown as {
+        pollContributions: () => Promise<void>;
+      }
+    ).pollContributions();
+    const forwarded = runtime.sendCalls.slice(before);
+
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0]!.message).toContain("Local coder contribution");
+    expect(forwarded[0]!.message).not.toContain("Foreign coder contribution");
+
+    await orchestrator.stop("done");
+    bus.close();
+  });
+
+  test("polling still accepts contributions from pre-resume session IDs", async () => {
+    const contract = makeContract();
+    const contributions: Contribution[] = [];
+    const contributionStore = {
+      list: async (_query?: { limit?: number }): Promise<readonly Contribution[]> => contributions,
+    };
+    const { orchestrator, runtime, bus } = makeOrchestrator(contract, { contributionStore });
+
+    const status = await orchestrator.start();
+    const originalCoderSession = status.agents.find((a) => a.role === "coder")?.session.id;
+    expect(originalCoderSession).toBeDefined();
+    if (originalCoderSession === undefined) {
+      throw new Error("Expected original coder session to be defined");
+    }
+
+    await orchestrator.resumeAgent("coder");
+
+    contributions.push({
+      cid: `blake3:${"c".repeat(64)}`,
+      manifestVersion: 1,
+      kind: ContributionKind.Work,
+      mode: ContributionMode.Exploration,
+      summary: "Contribution from old coder session",
+      artifacts: {},
+      relations: [],
+      tags: ["work"],
+      agent: { agentId: originalCoderSession, role: "coder" },
+      createdAt: "2026-01-01T00:00:02.000Z",
+    });
+
+    const before = runtime.sendCalls.length;
+    await (
+      orchestrator as unknown as {
+        pollContributions: () => Promise<void>;
+      }
+    ).pollContributions();
+    const forwarded = runtime.sendCalls.slice(before);
+
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0]!.message).toContain("Contribution from old coder session");
+
+    await orchestrator.stop("done");
+    bus.close();
+  });
+
   test("stop events are not forwarded to agents", async () => {
     const contract = makeContract();
     const { orchestrator, runtime, bus } = makeOrchestrator(contract);
@@ -191,6 +299,26 @@ describe("SessionOrchestrator", () => {
 
     // 2 goal sends (MockRuntime), no forwarded stop events
     expect(runtime.sendCalls.length).toBe(2);
+    bus.close();
+  });
+
+  test("contribution events are ignored after stop", async () => {
+    const contract = makeContract();
+    const { orchestrator, runtime, bus } = makeOrchestrator(contract);
+
+    await orchestrator.start();
+    await orchestrator.stop("done");
+
+    const before = runtime.sendCalls.length;
+    await bus.publish({
+      type: "contribution",
+      sourceRole: "coder",
+      targetRole: "reviewer",
+      payload: { cid: "blake3:abc", summary: "late event" },
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(runtime.sendCalls.length).toBe(before);
     bus.close();
   });
 
@@ -309,6 +437,34 @@ describe("SessionOrchestrator", () => {
     const stopped = await orchestrator.checkIdleCompletion();
     expect(stopped).toBe(false);
     expect(orchestrator.getStatus().stopped).toBe(false);
+    bus.close();
+  });
+
+  test("waitForCompletion times out even when idle checks throw", async () => {
+    class ThrowingListSessionsRuntime extends MockRuntime {
+      override async listSessions(): Promise<readonly import("./agent-runtime.js").AgentSession[]> {
+        throw new Error("listSessions failed");
+      }
+    }
+
+    const contract = makeContract();
+    const runtime = new ThrowingListSessionsRuntime();
+    const bus = new LocalEventBus();
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract,
+      topology: contract.topology!,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+    });
+
+    await orchestrator.start();
+    const reason = await orchestrator.waitForCompletion(40, 10);
+    expect(reason).toBe("Session timed out");
+    expect(orchestrator.getStatus().stopped).toBe(true);
     bus.close();
   });
 

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -114,7 +114,9 @@ export class SessionOrchestrator {
   private contributionCount = 0;
   private startedAt = 0;
   private readonly seenCids = new Set<string>();
+  private readonly sessionAgentIdsByRole = new Map<string, Set<string>>();
   private contributionPollTimer: ReturnType<typeof setInterval> | null = null;
+  private contributionPollStartTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor(config: SessionConfig) {
     this.config = config;
@@ -187,6 +189,7 @@ export class SessionOrchestrator {
     for (const result of spawnResults) {
       if (result.status === "fulfilled") {
         this.agents.push(result.value);
+        this.recordSessionAgentId(result.value.role, result.value.session.id);
       } else {
         process.stderr.write(`[SessionOrchestrator] spawn failed: ${result.reason}\n`);
       }
@@ -241,8 +244,15 @@ export class SessionOrchestrator {
 
   /** Stop the session gracefully. */
   async stop(reason: string): Promise<void> {
+    if (this.stopped) return;
     this.stopped = true;
     this.stopReason = reason;
+
+    // Stop contribution polling
+    if (this.contributionPollStartTimeout) {
+      clearTimeout(this.contributionPollStartTimeout);
+      this.contributionPollStartTimeout = null;
+    }
 
     // Stop contribution polling
     if (this.contributionPollTimer) {
@@ -253,9 +263,25 @@ export class SessionOrchestrator {
     // Notify all agents
     await this.router.broadcastStop(reason);
 
-    // Close all agent sessions
-    for (const agent of this.agents) {
-      await this.config.runtime.close(agent.session);
+    // Unsubscribe all role handlers to avoid post-stop forwarding/memory leaks.
+    if (this.eventHandlers) {
+      for (const [role, handler] of this.eventHandlers) {
+        this.config.eventBus.unsubscribe(role, handler);
+      }
+      this.eventHandlers.clear();
+    }
+
+    // Close all agent sessions (best-effort)
+    const closeResults = await Promise.allSettled(
+      this.agents.map((agent) => this.config.runtime.close(agent.session)),
+    );
+    for (const [index, result] of closeResults.entries()) {
+      if (result.status === "rejected") {
+        const role = this.agents[index]?.role ?? "(unknown)";
+        process.stderr.write(
+          `[SessionOrchestrator] close failed for role '${role}': ${String(result.reason)}\n`,
+        );
+      }
     }
   }
 
@@ -272,16 +298,33 @@ export class SessionOrchestrator {
     const POLL_MS = 3_000;
     const INITIAL_DELAY_MS = 15_000; // wait for agents to go idle first
 
+    if (this.contributionPollStartTimeout) {
+      clearTimeout(this.contributionPollStartTimeout);
+      this.contributionPollStartTimeout = null;
+    }
+
+    if (this.contributionPollTimer) {
+      clearInterval(this.contributionPollTimer);
+      this.contributionPollTimer = null;
+    }
+
     // Seed seenCids with ALL contributions that existed before session started.
     // Use same limit as poll to ensure no gap between seed and first poll.
-    void this.config.contributionStore?.list({ limit: 1000 }).then((existing) => {
-      for (const c of existing) {
-        this.seenCids.add(c.cid);
-      }
-    });
+    void this.config.contributionStore
+      ?.list({ limit: 1000 })
+      .then((existing) => {
+        for (const c of existing) {
+          this.seenCids.add(c.cid);
+        }
+      })
+      .catch(() => {
+        // Best effort: failure here just means the first poll may
+        // re-observe some pre-existing contributions.
+      });
 
     // Start polling after initial delay
-    setTimeout(() => {
+    this.contributionPollStartTimeout = setTimeout(() => {
+      this.contributionPollStartTimeout = null;
       if (this.stopped) return;
       this.contributionPollTimer = setInterval(() => {
         void this.pollContributions();
@@ -298,27 +341,27 @@ export class SessionOrchestrator {
       // Fetch recent contributions (newest first via DESC, then reverse for processing order).
       // Using a large limit ensures we don't miss contributions in active sessions.
       const contributions = await this.config.contributionStore.list({ limit: 200 });
+      const agentsByRole = new Map(this.agents.map((a) => [a.role, a] as const));
       for (const c of contributions) {
         if (this.seenCids.has(c.cid)) continue;
         this.seenCids.add(c.cid);
-        this.contributionCount++;
 
         const sourceRole = c.agent.role;
         if (!sourceRole) continue;
+        const sourceAgent = agentsByRole.get(sourceRole);
+        if (!sourceAgent) continue;
 
         // Only process contributions from agents in THIS session.
-        // Match by agentId (unique per spawn), not just role name (shared across sessions).
+        // Match by an explicit allowlist of session IDs observed in this orchestrator,
+        // not just role name (shared across sessions).
         const agentId = c.agent.agentId;
-        const isOurAgent = this.agents.some(
-          (a) =>
-            a.role === sourceRole && (a.session.id === agentId || a.session.role === sourceRole),
-        );
-        if (!isOurAgent) continue;
+        const allowedAgentIds = this.sessionAgentIdsByRole.get(sourceRole);
+        if (allowedAgentIds === undefined || !allowedAgentIds.has(agentId)) continue;
+        this.contributionCount++;
 
         // Find the source agent's workspace path — this is the handoff artifact.
         // The receiving agent reads files directly from this path, no git merge needed.
-        const sourceAgent = this.agents.find((a) => a.role === sourceRole);
-        const sourceWorkspace = sourceAgent?.workspaceMode.path ?? "(unknown)";
+        const sourceWorkspace = sourceAgent.workspaceMode.path;
 
         const action =
           c.kind === "review"
@@ -340,7 +383,7 @@ export class SessionOrchestrator {
         });
 
         for (const { targetRole } of routeResults) {
-          const targetAgent = this.agents.find((a) => a.role === targetRole);
+          const targetAgent = agentsByRole.get(targetRole);
           if (targetAgent) {
             const turn = await this.config.runtime.send(targetAgent.session, message);
             this.watchTurn(targetAgent.role, turn);
@@ -495,6 +538,8 @@ export class SessionOrchestrator {
   }
 
   private async handleEvent(agent: AgentSessionInfo, event: GroveEvent): Promise<void> {
+    if (this.stopped) return;
+
     if (event.type === "stop") {
       // Auto-close session on stop event
       if (!this.stopped) {
@@ -569,15 +614,23 @@ export class SessionOrchestrator {
 
     const deadline = Date.now() + timeoutMs;
     return new Promise<string>((resolve) => {
-      const poll = setInterval(async () => {
-        await this.checkAllIdle();
-        if (this.stopped || Date.now() >= deadline) {
-          clearInterval(poll);
-          if (!this.stopped) {
-            void this.stop("Session timed out");
+      const poll = setInterval(() => {
+        void (async () => {
+          try {
+            await this.checkAllIdle();
+          } catch {
+            // Best effort: transient runtime/listSessions failures should not
+            // leave waiters hanging forever.
           }
-          resolve(this.stopReason ?? "Timed out");
-        }
+
+          if (this.stopped || Date.now() >= deadline) {
+            clearInterval(poll);
+            if (!this.stopped) {
+              void this.stop("Session timed out");
+            }
+            resolve(this.stopReason ?? "Timed out");
+          }
+        })();
       }, pollMs);
     });
   }
@@ -621,6 +674,7 @@ export class SessionOrchestrator {
     } else {
       this.agents.push(newSession);
     }
+    this.recordSessionAgentId(newSession.role, newSession.session.id);
 
     // Unsubscribe old handler before re-subscribing (prevents leak)
     const oldHandler = this.eventHandlers?.get(role);
@@ -633,5 +687,14 @@ export class SessionOrchestrator {
     this.config.eventBus.subscribe(role, newHandler);
 
     return newSession;
+  }
+
+  private recordSessionAgentId(role: string, sessionId: string): void {
+    const existing = this.sessionAgentIdsByRole.get(role);
+    if (existing) {
+      existing.add(sessionId);
+      return;
+    }
+    this.sessionAgentIdsByRole.set(role, new Set([sessionId]));
   }
 }


### PR DESCRIPTION
## Summary
- prevent cross-session contribution forwarding in `SessionOrchestrator` by using a per-role session-id allowlist instead of role-only fallback matching
- harden orchestrator lifecycle handling by cleaning poll timers/handlers on stop and making `waitForCompletion` timeout reliably even when idle checks throw
- ensure `EnforcingContributionStore` pre-write hooks are always cleaned up on failed enforcement/write paths, and optimize retry-after calculation to a single-pass scan
- add regression coverage for resumed-session polling, post-stop event handling, timeout-on-errors, and hook lifecycle edge cases

## Test plan
- [x] `bunx biome check src/core/session-orchestrator.ts src/core/session-orchestrator.test.ts src/core/enforcing-store.ts src/core/enforcing-store.test.ts`
- [x] `bun run typecheck`
- [x] `bun test src/core/session-orchestrator.test.ts src/core/enforcing-store.test.ts`
- [x] `bun test src/core` (tests pass; repo coverage gate can return non-zero)

Made with [Cursor](https://cursor.com)