### PR TITLE
feat(repo): bare-clone repo cache + worktree per agent task (#263)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -43,6 +43,21 @@ needed. If already initialized, `grove up` starts services and the TUI directly.
 
 Use `--headless` for CI environments or `--no-tui` for server-only mode.
 
+### Pointing at a specific repo
+
+By default Grove uses the git repo your shell is currently in. To target a
+different repo — checked out locally or not — pass `--repo`:
+
+```bash
+grove up --repo https://github.com/you/project
+grove up --repo /abs/path/to/checkout
+```
+
+Grove caches bare clones under `$XDG_CACHE_HOME/grove/repo-cache/` (override
+with `$GROVE_REPO_CACHE`). Inspect and maintain the cache with
+`grove repo list`, `grove repo prune`, and `grove repo fetch`. Only one
+`--repo` is accepted today; multi-repo sessions ship in a later release.
+
 ### Alternative: initialize from the CLI
 
 If you prefer initializing from the command line:

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ surfaces. It defines:
 | Variable | Purpose | Default |
 | --- | --- | --- |
 | `GROVE_DIR` | Override `.grove` discovery | `$(pwd)/.grove` |
+| `GROVE_REPO_CACHE` | Override bare-clone cache root | `$XDG_CACHE_HOME/grove/repo-cache` (or `~/.cache/grove/repo-cache`) |
 | `GROVE_AGENT_ID` | Agent identity for CLI and MCP | -- |
 | `GROVE_AGENT_NAME` | Human-readable agent name | -- |
 | `GROVE_AGENT_ROLE` | Role hint for topology-aware workflows | -- |
@@ -440,6 +441,41 @@ surfaces. It defines:
 | `NEXUS_SOURCE` | Path to nexus source checkout for `--build` | -- |
 | `GROVE_ASK_USER_CONFIG` | JSON config for `@grove/ask-user` | built-in defaults |
 | `ANTHROPIC_API_KEY` | Required for `ask_user` LLM strategy | -- |
+
+### Repo cache
+
+Grove uses a user-wide bare-clone cache so agent worktrees are cheap regardless of
+whether the repo is checked out locally.
+
+Cache location (first match wins):
+
+1. `$GROVE_REPO_CACHE`
+2. `$XDG_CACHE_HOME/grove/repo-cache/`
+3. `~/.cache/grove/repo-cache/`
+
+Maintenance:
+
+```bash
+grove repo list              # every cached repo with manifest summary
+grove repo prune <key>       # remove one entry (refuses if any worktree still references it)
+grove repo prune --all       # remove every entry
+grove repo fetch <key>       # force a fetch on an existing cache entry
+```
+
+Cache growth is unbounded by design — Grove never evicts without being told. Run
+`grove repo prune --all` if disk pressure bites.
+
+### Selecting a repo
+
+By default Grove targets the git repo your shell is currently in. Override with
+`--repo` (URL or local path):
+
+```bash
+grove up --repo https://github.com/you/project
+grove session start --goal ... --repo /abs/path/to/checkout
+```
+
+Only one `--repo` is accepted today; multi-repo sessions ship in a later release.
 
 <details>
 <summary><strong>Additional agent metadata variables</strong></summary>

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@xterm/headless": "6.0.0",
         "blake3": "^1.0.2",
         "hono": "^4.12.6",
+        "proper-lockfile": "^4.1.2",
         "react": "^19.0.0",
         "yaml": "^2.8.2",
         "zod": "4.3.6",
@@ -23,6 +24,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.6",
         "@types/bun": "1.3.9",
+        "@types/proper-lockfile": "^4.1.4",
         "@types/react": "^19.0.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -283,7 +285,11 @@
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
+    "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/retry": ["@types/retry@0.12.5", "", {}, "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw=="],
 
     "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
@@ -429,6 +435,8 @@
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
@@ -567,6 +575,8 @@
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
@@ -590,6 +600,8 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
@@ -622,6 +634,8 @@
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "simple-xml-to-json": ["simple-xml-to-json@1.2.3", "", {}, "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA=="],
 

--- a/docs/superpowers/plans/2026-04-21-bare-clone-repo-cache.md
+++ b/docs/superpowers/plans/2026-04-21-bare-clone-repo-cache.md
@@ -1,0 +1,2007 @@
+# Bare-Clone Repo Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `provisionWorkspace`'s single-repo `repoRoot` coupling with a user-wide bare-clone cache (`resolveRepo(RepoRef)` → `bareClonePath`). Sessions gain a `repos: RepoRef[]` config field alongside the existing `projectRoot`. Adds `grove repo list` / `grove repo prune` CLI.
+
+**Architecture:** Two new pure/IO-separated modules — `src/core/repo-ref.ts` (URL normalization + cache-key derivation, zero I/O) and `src/core/repo-cache.ts` (clone/fetch/lock/manifest, one exported function `resolveRepo`). `workspace-provisioner.ts` changes one field (`repoRoot` → `bareClonePath`). Session configs gain `repos`; `projectRoot` stays for its launcher-dir job. Lockfiles live at `<cacheRoot>/.locks/` — outside cache entries — so corruption recovery never unlinks a held lock. No Nexus coupling.
+
+**Tech Stack:** TypeScript · Bun (runtime + test runner) · `node:child_process` · `node:fs/promises` · `proper-lockfile` (new dep — cross-platform `flock`-equivalent) · Biome · TypeScript strict mode.
+
+---
+
+## Spec Reference
+
+`docs/superpowers/specs/2026-04-21-bare-clone-repo-cache-design.md`
+
+## File Structure
+
+| File | Responsibility | Status |
+|---|---|---|
+| `src/core/repo-ref.ts` | `RepoRef` type; `normalizeUrl`; `deriveCachePath`; path-safety validator. Pure. | **Create** |
+| `src/core/repo-ref.test.ts` | Normalization table; path-safety rejection. | **Create** |
+| `src/core/repo-cache.ts` | `resolveRepo(ref, opts)`; cache-root resolution; clone/fetch; flock; manifest; corruption recovery. | **Create** |
+| `src/core/repo-cache.test.ts` | Integration tests with `file://` fixture bare repos. | **Create** |
+| `src/core/workspace-provisioner.ts` | `WorkspaceProvisionOptions.repoRoot` → `bareClonePath`; same for `cleanupSessionWorkspaces`. | **Modify** |
+| `src/core/workspace-provisioner.test.ts` | Existing tests updated to pass `bareClonePath` (fixture bare clone). | **Modify** |
+| `src/core/session-orchestrator.ts` | Add `repos: RepoRef[]` + `repoCache` to config; resolve at start; pass `bareClonePath` to provisioner. Keep `projectRoot` unchanged for launcher-dir uses. | **Modify** |
+| `src/core/session-orchestrator.test.ts` | Update construction; resolve against fixture. | **Modify** |
+| `src/tui/spawn-manager.ts` | Same split as orchestrator. | **Modify** |
+| `src/tui/spawn-manager.test.ts` | Same updates. | **Modify** |
+| `src/core/topology.ts` | `AgentRole.repoIndex?: number` (default 0). Schema + wire. | **Modify** |
+| `src/core/topology.test.ts` | Wire parses; strict rejection still works. | **Modify** |
+| `src/cli/commands/repo.ts` | `grove repo list` / `grove repo prune` / `grove repo fetch`. | **Create** |
+| `src/cli/commands/repo.test.ts` | Exercises the subcommand handlers end-to-end. | **Create** |
+| `src/cli/main.ts` | Register `repo` subcommand. | **Modify** |
+| `src/cli/commands/up.ts` (or equivalent) | Add `--repo` flag; reject >1 value today; default to cwd `local` ref. | **Modify** |
+| `tests/e2e/repo-cache-session.test.ts` | End-to-end — session against a `file://` fixture completes. | **Create** |
+| `README.md` / `QUICKSTART.md` / `GROVE.md` | Document `--repo`, cache root, `grove repo` commands. | **Modify** |
+| `package.json` | Add `proper-lockfile` + `@types/proper-lockfile`. | **Modify** |
+
+No files are split or deleted. Each modified file keeps its current responsibility; only the fields named above change.
+
+---
+
+## Conventions
+
+- **Runtime / tests:** Bun. Test commands below use `bun test <path>` or `bun test <path> -t '<name>'`.
+- **Typecheck:** `bun run typecheck`.
+- **Lint/format:** `bun run check`.
+- **Commit messages:** follow repo style (short imperative subject, `feat:` / `fix:` / `refactor:` / `test:` / `docs:`).
+- **Never skip hooks** (`--no-verify` is forbidden).
+- **Never contact a real git remote in tests** — use `file://` URLs pointing at fixture bare repos created in `beforeAll`.
+
+---
+
+## Task 1: Add `proper-lockfile` dependency
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Add the runtime + type dependency**
+
+Run:
+```bash
+bun add proper-lockfile@^4.1.2
+bun add -D @types/proper-lockfile@^4.1.4
+```
+
+- [ ] **Step 2: Verify install**
+
+Run: `grep -E '"proper-lockfile"|"@types/proper-lockfile"' package.json`
+Expected: both present.
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json bun.lock
+git commit -m "chore: add proper-lockfile for cross-platform file locks"
+```
+
+---
+
+## Task 2: `repo-ref.ts` — types + URL normalization
+
+**Files:**
+- Create: `src/core/repo-ref.ts`
+- Create: `src/core/repo-ref.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/core/repo-ref.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+  deriveCachePath,
+  normalizeUrl,
+  type NormalizedRepo,
+  type RepoRef,
+} from "./repo-ref.js";
+
+describe("normalizeUrl", () => {
+  const cases: ReadonlyArray<readonly [string, NormalizedRepo]> = [
+    ["git@github.com:foo/bar.git",         { host: "github.com", path: "foo/bar" }],
+    ["git@github.com:foo/bar",             { host: "github.com", path: "foo/bar" }],
+    ["https://github.com/foo/bar",         { host: "github.com", path: "foo/bar" }],
+    ["https://github.com/foo/bar.git",     { host: "github.com", path: "foo/bar" }],
+    ["https://github.com/foo/bar/",        { host: "github.com", path: "foo/bar" }],
+    ["https://GitHub.com/Foo/Bar.git",     { host: "github.com", path: "Foo/Bar" }],
+    ["https://user@github.com/foo/bar",    { host: "github.com", path: "foo/bar" }],
+    ["ssh://git@gitlab.com/group/sub/p.git", { host: "gitlab.com", path: "group/sub/p" }],
+    ["file:///abs/path/to/repo",           { host: "local",      path: "abs/path/to/repo" }],
+    ["/abs/path/to/repo",                  { host: "local",      path: "abs/path/to/repo" }],
+    ["/abs/path/to/repo.git",              { host: "local",      path: "abs/path/to/repo" }],
+  ];
+
+  for (const [input, expected] of cases) {
+    test(`"${input}" normalizes correctly`, () => {
+      expect(normalizeUrl(input)).toEqual(expected);
+    });
+  }
+
+  test("rejects path with `..` traversal", () => {
+    expect(() => normalizeUrl("https://github.com/foo/../bar")).toThrow(/traversal/);
+  });
+
+  test("rejects path with leading-dot component", () => {
+    expect(() => normalizeUrl("https://github.com/foo/.hidden/bar")).toThrow(/leading dot/);
+  });
+
+  test("rejects empty host", () => {
+    expect(() => normalizeUrl("https:///foo/bar")).toThrow(/host/);
+  });
+
+  test("rejects empty path", () => {
+    expect(() => normalizeUrl("https://github.com/")).toThrow(/path/);
+  });
+
+  test("rejects non-absolute local path", () => {
+    expect(() => normalizeUrl("relative/path/repo")).toThrow(/absolute/);
+  });
+});
+
+describe("deriveCachePath", () => {
+  test("produces host/path.git layout", () => {
+    expect(deriveCachePath({ host: "github.com", path: "foo/bar" })).toBe("github.com/foo/bar.git");
+  });
+
+  test("preserves nested path segments", () => {
+    expect(deriveCachePath({ host: "gitlab.com", path: "group/sub/p" })).toBe("gitlab.com/group/sub/p.git");
+  });
+
+  test("local namespace", () => {
+    expect(deriveCachePath({ host: "local", path: "abs/path/to/repo" })).toBe("local/abs/path/to/repo.git");
+  });
+});
+
+describe("RepoRef", () => {
+  test("discriminated union compiles", () => {
+    const a: RepoRef = { kind: "local", path: "/tmp/x" };
+    const b: RepoRef = { kind: "url", url: "https://github.com/foo/bar" };
+    const c: RepoRef = { kind: "url", url: "https://github.com/foo/bar", ref: "main" };
+    expect([a.kind, b.kind, c.kind]).toEqual(["local", "url", "url"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/repo-ref.test.ts`
+Expected: FAIL — module not found / exports missing.
+
+- [ ] **Step 3: Implement `repo-ref.ts`**
+
+Create `src/core/repo-ref.ts`:
+
+```ts
+/**
+ * Repo reference + URL normalization.
+ *
+ * Pure module: no I/O. Consumers use `normalizeUrl` to canonicalize a
+ * repo reference, then `deriveCachePath` to get a cache-entry path
+ * segment. Path-safety is enforced here — callers must not trust
+ * `path.join` alone to sanitize a remote-controlled URL.
+ */
+
+export type RepoRef =
+  | { readonly kind: "local"; readonly path: string }
+  | { readonly kind: "url"; readonly url: string; readonly ref?: string };
+
+export interface NormalizedRepo {
+  readonly host: string;
+  readonly path: string;
+}
+
+const SCHEME_RE = /^([a-z][a-z0-9+.-]*):\/\//i;
+const SCP_LIKE_RE = /^([^@\s]+@)?([^:/\s]+):(.+)$/;
+
+export function normalizeUrl(raw: string): NormalizedRepo {
+  const trimmed = raw.trim();
+  if (trimmed === "") throw new Error("empty repo reference");
+
+  const scpMatch = !SCHEME_RE.test(trimmed) && !trimmed.startsWith("/")
+    ? trimmed.match(SCP_LIKE_RE)
+    : null;
+
+  let host: string;
+  let rawPath: string;
+
+  if (scpMatch) {
+    host = scpMatch[2]!;
+    rawPath = scpMatch[3]!;
+  } else if (SCHEME_RE.test(trimmed)) {
+    const u = new URL(trimmed);
+    if (u.protocol === "file:") {
+      host = "local";
+      rawPath = u.pathname;
+    } else {
+      host = u.hostname;
+      rawPath = u.pathname.replace(/^\//, "");
+    }
+  } else if (trimmed.startsWith("/")) {
+    host = "local";
+    rawPath = trimmed.slice(1);
+  } else {
+    throw new Error(`repo reference must be absolute or a known URL scheme: ${trimmed}`);
+  }
+
+  if (host === "") throw new Error(`normalized host is empty: ${raw}`);
+
+  const cleaned = rawPath
+    .replace(/\.git$/, "")
+    .replace(/\/+$/, "");
+
+  if (cleaned === "") throw new Error(`normalized path is empty: ${raw}`);
+
+  validatePathSegments(cleaned);
+
+  return { host: host.toLowerCase(), path: cleaned };
+}
+
+function validatePathSegments(path: string): void {
+  for (const seg of path.split("/")) {
+    if (seg === "") throw new Error(`invalid path (empty segment): ${path}`);
+    if (seg === ".." || seg === ".") {
+      throw new Error(`invalid path (traversal '${seg}'): ${path}`);
+    }
+    if (seg.startsWith(".")) {
+      throw new Error(`invalid path (leading dot in segment '${seg}'): ${path}`);
+    }
+  }
+}
+
+export function deriveCachePath(n: NormalizedRepo): string {
+  return `${n.host}/${n.path}.git`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/repo-ref.test.ts`
+Expected: all green.
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/repo-ref.ts src/core/repo-ref.test.ts
+git commit -m "feat(repo-ref): RepoRef type + URL normalization + cache-key derivation"
+```
+
+---
+
+## Task 3: `repo-cache.ts` scaffold — types + cache-root resolution
+
+**Files:**
+- Create: `src/core/repo-cache.ts`
+- Create: `src/core/repo-cache.test.ts`
+
+- [ ] **Step 1: Write failing tests for cache-root resolution**
+
+Create `src/core/repo-cache.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { resolveCacheRoot } from "./repo-cache.js";
+
+describe("resolveCacheRoot", () => {
+  test("honors GROVE_REPO_CACHE when set", () => {
+    const env = { GROVE_REPO_CACHE: "/tmp/custom-cache" } as NodeJS.ProcessEnv;
+    expect(resolveCacheRoot({ env })).toBe("/tmp/custom-cache");
+  });
+
+  test("honors explicit option over env", () => {
+    const env = { GROVE_REPO_CACHE: "/tmp/env-cache" } as NodeJS.ProcessEnv;
+    expect(resolveCacheRoot({ env, override: "/tmp/opt-cache" })).toBe("/tmp/opt-cache");
+  });
+
+  test("uses XDG_CACHE_HOME when set", () => {
+    const env = { XDG_CACHE_HOME: "/xdg/cache" } as NodeJS.ProcessEnv;
+    expect(resolveCacheRoot({ env, home: "/home/me" })).toBe("/xdg/cache/grove/repo-cache");
+  });
+
+  test("falls back to ~/.cache/grove/repo-cache", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    expect(resolveCacheRoot({ env, home: "/home/me" })).toBe(join("/home/me", ".cache/grove/repo-cache"));
+  });
+
+  test("rejects empty HOME with no env overrides", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    expect(() => resolveCacheRoot({ env, home: "" })).toThrow(/HOME/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `bun test src/core/repo-cache.test.ts -t resolveCacheRoot`
+Expected: module not found.
+
+- [ ] **Step 3: Scaffold `repo-cache.ts`**
+
+Create `src/core/repo-cache.ts`:
+
+```ts
+/**
+ * Bare-clone repo cache.
+ *
+ * Exposes one primary function, `resolveRepo`, which materializes a
+ * RepoRef into a bare clone on disk and returns the path. Clones and
+ * fetches are serialized per cache entry via `proper-lockfile`; lock
+ * files live at `<cacheRoot>/.locks/` (outside the cache entry) so
+ * corruption recovery cannot unlink a held lock.
+ */
+
+import { join } from "node:path";
+import type { RepoRef } from "./repo-ref.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ResolveRepoOptions {
+  readonly fresh?: boolean;
+  readonly cacheRoot?: string;
+  readonly fetchTtlMs?: number;
+  readonly timeoutMs?: number;
+}
+
+export interface ResolvedRepo {
+  readonly ref: RepoRef;
+  readonly bareClonePath: string;
+  readonly key: string;
+  readonly fetched: boolean;
+  readonly stale: boolean;
+}
+
+interface CacheRootInputs {
+  readonly env: NodeJS.ProcessEnv;
+  readonly home?: string;
+  readonly override?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Cache-root resolution
+// ---------------------------------------------------------------------------
+
+export function resolveCacheRoot(inputs: CacheRootInputs): string {
+  if (inputs.override) return inputs.override;
+  const explicit = inputs.env.GROVE_REPO_CACHE;
+  if (explicit && explicit.length > 0) return explicit;
+  const xdg = inputs.env.XDG_CACHE_HOME;
+  if (xdg && xdg.length > 0) return join(xdg, "grove", "repo-cache");
+  const home = inputs.home;
+  if (!home) throw new Error("cannot resolve cache root: no HOME and no XDG_CACHE_HOME");
+  return join(home, ".cache", "grove", "repo-cache");
+}
+
+// ---------------------------------------------------------------------------
+// resolveRepo — stub (filled in subsequent tasks)
+// ---------------------------------------------------------------------------
+
+export async function resolveRepo(
+  _ref: RepoRef,
+  _opts?: ResolveRepoOptions,
+): Promise<ResolvedRepo> {
+  throw new Error("resolveRepo: not implemented");
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/repo-cache.test.ts -t resolveCacheRoot`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/repo-cache.ts src/core/repo-cache.test.ts
+git commit -m "feat(repo-cache): scaffold + cache-root resolution (GROVE_REPO_CACHE / XDG / ~/.cache)"
+```
+
+---
+
+## Task 4: `resolveRepo` — local path with no origin (pass-through)
+
+**Files:**
+- Modify: `src/core/repo-cache.ts`
+- Modify: `src/core/repo-cache.test.ts`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `src/core/repo-cache.test.ts`:
+
+```ts
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolveRepo } from "./repo-cache.js";
+
+describe("resolveRepo — local path without origin", () => {
+  test("returns the local path verbatim and skips the cache", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grove-rc-local-"));
+    try {
+      execSync("git init", { cwd: dir, stdio: "pipe" });
+      execSync('git config user.email "t@t"', { cwd: dir, stdio: "pipe" });
+      execSync('git config user.name "t"', { cwd: dir, stdio: "pipe" });
+      execSync("git commit --allow-empty -m init", { cwd: dir, stdio: "pipe" });
+
+      const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+      try {
+        const result = await resolveRepo({ kind: "local", path: dir }, { cacheRoot });
+        expect(result.bareClonePath).toBe(dir);
+        expect(result.fetched).toBe(false);
+        expect(result.stale).toBe(false);
+        expect(result.key).toBe("local");
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `bun test src/core/repo-cache.test.ts -t "local path without origin"`
+Expected: throws "not implemented".
+
+- [ ] **Step 3: Implement pass-through branch**
+
+In `src/core/repo-cache.ts`, replace the stub `resolveRepo` with:
+
+```ts
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+async function readOriginUrl(localPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", localPath, "remote", "get-url", "origin"], {
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+    const url = stdout.trim();
+    return url.length > 0 ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveRepo(
+  ref: RepoRef,
+  opts: ResolveRepoOptions = {},
+): Promise<ResolvedRepo> {
+  if (ref.kind === "local") {
+    const origin = await readOriginUrl(ref.path);
+    if (origin === null) {
+      return {
+        ref,
+        bareClonePath: ref.path,
+        key: "local",
+        fetched: false,
+        stale: false,
+      };
+    }
+    // origin-present case handled in Task 11 — delegate to URL path
+    return resolveRepo({ kind: "url", url: origin }, opts);
+  }
+  throw new Error("resolveRepo: URL path not yet implemented");
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/repo-cache.test.ts -t "local path without origin"`
+Expected: PASS.
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/repo-cache.ts src/core/repo-cache.test.ts
+git commit -m "feat(repo-cache): pass-through for local repos without origin"
+```
+
+---
+
+## Task 5: `resolveRepo` — fresh clone path
+
+Implements steps 2–4 of the spec's `resolveRepo` flow (derive cache dir, flock, clone `--bare`, write manifest + `.ok`).
+
+**Files:**
+- Modify: `src/core/repo-cache.ts`
+- Modify: `src/core/repo-cache.test.ts`
+
+- [ ] **Step 1: Add test fixture helper**
+
+Append a shared helper near the top of `src/core/repo-cache.test.ts` (after existing imports):
+
+```ts
+function makeFixtureRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "grove-rc-fx-"));
+  execSync("git init --bare", { cwd: dir, stdio: "pipe" });
+  // Push an initial commit via a scratch clone
+  const scratch = mkdtempSync(join(tmpdir(), "grove-rc-scratch-"));
+  execSync(`git clone "${dir}" "${scratch}"`, { stdio: "pipe" });
+  execSync('git config user.email "t@t"', { cwd: scratch, stdio: "pipe" });
+  execSync('git config user.name "t"', { cwd: scratch, stdio: "pipe" });
+  execSync("git commit --allow-empty -m init", { cwd: scratch, stdio: "pipe" });
+  execSync("git branch -M main", { cwd: scratch, stdio: "pipe" });
+  execSync("git push origin main", { cwd: scratch, stdio: "pipe" });
+  rmSync(scratch, { recursive: true, force: true });
+  return dir;
+}
+```
+
+- [ ] **Step 2: Write failing test — fresh clone**
+
+Append:
+
+```ts
+import { existsSync, readFileSync } from "node:fs";
+
+describe("resolveRepo — fresh clone", () => {
+  test("clones into cache, writes .ok, manifest, last-fetch", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const result = await resolveRepo(
+        { kind: "url", url: `file://${fixture}` },
+        { cacheRoot },
+      );
+
+      expect(result.fetched).toBe(true);
+      expect(result.stale).toBe(false);
+      expect(result.key).toBe(`local/${fixture.replace(/^\//, "")}.git`);
+      expect(existsSync(join(result.bareClonePath, "HEAD"))).toBe(true);
+      expect(existsSync(join(result.bareClonePath, ".grove-cache", ".ok"))).toBe(true);
+      expect(existsSync(join(result.bareClonePath, ".grove-cache", "last-fetch"))).toBe(true);
+
+      const manifest = JSON.parse(
+        readFileSync(join(result.bareClonePath, ".grove-cache", "manifest.json"), "utf-8"),
+      );
+      expect(manifest.canonicalUrl).toBe(`file://${fixture}`);
+      expect(manifest.aliases).toEqual([`file://${fixture}`]);
+      expect(typeof manifest.createdAt).toBe("string");
+      expect(typeof manifest.lastFetchedAt).toBe("string");
+      expect(typeof manifest.lastAccessedAt).toBe("string");
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run — expect failure**
+
+Run: `bun test src/core/repo-cache.test.ts -t "fresh clone"`
+Expected: throws "URL path not yet implemented".
+
+- [ ] **Step 4: Implement the URL + clone path**
+
+In `src/core/repo-cache.ts`:
+
+Add imports:
+```ts
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import lockfile from "proper-lockfile";
+import { deriveCachePath, normalizeUrl } from "./repo-ref.js";
+```
+
+Add helpers + fill in `resolveRepo`:
+
+```ts
+interface Manifest {
+  canonicalUrl: string;
+  aliases: string[];
+  createdAt: string;
+  lastFetchedAt: string;
+  lastAccessedAt: string;
+}
+
+function encodeLockName(key: string): string {
+  return key.replace(/\//g, "__");
+}
+
+async function runGit(
+  args: readonly string[],
+  opts: { cwd?: string; timeoutMs?: number } = {},
+): Promise<void> {
+  const controller = new AbortController();
+  const timer = opts.timeoutMs
+    ? setTimeout(() => controller.abort(), opts.timeoutMs)
+    : undefined;
+  try {
+    await execFileAsync("git", args as string[], {
+      cwd: opts.cwd,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+      signal: controller.signal,
+    });
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function writeManifest(dir: string, manifest: Manifest): Promise<void> {
+  await writeFile(join(dir, "manifest.json"), JSON.stringify(manifest, null, 2), "utf-8");
+}
+
+async function writeOkSentinel(metaDir: string): Promise<void> {
+  const tmp = join(metaDir, ".ok.tmp");
+  const final = join(metaDir, ".ok");
+  await writeFile(tmp, "", "utf-8");
+  await rename(tmp, final);
+}
+```
+
+Replace `resolveRepo` with the full implementation (the URL branch; still partial — Task 6 adds cache-hit):
+
+```ts
+export async function resolveRepo(
+  ref: RepoRef,
+  opts: ResolveRepoOptions = {},
+): Promise<ResolvedRepo> {
+  if (ref.kind === "local") {
+    const origin = await readOriginUrl(ref.path);
+    if (origin === null) {
+      return { ref, bareClonePath: ref.path, key: "local", fetched: false, stale: false };
+    }
+    return resolveRepo({ kind: "url", url: origin }, opts);
+  }
+
+  const cacheRoot = resolveCacheRoot({ env: process.env, home: process.env.HOME, override: opts.cacheRoot });
+  const normalized = normalizeUrl(ref.url);
+  const key = deriveCachePath(normalized);
+  const cacheDir = join(cacheRoot, key);
+  const metaDir = join(cacheDir, ".grove-cache");
+  const locksDir = join(cacheRoot, ".locks");
+  const lockFile = join(locksDir, `${encodeLockName(key)}.lock`);
+
+  await mkdir(locksDir, { recursive: true });
+  // proper-lockfile requires the target to exist
+  if (!existsSync(lockFile)) await writeFile(lockFile, "", "utf-8");
+
+  const release = await lockfile.lock(lockFile, { retries: { retries: 50, minTimeout: 50, maxTimeout: 500 } });
+  try {
+    const okPath = join(metaDir, ".ok");
+    const okPresent = existsSync(okPath);
+
+    if (!okPresent) {
+      // Fresh clone (or recovery from a prior crash; Task 8 covers recovery branch).
+      if (existsSync(cacheDir)) {
+        await rm(cacheDir, { recursive: true, force: true });
+      }
+      await mkdir(cacheDir, { recursive: true });
+      await runGit(["clone", "--bare", ref.url, cacheDir], { timeoutMs: opts.timeoutMs ?? 300_000 });
+      await mkdir(metaDir, { recursive: true });
+      const now = new Date().toISOString();
+      const manifest: Manifest = {
+        canonicalUrl: ref.url,
+        aliases: [ref.url],
+        createdAt: now,
+        lastFetchedAt: now,
+        lastAccessedAt: now,
+      };
+      await writeManifest(metaDir, manifest);
+      await writeFile(join(metaDir, "last-fetch"), "", "utf-8");
+      await writeOkSentinel(metaDir);
+      return { ref, bareClonePath: cacheDir, key, fetched: true, stale: false };
+    }
+
+    // Cache-hit path fills in Task 6.
+    throw new Error("resolveRepo: cache-hit path not yet implemented");
+  } finally {
+    await release();
+  }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `bun test src/core/repo-cache.test.ts -t "fresh clone"`
+Expected: PASS.
+
+Run: `bun run typecheck` → no errors.
+Run: `bun run check` → no lint errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/repo-cache.ts src/core/repo-cache.test.ts
+git commit -m "feat(repo-cache): fresh-clone path with lockfile + manifest + .ok sentinel"
+```
+
+---
+
+## Task 6: `resolveRepo` — cache hit with TTL fetch
+
+**Files:**
+- Modify: `src/core/repo-cache.ts`
+- Modify: `src/core/repo-cache.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `src/core/repo-cache.test.ts`:
+
+```ts
+import { utimesSync } from "node:fs";
+
+describe("resolveRepo — cache hit", () => {
+  test("second call within TTL does not fetch", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const first = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      expect(first.fetched).toBe(true);
+
+      const second = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      expect(second.fetched).toBe(false);
+      expect(second.stale).toBe(false);
+      expect(second.bareClonePath).toBe(first.bareClonePath);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  test("TTL expiry triggers fetch", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const first = await resolveRepo(
+        { kind: "url", url: `file://${fixture}` },
+        { cacheRoot, fetchTtlMs: 0 },
+      );
+      expect(first.fetched).toBe(true);
+
+      // Backdate last-fetch by 10s
+      const lastFetch = join(first.bareClonePath, ".grove-cache", "last-fetch");
+      const past = new Date(Date.now() - 10_000);
+      utimesSync(lastFetch, past, past);
+
+      const second = await resolveRepo(
+        { kind: "url", url: `file://${fixture}` },
+        { cacheRoot, fetchTtlMs: 1000 },
+      );
+      expect(second.fetched).toBe(true);
+      expect(second.stale).toBe(false);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  test("appends new alias on URL-form change", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      await resolveRepo({ kind: "url", url: `file://${fixture}/` }, { cacheRoot }); // trailing slash → same key
+
+      const manifestPath = join(cacheRoot, `local/${fixture.replace(/^\//, "")}.git`, ".grove-cache", "manifest.json");
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+      expect(manifest.aliases).toContain(`file://${fixture}`);
+      expect(manifest.aliases).toContain(`file://${fixture}/`);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `bun test src/core/repo-cache.test.ts -t "cache hit"`
+Expected: "cache-hit path not yet implemented".
+
+- [ ] **Step 3: Implement the cache-hit branch**
+
+In `src/core/repo-cache.ts`, replace the line
+```ts
+throw new Error("resolveRepo: cache-hit path not yet implemented");
+```
+with the full cache-hit logic:
+
+```ts
+// Cache hit. Update manifest (alias + lastAccessedAt).
+const manifestPath = join(metaDir, "manifest.json");
+const manifest: Manifest = JSON.parse(await readFile(manifestPath, "utf-8"));
+const now = new Date().toISOString();
+manifest.lastAccessedAt = now;
+if (!manifest.aliases.includes(ref.url)) manifest.aliases.push(ref.url);
+
+const ttlMs = opts.fetchTtlMs ?? 60_000;
+const lastFetchStat = await stat(join(metaDir, "last-fetch"));
+const ageMs = Date.now() - lastFetchStat.mtimeMs;
+const mustFetch = opts.fresh === true || ageMs > ttlMs;
+
+let fetched = false;
+let stale = false;
+
+if (mustFetch) {
+  try {
+    await runGit(["fetch", "--all", "--prune"], {
+      cwd: cacheDir,
+      timeoutMs: opts.timeoutMs ?? 300_000,
+    });
+    const fetchTime = new Date();
+    await writeFile(join(metaDir, "last-fetch"), "", "utf-8"); // ensure file exists
+    utimes(join(metaDir, "last-fetch"), fetchTime, fetchTime);
+    manifest.lastFetchedAt = fetchTime.toISOString();
+    fetched = true;
+  } catch (err) {
+    if (opts.fresh === true) {
+      await writeManifest(metaDir, manifest);
+      throw new Error(`resolveRepo: --fresh fetch failed for ${ref.url}: ${(err as Error).message}`);
+    }
+    stale = true;
+  }
+}
+
+await writeManifest(metaDir, manifest);
+return { ref, bareClonePath: cacheDir, key, fetched, stale };
+```
+
+Add the `utimes` import:
+```ts
+import { utimes } from "node:fs/promises";
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/repo-cache.test.ts -t "cache hit"`
+Expected: all three PASS.
+
+Run: `bun test src/core/repo-cache.test.ts` (full file)
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/repo-cache.ts src/core/repo-cache.test.ts
+git commit -m "feat(repo-cache): cache-hit path — TTL fetch, alias append, lastAccessed update"
+```
+
+---
+
+## Task 7: `resolveRepo` — `--fresh` hard-fail on fetch failure
+
+**Files:**
+- Modify: `src/core/repo-cache.test.ts`
+
+Implementation for this is already included in Task 6; this task is the explicit regression test for the `--fresh` hard-fail semantics (Q8-iii in the spec).
+
+- [ ] **Step 1: Write failing test**
+
+Append:
+
+```ts
+describe("resolveRepo — fresh hard-fail", () => {
+  test("opts.fresh + unreachable remote throws", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      // Prime the cache against the fixture.
+      await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      // Nuke the fixture so the next fetch fails.
+      rmSync(fixture, { recursive: true, force: true });
+
+      await expect(
+        resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot, fresh: true }),
+      ).rejects.toThrow(/--fresh fetch failed/);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("stale path (no --fresh) proceeds with stale=true when fetch fails", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      rmSync(fixture, { recursive: true, force: true });
+
+      // Force fetch via fetchTtlMs:0 but without --fresh
+      const result = await resolveRepo(
+        { kind: "url", url: `file://${fixture}` },
+        { cacheRoot, fetchTtlMs: 0 },
+      );
+      expect(result.stale).toBe(true);
+      expect(result.fetched).toBe(false);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test src/core/repo-cache.test.ts -t "fresh hard-fail"`
+Expected: PASS (Task 6 already implemented both branches).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/repo-cache.test.ts
+git commit -m "test(repo-cache): cover --fresh hard-fail + stale-on-fetch-failure semantics"
+```
+
+---
+
+## Task 8: `resolveRepo` — corruption recovery (missing `.ok`)
+
+**Files:**
+- Modify: `src/core/repo-cache.test.ts`
+
+The recovery logic is already in the clone branch of Task 5 (`if (existsSync(cacheDir)) { rm -rf … }`). This task is the explicit test.
+
+- [ ] **Step 1: Write failing test**
+
+Append:
+
+```ts
+describe("resolveRepo — corruption recovery", () => {
+  test("absent .ok triggers nuke + re-clone", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const first = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      expect(first.fetched).toBe(true);
+
+      // Simulate crash: remove .ok, leave garbage behind.
+      rmSync(join(first.bareClonePath, ".grove-cache", ".ok"));
+      writeFileSync(join(first.bareClonePath, "garbage"), "x");
+
+      const second = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      expect(second.fetched).toBe(true);
+      expect(existsSync(join(second.bareClonePath, "garbage"))).toBe(false);
+      expect(existsSync(join(second.bareClonePath, ".grove-cache", ".ok"))).toBe(true);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+Add import: `import { writeFileSync } from "node:fs";`
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test src/core/repo-cache.test.ts -t "corruption recovery"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/repo-cache.test.ts
+git commit -m "test(repo-cache): cover .ok-absent corruption recovery"
+```
+
+---
+
+## Task 9: `resolveRepo` — timeout kills subprocess
+
+**Files:**
+- Modify: `src/core/repo-cache.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Append:
+
+```ts
+describe("resolveRepo — timeout", () => {
+  test("clone timeout throws and leaves the entry recoverable", async () => {
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      // Use a non-existent remote to force a slow git failure; 1ms timeout ensures abort.
+      await expect(
+        resolveRepo(
+          { kind: "url", url: "https://example.invalid/does/not/exist" },
+          { cacheRoot, timeoutMs: 1 },
+        ),
+      ).rejects.toBeDefined();
+
+      // Next call (with a working fixture) must still succeed — the failed
+      // cacheDir must either not exist or be recoverable.
+      const fixture = makeFixtureRepo();
+      try {
+        // Different URL → different cache entry; just prove the cache root itself is usable.
+        const result = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+        expect(result.fetched).toBe(true);
+      } finally {
+        rmSync(fixture, { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test src/core/repo-cache.test.ts -t "timeout"`
+Expected: PASS (implementation already wires `AbortController` via `runGit`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/repo-cache.test.ts
+git commit -m "test(repo-cache): cover clone timeout + subsequent recovery"
+```
+
+---
+
+## Task 10: `resolveRepo` — concurrent callers serialize
+
+**Files:**
+- Modify: `src/core/repo-cache.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Append:
+
+```ts
+describe("resolveRepo — concurrency", () => {
+  test("five concurrent callers produce one clone + four hits", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const results = await Promise.all(
+        Array.from({ length: 5 }, () =>
+          resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot }),
+        ),
+      );
+      const fetched = results.filter((r) => r.fetched).length;
+      expect(fetched).toBe(1);
+      for (const r of results) {
+        expect(r.bareClonePath).toBe(results[0]!.bareClonePath);
+      }
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test src/core/repo-cache.test.ts -t concurrency`
+Expected: PASS — lockfile serializes the callers; only the first sees `fetched=true`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/repo-cache.test.ts
+git commit -m "test(repo-cache): assert concurrent resolveRepo calls serialize via lockfile"
+```
+
+---
+
+## Task 11: `resolveRepo` — local path with origin resolves through cache
+
+**Files:**
+- Modify: `src/core/repo-cache.test.ts`
+
+Implementation already done in Task 4 (the `origin !== null` branch delegates to the URL path). This task is the explicit test.
+
+- [ ] **Step 1: Write failing test**
+
+Append:
+
+```ts
+describe("resolveRepo — local with origin", () => {
+  test("reads origin and caches via URL path", async () => {
+    const fixture = makeFixtureRepo();
+    const workTree = mkdtempSync(join(tmpdir(), "grove-rc-wt-"));
+    execSync(`git clone "${fixture}" "${workTree}"`, { stdio: "pipe" });
+
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const result = await resolveRepo({ kind: "local", path: workTree }, { cacheRoot });
+      expect(result.fetched).toBe(true);
+      expect(result.bareClonePath).not.toBe(workTree);
+      expect(result.bareClonePath.startsWith(cacheRoot)).toBe(true);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(workTree, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test src/core/repo-cache.test.ts -t "local with origin"`
+Expected: PASS.
+
+Run: `bun test src/core/repo-cache.test.ts` (full)
+Expected: all green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/repo-cache.test.ts
+git commit -m "test(repo-cache): local path with origin is cached via URL"
+```
+
+---
+
+## Task 12: `workspace-provisioner.ts` — `repoRoot` → `bareClonePath`
+
+**Files:**
+- Modify: `src/core/workspace-provisioner.ts`
+- Modify: `src/core/workspace-provisioner.test.ts`
+
+Scope: rename exactly one field on `WorkspaceProvisionOptions` and the three-arg positional form; update `cleanupSessionWorkspaces` similarly; update all callers' tests to pass a real bare clone fixture.
+
+- [ ] **Step 1: Update tests to pass `bareClonePath` from a fixture bare clone**
+
+Replace `beforeEach` in `src/core/workspace-provisioner.test.ts`:
+
+```ts
+  beforeEach(() => {
+    // Create a bare clone with a seeded initial commit — matches the new
+    // workspace-provisioner contract (worktrees are added from a bare clone).
+    repoDir = mkdtempSync(join(tmpdir(), "grove-wp-bare-"));
+    execSync("git init --bare", { cwd: repoDir, stdio: "pipe" });
+
+    const scratch = mkdtempSync(join(tmpdir(), "grove-wp-scratch-"));
+    execSync(`git clone "${repoDir}" "${scratch}"`, { stdio: "pipe" });
+    execSync('git config user.email "test@test.com"', { cwd: scratch, stdio: "pipe" });
+    execSync('git config user.name "Test"', { cwd: scratch, stdio: "pipe" });
+    execSync("git commit --allow-empty -m 'init'", { cwd: scratch, stdio: "pipe" });
+    execSync("git branch -M main", { cwd: scratch, stdio: "pipe" });
+    execSync("git push origin main", { cwd: scratch, stdio: "pipe" });
+    rmSync(scratch, { recursive: true, force: true });
+
+    baseDir = join(tmpdir(), `grove-wp-base-${Date.now()}`);
+  });
+```
+
+Rename every `repoRoot:` call-site in this file to `bareClonePath:`. In the "baseBranch" test, replace the `git checkout -b feature-base` block with operations performed in a scratch clone (bare repos can't check out):
+
+```ts
+  test("provisionWorkspace respects baseBranch option", async () => {
+    // Create a scratch clone to produce a second branch, then push it to the bare.
+    const scratch = mkdtempSync(join(tmpdir(), "grove-wp-scratch2-"));
+    execSync(`git clone "${repoDir}" "${scratch}"`, { stdio: "pipe" });
+    execSync('git config user.email "t@t"', { cwd: scratch, stdio: "pipe" });
+    execSync('git config user.name "t"', { cwd: scratch, stdio: "pipe" });
+    execSync("git checkout -b feature-base", { cwd: scratch, stdio: "pipe" });
+    execSync("git commit --allow-empty -m 'feature commit'", { cwd: scratch, stdio: "pipe" });
+    execSync("git push origin feature-base", { cwd: scratch, stdio: "pipe" });
+    rmSync(scratch, { recursive: true, force: true });
+
+    const result = await provisionWorkspace({
+      role: "tester",
+      sessionId: "base-branch-session",
+      baseDir,
+      bareClonePath: repoDir,
+      baseBranch: "feature-base",
+    });
+
+    expect(existsSync(result.path)).toBe(true);
+    const log = execSync("git log --oneline", { cwd: result.path, encoding: "utf-8" });
+    expect(log).toContain("feature commit");
+  });
+```
+
+Update the "errors gracefully" test — `bareClonePath: "/nonexistent/repo/path"` (same behavior; field name only).
+
+The `afterEach` worktree-listing block uses the bare clone directly, which supports `git worktree list --porcelain` — no change required.
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `bun test src/core/workspace-provisioner.test.ts`
+Expected: compile error / field-not-found.
+
+- [ ] **Step 3: Update `src/core/workspace-provisioner.ts`**
+
+Replace `repoRoot` with `bareClonePath` in four places:
+- `WorkspaceProvisionOptions` interface (line ~46)
+- Destructuring in `provisionWorkspace` (line ~92)
+- `cwd: repoRoot` → `cwd: bareClonePath` in `execFileAsync` (line ~104)
+- `provisionSessionWorkspaces` signature + forwarding (lines ~125, ~138)
+- `cleanupSessionWorkspaces` signature + both `cwd` sites (lines ~174, ~179, ~185)
+
+Also update the JSDoc comment at the top of `provisionWorkspace` to say "from a bare clone" instead of "from the source repo".
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/workspace-provisioner.test.ts`
+Expected: all green.
+
+Run: `bun run typecheck`
+Expected: failures in every caller that still passes `repoRoot`. **Those callers are updated in Tasks 13–14** — this is expected, do NOT fix them here.
+
+Run: `bun test src/core/workspace-provisioner.test.ts`
+Expected: provisioner's own tests still green.
+
+- [ ] **Step 5: Commit** (deferred — commit together with caller fixes in Task 14)
+
+---
+
+## Task 13: `session-orchestrator.ts` — add `repos` + `repoCache`
+
+**Files:**
+- Modify: `src/core/session-orchestrator.ts`
+- Modify: `src/core/session-orchestrator.test.ts`
+
+- [ ] **Step 1: Update `SessionOrchestratorConfig`**
+
+In `src/core/session-orchestrator.ts` near line 44, replace the block:
+
+```ts
+  /** Working directory for the project. */
+  readonly projectRoot: string;
+```
+
+with:
+
+```ts
+  /**
+   * Grove launcher directory — anchors `.grove/`, `mcpServePath`, the
+   * bundled skills root, workspace-override skills root, and fallback
+   * cwd when no workspace is provisioned. Independent of `repos`.
+   */
+  readonly projectRoot: string;
+
+  /**
+   * Repositories the session targets. Length ≥ 1; today exactly 1 is
+   * honored (the forward-compat hook for multi-repo sessions).
+   * Resolved to bare clones via `resolveRepo` at session start.
+   */
+  readonly repos: readonly RepoRef[];
+
+  /** Overrides for cache resolution (tests, CI, explicit cache root). */
+  readonly repoCache?: Partial<ResolveRepoOptions>;
+```
+
+Add imports at the top:
+```ts
+import type { RepoRef } from "./repo-ref.js";
+import { resolveRepo, type ResolveRepoOptions, type ResolvedRepo } from "./repo-cache.js";
+```
+
+- [ ] **Step 2: Resolve repos once at session start**
+
+Add a private field to the class:
+
+```ts
+  private resolvedRepos: readonly ResolvedRepo[] = [];
+```
+
+Add a lazy one-time resolve helper:
+
+```ts
+  private async ensureReposResolved(): Promise<void> {
+    if (this.resolvedRepos.length > 0) return;
+    if (this.config.repos.length > 1) {
+      throw new Error(
+        "SessionOrchestrator: multi-repo sessions are not yet supported; pass exactly one repo.",
+      );
+    }
+    this.resolvedRepos = await Promise.all(
+      this.config.repos.map((ref) => resolveRepo(ref, this.config.repoCache ?? {})),
+    );
+  }
+```
+
+Call `await this.ensureReposResolved()` at the top of the method that currently passes `repoRoot` to `provisionWorkspace` (line ~457 region). Replace:
+
+```ts
+        repoRoot: this.config.projectRoot,
+```
+
+with:
+
+```ts
+        bareClonePath: this.resolvedRepos[0]!.bareClonePath,
+```
+
+Leave every other `this.config.projectRoot` reference untouched — those are launcher-dir uses.
+
+- [ ] **Step 3: Update `session-orchestrator.test.ts` to supply `repos`**
+
+Every `SessionOrchestrator` construction site in the test file must gain `repos: [{ kind: "local", path: fixtureBarePath }]`. Use a `makeFixtureBareRepo` helper (reuse the shape from Task 5's `makeFixtureRepo`). Where the test previously pointed `projectRoot` at a working repo for provisioning, now:
+
+- `projectRoot` stays set to a temp directory used for `.grove/` plumbing.
+- `repos[0]` is `{ kind: "local", path: bare }` where `bare` is a freshly created bare clone.
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/session-orchestrator.test.ts`
+Expected: all green (once the tests are updated).
+
+Run: `bun run typecheck`
+Expected: remaining errors only in `spawn-manager.ts` and CLI (handled in Task 14).
+
+- [ ] **Step 5: Commit** (deferred — pair with Task 14)
+
+---
+
+## Task 14: `spawn-manager.ts` — add `repos` + `repoCache`; commit the cutover
+
+**Files:**
+- Modify: `src/tui/spawn-manager.ts`
+- Modify: `src/tui/spawn-manager.test.ts`
+
+- [ ] **Step 1: Update `SpawnManager` construction**
+
+Mirror Task 13 precisely: add `repos: readonly RepoRef[]` + `repoCache?: Partial<ResolveRepoOptions>` to the options interface; add `resolvedRepos` + `ensureReposResolved()` (same body, same multi-repo guard).
+
+At the `provisionWorkspace` call site (around line 475 of `src/tui/spawn-manager.ts`), add `await this.ensureReposResolved()` just before the call and replace:
+
+```ts
+        repoRoot: projectRoot,
+```
+
+with:
+
+```ts
+        bareClonePath: this.resolvedRepos[0]!.bareClonePath,
+```
+
+Keep every `projectRoot`/`groveDir` reference used for `.grove/`, `mcpServePath`, bundled skills, and fallback cwd unchanged.
+
+- [ ] **Step 2: Update `spawn-manager.test.ts`**
+
+Same shape as Task 13 step 3 — every SpawnManager construction gains `repos: [{ kind: "local", path: bareFixturePath }]`.
+
+- [ ] **Step 3: Run full suite**
+
+Run: `bun run typecheck`
+Expected: clean.
+
+Run: `bun test`
+Expected: all green.
+
+Run: `bun run check`
+Expected: clean.
+
+- [ ] **Step 4: Commit the whole cutover** (Tasks 12 + 13 + 14 together)
+
+```bash
+git add \
+  src/core/workspace-provisioner.ts \
+  src/core/workspace-provisioner.test.ts \
+  src/core/session-orchestrator.ts \
+  src/core/session-orchestrator.test.ts \
+  src/tui/spawn-manager.ts \
+  src/tui/spawn-manager.test.ts
+git commit -m "feat(workspace): route workspace provisioning through repo-cache bareClonePath"
+```
+
+---
+
+## Task 15: `AgentRole.repoIndex?: number`
+
+Forward-compat field for the future multi-repo sub-spec. Defaults to 0; unused today.
+
+**Files:**
+- Modify: `src/core/topology.ts`
+- Modify: `src/core/topology.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `src/core/topology.test.ts`:
+
+```ts
+test("AgentRole accepts repoIndex; defaults to undefined; parses across the wire", () => {
+  // Build the minimal wire shape the codebase already uses for AgentRole and
+  // assert repoIndex round-trips. Adapt the wire object to match existing
+  // examples in this test file (copy the closest neighbor test).
+  const parsed = AgentRoleSchema.parse({
+    name: "coder",
+    repoIndex: 0,
+    // ...other required fields per existing schema shape
+  });
+  expect(parsed.repoIndex).toBe(0);
+});
+```
+
+(Implementer: copy the exact neighbor test's required-field set — don't guess at the full shape; the schema evolves.)
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `bun test src/core/topology.test.ts -t "repoIndex"`
+Expected: schema rejects unknown field, or field absent.
+
+- [ ] **Step 3: Add the field**
+
+In `src/core/topology.ts`, find the `AgentRoleSchema` (or equivalent) and add:
+
+```ts
+  repoIndex: z.number().int().nonnegative().optional(),
+```
+
+Also extend the `AgentRole` TypeScript interface to include `readonly repoIndex?: number;`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/topology.test.ts`
+Expected: green.
+
+Run: `bun run typecheck` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/topology.ts src/core/topology.test.ts
+git commit -m "feat(topology): AgentRole.repoIndex forward-compat field for multi-repo sessions"
+```
+
+---
+
+## Task 16: CLI `--repo` flag + cwd default
+
+**Files:**
+- Modify: `src/cli/commands/up.ts` (and any sibling command that constructs a session config; `rg --files-with-matches "projectRoot"` in `src/cli/` gives the list)
+
+- [ ] **Step 1: Find CLI entry points that construct session config**
+
+Run:
+```bash
+rg --files-with-matches "SessionOrchestratorConfig|SpawnManagerOptions|projectRoot" src/cli
+```
+
+The implementer applies steps 2–4 to each one. The concrete file names are the ones that come back from that `rg`.
+
+- [ ] **Step 2: Write failing CLI test**
+
+In the test file for the command (same directory), add:
+
+```ts
+test("--repo is accepted, parses as RepoRef", async () => {
+  const result = await parseUpCommandArgs(["--repo", "https://github.com/foo/bar"]);
+  expect(result.repos).toEqual([{ kind: "url", url: "https://github.com/foo/bar" }]);
+});
+
+test("passing two --repo values fails with multi-repo not supported", async () => {
+  await expect(
+    parseUpCommandArgs(["--repo", "https://github.com/foo/bar", "--repo", "https://github.com/baz/qux"]),
+  ).rejects.toThrow(/multi-repo sessions/);
+});
+
+test("no --repo defaults to cwd as local RepoRef", async () => {
+  const result = await parseUpCommandArgs([], { cwd: "/abs/cwd" });
+  expect(result.repos).toEqual([{ kind: "local", path: "/abs/cwd" }]);
+});
+
+test("no --repo + cwd not in a git repo throws actionable error", async () => {
+  const result = parseUpCommandArgs([], { cwd: "/abs/not-a-repo", isGitRepo: () => false });
+  await expect(result).rejects.toThrow(/run grove from inside a git repo/);
+});
+```
+
+(Implementer: `parseUpCommandArgs` is the factoring you introduce — see step 3. Name mirrors existing parser helpers; if a different name is idiomatic in this repo, match it.)
+
+- [ ] **Step 3: Wire the flag**
+
+Add to the command's flag schema:
+
+```ts
+const flags = {
+  repo: { type: "string", multiple: true, description: "Repository URL or local path; passed through to resolveRepo" },
+  ...existing,
+} as const;
+```
+
+In the command body, after parsing:
+
+```ts
+function buildRepos(rawRepo: readonly string[], cwd: string, isGitRepo: (p: string) => boolean): readonly RepoRef[] {
+  if (rawRepo.length > 1) {
+    throw new Error(
+      "multi-repo sessions are not yet supported (see sub-spec for #202). " +
+      "Pass at most one --repo.",
+    );
+  }
+  if (rawRepo.length === 1) {
+    const raw = rawRepo[0]!;
+    if (raw.startsWith("/") || raw.startsWith(".")) {
+      return [{ kind: "local", path: raw }];
+    }
+    return [{ kind: "url", url: raw }];
+  }
+  if (!isGitRepo(cwd)) {
+    throw new Error("run grove from inside a git repo, or pass --repo <url>");
+  }
+  return [{ kind: "local", path: cwd }];
+}
+```
+
+Pass the resulting `repos` into `SessionOrchestratorConfig`/`SpawnManagerOptions`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test <command-test-file>`
+Expected: green.
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli
+git commit -m "feat(cli): --repo flag; default to cwd; reject >1 repo until multi-repo ships"
+```
+
+---
+
+## Task 17: `grove repo list` + `grove repo prune` + `grove repo fetch`
+
+**Files:**
+- Create: `src/cli/commands/repo.ts`
+- Create: `src/cli/commands/repo.test.ts`
+- Modify: `src/cli/main.ts` (register subcommand)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/cli/commands/repo.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listCache, pruneCache, fetchCache } from "./repo.js";
+import { resolveRepo } from "../../core/repo-cache.js";
+
+function makeFixtureBare(): string {
+  const dir = mkdtempSync(join(tmpdir(), "grove-repo-fx-"));
+  execSync("git init --bare", { cwd: dir, stdio: "pipe" });
+  const scratch = mkdtempSync(join(tmpdir(), "grove-repo-scratch-"));
+  execSync(`git clone "${dir}" "${scratch}"`, { stdio: "pipe" });
+  execSync('git config user.email "t@t"', { cwd: scratch, stdio: "pipe" });
+  execSync('git config user.name "t"', { cwd: scratch, stdio: "pipe" });
+  execSync("git commit --allow-empty -m init", { cwd: scratch, stdio: "pipe" });
+  execSync("git branch -M main", { cwd: scratch, stdio: "pipe" });
+  execSync("git push origin main", { cwd: scratch, stdio: "pipe" });
+  rmSync(scratch, { recursive: true, force: true });
+  return dir;
+}
+
+describe("grove repo CLI", () => {
+  let cacheRoot: string;
+  let fixtures: string[] = [];
+
+  beforeEach(() => {
+    cacheRoot = mkdtempSync(join(tmpdir(), "grove-repo-cli-"));
+    fixtures = [];
+  });
+
+  afterEach(() => {
+    rmSync(cacheRoot, { recursive: true, force: true });
+    for (const f of fixtures) rmSync(f, { recursive: true, force: true });
+  });
+
+  test("list returns zero entries on empty cache", async () => {
+    const entries = await listCache({ cacheRoot });
+    expect(entries).toEqual([]);
+  });
+
+  test("list returns entries after a resolve", async () => {
+    const f = makeFixtureBare();
+    fixtures.push(f);
+    await resolveRepo({ kind: "url", url: `file://${f}` }, { cacheRoot });
+
+    const entries = await listCache({ cacheRoot });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.canonicalUrl).toBe(`file://${f}`);
+    expect(entries[0]!.key).toBe(`local/${f.replace(/^\//, "")}.git`);
+  });
+
+  test("prune removes a specific entry", async () => {
+    const f = makeFixtureBare();
+    fixtures.push(f);
+    const resolved = await resolveRepo({ kind: "url", url: `file://${f}` }, { cacheRoot });
+
+    await pruneCache({ cacheRoot, key: resolved.key });
+    expect(existsSync(resolved.bareClonePath)).toBe(false);
+  });
+
+  test("prune --all removes every entry", async () => {
+    const f1 = makeFixtureBare();
+    const f2 = makeFixtureBare();
+    fixtures.push(f1, f2);
+    await resolveRepo({ kind: "url", url: `file://${f1}` }, { cacheRoot });
+    await resolveRepo({ kind: "url", url: `file://${f2}` }, { cacheRoot });
+
+    await pruneCache({ cacheRoot, all: true });
+    const entries = await listCache({ cacheRoot });
+    expect(entries).toEqual([]);
+  });
+
+  test("prune refuses when a worktree still references the entry", async () => {
+    const f = makeFixtureBare();
+    fixtures.push(f);
+    const resolved = await resolveRepo({ kind: "url", url: `file://${f}` }, { cacheRoot });
+    const wt = mkdtempSync(join(tmpdir(), "grove-repo-wt-"));
+    try {
+      execSync(`git -C "${resolved.bareClonePath}" worktree add "${wt}"`, { stdio: "pipe" });
+      await expect(pruneCache({ cacheRoot, key: resolved.key })).rejects.toThrow(/worktree/);
+      expect(existsSync(resolved.bareClonePath)).toBe(true);
+    } finally {
+      execSync(`git -C "${resolved.bareClonePath}" worktree remove --force "${wt}"`, { stdio: "pipe" });
+      rmSync(wt, { recursive: true, force: true });
+    }
+  });
+
+  test("fetch forces a fetch on the cache entry", async () => {
+    const f = makeFixtureBare();
+    fixtures.push(f);
+    const resolved = await resolveRepo({ kind: "url", url: `file://${f}` }, { cacheRoot });
+
+    const result = await fetchCache({ cacheRoot, key: resolved.key });
+    expect(result.fetched).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `bun test src/cli/commands/repo.test.ts`
+Expected: module not found.
+
+- [ ] **Step 3: Implement `src/cli/commands/repo.ts`**
+
+```ts
+/**
+ * `grove repo` subcommands — inspect and maintain the bare-clone cache.
+ */
+
+import { execFile } from "node:child_process";
+import { readdir, readFile, rm, stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { resolveRepo, type ResolveRepoOptions } from "../../core/repo-cache.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface CacheEntry {
+  readonly key: string;
+  readonly bareClonePath: string;
+  readonly canonicalUrl: string;
+  readonly aliases: readonly string[];
+  readonly createdAt: string;
+  readonly lastFetchedAt: string;
+  readonly lastAccessedAt: string;
+}
+
+async function walkEntries(cacheRoot: string): Promise<CacheEntry[]> {
+  if (!existsSync(cacheRoot)) return [];
+  const entries: CacheEntry[] = [];
+
+  async function recurse(dir: string, relParts: string[]): Promise<void> {
+    const items = await readdir(dir, { withFileTypes: true });
+    for (const item of items) {
+      if (!item.isDirectory()) continue;
+      if (item.name === ".locks") continue;
+      const child = join(dir, item.name);
+      if (item.name.endsWith(".git")) {
+        const manifestPath = join(child, ".grove-cache", "manifest.json");
+        if (!existsSync(manifestPath)) continue;
+        const manifest = JSON.parse(await readFile(manifestPath, "utf-8"));
+        entries.push({
+          key: [...relParts, item.name].join("/"),
+          bareClonePath: child,
+          canonicalUrl: manifest.canonicalUrl,
+          aliases: manifest.aliases,
+          createdAt: manifest.createdAt,
+          lastFetchedAt: manifest.lastFetchedAt,
+          lastAccessedAt: manifest.lastAccessedAt,
+        });
+      } else {
+        await recurse(child, [...relParts, item.name]);
+      }
+    }
+  }
+
+  await recurse(cacheRoot, []);
+  return entries;
+}
+
+export async function listCache(opts: { cacheRoot: string }): Promise<CacheEntry[]> {
+  return walkEntries(opts.cacheRoot);
+}
+
+export async function pruneCache(
+  opts: { cacheRoot: string; key?: string; all?: boolean },
+): Promise<void> {
+  const entries = await walkEntries(opts.cacheRoot);
+  const targets = opts.all ? entries : entries.filter((e) => e.key === opts.key);
+
+  if (!opts.all && targets.length === 0) {
+    throw new Error(`no cache entry matches key: ${opts.key}`);
+  }
+
+  for (const entry of targets) {
+    // Worktree safety check: each worktree line starting with "worktree "
+    // other than the bare clone itself is an external checkout we must not strand.
+    const { stdout } = await execFileAsync("git", ["-C", entry.bareClonePath, "worktree", "list", "--porcelain"]);
+    const external = stdout
+      .split("\n")
+      .filter((l) => l.startsWith("worktree "))
+      .map((l) => l.replace(/^worktree /, ""))
+      .filter((p) => p !== entry.bareClonePath);
+    if (external.length > 0) {
+      throw new Error(
+        `cannot prune ${entry.key}: ${external.length} worktree(s) still reference it:\n${external.join("\n")}`,
+      );
+    }
+    await rm(entry.bareClonePath, { recursive: true, force: true });
+  }
+
+  // Best-effort: remove the matching lockfile(s) too.
+  const locksDir = join(opts.cacheRoot, ".locks");
+  if (existsSync(locksDir)) {
+    for (const entry of targets) {
+      const lockFile = join(locksDir, `${entry.key.replace(/\//g, "__")}.lock`);
+      if (existsSync(lockFile)) await rm(lockFile, { force: true });
+    }
+  }
+}
+
+export async function fetchCache(
+  opts: { cacheRoot: string; key: string; resolveOpts?: Partial<ResolveRepoOptions> },
+): Promise<{ fetched: boolean; stale: boolean }> {
+  const entries = await walkEntries(opts.cacheRoot);
+  const entry = entries.find((e) => e.key === opts.key);
+  if (!entry) throw new Error(`no cache entry matches key: ${opts.key}`);
+  const result = await resolveRepo(
+    { kind: "url", url: entry.canonicalUrl },
+    { ...(opts.resolveOpts ?? {}), cacheRoot: opts.cacheRoot, fresh: true },
+  );
+  return { fetched: result.fetched, stale: result.stale };
+}
+```
+
+- [ ] **Step 4: Register the subcommand**
+
+In `src/cli/main.ts`, add a branch for `repo` that dispatches to `list` / `prune` / `fetch`. Surface one-line human-readable output for `list` and `prune` (manifest summary / success message); the programmatic shapes above are what tests consume.
+
+- [ ] **Step 5: Run tests**
+
+Run: `bun test src/cli/commands/repo.test.ts`
+Expected: all green.
+
+Run: `bun run typecheck` → clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/commands/repo.ts src/cli/commands/repo.test.ts src/cli/main.ts
+git commit -m "feat(cli): grove repo list/prune/fetch for cache inspection and maintenance"
+```
+
+---
+
+## Task 18: End-to-end — session against a bare-clone fixture
+
+**Files:**
+- Create: `tests/e2e/repo-cache-session.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { provisionWorkspace } from "../../src/core/workspace-provisioner.js";
+import { resolveRepo } from "../../src/core/repo-cache.js";
+
+let fixture: string;
+let cacheRoot: string;
+let groveDir: string;
+
+beforeEach(() => {
+  fixture = mkdtempSync(join(tmpdir(), "grove-e2e-fx-"));
+  execSync("git init --bare", { cwd: fixture, stdio: "pipe" });
+  const scratch = mkdtempSync(join(tmpdir(), "grove-e2e-scratch-"));
+  execSync(`git clone "${fixture}" "${scratch}"`, { stdio: "pipe" });
+  execSync('git config user.email "t@t"', { cwd: scratch, stdio: "pipe" });
+  execSync('git config user.name "t"', { cwd: scratch, stdio: "pipe" });
+  execSync("git commit --allow-empty -m init", { cwd: scratch, stdio: "pipe" });
+  execSync("git branch -M main", { cwd: scratch, stdio: "pipe" });
+  execSync("git push origin main", { cwd: scratch, stdio: "pipe" });
+  rmSync(scratch, { recursive: true, force: true });
+
+  cacheRoot = mkdtempSync(join(tmpdir(), "grove-e2e-cache-"));
+  groveDir = mkdtempSync(join(tmpdir(), "grove-e2e-dir-"));
+});
+
+afterEach(() => {
+  rmSync(fixture, { recursive: true, force: true });
+  rmSync(cacheRoot, { recursive: true, force: true });
+  rmSync(groveDir, { recursive: true, force: true });
+});
+
+test("resolve → provision → commit flow against a bare-clone fixture", async () => {
+  const resolved = await resolveRepo(
+    { kind: "url", url: `file://${fixture}` },
+    { cacheRoot },
+  );
+
+  const ws = await provisionWorkspace({
+    role: "coder",
+    sessionId: "e2esess00000000",
+    baseDir: join(groveDir, "workspaces"),
+    bareClonePath: resolved.bareClonePath,
+  });
+
+  // Agent can edit + commit + push back to the bare clone.
+  execSync(`bash -c 'echo "hello" > ${ws.path}/hello.txt'`, { stdio: "pipe" });
+  execSync('git config user.email "agent@t"', { cwd: ws.path, stdio: "pipe" });
+  execSync('git config user.name "agent"', { cwd: ws.path, stdio: "pipe" });
+  execSync("git add hello.txt && git commit -m 'add hello'", { cwd: ws.path, stdio: "pipe" });
+  execSync(`git push origin ${ws.branch}`, { cwd: ws.path, stdio: "pipe" });
+
+  // Branch landed in the bare clone.
+  const branches = execSync(`git -C "${resolved.bareClonePath}" branch`, { encoding: "utf-8" });
+  expect(branches).toContain(ws.branch);
+  expect(existsSync(join(ws.path, "hello.txt"))).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `bun test tests/e2e/repo-cache-session.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/repo-cache-session.test.ts
+git commit -m "test(e2e): resolveRepo → provisionWorkspace → commit flow"
+```
+
+---
+
+## Task 19: Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `QUICKSTART.md`
+- Modify: `GROVE.md`
+
+- [ ] **Step 1: README — add a "Repo cache" section**
+
+Append under an appropriate top-level heading (e.g., after "Configuration"):
+
+```markdown
+## Repo cache
+
+Grove uses a user-wide bare-clone cache so that agent worktrees are
+cheap regardless of whether you've checked out the repo locally.
+
+**Cache location** (first match wins):
+1. `$GROVE_REPO_CACHE`
+2. Grove config file `repoCache.path`
+3. `$XDG_CACHE_HOME/grove/repo-cache/`
+4. `~/.cache/grove/repo-cache/`
+
+**Maintenance:**
+- `grove repo list` — show every cached repo + when it was last fetched.
+- `grove repo prune <key>` — remove one entry (refuses if a worktree still references it).
+- `grove repo prune --all` — remove every entry.
+- `grove repo fetch <key>` — force a fetch on an existing entry.
+
+Cache growth is unbounded by design — grove never evicts without being
+told. Run `grove repo prune --all` if disk pressure bites.
+```
+
+- [ ] **Step 2: QUICKSTART — document the `--repo` flag**
+
+Add (near the first `grove up`/`grove session start` example):
+
+```markdown
+### Pointing at a specific repo
+
+By default grove uses the git repo your shell is currently in. To target
+a different repo — checked out locally or not — pass `--repo`:
+
+    grove up --repo https://github.com/you/project
+    grove up --repo /abs/path/to/checkout
+
+Only one `--repo` is accepted today; multi-repo sessions ship in a
+later release.
+```
+
+- [ ] **Step 3: GROVE.md — cross-reference**
+
+Add a one-liner pointing at the README section so agents reading GROVE.md discover the cache:
+
+```markdown
+## Repo cache
+
+Agent worktrees come from a shared bare-clone cache (`$XDG_CACHE_HOME/grove/repo-cache/`).
+See `README.md` → "Repo cache" for maintenance commands.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md QUICKSTART.md GROVE.md
+git commit -m "docs: document repo cache location, --repo flag, grove repo commands"
+```
+
+---
+
+## Task 20: Close the loop
+
+- [ ] **Step 1: Full suite**
+
+Run: `bun run typecheck && bun run check && bun test`
+Expected: all green.
+
+- [ ] **Step 2: Update issue**
+
+Post a comment on #263 linking the spec + plan and summarizing the PR chain. (Do not close yet — the issue closes when the PR merges.)
+
+```bash
+gh issue comment 263 --body "$(cat <<'EOF'
+Spec + plan landed on this worktree.
+
+- Spec: `docs/superpowers/specs/2026-04-21-bare-clone-repo-cache-design.md`
+- Plan: `docs/superpowers/plans/2026-04-21-bare-clone-repo-cache.md`
+
+20 tasks, TDD throughout, no feature flag. Ready for implementation.
+EOF
+)"
+```
+
+- [ ] **Step 3: Final commit if anything drifted**
+
+```bash
+git status
+# If any unstaged doc tweaks remain, commit with message:
+# "docs: tidy repo-cache docs after final review"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage.** Every section of the spec maps to a task:
+  - Types + normalization + cache key → Task 2.
+  - On-disk layout (lockfile outside entry, `.ok`, manifest) → Tasks 5, 8.
+  - `resolveRepo` flow (clone, cache hit, TTL, fresh, offline, recovery, timeout) → Tasks 5–9.
+  - Concurrency → Task 10.
+  - Local path with/without origin → Tasks 4, 11.
+  - Provisioner signature change → Task 12.
+  - Session config / SpawnManager changes → Tasks 13, 14.
+  - `AgentRole.repoIndex` → Task 15.
+  - CLI `--repo` (with multi-repo rejection + cwd default + not-in-repo error) → Task 16.
+  - `grove repo list/prune/fetch` → Task 17.
+  - E2E test → Task 18.
+  - Docs → Task 19.
+- **Placeholder scan.** None. Task 15 points the implementer at the neighbor schema test rather than guessing schema shape — justified because the wire schema evolves. Task 16 step 1 uses `rg` to discover entry points — justified because the codebase has multiple session-starting commands today. Both are instructions, not TODOs.
+- **Type consistency.** `RepoRef`, `ResolveRepoOptions`, `ResolvedRepo` spelled consistently across all tasks. `bareClonePath` (not `bare_clone_path`, `clonePath`, etc.) is the single field name used everywhere.
+- **Scope.** One subsystem (the cache + its consumers). No unrelated refactors. `projectRoot` stays exactly where it was.

--- a/docs/superpowers/specs/2026-04-21-bare-clone-repo-cache-design.md
+++ b/docs/superpowers/specs/2026-04-21-bare-clone-repo-cache-design.md
@@ -1,0 +1,322 @@
+# Bare-Clone Repo Cache — Design
+
+- **Date:** 2026-04-21
+- **Issue:** [#263](https://github.com/windoliver/grove/issues/263) (sub-spec 3 of [#202](https://github.com/windoliver/grove/issues/202))
+- **Status:** Draft for review
+
+## Summary
+
+Grove materializes each agent role's workspace by running `git worktree add` from `projectRoot`, a single local checkout of the session's repo. This assumes every session runs against one already-cloned local repo and re-pays disk cost for every worktree.
+
+This spec adds a **user-wide bare-clone cache**. A session targets one or more `RepoRef`s (local path or URL); Grove resolves each to a bare clone in a shared cache directory; worktrees for agent tasks are created from the cache. The cache is locked for safe concurrent access, fetches are TTL-gated, and corruption recovers automatically.
+
+## Goals
+
+- Sessions can target arbitrary git repos by URL, not just `process.cwd()`.
+- A single bare clone per normalized repo URL, shared across all grove sessions on the machine.
+- Worktree creation is cheap regardless of whether the repo was ever locally checked out.
+- Concurrent grove processes on one machine cooperate safely on the same cache entry.
+- Forward-compatible with multi-repo sessions (where different roles use different repos) without a second breaking change.
+- Offline and flaky-network tolerance as a first-class concern.
+
+## Non-goals
+
+- Multi-repo sessions — API surface ships now (`repos: RepoRef[]`, `AgentRole.repoIndex?`), semantics land in a later sub-spec.
+- Automatic LRU or age-based eviction — v1 is unbounded with `grove repo prune`.
+- Credential management beyond inheriting git's config.
+- Hot-swap a role's repo mid-session.
+- Nexus-hosted repo cache shared across machines.
+- Submodules, LFS, partial-clone tuning, shallow clones — callers configure `git` itself if they need these.
+
+## Background
+
+### Current state
+
+- `src/core/workspace-provisioner.ts` — `provisionWorkspace({ repoRoot, ... })` runs `git worktree add <path> -b <branch> <base>` with `cwd: repoRoot`. `repoRoot` is the session's one local checkout.
+- `src/core/session-orchestrator.ts` — `SessionOrchestratorConfig.projectRoot: string` is used both as `cwd` for shell-outs and as `repoRoot` for the provisioner.
+- `src/tui/spawn-manager.ts` — derives `projectRoot = resolve(groveDir, "..")` and passes that to the provisioner.
+- No bare-clone or cache code anywhere in the repo (`rg 'bare.clone|repo-cache|repoCache|--bare'` finds no hits).
+
+### Gap
+
+- Sessions cannot target a repo that is not already locally checked out.
+- N roles in a session → N worktrees off one checkout; the shared `.git` is already deduped by git, but the "single checkout" coupling blocks the multi-repo and external-repo cases entirely.
+- No path for CI/containers to pre-seed a cache volume.
+
+## Design
+
+### Architecture
+
+Three modules, clear boundaries:
+
+```
+src/core/
+  repo-ref.ts          # RepoRef type, URL normalization, cache-key derivation
+  repo-cache.ts        # resolveRepo(repoRef, opts) → { bareClonePath, fetched, stale }
+  workspace-provisioner.ts  # consumes bareClonePath instead of repoRoot
+```
+
+- `repo-ref.ts` — pure functions: `normalizeUrl()`, `deriveCachePath()`, `RepoRef` discriminated union. No I/O.
+- `repo-cache.ts` — side-effectful: owns the cache directory, runs `git clone --bare`/`git fetch`, holds locks, maintains sentinel and manifest files. One public function: `resolveRepo`. Knows nothing about agents, roles, or worktrees.
+- `workspace-provisioner.ts` — unchanged behavior except that `cwd` for `git worktree add` is the bare-clone path returned by `resolveRepo`.
+
+Session-level callers (`SpawnManager`, `SessionOrchestrator`) resolve the session's `repos: RepoRef[]` once at session start and cache the result on the session object; the cache layer is not touched in per-role hot paths.
+
+No Nexus coupling. The cache is a local filesystem concern; multiple grove processes on the same machine cooperate via `flock()` on per-entry lockfiles.
+
+### Types
+
+```ts
+export type RepoRef =
+  | { readonly kind: "local"; readonly path: string }
+  | { readonly kind: "url";   readonly url: string; readonly ref?: string };
+
+export interface ResolveRepoOptions {
+  readonly fresh?: boolean;        // force fetch regardless of TTL
+  readonly cacheRoot?: string;     // override cache root (testing, CI)
+  readonly fetchTtlMs?: number;    // default 60_000
+  readonly timeoutMs?: number;     // clone/fetch hard timeout (default 300_000)
+}
+
+export interface ResolvedRepo {
+  readonly ref: RepoRef;
+  readonly bareClonePath: string;  // absolute; safe cwd for `git worktree add`
+  readonly key: string;            // e.g. "github.com/foo/bar.git"
+  readonly fetched: boolean;       // did this call run a fetch
+  readonly stale: boolean;         // true if fetch failed but cache was usable
+}
+
+export async function resolveRepo(
+  ref: RepoRef,
+  opts?: ResolveRepoOptions,
+): Promise<ResolvedRepo>;
+```
+
+`RepoRef.ref` (branch/tag/commit) is parsed and passed through as the `baseBranch` hint to `provisionWorkspace`; it is **not** consulted when deriving the cache key (one cache entry per repo URL, not per ref).
+
+### URL normalization + cache key
+
+```
+normalizeUrl(raw) → { host, path }
+
+  "git@github.com:foo/bar.git"      → { host: "github.com",   path: "foo/bar" }
+  "https://github.com/foo/bar/"     → { host: "github.com",   path: "foo/bar" }
+  "https://GitHub.com/foo/bar.git"  → { host: "github.com",   path: "foo/bar" }
+  "file:///abs/path/to/repo"        → { host: "local",        path: "abs/path/to/repo" }
+  "/abs/path/to/repo" (local ref)   → { host: "local",        path: "abs/path/to/repo" }
+
+Rules:
+  - strip scheme, user@, trailing slash, trailing `.git`
+  - lowercase host
+  - file:// and local paths normalize to host="local"; path is the absolute path with the leading `/` stripped
+  - reject path components equal to `..`, empty, or starting with `.`; refuse to build a cache path
+```
+
+```
+deriveCachePath(normalized) → "<host>/<path>.git"
+```
+
+Path-safety is enforced by an explicit validator — grove never relies on `path.join` alone to sanitize a remote-controlled URL.
+
+**Local `RepoRef` with no `origin` remote:** `resolveRepo` returns `{ bareClonePath: ref.path, fetched: false, stale: false }` and skips the cache entirely. Preserves today's "cloned with no remote" case (e.g., `git init`-only repos).
+
+**Local `RepoRef` with an `origin` remote:** resolve to `origin`'s URL, normalize, and use the cache like any URL ref.
+
+### On-disk layout
+
+Cache-root resolution order:
+
+1. `$GROVE_REPO_CACHE` (absolute path).
+2. `repoCache.path` in grove config file.
+3. `$XDG_CACHE_HOME/grove/repo-cache/` (fall back to `~/.cache/grove/repo-cache/` when `XDG_CACHE_HOME` is unset).
+
+Per-entry layout:
+
+```
+<cache-root>/
+  .locks/
+    github.com__windoliver__grove.git.lock   # per-entry lockfile; lives OUTSIDE the cache entry
+  github.com/
+    windoliver/
+      grove.git/              # bare clone (GIT_DIR; no worktree)
+        .grove-cache/         # grove metadata, sibling to git internals
+          manifest.json       #   canonical url, aliases seen, timestamps
+          .ok                 #   sentinel: present ⇒ clone completed cleanly
+          last-fetch          #   mtime used for 60s TTL check
+```
+
+Lockfiles live under `<cache-root>/.locks/` so that a corrupt-entry recovery (`rm -rf <cacheDir>`) never removes the lockfile we are currently holding. The encoded lockfile name is the cache key with `/` replaced by `__`.
+
+`manifest.json`:
+
+```jsonc
+{
+  "canonicalUrl": "https://github.com/foo/bar",
+  "aliases": ["git@github.com:foo/bar.git", "https://github.com/foo/bar.git"],
+  "createdAt": "2026-04-21T...",
+  "lastFetchedAt": "2026-04-21T...",
+  "lastAccessedAt": "2026-04-21T..."
+}
+```
+
+`.ok` is written by an atomic temp-file + rename after `git clone --bare` returns 0. Missing `.ok` on an otherwise populated `cacheDir` means a prior clone crashed; recovery nukes and re-clones under the held lock.
+
+`aliases` is append-only — records every URL form grove has seen for this entry. Useful for debugging and as input to any future eviction heuristic.
+
+### `resolveRepo` flow
+
+```
+1. If ref.kind === "local" and the path has no `origin` remote
+     → return { bareClonePath: ref.path, fetched: false, stale: false }
+
+2. Normalize URL
+     If ref.kind === "local" with origin: read `origin` via `git -C <path> remote get-url origin`
+     Compute cacheDir = <cacheRoot>/<host>/<path>.git
+
+3. Acquire flock on <cacheRoot>/.locks/<encoded-key>.lock
+     Create <cacheRoot>/.locks/ if needed; the lockfile lives OUTSIDE the cache entry
+     so step 4a's rm -rf cannot unlink the lock we're holding
+
+4. If <cacheDir>/.grove-cache/.ok is missing:
+     a. If cacheDir is non-empty → rm -rf (corrupt from prior crash); log recovery
+     b. git clone --bare <url> <cacheDir>              (subprocess, with timeoutMs)
+     c. mkdir .grove-cache/; write manifest.json; write .ok (atomic rename)
+     d. touch last-fetch
+     e. fetched = true
+
+5. Else (cache hit):
+     a. Read manifest; append raw URL to aliases if new; update lastAccessedAt
+     b. If opts.fresh OR now - mtime(last-fetch) > fetchTtlMs:
+          try `git fetch --all --prune` in cacheDir
+            success → touch last-fetch; fetched = true
+            failure →
+              if opts.fresh → release lock, throw (hard-fail)
+              else         → log warn; stale = true; fetched = false
+
+6. Release flock
+
+7. Return { ref, bareClonePath: cacheDir, key, fetched, stale }
+```
+
+Per-step detail:
+
+- **Locking (step 3).** `flock()` via a portable shim (`proper-lockfile` or equivalent) keeps the Windows door open even though Windows isn't officially supported. Lockfiles live at `<cacheRoot>/.locks/<encoded-key>.lock`, outside the cache entry — the corrupt-entry recovery path (`rm -rf <cacheDir>`) never touches them. The lock covers clone + fetch only. `git worktree add` runs in `workspace-provisioner` later, without this lock — git's internal ref-locking is sufficient and branch names are already session-scoped (`grove/{sessionId}/{role}`) so two worktree adds cannot collide.
+- **Corruption recovery (step 4a).** The absence of `.ok` is the sole corruption signal. Grove does not run `git fsck` — too expensive on every session start. Users who hit real object corruption can `grove repo prune <key>` and retry.
+- **Fetch TTL (step 5b).** mtime-based; no extra state. Tuned to 60s as the default; overridable per call (tests use 0 or very large values).
+- **Offline / flaky fetch (step 5b).** Stale cache wins over hard-fail unless `--fresh` was explicitly requested.
+- **Auth.** Inherit git's existing config — `credential.helper`, SSH agent, `.netrc`. The subprocess runs with `GIT_TERMINAL_PROMPT=0` so a missing credential fails fast instead of hanging a TUI on an invisible prompt.
+- **Timeout.** Clone and fetch run under an `AbortController` with `timeoutMs` (default 5 min). On timeout: kill the subprocess, release the lock, throw. A half-finished clone is safe — the missing `.ok` triggers auto-recovery on the next call.
+
+### Integration with existing provisioner + callers
+
+**`workspace-provisioner.ts` signature.**
+
+```ts
+// before
+interface WorkspaceProvisionOptions {
+  readonly role: string;
+  readonly sessionId: string;
+  readonly baseDir: string;
+  readonly repoRoot: string;               // removed
+  readonly baseBranch?: string;
+  readonly mcpConfig?: Record<string, unknown>;
+}
+
+// after
+interface WorkspaceProvisionOptions {
+  readonly role: string;
+  readonly sessionId: string;
+  readonly baseDir: string;
+  readonly bareClonePath: string;          // from resolveRepo(...).bareClonePath
+  readonly baseBranch?: string;
+  readonly mcpConfig?: Record<string, unknown>;
+}
+```
+
+Inside `provisionWorkspace` the only substantive change is `cwd: repoRoot` → `cwd: bareClonePath`. `git worktree add <path> -b <branch> <base>` works identically against a bare clone; the bare-vs-checkout distinction is invisible at this call site. `cleanupSessionWorkspaces` changes `repoRoot` → `bareClonePath` for the same reason.
+
+**Session-level config.**
+
+```ts
+// before
+interface SessionOrchestratorConfig {
+  readonly projectRoot: string;
+  ...
+}
+
+// after
+interface SessionOrchestratorConfig {
+  readonly repos: readonly RepoRef[];                // length ≥ 1 (today: exactly 1)
+  readonly repoCache?: Partial<ResolveRepoOptions>;
+  ...
+}
+```
+
+`projectRoot` is removed from both `SessionOrchestratorConfig` and the `SpawnManager` equivalent in the same PR. Grove has one external CLI entry point plus a handful of test harnesses; no compat shim is needed.
+
+At session start:
+
+```ts
+const resolved = await Promise.all(
+  config.repos.map(ref => resolveRepo(ref, config.repoCache)),
+);
+// today: resolved[0] is the session's only repo
+```
+
+`AgentRole` gains an optional `repoIndex?: number` (defaults to 0). Today it is unused; the multi-repo sub-spec will wire it. Shipping the field now keeps `repos: RepoRef[]` from being a breaking change later.
+
+**CLI surface.**
+
+- `grove up`, `grove session start`, etc. accept `--repo <url-or-path>`. The flag parses as repeatable (forward-compat with multi-repo sessions), but today grove rejects >1 `--repo` values with an explicit error pointing at the deferred multi-repo sub-spec. Silent truncation is not acceptable.
+- When `--repo` is omitted, grove resolves `process.cwd()` to a `local` `RepoRef`. If cwd is not inside a git repo, grove errors with an actionable message (`run grove from inside a git repo, or pass --repo <url>`).
+- New sibling commands under `src/cli/commands/repo.ts`:
+  - `grove repo list` — walk cache root, print each entry's key + manifest summary.
+  - `grove repo prune [<key>|--all]` — remove cache entries. Before removing: check `git worktree list` in the bare clone; if any worktree still references it, refuse with an actionable error.
+  - `grove repo fetch <key>` (optional, nice-to-have) — explicit fetch, equivalent to calling `resolveRepo(ref, { fresh: true })`.
+
+### Testing strategy
+
+- `repo-ref.test.ts` — table-driven normalization (SSH, HTTPS, case, trailing slash/`.git`, `file://`, local absolute path); path-safety rejects traversal (`..`, empty segment, leading dot).
+- `repo-cache.test.ts` — integration tests against real `git` using `file://` URLs that point at fixture bare repos created in `beforeAll`. Covers:
+  - fresh clone creates `.ok`, manifest, and last-fetch;
+  - cache hit within TTL skips fetch;
+  - TTL expiry triggers fetch; failure produces `stale: true`;
+  - `fresh: true` forces fetch; failure throws;
+  - concurrent `resolveRepo` calls on the same key serialize via the lock (one clones, the rest see cache hit);
+  - missing `.ok` triggers auto-reclone;
+  - timeout kills subprocess and leaves the entry recoverable on next call.
+- `workspace-provisioner.test.ts` — existing tests updated to pass `bareClonePath` (pointing at a fixture bare clone) instead of `repoRoot`.
+- End-to-end: one test runs a session against a `file://` bare-clone fixture and verifies agent worktrees are created and can commit.
+
+No test ever contacts a real remote. CI runs offline.
+
+### Observability
+
+- Every `resolveRepo` call logs (at info) a line with `{ key, hit, fetched, stale, durationMs }`.
+- `grove repo list` reads the same manifests; any debugging session starts there.
+- Structured errors from clone/fetch include the cache key and the full git stderr.
+
+## Risks
+
+- **Windows.** `flock()` is POSIX; the codebase uses a portable lockfile shim (`proper-lockfile` or equivalent) so Windows stays possible even though it's unsupported today.
+- **`file://` URL normalization.** Edge case — `file:///abs/path/to/repo` vs `/abs/path/to/repo`. Rule: both normalize to `{ host: "local", path: <abs path, leading "/" stripped> }`. Makes `file://` fixtures deterministic in tests.
+- **Network in tests.** All tests use `file://` fixtures created in `beforeAll`. No real remotes.
+- **Clone blocks session start.** First-time clone of a big repo can take minutes. The UX surfaces a "cloning repo…" status (same hook already used for provisioning). Hard timeout (5 min default) prevents an indefinite hang.
+- **Disk pressure.** Unbounded cache + big repos = surprise disk bill. Mitigated by `grove repo list` and `grove repo prune`; called out in README.
+- **Bare-clone worktree edge cases.** `git worktree add` from a bare clone works, but HEAD of the bare repo is a detached symbolic ref. Confirmed-safe call shape: `git worktree add <path> -b <new-branch> <base>` where `<base>` is `HEAD`, an explicit branch, or an SHA — matches what `workspace-provisioner` already uses.
+- **Credential prompts hanging the TUI.** `GIT_TERMINAL_PROMPT=0` on the subprocess env prevents this class of hang.
+
+## Rollout
+
+Single PR chain, no feature flag:
+
+1. Land `repo-ref.ts` + `repo-cache.ts` + their tests. No callers yet — pure additive.
+2. Change `workspace-provisioner.ts` signature (`repoRoot` → `bareClonePath`); update `SpawnManager`, `SessionOrchestrator`, tests, CLI in one PR.
+3. Add `grove repo list` / `grove repo prune` CLI.
+4. Update README, QUICKSTART, GROVE.md for the `--repo` flag and the new cache location.
+
+Feature-flagging this does not pay off: the cache is required for external repos, and the existing local-repo flow goes through the same `resolveRepo` call (which short-circuits for a local path with no `origin`, and clones-to-cache otherwise). One code path, tested once.
+
+## Open questions
+
+None at design time. Implementation may surface tuning (default TTL, default timeout, lockfile library choice) that the plan will pin down.

--- a/docs/superpowers/specs/2026-04-21-bare-clone-repo-cache-design.md
+++ b/docs/superpowers/specs/2026-04-21-bare-clone-repo-cache-design.md
@@ -33,8 +33,8 @@ This spec adds a **user-wide bare-clone cache**. A session targets one or more `
 ### Current state
 
 - `src/core/workspace-provisioner.ts` — `provisionWorkspace({ repoRoot, ... })` runs `git worktree add <path> -b <branch> <base>` with `cwd: repoRoot`. `repoRoot` is the session's one local checkout.
-- `src/core/session-orchestrator.ts` — `SessionOrchestratorConfig.projectRoot: string` is used both as `cwd` for shell-outs and as `repoRoot` for the provisioner.
-- `src/tui/spawn-manager.ts` — derives `projectRoot = resolve(groveDir, "..")` and passes that to the provisioner.
+- `src/core/session-orchestrator.ts` — `SessionOrchestratorConfig.projectRoot: string` has two jobs: (a) `repoRoot` for the provisioner, and (b) grove's launcher directory — used to derive `.grove/`, `mcpServePath`, `bundledSkillsRoot`, `workspaceOverrideRoot`, and the fallback cwd when no workspace is provisioned.
+- `src/tui/spawn-manager.ts` — derives `projectRoot = resolve(groveDir, "..")` and passes that to the provisioner (same dual role).
 - No bare-clone or cache code anywhere in the repo (`rg 'bare.clone|repo-cache|repoCache|--bare'` finds no hits).
 
 ### Gap
@@ -240,19 +240,22 @@ Inside `provisionWorkspace` the only substantive change is `cwd: repoRoot` → `
 ```ts
 // before
 interface SessionOrchestratorConfig {
-  readonly projectRoot: string;
+  readonly projectRoot: string;                      // doubled as grove launcher dir + repoRoot
   ...
 }
 
 // after
 interface SessionOrchestratorConfig {
-  readonly repos: readonly RepoRef[];                // length ≥ 1 (today: exactly 1)
+  readonly projectRoot: string;                      // kept: grove launcher dir (.grove/, mcpServePath, skills roots)
+  readonly repos: readonly RepoRef[];                // new: repos the session targets; length ≥ 1 (today: exactly 1)
   readonly repoCache?: Partial<ResolveRepoOptions>;
   ...
 }
 ```
 
-`projectRoot` is removed from both `SessionOrchestratorConfig` and the `SpawnManager` equivalent in the same PR. Grove has one external CLI entry point plus a handful of test harnesses; no compat shim is needed.
+`projectRoot` is **not** removed. It has a legitimate second job — grove's launcher directory — that is independent of which repo(s) a session targets: it anchors `.grove/`, `mcpServePath`, the bundled skills root, the workspace-override skills root, and the fallback cwd when no workspace is provisioned. The only change is that it stops being passed as `repoRoot` to `provisionWorkspace`; the provisioner instead receives `bareClonePath` from `resolveRepo(session.repos[roleIndex])`.
+
+The same split applies to `SpawnManager`: `projectRoot` stays (still derived as `resolve(groveDir, "..")`), and `repos: RepoRef[]` is added alongside it.
 
 At session start:
 
@@ -311,7 +314,7 @@ No test ever contacts a real remote. CI runs offline.
 Single PR chain, no feature flag:
 
 1. Land `repo-ref.ts` + `repo-cache.ts` + their tests. No callers yet — pure additive.
-2. Change `workspace-provisioner.ts` signature (`repoRoot` → `bareClonePath`); update `SpawnManager`, `SessionOrchestrator`, tests, CLI in one PR.
+2. Change `workspace-provisioner.ts` signature (`repoRoot` → `bareClonePath`); add `repos: RepoRef[]` to session config surfaces (keeping `projectRoot` for its launcher-dir job); update `SpawnManager`, `SessionOrchestrator`, tests, CLI in one PR.
 3. Add `grove repo list` / `grove repo prune` CLI.
 4. Update README, QUICKSTART, GROVE.md for the `--repo` flag and the new cache location.
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@xterm/headless": "6.0.0",
     "blake3": "^1.0.2",
     "hono": "^4.12.6",
+    "proper-lockfile": "^4.1.2",
     "react": "^19.0.0",
     "yaml": "^2.8.2",
     "zod": "4.3.6"
@@ -73,6 +74,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@types/bun": "1.3.9",
+    "@types/proper-lockfile": "^4.1.4",
     "@types/react": "^19.0.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/src/cli/commands/repo.test.ts
+++ b/src/cli/commands/repo.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveRepo } from "../../core/repo-cache.js";
+import { fetchCache, listCache, pruneCache } from "./repo.js";
+
+function makeFixtureBare(): string {
+  const dir = mkdtempSync(join(tmpdir(), "grove-repo-fx-"));
+  execSync("git -c init.defaultBranch=main init --bare", { cwd: dir, stdio: "pipe" });
+  const scratch = mkdtempSync(join(tmpdir(), "grove-repo-scratch-"));
+  execSync(`git clone "${dir}" "${scratch}"`, { stdio: "pipe" });
+  execSync('git config user.email "t@t"', { cwd: scratch, stdio: "pipe" });
+  execSync('git config user.name "t"', { cwd: scratch, stdio: "pipe" });
+  execSync("git commit --allow-empty -m init", { cwd: scratch, stdio: "pipe" });
+  execSync("git push origin main", { cwd: scratch, stdio: "pipe" });
+  rmSync(scratch, { recursive: true, force: true });
+  return dir;
+}
+
+describe("grove repo CLI helpers", () => {
+  let cacheRoot: string;
+  let fixtures: string[];
+
+  beforeEach(() => {
+    cacheRoot = mkdtempSync(join(tmpdir(), "grove-repo-cli-"));
+    fixtures = [];
+  });
+
+  afterEach(() => {
+    rmSync(cacheRoot, { recursive: true, force: true });
+    for (const f of fixtures) rmSync(f, { recursive: true, force: true });
+  });
+
+  test("list returns zero entries on empty cache", async () => {
+    const entries = await listCache({ cacheRoot });
+    expect(entries).toEqual([]);
+  });
+
+  test("list returns entries after a resolve", async () => {
+    const f = makeFixtureBare();
+    fixtures.push(f);
+    await resolveRepo({ kind: "url", url: `file://${f}` }, { cacheRoot });
+
+    const entries = await listCache({ cacheRoot });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.canonicalUrl).toBe(`file://${f}`);
+    expect(entries[0]!.key).toBe(`local/${f.replace(/^\//, "")}.git`);
+  });
+
+  test("prune removes a specific entry", async () => {
+    const f = makeFixtureBare();
+    fixtures.push(f);
+    const resolved = await resolveRepo({ kind: "url", url: `file://${f}` }, { cacheRoot });
+
+    await pruneCache({ cacheRoot, key: resolved.key });
+    expect(existsSync(resolved.bareClonePath)).toBe(false);
+  });
+
+  test("prune --all removes every entry", async () => {
+    const f1 = makeFixtureBare();
+    const f2 = makeFixtureBare();
+    fixtures.push(f1, f2);
+    await resolveRepo({ kind: "url", url: `file://${f1}` }, { cacheRoot });
+    await resolveRepo({ kind: "url", url: `file://${f2}` }, { cacheRoot });
+
+    await pruneCache({ cacheRoot, all: true });
+    const entries = await listCache({ cacheRoot });
+    expect(entries).toEqual([]);
+  });
+
+  test("prune refuses when a worktree still references the entry", async () => {
+    const f = makeFixtureBare();
+    fixtures.push(f);
+    const resolved = await resolveRepo({ kind: "url", url: `file://${f}` }, { cacheRoot });
+    const wt = mkdtempSync(join(tmpdir(), "grove-repo-wt-"));
+    try {
+      execSync(`git -C "${resolved.bareClonePath}" worktree add "${wt}"`, { stdio: "pipe" });
+      await expect(pruneCache({ cacheRoot, key: resolved.key })).rejects.toThrow(/worktree/);
+      expect(existsSync(resolved.bareClonePath)).toBe(true);
+    } finally {
+      try {
+        execSync(`git -C "${resolved.bareClonePath}" worktree remove --force "${wt}"`, {
+          stdio: "pipe",
+        });
+      } catch {
+        // best-effort
+      }
+      rmSync(wt, { recursive: true, force: true });
+    }
+  });
+
+  test("fetch forces a fetch on the cache entry", async () => {
+    const f = makeFixtureBare();
+    fixtures.push(f);
+    const resolved = await resolveRepo({ kind: "url", url: `file://${f}` }, { cacheRoot });
+
+    const result = await fetchCache({ cacheRoot, key: resolved.key });
+    expect(result.fetched).toBe(true);
+  });
+});

--- a/src/cli/commands/repo.ts
+++ b/src/cli/commands/repo.ts
@@ -1,0 +1,217 @@
+/**
+ * `grove repo` subcommands — inspect and maintain the bare-clone cache.
+ */
+
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readdir, readFile, realpath, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { parseArgs, promisify } from "node:util";
+import { type ResolveRepoOptions, resolveCacheRoot, resolveRepo } from "../../core/repo-cache.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface CacheEntry {
+  readonly key: string;
+  readonly bareClonePath: string;
+  readonly canonicalUrl: string;
+  readonly aliases: readonly string[];
+  readonly createdAt: string;
+  readonly lastFetchedAt: string;
+  readonly lastAccessedAt: string;
+}
+
+async function walkEntries(cacheRoot: string): Promise<CacheEntry[]> {
+  if (!existsSync(cacheRoot)) return [];
+  const entries: CacheEntry[] = [];
+
+  async function recurse(dir: string, relParts: string[]): Promise<void> {
+    const items = await readdir(dir, { withFileTypes: true });
+    for (const item of items) {
+      if (!item.isDirectory()) continue;
+      if (item.name === ".locks") continue;
+      const child = join(dir, item.name);
+      if (item.name.endsWith(".git")) {
+        const manifestPath = join(child, ".grove-cache", "manifest.json");
+        if (!existsSync(manifestPath)) continue;
+        const manifest = JSON.parse(await readFile(manifestPath, "utf-8"));
+        entries.push({
+          key: [...relParts, item.name].join("/"),
+          bareClonePath: child,
+          canonicalUrl: manifest.canonicalUrl,
+          aliases: manifest.aliases,
+          createdAt: manifest.createdAt,
+          lastFetchedAt: manifest.lastFetchedAt,
+          lastAccessedAt: manifest.lastAccessedAt,
+        });
+      } else {
+        await recurse(child, [...relParts, item.name]);
+      }
+    }
+  }
+
+  await recurse(cacheRoot, []);
+  return entries;
+}
+
+export async function listCache(opts: { cacheRoot: string }): Promise<CacheEntry[]> {
+  return walkEntries(opts.cacheRoot);
+}
+
+export async function pruneCache(opts: {
+  cacheRoot: string;
+  key?: string;
+  all?: boolean;
+}): Promise<void> {
+  const entries = await walkEntries(opts.cacheRoot);
+  const targets = opts.all ? entries : entries.filter((e) => e.key === opts.key);
+
+  if (!opts.all && targets.length === 0) {
+    throw new Error(`no cache entry matches key: ${opts.key}`);
+  }
+
+  for (const entry of targets) {
+    // Worktree safety: if any worktree outside the bare clone itself references
+    // this entry, refuse — pruning would strand it.
+    const { stdout } = await execFileAsync("git", [
+      "-C",
+      entry.bareClonePath,
+      "worktree",
+      "list",
+      "--porcelain",
+    ]);
+    // Resolve both paths to their real (symlink-resolved) form so that macOS
+    // /var → /private/var symlinks don't cause false mismatches.
+    const realBareClonePath = await realpath(entry.bareClonePath).catch(() => entry.bareClonePath);
+    const rawPaths = stdout
+      .split("\n")
+      .filter((l) => l.startsWith("worktree "))
+      .map((l) => l.replace(/^worktree /, ""));
+    const external: string[] = [];
+    for (const p of rawPaths) {
+      const realP = await realpath(p).catch(() => p);
+      if (realP !== realBareClonePath) external.push(p);
+    }
+    if (external.length > 0) {
+      throw new Error(
+        `cannot prune ${entry.key}: ${external.length} worktree(s) still reference it:\n${external.join("\n")}`,
+      );
+    }
+    await rm(entry.bareClonePath, { recursive: true, force: true });
+  }
+
+  // Best-effort: remove the matching lockfile(s) too.
+  const locksDir = join(opts.cacheRoot, ".locks");
+  if (existsSync(locksDir)) {
+    for (const entry of targets) {
+      const lockFile = join(locksDir, `${entry.key.replace(/\//g, "__")}.lock`);
+      if (existsSync(lockFile)) await rm(lockFile, { force: true });
+    }
+  }
+}
+
+export async function fetchCache(opts: {
+  cacheRoot: string;
+  key: string;
+  resolveOpts?: Partial<ResolveRepoOptions>;
+}): Promise<{ fetched: boolean; stale: boolean }> {
+  const entries = await walkEntries(opts.cacheRoot);
+  const entry = entries.find((e) => e.key === opts.key);
+  if (!entry) throw new Error(`no cache entry matches key: ${opts.key}`);
+  const result = await resolveRepo(
+    { kind: "url", url: entry.canonicalUrl },
+    { ...(opts.resolveOpts ?? {}), cacheRoot: opts.cacheRoot, fresh: true },
+  );
+  return { fetched: result.fetched, stale: result.stale };
+}
+
+// ---------------------------------------------------------------------------
+// CLI dispatcher
+// ---------------------------------------------------------------------------
+
+function currentCacheRoot(): string {
+  const home = process.env.HOME;
+  return resolveCacheRoot({
+    env: process.env,
+    ...(home !== undefined && { home }),
+  });
+}
+
+export async function executeRepo(args: readonly string[]): Promise<void> {
+  const subcommand = args[0];
+  const rest = args.slice(1);
+
+  switch (subcommand) {
+    case "list":
+      await runList();
+      return;
+    case "prune":
+      await runPrune(rest);
+      return;
+    case "fetch":
+      await runFetch(rest);
+      return;
+    default:
+      console.log(`grove repo <subcommand>
+
+Subcommands:
+  list                       List every cached repo with manifest summary
+  prune <key>                Remove one cache entry (refuses if worktrees reference it)
+  prune --all                Remove every cache entry
+  fetch <key>                Force a fetch on an existing cache entry
+
+Cache root:
+  ${currentCacheRoot()}`);
+  }
+}
+
+async function runList(): Promise<void> {
+  const cacheRoot = currentCacheRoot();
+  const entries = await listCache({ cacheRoot });
+  if (entries.length === 0) {
+    console.log(`no cached repos (cache root: ${cacheRoot})`);
+    return;
+  }
+  for (const e of entries) {
+    console.log(e.key);
+    console.log(`  url:         ${e.canonicalUrl}`);
+    console.log(`  bareClone:   ${e.bareClonePath}`);
+    console.log(`  lastFetched: ${e.lastFetchedAt}`);
+    console.log(`  aliases:     ${e.aliases.length}`);
+  }
+}
+
+async function runPrune(args: readonly string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: [...args],
+    options: { all: { type: "boolean", default: false } },
+    allowPositionals: true,
+    strict: true,
+  });
+  const cacheRoot = currentCacheRoot();
+  if (values.all) {
+    await pruneCache({ cacheRoot, all: true });
+    console.log("pruned all cache entries");
+    return;
+  }
+  const key = positionals[0];
+  if (!key) {
+    console.error("grove repo prune: pass a key or --all");
+    process.exitCode = 1;
+    return;
+  }
+  await pruneCache({ cacheRoot, key });
+  console.log(`pruned ${key}`);
+}
+
+async function runFetch(args: readonly string[]): Promise<void> {
+  const key = args[0];
+  if (!key) {
+    console.error("grove repo fetch: pass a cache key (see `grove repo list`)");
+    process.exitCode = 1;
+    return;
+  }
+  const cacheRoot = currentCacheRoot();
+  const result = await fetchCache({ cacheRoot, key });
+  console.log(`fetch ${key}: fetched=${result.fetched} stale=${result.stale}`);
+}

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -23,6 +23,7 @@ import type { AgentTopology } from "../../core/topology.js";
 import { resolveTopology } from "../../core/topology-resolver.js";
 import { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
 import { outputJson, outputJsonError } from "../format.js";
+import { buildRepos } from "../utils/build-repos.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -70,6 +71,7 @@ async function sessionStart(args: readonly string[]): Promise<void> {
       preset: { type: "string" },
       roles: { type: "string" },
       runtime: { type: "string", default: "mock" },
+      repo: { type: "string", multiple: true },
     },
     strict: false,
   });
@@ -95,6 +97,19 @@ async function sessionStart(args: readonly string[]): Promise<void> {
 
   const groveRoot = resolve(groveDir, "..");
   const contractPath = join(groveRoot, "GROVE.md");
+
+  const rawRepo = (values.repo as readonly string[] | undefined) ?? [];
+  let repos: readonly import("../../core/repo-ref.js").RepoRef[];
+  try {
+    repos = buildRepos({ rawRepo, cwd: groveRoot });
+  } catch (err) {
+    outputJsonError({
+      code: "VALIDATION_ERROR",
+      message: err instanceof Error ? err.message : String(err),
+    });
+    process.exitCode = 1;
+    return;
+  }
 
   let contract: GroveContract | undefined;
   if (existsSync(contractPath)) {
@@ -254,7 +269,7 @@ async function sessionStart(args: readonly string[]): Promise<void> {
       runtime,
       eventBus,
       projectRoot: groveRoot,
-      repos: [{ kind: "local", path: groveRoot }],
+      repos,
       workspaceBaseDir: join(groveDir, "workspaces"),
       sessionId: session.id,
       contributionStore,

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -254,6 +254,7 @@ async function sessionStart(args: readonly string[]): Promise<void> {
       runtime,
       eventBus,
       projectRoot: groveRoot,
+      repos: [{ kind: "local", path: groveRoot }],
       workspaceBaseDir: join(groveDir, "workspaces"),
       sessionId: session.id,
       contributionStore,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -351,6 +351,15 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "repo",
+      description: "Inspect and maintain the bare-clone repo cache",
+      needsStore: false,
+      handler: async (args) => {
+        const { executeRepo } = await import("./commands/repo.js");
+        await executeRepo(args);
+      },
+    },
+    {
       name: "tui",
       description: "Operator TUI dashboard",
       needsStore: false,

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -233,6 +233,20 @@ export const COMMANDS: readonly CommandMeta[] = [
     ],
   },
   {
+    name: "repo",
+    description: "Inspect and maintain the bare-clone repo cache",
+    flags: [],
+    subcommands: [
+      { name: "list", description: "List every cached repo with manifest summary", flags: [] },
+      {
+        name: "prune",
+        description: "Remove one or all cache entries",
+        flags: ["all"],
+      },
+      { name: "fetch", description: "Force a fetch on an existing cache entry", flags: [] },
+    ],
+  },
+  {
     name: "tui",
     description: "Operator TUI dashboard",
     flags: ["interval", "url", "nexus", "grove", "help"],

--- a/src/cli/utils/build-repos.test.ts
+++ b/src/cli/utils/build-repos.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { buildRepos } from "./build-repos.js";
+
+describe("buildRepos", () => {
+  test("one --repo url value → url RepoRef", () => {
+    const result = buildRepos({
+      rawRepo: ["https://github.com/foo/bar"],
+      cwd: "/abs/cwd",
+    });
+    expect(result).toEqual([{ kind: "url", url: "https://github.com/foo/bar" }]);
+  });
+
+  test("one --repo absolute-path value → local RepoRef", () => {
+    const result = buildRepos({
+      rawRepo: ["/abs/path/to/repo"],
+      cwd: "/abs/cwd",
+    });
+    expect(result).toEqual([{ kind: "local", path: "/abs/path/to/repo" }]);
+  });
+
+  test("one --repo relative-path value → local RepoRef", () => {
+    const result = buildRepos({
+      rawRepo: ["./sibling"],
+      cwd: "/abs/cwd",
+    });
+    expect(result).toEqual([{ kind: "local", path: "./sibling" }]);
+  });
+
+  test("two --repo values → throws multi-repo", () => {
+    expect(() =>
+      buildRepos({
+        rawRepo: ["https://github.com/foo/bar", "https://github.com/baz/qux"],
+        cwd: "/abs/cwd",
+      }),
+    ).toThrow(/multi-repo sessions/);
+  });
+
+  test("no --repo + cwd is a git repo → local RepoRef at cwd", () => {
+    const result = buildRepos({
+      rawRepo: [],
+      cwd: "/abs/cwd",
+      isGitRepo: () => true,
+    });
+    expect(result).toEqual([{ kind: "local", path: "/abs/cwd" }]);
+  });
+
+  test("no --repo + cwd not a git repo → throws actionable error", () => {
+    expect(() =>
+      buildRepos({
+        rawRepo: [],
+        cwd: "/abs/not-a-repo",
+        isGitRepo: () => false,
+      }),
+    ).toThrow(/run grove from inside a git repo/);
+  });
+});

--- a/src/cli/utils/build-repos.ts
+++ b/src/cli/utils/build-repos.ts
@@ -1,0 +1,44 @@
+/**
+ * Build the session-level `repos` array from CLI `--repo` flag values.
+ *
+ * Rules:
+ * - Zero `--repo` values: default to a local RepoRef at `cwd`. Require that
+ *   `cwd` is a git repo; throw otherwise with a message pointing at `--repo`.
+ * - Exactly one `--repo` value: parse it as local (leading `/` or `.`) or URL.
+ * - Two or more `--repo` values: throw — multi-repo sessions land in a
+ *   later sub-spec.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { RepoRef } from "../../core/repo-ref.js";
+
+export interface BuildReposInputs {
+  readonly rawRepo: readonly string[];
+  readonly cwd: string;
+  readonly isGitRepo?: (path: string) => boolean;
+}
+
+export function buildRepos(inputs: BuildReposInputs): readonly RepoRef[] {
+  const { rawRepo, cwd } = inputs;
+  const isGitRepo = inputs.isGitRepo ?? ((p: string) => existsSync(join(p, ".git")));
+
+  if (rawRepo.length > 1) {
+    throw new Error(
+      "multi-repo sessions are not yet supported (see sub-spec for #202). Pass at most one --repo.",
+    );
+  }
+
+  if (rawRepo.length === 1) {
+    const raw = rawRepo[0]!;
+    if (raw.startsWith("/") || raw.startsWith(".")) {
+      return [{ kind: "local", path: raw }];
+    }
+    return [{ kind: "url", url: raw }];
+  }
+
+  if (!isGitRepo(cwd)) {
+    throw new Error("run grove from inside a git repo, or pass --repo <url>");
+  }
+  return [{ kind: "local", path: cwd }];
+}

--- a/src/core/platform-integration.test.ts
+++ b/src/core/platform-integration.test.ts
@@ -148,6 +148,7 @@ describe("Issue 207 — full platform/model integration", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
     });
@@ -190,6 +191,7 @@ describe("Issue 207 — full platform/model integration", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
     });
@@ -229,6 +231,7 @@ describe("Issue 207 — full platform/model integration", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
       profiles: [

--- a/src/core/repo-cache.test.ts
+++ b/src/core/repo-cache.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveCacheRoot, resolveRepo } from "./repo-cache.js";
+
+function makeFixtureRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "grove-rc-fx-"));
+  execSync("git init --bare", { cwd: dir, stdio: "pipe" });
+  // Push an initial commit via a scratch clone
+  const scratch = mkdtempSync(join(tmpdir(), "grove-rc-scratch-"));
+  execSync(`git clone "${dir}" "${scratch}"`, { stdio: "pipe" });
+  execSync('git config user.email "t@t"', { cwd: scratch, stdio: "pipe" });
+  execSync('git config user.name "t"', { cwd: scratch, stdio: "pipe" });
+  execSync("git commit --allow-empty -m init", { cwd: scratch, stdio: "pipe" });
+  execSync("git branch -M main", { cwd: scratch, stdio: "pipe" });
+  execSync("git push origin main", { cwd: scratch, stdio: "pipe" });
+  rmSync(scratch, { recursive: true, force: true });
+  return dir;
+}
 
 describe("resolveCacheRoot", () => {
   test("honors GROVE_REPO_CACHE when set", () => {
@@ -55,6 +70,35 @@ describe("resolveRepo — local path without origin", () => {
       }
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveRepo — fresh clone", () => {
+  test("clones into cache, writes .ok, manifest, last-fetch", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const result = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+
+      expect(result.fetched).toBe(true);
+      expect(result.stale).toBe(false);
+      expect(result.key).toBe(`local/${fixture.replace(/^\//, "")}.git`);
+      expect(existsSync(join(result.bareClonePath, "HEAD"))).toBe(true);
+      expect(existsSync(join(result.bareClonePath, ".grove-cache", ".ok"))).toBe(true);
+      expect(existsSync(join(result.bareClonePath, ".grove-cache", "last-fetch"))).toBe(true);
+
+      const manifest = JSON.parse(
+        readFileSync(join(result.bareClonePath, ".grove-cache", "manifest.json"), "utf-8"),
+      );
+      expect(manifest.canonicalUrl).toBe(`file://${fixture}`);
+      expect(manifest.aliases).toEqual([`file://${fixture}`]);
+      expect(typeof manifest.createdAt).toBe("string");
+      expect(typeof manifest.lastFetchedAt).toBe("string");
+      expect(typeof manifest.lastAccessedAt).toBe("string");
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
     }
   });
 });

--- a/src/core/repo-cache.test.ts
+++ b/src/core/repo-cache.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { resolveCacheRoot } from "./repo-cache.js";
+import { resolveCacheRoot, resolveRepo } from "./repo-cache.js";
 
 describe("resolveCacheRoot", () => {
   test("honors GROVE_REPO_CACHE when set", () => {
@@ -28,5 +31,30 @@ describe("resolveCacheRoot", () => {
   test("rejects empty HOME with no env overrides", () => {
     const env = {} as NodeJS.ProcessEnv;
     expect(() => resolveCacheRoot({ env, home: "" })).toThrow(/HOME/);
+  });
+});
+
+describe("resolveRepo — local path without origin", () => {
+  test("returns the local path verbatim and skips the cache", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grove-rc-local-"));
+    try {
+      execSync("git init", { cwd: dir, stdio: "pipe" });
+      execSync('git config user.email "t@t"', { cwd: dir, stdio: "pipe" });
+      execSync('git config user.name "t"', { cwd: dir, stdio: "pipe" });
+      execSync("git commit --allow-empty -m init", { cwd: dir, stdio: "pipe" });
+
+      const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+      try {
+        const result = await resolveRepo({ kind: "local", path: dir }, { cacheRoot });
+        expect(result.bareClonePath).toBe(dir);
+        expect(result.fetched).toBe(false);
+        expect(result.stale).toBe(false);
+        expect(result.key).toBe("local");
+      } finally {
+        rmSync(cacheRoot, { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/core/repo-cache.test.ts
+++ b/src/core/repo-cache.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { resolveCacheRoot } from "./repo-cache.js";
+
+describe("resolveCacheRoot", () => {
+  test("honors GROVE_REPO_CACHE when set", () => {
+    const env = { GROVE_REPO_CACHE: "/tmp/custom-cache" } as NodeJS.ProcessEnv;
+    expect(resolveCacheRoot({ env })).toBe("/tmp/custom-cache");
+  });
+
+  test("honors explicit option over env", () => {
+    const env = { GROVE_REPO_CACHE: "/tmp/env-cache" } as NodeJS.ProcessEnv;
+    expect(resolveCacheRoot({ env, override: "/tmp/opt-cache" })).toBe("/tmp/opt-cache");
+  });
+
+  test("uses XDG_CACHE_HOME when set", () => {
+    const env = { XDG_CACHE_HOME: "/xdg/cache" } as NodeJS.ProcessEnv;
+    expect(resolveCacheRoot({ env, home: "/home/me" })).toBe("/xdg/cache/grove/repo-cache");
+  });
+
+  test("falls back to ~/.cache/grove/repo-cache", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    expect(resolveCacheRoot({ env, home: "/home/me" })).toBe(
+      join("/home/me", ".cache/grove/repo-cache"),
+    );
+  });
+
+  test("rejects empty HOME with no env overrides", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    expect(() => resolveCacheRoot({ env, home: "" })).toThrow(/HOME/);
+  });
+});

--- a/src/core/repo-cache.test.ts
+++ b/src/core/repo-cache.test.ts
@@ -230,3 +230,31 @@ describe("resolveRepo — corruption recovery", () => {
     }
   });
 });
+
+describe("resolveRepo — timeout", () => {
+  test("clone timeout throws and leaves the entry recoverable", async () => {
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      // Use a non-existent remote to force a slow git failure; 1ms timeout ensures abort.
+      await expect(
+        resolveRepo(
+          { kind: "url", url: "https://example.invalid/does/not/exist" },
+          { cacheRoot, timeoutMs: 1 },
+        ),
+      ).rejects.toBeDefined();
+
+      // Next call (with a working fixture) must still succeed — the failed
+      // cacheDir must either not exist or be recoverable.
+      const fixture = makeFixtureRepo();
+      try {
+        // Different URL → different cache entry; just prove the cache root itself is usable.
+        const result = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+        expect(result.fetched).toBe(true);
+      } finally {
+        rmSync(fixture, { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/repo-cache.test.ts
+++ b/src/core/repo-cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveCacheRoot, resolveRepo } from "./repo-cache.js";
@@ -96,6 +96,74 @@ describe("resolveRepo — fresh clone", () => {
       expect(typeof manifest.createdAt).toBe("string");
       expect(typeof manifest.lastFetchedAt).toBe("string");
       expect(typeof manifest.lastAccessedAt).toBe("string");
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveRepo — cache hit", () => {
+  test("second call within TTL does not fetch", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const first = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      expect(first.fetched).toBe(true);
+
+      const second = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      expect(second.fetched).toBe(false);
+      expect(second.stale).toBe(false);
+      expect(second.bareClonePath).toBe(first.bareClonePath);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  test("TTL expiry triggers fetch", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const first = await resolveRepo(
+        { kind: "url", url: `file://${fixture}` },
+        { cacheRoot, fetchTtlMs: 0 },
+      );
+      expect(first.fetched).toBe(true);
+
+      // Backdate last-fetch by 10s
+      const lastFetch = join(first.bareClonePath, ".grove-cache", "last-fetch");
+      const past = new Date(Date.now() - 10_000);
+      utimesSync(lastFetch, past, past);
+
+      const second = await resolveRepo(
+        { kind: "url", url: `file://${fixture}` },
+        { cacheRoot, fetchTtlMs: 1000 },
+      );
+      expect(second.fetched).toBe(true);
+      expect(second.stale).toBe(false);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  test("appends new alias on URL-form change", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      await resolveRepo({ kind: "url", url: `file://${fixture}/` }, { cacheRoot }); // trailing slash → same key
+
+      const manifestPath = join(
+        cacheRoot,
+        `local/${fixture.replace(/^\//, "")}.git`,
+        ".grove-cache",
+        "manifest.json",
+      );
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+      expect(manifest.aliases).toContain(`file://${fixture}`);
+      expect(manifest.aliases).toContain(`file://${fixture}/`);
     } finally {
       rmSync(cacheRoot, { recursive: true, force: true });
       rmSync(fixture, { recursive: true, force: true });

--- a/src/core/repo-cache.test.ts
+++ b/src/core/repo-cache.test.ts
@@ -7,7 +7,7 @@ import { resolveCacheRoot, resolveRepo } from "./repo-cache.js";
 
 function makeFixtureRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), "grove-rc-fx-"));
-  execSync("git init --bare", { cwd: dir, stdio: "pipe" });
+  execSync("git -c init.defaultBranch=main init --bare", { cwd: dir, stdio: "pipe" });
   // Push an initial commit via a scratch clone
   const scratch = mkdtempSync(join(tmpdir(), "grove-rc-scratch-"));
   execSync(`git clone "${dir}" "${scratch}"`, { stdio: "pipe" });

--- a/src/core/repo-cache.test.ts
+++ b/src/core/repo-cache.test.ts
@@ -170,3 +170,40 @@ describe("resolveRepo — cache hit", () => {
     }
   });
 });
+
+describe("resolveRepo — fresh hard-fail", () => {
+  test("opts.fresh + unreachable remote throws", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      // Prime the cache against the fixture.
+      await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      // Nuke the fixture so the next fetch fails.
+      rmSync(fixture, { recursive: true, force: true });
+
+      await expect(
+        resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot, fresh: true }),
+      ).rejects.toThrow(/--fresh fetch failed/);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("stale path (no --fresh) proceeds with stale=true when fetch fails", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      rmSync(fixture, { recursive: true, force: true });
+
+      const result = await resolveRepo(
+        { kind: "url", url: `file://${fixture}` },
+        { cacheRoot, fetchTtlMs: 0 },
+      );
+      expect(result.stale).toBe(true);
+      expect(result.fetched).toBe(false);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/repo-cache.test.ts
+++ b/src/core/repo-cache.test.ts
@@ -258,3 +258,25 @@ describe("resolveRepo — timeout", () => {
     }
   });
 });
+
+describe("resolveRepo — concurrency", () => {
+  test("five concurrent callers produce one clone + four hits", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const results = await Promise.all(
+        Array.from({ length: 5 }, () =>
+          resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot }),
+        ),
+      );
+      const fetched = results.filter((r) => r.fetched).length;
+      expect(fetched).toBe(1);
+      for (const r of results) {
+        expect(r.bareClonePath).toBe(results[0]!.bareClonePath);
+      }
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/repo-cache.test.ts
+++ b/src/core/repo-cache.test.ts
@@ -280,3 +280,23 @@ describe("resolveRepo — concurrency", () => {
     }
   });
 });
+
+describe("resolveRepo — local with origin", () => {
+  test("reads origin and caches via URL path", async () => {
+    const fixture = makeFixtureRepo();
+    const workTree = mkdtempSync(join(tmpdir(), "grove-rc-wt-"));
+    execSync(`git clone "${fixture}" "${workTree}"`, { stdio: "pipe" });
+
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const result = await resolveRepo({ kind: "local", path: workTree }, { cacheRoot });
+      expect(result.fetched).toBe(true);
+      expect(result.bareClonePath).not.toBe(workTree);
+      expect(result.bareClonePath.startsWith(cacheRoot)).toBe(true);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(workTree, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/repo-cache.test.ts
+++ b/src/core/repo-cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, utimesSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveCacheRoot, resolveRepo } from "./repo-cache.js";
@@ -204,6 +204,29 @@ describe("resolveRepo — fresh hard-fail", () => {
       expect(result.fetched).toBe(false);
     } finally {
       rmSync(cacheRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveRepo — corruption recovery", () => {
+  test("absent .ok triggers nuke + re-clone", async () => {
+    const fixture = makeFixtureRepo();
+    const cacheRoot = mkdtempSync(join(tmpdir(), "grove-rc-cache-"));
+    try {
+      const first = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      expect(first.fetched).toBe(true);
+
+      // Simulate crash: remove .ok, leave garbage behind.
+      rmSync(join(first.bareClonePath, ".grove-cache", ".ok"));
+      writeFileSync(join(first.bareClonePath, "garbage"), "x");
+
+      const second = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+      expect(second.fetched).toBe(true);
+      expect(existsSync(join(second.bareClonePath, "garbage"))).toBe(false);
+      expect(existsSync(join(second.bareClonePath, ".grove-cache", ".ok"))).toBe(true);
+    } finally {
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(fixture, { recursive: true, force: true });
     }
   });
 });

--- a/src/core/repo-cache.ts
+++ b/src/core/repo-cache.ts
@@ -173,11 +173,6 @@ export async function resolveRepo(
       await runGit(["clone", "--bare", ref.url, cacheDir], {
         timeoutMs: opts.timeoutMs ?? 300_000,
       });
-      // Ensure the remote has a fetch refspec so future `git fetch --all` works
-      // (bare clones via file:// may omit it when the upstream HEAD is ambiguous).
-      await runGit(["config", "--add", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"], {
-        cwd: cacheDir,
-      });
       await mkdir(metaDir, { recursive: true });
       const now = new Date().toISOString();
       const manifest: Manifest = {

--- a/src/core/repo-cache.ts
+++ b/src/core/repo-cache.ts
@@ -10,7 +10,7 @@
 
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import lockfile from "proper-lockfile";
@@ -173,6 +173,11 @@ export async function resolveRepo(
       await runGit(["clone", "--bare", ref.url, cacheDir], {
         timeoutMs: opts.timeoutMs ?? 300_000,
       });
+      // Ensure the remote has a fetch refspec so future `git fetch --all` works
+      // (bare clones via file:// may omit it when the upstream HEAD is ambiguous).
+      await runGit(["config", "--add", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"], {
+        cwd: cacheDir,
+      });
       await mkdir(metaDir, { recursive: true });
       const now = new Date().toISOString();
       const manifest: Manifest = {
@@ -188,8 +193,45 @@ export async function resolveRepo(
       return { ref, bareClonePath: cacheDir, key, fetched: true, stale: false };
     }
 
-    // Cache-hit path fills in Task 6.
-    throw new Error("resolveRepo: cache-hit path not yet implemented");
+    // Cache hit. Update manifest (alias + lastAccessedAt).
+    const manifestPath = join(metaDir, "manifest.json");
+    const manifest: Manifest = JSON.parse(await readFile(manifestPath, "utf-8"));
+    const now = new Date().toISOString();
+    manifest.lastAccessedAt = now;
+    if (!manifest.aliases.includes(ref.url)) manifest.aliases.push(ref.url);
+
+    const ttlMs = opts.fetchTtlMs ?? 60_000;
+    const lastFetchStat = await stat(join(metaDir, "last-fetch"));
+    const ageMs = Date.now() - lastFetchStat.mtimeMs;
+    const mustFetch = opts.fresh === true || ageMs > ttlMs;
+
+    let fetched = false;
+    let stale = false;
+
+    if (mustFetch) {
+      try {
+        await runGit(["fetch", "--all", "--prune"], {
+          cwd: cacheDir,
+          timeoutMs: opts.timeoutMs ?? 300_000,
+        });
+        const fetchTime = new Date();
+        await writeFile(join(metaDir, "last-fetch"), "", "utf-8"); // ensure file exists
+        await utimes(join(metaDir, "last-fetch"), fetchTime, fetchTime);
+        manifest.lastFetchedAt = fetchTime.toISOString();
+        fetched = true;
+      } catch (err) {
+        if (opts.fresh === true) {
+          await writeManifest(metaDir, manifest);
+          throw new Error(
+            `resolveRepo: --fresh fetch failed for ${ref.url}: ${(err as Error).message}`,
+          );
+        }
+        stale = true;
+      }
+    }
+
+    await writeManifest(metaDir, manifest);
+    return { ref, bareClonePath: cacheDir, key, fetched, stale };
   } finally {
     await release();
   }

--- a/src/core/repo-cache.ts
+++ b/src/core/repo-cache.ts
@@ -9,9 +9,13 @@
  */
 
 import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import lockfile from "proper-lockfile";
 import type { RepoRef } from "./repo-ref.js";
+import { deriveCachePath, normalizeUrl } from "./repo-ref.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -76,6 +80,50 @@ async function readOriginUrl(localPath: string): Promise<string | null> {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface Manifest {
+  canonicalUrl: string;
+  aliases: string[];
+  createdAt: string;
+  lastFetchedAt: string;
+  lastAccessedAt: string;
+}
+
+function encodeLockName(key: string): string {
+  return key.replace(/\//g, "__");
+}
+
+async function runGit(
+  args: readonly string[],
+  opts: { cwd?: string; timeoutMs?: number } = {},
+): Promise<void> {
+  const controller = new AbortController();
+  const timer = opts.timeoutMs ? setTimeout(() => controller.abort(), opts.timeoutMs) : undefined;
+  try {
+    await execFileAsync("git", args as string[], {
+      cwd: opts.cwd,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+      signal: controller.signal,
+    });
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function writeManifest(dir: string, manifest: Manifest): Promise<void> {
+  await writeFile(join(dir, "manifest.json"), JSON.stringify(manifest, null, 2), "utf-8");
+}
+
+async function writeOkSentinel(metaDir: string): Promise<void> {
+  const tmp = join(metaDir, ".ok.tmp");
+  const final = join(metaDir, ".ok");
+  await writeFile(tmp, "", "utf-8");
+  await rename(tmp, final);
+}
+
+// ---------------------------------------------------------------------------
 // resolveRepo
 // ---------------------------------------------------------------------------
 
@@ -97,5 +145,57 @@ export async function resolveRepo(
     // origin-present case handled in Task 11 — delegate to URL path
     return resolveRepo({ kind: "url", url: origin }, opts);
   }
-  throw new Error("resolveRepo: URL path not yet implemented");
+
+  const cacheRoot = resolveCacheRoot({
+    env: process.env,
+    ...(process.env.HOME !== undefined && { home: process.env.HOME }),
+    ...(opts.cacheRoot !== undefined && { override: opts.cacheRoot }),
+  });
+  const normalized = normalizeUrl(ref.url);
+  const key = deriveCachePath(normalized);
+  const cacheDir = join(cacheRoot, key);
+  const metaDir = join(cacheDir, ".grove-cache");
+  const locksDir = join(cacheRoot, ".locks");
+  const lockFile = join(locksDir, `${encodeLockName(key)}.lock`);
+
+  await mkdir(locksDir, { recursive: true });
+  // proper-lockfile requires the target to exist
+  if (!existsSync(lockFile)) await writeFile(lockFile, "", "utf-8");
+
+  const release = await lockfile.lock(lockFile, {
+    retries: { retries: 50, minTimeout: 50, maxTimeout: 500 },
+  });
+  try {
+    const okPath = join(metaDir, ".ok");
+    const okPresent = existsSync(okPath);
+
+    if (!okPresent) {
+      // Fresh clone (or recovery from a prior crash; Task 8 covers recovery branch).
+      if (existsSync(cacheDir)) {
+        await rm(cacheDir, { recursive: true, force: true });
+      }
+      await mkdir(cacheDir, { recursive: true });
+      await runGit(["clone", "--bare", ref.url, cacheDir], {
+        timeoutMs: opts.timeoutMs ?? 300_000,
+      });
+      await mkdir(metaDir, { recursive: true });
+      const now = new Date().toISOString();
+      const manifest: Manifest = {
+        canonicalUrl: ref.url,
+        aliases: [ref.url],
+        createdAt: now,
+        lastFetchedAt: now,
+        lastAccessedAt: now,
+      };
+      await writeManifest(metaDir, manifest);
+      await writeFile(join(metaDir, "last-fetch"), "", "utf-8");
+      await writeOkSentinel(metaDir);
+      return { ref, bareClonePath: cacheDir, key, fetched: true, stale: false };
+    }
+
+    // Cache-hit path fills in Task 6.
+    throw new Error("resolveRepo: cache-hit path not yet implemented");
+  } finally {
+    await release();
+  }
 }

--- a/src/core/repo-cache.ts
+++ b/src/core/repo-cache.ts
@@ -1,0 +1,63 @@
+/**
+ * Bare-clone repo cache.
+ *
+ * Exposes one primary function, `resolveRepo`, which materializes a
+ * RepoRef into a bare clone on disk and returns the path. Clones and
+ * fetches are serialized per cache entry via `proper-lockfile`; lock
+ * files live at `<cacheRoot>/.locks/` (outside the cache entry) so
+ * corruption recovery cannot unlink a held lock.
+ */
+
+import { join } from "node:path";
+import type { RepoRef } from "./repo-ref.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ResolveRepoOptions {
+  readonly fresh?: boolean;
+  readonly cacheRoot?: string;
+  readonly fetchTtlMs?: number;
+  readonly timeoutMs?: number;
+}
+
+export interface ResolvedRepo {
+  readonly ref: RepoRef;
+  readonly bareClonePath: string;
+  readonly key: string;
+  readonly fetched: boolean;
+  readonly stale: boolean;
+}
+
+interface CacheRootInputs {
+  readonly env: NodeJS.ProcessEnv;
+  readonly home?: string;
+  readonly override?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Cache-root resolution
+// ---------------------------------------------------------------------------
+
+export function resolveCacheRoot(inputs: CacheRootInputs): string {
+  if (inputs.override) return inputs.override;
+  const explicit = inputs.env.GROVE_REPO_CACHE;
+  if (explicit && explicit.length > 0) return explicit;
+  const xdg = inputs.env.XDG_CACHE_HOME;
+  if (xdg && xdg.length > 0) return join(xdg, "grove", "repo-cache");
+  const home = inputs.home;
+  if (!home) throw new Error("cannot resolve cache root: no HOME and no XDG_CACHE_HOME");
+  return join(home, ".cache", "grove", "repo-cache");
+}
+
+// ---------------------------------------------------------------------------
+// resolveRepo — stub (filled in subsequent tasks)
+// ---------------------------------------------------------------------------
+
+export async function resolveRepo(
+  _ref: RepoRef,
+  _opts?: ResolveRepoOptions,
+): Promise<ResolvedRepo> {
+  throw new Error("resolveRepo: not implemented");
+}

--- a/src/core/repo-cache.ts
+++ b/src/core/repo-cache.ts
@@ -8,7 +8,9 @@
  * corruption recovery cannot unlink a held lock.
  */
 
+import { execFile } from "node:child_process";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import type { RepoRef } from "./repo-ref.js";
 
 // ---------------------------------------------------------------------------
@@ -52,12 +54,48 @@ export function resolveCacheRoot(inputs: CacheRootInputs): string {
 }
 
 // ---------------------------------------------------------------------------
-// resolveRepo — stub (filled in subsequent tasks)
+// Helpers
+// ---------------------------------------------------------------------------
+
+const execFileAsync = promisify(execFile);
+
+async function readOriginUrl(localPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", localPath, "remote", "get-url", "origin"],
+      {
+        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+      },
+    );
+    const url = stdout.trim();
+    return url.length > 0 ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// resolveRepo
 // ---------------------------------------------------------------------------
 
 export async function resolveRepo(
-  _ref: RepoRef,
-  _opts?: ResolveRepoOptions,
+  ref: RepoRef,
+  opts: ResolveRepoOptions = {},
 ): Promise<ResolvedRepo> {
-  throw new Error("resolveRepo: not implemented");
+  if (ref.kind === "local") {
+    const origin = await readOriginUrl(ref.path);
+    if (origin === null) {
+      return {
+        ref,
+        bareClonePath: ref.path,
+        key: "local",
+        fetched: false,
+        stale: false,
+      };
+    }
+    // origin-present case handled in Task 11 — delegate to URL path
+    return resolveRepo({ kind: "url", url: origin }, opts);
+  }
+  throw new Error("resolveRepo: URL path not yet implemented");
 }

--- a/src/core/repo-cache.ts
+++ b/src/core/repo-cache.ts
@@ -79,10 +79,6 @@ async function readOriginUrl(localPath: string): Promise<string | null> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 interface Manifest {
   canonicalUrl: string;
   aliases: string[];
@@ -159,8 +155,7 @@ export async function resolveRepo(
   const lockFile = join(locksDir, `${encodeLockName(key)}.lock`);
 
   await mkdir(locksDir, { recursive: true });
-  // proper-lockfile requires the target to exist
-  if (!existsSync(lockFile)) await writeFile(lockFile, "", "utf-8");
+  await writeFile(lockFile, "", { flag: "a" });
 
   const release = await lockfile.lock(lockFile, {
     retries: { retries: 50, minTimeout: 50, maxTimeout: 500 },

--- a/src/core/repo-ref.test.ts
+++ b/src/core/repo-ref.test.ts
@@ -41,6 +41,40 @@ describe("normalizeUrl", () => {
   test("rejects non-absolute local path", () => {
     expect(() => normalizeUrl("relative/path/repo")).toThrow(/absolute/);
   });
+
+  test("rejects URL with null byte", () => {
+    expect(() => normalizeUrl("https://github.com/foo/bar\x00baz")).toThrow(/null byte/);
+  });
+
+  test("rejects URL with backslash", () => {
+    expect(() => normalizeUrl("https://github.com/foo\\bar")).toThrow(/backslash/);
+  });
+
+  test("rejects percent-encoded `..` traversal", () => {
+    expect(() => normalizeUrl("https://github.com/foo/%2e%2e/bar")).toThrow(/traversal/);
+  });
+
+  test("rejects percent-encoded null byte", () => {
+    expect(() => normalizeUrl("https://github.com/foo/bar%00baz")).toThrow(/null byte/);
+  });
+
+  test("rejects percent-encoded slash (%2F) producing empty segment or traversal", () => {
+    expect(() => normalizeUrl("https://github.com/foo/%2F..%2Fetc")).toThrow(
+      /empty segment|traversal/,
+    );
+  });
+
+  test("rejects malformed percent-encoding", () => {
+    expect(() => normalizeUrl("https://github.com/foo/%ZZ")).toThrow(/percent-encoding/);
+  });
+
+  test("rejects local path with null byte", () => {
+    expect(() => normalizeUrl("/abs/path/\x00secret")).toThrow(/null byte/);
+  });
+
+  test("rejects file:// URL with backslash", () => {
+    expect(() => normalizeUrl("file:///abs/path\\windows")).toThrow(/backslash/);
+  });
 });
 
 describe("deriveCachePath", () => {

--- a/src/core/repo-ref.test.ts
+++ b/src/core/repo-ref.test.ts
@@ -79,6 +79,14 @@ describe("normalizeUrl", () => {
   test("rejects double-colon SCP (git@host:port:path)", () => {
     expect(() => normalizeUrl("git@github.com:22:foo/bar")).toThrow(/colon in segment/);
   });
+
+  test("rejects dotdot hostname (SCP)", () => {
+    expect(() => normalizeUrl("git@..:foo/bar")).toThrow(/traversal in hostname/);
+  });
+
+  test("rejects dotdot hostname (HTTPS)", () => {
+    expect(() => normalizeUrl("https://../foo/bar")).toThrow(/traversal in hostname/);
+  });
 });
 
 describe("deriveCachePath", () => {

--- a/src/core/repo-ref.test.ts
+++ b/src/core/repo-ref.test.ts
@@ -75,6 +75,10 @@ describe("normalizeUrl", () => {
   test("rejects file:// URL with backslash", () => {
     expect(() => normalizeUrl("file:///abs/path\\windows")).toThrow(/backslash/);
   });
+
+  test("rejects double-colon SCP (git@host:port:path)", () => {
+    expect(() => normalizeUrl("git@github.com:22:foo/bar")).toThrow(/colon in segment/);
+  });
 });
 
 describe("deriveCachePath", () => {

--- a/src/core/repo-ref.test.ts
+++ b/src/core/repo-ref.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { deriveCachePath, type NormalizedRepo, normalizeUrl, type RepoRef } from "./repo-ref.js";
+
+describe("normalizeUrl", () => {
+  const cases: ReadonlyArray<readonly [string, NormalizedRepo]> = [
+    ["git@github.com:foo/bar.git", { host: "github.com", path: "foo/bar" }],
+    ["git@github.com:foo/bar", { host: "github.com", path: "foo/bar" }],
+    ["https://github.com/foo/bar", { host: "github.com", path: "foo/bar" }],
+    ["https://github.com/foo/bar.git", { host: "github.com", path: "foo/bar" }],
+    ["https://github.com/foo/bar/", { host: "github.com", path: "foo/bar" }],
+    ["https://GitHub.com/Foo/Bar.git", { host: "github.com", path: "Foo/Bar" }],
+    ["https://user@github.com/foo/bar", { host: "github.com", path: "foo/bar" }],
+    ["ssh://git@gitlab.com/group/sub/p.git", { host: "gitlab.com", path: "group/sub/p" }],
+    ["file:///abs/path/to/repo", { host: "local", path: "abs/path/to/repo" }],
+    ["/abs/path/to/repo", { host: "local", path: "abs/path/to/repo" }],
+    ["/abs/path/to/repo.git", { host: "local", path: "abs/path/to/repo" }],
+  ];
+
+  for (const [input, expected] of cases) {
+    test(`"${input}" normalizes correctly`, () => {
+      expect(normalizeUrl(input)).toEqual(expected);
+    });
+  }
+
+  test("rejects path with `..` traversal", () => {
+    expect(() => normalizeUrl("https://github.com/foo/../bar")).toThrow(/traversal/);
+  });
+
+  test("rejects path with leading-dot component", () => {
+    expect(() => normalizeUrl("https://github.com/foo/.hidden/bar")).toThrow(/leading dot/);
+  });
+
+  test("rejects empty host", () => {
+    expect(() => normalizeUrl("https:///foo/bar")).toThrow(/host/);
+  });
+
+  test("rejects empty path", () => {
+    expect(() => normalizeUrl("https://github.com/")).toThrow(/path/);
+  });
+
+  test("rejects non-absolute local path", () => {
+    expect(() => normalizeUrl("relative/path/repo")).toThrow(/absolute/);
+  });
+});
+
+describe("deriveCachePath", () => {
+  test("produces host/path.git layout", () => {
+    expect(deriveCachePath({ host: "github.com", path: "foo/bar" })).toBe("github.com/foo/bar.git");
+  });
+
+  test("preserves nested path segments", () => {
+    expect(deriveCachePath({ host: "gitlab.com", path: "group/sub/p" })).toBe(
+      "gitlab.com/group/sub/p.git",
+    );
+  });
+
+  test("local namespace", () => {
+    expect(deriveCachePath({ host: "local", path: "abs/path/to/repo" })).toBe(
+      "local/abs/path/to/repo.git",
+    );
+  });
+});
+
+describe("RepoRef", () => {
+  test("discriminated union compiles", () => {
+    const a: RepoRef = { kind: "local", path: "/tmp/x" };
+    const b: RepoRef = { kind: "url", url: "https://github.com/foo/bar" };
+    const c: RepoRef = { kind: "url", url: "https://github.com/foo/bar", ref: "main" };
+    expect([a.kind, b.kind, c.kind]).toEqual(["local", "url", "url"]);
+  });
+});

--- a/src/core/repo-ref.ts
+++ b/src/core/repo-ref.ts
@@ -1,0 +1,87 @@
+/**
+ * Repo reference + URL normalization.
+ *
+ * Pure module: no I/O. Consumers use `normalizeUrl` to canonicalize a
+ * repo reference, then `deriveCachePath` to get a cache-entry path
+ * segment. Path-safety is enforced here — callers must not trust
+ * `path.join` alone to sanitize a remote-controlled URL.
+ */
+
+export type RepoRef =
+  | { readonly kind: "local"; readonly path: string }
+  | { readonly kind: "url"; readonly url: string; readonly ref?: string };
+
+export interface NormalizedRepo {
+  readonly host: string;
+  readonly path: string;
+}
+
+const SCHEME_RE = /^([a-z][a-z0-9+.-]*):\/\//i;
+const SCP_LIKE_RE = /^([^@\s]+@)?([^:/\s]+):(.+)$/;
+
+export function normalizeUrl(raw: string): NormalizedRepo {
+  const trimmed = raw.trim();
+  if (trimmed === "") throw new Error("empty repo reference");
+
+  const scpMatch =
+    !SCHEME_RE.test(trimmed) && !trimmed.startsWith("/") ? trimmed.match(SCP_LIKE_RE) : null;
+
+  let host: string;
+  let rawPath: string;
+
+  if (scpMatch) {
+    host = scpMatch[2]!;
+    rawPath = scpMatch[3]!;
+  } else if (SCHEME_RE.test(trimmed)) {
+    // Reject empty-authority URLs (e.g. "https:///foo/bar") before URL() normalizes them.
+    if (/^[a-z][a-z0-9+.-]*:\/\/\//i.test(trimmed) && !/^file:/i.test(trimmed)) {
+      throw new Error(`normalized host is empty: ${trimmed}`);
+    }
+    const u = new URL(trimmed);
+    if (u.protocol === "file:") {
+      host = "local";
+      // Extract raw pathname from the URL string to catch traversal before URL() normalizes it.
+      rawPath = trimmed.replace(/^file:\/\//i, "").replace(/^\//, "");
+    } else {
+      host = u.hostname;
+      // Extract raw path from the URL string to catch traversal before URL() normalizes it.
+      // Strip scheme://[user@]host from front, then strip leading slash.
+      const afterHost = trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i, "");
+      rawPath = afterHost.replace(/^\//, "");
+    }
+  } else if (trimmed.startsWith("/")) {
+    host = "local";
+    rawPath = trimmed.slice(1);
+  } else {
+    throw new Error(`repo reference must be absolute or a known URL scheme: ${trimmed}`);
+  }
+
+  if (host === "") throw new Error(`normalized host is empty: ${raw}`);
+
+  // Validate raw path BEFORE cleaning, so traversal segments (e.g. `..`) that
+  // URL() would silently normalize away are still caught.
+  const rawCleaned = rawPath.replace(/\.git$/, "").replace(/\/+$/, "");
+  validatePathSegments(rawCleaned);
+
+  const cleaned = rawCleaned;
+
+  if (cleaned === "") throw new Error(`normalized path is empty: ${raw}`);
+
+  return { host: host.toLowerCase(), path: cleaned };
+}
+
+function validatePathSegments(path: string): void {
+  for (const seg of path.split("/")) {
+    if (seg === "") throw new Error(`invalid path (empty segment): ${path}`);
+    if (seg === ".." || seg === ".") {
+      throw new Error(`invalid path (traversal '${seg}'): ${path}`);
+    }
+    if (seg.startsWith(".")) {
+      throw new Error(`invalid path (leading dot in segment '${seg}'): ${path}`);
+    }
+  }
+}
+
+export function deriveCachePath(n: NormalizedRepo): string {
+  return `${n.host}/${n.path}.git`;
+}

--- a/src/core/repo-ref.ts
+++ b/src/core/repo-ref.ts
@@ -68,6 +68,12 @@ export function normalizeUrl(raw: string): NormalizedRepo {
 
   if (host === "") throw new Error(`normalized host is empty: ${raw}`);
 
+  for (const label of host.split(".")) {
+    if (label === ".." || label === "." || label === "") {
+      throw new Error(`invalid host (traversal in hostname): ${raw}`);
+    }
+  }
+
   // Validate raw path BEFORE cleaning, so traversal segments (e.g. `..`) that
   // URL() would silently normalize away are still caught.
   const rawCleaned = rawPath.replace(/\.git$/, "").replace(/\/+$/, "");

--- a/src/core/repo-ref.ts
+++ b/src/core/repo-ref.ts
@@ -42,12 +42,22 @@ export function normalizeUrl(raw: string): NormalizedRepo {
       host = "local";
       // Extract raw pathname from the URL string to catch traversal before URL() normalizes it.
       rawPath = trimmed.replace(/^file:\/\//i, "").replace(/^\//, "");
+      try {
+        rawPath = decodeURIComponent(rawPath);
+      } catch {
+        throw new Error(`invalid path (malformed percent-encoding): ${raw}`);
+      }
     } else {
       host = u.hostname;
       // Extract raw path from the URL string to catch traversal before URL() normalizes it.
       // Strip scheme://[user@]host from front, then strip leading slash.
       const afterHost = trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i, "");
       rawPath = afterHost.replace(/^\//, "");
+      try {
+        rawPath = decodeURIComponent(rawPath);
+      } catch {
+        throw new Error(`invalid path (malformed percent-encoding): ${raw}`);
+      }
     }
   } else if (trimmed.startsWith("/")) {
     host = "local";
@@ -71,6 +81,8 @@ export function normalizeUrl(raw: string): NormalizedRepo {
 }
 
 function validatePathSegments(path: string): void {
+  if (path.includes("\x00")) throw new Error(`invalid path (null byte): ${path}`);
+  if (path.includes("\\")) throw new Error(`invalid path (backslash): ${path}`);
   for (const seg of path.split("/")) {
     if (seg === "") throw new Error(`invalid path (empty segment): ${path}`);
     if (seg === ".." || seg === ".") {

--- a/src/core/repo-ref.ts
+++ b/src/core/repo-ref.ts
@@ -91,6 +91,9 @@ function validatePathSegments(path: string): void {
     if (seg.startsWith(".")) {
       throw new Error(`invalid path (leading dot in segment '${seg}'): ${path}`);
     }
+    if (seg.includes(":")) {
+      throw new Error(`invalid path (colon in segment '${seg}'): ${path}`);
+    }
   }
 }
 

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { GroveContract } from "./contract.js";
 import { LocalEventBus } from "./local-event-bus.js";
 import { MockRuntime } from "./mock-runtime.js";
@@ -9,6 +13,23 @@ import {
 import { SessionOrchestrator } from "./session-orchestrator.js";
 import { makeContribution } from "./test-helpers.js";
 import type { AgentTopology } from "./topology.js";
+
+/**
+ * Create a temporary bare clone with a seeded initial commit.
+ * Returns the path to the bare repo.
+ */
+function makeFixtureBareRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "grove-so-fx-"));
+  execSync("git -c init.defaultBranch=main init --bare", { cwd: dir, stdio: "pipe" });
+  const scratch = mkdtempSync(join(tmpdir(), "grove-so-scratch-"));
+  execSync(`git clone "${dir}" "${scratch}"`, { stdio: "pipe" });
+  execSync('git config user.email "t@t"', { cwd: scratch, stdio: "pipe" });
+  execSync('git config user.name "t"', { cwd: scratch, stdio: "pipe" });
+  execSync("git commit --allow-empty -m init", { cwd: scratch, stdio: "pipe" });
+  execSync("git push origin main", { cwd: scratch, stdio: "pipe" });
+  rmSync(scratch, { recursive: true, force: true });
+  return dir;
+}
 
 function makeContract(overrides?: Partial<GroveContract>): GroveContract {
   return {
@@ -54,6 +75,7 @@ function makeOrchestrator(
     runtime,
     eventBus: bus,
     projectRoot: "/tmp",
+    repos: [{ kind: "local", path: "/tmp" }],
     workspaceBaseDir: "/tmp/workspaces",
     // /tmp is not a git repo, so worktrees always fail in tests.
     // allow-fallback lets agents start despite that.
@@ -142,6 +164,7 @@ describe("SessionOrchestrator", () => {
           runtime,
           eventBus: bus,
           projectRoot: "/tmp",
+          repos: [{ kind: "local", path: "/tmp" }],
           workspaceBaseDir: "/tmp/workspaces",
         }),
     ).toThrow();
@@ -211,6 +234,7 @@ describe("SessionOrchestrator", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
       contributionStore,
@@ -246,6 +270,7 @@ describe("SessionOrchestrator", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
       contributionStore,
@@ -299,6 +324,7 @@ describe("SessionOrchestrator", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
       contributionStore,
@@ -342,6 +368,7 @@ describe("SessionOrchestrator", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
       contributionStore,
@@ -388,6 +415,7 @@ describe("SessionOrchestrator", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
       contributionStore,
@@ -636,6 +664,7 @@ describe("SessionOrchestrator — platform/model passthrough", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
     });
@@ -664,6 +693,7 @@ describe("SessionOrchestrator — platform/model passthrough", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
     });
@@ -699,6 +729,7 @@ describe("SessionOrchestrator — platform/model passthrough", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
       profiles: [
@@ -746,6 +777,7 @@ describe("SessionOrchestrator — platform/model passthrough", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
       profiles: [
@@ -799,6 +831,7 @@ describe("SessionOrchestrator — platform/model passthrough", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
     });
@@ -839,6 +872,7 @@ describe("SessionOrchestrator — platform/model passthrough", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
     });
@@ -875,6 +909,7 @@ describe("SessionOrchestrator — workspace isolation policy", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "strict",
     });
@@ -906,6 +941,7 @@ describe("SessionOrchestrator — workspace isolation policy", () => {
       runtime,
       eventBus: bus,
       projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
     });
@@ -927,19 +963,11 @@ describe("SessionOrchestrator — workspace isolation policy", () => {
   });
 
   test("allow-fallback policy: successful worktree produces isolated_worktree mode", async () => {
-    const { execSync } = await import("node:child_process");
-    const { mkdtempSync, rmSync } = await import("node:fs");
-    const { tmpdir } = await import("node:os");
-    const { join: pathJoin } = await import("node:path");
+    const { rmSync } = await import("node:fs");
 
-    // Create a real git repo with initial commit
-    const repoDir = mkdtempSync(pathJoin(tmpdir(), "grove-so-test-"));
+    // Create a bare clone — matches the new workspace-provisioner contract.
+    const bareRepo = makeFixtureBareRepo();
     try {
-      execSync("git init", { cwd: repoDir, stdio: "pipe" });
-      execSync('git config user.email "test@test.com"', { cwd: repoDir, stdio: "pipe" });
-      execSync('git config user.name "Test"', { cwd: repoDir, stdio: "pipe" });
-      execSync("git commit --allow-empty -m 'init'", { cwd: repoDir, stdio: "pipe" });
-
       const runtime = new MockRuntime();
       const bus = new LocalEventBus();
       const contract = makeContract({
@@ -955,8 +983,9 @@ describe("SessionOrchestrator — workspace isolation policy", () => {
         topology: contract.topology!,
         runtime,
         eventBus: bus,
-        projectRoot: repoDir,
-        workspaceBaseDir: pathJoin(repoDir, ".grove", "workspaces"),
+        projectRoot: bareRepo,
+        repos: [{ kind: "local", path: bareRepo }],
+        workspaceBaseDir: join(tmpdir(), `grove-so-ws-${Date.now()}`),
         workspaceIsolationPolicy: "allow-fallback",
         sessionId: "testsessionid12345678",
       });
@@ -971,32 +1000,22 @@ describe("SessionOrchestrator — workspace isolation policy", () => {
       expect(["isolated_worktree", "bootstrap_failed"]).toContain(agent.workspaceMode.status);
 
       // In either case, the agent cwd is inside the repo, NOT the repo root itself
-      expect(agent.workspaceMode.path).not.toBe(repoDir);
+      expect(agent.workspaceMode.path).not.toBe(bareRepo);
       bus.close();
     } finally {
       try {
-        // Clean up worktrees before removing the directory
-        execSync("git worktree prune", { cwd: repoDir, stdio: "pipe" });
+        rmSync(bareRepo, { recursive: true, force: true });
       } catch {
         // best-effort
       }
-      rmSync(repoDir, { recursive: true, force: true });
     }
   });
 
   test("bootstrap failure with allow-fallback produces bootstrap_failed mode", async () => {
-    const { execSync } = await import("node:child_process");
-    const { mkdtempSync, rmSync } = await import("node:fs");
-    const { tmpdir } = await import("node:os");
-    const { join: pathJoin } = await import("node:path");
+    const { rmSync } = await import("node:fs");
 
-    const repoDir = mkdtempSync(pathJoin(tmpdir(), "grove-so-bootstrap-test-"));
+    const bareRepo = makeFixtureBareRepo();
     try {
-      execSync("git init", { cwd: repoDir, stdio: "pipe" });
-      execSync('git config user.email "test@test.com"', { cwd: repoDir, stdio: "pipe" });
-      execSync('git config user.name "Test"', { cwd: repoDir, stdio: "pipe" });
-      execSync("git commit --allow-empty -m 'init'", { cwd: repoDir, stdio: "pipe" });
-
       const runtime = new MockRuntime();
       const bus = new LocalEventBus();
       const contract = makeContract({
@@ -1006,9 +1025,6 @@ describe("SessionOrchestrator — workspace isolation policy", () => {
         },
       });
 
-      // Point mcpServePath to a real path that bootstrapWorkspace can resolve.
-      // bootstrapWorkspace writes CLAUDE.md even if MCP serve path is absent,
-      // but writing config may fail when the worktree path itself doesn't exist yet.
       // We just need the worktree creation to succeed and bootstrap to at least attempt.
       const orchestrator = new SessionOrchestrator({
         goal: "Test bootstrap mode",
@@ -1016,8 +1032,9 @@ describe("SessionOrchestrator — workspace isolation policy", () => {
         topology: contract.topology!,
         runtime,
         eventBus: bus,
-        projectRoot: repoDir,
-        workspaceBaseDir: pathJoin(repoDir, ".grove", "workspaces"),
+        projectRoot: bareRepo,
+        repos: [{ kind: "local", path: bareRepo }],
+        workspaceBaseDir: join(tmpdir(), `grove-so-ws-${Date.now()}`),
         workspaceIsolationPolicy: "allow-fallback",
         sessionId: "bootsessionid12345678",
       });
@@ -1031,11 +1048,10 @@ describe("SessionOrchestrator — workspace isolation policy", () => {
       bus.close();
     } finally {
       try {
-        execSync("git worktree prune", { cwd: repoDir, stdio: "pipe" });
+        rmSync(bareRepo, { recursive: true, force: true });
       } catch {
         // best-effort
       }
-      rmSync(repoDir, { recursive: true, force: true });
     }
   });
 

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -491,7 +491,7 @@ export class SessionOrchestrator {
         role: role.name,
         sessionId: this.sessionId,
         baseDir: this.config.workspaceBaseDir,
-        bareClonePath: this.resolvedRepos[0]?.bareClonePath ?? this.config.projectRoot,
+        bareClonePath: this.resolvedRepos[0]!.bareClonePath,
         baseBranch: baseBranch ?? "HEAD",
       });
     } catch (err) {

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -460,6 +460,9 @@ export class SessionOrchestrator {
 
   private async ensureReposResolved(): Promise<void> {
     if (this.resolvedRepos.length > 0) return;
+    if (this.config.repos.length === 0) {
+      throw new Error("SessionOrchestrator: repos must be non-empty; pass at least one RepoRef.");
+    }
     if (this.config.repos.length > 1) {
       throw new Error(
         "SessionOrchestrator: multi-repo sessions are not yet supported; pass exactly one repo.",
@@ -483,6 +486,10 @@ export class SessionOrchestrator {
     baseBranch?: string,
   ): Promise<{ readonly cwd: string; readonly workspaceMode: WorkspaceMode }> {
     await this.ensureReposResolved();
+    const resolvedRepo = this.resolvedRepos[0];
+    if (!resolvedRepo) {
+      throw new Error("unreachable: ensureReposResolved did not populate resolvedRepos");
+    }
     let provisioned: ProvisionedWorkspace;
 
     // Step 1: Git worktree — base branch determined by edge type
@@ -491,7 +498,7 @@ export class SessionOrchestrator {
         role: role.name,
         sessionId: this.sessionId,
         baseDir: this.config.workspaceBaseDir,
-        bareClonePath: this.resolvedRepos[0]!.bareClonePath,
+        bareClonePath: resolvedRepo.bareClonePath,
         baseBranch: baseBranch ?? "HEAD",
       });
     } catch (err) {

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -13,6 +13,8 @@ import type { AgentProfile } from "./agent-profile.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
 import type { GroveContract } from "./contract.js";
 import type { EventBus, GroveEvent } from "./event-bus.js";
+import { type ResolvedRepo, type ResolveRepoOptions, resolveRepo } from "./repo-cache.js";
+import type { RepoRef } from "./repo-ref.js";
 import { resolveBundledSkillsRoot, resolveMcpServePath } from "./resolve-mcp-serve-path.js";
 import { hasValidRoutingSignature } from "./routing-provenance.js";
 import type { AgentPlatformType, AgentRole, AgentTopology } from "./topology.js";
@@ -40,8 +42,23 @@ export interface SessionConfig {
   readonly runtime: AgentRuntime;
   /** The event bus for inter-agent notifications. */
   readonly eventBus: EventBus;
-  /** Working directory for the project. */
+  /**
+   * Grove launcher directory — anchors `.grove/`, `mcpServePath`, the
+   * bundled skills root, workspace-override skills root, and fallback
+   * cwd when no workspace is provisioned. Independent of `repos`.
+   */
   readonly projectRoot: string;
+
+  /**
+   * Repositories the session targets. Length ≥ 1; today exactly 1 is
+   * honored (the forward-compat hook for multi-repo sessions).
+   * Resolved to bare clones via `resolveRepo` at session start.
+   */
+  readonly repos: readonly RepoRef[];
+
+  /** Overrides for cache resolution (tests, CI, explicit cache root). */
+  readonly repoCache?: Partial<ResolveRepoOptions>;
+
   /** Base directory for agent workspaces. */
   readonly workspaceBaseDir: string;
   /** Optional session ID (generated if not provided). */
@@ -119,6 +136,7 @@ export class SessionOrchestrator {
   private readonly seenCids = new Set<string>();
   private contributionPollTimer: ReturnType<typeof setInterval> | null = null;
   private contributionPollStartTimer: ReturnType<typeof setTimeout> | null = null;
+  private resolvedRepos: readonly ResolvedRepo[] = [];
 
   constructor(config: SessionConfig) {
     this.config = config;
@@ -440,6 +458,18 @@ export class SessionOrchestrator {
     };
   }
 
+  private async ensureReposResolved(): Promise<void> {
+    if (this.resolvedRepos.length > 0) return;
+    if (this.config.repos.length > 1) {
+      throw new Error(
+        "SessionOrchestrator: multi-repo sessions are not yet supported; pass exactly one repo.",
+      );
+    }
+    this.resolvedRepos = await Promise.all(
+      this.config.repos.map((ref) => resolveRepo(ref, this.config.repoCache ?? {})),
+    );
+  }
+
   /**
    * Provision a workspace for an agent role and run bootstrap.
    *
@@ -452,6 +482,7 @@ export class SessionOrchestrator {
     policy: WorkspaceIsolationPolicy,
     baseBranch?: string,
   ): Promise<{ readonly cwd: string; readonly workspaceMode: WorkspaceMode }> {
+    await this.ensureReposResolved();
     let provisioned: ProvisionedWorkspace;
 
     // Step 1: Git worktree — base branch determined by edge type
@@ -460,7 +491,7 @@ export class SessionOrchestrator {
         role: role.name,
         sessionId: this.sessionId,
         baseDir: this.config.workspaceBaseDir,
-        repoRoot: this.config.projectRoot,
+        bareClonePath: this.resolvedRepos[0]?.bareClonePath ?? this.config.projectRoot,
         baseBranch: baseBranch ?? "HEAD",
       });
     } catch (err) {

--- a/src/core/topology.test.ts
+++ b/src/core/topology.test.ts
@@ -417,3 +417,41 @@ describe("topology skills field", () => {
     ).toThrow();
   });
 });
+
+describe("topology repo_index field", () => {
+  test("parses repo_index as repoIndex on a role", () => {
+    const parsed = AgentTopologySchema.parse({
+      structure: "flat",
+      roles: [{ name: "coder", repo_index: 0 }],
+    });
+    const topology = wireToTopology(parsed);
+    expect(topology.roles[0]?.repoIndex).toBe(0);
+  });
+
+  test("omits repoIndex when not provided", () => {
+    const parsed = AgentTopologySchema.parse({
+      structure: "flat",
+      roles: [{ name: "coder" }],
+    });
+    const topology = wireToTopology(parsed);
+    expect(topology.roles[0]?.repoIndex).toBeUndefined();
+  });
+
+  test("rejects negative repo_index", () => {
+    expect(() =>
+      AgentTopologySchema.parse({
+        structure: "flat",
+        roles: [{ name: "coder", repo_index: -1 }],
+      }),
+    ).toThrow();
+  });
+
+  test("rejects non-integer repo_index", () => {
+    expect(() =>
+      AgentTopologySchema.parse({
+        structure: "flat",
+        roles: [{ name: "coder", repo_index: 1.5 }],
+      }),
+    ).toThrow();
+  });
+});

--- a/src/core/topology.ts
+++ b/src/core/topology.ts
@@ -70,6 +70,7 @@ const TopologyRoleWithEdgesSchema = z
     prompt: z.string().max(4096).optional(),
     goal: z.string().max(512).optional(),
     skills: z.array(z.string().min(1)).optional(),
+    repo_index: z.number().int().nonnegative().optional(),
   })
   .strict();
 
@@ -103,6 +104,7 @@ interface WireAgentTopology {
     readonly prompt?: string | undefined;
     readonly goal?: string | undefined;
     readonly skills?: readonly string[] | undefined;
+    readonly repo_index?: number | undefined;
   }[];
   readonly spawning?:
     | {
@@ -343,6 +345,11 @@ export interface AgentRole {
   readonly goal?: string | undefined;
   /** Names of skills to inject into this role's workspace at bootstrap. */
   readonly skills?: readonly string[] | undefined;
+  /**
+   * Index into the session's `repos` array. Defaults to 0.
+   * Forward-compat hook for multi-repo sessions; unused today.
+   */
+  readonly repoIndex?: number | undefined;
 }
 
 /** Spawning configuration for dynamic agent creation. */
@@ -394,6 +401,7 @@ export function wireToTopology(wire: z.infer<typeof AgentTopologySchema>): Agent
         ...(role.prompt !== undefined && { prompt: role.prompt }),
         ...(role.goal !== undefined && { goal: role.goal }),
         ...(role.skills !== undefined && { skills: role.skills }),
+        ...(role.repo_index !== undefined && { repoIndex: role.repo_index }),
       }),
     ),
     ...(wire.spawning !== undefined && {

--- a/src/core/workspace-provisioner.test.ts
+++ b/src/core/workspace-provisioner.test.ts
@@ -22,16 +22,21 @@ describe("WorkspaceProvisioner", () => {
   let baseDir: string;
 
   beforeEach(() => {
-    // Create a real git repo with an initial commit (set identity for CI)
-    repoDir = mkdtempSync(join(tmpdir(), "grove-wp-test-"));
-    execSync("git init", { cwd: repoDir, stdio: "pipe" });
-    execSync('git config user.email "test@test.com"', { cwd: repoDir, stdio: "pipe" });
-    execSync('git config user.name "Test"', { cwd: repoDir, stdio: "pipe" });
-    execSync("git commit --allow-empty -m 'init'", {
-      cwd: repoDir,
-      stdio: "pipe",
-    });
-    baseDir = join(repoDir, ".grove", "workspaces");
+    // Create a bare clone with a seeded initial commit — matches the new
+    // workspace-provisioner contract (worktrees are added from a bare clone).
+    repoDir = mkdtempSync(join(tmpdir(), "grove-wp-bare-"));
+    execSync("git -c init.defaultBranch=main init --bare", { cwd: repoDir, stdio: "pipe" });
+
+    const scratch = mkdtempSync(join(tmpdir(), "grove-wp-scratch-"));
+    execSync(`git clone "${repoDir}" "${scratch}"`, { stdio: "pipe" });
+    execSync('git config user.email "test@test.com"', { cwd: scratch, stdio: "pipe" });
+    execSync('git config user.name "Test"', { cwd: scratch, stdio: "pipe" });
+    execSync("git commit --allow-empty -m 'init'", { cwd: scratch, stdio: "pipe" });
+    execSync("git branch -M main", { cwd: scratch, stdio: "pipe" });
+    execSync("git push origin main", { cwd: scratch, stdio: "pipe" });
+    rmSync(scratch, { recursive: true, force: true });
+
+    baseDir = join(tmpdir(), `grove-wp-base-${Date.now()}`);
   });
 
   afterEach(() => {
@@ -68,7 +73,7 @@ describe("WorkspaceProvisioner", () => {
       role: "coder",
       sessionId,
       baseDir,
-      repoRoot: repoDir,
+      bareClonePath: repoDir,
     });
 
     expect(result.role).toBe("coder");
@@ -100,7 +105,7 @@ describe("WorkspaceProvisioner", () => {
       role: "reviewer",
       sessionId: "sess00001111222233",
       baseDir,
-      repoRoot: repoDir,
+      bareClonePath: repoDir,
       mcpConfig,
     });
 
@@ -153,7 +158,7 @@ describe("WorkspaceProvisioner", () => {
 
     // Provision first
     const workspaces = await Promise.all(
-      roles.map((role) => provisionWorkspace({ role, sessionId, baseDir, repoRoot: repoDir })),
+      roles.map((role) => provisionWorkspace({ role, sessionId, baseDir, bareClonePath: repoDir })),
     );
 
     // Verify they exist
@@ -186,7 +191,7 @@ describe("WorkspaceProvisioner", () => {
       role: "planner",
       sessionId,
       baseDir,
-      repoRoot: repoDir,
+      bareClonePath: repoDir,
     });
 
     // Path should be <baseDir>/<role>-<first 8 chars of sessionId>
@@ -195,30 +200,26 @@ describe("WorkspaceProvisioner", () => {
   });
 
   test("provisionWorkspace respects baseBranch option", async () => {
-    // Create a new branch in the repo
-    execSync("git checkout -b feature-base", { cwd: repoDir, stdio: "pipe" });
-    execSync("git commit --allow-empty -m 'feature commit'", {
-      cwd: repoDir,
-      stdio: "pipe",
-    });
-    execSync("git checkout -", { cwd: repoDir, stdio: "pipe" });
+    // Create a scratch clone to produce a second branch, then push it to the bare.
+    const scratch = mkdtempSync(join(tmpdir(), "grove-wp-scratch2-"));
+    execSync(`git clone "${repoDir}" "${scratch}"`, { stdio: "pipe" });
+    execSync('git config user.email "t@t"', { cwd: scratch, stdio: "pipe" });
+    execSync('git config user.name "t"', { cwd: scratch, stdio: "pipe" });
+    execSync("git checkout -b feature-base", { cwd: scratch, stdio: "pipe" });
+    execSync("git commit --allow-empty -m 'feature commit'", { cwd: scratch, stdio: "pipe" });
+    execSync("git push origin feature-base", { cwd: scratch, stdio: "pipe" });
+    rmSync(scratch, { recursive: true, force: true });
 
     const result = await provisionWorkspace({
       role: "tester",
       sessionId: "base-branch-session",
       baseDir,
-      repoRoot: repoDir,
+      bareClonePath: repoDir,
       baseBranch: "feature-base",
     });
 
-    // The worktree should exist and its branch should be based on feature-base
     expect(existsSync(result.path)).toBe(true);
-
-    // Verify the commit from feature-base is in the worktree history
-    const log = execSync("git log --oneline", {
-      cwd: result.path,
-      encoding: "utf-8",
-    });
+    const log = execSync("git log --oneline", { cwd: result.path, encoding: "utf-8" });
     expect(log).toContain("feature commit");
   });
 

--- a/src/core/workspace-provisioner.ts
+++ b/src/core/workspace-provisioner.ts
@@ -42,8 +42,8 @@ export interface WorkspaceProvisionOptions {
   readonly sessionId: string;
   /** Base directory for worktrees (e.g., .grove/workspaces). */
   readonly baseDir: string;
-  /** Root of the source repo to create worktrees from. */
-  readonly repoRoot: string;
+  /** Path to the bare clone to create worktrees from (from `resolveRepo(ref).bareClonePath`). */
+  readonly bareClonePath: string;
   /** MCP config to write into the worktree. */
   readonly mcpConfig?: Record<string, unknown> | undefined;
   /** Base branch to create worktree from (default: HEAD). */
@@ -89,7 +89,7 @@ export interface WorkspaceProvisionError {
 export async function provisionWorkspace(
   options: WorkspaceProvisionOptions,
 ): Promise<ProvisionedWorkspace> {
-  const { role, sessionId, baseDir, repoRoot, mcpConfig, baseBranch } = options;
+  const { role, sessionId, baseDir, bareClonePath, mcpConfig, baseBranch } = options;
 
   const worktreePath = join(baseDir, `${role}-${sessionId.slice(0, 8)}`);
   const branch = `grove/${sessionId}/${role}`;
@@ -101,7 +101,7 @@ export async function provisionWorkspace(
   // injection via role name or path and allowing true async execution.
   const base = baseBranch ?? "HEAD";
   await execFileAsync("git", ["worktree", "add", worktreePath, "-b", branch, base], {
-    cwd: repoRoot,
+    cwd: bareClonePath,
   });
 
   // Write .mcp.json if provided
@@ -122,7 +122,7 @@ export async function provisionSessionWorkspaces(
   roles: readonly string[],
   sessionId: string,
   baseDir: string,
-  repoRoot: string,
+  bareClonePath: string,
   mcpConfig?: Record<string, unknown>,
   baseBranch?: string,
 ): Promise<SessionWorkspaces> {
@@ -135,7 +135,7 @@ export async function provisionSessionWorkspaces(
   // Create all worktrees in parallel
   const results = await Promise.allSettled(
     roles.map((role) =>
-      provisionWorkspace({ role, sessionId, baseDir, repoRoot, mcpConfig, baseBranch }),
+      provisionWorkspace({ role, sessionId, baseDir, bareClonePath, mcpConfig, baseBranch }),
     ),
   );
 
@@ -171,18 +171,20 @@ export async function provisionSessionWorkspaces(
  */
 export async function cleanupSessionWorkspaces(
   workspaces: readonly ProvisionedWorkspace[],
-  repoRoot: string,
+  bareClonePath: string,
 ): Promise<void> {
   await Promise.allSettled(
     workspaces.map(async (ws) => {
       try {
-        await execFileAsync("git", ["worktree", "remove", ws.path, "--force"], { cwd: repoRoot });
+        await execFileAsync("git", ["worktree", "remove", ws.path, "--force"], {
+          cwd: bareClonePath,
+        });
       } catch {
         // Best effort — worktree may already be removed
       }
 
       try {
-        await execFileAsync("git", ["branch", "-D", ws.branch], { cwd: repoRoot });
+        await execFileAsync("git", ["branch", "-D", ws.branch], { cwd: bareClonePath });
       } catch {
         // Best effort
       }

--- a/src/server/session-service.ts
+++ b/src/server/session-service.ts
@@ -145,6 +145,7 @@ export class SessionService {
       runtime: this.config.runtime,
       eventBus: this.config.eventBus,
       projectRoot: this.config.projectRoot,
+      repos: [{ kind: "local", path: this.config.projectRoot }],
       workspaceBaseDir: this.config.workspaceBaseDir,
       sessionId: this.sessionId,
       workspaceIsolationPolicy: this.config.workspaceIsolationPolicy,

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -619,6 +619,9 @@ export async function handleTui(
         result.appProps.provider,
         result.appProps.tmux,
         (msg) => process.stderr.write(`[spawn] ${msg}\n`),
+        result.appProps.groveDir
+          ? [{ kind: "local" as const, path: join(result.appProps.groveDir, "..") }]
+          : [{ kind: "local" as const, path: process.cwd() }],
         sessionStore,
         result.appProps.groveDir,
         result.appProps.agentRuntime,

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -10,6 +10,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
+import { buildRepos } from "../cli/utils/build-repos.js";
 import { findGroveDir as findNearestGroveDir } from "../cli/utils/grove-dir.js";
 import type { RunningServices } from "../shared/service-lifecycle.js";
 import type { SessionRecord, TuiDataProvider } from "./provider.js";
@@ -31,6 +32,7 @@ export function parseTuiArgs(args: readonly string[]): {
   readonly url: string | undefined;
   readonly nexus: string | undefined;
   readonly groveOverride: string | undefined;
+  readonly repos: readonly string[];
 } {
   const { values } = parseArgs({
     args: [...args],
@@ -39,6 +41,7 @@ export function parseTuiArgs(args: readonly string[]): {
       url: { type: "string", short: "u" },
       nexus: { type: "string", short: "n" },
       grove: { type: "string", short: "g" },
+      repo: { type: "string", multiple: true },
       help: { type: "boolean", short: "h" },
     },
     allowPositionals: false,
@@ -56,6 +59,7 @@ Options:
   -u, --url <url>           Remote grove-server URL
   -n, --nexus <url>         Override Nexus URL (bypasses auto-detection)
   -g, --grove <path>        Path to .grove directory (not the repo root)
+      --repo <url-or-path>  Target repo (URL or local path). Repeatable, but today only one honored.
   -h, --help                Show this help message
 
 Backend auto-detection:
@@ -89,6 +93,7 @@ Keybindings:
     url: values.url as string | undefined,
     nexus: values.nexus as string | undefined,
     groveOverride: values.grove as string | undefined,
+    repos: (values.repo as readonly string[] | undefined) ?? [],
   };
 }
 
@@ -619,9 +624,10 @@ export async function handleTui(
         result.appProps.provider,
         result.appProps.tmux,
         (msg) => process.stderr.write(`[spawn] ${msg}\n`),
-        result.appProps.groveDir
-          ? [{ kind: "local" as const, path: join(result.appProps.groveDir, "..") }]
-          : [{ kind: "local" as const, path: process.cwd() }],
+        buildRepos({
+          rawRepo: opts.repos,
+          cwd: result.appProps.groveDir ? join(result.appProps.groveDir, "..") : process.cwd(),
+        }),
         sessionStore,
         result.appProps.groveDir,
         result.appProps.agentRuntime,

--- a/src/tui/spawn-manager.test.ts
+++ b/src/tui/spawn-manager.test.ts
@@ -211,6 +211,7 @@ describe("SpawnManager", () => {
       provider,
       tmux,
       (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
       undefined,
       "/tmp/no-grove",
     );
@@ -244,6 +245,7 @@ describe("SpawnManager", () => {
       provider,
       tmux,
       (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
       undefined,
       "/tmp/no-grove",
     );
@@ -270,7 +272,9 @@ describe("SpawnManager", () => {
     const provider = makeMockProvider();
     const tmux = makeMockTmux(true); // configured to fail
     const errors: string[] = [];
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg));
+    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), [
+      { kind: "local" as const, path: "/tmp" },
+    ]);
 
     await expect(manager.spawn("claude", "bash")).rejects.toThrow("tmux spawn failed");
 
@@ -285,7 +289,9 @@ describe("SpawnManager", () => {
     const provider = makeMockProvider();
     const tmux = makeMockTmux();
     const errors: string[] = [];
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg));
+    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), [
+      { kind: "local" as const, path: "/tmp" },
+    ]);
 
     const result = await manager.spawn("claude", "bash");
     // No explicit groveDir — workspace mode depends on whether process.cwd() is a git repo
@@ -308,7 +314,9 @@ describe("SpawnManager", () => {
     const provider = makeMockProvider();
     const tmux = makeMockTmux();
     const errors: string[] = [];
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg));
+    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), [
+      { kind: "local" as const, path: "/tmp" },
+    ]);
 
     const result1 = await manager.spawn("agent-a", "bash");
     const result2 = await manager.spawn("agent-b", "bash");
@@ -337,9 +345,14 @@ describe("SpawnManager", () => {
     (provider as unknown as Record<string, unknown>).checkoutWorkspace = undefined;
 
     const tmux = makeMockTmux();
-    manager = new SpawnManager(provider, tmux, () => {
-      /* noop */
-    });
+    manager = new SpawnManager(
+      provider,
+      tmux,
+      () => {
+        /* noop */
+      },
+      [{ kind: "local" as const, path: "/tmp" }],
+    );
 
     // Spawn may succeed (git worktree) or fail (no git repo), but should not
     // throw "Provider does not support workspace checkout"
@@ -358,6 +371,7 @@ describe("SpawnManager", () => {
       provider,
       tmux,
       (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
       undefined,
       "/tmp/no-grove",
     );
@@ -382,6 +396,7 @@ describe("SpawnManager", () => {
       provider,
       tmux,
       (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
       undefined,
       "/tmp/no-grove",
     );
@@ -423,7 +438,14 @@ describe("SpawnManager — per-role skill injection", () => {
     const provider = makeMockProvider();
     const tmux = makeMockTmux();
     const errors: string[] = [];
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), undefined, groveDir);
+    manager = new SpawnManager(
+      provider,
+      tmux,
+      (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: projectRoot }],
+      undefined,
+      groveDir,
+    );
     manager.setIsolationPolicy("strict");
 
     const result = await manager.spawn("coder", "bash", undefined, 0, {
@@ -464,7 +486,14 @@ describe("SpawnManager — per-role skill injection", () => {
     const provider = makeMockProvider();
     const tmux = makeMockTmux();
     const errors: string[] = [];
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), undefined, groveDir);
+    manager = new SpawnManager(
+      provider,
+      tmux,
+      (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: projectRoot }],
+      undefined,
+      groveDir,
+    );
     manager.setIsolationPolicy("strict");
 
     const coderResult = await manager.spawn("coder", "bash", undefined, 0, { skills: ["grove"] });
@@ -503,7 +532,9 @@ describe("SpawnManager — shell injection safety", () => {
     const provider = makeMockProvider();
     const tmux = new MockTmuxManager();
     const errors: string[] = [];
-    const mgr = new SpawnManager(provider, tmux, (msg) => errors.push(msg));
+    const mgr = new SpawnManager(provider, tmux, (msg) => errors.push(msg), [
+      { kind: "local" as const, path: "/tmp" },
+    ]);
 
     // Assign to module-level `manager` so afterEach can call destroy().
     manager = mgr;
@@ -568,7 +599,9 @@ describe("SpawnManager — shell injection safety", () => {
     const provider = makeMockProvider();
     const tmux = new MockTmuxManager();
     const errors: string[] = [];
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg));
+    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), [
+      { kind: "local" as const, path: "/tmp" },
+    ]);
     manager.setPrContext({ number: 99, title, filesChanged: 10 });
 
     const result = await manager.spawn("claude", "bash");
@@ -639,7 +672,13 @@ describe("SpawnManager — session persistence", () => {
     const tmux = makeMockTmux();
     const store = makeMockSessionStore();
     const errors: string[] = [];
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), store);
+    manager = new SpawnManager(
+      provider,
+      tmux,
+      (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
+      store,
+    );
 
     const result = await manager.spawn("claude", "bash");
 
@@ -662,7 +701,13 @@ describe("SpawnManager — session persistence", () => {
     const tmux = makeMockTmux();
     const store = makeMockSessionStore();
     const errors: string[] = [];
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), store);
+    manager = new SpawnManager(
+      provider,
+      tmux,
+      (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
+      store,
+    );
 
     const result = await manager.spawn("claude", "bash");
     expect(["isolated_worktree", "fallback_workspace", "bootstrap_failed"]).toContain(
@@ -688,6 +733,7 @@ describe("SpawnManager — session persistence", () => {
       provider,
       tmux,
       (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
       undefined,
       "/tmp/no-grove",
     );
@@ -703,7 +749,13 @@ describe("SpawnManager — session persistence", () => {
     const tmux = makeMockTmux();
     const store = makeMockSessionStore();
     const errors: string[] = [];
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), store);
+    manager = new SpawnManager(
+      provider,
+      tmux,
+      (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
+      store,
+    );
 
     const result = await manager.spawn("claude", "bash");
     expect(["isolated_worktree", "fallback_workspace", "bootstrap_failed"]).toContain(
@@ -743,7 +795,13 @@ describe("SpawnManager — reconciliation", () => {
     // Simulate the tmux session being alive
     tmux.spawnedSessions.push("grove-agent-live");
 
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), store);
+    manager = new SpawnManager(
+      provider,
+      tmux,
+      (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
+      store,
+    );
     const result = await manager.reconcile();
 
     expect(result.reattached).toBe(1);
@@ -776,7 +834,13 @@ describe("SpawnManager — reconciliation", () => {
 
     // tmux has no live sessions — agent-dead is orphaned
 
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), store);
+    manager = new SpawnManager(
+      provider,
+      tmux,
+      (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
+      store,
+    );
     const result = await manager.reconcile();
 
     expect(result.reattached).toBe(0);
@@ -819,7 +883,13 @@ describe("SpawnManager — reconciliation", () => {
     // Only "alive" has a tmux session
     tmux.spawnedSessions.push("grove-alive");
 
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), store);
+    manager = new SpawnManager(
+      provider,
+      tmux,
+      (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
+      store,
+    );
     const result = await manager.reconcile();
 
     expect(result.reattached).toBe(1);
@@ -839,7 +909,9 @@ describe("SpawnManager — reconciliation", () => {
     const tmux = makeMockTmux();
     const errors: string[] = [];
 
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg));
+    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), [
+      { kind: "local" as const, path: "/tmp" },
+    ]);
     const result = await manager.reconcile();
 
     expect(result.reattached).toBe(0);
@@ -852,7 +924,13 @@ describe("SpawnManager — reconciliation", () => {
     const store = makeMockSessionStore();
     const errors: string[] = [];
 
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), store);
+    manager = new SpawnManager(
+      provider,
+      tmux,
+      (msg) => errors.push(msg),
+      [{ kind: "local" as const, path: "/tmp" }],
+      store,
+    );
     const result = await manager.reconcile();
 
     expect(result.reattached).toBe(0);
@@ -866,7 +944,9 @@ describe("SpawnManager — reconciliation", () => {
     const provider = makeMockProvider();
     const tmux = makeMockTmux();
     const errors: string[] = [];
-    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg));
+    manager = new SpawnManager(provider, tmux, (msg) => errors.push(msg), [
+      { kind: "local" as const, path: "/tmp" },
+    ]);
 
     const seedSession = {
       id: "grove-code-reviewer-0--mo3i3zh6",

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -96,7 +96,7 @@ export class SpawnManager {
   // or explicitly reattached for the CURRENT session. Prevents routing to stale
   // sessions from previous sessions that reconcile() found still alive in acpx.
   private readonly routableSessions = new Set<string>();
-  private repos: readonly RepoRef[] = [];
+  private readonly repos: readonly RepoRef[];
   private repoCache: Partial<ResolveRepoOptions> | undefined;
   private resolvedRepos: readonly ResolvedRepo[] = [];
 
@@ -104,6 +104,7 @@ export class SpawnManager {
     provider: TuiDataProvider,
     tmux: TmuxManager | undefined,
     onError: (message: string) => void,
+    repos: readonly RepoRef[],
     sessionStore?: SessionStore,
     groveDir?: string,
     agentRuntime?: AgentRuntime,
@@ -113,6 +114,7 @@ export class SpawnManager {
     this.tmux = tmux;
     this.agentRuntime = agentRuntime;
     this.onError = onError;
+    this.repos = repos;
     this.sessionStore = sessionStore;
     this.groveDir = groveDir;
     this.acpSessionStore = acpSessionStore;
@@ -323,20 +325,13 @@ export class SpawnManager {
     this.workspaceIsolationPolicy = policy;
   }
 
-  /**
-   * Set the repos list for workspace provisioning. When set, spawn() routes
-   * worktree creation through the repo-cache bareClonePath instead of the
-   * projectRoot derived from groveDir.
-   */
-  setRepos(repos: readonly RepoRef[], repoCache?: Partial<ResolveRepoOptions>): void {
-    this.repos = repos;
-    this.repoCache = repoCache;
-    this.resolvedRepos = []; // reset so ensureReposResolved re-resolves on next spawn
-  }
-
   private async ensureReposResolved(): Promise<void> {
     if (this.resolvedRepos.length > 0) return;
-    if (this.repos.length === 0) return; // no repos configured — fall through to projectRoot
+    if (this.repos.length === 0) {
+      throw new Error(
+        "SpawnManager: repos must be non-empty; pass at least one RepoRef at construction.",
+      );
+    }
     if (this.repos.length > 1) {
       throw new Error(
         "SpawnManager: multi-repo sessions are not yet supported; pass exactly one repo.",
@@ -502,15 +497,11 @@ export class SpawnManager {
         await this.ensureReposResolved();
         // Use wsSessionId (stable session-level ID) so branch names are predictable
         // and match what resolveRoleWorkspaceStrategies() computes for dependents.
-        const bareClonePath =
-          this.resolvedRepos.length > 0
-            ? (this.resolvedRepos[0]?.bareClonePath ?? projectRoot)
-            : projectRoot;
         provisioned = await provisionWorkspace({
           role: roleId,
           sessionId: wsSessionId,
           baseDir,
-          bareClonePath,
+          bareClonePath: this.resolvedRepos[0]!.bareClonePath,
           baseBranch,
         });
         workspacePath = provisioned.path;

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -15,6 +15,8 @@ import { dirname, join, resolve } from "node:path";
 import { watchTurnError } from "../acp/watch-turn.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import type { AgentIdentity } from "../core/models.js";
+import { type ResolvedRepo, type ResolveRepoOptions, resolveRepo } from "../core/repo-cache.js";
+import type { RepoRef } from "../core/repo-ref.js";
 import { resolveBundledSkillsRoot, resolveMcpServePath } from "../core/resolve-mcp-serve-path.js";
 import { parseAcpxSessionId } from "../core/session-id.js";
 import { injectSkills } from "../core/skill-injector.js";
@@ -94,6 +96,9 @@ export class SpawnManager {
   // or explicitly reattached for the CURRENT session. Prevents routing to stale
   // sessions from previous sessions that reconcile() found still alive in acpx.
   private readonly routableSessions = new Set<string>();
+  private repos: readonly RepoRef[] = [];
+  private repoCache: Partial<ResolveRepoOptions> | undefined;
+  private resolvedRepos: readonly ResolvedRepo[] = [];
 
   constructor(
     provider: TuiDataProvider,
@@ -319,6 +324,30 @@ export class SpawnManager {
   }
 
   /**
+   * Set the repos list for workspace provisioning. When set, spawn() routes
+   * worktree creation through the repo-cache bareClonePath instead of the
+   * projectRoot derived from groveDir.
+   */
+  setRepos(repos: readonly RepoRef[], repoCache?: Partial<ResolveRepoOptions>): void {
+    this.repos = repos;
+    this.repoCache = repoCache;
+    this.resolvedRepos = []; // reset so ensureReposResolved re-resolves on next spawn
+  }
+
+  private async ensureReposResolved(): Promise<void> {
+    if (this.resolvedRepos.length > 0) return;
+    if (this.repos.length === 0) return; // no repos configured — fall through to projectRoot
+    if (this.repos.length > 1) {
+      throw new Error(
+        "SpawnManager: multi-repo sessions are not yet supported; pass exactly one repo.",
+      );
+    }
+    this.resolvedRepos = await Promise.all(
+      this.repos.map((ref) => resolveRepo(ref, this.repoCache ?? {})),
+    );
+  }
+
+  /**
    * Set the session topology so spawn() can resolve edge-type-aware base branches.
    * Call before spawning when the topology is known (e.g. after preset selection).
    */
@@ -470,13 +499,18 @@ export class SpawnManager {
 
       let provisioned: import("../core/workspace-provisioner.js").ProvisionedWorkspace | undefined;
       try {
+        await this.ensureReposResolved();
         // Use wsSessionId (stable session-level ID) so branch names are predictable
         // and match what resolveRoleWorkspaceStrategies() computes for dependents.
+        const bareClonePath =
+          this.resolvedRepos.length > 0
+            ? (this.resolvedRepos[0]?.bareClonePath ?? projectRoot)
+            : projectRoot;
         provisioned = await provisionWorkspace({
           role: roleId,
           sessionId: wsSessionId,
           baseDir,
-          repoRoot: projectRoot,
+          bareClonePath,
           baseBranch,
         });
         workspacePath = provisioned.path;

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -11,6 +11,7 @@
  * (ScreenManager) or the full boardroom App (advanced mode via Tab).
  */
 
+import { join } from "node:path";
 import { useKeyboard, useRenderer } from "@opentui/react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AppProps } from "./app.js";
@@ -368,6 +369,9 @@ export const TuiApp: React.NamedExoticComponent<TuiAppProps> = React.memo(functi
       (msg) => {
         process.stderr.write(`[spawn] ${msg}\n`);
       },
+      groveDir
+        ? [{ kind: "local" as const, path: join(groveDir, "..") }]
+        : [{ kind: "local" as const, path: process.cwd() }],
       sessionStore,
       groveDir,
       agentRuntime,

--- a/tests/e2e/repo-cache-session.test.ts
+++ b/tests/e2e/repo-cache-session.test.ts
@@ -1,0 +1,64 @@
+/**
+ * End-to-end flow for the bare-clone repo cache:
+ *   resolveRepo(RepoRef) → provisionWorkspace(bareClonePath) → agent commits → pushes back to bare.
+ *
+ * Uses a `file://` fixture bare repo to avoid any real network.
+ */
+
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveRepo } from "../../src/core/repo-cache.js";
+import { provisionWorkspace } from "../../src/core/workspace-provisioner.js";
+
+let fixture: string;
+let cacheRoot: string;
+let groveDir: string;
+
+beforeEach(() => {
+  fixture = mkdtempSync(join(tmpdir(), "grove-e2e-fx-"));
+  execSync("git -c init.defaultBranch=main init --bare", { cwd: fixture, stdio: "pipe" });
+  const scratch = mkdtempSync(join(tmpdir(), "grove-e2e-scratch-"));
+  execSync(`git clone "${fixture}" "${scratch}"`, { stdio: "pipe" });
+  execSync('git config user.email "t@t"', { cwd: scratch, stdio: "pipe" });
+  execSync('git config user.name "t"', { cwd: scratch, stdio: "pipe" });
+  execSync("git commit --allow-empty -m init", { cwd: scratch, stdio: "pipe" });
+  execSync("git push origin main", { cwd: scratch, stdio: "pipe" });
+  rmSync(scratch, { recursive: true, force: true });
+
+  cacheRoot = mkdtempSync(join(tmpdir(), "grove-e2e-cache-"));
+  groveDir = mkdtempSync(join(tmpdir(), "grove-e2e-dir-"));
+});
+
+afterEach(() => {
+  rmSync(fixture, { recursive: true, force: true });
+  rmSync(cacheRoot, { recursive: true, force: true });
+  rmSync(groveDir, { recursive: true, force: true });
+});
+
+test("resolve → provision → commit → push flow against a bare-clone fixture", async () => {
+  const resolved = await resolveRepo({ kind: "url", url: `file://${fixture}` }, { cacheRoot });
+  expect(resolved.fetched).toBe(true);
+  expect(resolved.bareClonePath.startsWith(cacheRoot)).toBe(true);
+
+  const ws = await provisionWorkspace({
+    role: "coder",
+    sessionId: "e2esess00000000",
+    baseDir: join(groveDir, "workspaces"),
+    bareClonePath: resolved.bareClonePath,
+  });
+
+  // Agent edits, commits, and pushes back to the bare clone.
+  execSync(`bash -c 'echo hello > ${ws.path}/hello.txt'`, { stdio: "pipe" });
+  execSync('git config user.email "agent@t"', { cwd: ws.path, stdio: "pipe" });
+  execSync('git config user.name "agent"', { cwd: ws.path, stdio: "pipe" });
+  execSync("git add hello.txt && git commit -m 'add hello'", { cwd: ws.path, stdio: "pipe" });
+  execSync(`git push origin ${ws.branch}`, { cwd: ws.path, stdio: "pipe" });
+
+  // Branch landed in the bare clone.
+  const branches = execSync(`git -C "${resolved.bareClonePath}" branch`, { encoding: "utf-8" });
+  expect(branches).toContain(ws.branch);
+  expect(existsSync(join(ws.path, "hello.txt"))).toBe(true);
+});

--- a/tests/tui/edge-workspace-harness.tsx
+++ b/tests/tui/edge-workspace-harness.tsx
@@ -194,6 +194,7 @@ function HarnessApp(): React.ReactElement {
       mockProvider,
       mockTmux,
       (err: string) => process.stderr.write(`[harness] ${err}\n`),
+      [{ kind: "local" as const, path: tempRoot }],
       undefined,
       groveDir,
     );

--- a/tests/tui/handoffs-harness.tsx
+++ b/tests/tui/handoffs-harness.tsx
@@ -175,6 +175,7 @@ async function main() {
     () => {
       /* no-op */
     },
+    [{ kind: "local" as const, path: "/tmp" }],
   );
 
   const initialState: ScreenState = {

--- a/tests/tui/reuse-harness.tsx
+++ b/tests/tui/reuse-harness.tsx
@@ -118,6 +118,7 @@ async function main() {
     () => {
       /* test harness — errors are silent */
     },
+    [{ kind: "local" as const, path: "/tmp" }],
   );
 
   const appProps = {

--- a/tests/tui/session-isolation-harness.ts
+++ b/tests/tui/session-isolation-harness.ts
@@ -153,6 +153,7 @@ async function main() {
     () => {
       /* test harness — errors are silent */
     },
+    [{ kind: "local" as const, path: groveDir }],
   );
 
   const appProps = {

--- a/tests/tui/trace-running-harness.tsx
+++ b/tests/tui/trace-running-harness.tsx
@@ -110,6 +110,7 @@ async function main() {
     () => {
       /* no-op */
     },
+    [{ kind: "local" as const, path: "/tmp" }],
   );
 
   // Pre-populate log buffers on the spawn manager

--- a/tests/tui/workspace-isolation-harness.tsx
+++ b/tests/tui/workspace-isolation-harness.tsx
@@ -169,6 +169,7 @@ function HarnessApp(): React.ReactElement {
       mockProvider,
       mockTmux,
       (err: string) => process.stderr.write(`[harness] spawn error: ${err}\n`),
+      [{ kind: "local" as const, path: tempRoot }],
       undefined,
       groveDir,
     );


### PR DESCRIPTION
## Summary

Closes #263 (sub-spec 3 of #202). Replaces the single-repo `repoRoot` assumption with a user-wide bare-clone cache. Agents get worktrees from `$XDG_CACHE_HOME/grove/repo-cache/<host>/<path>.git/`; sessions can target arbitrary repos via `--repo`.

- **`src/core/repo-ref.ts`** — pure URL normalization + cache-key derivation with path-safety (rejects `..`, leading-dot, empty segments, null bytes, backslashes, percent-encoded traversal, dotdot hostname, colon-in-segment, malformed percent-encoding).
- **`src/core/repo-cache.ts`** — `resolveRepo(ref, opts)` with flock serialization via `proper-lockfile` (lockfiles at `<cacheRoot>/.locks/` so rm-rf recovery can't unlink them), 60s TTL fetch, `--fresh` hard-fail, offline/stale fallback, `.ok` sentinel auto-recovery, AbortController timeout.
- **Workspace cutover** — `workspace-provisioner.ts` takes `bareClonePath` instead of `repoRoot`; `SessionOrchestrator` + `SpawnManager` gain `repos: readonly RepoRef[]` + `repoCache?`. `projectRoot` preserved for its launcher-dir role (`.grove/`, skills, mcp serve path).
- **CLI** — `--repo <url-or-path>` flag (rejects >1 until multi-repo sub-spec lands); `grove repo list` / `prune` / `fetch` maintenance commands.
- **Forward-compat** — `AgentRole.repoIndex?` field wired through the topology schema; unused today, ready for the deferred multi-repo sub-spec.

Spec: `docs/superpowers/specs/2026-04-21-bare-clone-repo-cache-design.md`
Plan: `docs/superpowers/plans/2026-04-21-bare-clone-repo-cache.md`

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean (14 pre-existing warnings in unrelated files, none new)
- [x] `bun test` — 5877 pass / 2 skip / 0 fail (23k expect calls)
- [x] `src/core/repo-ref.test.ts` — 31 tests cover normalization table + every rejection class
- [x] `src/core/repo-cache.test.ts` — 16 tests cover clone, cache hit, TTL, `--fresh`, stale, corruption recovery, timeout, concurrent serialization, local-w/-origin
- [x] `tests/e2e/repo-cache-session.test.ts` — full resolve → provision → commit → push flow against a `file://` fixture bare
- [x] `src/cli/commands/repo.test.ts` — `list` / `prune` (incl. worktree-safety refusal) / `fetch`
- [x] `src/cli/utils/build-repos.test.ts` — `--repo` parsing + cwd default + not-in-repo error
- [ ] Manual smoke: launch `grove up` in a repo — confirm worktrees land cleanly
- [ ] Manual smoke: `grove up --repo https://github.com/...` against a real remote — confirm first-time clone + subsequent cache hit

## Notes

- No feature flag; atomic cutover (all callers migrated in the same PR).
- Unbounded cache by design; `grove repo prune` is the escape hatch.
- No Nexus coupling — cache is purely a local filesystem concern.