### PR TITLE
fix(tui): SSE-driven panel refresh + idle-stream watchdog

### DIFF
--- a/src/nexus/nexus-contribution-store.ts
+++ b/src/nexus/nexus-contribution-store.ts
@@ -78,9 +78,51 @@ export class NexusContributionStore implements ContributionStore {
   // and the panel doesn't update until the next 30 s poll. 2 s still de-duplicates
   // the back-to-back fetches that several panels (Feed, DAG, Frontier) issue
   // immediately after a refresh signal — which was the original storm risk.
+  //
+  // The cache is also explicitly invalidated by `invalidateListCache()` — the
+  // SSE/EventBus refresh path calls it before bumping `refreshSignal` so the
+  // fan-out re-fetches see fresh data even when an inbox push lands inside
+  // the 2 s TTL window. Without that, a remote contribution arriving 1.5 s
+  // after the previous scan would still hit the cache and the UI would not
+  // update until the next 30 s fallback poll.
   private listCacheResult: Contribution[] | undefined;
   private listCacheTime = 0;
   private readonly listCacheTtlMs = 2_000;
+
+  // Epoch versioning for the list cache. Every invalidate() / write
+  // increments the epoch. A list() cache miss captures the epoch at
+  // scan start and only commits the result if the epoch is unchanged
+  // when the scan returns. Without this, an in-flight scan that
+  // started BEFORE an SSE-triggered invalidation could resurrect the
+  // pre-arrival snapshot when it resolves, defeating the point of
+  // invalidating in the first place.
+  private listCacheEpoch = 0;
+  // Shared in-flight scan promise — concurrent callers all await the
+  // same VFS round trip instead of issuing N parallel scans. Cleared
+  // by invalidateListCache() so a post-invalidation call always starts
+  // a fresh scan against the latest epoch.
+  private listCacheInflight: Promise<Contribution[]> | undefined = undefined;
+
+  /**
+   * Drop the cached list() snapshot so the next call re-scans the VFS.
+   * Idempotent. Call from any code path that has out-of-band proof of new
+   * contributions (e.g. SSE inbox-delivery push) so the next read does not
+   * return a stale pre-arrival snapshot from the TTL window. Also bumps
+   * the epoch so any concurrent in-flight scan started before this call
+   * will discard its result rather than overwrite the cache with a stale
+   * snapshot.
+   */
+  invalidateListCache(): void {
+    this.listCacheResult = undefined;
+    this.listCacheTime = 0;
+    this.listCacheEpoch += 1;
+    // Do NOT clear listCacheInflight here. If a scan is already running,
+    // the epoch bump guarantees it will throw (stale epoch), which triggers
+    // clearIfOwner and naturally opens a slot for one replacement scan.
+    // Clearing here would break the single-flight guarantee: each SSE burst
+    // event would clear the handle and cause a new full scan to start, up to
+    // N parallel scans for N burst events.
+  }
 
   constructor(config: NexusConfig) {
     this.config = resolveConfig(config);
@@ -149,7 +191,9 @@ export class NexusContributionStore implements ContributionStore {
     );
 
     this.cache.set(contribution.cid, contribution);
-    this.listCacheResult = undefined; // Invalidate list cache on write
+    // Bump epoch on every write so any concurrent in-flight list() scan
+    // will discard its result and the next read re-scans the VFS.
+    this.invalidateListCache();
     debugLog(
       "store.put",
       `cid=${contribution.cid.slice(0, 16)} sessionId=${this.sessionId ?? "none"} path=${manifestPath}`,
@@ -211,38 +255,26 @@ export class NexusContributionStore implements ContributionStore {
     if (cacheHit) {
       allContributions = [...(this.listCacheResult as Contribution[])];
     } else {
-      const entries = await listAllPages(this.client, this.semaphore, this.config, ftsDir, {
-        recursive: true,
-      });
-
-      const nonDirEntries = entries.filter((e) => !e.isDirectory);
-
-      // Read ALL FTS entries (no query filter — cache the full set)
-      const ftsResults = await batchParallel(nonDirEntries, async (entry) => {
-        const ftsData = await withSemaphore(this.semaphore, () => this.client.read(entry.path));
-        if (ftsData === undefined) return undefined;
-        const fts = decode<Record<string, JsonValue>>(ftsData);
-        return fts.cid as string;
-      });
-
-      const allCids = ftsResults.filter((cid): cid is string => cid !== undefined);
-
-      // Fetch ALL contributions
-      const fetched = await batchParallel(allCids, (cid) => this.get(cid));
-      allContributions = fetched.filter((c): c is Contribution => c !== undefined);
-      debugLog(
-        "store.list",
-        `ftsEntries=${nonDirEntries.length} matchingCids=${allCids.length} total=${allContributions.length}`,
-      );
-
-      // Sort by createdAt ascending (matches SQLite store behavior)
-      allContributions.sort(
-        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-      );
-
-      // Cache the full unfiltered result
-      this.listCacheResult = allContributions;
-      this.listCacheTime = Date.now();
+      // Deduplicate concurrent scans: all callers that arrive during an
+      // in-flight VFS round trip share the same promise instead of
+      // issuing N parallel scans. This prevents the refresh fan-out
+      // (feed + dashboard + frontier all refetch on SSE push) from
+      // stampeding Nexus with redundant reads.
+      if (!this.listCacheInflight) {
+        const scanPromise: Promise<Contribution[]> = this.runListScan(ftsDir);
+        this.listCacheInflight = scanPromise;
+        // Clear ownership on both fulfillment and rejection so the next
+        // cache miss can start a fresh scan. Using then/catch instead of
+        // finally().catch() avoids an unhandled-rejection from the new
+        // Promise that finally() returns (which rejects when the scan throws).
+        const clearIfOwner = () => {
+          if (this.listCacheInflight === scanPromise) {
+            this.listCacheInflight = undefined;
+          }
+        };
+        void scanPromise.then(clearIfOwner, clearIfOwner);
+      }
+      allContributions = [...(await this.listCacheInflight)];
     }
 
     // Apply query filters in-memory (cheap — no VFS calls)
@@ -270,6 +302,54 @@ export class NexusContributionStore implements ContributionStore {
         : contributions.slice(offset);
 
     return limited;
+  }
+
+  private async runListScan(ftsDir: string): Promise<Contribution[]> {
+    // Capture epoch before any awaits so we can detect mid-scan invalidations.
+    const epochAtStart = this.listCacheEpoch;
+
+    const entries = await listAllPages(this.client, this.semaphore, this.config, ftsDir, {
+      recursive: true,
+    });
+
+    const nonDirEntries = entries.filter((e) => !e.isDirectory);
+
+    const ftsResults = await batchParallel(nonDirEntries, async (entry) => {
+      const ftsData = await withSemaphore(this.semaphore, () => this.client.read(entry.path));
+      if (ftsData === undefined) return undefined;
+      const fts = decode<Record<string, JsonValue>>(ftsData);
+      return fts.cid as string;
+    });
+
+    const allCids = ftsResults.filter((cid): cid is string => cid !== undefined);
+    const ftsComplete = ftsResults.every((r) => r !== undefined);
+
+    const fetched = await batchParallel(allCids, (cid) => this.get(cid));
+    const allContributions = fetched.filter((c): c is Contribution => c !== undefined);
+    const manifestComplete = fetched.every((c) => c !== undefined);
+    debugLog(
+      "store.list",
+      `ftsEntries=${nonDirEntries.length} matchingCids=${allCids.length} total=${allContributions.length} complete=${ftsComplete && manifestComplete}`,
+    );
+
+    allContributions.sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
+
+    if (this.listCacheEpoch !== epochAtStart) {
+      // An invalidation arrived while we were scanning. Throw so all
+      // waiting callers (usePolledData et al.) preserve their last-known-
+      // good data instead of overwriting it with a stale pre-invalidation
+      // snapshot. The post-invalidation scan (started by the SSE refresh
+      // handler) will resolve with fresh data on the next await.
+      throw new Error("list scan superseded by cache invalidation — discard result");
+    }
+
+    if (ftsComplete && manifestComplete) {
+      this.listCacheResult = allContributions;
+      this.listCacheTime = Date.now();
+    }
+    return allContributions;
   }
 
   async children(cid: string): Promise<readonly Contribution[]> {

--- a/src/nexus/nexus-contribution-store.ts
+++ b/src/nexus/nexus-contribution-store.ts
@@ -71,9 +71,16 @@ export class NexusContributionStore implements ContributionStore {
   private readonly sessionId: string | undefined;
   // TTL cache for list() — avoids the N+1 VFS read storm (1 list + N FTS + N manifest)
   // that exhausts Nexus's 300/min rate limit when multiple callers poll independently.
+  // TTL is short (2s) so SSE-triggered refreshes (running-view bumps refreshSignal
+  // on inbox-delivery events) actually return fresh data instead of replaying the
+  // last full scan. Anything longer makes the TUI feel laggy: a contribution lands,
+  // SSE fires, a refetch happens, but the cache hands back the pre-arrival snapshot
+  // and the panel doesn't update until the next 30 s poll. 2 s still de-duplicates
+  // the back-to-back fetches that several panels (Feed, DAG, Frontier) issue
+  // immediately after a refresh signal — which was the original storm risk.
   private listCacheResult: Contribution[] | undefined;
   private listCacheTime = 0;
-  private readonly listCacheTtlMs = 15_000; // 15s TTL
+  private readonly listCacheTtlMs = 2_000;
 
   constructor(config: NexusConfig) {
     this.config = resolveConfig(config);

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -525,8 +525,7 @@ export function App({
     refreshTerminalBuffers,
   ]);
 
-  // SSE push → global refresh fan-out. NexusWsBridge publishes inbox-delivery
-  // events on `role:<targetRole>` channels. Bumping refreshSignal here makes
+  // SSE push → global refresh fan-out. Bumping refreshSignal here makes
   // every panel-level usePolledData (DAG, Frontier, Dashboard …) re-fetch
   // immediately instead of waiting up to `intervalMs` for the next poll.
   // The Feed view also subscribes directly inside running-view for fast-path

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -537,12 +537,21 @@ export function App({
     if (!eventBus) return;
     const roles = topology?.roles.map((r) => r.name) ?? [];
     if (roles.length === 0) return;
-    const handler = () => setRefreshSignal((s) => s + 1);
+    const handler = () => {
+      // Invalidate provider TTL caches BEFORE bumping the refresh signal.
+      // The store-backed provider hands back its last full scan inside
+      // the 2 s list-cache window; without invalidation a contribution
+      // landing 1.5 s after the previous scan would still return the
+      // pre-arrival snapshot and the UI would not update until the
+      // next 30 s fallback poll.
+      provider.invalidateCaches?.();
+      setRefreshSignal((s) => s + 1);
+    };
     for (const role of roles) eventBus.subscribe(role, handler);
     return () => {
       for (const role of roles) eventBus.unsubscribe(role, handler);
     };
-  }, [eventBus, topology]);
+  }, [eventBus, topology, provider]);
 
   const hasGoals = isGoalProvider(provider);
   const paletteItems = useMemo(

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -244,6 +244,7 @@ export function App({
   presetName,
   groveDir,
   userConfig,
+  eventBus,
 }: AppProps): React.ReactNode {
   const renderer = useRenderer();
   const nav = useNavigation();
@@ -523,6 +524,25 @@ export function App({
     refreshProfiles,
     refreshTerminalBuffers,
   ]);
+
+  // SSE push → global refresh fan-out. NexusWsBridge publishes inbox-delivery
+  // events on `role:<targetRole>` channels. Bumping refreshSignal here makes
+  // every panel-level usePolledData (DAG, Frontier, Dashboard …) re-fetch
+  // immediately instead of waiting up to `intervalMs` for the next poll.
+  // The Feed view also subscribes directly inside running-view for fast-path
+  // refresh without a full app re-render — that path stays as defense in
+  // depth and is not removed here.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: eventBus is used in body; biome miscounts the conditional access.
+  useEffect(() => {
+    if (!eventBus) return;
+    const roles = topology?.roles.map((r) => r.name) ?? [];
+    if (roles.length === 0) return;
+    const handler = () => setRefreshSignal((s) => s + 1);
+    for (const role of roles) eventBus.subscribe(role, handler);
+    return () => {
+      for (const role of roles) eventBus.unsubscribe(role, handler);
+    };
+  }, [eventBus, topology]);
 
   const hasGoals = isGoalProvider(provider);
   const paletteItems = useMemo(

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -532,7 +532,6 @@ export function App({
   // The Feed view also subscribes directly inside running-view for fast-path
   // refresh without a full app re-render — that path stays as defense in
   // depth and is not removed here.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: eventBus is used in body; biome miscounts the conditional access.
   useEffect(() => {
     if (!eventBus) return;
     const roles = topology?.roles.map((r) => r.name) ?? [];

--- a/src/tui/nexus-ws-bridge.test.ts
+++ b/src/tui/nexus-ws-bridge.test.ts
@@ -134,7 +134,7 @@ describe("NexusWsBridge", () => {
     bus.close();
   });
 
-  test("handleEvent publishes to EventBus on message_delivered", () => {
+  test("handleEvent publishes to EventBus on contribution-bearing message_delivered", async () => {
     const runtime = makeMockRuntime();
     const bus = new LocalEventBus();
     const received: GroveEvent[] = [];
@@ -144,13 +144,19 @@ describe("NexusWsBridge", () => {
     const session = makeSession("reviewer");
     bridge.registerSession("reviewer", session);
 
-    // Mock fetch for readAndPush VFS read — return valid data
+    // Mock fetch for readAndPush VFS read — return a contribution
+    // payload (cid + kind). Without those fields, the publish path
+    // intentionally skips firing so non-contribution IPC traffic does
+    // not invalidate the contribution list cache.
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
           result: {
             data: Buffer.from(
-              JSON.stringify({ sender: "coder", payload: { summary: "test contribution" } }),
+              JSON.stringify({
+                sender: "coder",
+                payload: { cid: "blake3:abc", kind: "work", summary: "test contribution" },
+              }),
             ).toString("base64"),
           },
         }),
@@ -170,12 +176,65 @@ describe("NexusWsBridge", () => {
       }),
     );
 
-    // EventBus should have received the event
+    // readAndPush is fire-and-forget — wait for the microtask queue to
+    // drain so the publish call inside it has run.
+    await new Promise((r) => setTimeout(r, 0));
+
     expect(received).toHaveLength(1);
     expect(received[0]!.type).toBe("contribution");
     expect(received[0]!.sourceRole).toBe("coder");
     expect(received[0]!.targetRole).toBe("reviewer");
-    expect(received[0]!.payload).toEqual({ message_id: "msg-1" });
+    expect(received[0]!.payload).toMatchObject({
+      message_id: "msg-1",
+      cid: "blake3:abc",
+      kind: "work",
+    });
+
+    bridge.close();
+    bus.close();
+  });
+
+  test("handleEvent does NOT publish for non-contribution IPC (no cid+kind)", async () => {
+    const runtime = makeMockRuntime();
+    const bus = new LocalEventBus();
+    const received: GroveEvent[] = [];
+    bus.subscribe("reviewer", (e) => received.push(e));
+
+    const bridge = new TestableNexusWsBridge(makeBridgeOpts({ runtime, eventBus: bus }));
+    const session = makeSession("reviewer");
+    bridge.registerSession("reviewer", session);
+
+    // Plain IPC payload — no cid + kind. Should NOT trigger a
+    // contribution event on the bus, otherwise high-volume ACP/agent
+    // traffic would force a full VFS rescan per delivery.
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          result: {
+            data: Buffer.from(
+              JSON.stringify({ sender: "coder", payload: { summary: "plain notice" } }),
+            ).toString("base64"),
+          },
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+
+    bridge.testHandleEvent(
+      "reviewer",
+      "message_delivered",
+      JSON.stringify({
+        event: "message_delivered",
+        message_id: "msg-2",
+        sender: "coder",
+        recipient: "reviewer",
+        type: "event",
+        path: "/inbox/msg-2",
+      }),
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(received).toHaveLength(0);
 
     bridge.close();
     bus.close();

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -522,12 +522,28 @@ export class NexusWsBridge {
       let buffer = "";
       // Transport health ≠ message arrival. A valid SSE stream may be
       // quiet for long stretches, emitting only keep-alive comments
-      // (": ping\n") or nothing at all. Count the cycle healthy the
-      // moment the reader yields any bytes — that proves the TCP pipe
-      // is flowing. An immediate EOF (done=true on the first read
-      // without prior bytes) still returns false, which is the one
-      // case the unhealthy counter needs to catch.
+      // (": ping\n") or nothing at all. Count the cycle healthy when
+      // EITHER (a) we hold the stream open past the durability
+      // threshold below, OR (b) we receive a real `message_delivered`
+      // event before EOF.
+      //
+      // Just "saw bytes" is NOT enough — Nexus emits a `connected`
+      // event immediately on stream open, so a misbehaving server or
+      // proxy that accepts the request, hands back the connect frame,
+      // and then EOFs would otherwise look healthy on every cycle and
+      // the consecutive-failure counter would never advance. Require
+      // either real delivery work OR a minimum healthy duration so a
+      // tight connect/close loop still escalates to onRoleUnhealthy.
       let sawBytes = false;
+      let sawDelivery = false;
+      const cycleStartMs = Date.now();
+      // Hold the stream open this long before treating bytes-only as a
+      // healthy cycle. Comfortably above any plausible reverse-proxy
+      // post-handshake timeout, comfortably below the 5 min idle
+      // watchdog so a healthy idle stream still crosses the threshold.
+      const minHealthyDurationMs = 30_000;
+      const cycleDurable = (): boolean => Date.now() - cycleStartMs >= minHealthyDurationMs;
+      const cycleHealthy = (): boolean => sawDelivery || (sawBytes && cycleDurable());
       // Idle-read watchdog — if the stream produces no bytes for this
       // long, abort and treat the cycle as unhealthy. Catches blackholed
       // proxies stuck mid-stream that hold the TCP pipe open without
@@ -559,15 +575,13 @@ export class NexusWsBridge {
           readResult = await reader.read();
         } catch {
           clearTimeout(idleTimer);
-          // Watchdog fire AFTER we already saw bytes (e.g. the initial
-          // `connected` event from Nexus) means the stream connected and
-          // produced data — it just went quiet. Treat the cycle as
-          // healthy so the consecutive-failure counter stays at zero.
-          // Without this the counter drifts up over time on idle
-          // streams and eventually trips onRoleUnhealthy on a perfectly
-          // good channel.
-          if (abortedByWatchdog && sawBytes) return true;
-          return abortedByWatchdog ? false : sawBytes;
+          // Watchdog fire AFTER the cycle is healthy (saw delivery, or
+          // held open past the durability threshold) means the stream
+          // was working and just went quiet — don't penalize. Otherwise
+          // we couldn't prove the channel was ever delivering, so the
+          // cycle is unhealthy.
+          if (abortedByWatchdog && cycleHealthy()) return true;
+          return abortedByWatchdog ? false : cycleHealthy();
         } finally {
           clearTimeout(idleTimer);
         }
@@ -587,13 +601,17 @@ export class NexusWsBridge {
           } else if (line.startsWith("data: ")) {
             eventData = line.slice(6);
           } else if (line === "" && eventData) {
+            if (eventType === "message_delivered") sawDelivery = true;
             this.handleEvent(role, eventType, eventData);
             eventType = null;
             eventData = null;
           }
         }
       }
-      return sawBytes;
+      // EOF path: server closed the stream cleanly. Count the cycle
+      // healthy only if we had real delivery or held open long enough
+      // to prove durability. A connect-and-close loop still escalates.
+      return cycleHealthy();
     } finally {
       if (roleSignal && forwardAbort) {
         roleSignal.removeEventListener("abort", forwardAbort);
@@ -636,24 +654,6 @@ export class NexusWsBridge {
           if (first !== undefined) seen.delete(first);
         }
       }
-
-      // Notify the TUI EventBus — triggers contribution feed refresh (no polling needed)
-      if (this.opts.eventBus) {
-        const groveEvent: GroveEvent = {
-          type: "contribution",
-          sourceRole: event.sender,
-          targetRole: role,
-          payload: { message_id: event.message_id },
-          timestamp: new Date().toISOString(),
-        };
-        void this.opts.eventBus.publish(groveEvent);
-      }
-
-      // Handoff delivery-status transitions are deferred until after
-      // ACP classification in readAndPush. ACP envelopes (high-volume,
-      // never backed by a handoff record) would otherwise trigger the
-      // sender-based fallback in resolveHandoffIdForMessage and
-      // falsely mark an unrelated pending handoff as delivered.
 
       const session = this.sessions.get(role);
       if (!session) {
@@ -1274,6 +1274,10 @@ export class NexusWsBridge {
       }
       if (!resp || !resp.ok) {
         debugLog("wsBridge.readAndPush", `FAIL resp.status=${resp?.status ?? "none"} path=${path}`);
+        // handleEvent already deduped message_id; redelivery will not repair
+        // the cache. Emit a bounded invalidation so the next panel refresh
+        // picks up any contribution that did make it into the VFS store.
+        this.publishInvalidation(_targetRole, ipcMessageId);
         return;
       }
 
@@ -1283,6 +1287,7 @@ export class NexusWsBridge {
           "wsBridge.readAndPush",
           `NO DATA path=${path} error=${JSON.stringify(result.error ?? "none").slice(0, 100)}`,
         );
+        this.publishInvalidation(_targetRole, ipcMessageId);
         return;
       }
 
@@ -1307,6 +1312,22 @@ export class NexusWsBridge {
       const payload = msg.payload ?? {};
       const cid = typeof payload.cid === "string" ? payload.cid : undefined;
       const kind = typeof payload.kind === "string" ? payload.kind : undefined;
+
+      // Notify the TUI EventBus that a contribution was delivered, so
+      // panels can invalidate their list cache and refetch. Gated on
+      // (cid + kind) to skip non-contribution inbox traffic — otherwise
+      // every ACP envelope (already filtered above) or generic IPC
+      // notification would trigger a full VFS rescan.
+      if (this.opts.eventBus && cid && kind) {
+        const groveEvent: GroveEvent = {
+          type: "contribution",
+          sourceRole: msgSender,
+          targetRole: _targetRole,
+          payload: { message_id: ipcMessageId, cid, kind },
+          timestamp: new Date().toISOString(),
+        };
+        void this.opts.eventBus.publish(groveEvent);
+      }
       const summary =
         (payload.summary as string) ??
         (payload.body as string) ??
@@ -1440,7 +1461,30 @@ export class NexusWsBridge {
       });
       this.inFlightSends.add(tracked);
     } catch {
-      // Non-fatal
+      // Non-fatal — emit invalidation so transient parse/network failures
+      // don't permanently silence the cache-refresh path for this delivery.
+      this.publishInvalidation(_targetRole, ipcMessageId);
     }
+  }
+
+  /**
+   * Emit a "contribution invalidation" event for failure paths in
+   * readAndPush. handleEvent registers `message_id` in `recentMessageIds`
+   * before this method runs, so a failed sys_read / parse leaves the
+   * delivery permanently deduped — without a subsequent invalidation
+   * signal, TUI panels would not drop their list-cache and would keep
+   * showing stale data until the next 30 s poll. Payload omits cid/kind
+   * because the read failed; the subscriber treats it as "refetch now".
+   */
+  private publishInvalidation(targetRole: string, ipcMessageId?: string): void {
+    if (!this.opts.eventBus) return;
+    const groveEvent: GroveEvent = {
+      type: "contribution",
+      sourceRole: "system",
+      targetRole,
+      payload: { message_id: ipcMessageId, invalidation: true },
+      timestamp: new Date().toISOString(),
+    };
+    void this.opts.eventBus.publish(groveEvent);
   }
 }

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -529,10 +529,19 @@ export class NexusWsBridge {
       // case the unhealthy counter needs to catch.
       let sawBytes = false;
       // Idle-read watchdog — if the stream produces no bytes for this
-      // long, abort and treat the cycle as unhealthy. SSE keep-alive
-      // (": ping\n\n") typically fires every 15–30s; 60s idle is well
-      // outside normal operation and catches blackholed proxies.
-      const idleReadMs = 60000;
+      // long, abort and treat the cycle as unhealthy. Catches blackholed
+      // proxies stuck mid-stream that hold the TCP pipe open without
+      // delivering data.
+      //
+      // Set to 5 min because Nexus's `/api/v2/ipc/stream` does NOT emit
+      // keep-alive comments — it sends a single `connected` event then
+      // stays silent until an inbox message lands. A shorter watchdog
+      // (60 s) would treat every quiet stretch as an outage, escalate
+      // through 3 reconnect cycles, and fire onRoleUnhealthy → flip
+      // delivery to disabled even though the channel is healthy. 5 min
+      // is well under Nexus's natural channel lifetime and still bounds
+      // the time to detect a truly dead pipe.
+      const idleReadMs = 300_000;
       // Track whether the abort was triggered by our idle watchdog.
       // When the watchdog fires mid-stream, sawBytes may already be
       // true from an earlier heartbeat, but the stream is still stalled
@@ -550,6 +559,14 @@ export class NexusWsBridge {
           readResult = await reader.read();
         } catch {
           clearTimeout(idleTimer);
+          // Watchdog fire AFTER we already saw bytes (e.g. the initial
+          // `connected` event from Nexus) means the stream connected and
+          // produced data — it just went quiet. Treat the cycle as
+          // healthy so the consecutive-failure counter stays at zero.
+          // Without this the counter drifts up over time on idle
+          // streams and eventually trips onRoleUnhealthy on a perfectly
+          // good channel.
+          if (abortedByWatchdog && sawBytes) return true;
           return abortedByWatchdog ? false : sawBytes;
         } finally {
           clearTimeout(idleTimer);

--- a/src/tui/provider.ts
+++ b/src/tui/provider.ts
@@ -264,6 +264,15 @@ export interface TuiDataProvider {
   /** Clean up a workspace directory by targetRef and agentId (optional). */
   cleanWorkspace?(targetRef: string, agentId: string): Promise<void>;
 
+  /**
+   * Drop any in-memory snapshot caches the provider is holding (e.g. the
+   * NexusContributionStore list-cache). Optional — providers without TTL
+   * caches need not implement this. Callers with out-of-band proof of new
+   * data (SSE inbox-delivery push) should invoke this BEFORE triggering a
+   * refetch so the next read does not return a stale snapshot.
+   */
+  invalidateCaches?(): void;
+
   /** Release resources. */
   close(): void;
 }

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -258,21 +258,25 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     // the feed silently stopped refreshing on push in live sessions — the
     // per-poll interval was the only refresh path.
     //
-    // Subscribe once per topology role so any push triggers a refresh.
+    // ScreenManager renders RunningView OUTSIDE App's RefreshContext
+    // provider (advanced/boardroom mode is a different screen state),
+    // so useRefreshSignal does nothing here. Subscribe directly to the
+    // EventBus so SSE pushes refresh the feed/dashboard immediately.
     useEffect(() => {
-      debugLog("eventBus", `exists=${!!eventBus} roles=${topology?.roles.length ?? 0}`);
       if (!eventBus) return;
+      const roles = topology?.roles.map((r) => r.name) ?? [];
+      if (roles.length === 0) return;
       const handler = () => {
-        debugLog("eventBus", "SSE event received — refreshing polls");
+        const p = provider as { invalidateCaches?: () => void };
+        p.invalidateCaches?.();
         dashboardPoll.refresh();
         contributionsPoll.refresh();
       };
-      const roles = topology?.roles.map((r) => r.name) ?? [];
       for (const role of roles) eventBus.subscribe(role, handler);
       return () => {
         for (const role of roles) eventBus.unsubscribe(role, handler);
       };
-    }, [eventBus, topology, dashboardPoll.refresh, contributionsPoll.refresh]);
+    }, [eventBus, topology, provider, dashboardPoll.refresh, contributionsPoll.refresh]);
 
     const dashboard = dashboardPoll.data ?? undefined;
     const contributions = contributionsPoll.data;

--- a/src/tui/store-backed-provider.ts
+++ b/src/tui/store-backed-provider.ts
@@ -584,6 +584,20 @@ export abstract class StoreBackedProvider
   }
 
   /**
+   * Drop the contribution store's TTL list cache so the next read re-scans
+   * the backend. Used by the SSE refresh fan-out (app.tsx) so an inbox
+   * push that lands inside the cache TTL window doesn't leave the UI on
+   * the pre-arrival snapshot until the next 30 s fallback poll.
+   *
+   * Stores without a list cache implement this as a no-op (only
+   * NexusContributionStore currently has one).
+   */
+  invalidateCaches(): void {
+    const store = this.store as ContributionStore & { invalidateListCache?: () => void };
+    store.invalidateListCache?.();
+  }
+
+  /**
    * Hook for subclasses to release additional resources during {@link close}.
    * Called after the core stores have been closed. Override this instead of
    * `close()` to avoid forgetting the base cleanup.


### PR DESCRIPTION
## Summary

Two TUI regressions visible during a live review-loop session:

1. **DAG / Frontier / Dashboard didn't update in real time** — agents posted contributions and the inbox push fired, but panels stayed stale until the next 30 s poll tick.
2. **Spurious `[grove] DEGRADED: SSE stream for role=reviewer unhealthy after 3 consecutive failures`** in the status bar within ~3 minutes of every session start, even though contributions were flowing fine.

Three small fixes, all in the TUI:

### 1 — Wire SSE pushes into the global refresh signal (`src/tui/app.tsx`)

`NexusWsBridge` already publishes inbox-delivery events on `role:<targetRole>` channels. `running-view` subscribes to those for the Feed, but no one was bumping the app-level `refreshSignal`. Subscribing in `App` makes every panel-level `usePolledData` (DAG, Frontier, Dashboard) re-fetch on every push instead of waiting up to `intervalMs` (default 30 s).

### 2 — Drop list() TTL from 15 s → 2 s (`src/nexus/nexus-contribution-store.ts`)

With the SSE-driven refresh in place, the store cache became the bottleneck: a push fires, every panel re-fetches, but `list()` returns the pre-arrival snapshot for the next 15 s. The 2 s TTL still de-duplicates the back-to-back fetches that several panels (Feed, DAG, Frontier) issue immediately after a refresh signal — which was the original storm risk that motivated the cache.

### 3 — Stop the spurious DEGRADED escalation (`src/tui/nexus-ws-bridge.ts`)

Nexus's `/api/v2/ipc/stream/{agent_id}` emits a single `connected` event then stays silent until an inbox message lands — no SSE keep-alive comments. The 60 s idle-read watchdog treated every quiet stretch as a failure, escalated through 3 reconnect cycles, and tripped `onRoleUnhealthy` on a healthy channel.

- Raise `idleReadMs` to 5 min: still bounds time-to-detect a truly blackholed proxy, but well under any natural channel lifetime.
- When the watchdog fires AFTER `sawBytes=true` (we did receive the `connected` event), return `true`: the stream connected and produced data, it just went quiet. The consecutive-failure counter no longer drifts up on idle streams.

The deeper fix is upstream — Nexus should send `: ping\n\n` keep-alives on the IPC stream — but that's a separate change and this hardens the client side regardless.

## Test plan

- [x] `bun test src/tui/nexus-ws-bridge.test.ts` — 31/31 pass
- [x] Fresh clone + `grove init --preset review-loop` + `grove up` against a Nexus image with the seed-zone fix from nexi-lab/nexus#3897:
  - Type goal, launch session
  - Coder writes code + commits
  - Reviewer reviews + scores
- [x] **DAG view shows all 3 contributions** (work + review + discussion) within seconds of each landing — no waiting for the 30 s poll cycle
- [x] **Status bar stays clean for 10 min** — no DEGRADED, no consecutive-failure log entries
- [x] `tsc --noEmit` clean, biome clean