### PR TITLE
[codex] fix serial idempotency post-commit failure

### DIFF
--- a/src/core/operations/contribute.test.ts
+++ b/src/core/operations/contribute.test.ts
@@ -706,6 +706,60 @@ describe("contributeOperation: idempotencyKey", () => {
     expect(matching).toHaveLength(1);
   });
 
+  test("serial idempotency commit failure after put does not turn committed write into error", async () => {
+    // biome-ignore lint/suspicious/noEmptyBlockStatements: spy suppresses output intentionally
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    let storeCalls = 0;
+    const flakyIdempotencyStore: FullOperationDeps["idempotencyStore"] = {
+      lookup: deps.idempotencyStore.lookup.bind(deps.idempotencyStore),
+      reserve: deps.idempotencyStore.reserve.bind(deps.idempotencyStore),
+      rollback: deps.idempotencyStore.rollback.bind(deps.idempotencyStore),
+      store: (cacheKey, fingerprint, resultJson) => {
+        storeCalls++;
+        if (storeCalls === 1) {
+          throw new Error("simulated idempotency commit failure");
+        }
+        deps.idempotencyStore.store(cacheKey, fingerprint, resultJson);
+      },
+      clear: deps.idempotencyStore.clear.bind(deps.idempotencyStore),
+    };
+
+    // Object spread copies the store's arrow-method implementation but not
+    // the prototype putWithCowrite() capability, forcing writeSerial().
+    const serialContributionStore = {
+      ...deps.contributionStore,
+    };
+
+    const serialDeps: FullOperationDeps = {
+      ...deps,
+      contributionStore: serialContributionStore,
+      idempotencyStore: flakyIdempotencyStore,
+    };
+
+    const input = {
+      kind: "work" as const,
+      summary: "serial-idempotency-store-failure",
+      agent: { agentId: "a1" },
+      idempotencyKey: "serial-idempotency-store-failure-key",
+    };
+
+    const first = await contributeOperation(input, serialDeps);
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+
+    const second = await contributeOperation(input, serialDeps);
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.value.cid).toBe(first.value.cid);
+
+    const stored = await deps.contributionStore.list({ limit: 20 });
+    const matching = stored.filter((c) => c.summary === "serial-idempotency-store-failure");
+    expect(matching).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
   test("ephemeral flag on non-discussion kind is rejected", async () => {
     // Regression guard: context.ephemeral=true is reserved for discussions
     // (chat messages + grove_done markers). Allowing it on work/review

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -626,7 +626,14 @@ async function writeSerial(
   // immediately after the contribution commit. Not fully crash-safe (the
   // contribution and idempotency row are separate writes), but the window
   // is minimal and matches the existing handoff best-effort pattern.
-  onCommit?.();
+  try {
+    onCommit?.();
+  } catch (err) {
+    // The contribution is already committed on the serial path. Do not let a
+    // secondary idempotency write failure turn the durable write into an error:
+    // the final post-commit refresh below can still update the durable row.
+    console.warn(`[grove] post-commit callback failed for cid=${contribution.cid}`, err);
+  }
 
   const handoffIds: string[] = [];
   if (handoffStore === undefined || routedTo === undefined || agentRole === undefined) {


### PR DESCRIPTION
## Summary

Fixes a serial contribution write correctness issue where an idempotency post-commit write failure could be surfaced as an operation error even though the contribution was already durably committed.

## Root Cause

On the non-atomic serial write path, `store.put(contribution)` committed the contribution before `onCommit` wrote the idempotency row. If `onCommit` threw, the outer operation catch path treated the whole operation as failed and released/rolled back idempotency state, allowing a retry with the same key to create a duplicate contribution.

## Changes

- Treat the serial-path idempotency post-commit callback as best-effort after the contribution is committed.
- Log the secondary callback failure instead of turning the committed contribution into an operation error.
- Add a regression test that forces the serial write path and verifies retry deduplication after the first idempotency store write throws.

## Validation

- `bun run typecheck`
- `bun run check`
- `bun test src/core` (1,742 pass, 4 skip, 0 fail; command exits 1 because the repo coverage gate is applied to the `src/core` subset)
- pre-push hook: `typecheck` and `build`
