### PR TITLE
[codex] Fix server session-scoped routes

### DIFF
--- a/src/core/operations/query.ts
+++ b/src/core/operations/query.ts
@@ -188,6 +188,7 @@ export interface SearchInput {
   readonly agentName?: string | undefined;
   readonly limit?: number | undefined;
   readonly offset?: number | undefined;
+  readonly sessionId?: string | undefined;
 }
 
 /** Input for the log operation. */
@@ -277,6 +278,7 @@ export async function searchOperation(
       agentName: input.agentName,
       limit: input.limit,
       offset: input.offset,
+      ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
     });
 
     const summaries = results.map(toContributionSummary);

--- a/src/server/routes/boardroom.ts
+++ b/src/server/routes/boardroom.ts
@@ -20,6 +20,7 @@ import { answerQuestion } from "../../core/operations/ask-user-bus.js";
 import { sendMessageAsDiscussion } from "../../core/operations/messaging.js";
 import type { ServerEnv } from "../deps.js";
 import { toOperationDeps } from "../operation-adapter.js";
+import { contributionStoreForSession } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // File-local schemas (not exported — avoids isolatedDeclarations issues)
@@ -92,9 +93,9 @@ export const boardroom: Hono<ServerEnv> = new Hono<ServerEnv>();
  */
 boardroom.get("/summary", zValidator("query", summaryQuerySchema), async (c) => {
   const deps = c.get("deps");
-  const store = deps.contributionStore;
   const claimStore = deps.claimStore;
   const { sessionId } = c.req.valid("query");
+  const store = contributionStoreForSession(deps, sessionId);
 
   // Fetch ephemeral discussions in a single query, optionally scoped to a session
   const discussions = await store.list({
@@ -210,9 +211,8 @@ boardroom.get("/summary", zValidator("query", summaryQuerySchema), async (c) => 
  */
 boardroom.post("/answer", zValidator("json", answerBodySchema), async (c) => {
   const deps = c.get("deps");
-  const store = deps.contributionStore;
-
   const body = c.req.valid("json");
+  const store = contributionStoreForSession(deps, body.sessionId);
 
   const operator = { agentId: "tui-operator", agentName: "operator" };
   const contribution = await answerQuestion(
@@ -242,6 +242,7 @@ boardroom.post("/answer", zValidator("json", answerBodySchema), async (c) => {
 boardroom.post("/message", zValidator("json", messageBodySchema), async (c) => {
   const deps = c.get("deps");
   const body = c.req.valid("json");
+  const store = contributionStoreForSession(deps, body.sessionId);
 
   const result = await sendMessageAsDiscussion(
     {
@@ -250,7 +251,7 @@ boardroom.post("/message", zValidator("json", messageBodySchema), async (c) => {
       recipients: body.recipients,
       ...(body.inReplyTo !== undefined ? { inReplyTo: body.inReplyTo } : {}),
     },
-    toOperationDeps(deps),
+    toOperationDeps({ ...deps, contributionStore: store }),
   );
 
   if (!result.ok) {

--- a/src/server/routes/contributions.ts
+++ b/src/server/routes/contributions.ts
@@ -26,6 +26,7 @@ import type { ContributionQuery } from "../../core/store.js";
 import type { ServerEnv } from "../deps.js";
 import { toHttpResult, toOperationDeps } from "../operation-adapter.js";
 import { CID_REGEX, MAX_REQUEST_SIZE } from "../schemas.js";
+import { contributionStoreForSession } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // File-local schemas (not exported — avoids isolatedDeclarations issues)
@@ -267,8 +268,8 @@ contributions.post("/", async (c) => {
   // the HTTP submit path would write to the zone root while MCP writes go to
   // sessions/{sessionId}/, splitting the data across two directories.
   const scopedContributionStore =
-    parsed.sessionId && serverDeps.contributionStoreForSession
-      ? serverDeps.contributionStoreForSession(parsed.sessionId)
+    parsed.sessionId !== undefined
+      ? contributionStoreForSession(serverDeps, parsed.sessionId)
       : serverDeps.contributionStore;
 
   // Session-scoped enforcement: override contract with session config
@@ -338,10 +339,7 @@ contributions.get("/", zValidator("query", listQuerySchema), async (c) => {
   // (Nexus mode), build a per-request store so list()/count() hit the
   // session-scoped FTS index instead of the zone root. Falls back to the
   // process-global store when no factory is wired (tests, local-only mode).
-  const listStore =
-    raw.sessionId !== undefined && deps.contributionStoreForSession !== undefined
-      ? deps.contributionStoreForSession(raw.sessionId)
-      : deps.contributionStore;
+  const listStore = contributionStoreForSession(deps, raw.sessionId);
 
   // When outcome filter is specified, we must fetch ALL matching contributions
   // (without limit/offset), filter by outcome status, then paginate manually.
@@ -391,7 +389,7 @@ contributions.get("/", zValidator("query", listQuerySchema), async (c) => {
 
 /** GET /api/contributions/:cid — Get a single contribution by CID. */
 contributions.get("/:cid", zValidator("param", cidParamSchema), async (c) => {
-  const { contributionStore } = c.get("deps");
+  const contributionStore = contributionStoreForSession(c.get("deps"), c.req.query("sessionId"));
   const { cid } = c.req.valid("param");
 
   const contribution = await contributionStore.get(cid);
@@ -404,7 +402,9 @@ contributions.get("/:cid", zValidator("param", cidParamSchema), async (c) => {
 
 /** GET /api/contributions/:cid/artifacts/:name — Download artifact blob. */
 contributions.get("/:cid/artifacts/:name", async (c) => {
-  const { contributionStore, cas } = c.get("deps");
+  const deps = c.get("deps");
+  const contributionStore = contributionStoreForSession(deps, c.req.query("sessionId"));
+  const { cas } = deps;
   const cid = c.req.param("cid");
   const name = c.req.param("name");
 
@@ -446,7 +446,9 @@ contributions.get("/:cid/artifacts/:name", async (c) => {
 
 /** GET /api/contributions/:cid/artifacts/:name/meta — Artifact metadata (size + mediaType). */
 contributions.get("/:cid/artifacts/:name/meta", async (c) => {
-  const { contributionStore, cas } = c.get("deps");
+  const deps = c.get("deps");
+  const contributionStore = contributionStoreForSession(deps, c.req.query("sessionId"));
+  const { cas } = deps;
   const cid = c.req.param("cid");
   const name = c.req.param("name");
 

--- a/src/server/routes/dag.ts
+++ b/src/server/routes/dag.ts
@@ -11,27 +11,44 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { ServerEnv } from "../deps.js";
 import { CID_REGEX } from "../schemas.js";
+import { contributionStoreForSession } from "./shared.js";
 
 const cidParamSchema = z.object({
   cid: z.string().regex(CID_REGEX, "CID must be in format blake3:<64-hex-chars>"),
 });
 
+const sessionQuerySchema = z.object({
+  sessionId: z.string().optional(),
+});
+
 const dag: HonoType<ServerEnv> = new Hono<ServerEnv>();
 
 /** GET /api/dag/:cid/children — Incoming edges (who references this CID). */
-dag.get("/:cid/children", zValidator("param", cidParamSchema), async (c) => {
-  const { contributionStore } = c.get("deps");
-  const { cid } = c.req.valid("param");
-  const children = await contributionStore.children(cid);
-  return c.json(children);
-});
+dag.get(
+  "/:cid/children",
+  zValidator("param", cidParamSchema),
+  zValidator("query", sessionQuerySchema),
+  async (c) => {
+    const { sessionId } = c.req.valid("query");
+    const contributionStore = contributionStoreForSession(c.get("deps"), sessionId);
+    const { cid } = c.req.valid("param");
+    const children = await contributionStore.children(cid);
+    return c.json(children);
+  },
+);
 
 /** GET /api/dag/:cid/ancestors — Outgoing edge targets (who this CID references). */
-dag.get("/:cid/ancestors", zValidator("param", cidParamSchema), async (c) => {
-  const { contributionStore } = c.get("deps");
-  const { cid } = c.req.valid("param");
-  const ancestors = await contributionStore.ancestors(cid);
-  return c.json(ancestors);
-});
+dag.get(
+  "/:cid/ancestors",
+  zValidator("param", cidParamSchema),
+  zValidator("query", sessionQuerySchema),
+  async (c) => {
+    const { sessionId } = c.req.valid("query");
+    const contributionStore = contributionStoreForSession(c.get("deps"), sessionId);
+    const { cid } = c.req.valid("param");
+    const ancestors = await contributionStore.ancestors(cid);
+    return c.json(ancestors);
+  },
+);
 
 export { dag };

--- a/src/server/routes/diff.ts
+++ b/src/server/routes/diff.ts
@@ -8,12 +8,15 @@
 import type { Hono as HonoType } from "hono";
 import { Hono } from "hono";
 import type { ServerEnv } from "../deps.js";
+import { contributionStoreForSession } from "./shared.js";
 
 const diff: HonoType<ServerEnv> = new Hono<ServerEnv>();
 
 /** GET /api/diff/:parentCid/:childCid/:artifactName */
 diff.get("/:parentCid/:childCid/:artifactName", async (c) => {
-  const { contributionStore, cas } = c.get("deps");
+  const deps = c.get("deps");
+  const contributionStore = contributionStoreForSession(deps, c.req.query("sessionId"));
+  const { cas } = deps;
   const parentCid = c.req.param("parentCid");
   const childCid = c.req.param("childCid");
   const artifactName = c.req.param("artifactName");

--- a/src/server/routes/frontier.ts
+++ b/src/server/routes/frontier.ts
@@ -8,10 +8,12 @@ import { zValidator } from "@hono/zod-validator";
 import type { Hono as HonoType } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
+import { DefaultFrontierCalculator } from "../../core/frontier.js";
 import type { ContributionKind, ContributionMode, JsonValue } from "../../core/models.js";
 import { frontierOperation } from "../../core/operations/index.js";
 import type { ServerEnv } from "../deps.js";
 import { toHttpResult, toOperationDeps } from "../operation-adapter.js";
+import { contributionStoreForSession } from "./shared.js";
 
 const querySchema = z.object({
   kind: z.string().optional(),
@@ -48,7 +50,17 @@ frontier.get("/", zValidator("query", querySchema), async (c) => {
     contextFilter = parsed as Record<string, JsonValue>;
   }
 
-  const deps = toOperationDeps(c.get("deps"));
+  const serverDeps = c.get("deps");
+  const scopedStore = contributionStoreForSession(serverDeps, query.sessionId);
+  const scopedFrontier =
+    scopedStore === serverDeps.contributionStore
+      ? serverDeps.frontier
+      : new DefaultFrontierCalculator(scopedStore);
+  const deps = toOperationDeps({
+    ...serverDeps,
+    contributionStore: scopedStore,
+    frontier: scopedFrontier,
+  });
   const result = await frontierOperation(
     {
       metric: query.metric,

--- a/src/server/routes/goals.ts
+++ b/src/server/routes/goals.ts
@@ -8,7 +8,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import type { ServerEnv } from "../deps.js";
-import { notConfigured } from "./shared.js";
+import { notConfigured, readJsonBody } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -31,8 +31,10 @@ goals.put("/goal", async (c) => {
   const { goalSessionStore } = c.get("deps");
   if (!goalSessionStore) return notConfigured(c, "Goal/session store is not configured");
 
-  const body = await c.req.json();
-  const parsed = setGoalSchema.safeParse(body);
+  const json = await readJsonBody(c);
+  if (!json.ok) return json.response;
+
+  const parsed = setGoalSchema.safeParse(json.body);
   if (!parsed.success) {
     return c.json({ error: { code: "VALIDATION_ERROR", details: parsed.error.issues } }, 400);
   }

--- a/src/server/routes/outcomes.ts
+++ b/src/server/routes/outcomes.ts
@@ -22,6 +22,7 @@ import { postCheckRun, postOutcomeComment } from "../../github/outcome-poster.js
 import type { ServerEnv } from "../deps.js";
 import { toHttpResult, toOperationDeps } from "../operation-adapter.js";
 import { CID_REGEX } from "../schemas.js";
+import { readJsonBody } from "./shared.js";
 
 const cidParamSchema = z.object({
   cid: z.string().regex(CID_REGEX, "CID must be in format blake3:<64-hex-chars>"),
@@ -67,8 +68,10 @@ outcomes.get("/:cid", zValidator("param", cidParamSchema), async (c) => {
 // POST /api/outcomes/:cid
 outcomes.post("/:cid", zValidator("param", cidParamSchema), async (c) => {
   const { cid } = c.req.valid("param");
-  const body = await c.req.json();
-  const parsed = setOutcomeSchema.safeParse(body);
+  const json = await readJsonBody(c);
+  if (!json.ok) return json.response;
+
+  const parsed = setOutcomeSchema.safeParse(json.body);
   if (!parsed.success) {
     return c.json({ error: "Invalid input", details: parsed.error.issues }, 400);
   }

--- a/src/server/routes/search.ts
+++ b/src/server/routes/search.ts
@@ -12,6 +12,7 @@ import type { ContributionKind, ContributionMode } from "../../core/models.js";
 import { searchOperation } from "../../core/operations/index.js";
 import type { ServerEnv } from "../deps.js";
 import { toHttpResult, toOperationDeps } from "../operation-adapter.js";
+import { contributionStoreForSession } from "./shared.js";
 
 const querySchema = z.object({
   q: z.string().min(1, "Search query is required"),
@@ -22,6 +23,7 @@ const querySchema = z.object({
   tags: z.string().optional(),
   agentId: z.string().optional(),
   agentName: z.string().optional(),
+  sessionId: z.string().optional(),
 });
 
 const search: HonoType<ServerEnv> = new Hono<ServerEnv>();
@@ -30,7 +32,9 @@ const search: HonoType<ServerEnv> = new Hono<ServerEnv>();
 search.get("/", zValidator("query", querySchema), async (c) => {
   const raw = c.req.valid("query");
 
-  const deps = toOperationDeps(c.get("deps"));
+  const serverDeps = c.get("deps");
+  const scopedStore = contributionStoreForSession(serverDeps, raw.sessionId);
+  const deps = toOperationDeps({ ...serverDeps, contributionStore: scopedStore });
   const result = await searchOperation(
     {
       query: raw.q,
@@ -41,6 +45,7 @@ search.get("/", zValidator("query", querySchema), async (c) => {
       agentName: raw.agentName,
       limit: raw.limit,
       offset: raw.offset,
+      ...(raw.sessionId !== undefined ? { sessionId: raw.sessionId } : {}),
     },
     deps,
   );

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -18,7 +18,7 @@ import type { AgentTopology } from "../../core/topology.js";
 import { AgentTopologySchema, wireToTopology } from "../../core/topology.js";
 import { resolveTopology } from "../../core/topology-resolver.js";
 import type { ServerEnv } from "../deps.js";
-import { notConfigured } from "./shared.js";
+import { contributionStoreForSession, notConfigured, readJsonBody } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -73,8 +73,10 @@ sessions.post("/", async (c) => {
   const { goalSessionStore, contract } = c.get("deps");
   if (!goalSessionStore) return notConfigured(c, "Goal/session store is not configured");
 
-  const body = await c.req.json();
-  const parsed = createSessionSchema.safeParse(body);
+  const json = await readJsonBody(c);
+  if (!json.ok) return json.response;
+
+  const parsed = createSessionSchema.safeParse(json.body);
   if (!parsed.success) {
     return c.json({ error: { code: "VALIDATION_ERROR", details: parsed.error.issues } }, 400);
   }
@@ -240,7 +242,7 @@ sessions.put("/:id/archive", async (c) => {
 /** POST /api/sessions/:id/contributions — Record a contribution against a session. */
 sessions.post("/:id/contributions", async (c) => {
   const deps = c.get("deps");
-  const { goalSessionStore, contributionStore } = deps;
+  const { goalSessionStore } = deps;
   if (!goalSessionStore) return notConfigured(c, "Goal/session store is not configured");
 
   const sessionId = c.req.param("id");
@@ -254,13 +256,16 @@ sessions.post("/:id/contributions", async (c) => {
     );
   }
 
-  const body = await c.req.json();
-  const parsed = addContributionSchema.safeParse(body);
+  const json = await readJsonBody(c);
+  if (!json.ok) return json.response;
+
+  const parsed = addContributionSchema.safeParse(json.body);
   if (!parsed.success) {
     return c.json({ error: { code: "VALIDATION_ERROR", details: parsed.error.issues } }, 400);
   }
 
   // Verify contribution exists and run policy enforcement when possible
+  const contributionStore = contributionStoreForSession(deps, sessionId);
   const contribution = await contributionStore.get(parsed.data.cid);
   if (contribution) {
     // Policy enforcement against session config (only when contribution is available)

--- a/src/server/routes/shared.ts
+++ b/src/server/routes/shared.ts
@@ -7,6 +7,8 @@
 
 import type { Context } from "hono";
 import { z } from "zod";
+import type { ContributionStore } from "../../core/store.js";
+import type { ServerDeps } from "../deps.js";
 import { CID_REGEX } from "../schemas.js";
 
 // ---------------------------------------------------------------------------
@@ -33,4 +35,31 @@ export const cidParamSchema: z.ZodObject<{ cid: z.ZodString }> = z.object({
  */
 export function notConfigured(c: Context, message: string): Response {
   return c.json({ error: { code: "NOT_CONFIGURED", message } }, 501);
+}
+
+/** Resolve the contribution store for an optional session-scoped request. */
+export function contributionStoreForSession(
+  deps: ServerDeps,
+  sessionId: string | undefined,
+): ContributionStore {
+  if (sessionId !== undefined && deps.contributionStoreForSession !== undefined) {
+    return deps.contributionStoreForSession(sessionId);
+  }
+  return deps.contributionStore;
+}
+
+export type JsonBodyResult =
+  | { readonly ok: true; readonly body: unknown }
+  | { readonly ok: false; readonly response: Response };
+
+/** Parse a JSON request body, returning a consistent 400 on malformed input. */
+export async function readJsonBody(c: Context): Promise<JsonBodyResult> {
+  try {
+    return { ok: true, body: await c.req.json() };
+  } catch {
+    return {
+      ok: false,
+      response: c.json({ error: { code: "VALIDATION_ERROR", message: "Invalid JSON body" } }, 400),
+    };
+  }
 }

--- a/src/server/routes/threads.ts
+++ b/src/server/routes/threads.ts
@@ -13,6 +13,7 @@ import { threadOperation, threadsOperation } from "../../core/operations/index.j
 import type { ServerEnv } from "../deps.js";
 import { toHttpResult, toOperationDeps } from "../operation-adapter.js";
 import { CID_REGEX } from "../schemas.js";
+import { contributionStoreForSession } from "./shared.js";
 
 const cidParamSchema = z.object({
   cid: z.string().regex(CID_REGEX, "CID must be in format blake3:<64-hex-chars>"),
@@ -21,11 +22,13 @@ const cidParamSchema = z.object({
 const threadQuerySchema = z.object({
   maxDepth: z.coerce.number().int().min(0).max(100).default(50),
   limit: z.coerce.number().int().min(1).max(500).default(100),
+  sessionId: z.string().optional(),
 });
 
 const threadsQuerySchema = z.object({
   tags: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(100).default(20),
+  sessionId: z.string().optional(),
 });
 
 const threads: HonoType<ServerEnv> = new Hono<ServerEnv>();
@@ -37,10 +40,12 @@ threads.get(
   zValidator("query", threadQuerySchema),
   async (c) => {
     const { cid } = c.req.valid("param");
-    const { maxDepth, limit } = c.req.valid("query");
+    const { maxDepth, limit, sessionId } = c.req.valid("query");
 
     // Use operation for validation (e.g., 404 on missing root)
-    const deps = toOperationDeps(c.get("deps"));
+    const serverDeps = c.get("deps");
+    const contributionStore = contributionStoreForSession(serverDeps, sessionId);
+    const deps = toOperationDeps({ ...serverDeps, contributionStore });
     const result = await threadOperation({ cid, maxDepth, limit }, deps);
 
     if (!result.ok) {
@@ -49,7 +54,6 @@ threads.get(
     }
 
     // Return full thread nodes for HTTP consumers (TUI remote provider)
-    const { contributionStore } = c.get("deps");
     const nodes = await contributionStore.thread(cid, { maxDepth, limit });
     return c.json({
       nodes: nodes.map((n) => ({
@@ -69,7 +73,9 @@ threads.get("/", zValidator("query", threadsQuerySchema), async (c) => {
   const tags = raw.tags ? raw.tags.split(",").filter((t) => t.length > 0) : undefined;
 
   // Use operation for validation
-  const deps = toOperationDeps(c.get("deps"));
+  const serverDeps = c.get("deps");
+  const contributionStore = contributionStoreForSession(serverDeps, raw.sessionId);
+  const deps = toOperationDeps({ ...serverDeps, contributionStore });
   const result = await threadsOperation({ tags, limit: raw.limit }, deps);
 
   if (!result.ok) {
@@ -78,7 +84,6 @@ threads.get("/", zValidator("query", threadsQuerySchema), async (c) => {
   }
 
   // Return full thread summaries for HTTP consumers (TUI remote provider)
-  const { contributionStore } = c.get("deps");
   const threadList = await contributionStore.hotThreads({ tags, limit: raw.limit });
   return c.json({
     threads: threadList.map((t) => ({

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -20,6 +20,7 @@ import { parseGossipSeeds, parsePort } from "../shared/env.js";
 import { createApp } from "./app.js";
 import type { ServerDeps } from "./deps.js";
 import { SessionService } from "./session-service.js";
+import { memoizeContributionStoreForSession } from "./session-store-factory.js";
 import { createWsHandler } from "./ws-handler.js";
 
 const GROVE_DIR = process.env.GROVE_DIR ?? join(process.cwd(), ".grove");
@@ -144,8 +145,9 @@ if (nexusUrl) {
   serverBountyStore = new NexusBountyStore({ client: nexusClient, zoneId });
   serverOutcomeStore = new NexusOutcomeStore({ client: nexusClient, zoneId });
   serverCas = new NexusCas({ client: nexusClient, zoneId });
-  contributionStoreForSessionFactory = (sessionId: string) =>
-    new NexusContributionStore({ client: nexusClient, zoneId, sessionId });
+  contributionStoreForSessionFactory = memoizeContributionStoreForSession(
+    (sessionId: string) => new NexusContributionStore({ client: nexusClient, zoneId, sessionId }),
+  );
   console.log(`grove-server: using Nexus stores at ${nexusUrl} (zone=${zoneId})`);
 }
 

--- a/src/server/session-store-factory.test.ts
+++ b/src/server/session-store-factory.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { InMemoryContributionStore } from "../core/testing.js";
+import { memoizeContributionStoreForSession } from "./session-store-factory.js";
+
+describe("memoizeContributionStoreForSession", () => {
+  test("reuses a contribution store per session id", () => {
+    const calls: string[] = [];
+    const factory = memoizeContributionStoreForSession((sessionId) => {
+      calls.push(sessionId);
+      return new InMemoryContributionStore();
+    });
+
+    const first = factory("session-a");
+    const second = factory("session-a");
+    const other = factory("session-b");
+
+    expect(second).toBe(first);
+    expect(other).not.toBe(first);
+    expect(calls).toEqual(["session-a", "session-b"]);
+  });
+});

--- a/src/server/session-store-factory.ts
+++ b/src/server/session-store-factory.ts
@@ -1,0 +1,17 @@
+import type { ContributionStore } from "../core/store.js";
+
+/** Reuse session-scoped contribution stores so their internal caches stay effective. */
+export function memoizeContributionStoreForSession(
+  factory: (sessionId: string) => ContributionStore,
+): (sessionId: string) => ContributionStore {
+  const storesBySession = new Map<string, ContributionStore>();
+
+  return (sessionId: string): ContributionStore => {
+    let store = storesBySession.get(sessionId);
+    if (store === undefined) {
+      store = factory(sessionId);
+      storesBySession.set(sessionId, store);
+    }
+    return store;
+  };
+}

--- a/src/server/ws-handler.test.ts
+++ b/src/server/ws-handler.test.ts
@@ -99,7 +99,7 @@ describe("createWsHandler", () => {
     bus.close();
   });
 
-  test("message: get_state returns state snapshot", () => {
+  test("message: get_state returns state snapshot", async () => {
     const { service, bus } = makeService();
     const handler = createWsHandler(service);
     const ws = new MockWs();
@@ -107,31 +107,25 @@ describe("createWsHandler", () => {
     handler.open(ws);
     const countAfterOpen = ws.sent.length;
 
-    handler.message(ws, JSON.stringify({ type: "command", command: "get_state" }));
+    await handler.message(ws, JSON.stringify({ type: "command", command: "get_state" }));
 
-    // Allow the async handler to settle
-    // The handler is fire-and-forget async, so we give it a tick
-    return new Promise<void>((resolve) => {
-      setTimeout(() => {
-        expect(ws.sent.length).toBeGreaterThan(countAfterOpen);
-        const lastMsg = JSON.parse(ws.sent[ws.sent.length - 1]!) as Record<string, unknown>;
-        expect(lastMsg.type).toBe("state");
-        handler.close(ws);
-        service.destroy();
-        bus.close();
-        resolve();
-      }, 50);
-    });
+    expect(ws.sent.length).toBeGreaterThan(countAfterOpen);
+    const lastMsg = JSON.parse(ws.sent[ws.sent.length - 1]!) as Record<string, unknown>;
+    expect(lastMsg.type).toBe("state");
+
+    handler.close(ws);
+    service.destroy();
+    bus.close();
   });
 
-  test("message: start_session spawns agents", () => {
+  test("message: start_session spawns agents", async () => {
     const { service, runtime, bus } = makeService();
     const handler = createWsHandler(service);
     const ws = new MockWs();
 
     handler.open(ws);
 
-    handler.message(
+    await handler.message(
       ws,
       JSON.stringify({
         type: "command",
@@ -140,60 +134,48 @@ describe("createWsHandler", () => {
       }),
     );
 
-    return new Promise<void>((resolve) => {
-      setTimeout(() => {
-        expect(runtime.spawnCalls.length).toBeGreaterThan(0);
-        // Should have received a state message with running status
-        const stateMessages = ws.sent
-          .map((s) => JSON.parse(s) as Record<string, unknown>)
-          .filter((m) => m.type === "state");
-        const lastState = stateMessages[stateMessages.length - 1];
-        expect(lastState?.status).toBe("running");
-        expect(lastState?.goal).toBe("Build auth");
+    expect(runtime.spawnCalls.length).toBeGreaterThan(0);
+    // Should have received a state message with running status
+    const stateMessages = ws.sent
+      .map((s) => JSON.parse(s) as Record<string, unknown>)
+      .filter((m) => m.type === "state");
+    const lastState = stateMessages[stateMessages.length - 1];
+    expect(lastState?.status).toBe("running");
+    expect(lastState?.goal).toBe("Build auth");
 
-        handler.close(ws);
-        service.destroy();
-        bus.close();
-        resolve();
-      }, 50);
-    });
+    handler.close(ws);
+    service.destroy();
+    bus.close();
   });
 
-  test("message: stop_session stops the session", () => {
+  test("message: stop_session stops the session", async () => {
     const { service, bus } = makeService();
     const handler = createWsHandler(service);
     const ws = new MockWs();
 
     handler.open(ws);
 
-    return new Promise<void>((resolve) => {
-      // Start first, then stop
-      void service.startSession("Test").then(() => {
-        handler.message(
-          ws,
-          JSON.stringify({
-            type: "command",
-            command: "stop_session",
-            payload: { reason: "Done" },
-          }),
-        );
+    await service.startSession("Test");
+    await handler.message(
+      ws,
+      JSON.stringify({
+        type: "command",
+        command: "stop_session",
+        payload: { reason: "Done" },
+      }),
+    );
 
-        setTimeout(() => {
-          const events = ws.sent
-            .map((s) => JSON.parse(s) as Record<string, unknown>)
-            .filter((m) => m.type === "session_complete");
-          expect(events.length).toBeGreaterThanOrEqual(1);
+    const events = ws.sent
+      .map((s) => JSON.parse(s) as Record<string, unknown>)
+      .filter((m) => m.type === "session_complete");
+    expect(events.length).toBeGreaterThanOrEqual(1);
 
-          handler.close(ws);
-          service.destroy();
-          bus.close();
-          resolve();
-        }, 50);
-      });
-    });
+    handler.close(ws);
+    service.destroy();
+    bus.close();
   });
 
-  test("message: invalid JSON sends error", () => {
+  test("message: invalid JSON sends error", async () => {
     const { service, bus } = makeService();
     const handler = createWsHandler(service);
     const ws = new MockWs();
@@ -201,21 +183,16 @@ describe("createWsHandler", () => {
     handler.open(ws);
     const countAfterOpen = ws.sent.length;
 
-    handler.message(ws, "not-json{{{");
+    await handler.message(ws, "not-json{{{");
 
-    return new Promise<void>((resolve) => {
-      setTimeout(() => {
-        const errorMessages = ws.sent
-          .slice(countAfterOpen)
-          .map((s) => JSON.parse(s) as Record<string, unknown>)
-          .filter((m) => m.type === "error");
-        expect(errorMessages.length).toBeGreaterThanOrEqual(1);
+    const errorMessages = ws.sent
+      .slice(countAfterOpen)
+      .map((s) => JSON.parse(s) as Record<string, unknown>)
+      .filter((m) => m.type === "error");
+    expect(errorMessages.length).toBeGreaterThanOrEqual(1);
 
-        handler.close(ws);
-        service.destroy();
-        bus.close();
-        resolve();
-      }, 50);
-    });
+    handler.close(ws);
+    service.destroy();
+    bus.close();
   });
 });

--- a/src/server/ws-handler.ts
+++ b/src/server/ws-handler.ts
@@ -64,7 +64,7 @@ interface WsSocketInternal extends WsSocket {
  */
 export function createWsHandler(service: SessionService): {
   open(ws: WsSocket): void;
-  message(ws: WsSocket, message: string): void;
+  message(ws: WsSocket, message: string): Promise<void>;
   close(ws: WsSocket): void;
 } {
   return {
@@ -87,7 +87,7 @@ export function createWsHandler(service: SessionService): {
     },
 
     message(ws: WsSocket, message: string) {
-      void handleMessage(ws, message, service);
+      return handleMessage(ws, message, service);
     },
 
     close(ws: WsSocket) {

--- a/tests/server/goals-sessions.test.ts
+++ b/tests/server/goals-sessions.test.ts
@@ -141,6 +141,18 @@ describe("PUT /api/session/goal", () => {
     expect(data.goal).toBe("Ship it");
     expect(data.acceptance).toEqual([]);
   });
+
+  test("rejects malformed JSON with 400", async () => {
+    const res = await ctx.app.request("/api/session/goal", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json{{{",
+    });
+
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: { code: string } };
+    expect(data.error.code).toBe("VALIDATION_ERROR");
+  });
 });
 
 describe("GET /api/session/goal", () => {
@@ -199,6 +211,18 @@ describe("POST /api/sessions", () => {
     expect(res.status).toBe(201);
     const data = await res.json();
     expect(data.goal).toBe("Fix all bugs");
+  });
+
+  test("rejects malformed JSON with 400", async () => {
+    const res = await ctx.app.request("/api/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json{{{",
+    });
+
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: { code: string } };
+    expect(data.error.code).toBe("VALIDATION_ERROR");
   });
 });
 

--- a/tests/server/outcomes.test.ts
+++ b/tests/server/outcomes.test.ts
@@ -108,6 +108,18 @@ describe("POST /api/outcomes/:cid", () => {
     expect(res.status).toBe(400);
   });
 
+  test("returns 400 for malformed JSON body", async () => {
+    const res = await ctx.app.request(`/api/outcomes/${VALID_CID}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json{{{",
+    });
+
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { error: { code: string } };
+    expect(data.error.code).toBe("VALIDATION_ERROR");
+  });
+
   test("overwrites existing outcome", async () => {
     // Create initial outcome
     await ctx.app.request(`/api/outcomes/${VALID_CID}`, {

--- a/tests/server/session-scoped-routes.test.ts
+++ b/tests/server/session-scoped-routes.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+import type { Hono } from "hono";
+import { DefaultFrontierCalculator } from "../../src/core/frontier.js";
+import type { Contribution } from "../../src/core/models.js";
+import { ContributionKind, ContributionMode, RelationType } from "../../src/core/models.js";
+import { InMemoryContributionStore } from "../../src/core/testing.js";
+import { createApp } from "../../src/server/app.js";
+import type { ServerEnv } from "../../src/server/deps.js";
+import { InMemoryClaimStore, InMemoryContentStore } from "../../src/server/test-helpers.js";
+
+const SESSION_ID = "session-1";
+const ROOT_CID = `blake3:${"1".repeat(64)}`;
+const CHILD_CID = `blake3:${"2".repeat(64)}`;
+
+function makeContribution(overrides?: Partial<Contribution>): Contribution {
+  return {
+    manifestVersion: 1,
+    cid: ROOT_CID,
+    kind: ContributionKind.Work,
+    mode: ContributionMode.Evaluation,
+    summary: "Session scoped needle",
+    artifacts: {},
+    relations: [],
+    tags: ["session"],
+    agent: { agentId: "agent-1" },
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeAppWithScopedStore(contributions: readonly Contribution[]): {
+  readonly app: Hono<ServerEnv>;
+  readonly scopedStore: InMemoryContributionStore;
+  readonly cas: InMemoryContentStore;
+} {
+  const globalStore = new InMemoryContributionStore();
+  const scopedStore = new InMemoryContributionStore(contributions);
+  const cas = new InMemoryContentStore();
+  const deps = {
+    contributionStore: globalStore,
+    contributionStoreForSession: (sessionId: string) =>
+      sessionId === SESSION_ID ? scopedStore : globalStore,
+    claimStore: new InMemoryClaimStore(),
+    cas,
+    frontier: new DefaultFrontierCalculator(globalStore),
+  };
+  return { app: createApp(deps), scopedStore, cas };
+}
+
+describe("session-scoped server routes", () => {
+  test("GET /api/contributions/:cid reads from the session-scoped store", async () => {
+    const contribution = makeContribution();
+    const { app } = makeAppWithScopedStore([contribution]);
+
+    const res = await app.request(`/api/contributions/${contribution.cid}?sessionId=${SESSION_ID}`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { cid: string; summary: string };
+    expect(body.cid).toBe(contribution.cid);
+    expect(body.summary).toBe("Session scoped needle");
+  });
+
+  test("GET /api/contributions/:cid/artifacts/:name reads metadata from the scoped store", async () => {
+    const { app, scopedStore, cas } = makeAppWithScopedStore([]);
+    const hash = await cas.put(new TextEncoder().encode("artifact body"), {
+      mediaType: "text/plain",
+    });
+    const contribution = makeContribution({ artifacts: { "note.txt": hash } });
+    await scopedStore.put(contribution);
+
+    const res = await app.request(
+      `/api/contributions/${contribution.cid}/artifacts/note.txt/meta?sessionId=${SESSION_ID}`,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { sizeBytes: number; mediaType?: string };
+    expect(body.sizeBytes).toBe("artifact body".length);
+    expect(body.mediaType).toBe("text/plain");
+  });
+
+  test("GET /api/frontier uses the session-scoped contribution store", async () => {
+    const contribution = makeContribution();
+    const { app } = makeAppWithScopedStore([contribution]);
+
+    const res = await app.request(`/api/frontier?sessionId=${SESSION_ID}`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { byRecency: readonly { cid: string }[] };
+    expect(body.byRecency.map((entry) => entry.cid)).toEqual([contribution.cid]);
+  });
+
+  test("GET /api/search uses the session-scoped contribution store", async () => {
+    const contribution = makeContribution();
+    const { app } = makeAppWithScopedStore([contribution]);
+
+    const res = await app.request(`/api/search?q=needle&sessionId=${SESSION_ID}`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { results: readonly { cid: string }[] };
+    expect(body.results.map((entry) => entry.cid)).toEqual([contribution.cid]);
+  });
+
+  test("GET /api/dag/:cid/children uses the session-scoped contribution store", async () => {
+    const root = makeContribution();
+    const child = makeContribution({
+      cid: CHILD_CID,
+      summary: "Child contribution",
+      relations: [{ targetCid: root.cid, relationType: RelationType.DerivesFrom }],
+      createdAt: "2026-01-01T00:00:01.000Z",
+    });
+    const { app } = makeAppWithScopedStore([root, child]);
+
+    const res = await app.request(`/api/dag/${root.cid}/children?sessionId=${SESSION_ID}`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as readonly { cid: string }[];
+    expect(body.map((entry) => entry.cid)).toEqual([child.cid]);
+  });
+
+  test("GET /api/threads/:cid uses the session-scoped contribution store", async () => {
+    const root = makeContribution({ kind: ContributionKind.Discussion });
+    const reply = makeContribution({
+      cid: CHILD_CID,
+      kind: ContributionKind.Discussion,
+      summary: "Reply contribution",
+      relations: [{ targetCid: root.cid, relationType: RelationType.RespondsTo }],
+      createdAt: "2026-01-01T00:00:01.000Z",
+    });
+    const { app } = makeAppWithScopedStore([root, reply]);
+
+    const res = await app.request(`/api/threads/${root.cid}?sessionId=${SESSION_ID}`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { nodes: readonly { cid: string }[] };
+    expect(body.nodes.map((entry) => entry.cid)).toEqual([root.cid, reply.cid]);
+  });
+
+  test("GET /api/boardroom/summary uses the session-scoped contribution store", async () => {
+    const message = makeContribution({
+      kind: ContributionKind.Discussion,
+      mode: ContributionMode.Exploration,
+      summary: "Operator message",
+      context: {
+        ephemeral: true,
+        recipients: ["@all"],
+        message_body: "Visible in scoped boardroom",
+      },
+    });
+    const { app } = makeAppWithScopedStore([message]);
+
+    const res = await app.request(`/api/boardroom/summary?sessionId=${SESSION_ID}`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      recentMessages: readonly {
+        cid: string;
+        fromAgentId: string;
+        body: string;
+        recipients: readonly string[];
+        createdAt: string;
+      }[];
+    };
+    expect(body.recentMessages).toEqual([
+      {
+        cid: message.cid,
+        fromAgentId: "agent-1",
+        body: "Visible in scoped boardroom",
+        recipients: ["@all"],
+        createdAt: message.createdAt,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes several correctness and performance issues in the server HTTP surface:

- routes that accept `sessionId` now resolve the session-scoped contribution store consistently, including single contribution reads, artifact metadata, DAG, diff, frontier, search, threads, boardroom, and session contribution policy checks
- malformed JSON on goals, sessions, and outcomes now returns a 400 `VALIDATION_ERROR` instead of leaking as a 500
- WebSocket message handling now returns its async work so callers and tests can await completion without timing sleeps
- Nexus session-scoped contribution stores are memoized per session so their internal list/cache behavior is reused across polling requests

## Root Cause

Nexus-mode writes are session-scoped, but several HTTP read routes still used the process-global contribution store. That made valid session contributions invisible or inconsistent across endpoints. The per-request Nexus store factory also rebuilt stores on each request, defeating the cache designed to reduce VFS/list read pressure.

## Validation

- `bun --config=/tmp/grove-empty-bunfig.toml test src/server tests/server` (`231 pass, 0 fail`)
- `bun run check` passes, with existing warnings outside this patch
- pre-push hook ran `typecheck` and `build` successfully after Bun was added to PATH
