### PR TITLE
fix(local): harden workspace checkout and sqlite batching

### DIFF
--- a/src/local/runtime.test.ts
+++ b/src/local/runtime.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createLocalRuntime } from "./runtime.js";
+
+describe("createLocalRuntime", () => {
+  test("falls back to GROVE.md for configless sessions", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "grove-runtime-"));
+    const groveDir = join(rootDir, ".grove");
+    const previousSessionId = process.env.GROVE_SESSION_ID;
+
+    try {
+      await mkdir(groveDir, { recursive: true });
+      await Bun.write(
+        join(rootDir, "GROVE.md"),
+        `---
+contract_version: 1
+name: runtime-fallback-test
+---
+# Runtime fallback test
+`,
+      );
+
+      const seedRuntime = createLocalRuntime({
+        groveDir,
+        parseContract: false,
+      });
+      const session = await seedRuntime.goalSessionStore.createSession({
+        goal: "configless session",
+      });
+      seedRuntime.close();
+
+      process.env.GROVE_SESSION_ID = session.id;
+
+      const runtime = createLocalRuntime({ groveDir });
+      try {
+        expect(runtime.contract?.contractVersion).toBe(1);
+        expect(runtime.contract?.name).toBe("runtime-fallback-test");
+      } finally {
+        runtime.close();
+      }
+    } finally {
+      if (previousSessionId === undefined) {
+        delete process.env.GROVE_SESSION_ID;
+      } else {
+        process.env.GROVE_SESSION_ID = previousSessionId;
+      }
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/local/runtime.ts
+++ b/src/local/runtime.ts
@@ -128,26 +128,39 @@ export function createLocalRuntime(options: LocalRuntimeOptions): LocalRuntime {
   }
 
   let contract: GroveContract | undefined;
-  if (shouldParseContract) {
-    // Session-scoped config: when GROVE_SESSION_ID is set, load the frozen
-    // contract snapshot from the session record instead of reading GROVE.md.
-    const envSessionId = process.env.GROVE_SESSION_ID;
-    if (envSessionId) {
-      const sessionConfig = stores.goalSessionStore.getSessionConfigSync(envSessionId);
-      if (sessionConfig) {
-        contract = sessionConfig;
-      } else {
-        throw new Error(
-          `Session ${envSessionId} has no stored config. ` +
-            `Cannot load contract for GROVE_SESSION_ID=${envSessionId}.`,
-        );
+  try {
+    if (shouldParseContract) {
+      // Session-scoped config: when GROVE_SESSION_ID is set, prefer the frozen
+      // contract snapshot from the session record. Configless sessions are valid
+      // legacy/current state and should fall back to live GROVE.md.
+      if (envSessionId) {
+        const result = stores.goalSessionStore.resolveSessionConfigSync(envSessionId);
+        if (result.kind === "ok") {
+          contract = result.config;
+        } else if (result.kind === "not-found") {
+          throw new Error(
+            `Session ${envSessionId} not found. GROVE_SESSION_ID points at a ` +
+              `session that does not exist in this grove's session store.`,
+          );
+        } else if (result.kind === "malformed") {
+          throw new Error(
+            `Session ${envSessionId} has malformed config_json: ${result.reason}. ` +
+              `Refusing to proceed with unknown enforcement state.`,
+          );
+        }
       }
-    } else {
-      const contractPath = join(groveRoot, "GROVE.md");
-      if (existsSync(contractPath)) {
-        contract = parseGroveContract(readFileSync(contractPath, "utf-8"));
+      if (contract === undefined) {
+        const contractPath = join(groveRoot, "GROVE.md");
+        if (existsSync(contractPath)) {
+          contract = parseGroveContract(readFileSync(contractPath, "utf-8"));
+        }
       }
     }
+  } catch (err) {
+    workspace?.close();
+    cas.close();
+    stores.close();
+    throw err;
   }
 
   return {

--- a/src/local/sqlite-outcome-store.test.ts
+++ b/src/local/sqlite-outcome-store.test.ts
@@ -4,8 +4,17 @@
  */
 
 import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
 import { runOutcomeStoreTests } from "../core/outcome.conformance.js";
 import { SqliteOutcomeStore } from "./sqlite-outcome-store.js";
+
+function sqliteBindLimit(db: Database): number {
+  const rows = db.prepare("PRAGMA compile_options").all() as readonly {
+    compile_options: string;
+  }[];
+  const option = rows.find((row) => row.compile_options.startsWith("MAX_VARIABLE_NUMBER="));
+  return option ? Number(option.compile_options.slice("MAX_VARIABLE_NUMBER=".length)) : 999;
+}
 
 runOutcomeStoreTests(async () => {
   const db = new Database(":memory:");
@@ -18,4 +27,48 @@ runOutcomeStoreTests(async () => {
       db.close();
     },
   };
+});
+
+describe("SqliteOutcomeStore", () => {
+  test("list supports offset without an explicit limit", async () => {
+    const db = new Database(":memory:");
+    db.run("PRAGMA busy_timeout = 5000");
+    const store = new SqliteOutcomeStore(db);
+
+    try {
+      await store.set("cid-1", { status: "accepted", evaluatedBy: "alice" });
+      await store.set("cid-2", { status: "rejected", evaluatedBy: "alice" });
+      await store.set("cid-3", { status: "crashed", evaluatedBy: "bob" });
+
+      const listed = await store.list({ offset: 1 });
+      expect(listed).toHaveLength(2);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("getBatch chunks requests larger than SQLite's bind limit", async () => {
+    const db = new Database(":memory:");
+    db.run("PRAGMA busy_timeout = 5000");
+    const store = new SqliteOutcomeStore(db);
+
+    try {
+      const bindLimit = sqliteBindLimit(db);
+      await store.set("cid-1", { status: "accepted", evaluatedBy: "alice" });
+      await store.set("cid-2", { status: "rejected", evaluatedBy: "alice" });
+      await store.set("cid-3", { status: "crashed", evaluatedBy: "bob" });
+
+      const cids = Array.from({ length: bindLimit + 1 }, (_, index) =>
+        index < 3 ? `cid-${index + 1}` : `missing-${index}`,
+      );
+      const batch = await store.getBatch(cids);
+
+      expect(batch.size).toBe(3);
+      expect(batch.get("cid-1")?.status).toBe("accepted");
+      expect(batch.get("cid-2")?.status).toBe("rejected");
+      expect(batch.get("cid-3")?.status).toBe("crashed");
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/src/local/sqlite-outcome-store.ts
+++ b/src/local/sqlite-outcome-store.ts
@@ -29,6 +29,8 @@ export const OUTCOME_DDL = `
   CREATE INDEX IF NOT EXISTS idx_outcomes_evaluated_by ON outcomes(evaluated_by);
 `;
 
+const SQLITE_BIND_LIMIT = 900;
+
 /** SQLite-backed OutcomeStore. */
 export class SqliteOutcomeStore implements OutcomeStore {
   private readonly db: Database;
@@ -93,14 +95,17 @@ export class SqliteOutcomeStore implements OutcomeStore {
   async getBatch(cids: readonly string[]): Promise<ReadonlyMap<string, OutcomeRecord>> {
     if (cids.length === 0) return new Map();
 
-    const placeholders = cids.map(() => "?").join(",");
-    const rows = this.db
-      .prepare(`SELECT * FROM outcomes WHERE cid IN (${placeholders})`)
-      .all(...cids) as OutcomeRow[];
-
     const map = new Map<string, OutcomeRecord>();
-    for (const row of rows) {
-      map.set(row.cid, rowToRecord(row));
+    const uniqueCids = [...new Set(cids)];
+    for (let i = 0; i < uniqueCids.length; i += SQLITE_BIND_LIMIT) {
+      const chunk = uniqueCids.slice(i, i + SQLITE_BIND_LIMIT);
+      const placeholders = chunk.map(() => "?").join(",");
+      const rows = this.db
+        .prepare(`SELECT * FROM outcomes WHERE cid IN (${placeholders})`)
+        .all(...chunk) as OutcomeRow[];
+      for (const row of rows) {
+        map.set(row.cid, rowToRecord(row));
+      }
     }
     return map;
   }
@@ -119,11 +124,20 @@ export class SqliteOutcomeStore implements OutcomeStore {
     }
 
     const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
-    const limit = query?.limit ? `LIMIT ${query.limit}` : "";
-    const offset = query?.offset ? `OFFSET ${query.offset}` : "";
+    let pagination = "";
+    if (query?.limit !== undefined) {
+      pagination += " LIMIT ?";
+      params.push(query.limit);
+    } else if (query?.offset !== undefined) {
+      pagination += " LIMIT -1";
+    }
+    if (query?.offset !== undefined) {
+      pagination += " OFFSET ?";
+      params.push(query.offset);
+    }
 
     const rows = this.db
-      .prepare(`SELECT * FROM outcomes ${where} ORDER BY evaluated_at DESC ${limit} ${offset}`)
+      .prepare(`SELECT * FROM outcomes ${where} ORDER BY evaluated_at DESC${pagination}`)
       .all(...params) as OutcomeRow[];
 
     return rows.map(rowToRecord);

--- a/src/local/sqlite-store.migration.test.ts
+++ b/src/local/sqlite-store.migration.test.ts
@@ -32,7 +32,7 @@ describe("schema migration", () => {
       db.close();
 
       expect(row).toBeDefined();
-      expect(row?.version).toBe(9);
+      expect(row?.version).toBe(10);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -173,7 +173,7 @@ describe("schema migration", () => {
       db.close();
 
       expect(rows.length).toBe(1);
-      expect(rows[0]?.version).toBe(9);
+      expect(rows[0]?.version).toBe(10);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -191,7 +191,7 @@ describe("schema migration", () => {
         .get() as {
         version: number;
       } | null;
-      expect(row?.version).toBe(9);
+      expect(row?.version).toBe(10);
 
       db.close();
     } finally {
@@ -356,6 +356,103 @@ describe("schema migration", () => {
     }
   });
 
+  test("backfill repairs partially populated junction tables", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-migration-"));
+    const dbPath = join(dir, "test.db");
+    try {
+      const db = new Database(dbPath);
+      db.run("PRAGMA journal_mode = WAL");
+      db.run("PRAGMA foreign_keys = ON");
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+          version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS contributions (
+          cid TEXT PRIMARY KEY, kind TEXT NOT NULL, mode TEXT NOT NULL,
+          summary TEXT NOT NULL, description TEXT, agent_id TEXT NOT NULL,
+          agent_name TEXT, created_at TEXT NOT NULL,
+          tags_json TEXT NOT NULL DEFAULT '[]', manifest_json TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS contribution_tags (
+          cid TEXT NOT NULL,
+          tag TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS artifacts (
+          contribution_cid TEXT NOT NULL,
+          name TEXT NOT NULL,
+          content_hash TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS relations (
+          source_cid TEXT NOT NULL, target_cid TEXT NOT NULL,
+          relation_type TEXT NOT NULL, metadata_json TEXT,
+          FOREIGN KEY (source_cid) REFERENCES contributions(cid)
+        );
+        CREATE TABLE IF NOT EXISTS claims (
+          claim_id TEXT PRIMARY KEY, target_ref TEXT NOT NULL,
+          agent_id TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'active',
+          heartbeat_at TEXT NOT NULL, lease_expires_at TEXT NOT NULL,
+          intent_summary TEXT NOT NULL, agent_json TEXT NOT NULL
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS contributions_fts USING fts5(cid, summary, description);
+        INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (1, '2026-01-01T00:00:00Z');
+      `);
+
+      const contribution = makeContribution({
+        summary: "partial-backfill",
+        tags: ["alpha", "beta"],
+        artifacts: {
+          "a.txt": "artifact-hash-a",
+          "b.txt": "artifact-hash-b",
+        },
+      });
+      const manifestJson = JSON.stringify(toManifest(contribution));
+      db.run(
+        `INSERT INTO contributions (cid, kind, mode, summary, description,
+         agent_id, agent_name, created_at, tags_json, manifest_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          contribution.cid,
+          contribution.kind,
+          contribution.mode,
+          contribution.summary,
+          contribution.description ?? null,
+          contribution.agent.agentId,
+          contribution.agent.agentName ?? null,
+          contribution.createdAt,
+          JSON.stringify(contribution.tags),
+          manifestJson,
+        ],
+      );
+      db.run("INSERT INTO contribution_tags (cid, tag) VALUES (?, ?)", [contribution.cid, "alpha"]);
+      db.run("INSERT INTO artifacts (contribution_cid, name, content_hash) VALUES (?, ?, ?)", [
+        contribution.cid,
+        "a.txt",
+        "artifact-hash-a",
+      ]);
+      db.close();
+
+      const db2 = initSqliteDb(dbPath);
+      const tags = db2
+        .prepare("SELECT tag FROM contribution_tags WHERE cid = ? ORDER BY tag")
+        .all(contribution.cid) as readonly { tag: string }[];
+      const artifacts = db2
+        .prepare(
+          "SELECT name, content_hash FROM artifacts WHERE contribution_cid = ? ORDER BY name",
+        )
+        .all(contribution.cid) as readonly { name: string; content_hash: string }[];
+      db2.close();
+
+      expect(tags.map((row) => row.tag)).toEqual(["alpha", "beta"]);
+      expect(artifacts).toEqual([
+        { name: "a.txt", content_hash: "artifact-hash-a" },
+        { name: "b.txt", content_hash: "artifact-hash-b" },
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("legacy DB with no schema_migrations rows gets claims columns added", async () => {
     const dir = await mkdtemp(join(tmpdir(), "sqlite-migration-"));
     const dbPath = join(dir, "test.db");
@@ -437,7 +534,7 @@ describe("schema migration", () => {
           v: number | null;
         }
       ).v;
-      expect(version).toBe(9);
+      expect(version).toBe(10);
 
       db2.close();
     } finally {

--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -8,6 +8,7 @@
  * and SqliteClaimStore independently.
  */
 
+import type { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -18,6 +19,14 @@ import { runContributionStoreTests } from "../core/store.conformance.js";
 import type { ContributionStore } from "../core/store.js";
 import { makeContribution } from "../core/test-helpers.js";
 import { createSqliteStores, SqliteStore } from "./sqlite-store.js";
+
+function sqliteBindLimit(db: Database): number {
+  const rows = db.prepare("PRAGMA compile_options").all() as readonly {
+    compile_options: string;
+  }[];
+  const option = rows.find((row) => row.compile_options.startsWith("MAX_VARIABLE_NUMBER="));
+  return option ? Number(option.compile_options.slice("MAX_VARIABLE_NUMBER=".length)) : 999;
+}
 
 // ---------------------------------------------------------------------------
 // Legacy SqliteStore — ContributionStore conformance
@@ -97,6 +106,7 @@ describe("putMany with rich contributions", () => {
   let store: ContributionStore;
   let dir: string;
   let closeStore: () => void;
+  let db: Database;
 
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), "sqlite-putmany-rich-"));
@@ -104,6 +114,7 @@ describe("putMany with rich contributions", () => {
     const stores = createSqliteStores(dbPath);
     store = stores.contributionStore;
     closeStore = stores.close;
+    db = stores.db;
   });
 
   afterEach(async () => {
@@ -510,5 +521,25 @@ describe("putMany with rich contributions", () => {
     const uniqueSearchCids = [...new Set(searchCids)];
     expect(searchCids.length).toBe(uniqueSearchCids.length);
     expect(uniqueSearchCids.length).toBe(5);
+  });
+
+  test("getMany chunks requests larger than SQLite's bind limit", async () => {
+    const bindLimit = sqliteBindLimit(db);
+    const existing = [
+      makeContribution({ summary: "bind-limit-1", createdAt: "2026-06-01T00:00:00Z" }),
+      makeContribution({ summary: "bind-limit-2", createdAt: "2026-06-01T00:00:01Z" }),
+      makeContribution({ summary: "bind-limit-3", createdAt: "2026-06-01T00:00:02Z" }),
+    ];
+    await store.putMany(existing);
+
+    const cids = Array.from({ length: bindLimit + 1 }, (_, index) =>
+      index < existing.length ? (existing[index]?.cid ?? "") : `missing-${index}`,
+    );
+    const result = await store.getMany(cids);
+
+    expect(result.size).toBe(existing.length);
+    for (const contribution of existing) {
+      expect(result.get(contribution.cid)?.cid).toBe(contribution.cid);
+    }
   });
 });

--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -542,4 +542,12 @@ describe("putMany with rich contributions", () => {
       expect(result.get(contribution.cid)?.cid).toBe(contribution.cid);
     }
   });
+
+  test("list rejects tag filters beyond the SQLite-safe limit", async () => {
+    const tooManyTags = Array.from(
+      { length: sqliteBindLimit(db) + 1 },
+      (_, index) => `tag-${index}`,
+    );
+    await expect(store.list({ tags: tooManyTags })).rejects.toThrow("Too many tag filters");
+  });
 });

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -49,7 +49,8 @@ import { DEFAULT_LEASE_DURATION_MS } from "../core/claim-logic.js";
 import { ClaimConflictError, NotFoundError, StateConflictError } from "../core/errors.js";
 import { toUtcIso } from "../core/time.js";
 
-const CURRENT_SCHEMA_VERSION = 9;
+const CURRENT_SCHEMA_VERSION = 10;
+const SQLITE_BIND_LIMIT = 900;
 
 // ---------------------------------------------------------------------------
 // Schema DDL
@@ -153,6 +154,7 @@ const SCHEMA_DDL = `
 
   CREATE INDEX IF NOT EXISTS idx_workspaces_status ON workspaces(status);
   CREATE INDEX IF NOT EXISTS idx_workspaces_activity ON workspaces(last_activity_at);
+  CREATE INDEX IF NOT EXISTS idx_workspaces_agent_id ON workspaces(agent_id);
 
   -- Idempotency cache: persists across process restarts so CLI retries work.
   -- The in-memory Map in contribute.ts handles single-flight within a process;
@@ -257,6 +259,7 @@ export function initSqliteDb(dbPath: string): Database {
         v: number | null;
       }
     ).v;
+    const needsLegacyBackfill = currentVersion === null || currentVersion < CURRENT_SCHEMA_VERSION;
 
     // Column-safe migrations: always run regardless of schema version.
     // Each uses PRAGMA table_info to check before altering, making them
@@ -307,6 +310,7 @@ export function initSqliteDb(dbPath: string): Database {
         );
         CREATE INDEX IF NOT EXISTS idx_workspaces_status ON workspaces(status);
         CREATE INDEX IF NOT EXISTS idx_workspaces_activity ON workspaces(last_activity_at);
+        CREATE INDEX IF NOT EXISTS idx_workspaces_agent_id ON workspaces(agent_id);
       `);
     }
 
@@ -436,24 +440,28 @@ export function initSqliteDb(dbPath: string): Database {
       new Date().toISOString(),
     ]);
 
-    // Backfill junction tables for pre-existing contributions.
-    // INSERT OR IGNORE prevents duplicates when the tables already have rows.
-    db.run(`
-      INSERT OR IGNORE INTO contribution_tags (cid, tag)
-      SELECT c.cid, j.value
-      FROM contributions c, json_each(c.tags_json) j
-      WHERE NOT EXISTS (
-        SELECT 1 FROM contribution_tags ct WHERE ct.cid = c.cid
-      )
-    `);
-    db.run(`
-      INSERT OR IGNORE INTO artifacts (contribution_cid, name, content_hash)
-      SELECT c.cid, j.key, j.value
-      FROM contributions c, json_each(json_extract(c.manifest_json, '$.artifacts')) j
-      WHERE NOT EXISTS (
-        SELECT 1 FROM artifacts a WHERE a.contribution_cid = c.cid
-      )
-    `);
+    if (needsLegacyBackfill) {
+      // Backfill junction tables for pre-existing contributions once while
+      // upgrading legacy databases. INSERT OR IGNORE prevents duplicates.
+      db.run(`
+        INSERT OR IGNORE INTO contribution_tags (cid, tag)
+        SELECT c.cid, j.value
+        FROM contributions c, json_each(c.tags_json) j
+        WHERE NOT EXISTS (
+          SELECT 1 FROM contribution_tags ct WHERE ct.cid = c.cid AND ct.tag = j.value
+        )
+      `);
+      db.run(`
+        INSERT OR IGNORE INTO artifacts (contribution_cid, name, content_hash)
+        SELECT c.cid, j.key, j.value
+        FROM contributions c, json_each(json_extract(c.manifest_json, '$.artifacts')) j
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM artifacts a
+          WHERE a.contribution_cid = c.cid AND a.name = j.key AND a.content_hash = j.value
+        )
+      `);
+    }
   });
   initSchema.immediate();
 
@@ -900,12 +908,16 @@ export class SqliteContributionStore implements ContributionStore {
     const result = new Map<string, Contribution>();
     if (cids.length === 0) return result;
 
-    const placeholders = cids.map(() => "?").join(", ");
-    const sql = `SELECT manifest_json FROM contributions WHERE cid IN (${placeholders})`;
-    const rows = this.db.prepare(sql).all(...cids) as readonly { manifest_json: string }[];
-    for (const row of rows) {
-      const contribution = rowToContribution(row);
-      result.set(contribution.cid, contribution);
+    const uniqueCids = [...new Set(cids)];
+    for (let i = 0; i < uniqueCids.length; i += SQLITE_BIND_LIMIT) {
+      const chunk = uniqueCids.slice(i, i + SQLITE_BIND_LIMIT);
+      const placeholders = chunk.map(() => "?").join(", ");
+      const sql = `SELECT manifest_json FROM contributions WHERE cid IN (${placeholders})`;
+      const rows = this.db.prepare(sql).all(...chunk) as readonly { manifest_json: string }[];
+      for (const row of rows) {
+        const contribution = rowToContribution(row);
+        result.set(contribution.cid, contribution);
+      }
     }
     return result;
   };
@@ -1287,7 +1299,7 @@ export class SqliteContributionStore implements ContributionStore {
   /** Multi-row INSERT helper. Chunks rows to stay under SQLITE_MAX_VARIABLE_NUMBER (999). */
   private batchInsert(prefix: string, cols: number, rows: SQLQueryBindings[][]): void {
     if (rows.length === 0) return;
-    const chunkSize = Math.floor(999 / cols);
+    const chunkSize = Math.floor(SQLITE_BIND_LIMIT / cols);
     for (let i = 0; i < rows.length; i += chunkSize) {
       const chunk = rows.slice(i, i + chunkSize);
       const placeholderRow = `(${Array(cols).fill("?").join(", ")})`;

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -652,6 +652,9 @@ function buildFilteredQuery(opts: BuildFilteredQueryOptions): BuiltQuery {
   // Uses intersecting EXISTS subqueries for indexed point lookups on (tag, cid).
   if (query?.tags !== undefined && query.tags.length > 0) {
     const uniqueTags = [...new Set(query.tags)];
+    if (uniqueTags.length > SQLITE_BIND_LIMIT) {
+      throw new Error(`Too many tag filters: maximum ${SQLITE_BIND_LIMIT}`);
+    }
     for (const tag of uniqueTags) {
       conditions.push(
         `EXISTS (SELECT 1 FROM contribution_tags ct WHERE ct.cid = c.cid AND ct.tag = ?)`,

--- a/src/local/workspace.test.ts
+++ b/src/local/workspace.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { mkdir, readdir, rm, utimes } from "node:fs/promises";
+import { lstat, mkdir, readdir, rm, symlink, utimes } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -554,6 +554,32 @@ describe("LocalWorkspaceManager implementation", () => {
       const file = Bun.file(join(info.workspacePath, "file.txt"));
       expect(await file.text()).toBe("data");
     } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  test("checkout recreates an active workspace path replaced by a symlink", async () => {
+    const ctx = await createTestContext();
+    const outsideDir = join(tmpdir(), `grove-workspace-symlink-${Date.now()}`);
+    try {
+      const contribution = await ctx.createContributionWithArtifacts({
+        "file.txt": new TextEncoder().encode("data"),
+      });
+      const agent = makeAgent({ agentId: "symlink-agent" });
+
+      const first = await ctx.manager.checkout(contribution.cid, { agent });
+      await mkdir(outsideDir, { recursive: true });
+      await Bun.write(join(outsideDir, "file.txt"), "outside");
+
+      await rm(first.workspacePath, { recursive: true, force: true });
+      await symlink(outsideDir, first.workspacePath);
+
+      const second = await ctx.manager.checkout(contribution.cid, { agent });
+      const stats = await lstat(second.workspacePath);
+      expect(stats.isSymbolicLink()).toBe(false);
+      expect(await Bun.file(join(second.workspacePath, "file.txt")).text()).toBe("data");
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
       await ctx.cleanup();
     }
   });

--- a/src/local/workspace.test.ts
+++ b/src/local/workspace.test.ts
@@ -15,10 +15,11 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { mkdir, readdir, rm } from "node:fs/promises";
+import { mkdir, readdir, rm, utimes } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import type { HookRunner } from "../core/hooks.js";
 import { createContribution } from "../core/manifest.js";
 import type { ContributionInput } from "../core/models.js";
 import { ContributionKind, ContributionMode } from "../core/models.js";
@@ -35,7 +36,12 @@ import { LocalWorkspaceManager } from "./workspace.js";
 // Factory for conformance tests
 // ---------------------------------------------------------------------------
 
-async function createTestContext(): Promise<WorkspaceTestContext> {
+type LocalWorkspaceTestContext = WorkspaceTestContext & {
+  readonly createActiveClaimForAgent: (targetRef: string, agentId: string) => Promise<void>;
+  readonly workspacesRoot: string;
+};
+
+async function createTestContext(): Promise<LocalWorkspaceTestContext> {
   const dir = join(tmpdir(), `grove-workspace-test-${Date.now()}`);
   await mkdir(dir, { recursive: true });
 
@@ -59,9 +65,24 @@ async function createTestContext(): Promise<WorkspaceTestContext> {
   });
 
   let artifactCounter = 0;
+  const createActiveClaimForAgent = async (targetRef: string, agentId: string) => {
+    const now = new Date();
+    const lease = new Date(now.getTime() + 300_000);
+    await claimStore.createClaim({
+      claimId: `claim-${targetRef}-${agentId}-${Date.now()}`,
+      targetRef,
+      agent: makeAgent({ agentId }),
+      status: "active" as const,
+      intentSummary: "Test claim",
+      createdAt: now.toISOString(),
+      heartbeatAt: now.toISOString(),
+      leaseExpiresAt: lease.toISOString(),
+    });
+  };
 
   return {
     manager,
+    workspacesRoot: join(groveRoot, "workspaces"),
     createContributionWithArtifacts: async (
       artifacts: Record<string, Uint8Array>,
       overrides?: Partial<ContributionInput>,
@@ -90,20 +111,9 @@ async function createTestContext(): Promise<WorkspaceTestContext> {
       await contributionStore.put(contribution);
       return contribution;
     },
-    createActiveClaim: async (targetRef: string) => {
-      const now = new Date();
-      const lease = new Date(now.getTime() + 300_000);
-      await claimStore.createClaim({
-        claimId: `claim-${targetRef}-${Date.now()}`,
-        targetRef,
-        agent: makeAgent(),
-        status: "active" as const,
-        intentSummary: "Test claim",
-        createdAt: now.toISOString(),
-        heartbeatAt: now.toISOString(),
-        leaseExpiresAt: lease.toISOString(),
-      });
-    },
+    createActiveClaim: async (targetRef: string) =>
+      createActiveClaimForAgent(targetRef, makeAgent().agentId),
+    createActiveClaimForAgent,
     cleanup: async () => {
       db.close();
       await rm(dir, { recursive: true, force: true });
@@ -354,6 +364,238 @@ describe("LocalWorkspaceManager implementation", () => {
     } finally {
       db.close();
       await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("concurrent checkout waits for after_checkout hook completion", async () => {
+    const dir = join(tmpdir(), `grove-workspace-hook-race-${Date.now()}`);
+    await mkdir(dir, { recursive: true });
+
+    const dbPath = join(dir, "test.db");
+    const casRoot = join(dir, "cas");
+    const groveRoot = join(dir, "grove");
+
+    await mkdir(casRoot, { recursive: true });
+    await mkdir(groveRoot, { recursive: true });
+
+    const db = initSqliteDb(dbPath);
+    const contributionStore = new SqliteContributionStore(db);
+    const cas = new FsCas(casRoot);
+
+    let releaseHook!: () => void;
+    const hookReleased = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+    let signalHookStarted!: () => void;
+    const hookStarted = new Promise<void>((resolve) => {
+      signalHookStarted = resolve;
+    });
+    const hookRunner: HookRunner = {
+      run: async () => {
+        signalHookStarted();
+        await hookReleased;
+        return {
+          success: true,
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          command: "test-hook",
+          durationMs: 0,
+        };
+      },
+    };
+
+    const manager = new LocalWorkspaceManager({
+      groveRoot,
+      db,
+      contributionStore,
+      cas,
+      hookRunner,
+      hooksConfig: {
+        after_checkout: "test-hook",
+      },
+    });
+
+    try {
+      const hash = await cas.put(new TextEncoder().encode("data"));
+      const input: ContributionInput = {
+        kind: ContributionKind.Work,
+        mode: ContributionMode.Evaluation,
+        summary: "Hook race test",
+        artifacts: { "data.txt": hash },
+        relations: [],
+        tags: [],
+        agent: makeAgent(),
+        createdAt: new Date().toISOString(),
+      };
+      const contribution = createContribution(input);
+      await contributionStore.put(contribution);
+
+      const agent = makeAgent({ agentId: "hook-agent" });
+      const firstCheckout = manager.checkout(contribution.cid, { agent });
+      await hookStarted;
+
+      const secondCheckout = manager.checkout(contribution.cid, { agent });
+      const secondState = await Promise.race([
+        secondCheckout.then(() => "resolved" as const),
+        new Promise<"pending">((resolve) => {
+          setTimeout(() => resolve("pending"), 150);
+        }),
+      ]);
+
+      expect(secondState).toBe("pending");
+
+      releaseHook();
+
+      const [first, second] = await Promise.all([firstCheckout, secondCheckout]);
+      expect(first.workspacePath).toBe(second.workspacePath);
+    } finally {
+      db.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("concurrent checkout for the same agent waits for the first materialization", async () => {
+    const ctx = await createTestContext();
+    const manager = ctx.manager as unknown as {
+      casGetToFile: (contentHash: string, destPath: string) => Promise<boolean>;
+    };
+    const originalCasGetToFile = manager.casGetToFile.bind(ctx.manager);
+
+    let releaseFirstCopy!: () => void;
+    const firstCopyReleased = new Promise<void>((resolve) => {
+      releaseFirstCopy = resolve;
+    });
+    let signalFirstCopyStarted!: () => void;
+    const firstCopyStarted = new Promise<void>((resolve) => {
+      signalFirstCopyStarted = resolve;
+    });
+    let intercepted = false;
+
+    manager.casGetToFile = async (contentHash: string, destPath: string) => {
+      if (!intercepted) {
+        intercepted = true;
+        signalFirstCopyStarted();
+        await firstCopyReleased;
+      }
+      return originalCasGetToFile(contentHash, destPath);
+    };
+
+    try {
+      const contribution = await ctx.createContributionWithArtifacts({
+        "file.txt": new TextEncoder().encode("data"),
+      });
+      const agent = makeAgent({ agentId: "shared-agent" });
+
+      const firstCheckout = ctx.manager.checkout(contribution.cid, { agent });
+      await firstCopyStarted;
+
+      const secondCheckout = ctx.manager.checkout(contribution.cid, { agent });
+      const secondState = await Promise.race([
+        secondCheckout.then(() => "resolved" as const),
+        new Promise<"pending">((resolve) => {
+          setTimeout(() => resolve("pending"), 100);
+        }),
+      ]);
+
+      expect(secondState).toBe("pending");
+
+      releaseFirstCopy();
+
+      const [first, second] = await Promise.all([firstCheckout, secondCheckout]);
+      expect(first.workspacePath).toBe(second.workspacePath);
+
+      const file = Bun.file(join(first.workspacePath, "file.txt"));
+      expect(await file.text()).toBe("data");
+    } finally {
+      manager.casGetToFile = originalCasGetToFile;
+      await ctx.cleanup();
+    }
+  });
+
+  test("checkout recovers from a stale workspace lock owned by a dead process", async () => {
+    const ctx = await createTestContext();
+    try {
+      const contribution = await ctx.createContributionWithArtifacts({
+        "file.txt": new TextEncoder().encode("data"),
+      });
+      const agent = makeAgent({ agentId: "stale-lock-agent" });
+      const cidHex = contribution.cid.replace("blake3:", "");
+      const workspacePath = join(ctx.workspacesRoot, `${cidHex}-${agent.agentId}`);
+      const lockPath = `${workspacePath}.lock`;
+
+      await mkdir(lockPath, { recursive: true });
+      await Bun.write(join(lockPath, "owner.json"), JSON.stringify({ pid: 999_999_999 }));
+
+      const info = await ctx.manager.checkout(contribution.cid, { agent });
+      const file = Bun.file(join(info.workspacePath, "file.txt"));
+      expect(await file.text()).toBe("data");
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  test("checkout recovers from a stale workspace lock missing owner metadata", async () => {
+    const ctx = await createTestContext();
+    try {
+      const contribution = await ctx.createContributionWithArtifacts({
+        "file.txt": new TextEncoder().encode("data"),
+      });
+      const agent = makeAgent({ agentId: "missing-owner-agent" });
+      const cidHex = contribution.cid.replace("blake3:", "");
+      const workspacePath = join(ctx.workspacesRoot, `${cidHex}-${agent.agentId}`);
+      const lockPath = `${workspacePath}.lock`;
+      const staleTime = new Date(Date.now() - 10_000);
+
+      await mkdir(lockPath, { recursive: true });
+      await utimes(lockPath, staleTime, staleTime);
+
+      const info = await ctx.manager.checkout(contribution.cid, { agent });
+      const file = Bun.file(join(info.workspacePath, "file.txt"));
+      expect(await file.text()).toBe("data");
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  test("createBareWorkspace recreates a missing active directory", async () => {
+    const ctx = await createTestContext();
+    try {
+      const agent = makeAgent({ agentId: "bare-agent" });
+      const first = await ctx.manager.createBareWorkspace("spawn-1", { agent });
+
+      await rm(first.workspacePath, { recursive: true, force: true });
+
+      const second = await ctx.manager.createBareWorkspace("spawn-1", { agent });
+      await Bun.write(join(second.workspacePath, ".probe"), "ok");
+      expect(await Bun.file(join(second.workspacePath, ".probe")).text()).toBe("ok");
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  test("cleanup ignores an active claim held by another agent", async () => {
+    const ctx = await createTestContext();
+    try {
+      const contribution = await ctx.createContributionWithArtifacts({
+        "file.txt": new TextEncoder().encode("data"),
+      });
+      const alice = makeAgent({ agentId: "alice" });
+      const bob = makeAgent({ agentId: "bob" });
+
+      await ctx.manager.checkout(contribution.cid, { agent: alice });
+      const bobWorkspace = await ctx.manager.checkout(contribution.cid, { agent: bob });
+      await ctx.createActiveClaimForAgent(contribution.cid, "bob");
+
+      await expect(ctx.manager.cleanWorkspace(contribution.cid, "alice")).resolves.toBe(true);
+
+      const aliceInfo = await ctx.manager.getWorkspace(contribution.cid, "alice");
+      expect(aliceInfo?.status).toBe(WorkspaceStatus.Cleaned);
+
+      const bobFile = Bun.file(join(bobWorkspace.workspacePath, "file.txt"));
+      expect(await bobFile.text()).toBe("data");
+    } finally {
+      await ctx.cleanup();
     }
   });
 });

--- a/src/local/workspace.test.ts
+++ b/src/local/workspace.test.ts
@@ -524,8 +524,7 @@ describe("LocalWorkspaceManager implementation", () => {
       const workspacePath = join(ctx.workspacesRoot, `${cidHex}-${agent.agentId}`);
       const lockPath = `${workspacePath}.lock`;
 
-      await mkdir(lockPath, { recursive: true });
-      await Bun.write(join(lockPath, "owner.json"), JSON.stringify({ pid: 999_999_999 }));
+      await Bun.write(lockPath, JSON.stringify({ pid: 999_999_999, token: "dead-token" }));
 
       const info = await ctx.manager.checkout(contribution.cid, { agent });
       const file = Bun.file(join(info.workspacePath, "file.txt"));
@@ -545,9 +544,9 @@ describe("LocalWorkspaceManager implementation", () => {
       const cidHex = contribution.cid.replace("blake3:", "");
       const workspacePath = join(ctx.workspacesRoot, `${cidHex}-${agent.agentId}`);
       const lockPath = `${workspacePath}.lock`;
-      const staleTime = new Date(Date.now() - 10_000);
+      const staleTime = new Date(Date.now() - 10 * 60 * 1000);
 
-      await mkdir(lockPath, { recursive: true });
+      await Bun.write(lockPath, "");
       await utimes(lockPath, staleTime, staleTime);
 
       const info = await ctx.manager.checkout(contribution.cid, { agent });
@@ -596,6 +595,29 @@ describe("LocalWorkspaceManager implementation", () => {
       await Bun.write(join(second.workspacePath, ".probe"), "ok");
       expect(await Bun.file(join(second.workspacePath, ".probe")).text()).toBe("ok");
     } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  test("createBareWorkspace recreates an active workspace path replaced by a symlink", async () => {
+    const ctx = await createTestContext();
+    const outsideDir = join(tmpdir(), `grove-bare-workspace-symlink-${Date.now()}`);
+    try {
+      const agent = makeAgent({ agentId: "bare-symlink-agent" });
+      const first = await ctx.manager.createBareWorkspace("spawn-symlink", { agent });
+      await mkdir(outsideDir, { recursive: true });
+      await Bun.write(join(outsideDir, ".probe"), "outside");
+
+      await rm(first.workspacePath, { recursive: true, force: true });
+      await symlink(outsideDir, first.workspacePath);
+
+      const second = await ctx.manager.createBareWorkspace("spawn-symlink", { agent });
+      const stats = await lstat(second.workspacePath);
+      expect(stats.isSymbolicLink()).toBe(false);
+      await Bun.write(join(second.workspacePath, ".probe"), "ok");
+      expect(await Bun.file(join(second.workspacePath, ".probe")).text()).toBe("ok");
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
       await ctx.cleanup();
     }
   });

--- a/src/local/workspace.ts
+++ b/src/local/workspace.ts
@@ -16,7 +16,7 @@
 import type { Database } from "bun:sqlite";
 import { randomBytes } from "node:crypto";
 import { constants } from "node:fs";
-import { copyFile, lstat, mkdir, rename, rm, stat } from "node:fs/promises";
+import { copyFile, lstat, mkdir, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { HookEntry, HookRunner, HooksConfig } from "../core/hooks.js";
@@ -48,8 +48,6 @@ import type { FsCas } from "./fs-cas.js";
 const WORKSPACES_DIR = "workspaces";
 const WORKSPACE_LOCK_POLL_MS = 25;
 const WORKSPACE_LOCK_TIMEOUT_MS = 300_000;
-const WORKSPACE_LOCK_OWNER_FILE = "owner.json";
-const WORKSPACE_LOCK_OWNER_GRACE_MS = 5_000;
 
 // ---------------------------------------------------------------------------
 // SQLite workspace table operations
@@ -95,6 +93,7 @@ async function sleep(ms: number): Promise<void> {
 
 interface WorkspaceLockOwner {
   readonly pid: number;
+  readonly token: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -166,7 +165,12 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     // Serialize materialization per (cid, agentId). Without this, concurrent
     // checkouts can both race through temp-dir creation and one caller can
     // delete a workspace the other already returned.
-    while (!(await this.tryAcquireWorkspaceLock(lockPath))) {
+    let lockToken: string | undefined;
+    while (lockToken === undefined) {
+      lockToken = await this.tryAcquireWorkspaceLock(lockPath);
+      if (lockToken !== undefined) {
+        break;
+      }
       const ready = await this.waitForReadyWorkspace(cid, agentId, lockPath);
       if (ready !== undefined) {
         return ready;
@@ -208,9 +212,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
 
         // Atomic placement: rename temp dir to final location.
         // We only remove an existing path while holding the per-workspace lock.
-        if (await this.pathExists(workspacePath)) {
-          await rm(workspacePath, { recursive: true, force: true });
-        }
+        await this.removeWorkspacePathIfPresent(workspacePath);
         await rename(tmpDir, workspacePath);
       } catch (err) {
         // Clean up temp directory on failure
@@ -254,7 +256,9 @@ export class LocalWorkspaceManager implements WorkspaceManager {
         ...(options.context !== undefined && { context: options.context }),
       };
     } finally {
-      await this.releaseWorkspaceLock(lockPath);
+      if (lockToken !== undefined) {
+        await this.releaseWorkspaceLock(lockPath, lockToken);
+      }
     }
   }
 
@@ -308,7 +312,12 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     await assertWithinBoundary(workspace.workspacePath, this.workspacesRoot);
     const lockPath = `${workspace.workspacePath}.lock`;
 
-    while (!(await this.tryAcquireWorkspaceLock(lockPath))) {
+    let lockToken: string | undefined;
+    while (lockToken === undefined) {
+      lockToken = await this.tryAcquireWorkspaceLock(lockPath);
+      if (lockToken !== undefined) {
+        break;
+      }
       await this.waitForWorkspaceLockRelease(lockPath);
     }
 
@@ -337,7 +346,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
 
       // Remove the directory
       try {
-        await rm(current.workspacePath, { recursive: true, force: true });
+        await this.removeWorkspacePathIfPresent(current.workspacePath);
       } catch (err) {
         // Directory might already be gone — that's fine
         if (
@@ -360,7 +369,9 @@ export class LocalWorkspaceManager implements WorkspaceManager {
 
       return true;
     } finally {
-      await this.releaseWorkspaceLock(lockPath);
+      if (lockToken !== undefined) {
+        await this.releaseWorkspaceLock(lockPath, lockToken);
+      }
     }
   }
 
@@ -405,21 +416,23 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     const agentId = options.agent.agentId;
     validateWorkspaceKey(agentId);
     validateWorkspaceKey(key);
+    const workspacePath = join(this.workspacesRoot, `${key}-${agentId}`);
 
     // Idempotent: return existing active workspace
     const existing = await this.getWorkspace(key, agentId);
     if (
       existing !== undefined &&
       existing.status === WorkspaceStatus.Active &&
-      (await this.pathExists(existing.workspacePath))
+      existing.workspacePath === workspacePath &&
+      (await this.validateReadyWorkspacePath(existing.workspacePath))
     ) {
       return existing;
     }
 
     // Create empty workspace directory
     // Key is a spawnId (not a CID), so use it directly after validation
-    const workspacePath = join(this.workspacesRoot, `${key}-${agentId}`);
     await mkdir(this.workspacesRoot, { recursive: true });
+    await this.removeWorkspacePathIfPresent(workspacePath);
     await mkdir(workspacePath, { recursive: true });
 
     // Record in SQLite
@@ -544,7 +557,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
 
   private async pathExists(path: string): Promise<boolean> {
     try {
-      await stat(path);
+      await lstat(path);
       return true;
     } catch (err) {
       if (isErrnoCode(err, "ENOENT")) return false;
@@ -552,23 +565,40 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     }
   }
 
-  private async tryAcquireWorkspaceLock(lockPath: string): Promise<boolean> {
+  private async removeWorkspacePathIfPresent(path: string): Promise<void> {
     try {
-      await mkdir(lockPath);
-      await Bun.write(
-        join(lockPath, WORKSPACE_LOCK_OWNER_FILE),
-        JSON.stringify({ pid: process.pid } satisfies WorkspaceLockOwner),
-      );
-      return true;
+      const entry = await lstat(path);
+      if (entry.isDirectory() && !entry.isSymbolicLink()) {
+        await rm(path, { recursive: true, force: true });
+      } else {
+        await unlink(path);
+      }
     } catch (err) {
-      if (isErrnoCode(err, "EEXIST")) return false;
-      await safeCleanup(
-        rm(lockPath, { recursive: true, force: true }),
-        "remove failed workspace lock",
+      if (isErrnoCode(err, "ENOENT")) {
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private async tryAcquireWorkspaceLock(lockPath: string): Promise<string | undefined> {
+    const token = randomBytes(8).toString("hex");
+    try {
+      await writeFile(
+        lockPath,
+        JSON.stringify({ pid: process.pid, token } satisfies WorkspaceLockOwner),
         {
-          silent: true,
+          flag: "wx",
         },
       );
+      const owner = await this.readWorkspaceLockOwner(lockPath);
+      if (owner?.token !== token) {
+        await this.releaseWorkspaceLock(lockPath, token);
+        throw new Error(`Workspace lock '${lockPath}' could not verify its owner token`);
+      }
+      return token;
+    } catch (err) {
+      if (isErrnoCode(err, "EEXIST")) return undefined;
       throw err;
     }
   }
@@ -621,18 +651,28 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     throw new Error(`Timed out waiting for workspace lock '${lockPath}'`);
   }
 
-  private async releaseWorkspaceLock(lockPath: string): Promise<void> {
-    await safeCleanup(rm(lockPath, { recursive: true, force: true }), "remove workspace lock dir", {
+  private async releaseWorkspaceLock(lockPath: string, token: string): Promise<void> {
+    const owner = await this.readWorkspaceLockOwner(lockPath);
+    if (owner === undefined || owner.token !== token) {
+      return;
+    }
+    await safeCleanup(unlink(lockPath), "remove workspace lock file", {
       silent: true,
     });
   }
 
   private async readWorkspaceLockOwner(lockPath: string): Promise<WorkspaceLockOwner | undefined> {
     try {
-      const text = await Bun.file(join(lockPath, WORKSPACE_LOCK_OWNER_FILE)).text();
-      const parsed = JSON.parse(text) as { pid?: unknown };
-      if (typeof parsed.pid === "number" && Number.isInteger(parsed.pid) && parsed.pid > 0) {
-        return { pid: parsed.pid };
+      const text = await Bun.file(lockPath).text();
+      const parsed = JSON.parse(text) as { pid?: unknown; token?: unknown };
+      if (
+        typeof parsed.pid === "number" &&
+        Number.isInteger(parsed.pid) &&
+        parsed.pid > 0 &&
+        typeof parsed.token === "string" &&
+        parsed.token.length > 0
+      ) {
+        return { pid: parsed.pid, token: parsed.token };
       }
       return undefined;
     } catch (err) {
@@ -693,14 +733,16 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     const owner = await this.readWorkspaceLockOwner(lockPath);
     if (owner !== undefined) {
       if (!this.isProcessAlive(owner.pid)) {
-        await this.releaseWorkspaceLock(lockPath);
+        await this.releaseWorkspaceLock(lockPath, owner.token);
         return true;
       }
       return false;
     }
     const ageMs = await this.getLockAgeMs(lockPath);
-    if (ageMs !== undefined && ageMs >= WORKSPACE_LOCK_OWNER_GRACE_MS) {
-      await this.releaseWorkspaceLock(lockPath);
+    if (ageMs !== undefined && ageMs >= WORKSPACE_LOCK_TIMEOUT_MS) {
+      await safeCleanup(unlink(lockPath), "remove stale malformed workspace lock", {
+        silent: true,
+      });
       return true;
     }
     return false;

--- a/src/local/workspace.ts
+++ b/src/local/workspace.ts
@@ -16,7 +16,7 @@
 import type { Database } from "bun:sqlite";
 import { randomBytes } from "node:crypto";
 import { constants } from "node:fs";
-import { copyFile, mkdir, rename, rm, stat } from "node:fs/promises";
+import { copyFile, lstat, mkdir, rename, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { HookEntry, HookRunner, HooksConfig } from "../core/hooks.js";
@@ -24,6 +24,7 @@ import type { AgentIdentity, JsonValue } from "../core/models.js";
 import {
   assertWithinBoundary,
   ensureArtifactParentDir,
+  PathContainmentError,
   sanitizeCidForPath,
   validateArtifactName,
   validateWorkspaceKey,
@@ -145,9 +146,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     validateWorkspaceKey(agentId);
 
     // Compute workspace directory path — scoped by CID + agent
-    const cidHex = sanitizeCidForPath(cid);
-    const workspacePath = join(this.workspacesRoot, `${cidHex}-${agentId}`);
-    const lockPath = `${workspacePath}.lock`;
+    const { workspacePath, lockPath } = this.checkoutPaths(cid, agentId);
 
     // Check for existing active workspace for this (cid, agent) pair
     const existing = await this.getReadyWorkspace(cid, agentId);
@@ -229,6 +228,9 @@ export class LocalWorkspaceManager implements WorkspaceManager {
       // Run after_checkout before publishing the workspace as active so
       // concurrent callers do not race ahead of workspace-local setup.
       await this.runHook("after_checkout", workspacePath);
+      if (!(await this.validateReadyWorkspacePath(workspacePath))) {
+        throw new Error(`Workspace '${workspacePath}' became invalid during checkout`);
+      }
 
       // Record workspace in SQLite only after the workspace is fully ready.
       this.upsertWorkspaceRow({
@@ -300,46 +302,66 @@ export class LocalWorkspaceManager implements WorkspaceManager {
   async cleanWorkspace(cid: string, agentId: string): Promise<boolean> {
     const workspace = await this.getWorkspace(cid, agentId);
     if (workspace === undefined) return false;
+    validateWorkspaceKey(agentId);
 
-    // Check if there's an active claim for this CID
-    const activeClaim = this.db
-      .prepare(
-        `SELECT claim_id FROM claims
-         WHERE target_ref = ? AND agent_id = ? AND status = 'active'
-         AND lease_expires_at >= ?`,
-      )
-      .get(cid, agentId, new Date().toISOString()) as { claim_id: string } | null;
-
-    if (activeClaim !== null) {
-      throw new Error(
-        `Cannot clean workspace for '${cid}': claim '${activeClaim.claim_id}' is still active`,
-      );
-    }
-
-    // Re-validate workspace path is under our workspace root before rm()
-    // to protect against corrupted/tampered SQLite rows pointing outside Grove
+    // Validate before deriving the lock path from the persisted row.
     await assertWithinBoundary(workspace.workspacePath, this.workspacesRoot);
+    const lockPath = `${workspace.workspacePath}.lock`;
 
-    // Remove the directory
-    try {
-      await rm(workspace.workspacePath, { recursive: true, force: true });
-    } catch (err) {
-      // Directory might already be gone — that's fine
-      if (
-        !(err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT")
-      ) {
-        throw err;
-      }
+    while (!(await this.tryAcquireWorkspaceLock(lockPath))) {
+      await this.waitForWorkspaceLockRelease(lockPath);
     }
 
-    // Update status in SQLite
-    this.db
-      .prepare(
-        "UPDATE workspaces SET status = ?, last_activity_at = ? WHERE cid = ? AND agent_id = ?",
-      )
-      .run(WorkspaceStatus.Cleaned, new Date().toISOString(), cid, agentId);
+    try {
+      const current = await this.getWorkspace(cid, agentId);
+      if (current === undefined) return false;
 
-    return true;
+      // Check if there's an active claim for this CID
+      const activeClaim = this.db
+        .prepare(
+          `SELECT claim_id FROM claims
+           WHERE target_ref = ? AND agent_id = ? AND status = 'active'
+           AND lease_expires_at >= ?`,
+        )
+        .get(cid, agentId, new Date().toISOString()) as { claim_id: string } | null;
+
+      if (activeClaim !== null) {
+        throw new Error(
+          `Cannot clean workspace for '${cid}': claim '${activeClaim.claim_id}' is still active`,
+        );
+      }
+
+      // Re-validate workspace path is under our workspace root before rm()
+      // to protect against corrupted/tampered SQLite rows pointing outside Grove
+      await assertWithinBoundary(current.workspacePath, this.workspacesRoot);
+
+      // Remove the directory
+      try {
+        await rm(current.workspacePath, { recursive: true, force: true });
+      } catch (err) {
+        // Directory might already be gone — that's fine
+        if (
+          !(
+            err instanceof Error &&
+            "code" in err &&
+            (err as NodeJS.ErrnoException).code === "ENOENT"
+          )
+        ) {
+          throw err;
+        }
+      }
+
+      // Update status in SQLite
+      this.db
+        .prepare(
+          "UPDATE workspaces SET status = ?, last_activity_at = ? WHERE cid = ? AND agent_id = ?",
+        )
+        .run(WorkspaceStatus.Cleaned, new Date().toISOString(), cid, agentId);
+
+      return true;
+    } finally {
+      await this.releaseWorkspaceLock(lockPath);
+    }
   }
 
   async markStale(options: StaleOptions): Promise<readonly WorkspaceInfo[]> {
@@ -509,11 +531,15 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     cid: string,
     agentId: string,
   ): Promise<WorkspaceInfo | undefined> {
+    const { workspacePath } = this.checkoutPaths(cid, agentId);
     const existing = await this.getWorkspace(cid, agentId);
     if (existing === undefined || existing.status !== WorkspaceStatus.Active) {
       return undefined;
     }
-    return (await this.pathExists(existing.workspacePath)) ? existing : undefined;
+    if (existing.workspacePath !== workspacePath) {
+      return undefined;
+    }
+    return (await this.validateReadyWorkspacePath(existing.workspacePath)) ? existing : undefined;
   }
 
   private async pathExists(path: string): Promise<boolean> {
@@ -561,33 +587,38 @@ export class LocalWorkspaceManager implements WorkspaceManager {
       if (!(await this.pathExists(lockPath))) {
         return undefined;
       }
-      const owner = await this.readWorkspaceLockOwner(lockPath);
-      if (owner !== undefined && !this.isProcessAlive(owner.pid)) {
-        await this.releaseWorkspaceLock(lockPath);
+      if (await this.tryRecoverStaleWorkspaceLock(lockPath)) {
         return undefined;
-      }
-      if (owner === undefined) {
-        const ageMs = await this.getLockAgeMs(lockPath);
-        if (ageMs !== undefined && ageMs >= WORKSPACE_LOCK_OWNER_GRACE_MS) {
-          await this.releaseWorkspaceLock(lockPath);
-          return undefined;
-        }
       }
       await sleep(WORKSPACE_LOCK_POLL_MS);
     }
-    const owner = await this.readWorkspaceLockOwner(lockPath);
-    if (owner !== undefined && !this.isProcessAlive(owner.pid)) {
-      await this.releaseWorkspaceLock(lockPath);
+    if (!(await this.pathExists(lockPath))) {
       return undefined;
     }
-    if (owner === undefined) {
-      const ageMs = await this.getLockAgeMs(lockPath);
-      if (ageMs !== undefined && ageMs >= WORKSPACE_LOCK_OWNER_GRACE_MS) {
-        await this.releaseWorkspaceLock(lockPath);
-        return undefined;
-      }
+    if (await this.tryRecoverStaleWorkspaceLock(lockPath)) {
+      return undefined;
     }
     throw new Error(`Timed out waiting for workspace checkout for '${cid}' (agent '${agentId}')`);
+  }
+
+  private async waitForWorkspaceLockRelease(lockPath: string): Promise<void> {
+    const deadline = Date.now() + WORKSPACE_LOCK_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      if (!(await this.pathExists(lockPath))) {
+        return;
+      }
+      if (await this.tryRecoverStaleWorkspaceLock(lockPath)) {
+        return;
+      }
+      await sleep(WORKSPACE_LOCK_POLL_MS);
+    }
+    if (!(await this.pathExists(lockPath))) {
+      return;
+    }
+    if (await this.tryRecoverStaleWorkspaceLock(lockPath)) {
+      return;
+    }
+    throw new Error(`Timed out waiting for workspace lock '${lockPath}'`);
   }
 
   private async releaseWorkspaceLock(lockPath: string): Promise<void> {
@@ -631,6 +662,48 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     } catch (err) {
       return !isErrnoCode(err, "ESRCH");
     }
+  }
+
+  private checkoutPaths(
+    cid: string,
+    agentId: string,
+  ): { readonly workspacePath: string; readonly lockPath: string } {
+    const cidHex = sanitizeCidForPath(cid);
+    const workspacePath = join(this.workspacesRoot, `${cidHex}-${agentId}`);
+    return { workspacePath, lockPath: `${workspacePath}.lock` };
+  }
+
+  private async validateReadyWorkspacePath(workspacePath: string): Promise<boolean> {
+    try {
+      const entry = await lstat(workspacePath);
+      if (entry.isSymbolicLink() || !entry.isDirectory()) {
+        return false;
+      }
+      await assertWithinBoundary(workspacePath, this.workspacesRoot);
+      return true;
+    } catch (err) {
+      if (isErrnoCode(err, "ENOENT") || err instanceof PathContainmentError) {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  private async tryRecoverStaleWorkspaceLock(lockPath: string): Promise<boolean> {
+    const owner = await this.readWorkspaceLockOwner(lockPath);
+    if (owner !== undefined) {
+      if (!this.isProcessAlive(owner.pid)) {
+        await this.releaseWorkspaceLock(lockPath);
+        return true;
+      }
+      return false;
+    }
+    const ageMs = await this.getLockAgeMs(lockPath);
+    if (ageMs !== undefined && ageMs >= WORKSPACE_LOCK_OWNER_GRACE_MS) {
+      await this.releaseWorkspaceLock(lockPath);
+      return true;
+    }
+    return false;
   }
 
   /** Insert or update a workspace row in SQLite. */

--- a/src/local/workspace.ts
+++ b/src/local/workspace.ts
@@ -14,6 +14,7 @@
  */
 
 import type { Database } from "bun:sqlite";
+import { randomBytes } from "node:crypto";
 import { constants } from "node:fs";
 import { copyFile, mkdir, rename, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
@@ -44,6 +45,10 @@ import type { FsCas } from "./fs-cas.js";
 // ---------------------------------------------------------------------------
 
 const WORKSPACES_DIR = "workspaces";
+const WORKSPACE_LOCK_POLL_MS = 25;
+const WORKSPACE_LOCK_TIMEOUT_MS = 300_000;
+const WORKSPACE_LOCK_OWNER_FILE = "owner.json";
+const WORKSPACE_LOCK_OWNER_GRACE_MS = 5_000;
 
 // ---------------------------------------------------------------------------
 // SQLite workspace table operations
@@ -77,6 +82,18 @@ function rowToWorkspaceInfo(row: WorkspaceRow): WorkspaceInfo {
     };
   }
   return base;
+}
+
+function isErrnoCode(err: unknown, code: string): boolean {
+  return err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === code;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface WorkspaceLockOwner {
+  readonly pid: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -127,9 +144,14 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     // Validate agentId for safe use as a directory name
     validateWorkspaceKey(agentId);
 
+    // Compute workspace directory path — scoped by CID + agent
+    const cidHex = sanitizeCidForPath(cid);
+    const workspacePath = join(this.workspacesRoot, `${cidHex}-${agentId}`);
+    const lockPath = `${workspacePath}.lock`;
+
     // Check for existing active workspace for this (cid, agent) pair
-    const existing = await this.getWorkspace(cid, agentId);
-    if (existing !== undefined && existing.status === WorkspaceStatus.Active) {
+    const existing = await this.getReadyWorkspace(cid, agentId);
+    if (existing !== undefined) {
       return existing;
     }
 
@@ -139,89 +161,99 @@ export class LocalWorkspaceManager implements WorkspaceManager {
       throw new Error(`Contribution '${cid}' not found`);
     }
 
-    // Compute workspace directory path — scoped by CID + agent
-    const cidHex = sanitizeCidForPath(cid);
-    const workspacePath = join(this.workspacesRoot, `${cidHex}-${agentId}`);
-
     // Ensure workspaces root exists
     await mkdir(this.workspacesRoot, { recursive: true });
 
-    // Transactional materialization: temp dir → rename
-    const tmpDir = `${workspacePath}.tmp.${Date.now()}`;
-    await mkdir(tmpDir, { recursive: true });
-
-    try {
-      // Materialize each artifact from CAS into the temp directory
-      for (const [name, contentHash] of Object.entries(contribution.artifacts)) {
-        // Validate artifact name to prevent path traversal
-        validateArtifactName(name);
-
-        const destPath = join(tmpDir, name);
-
-        // Verify the destination stays within the temp directory
-        await assertWithinBoundary(destPath, tmpDir);
-
-        // Create parent directories for nested artifact paths (e.g., src/main.py)
-        await ensureArtifactParentDir(name, tmpDir);
-
-        // Copy from CAS using FICLONE (CoW when filesystem supports it)
-        const found = await this.casGetToFile(contentHash, destPath);
-        if (!found) {
-          throw new Error(`Artifact '${name}' with hash '${contentHash}' not found in CAS`);
-        }
+    // Serialize materialization per (cid, agentId). Without this, concurrent
+    // checkouts can both race through temp-dir creation and one caller can
+    // delete a workspace the other already returned.
+    while (!(await this.tryAcquireWorkspaceLock(lockPath))) {
+      const ready = await this.waitForReadyWorkspace(cid, agentId, lockPath);
+      if (ready !== undefined) {
+        return ready;
       }
-
-      // Atomic placement: rename temp dir to final location
-      // If the workspace directory already exists (e.g., from a cleaned workspace),
-      // remove it first
-      try {
-        await stat(workspacePath);
-        await rm(workspacePath, { recursive: true, force: true });
-      } catch (err) {
-        if (
-          !(
-            err instanceof Error &&
-            "code" in err &&
-            (err as NodeJS.ErrnoException).code === "ENOENT"
-          )
-        ) {
-          throw err;
-        }
-      }
-      await rename(tmpDir, workspacePath);
-    } catch (err) {
-      // Clean up temp directory on failure
-      await safeCleanup(rm(tmpDir, { recursive: true, force: true }), "remove temp workspace dir", {
-        silent: true,
-      });
-      throw err;
     }
 
-    // Record workspace in SQLite
-    const now = new Date().toISOString();
-    this.upsertWorkspaceRow({
-      cid,
-      agentId,
-      workspacePath,
-      agent: options.agent,
-      status: WorkspaceStatus.Active,
-      createdAt: now,
-      lastActivityAt: now,
-      context: options.context,
-    });
+    try {
+      // Another caller may have completed the checkout while we were waiting
+      // for the lock; return the ready workspace instead of rematerializing it.
+      const ready = await this.getReadyWorkspace(cid, agentId);
+      if (ready !== undefined) {
+        return ready;
+      }
 
-    // Run after_checkout hook if configured
-    await this.runHook("after_checkout", workspacePath);
+      // Transactional materialization: temp dir → rename
+      const tmpDir = `${workspacePath}.tmp.${Date.now()}.${randomBytes(4).toString("hex")}`;
+      await mkdir(tmpDir, { recursive: true });
 
-    return {
-      cid,
-      workspacePath,
-      agent: options.agent,
-      status: WorkspaceStatus.Active,
-      createdAt: now,
-      lastActivityAt: now,
-      ...(options.context !== undefined && { context: options.context }),
-    };
+      try {
+        // Materialize each artifact from CAS into the temp directory
+        for (const [name, contentHash] of Object.entries(contribution.artifacts)) {
+          // Validate artifact name to prevent path traversal
+          validateArtifactName(name);
+
+          const destPath = join(tmpDir, name);
+
+          // Verify the destination stays within the temp directory
+          await assertWithinBoundary(destPath, tmpDir);
+
+          // Create parent directories for nested artifact paths (e.g., src/main.py)
+          await ensureArtifactParentDir(name, tmpDir);
+
+          // Copy from CAS using FICLONE (CoW when filesystem supports it)
+          const found = await this.casGetToFile(contentHash, destPath);
+          if (!found) {
+            throw new Error(`Artifact '${name}' with hash '${contentHash}' not found in CAS`);
+          }
+        }
+
+        // Atomic placement: rename temp dir to final location.
+        // We only remove an existing path while holding the per-workspace lock.
+        if (await this.pathExists(workspacePath)) {
+          await rm(workspacePath, { recursive: true, force: true });
+        }
+        await rename(tmpDir, workspacePath);
+      } catch (err) {
+        // Clean up temp directory on failure
+        await safeCleanup(
+          rm(tmpDir, { recursive: true, force: true }),
+          "remove temp workspace dir",
+          {
+            silent: true,
+          },
+        );
+        throw err;
+      }
+
+      const now = new Date().toISOString();
+      // Run after_checkout before publishing the workspace as active so
+      // concurrent callers do not race ahead of workspace-local setup.
+      await this.runHook("after_checkout", workspacePath);
+
+      // Record workspace in SQLite only after the workspace is fully ready.
+      this.upsertWorkspaceRow({
+        cid,
+        agentId,
+        workspacePath,
+        agent: options.agent,
+        status: WorkspaceStatus.Active,
+        createdAt: now,
+        lastActivityAt: now,
+        context: options.context,
+      });
+
+      return {
+        cid,
+        workspacePath,
+        agent: options.agent,
+        status: WorkspaceStatus.Active,
+        createdAt: now,
+        lastActivityAt: now,
+        ...(options.context !== undefined && { context: options.context }),
+      };
+    } finally {
+      await this.releaseWorkspaceLock(lockPath);
+    }
   }
 
   async getWorkspace(cid: string, agentId: string): Promise<WorkspaceInfo | undefined> {
@@ -249,7 +281,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
       params.push(query.status);
     }
     if (query?.agentId !== undefined) {
-      conditions.push("json_extract(agent_json, '$.agentId') = ?");
+      conditions.push("agent_id = ?");
       params.push(query.agentId);
     }
     if (conditions.length > 0) {
@@ -273,10 +305,10 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     const activeClaim = this.db
       .prepare(
         `SELECT claim_id FROM claims
-         WHERE target_ref = ? AND status = 'active'
+         WHERE target_ref = ? AND agent_id = ? AND status = 'active'
          AND lease_expires_at >= ?`,
       )
-      .get(cid, new Date().toISOString()) as { claim_id: string } | null;
+      .get(cid, agentId, new Date().toISOString()) as { claim_id: string } | null;
 
     if (activeClaim !== null) {
       throw new Error(
@@ -354,7 +386,11 @@ export class LocalWorkspaceManager implements WorkspaceManager {
 
     // Idempotent: return existing active workspace
     const existing = await this.getWorkspace(key, agentId);
-    if (existing !== undefined && existing.status === WorkspaceStatus.Active) {
+    if (
+      existing !== undefined &&
+      existing.status === WorkspaceStatus.Active &&
+      (await this.pathExists(existing.workspacePath))
+    ) {
       return existing;
     }
 
@@ -466,6 +502,134 @@ export class LocalWorkspaceManager implements WorkspaceManager {
         return false;
       }
       throw err;
+    }
+  }
+
+  private async getReadyWorkspace(
+    cid: string,
+    agentId: string,
+  ): Promise<WorkspaceInfo | undefined> {
+    const existing = await this.getWorkspace(cid, agentId);
+    if (existing === undefined || existing.status !== WorkspaceStatus.Active) {
+      return undefined;
+    }
+    return (await this.pathExists(existing.workspacePath)) ? existing : undefined;
+  }
+
+  private async pathExists(path: string): Promise<boolean> {
+    try {
+      await stat(path);
+      return true;
+    } catch (err) {
+      if (isErrnoCode(err, "ENOENT")) return false;
+      throw err;
+    }
+  }
+
+  private async tryAcquireWorkspaceLock(lockPath: string): Promise<boolean> {
+    try {
+      await mkdir(lockPath);
+      await Bun.write(
+        join(lockPath, WORKSPACE_LOCK_OWNER_FILE),
+        JSON.stringify({ pid: process.pid } satisfies WorkspaceLockOwner),
+      );
+      return true;
+    } catch (err) {
+      if (isErrnoCode(err, "EEXIST")) return false;
+      await safeCleanup(
+        rm(lockPath, { recursive: true, force: true }),
+        "remove failed workspace lock",
+        {
+          silent: true,
+        },
+      );
+      throw err;
+    }
+  }
+
+  private async waitForReadyWorkspace(
+    cid: string,
+    agentId: string,
+    lockPath: string,
+  ): Promise<WorkspaceInfo | undefined> {
+    const deadline = Date.now() + WORKSPACE_LOCK_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const ready = await this.getReadyWorkspace(cid, agentId);
+      if (ready !== undefined) {
+        return ready;
+      }
+      if (!(await this.pathExists(lockPath))) {
+        return undefined;
+      }
+      const owner = await this.readWorkspaceLockOwner(lockPath);
+      if (owner !== undefined && !this.isProcessAlive(owner.pid)) {
+        await this.releaseWorkspaceLock(lockPath);
+        return undefined;
+      }
+      if (owner === undefined) {
+        const ageMs = await this.getLockAgeMs(lockPath);
+        if (ageMs !== undefined && ageMs >= WORKSPACE_LOCK_OWNER_GRACE_MS) {
+          await this.releaseWorkspaceLock(lockPath);
+          return undefined;
+        }
+      }
+      await sleep(WORKSPACE_LOCK_POLL_MS);
+    }
+    const owner = await this.readWorkspaceLockOwner(lockPath);
+    if (owner !== undefined && !this.isProcessAlive(owner.pid)) {
+      await this.releaseWorkspaceLock(lockPath);
+      return undefined;
+    }
+    if (owner === undefined) {
+      const ageMs = await this.getLockAgeMs(lockPath);
+      if (ageMs !== undefined && ageMs >= WORKSPACE_LOCK_OWNER_GRACE_MS) {
+        await this.releaseWorkspaceLock(lockPath);
+        return undefined;
+      }
+    }
+    throw new Error(`Timed out waiting for workspace checkout for '${cid}' (agent '${agentId}')`);
+  }
+
+  private async releaseWorkspaceLock(lockPath: string): Promise<void> {
+    await safeCleanup(rm(lockPath, { recursive: true, force: true }), "remove workspace lock dir", {
+      silent: true,
+    });
+  }
+
+  private async readWorkspaceLockOwner(lockPath: string): Promise<WorkspaceLockOwner | undefined> {
+    try {
+      const text = await Bun.file(join(lockPath, WORKSPACE_LOCK_OWNER_FILE)).text();
+      const parsed = JSON.parse(text) as { pid?: unknown };
+      if (typeof parsed.pid === "number" && Number.isInteger(parsed.pid) && parsed.pid > 0) {
+        return { pid: parsed.pid };
+      }
+      return undefined;
+    } catch (err) {
+      if (isErrnoCode(err, "ENOENT") || err instanceof SyntaxError) {
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
+  private async getLockAgeMs(lockPath: string): Promise<number | undefined> {
+    try {
+      const lockStats = await stat(lockPath);
+      return Date.now() - lockStats.mtimeMs;
+    } catch (err) {
+      if (isErrnoCode(err, "ENOENT")) {
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
+  private isProcessAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (err) {
+      return !isErrnoCode(err, "ESRCH");
     }
   }
 


### PR DESCRIPTION
## Summary
- harden local workspace checkout and cleanup against same-agent races, stale locks, and missing active workspaces
- chunk local SQLite contribution and outcome batch reads, fix offset-only outcome pagination, and repair partial legacy junction-table backfills while updating schema metadata/indexes
- fall back to `GROVE.md` for configless sessions and add focused regressions for runtime bootstrap, migrations, batching, and workspace concurrency

## Test plan
- [x] `bun test src/local/workspace.test.ts src/local/sqlite-store.test.ts src/local/sqlite-outcome-store.test.ts src/local/runtime.test.ts src/local/sqlite-store.migration.test.ts` (targeted tests passed; the narrowed run exits non-zero because `bunfig.toml` enforces repo-wide coverage thresholds)
- [x] `bun run typecheck`
- [x] `bun run check`


Made with [Cursor](https://cursor.com)