### PR TITLE
feat(migrate): A4 legacy → namespaced migration tool

### DIFF
--- a/src/cli/commands/migrate.test.ts
+++ b/src/cli/commands/migrate.test.ts
@@ -2,6 +2,7 @@
  * Tests for `grove migrate` command (A4: legacy → namespaced migration).
  */
 
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
@@ -441,10 +442,73 @@ describe("handleMigrate: rollback fails closed when server-keys version is unsup
 
   afterEach(() => cleanup(dir));
 
-  it("preserves inverse-plan.json when rollback fails", async () => {
-    await expect(handleMigrate(["--rollback"], join(dir, ".grove"))).rejects.toThrow("incomplete");
-    // Inverse plan must be preserved so operator can retry rollback.
+  it("preserves inverse-plan.json and credential files when preflight fails", async () => {
+    await expect(handleMigrate(["--rollback"], join(dir, ".grove"))).rejects.toThrow(
+      "unsupported state",
+    );
+    // Inverse plan + local credentials must be preserved so operator can retry.
     expect(existsSync(join(dir, ".grove", "migrations", "inverse-plan.json"))).toBe(true);
+    expect(existsSync(join(dir, ".grove", "project-id"))).toBe(true);
+    expect(existsSync(join(dir, ".grove", "api-key"))).toBe(true);
+    expect(existsSync(join(dir, ".grove", "namespace"))).toBe(true);
+  });
+});
+
+describe("handleMigrate: appendServerKey rejects forward-version registries", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+    // Pre-seed a forward-version registry that we should never silently overwrite.
+    writeFileSync(
+      join(dir, ".grove", "server-keys.yaml"),
+      ["version: 2", "keys:", "  grv_future_key: foo", ""].join("\n"),
+      "utf8",
+    );
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("refuses migration without clobbering forward-version data", async () => {
+    await expect(handleMigrate([], join(dir, ".grove"))).rejects.toThrow("unsupported version");
+    // Original future-version content must be intact.
+    const content = readFileSync(join(dir, ".grove", "server-keys.yaml"), "utf8");
+    expect(content).toContain("version: 2");
+    expect(content).toContain("grv_future_key");
+    // No project-id, no api-key written.
+    expect(existsSync(join(dir, ".grove", "project-id"))).toBe(false);
+    expect(existsSync(join(dir, ".grove", "api-key"))).toBe(false);
+  });
+});
+
+describe("handleMigrate: refused migration leaves DB schema untouched", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+    writeFileSync(join(dir, ".grove", "api-key"), "grv_preexisting\n", "utf8");
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("does not run schema migrations when clobber check fails", async () => {
+    // Capture the DB state before refusal: schema_migrations rows.
+    const dbPath = join(dir, ".grove", "grove.db");
+    const before = new Database(dbPath, { readonly: true });
+    const beforeRows = before
+      .prepare("SELECT version FROM schema_migrations ORDER BY version")
+      .all() as { version: number }[];
+    before.close();
+
+    await expect(handleMigrate([], join(dir, ".grove"))).rejects.toThrow("refusing to overwrite");
+
+    // schema_migrations table must be unchanged (or absent on truly legacy).
+    const after = new Database(dbPath, { readonly: true });
+    const afterRows = after
+      .prepare("SELECT version FROM schema_migrations ORDER BY version")
+      .all() as { version: number }[];
+    after.close();
+    expect(afterRows).toEqual(beforeRows);
   });
 });
 

--- a/src/cli/commands/migrate.test.ts
+++ b/src/cli/commands/migrate.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for `grove migrate` command (A4: legacy → namespaced migration).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isValidProjectId } from "../../core/project-id.js";
+import { initSqliteDb, readStoreNamespace } from "../../local/sqlite-store.js";
+import { handleMigrate, parseMigrateArgs } from "./migrate.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createLegacyGrove(): Promise<string> {
+  const dir = join(
+    tmpdir(),
+    `grove-migrate-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  const groveDir = join(dir, ".grove");
+  mkdirSync(groveDir, { recursive: true });
+
+  // Create a minimal grove.db (legacy: no project-id, no credentials).
+  initSqliteDb(join(groveDir, "grove.db")).close();
+
+  // Write a minimal grove.json so resolveGroveDir is satisfied.
+  writeFileSync(
+    join(groveDir, "grove.json"),
+    JSON.stringify({ name: "test-grove", mode: "evaluation" }),
+    "utf8",
+  );
+
+  return dir;
+}
+
+async function cleanup(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// parseMigrateArgs
+// ---------------------------------------------------------------------------
+
+describe("parseMigrateArgs", () => {
+  it("defaults: dryRun=false, rollback=false", () => {
+    const opts = parseMigrateArgs([]);
+    expect(opts.dryRun).toBe(false);
+    expect(opts.rollback).toBe(false);
+  });
+
+  it("parses --dry-run", () => {
+    const opts = parseMigrateArgs(["--dry-run"]);
+    expect(opts.dryRun).toBe(true);
+  });
+
+  it("parses --rollback", () => {
+    const opts = parseMigrateArgs(["--rollback"]);
+    expect(opts.rollback).toBe(true);
+  });
+
+  it("parses --grove override", () => {
+    const opts = parseMigrateArgs(["--grove", "/some/path/.grove"]);
+    expect(opts.groveOverride).toBe("/some/path/.grove");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleMigrate — fresh install guard
+// ---------------------------------------------------------------------------
+
+describe("handleMigrate: fresh install guard", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+    // Write project-id to simulate a fresh install.
+    writeFileSync(
+      join(dir, ".grove", "project-id"),
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\n",
+      "utf8",
+    );
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("skips migration when project-id already exists", async () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: unknown[]) => logs.push(a.join(" "));
+    try {
+      await handleMigrate([], join(dir, ".grove"));
+    } finally {
+      console.log = origLog;
+    }
+    expect(logs.some((l) => l.includes("no migration needed"))).toBe(true);
+    // Namespace should not have been set.
+    const db = initSqliteDb(join(dir, ".grove", "grove.db"));
+    const ns = readStoreNamespace(db);
+    db.close();
+    expect(ns).toBe("default");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleMigrate — dry run
+// ---------------------------------------------------------------------------
+
+describe("handleMigrate: --dry-run", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("prints plan but writes nothing", async () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: unknown[]) => logs.push(a.join(" "));
+    try {
+      await handleMigrate(["--dry-run"], join(dir, ".grove"));
+    } finally {
+      console.log = origLog;
+    }
+
+    expect(logs.some((l) => l.includes("Dry run"))).toBe(true);
+    expect(existsSync(join(dir, ".grove", "project-id"))).toBe(false);
+    expect(existsSync(join(dir, ".grove", "api-key"))).toBe(false);
+    expect(existsSync(join(dir, ".grove", "namespace"))).toBe(false);
+    expect(existsSync(join(dir, ".grove", "migrations", "inverse-plan.json"))).toBe(false);
+
+    const db = initSqliteDb(join(dir, ".grove", "grove.db"));
+    const ns = readStoreNamespace(db);
+    db.close();
+    expect(ns).toBe("default");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleMigrate — execute
+// ---------------------------------------------------------------------------
+
+describe("handleMigrate: execute", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("writes project-id as valid UUID", async () => {
+    await handleMigrate([], join(dir, ".grove"));
+    const raw = readFileSync(join(dir, ".grove", "project-id"), "utf8").trim();
+    expect(isValidProjectId(raw)).toBe(true);
+  });
+
+  it("writes api-key with grv_ prefix", async () => {
+    await handleMigrate([], join(dir, ".grove"));
+    const key = readFileSync(join(dir, ".grove", "api-key"), "utf8").trim();
+    expect(key.startsWith("grv_")).toBe(true);
+  });
+
+  it("writes namespace as {uuid}/main", async () => {
+    await handleMigrate([], join(dir, ".grove"));
+    const ns = readFileSync(join(dir, ".grove", "namespace"), "utf8").trim();
+    const projectId = readFileSync(join(dir, ".grove", "project-id"), "utf8").trim();
+    expect(ns).toBe(`${projectId}/main`);
+  });
+
+  it("writes server-keys.yaml", async () => {
+    await handleMigrate([], join(dir, ".grove"));
+    expect(existsSync(join(dir, ".grove", "server-keys.yaml"))).toBe(true);
+  });
+
+  it("sets store namespace in SQLite to {uuid}/main", async () => {
+    await handleMigrate([], join(dir, ".grove"));
+    const projectId = readFileSync(join(dir, ".grove", "project-id"), "utf8").trim();
+    const db = initSqliteDb(join(dir, ".grove", "grove.db"));
+    const ns = readStoreNamespace(db);
+    db.close();
+    expect(ns).toBe(`${projectId}/main`);
+  });
+
+  it("writes inverse-plan.json under .grove/migrations/", async () => {
+    await handleMigrate([], join(dir, ".grove"));
+    const planPath = join(dir, ".grove", "migrations", "inverse-plan.json");
+    expect(existsSync(planPath)).toBe(true);
+
+    const plan = JSON.parse(readFileSync(planPath, "utf8"));
+    expect(plan.type).toBe("namespace-migration");
+    expect(plan.version).toBe(1);
+    expect(plan.namespace).toContain("/main");
+    expect(plan.previousNamespace).toBe("default");
+    expect(Array.isArray(plan.filesCreated)).toBe(true);
+    expect(plan.filesCreated).toContain("project-id");
+  });
+
+  it("is idempotent: second run skips (project-id exists)", async () => {
+    await handleMigrate([], join(dir, ".grove"));
+    const firstId = readFileSync(join(dir, ".grove", "project-id"), "utf8").trim();
+
+    // Second call should skip.
+    await handleMigrate([], join(dir, ".grove"));
+    const secondId = readFileSync(join(dir, ".grove", "project-id"), "utf8").trim();
+    expect(secondId).toBe(firstId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleMigrate: --rollback
+// ---------------------------------------------------------------------------
+
+describe("handleMigrate: --rollback", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+    await handleMigrate([], join(dir, ".grove"));
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("removes project-id after rollback", async () => {
+    await handleMigrate(["--rollback"], join(dir, ".grove"));
+    expect(existsSync(join(dir, ".grove", "project-id"))).toBe(false);
+  });
+
+  it("removes api-key after rollback", async () => {
+    await handleMigrate(["--rollback"], join(dir, ".grove"));
+    expect(existsSync(join(dir, ".grove", "api-key"))).toBe(false);
+  });
+
+  it("removes namespace file after rollback", async () => {
+    await handleMigrate(["--rollback"], join(dir, ".grove"));
+    expect(existsSync(join(dir, ".grove", "namespace"))).toBe(false);
+  });
+
+  it("removes inverse-plan.json after rollback", async () => {
+    await handleMigrate(["--rollback"], join(dir, ".grove"));
+    expect(existsSync(join(dir, ".grove", "migrations", "inverse-plan.json"))).toBe(false);
+  });
+
+  it("resets store namespace to default after rollback", async () => {
+    await handleMigrate(["--rollback"], join(dir, ".grove"));
+    const db = initSqliteDb(join(dir, ".grove", "grove.db"));
+    const ns = readStoreNamespace(db);
+    db.close();
+    expect(ns).toBe("default");
+  });
+
+  it("throws if no inverse-plan.json exists", async () => {
+    // Already rolled back — try again.
+    await handleMigrate(["--rollback"], join(dir, ".grove"));
+    await expect(handleMigrate(["--rollback"], join(dir, ".grove"))).rejects.toThrow(
+      "no inverse-plan.json found",
+    );
+  });
+});

--- a/src/cli/commands/migrate.test.ts
+++ b/src/cli/commands/migrate.test.ts
@@ -398,6 +398,56 @@ describe("handleMigrate: surgical server-keys.yaml rollback", () => {
   });
 });
 
+describe("handleMigrate: orphan + leftover files refuses without DB mutation", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+    // Set orphaned namespace AND leave a stale credential file behind.
+    const db = initSqliteDb(join(dir, ".grove", "grove.db"));
+    db.run(
+      "INSERT OR REPLACE INTO project_settings (key, value) VALUES ('namespace', 'orphan/main')",
+    );
+    db.close();
+    writeFileSync(join(dir, ".grove", "api-key"), "grv_stale\n", "utf8");
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("refuses and leaves SQLite namespace unchanged", async () => {
+    await expect(handleMigrate([], join(dir, ".grove"))).rejects.toThrow(
+      "incomplete prior migration",
+    );
+    // Verify the orphan was NOT cleared (DB unchanged).
+    const db = initSqliteDb(join(dir, ".grove", "grove.db"));
+    expect(readStoreNamespace(db)).toBe("orphan/main");
+    db.close();
+    // Stale file still there for operator to inspect.
+    expect(existsSync(join(dir, ".grove", "api-key"))).toBe(true);
+  });
+});
+
+describe("handleMigrate: rollback fails closed when server-keys version is unsupported", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+    await handleMigrate([], join(dir, ".grove"));
+    // Tamper with server-keys.yaml: bump to a future version.
+    const skPath = join(dir, ".grove", "server-keys.yaml");
+    const tampered = readFileSync(skPath, "utf8").replace("version: 1", "version: 2");
+    writeFileSync(skPath, tampered, "utf8");
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("preserves inverse-plan.json when rollback fails", async () => {
+    await expect(handleMigrate(["--rollback"], join(dir, ".grove"))).rejects.toThrow("incomplete");
+    // Inverse plan must be preserved so operator can retry rollback.
+    expect(existsSync(join(dir, ".grove", "migrations", "inverse-plan.json"))).toBe(true);
+  });
+});
+
 describe("handleMigrate: --rollback rejects corrupted inverse-plan", () => {
   let dir: string;
 

--- a/src/cli/commands/migrate.test.ts
+++ b/src/cli/commands/migrate.test.ts
@@ -262,3 +262,169 @@ describe("handleMigrate: --rollback", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Round-2 hardening tests
+// ---------------------------------------------------------------------------
+
+describe("handleMigrate: --dry-run --rollback rejected", () => {
+  it("rejects both flags at parse time", () => {
+    expect(() => parseMigrateArgs(["--dry-run", "--rollback"])).toThrow("mutually exclusive");
+  });
+});
+
+describe("handleMigrate: refuses to clobber existing credential files", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("refuses if api-key already exists", async () => {
+    writeFileSync(join(dir, ".grove", "api-key"), "grv_preexisting\n", "utf8");
+    await expect(handleMigrate([], join(dir, ".grove"))).rejects.toThrow(
+      "refusing to overwrite existing .grove/api-key",
+    );
+    // No project-id should have been written.
+    expect(existsSync(join(dir, ".grove", "project-id"))).toBe(false);
+  });
+
+  it("refuses if namespace file already exists", async () => {
+    writeFileSync(join(dir, ".grove", "namespace"), "manual/ns\n", "utf8");
+    await expect(handleMigrate([], join(dir, ".grove"))).rejects.toThrow(
+      "refusing to overwrite existing .grove/namespace",
+    );
+  });
+});
+
+describe("handleMigrate: refuses on missing grove.db", () => {
+  it("errors with clear message when DB is missing", async () => {
+    const dir = join(
+      tmpdir(),
+      `grove-migrate-missingdb-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(join(dir, ".grove"), { recursive: true });
+    writeFileSync(join(dir, ".grove", "grove.json"), "{}", "utf8");
+    try {
+      await expect(handleMigrate([], join(dir, ".grove"))).rejects.toThrow("not found");
+      // Migration must not have stamped identity onto a non-existent DB.
+      expect(existsSync(join(dir, ".grove", "project-id"))).toBe(false);
+      expect(existsSync(join(dir, ".grove", "grove.db"))).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("handleMigrate: orphaned namespace recovery", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+    // Simulate a crashed previous run: SQLite has a non-default namespace
+    // but no project-id was ever written.
+    const db = initSqliteDb(join(dir, ".grove", "grove.db"));
+    db.run(
+      "INSERT OR REPLACE INTO project_settings (key, value) VALUES ('namespace', 'orphan-uuid/main')",
+    );
+    db.close();
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("clears orphan namespace and the new inverse-plan rolls back to 'default'", async () => {
+    await handleMigrate([], join(dir, ".grove"));
+    const planPath = join(dir, ".grove", "migrations", "inverse-plan.json");
+    const plan = JSON.parse(readFileSync(planPath, "utf8"));
+    expect(plan.previousNamespace).toBe("default");
+    expect(plan.namespace).not.toBe("orphan-uuid/main");
+
+    // Rollback should restore to default, NOT to the orphan value.
+    await handleMigrate(["--rollback"], join(dir, ".grove"));
+    const db = initSqliteDb(join(dir, ".grove", "grove.db"));
+    const ns = readStoreNamespace(db);
+    db.close();
+    expect(ns).toBe("default");
+  });
+});
+
+describe("handleMigrate: surgical server-keys.yaml rollback", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("rollback removes only the migrated key, preserving other entries", async () => {
+    // Pre-seed server-keys.yaml with an unrelated entry from a different worktree.
+    const serverKeysPath = join(dir, ".grove", "server-keys.yaml");
+    writeFileSync(
+      serverKeysPath,
+      [
+        "version: 1",
+        "keys:",
+        "  grv_other_worktree_key:",
+        "    namespace: other-uuid/branch-a",
+        "    createdAt: 2026-01-01T00:00:00Z",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await handleMigrate([], join(dir, ".grove"));
+    // Both keys present after migration.
+    const afterMigrate = readFileSync(serverKeysPath, "utf8");
+    expect(afterMigrate).toContain("grv_other_worktree_key");
+
+    await handleMigrate(["--rollback"], join(dir, ".grove"));
+    // File still exists; only our key was removed.
+    expect(existsSync(serverKeysPath)).toBe(true);
+    const afterRollback = readFileSync(serverKeysPath, "utf8");
+    expect(afterRollback).toContain("grv_other_worktree_key");
+    expect(afterRollback).not.toContain("/main");
+  });
+
+  it("rollback deletes server-keys.yaml when migrated key was the only entry", async () => {
+    await handleMigrate([], join(dir, ".grove"));
+    const serverKeysPath = join(dir, ".grove", "server-keys.yaml");
+    expect(existsSync(serverKeysPath)).toBe(true);
+
+    await handleMigrate(["--rollback"], join(dir, ".grove"));
+    expect(existsSync(serverKeysPath)).toBe(false);
+  });
+});
+
+describe("handleMigrate: --rollback rejects corrupted inverse-plan", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await createLegacyGrove();
+    await handleMigrate([], join(dir, ".grove"));
+  });
+
+  afterEach(() => cleanup(dir));
+
+  it("rejects path-traversal entries in filesCreated", async () => {
+    const planPath = join(dir, ".grove", "migrations", "inverse-plan.json");
+    const tampered = JSON.parse(readFileSync(planPath, "utf8"));
+    tampered.filesCreated = ["../../etc/passwd", ...tampered.filesCreated];
+    writeFileSync(planPath, JSON.stringify(tampered), "utf8");
+    await expect(handleMigrate(["--rollback"], join(dir, ".grove"))).rejects.toThrow(
+      "disallowed file",
+    );
+  });
+
+  it("rejects unsupported version", async () => {
+    const planPath = join(dir, ".grove", "migrations", "inverse-plan.json");
+    const tampered = JSON.parse(readFileSync(planPath, "utf8"));
+    tampered.version = 999;
+    writeFileSync(planPath, JSON.stringify(tampered), "utf8");
+    await expect(handleMigrate(["--rollback"], join(dir, ".grove"))).rejects.toThrow(
+      "unsupported inverse-plan version",
+    );
+  });
+});

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -21,6 +21,7 @@ import {
   CLIENT_KEY_FILE,
   generateApiKey,
   NAMESPACE_FILE,
+  parseServerKeys,
   removeServerKey,
   SERVER_KEYS_FILE,
   writeClientKey,
@@ -150,6 +151,43 @@ export async function handleMigrate(
     );
   }
 
+  // Filesystem preconditions BEFORE opening the DB. initSqliteDb runs
+  // schema migrations, so if we open it and then refuse on a clobber, we'd
+  // leave behind a schema upgrade despite migration not proceeding.
+  const apiKeyExists = existsSync(join(groveDir, CLIENT_KEY_FILE));
+  const namespaceFileExists = existsSync(join(groveDir, NAMESPACE_FILE));
+
+  // Read orphan flag via a read-only DB handle; readStoreNamespace tolerates
+  // a missing project_settings table on truly legacy DBs.
+  const orphanProbe = new Database(dbPath, { readonly: true });
+  let orphan: string;
+  try {
+    orphan = readStoreNamespace(orphanProbe);
+  } finally {
+    orphanProbe.close();
+  }
+
+  if (orphan !== "default" && (apiKeyExists || namespaceFileExists)) {
+    throw new Error(
+      "grove migrate: detected incomplete prior migration (orphaned SQLite namespace " +
+        `'${orphan}' plus leftover credential files). Inspect .grove/api-key, ` +
+        ".grove/namespace, and the project_settings row, remove them manually, " +
+        "then re-run.",
+    );
+  }
+  if (apiKeyExists) {
+    throw new Error(
+      "grove migrate: refusing to overwrite existing .grove/api-key. " +
+        "Investigate and remove it manually if this grove is truly a legacy install.",
+    );
+  }
+  if (namespaceFileExists) {
+    throw new Error(
+      "grove migrate: refusing to overwrite existing .grove/namespace. " +
+        "Investigate and remove it manually if this grove is truly a legacy install.",
+    );
+  }
+
   // Dry-run uses a read-only handle so planning never mutates the DB
   // (including running schema migrations).
   if (opts.dryRun) {
@@ -166,36 +204,6 @@ export async function handleMigrate(
 
   const db = initSqliteDb(dbPath);
   try {
-    // Run ALL preconditions up-front before mutating anything. The order
-    // matters: detect partial-migration state (orphan + leftover files)
-    // first, refuse if files-only conflict, and only then clear an orphan
-    // namespace if the rest of the setup is clean. This prevents the DB
-    // from being mutated when applyMigration is going to refuse anyway.
-    const orphan = readStoreNamespace(db);
-    const apiKeyExists = existsSync(join(groveDir, CLIENT_KEY_FILE));
-    const namespaceFileExists = existsSync(join(groveDir, NAMESPACE_FILE));
-
-    if (orphan !== "default" && (apiKeyExists || namespaceFileExists)) {
-      throw new Error(
-        "grove migrate: detected incomplete prior migration (orphaned SQLite namespace " +
-          `'${orphan}' plus leftover credential files). Inspect .grove/api-key, ` +
-          ".grove/namespace, and the project_settings row, remove them manually, " +
-          "then re-run.",
-      );
-    }
-    if (apiKeyExists) {
-      throw new Error(
-        "grove migrate: refusing to overwrite existing .grove/api-key. " +
-          "Investigate and remove it manually if this grove is truly a legacy install.",
-      );
-    }
-    if (namespaceFileExists) {
-      throw new Error(
-        "grove migrate: refusing to overwrite existing .grove/namespace. " +
-          "Investigate and remove it manually if this grove is truly a legacy install.",
-      );
-    }
-
     // Pure orphan with no leftover files: a previous run died between
     // writeStoreNamespace and writeClientKey. Safe to clear because no
     // migration-owned artifacts on disk reference this namespace.
@@ -450,10 +458,53 @@ async function executeRollback(groveDir: string, dbPath: string): Promise<void> 
   console.log(`  namespace was:  ${plan.namespace}`);
   console.log(`  reverting to:   ${plan.previousNamespace}`);
 
+  // Preflight: validate the server-keys.yaml registry parses before
+  // deleting anything. If parsing fails (unsupported version, malformed
+  // YAML), we abort rollback while local credential files are still
+  // intact — leaving the workspace authorized rather than half-revoked.
+  try {
+    parseServerKeys(groveDir);
+  } catch (err) {
+    throw new Error(
+      `grove migrate --rollback: cannot proceed; .grove/${SERVER_KEYS_FILE} ` +
+        `is in an unsupported state (${(err as Error).message}). ` +
+        `Local credentials and inverse-plan retained — fix the registry, then retry.`,
+    );
+  }
+
   // Collect failures rather than swallowing them. Rollback must fail closed:
   // if any expected mutation does not succeed (or cannot be verified as
   // already done), preserve inverse-plan.json so the operator can retry.
   const failures: string[] = [];
+
+  // Order: registry surgery FIRST, then local file deletes, then DB. This
+  // way a failure in registry mutation (the most likely failure path on
+  // unusual disk state) leaves the workspace fully authorized rather than
+  // partially de-authorized with credentials missing.
+  try {
+    const result = removeServerKey(groveDir, plan.apiKey);
+    if (result.registryFound && result.removed) {
+      if (result.remaining === 0) {
+        rmSync(join(groveDir, SERVER_KEYS_FILE), { force: true });
+        console.log(`  removed: .grove/${SERVER_KEYS_FILE} (empty after key removal)`);
+      } else {
+        console.log(
+          `  removed migrated key from .grove/${SERVER_KEYS_FILE} (${result.remaining} keys left)`,
+        );
+      }
+    } else if (!result.registryFound) {
+      console.log(`  .grove/${SERVER_KEYS_FILE} absent (skipping)`);
+    } else {
+      console.log(`  migrated key already absent from .grove/${SERVER_KEYS_FILE} (skipping)`);
+    }
+  } catch (err) {
+    // We already preflight-validated, so this is a write error (disk full,
+    // permissions). Bail before touching local files.
+    throw new Error(
+      `grove migrate --rollback: server-keys.yaml mutation failed (${(err as Error).message}). ` +
+        `Local credentials and inverse-plan retained — fix the registry, then retry.`,
+    );
+  }
 
   // Remove migration-owned credential files. Allowlist + basename check
   // prevents a tampered inverse-plan from deleting unrelated entries.
@@ -469,8 +520,6 @@ async function executeRollback(groveDir: string, dbPath: string): Promise<void> 
     const filePath = join(groveDir, file);
     try {
       rmSync(filePath, { force: true });
-      // Verify the file is gone; rmSync with force doesn't throw on ENOENT,
-      // but a permission/IO error elsewhere could leave it behind.
       if (existsSync(filePath)) {
         failures.push(`.grove/${file} still present after removal attempt`);
       } else {
@@ -479,32 +528,6 @@ async function executeRollback(groveDir: string, dbPath: string): Promise<void> 
     } catch (err) {
       failures.push(`could not remove .grove/${file}: ${(err as Error).message}`);
     }
-  }
-
-  // Surgical removal of OUR key from server-keys.yaml — preserves any other
-  // entries an operator may have added. Delete the file only if empty.
-  try {
-    const result = removeServerKey(groveDir, plan.apiKey);
-    if (result.registryFound && result.removed) {
-      if (result.remaining === 0) {
-        rmSync(join(groveDir, SERVER_KEYS_FILE), { force: true });
-        console.log(`  removed: .grove/${SERVER_KEYS_FILE} (empty after key removal)`);
-      } else {
-        console.log(
-          `  removed migrated key from .grove/${SERVER_KEYS_FILE} (${result.remaining} keys left)`,
-        );
-      }
-    } else if (!result.registryFound) {
-      // server-keys.yaml absent — already-rolled-back or never written.
-      console.log(`  .grove/${SERVER_KEYS_FILE} absent (skipping)`);
-    } else {
-      // Registry exists but our key is not in it — treat as already removed.
-      console.log(`  migrated key already absent from .grove/${SERVER_KEYS_FILE} (skipping)`);
-    }
-  } catch (err) {
-    failures.push(
-      `could not remove migrated key from .grove/${SERVER_KEYS_FILE}: ${(err as Error).message}`,
-    );
   }
 
   // Restore previous namespace in the SQLite store.

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -166,13 +166,39 @@ export async function handleMigrate(
 
   const db = initSqliteDb(dbPath);
   try {
-    // Recovery: if project-id is absent but the SQLite namespace is non-default,
-    // a previous migration died after writeStoreNamespace but before writing
-    // project-id. The non-default value is NOT a legitimate previous namespace —
-    // only `grove migrate` ever writes to project_settings on a legacy DB. Clear
-    // it so buildPlan sees the true baseline ("default"), preventing rollback
-    // from restoring to the orphaned namespace.
+    // Run ALL preconditions up-front before mutating anything. The order
+    // matters: detect partial-migration state (orphan + leftover files)
+    // first, refuse if files-only conflict, and only then clear an orphan
+    // namespace if the rest of the setup is clean. This prevents the DB
+    // from being mutated when applyMigration is going to refuse anyway.
     const orphan = readStoreNamespace(db);
+    const apiKeyExists = existsSync(join(groveDir, CLIENT_KEY_FILE));
+    const namespaceFileExists = existsSync(join(groveDir, NAMESPACE_FILE));
+
+    if (orphan !== "default" && (apiKeyExists || namespaceFileExists)) {
+      throw new Error(
+        "grove migrate: detected incomplete prior migration (orphaned SQLite namespace " +
+          `'${orphan}' plus leftover credential files). Inspect .grove/api-key, ` +
+          ".grove/namespace, and the project_settings row, remove them manually, " +
+          "then re-run.",
+      );
+    }
+    if (apiKeyExists) {
+      throw new Error(
+        "grove migrate: refusing to overwrite existing .grove/api-key. " +
+          "Investigate and remove it manually if this grove is truly a legacy install.",
+      );
+    }
+    if (namespaceFileExists) {
+      throw new Error(
+        "grove migrate: refusing to overwrite existing .grove/namespace. " +
+          "Investigate and remove it manually if this grove is truly a legacy install.",
+      );
+    }
+
+    // Pure orphan with no leftover files: a previous run died between
+    // writeStoreNamespace and writeClientKey. Safe to clear because no
+    // migration-owned artifacts on disk reference this namespace.
     if (orphan !== "default") {
       console.warn(
         `grove migrate: detected orphaned namespace '${orphan}' from a previous incomplete run; resetting before re-planning.`,
@@ -228,17 +254,9 @@ function printPlan(plan: MigrationPlan): void {
 // ---------------------------------------------------------------------------
 
 function applyMigration(plan: MigrationPlan, groveDir: string, db: Database): void {
-  // Refuse to clobber existing credential files. A legitimate legacy install
-  // has none of these — if they exist, an operator may have manually placed
-  // them, and we must not overwrite (or have them deleted by rollback).
-  for (const name of [CLIENT_KEY_FILE, NAMESPACE_FILE]) {
-    if (existsSync(join(groveDir, name))) {
-      throw new Error(
-        `grove migrate: refusing to overwrite existing .grove/${name}. ` +
-          `Investigate and remove it manually if this grove is truly a legacy install.`,
-      );
-    }
-  }
+  // Preconditions (clobber checks, orphan recovery) are enforced in
+  // handleMigrate before this function runs. By this point we own writes
+  // to api-key, namespace, project-id, and the project_settings row.
 
   // Order matters: project-id is written LAST as the "commit marker" — its
   // absence is the fresh-install guard's signal that migration may safely
@@ -326,8 +344,8 @@ function cleanupPartial(
   }
   if (serverKey !== undefined) {
     try {
-      const remaining = removeServerKey(groveDir, serverKey);
-      if (remaining === 0) {
+      const result = removeServerKey(groveDir, serverKey);
+      if (result.registryFound && result.removed && result.remaining === 0) {
         rmSync(join(groveDir, SERVER_KEYS_FILE), { force: true });
       }
     } catch {
@@ -432,59 +450,89 @@ async function executeRollback(groveDir: string, dbPath: string): Promise<void> 
   console.log(`  namespace was:  ${plan.namespace}`);
   console.log(`  reverting to:   ${plan.previousNamespace}`);
 
-  // Remove migration-owned credential files. The allowlist + basename check
-  // prevents a tampered inverse-plan from deleting unrelated entries (e.g.
-  // grove.db, path-traversal targets outside .grove/).
+  // Collect failures rather than swallowing them. Rollback must fail closed:
+  // if any expected mutation does not succeed (or cannot be verified as
+  // already done), preserve inverse-plan.json so the operator can retry.
+  const failures: string[] = [];
+
+  // Remove migration-owned credential files. Allowlist + basename check
+  // prevents a tampered inverse-plan from deleting unrelated entries.
   for (const file of plan.filesCreated) {
     if (!ALLOWED_FILES.has(file)) {
-      console.warn(`  warning: skipping unrecognized entry '${file}' (not in allowlist)`);
+      failures.push(`unrecognized entry '${file}' (not in allowlist)`);
       continue;
     }
     if (file.includes("/") || file.includes("\\") || file === "." || file === "..") {
-      console.warn(`  warning: skipping suspicious entry '${file}'`);
+      failures.push(`suspicious entry '${file}'`);
       continue;
     }
     const filePath = join(groveDir, file);
     try {
       rmSync(filePath, { force: true });
-      console.log(`  removed: .grove/${file}`);
+      // Verify the file is gone; rmSync with force doesn't throw on ENOENT,
+      // but a permission/IO error elsewhere could leave it behind.
+      if (existsSync(filePath)) {
+        failures.push(`.grove/${file} still present after removal attempt`);
+      } else {
+        console.log(`  removed: .grove/${file}`);
+      }
     } catch (err) {
-      console.warn(`  warning: could not remove .grove/${file}: ${(err as Error).message}`);
+      failures.push(`could not remove .grove/${file}: ${(err as Error).message}`);
     }
   }
 
   // Surgical removal of OUR key from server-keys.yaml — preserves any other
   // entries an operator may have added. Delete the file only if empty.
   try {
-    const remaining = removeServerKey(groveDir, plan.apiKey);
-    if (remaining === 0) {
-      rmSync(join(groveDir, SERVER_KEYS_FILE), { force: true });
-      console.log(`  removed: .grove/${SERVER_KEYS_FILE} (empty after key removal)`);
+    const result = removeServerKey(groveDir, plan.apiKey);
+    if (result.registryFound && result.removed) {
+      if (result.remaining === 0) {
+        rmSync(join(groveDir, SERVER_KEYS_FILE), { force: true });
+        console.log(`  removed: .grove/${SERVER_KEYS_FILE} (empty after key removal)`);
+      } else {
+        console.log(
+          `  removed migrated key from .grove/${SERVER_KEYS_FILE} (${result.remaining} keys left)`,
+        );
+      }
+    } else if (!result.registryFound) {
+      // server-keys.yaml absent — already-rolled-back or never written.
+      console.log(`  .grove/${SERVER_KEYS_FILE} absent (skipping)`);
     } else {
-      console.log(
-        `  removed migrated key from .grove/${SERVER_KEYS_FILE} (${remaining} keys left)`,
-      );
+      // Registry exists but our key is not in it — treat as already removed.
+      console.log(`  migrated key already absent from .grove/${SERVER_KEYS_FILE} (skipping)`);
     }
   } catch (err) {
-    console.warn(
-      `  warning: could not surgically remove key from .grove/${SERVER_KEYS_FILE}: ${(err as Error).message}`,
+    failures.push(
+      `could not remove migrated key from .grove/${SERVER_KEYS_FILE}: ${(err as Error).message}`,
     );
   }
 
   // Restore previous namespace in the SQLite store.
   const db = initSqliteDb(dbPath);
   try {
-    if (plan.previousNamespace === "default") {
-      // No explicit namespace was set before; remove the row.
-      db.run("DELETE FROM project_settings WHERE key = 'namespace'");
-    } else {
-      writeStoreNamespace(db, plan.previousNamespace);
+    try {
+      if (plan.previousNamespace === "default") {
+        db.run("DELETE FROM project_settings WHERE key = 'namespace'");
+      } else {
+        writeStoreNamespace(db, plan.previousNamespace);
+      }
+    } catch (err) {
+      failures.push(`could not restore SQLite namespace: ${(err as Error).message}`);
     }
   } finally {
     db.close();
   }
 
-  // Remove inverse-plan.json so rollback is idempotent.
+  if (failures.length > 0) {
+    // Preserve inverse-plan.json so the operator can retry rollback.
+    throw new Error(
+      `grove migrate --rollback: incomplete (${failures.length} failure${failures.length === 1 ? "" : "s"}). ` +
+        `Inverse plan retained at .grove/${MIGRATIONS_DIR}/${INVERSE_PLAN_FILE}. Failures:\n  - ` +
+        failures.join("\n  - "),
+    );
+  }
+
+  // Remove inverse-plan.json only on full success so rollback is idempotent.
   rmSync(inversePlanPath, { force: true });
 
   console.log("\nRollback complete.");

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -1,0 +1,270 @@
+/**
+ * `grove migrate` command — upgrade a legacy grove to namespaced identity.
+ *
+ * Targets installations that predate A2/A3 (no project-id, no credentials).
+ * Fresh installs (already have `.grove/project-id`) are skipped.
+ *
+ * Usage:
+ *   grove migrate              Execute migration
+ *   grove migrate --dry-run    Print plan without writing
+ *   grove migrate --rollback   Reverse a previous migration
+ */
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+
+import { generateProjectId, readProjectId, writeProjectId } from "../../core/project-id.js";
+import {
+  appendServerKey,
+  generateApiKey,
+  writeClientKey,
+  writeNamespace,
+} from "../../core/project-key.js";
+import { initSqliteDb, readStoreNamespace, writeStoreNamespace } from "../../local/sqlite-store.js";
+import { resolveGroveDir } from "../utils/grove-dir.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MigrateOptions {
+  readonly dryRun: boolean;
+  readonly rollback: boolean;
+  readonly cwd: string;
+  readonly groveOverride?: string | undefined;
+}
+
+interface MigrationPlan {
+  readonly projectId: string;
+  readonly namespace: string;
+  readonly apiKey: string;
+  readonly contributionCount: number;
+  readonly claimCount: number;
+  readonly previousNamespace: string;
+}
+
+interface InversePlan {
+  readonly type: "namespace-migration";
+  readonly version: 1;
+  readonly appliedAt: string;
+  readonly namespace: string;
+  readonly filesCreated: readonly string[];
+  readonly previousNamespace: string;
+  readonly contributionCount: number;
+  readonly claimCount: number;
+}
+
+const MIGRATIONS_DIR = "migrations";
+const INVERSE_PLAN_FILE = "inverse-plan.json";
+const WORKTREE_NAME = "main";
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+export function parseMigrateArgs(args: readonly string[]): MigrateOptions {
+  const { values } = parseArgs({
+    args: [...args],
+    options: {
+      "dry-run": { type: "boolean", default: false },
+      rollback: { type: "boolean", default: false },
+      grove: { type: "string" },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+
+  return {
+    dryRun: (values["dry-run"] as boolean) ?? false,
+    rollback: (values.rollback as boolean) ?? false,
+    cwd: process.cwd(),
+    groveOverride: values.grove as string | undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+export async function handleMigrate(
+  args: readonly string[],
+  groveOverride?: string,
+): Promise<void> {
+  const opts = parseMigrateArgs(args);
+  const effectiveGroveOverride = opts.groveOverride ?? groveOverride;
+
+  const { groveDir, dbPath } = resolveGroveDir(effectiveGroveOverride);
+
+  if (opts.rollback) {
+    await executeRollback(groveDir, dbPath);
+    return;
+  }
+
+  // Fresh-install guard: project-id already exists → skip migration.
+  const existingId = readProjectId(groveDir);
+  if (existingId !== null) {
+    console.log(
+      `grove migrate: project-id already present (${existingId}). Fresh install — no migration needed.`,
+    );
+    return;
+  }
+
+  const db = initSqliteDb(dbPath);
+  try {
+    const plan = buildPlan(groveDir, db);
+    printPlan(plan);
+
+    if (opts.dryRun) {
+      console.log("\nDry run — no changes written.");
+      return;
+    }
+
+    applyMigration(plan, groveDir, db);
+    console.log(`\nMigration complete. Namespace: ${plan.namespace}`);
+  } finally {
+    db.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plan
+// ---------------------------------------------------------------------------
+
+function buildPlan(_groveDir: string, db: ReturnType<typeof initSqliteDb>): MigrationPlan {
+  const projectId = generateProjectId();
+  const namespace = `${projectId}/${WORKTREE_NAME}`;
+  const apiKey = generateApiKey();
+
+  const previousNamespace = readStoreNamespace(db);
+
+  const contribRow = db.prepare("SELECT COUNT(*) as n FROM contributions").get() as { n: number };
+  const claimRow = db.prepare("SELECT COUNT(*) as n FROM claims").get() as { n: number };
+
+  return {
+    projectId,
+    namespace,
+    apiKey,
+    contributionCount: contribRow.n,
+    claimCount: claimRow.n,
+    previousNamespace,
+  };
+}
+
+function printPlan(plan: MigrationPlan): void {
+  console.log("grove migrate: migration plan");
+  console.log(`  project-id:           ${plan.projectId}`);
+  console.log(`  namespace:            ${plan.namespace}`);
+  console.log(`  previous namespace:   ${plan.previousNamespace}`);
+  console.log(`  contributions:        ${plan.contributionCount}`);
+  console.log(`  claims:               ${plan.claimCount}`);
+  console.log(`  files to create:      project-id, api-key, server-keys.yaml, namespace`);
+}
+
+// ---------------------------------------------------------------------------
+// Apply
+// ---------------------------------------------------------------------------
+
+function applyMigration(
+  plan: MigrationPlan,
+  groveDir: string,
+  db: ReturnType<typeof initSqliteDb>,
+): void {
+  const filesCreated: string[] = [];
+
+  // 1. Write project-id.
+  writeProjectId(groveDir, plan.projectId);
+  filesCreated.push("project-id");
+
+  // 2. Write credentials.
+  writeClientKey(groveDir, plan.apiKey);
+  filesCreated.push("api-key");
+  appendServerKey(groveDir, plan.apiKey, plan.namespace);
+  filesCreated.push("server-keys.yaml");
+  writeNamespace(groveDir, plan.namespace);
+  filesCreated.push("namespace");
+
+  // 3. Write namespace into the SQLite store so listEntities projects correctly.
+  writeStoreNamespace(db, plan.namespace);
+
+  // 4. Record inverse plan for rollback.
+  const migrationsDir = join(groveDir, MIGRATIONS_DIR);
+  mkdirSync(migrationsDir, { recursive: true });
+  const inversePlan: InversePlan = {
+    type: "namespace-migration",
+    version: 1,
+    appliedAt: new Date().toISOString(),
+    namespace: plan.namespace,
+    filesCreated,
+    previousNamespace: plan.previousNamespace,
+    contributionCount: plan.contributionCount,
+    claimCount: plan.claimCount,
+  };
+  writeFileSync(
+    join(migrationsDir, INVERSE_PLAN_FILE),
+    `${JSON.stringify(inversePlan, null, 2)}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rollback
+// ---------------------------------------------------------------------------
+
+async function executeRollback(groveDir: string, dbPath: string): Promise<void> {
+  const inversePlanPath = join(groveDir, MIGRATIONS_DIR, INVERSE_PLAN_FILE);
+
+  let raw: string;
+  try {
+    raw = readFileSync(inversePlanPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(
+        "grove migrate --rollback: no inverse-plan.json found. Has the migration been applied?",
+      );
+    }
+    throw err;
+  }
+
+  const plan = JSON.parse(raw) as InversePlan;
+
+  if (plan.type !== "namespace-migration" || plan.version !== 1) {
+    throw new Error(
+      `grove migrate --rollback: unrecognized inverse-plan format (type=${plan.type}, version=${plan.version})`,
+    );
+  }
+
+  console.log(`grove migrate --rollback: reversing migration applied at ${plan.appliedAt}`);
+  console.log(`  namespace was:  ${plan.namespace}`);
+  console.log(`  reverting to:   ${plan.previousNamespace}`);
+
+  // Remove credential files.
+  for (const file of plan.filesCreated) {
+    const filePath = join(groveDir, file);
+    try {
+      rmSync(filePath, { force: true });
+      console.log(`  removed: .grove/${file}`);
+    } catch (err) {
+      console.warn(`  warning: could not remove .grove/${file}: ${(err as Error).message}`);
+    }
+  }
+
+  // Restore previous namespace in the SQLite store.
+  const db = initSqliteDb(dbPath);
+  try {
+    if (plan.previousNamespace === "default") {
+      // No explicit namespace was set before; remove the row.
+      db.run("DELETE FROM project_settings WHERE key = 'namespace'");
+    } else {
+      writeStoreNamespace(db, plan.previousNamespace);
+    }
+  } finally {
+    db.close();
+  }
+
+  // Remove inverse-plan.json so rollback is idempotent.
+  rmSync(inversePlanPath, { force: true });
+
+  console.log("\nRollback complete.");
+}

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -18,7 +18,11 @@ import { parseArgs } from "node:util";
 import { generateProjectId, readProjectId, writeProjectId } from "../../core/project-id.js";
 import {
   appendServerKey,
+  CLIENT_KEY_FILE,
   generateApiKey,
+  NAMESPACE_FILE,
+  removeServerKey,
+  SERVER_KEYS_FILE,
   writeClientKey,
   writeNamespace,
 } from "../../core/project-key.js";
@@ -29,8 +33,12 @@ import { resolveGroveDir } from "../utils/grove-dir.js";
  * Files the migration is allowed to create or remove inside the grove dir.
  * Used as a whitelist for rollback to prevent a tampered inverse-plan.json
  * from deleting unrelated files (e.g. grove.db, grove.json).
+ *
+ * Note: server-keys.yaml is intentionally absent — rollback removes only
+ * the migrated key from it via removeServerKey, never the whole file
+ * (other worktrees may have entries there).
  */
-const ALLOWED_FILES = new Set(["project-id", "api-key", "server-keys.yaml", "namespace"]);
+const ALLOWED_FILES = new Set(["project-id", "api-key", "namespace"]);
 
 // ---------------------------------------------------------------------------
 // Types
@@ -61,6 +69,12 @@ interface InversePlan {
   readonly previousNamespace: string;
   readonly contributionCount: number;
   readonly claimCount: number;
+  /**
+   * Bearer token added to server-keys.yaml by this migration. Recorded so
+   * rollback can surgically remove only this key — preserving any other
+   * keys an operator may have added — instead of deleting the whole file.
+   */
+  readonly apiKey: string;
 }
 
 const MIGRATIONS_DIR = "migrations";
@@ -84,9 +98,16 @@ export function parseMigrateArgs(args: readonly string[]): MigrateOptions {
     strict: true,
   });
 
+  const dryRun = (values["dry-run"] as boolean) ?? false;
+  const rollback = (values.rollback as boolean) ?? false;
+  if (dryRun && rollback) {
+    throw new Error(
+      "grove migrate: --dry-run and --rollback are mutually exclusive (rollback is destructive).",
+    );
+  }
   return {
-    dryRun: (values["dry-run"] as boolean) ?? false,
-    rollback: (values.rollback as boolean) ?? false,
+    dryRun,
+    rollback,
     cwd: process.cwd(),
     groveOverride: values.grove as string | undefined,
   };
@@ -145,6 +166,20 @@ export async function handleMigrate(
 
   const db = initSqliteDb(dbPath);
   try {
+    // Recovery: if project-id is absent but the SQLite namespace is non-default,
+    // a previous migration died after writeStoreNamespace but before writing
+    // project-id. The non-default value is NOT a legitimate previous namespace —
+    // only `grove migrate` ever writes to project_settings on a legacy DB. Clear
+    // it so buildPlan sees the true baseline ("default"), preventing rollback
+    // from restoring to the orphaned namespace.
+    const orphan = readStoreNamespace(db);
+    if (orphan !== "default") {
+      console.warn(
+        `grove migrate: detected orphaned namespace '${orphan}' from a previous incomplete run; resetting before re-planning.`,
+      );
+      db.run("DELETE FROM project_settings WHERE key = 'namespace'");
+    }
+
     const plan = buildPlan(db);
     printPlan(plan);
     applyMigration(plan, groveDir, db);
@@ -193,6 +228,18 @@ function printPlan(plan: MigrationPlan): void {
 // ---------------------------------------------------------------------------
 
 function applyMigration(plan: MigrationPlan, groveDir: string, db: Database): void {
+  // Refuse to clobber existing credential files. A legitimate legacy install
+  // has none of these — if they exist, an operator may have manually placed
+  // them, and we must not overwrite (or have them deleted by rollback).
+  for (const name of [CLIENT_KEY_FILE, NAMESPACE_FILE]) {
+    if (existsSync(join(groveDir, name))) {
+      throw new Error(
+        `grove migrate: refusing to overwrite existing .grove/${name}. ` +
+          `Investigate and remove it manually if this grove is truly a legacy install.`,
+      );
+    }
+  }
+
   // Order matters: project-id is written LAST as the "commit marker" — its
   // absence is the fresh-install guard's signal that migration may safely
   // retry. If anything before fails, we roll back partial state and the
@@ -201,22 +248,27 @@ function applyMigration(plan: MigrationPlan, groveDir: string, db: Database): vo
   const migrationsDir = join(groveDir, MIGRATIONS_DIR);
   const inversePlanPath = join(migrationsDir, INVERSE_PLAN_FILE);
   let dbNamespaceWritten = false;
+  let serverKeyAppended = false;
 
   try {
     // 1. SQLite store namespace (idempotent via INSERT OR REPLACE).
     writeStoreNamespace(db, plan.namespace);
     dbNamespaceWritten = true;
 
-    // 2. Credential files.
+    // 2. Credential files. server-keys.yaml may already exist with unrelated
+    //    keys (e.g. another worktree's registration); appendServerKey
+    //    preserves them. Rollback removes only OUR key, never the file.
     writeClientKey(groveDir, plan.apiKey);
     filesCreated.push("api-key");
     appendServerKey(groveDir, plan.apiKey, plan.namespace);
-    filesCreated.push("server-keys.yaml");
+    serverKeyAppended = true;
     writeNamespace(groveDir, plan.namespace);
     filesCreated.push("namespace");
 
     // 3. Inverse plan (must include project-id even though we write it last,
-    //    so rollback after a successful migration removes it).
+    //    so rollback after a successful migration removes it). server-keys.yaml
+    //    is intentionally NOT in filesCreated — rollback removes our key
+    //    surgically via apiKey.
     mkdirSync(migrationsDir, { recursive: true });
     const inversePlan: InversePlan = {
       type: "namespace-migration",
@@ -227,6 +279,7 @@ function applyMigration(plan: MigrationPlan, groveDir: string, db: Database): vo
       previousNamespace: plan.previousNamespace,
       contributionCount: plan.contributionCount,
       claimCount: plan.claimCount,
+      apiKey: plan.apiKey,
     };
     writeFileSync(inversePlanPath, `${JSON.stringify(inversePlan, null, 2)}\n`, {
       encoding: "utf8",
@@ -237,7 +290,14 @@ function applyMigration(plan: MigrationPlan, groveDir: string, db: Database): vo
     //    runs hit the fresh-install guard and skip.
     writeProjectId(groveDir, plan.projectId);
   } catch (err) {
-    cleanupPartial(groveDir, db, filesCreated, dbNamespaceWritten, plan.previousNamespace);
+    cleanupPartial(
+      groveDir,
+      db,
+      filesCreated,
+      dbNamespaceWritten,
+      plan.previousNamespace,
+      serverKeyAppended ? plan.apiKey : undefined,
+    );
     rmSync(inversePlanPath, { force: true });
     throw err;
   }
@@ -254,11 +314,22 @@ function cleanupPartial(
   filesCreated: readonly string[],
   dbNamespaceWritten: boolean,
   previousNamespace: string,
+  serverKey: string | undefined,
 ): void {
   for (const name of filesCreated) {
     if (!ALLOWED_FILES.has(name)) continue;
     try {
       rmSync(join(groveDir, name), { force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+  if (serverKey !== undefined) {
+    try {
+      const remaining = removeServerKey(groveDir, serverKey);
+      if (remaining === 0) {
+        rmSync(join(groveDir, SERVER_KEYS_FILE), { force: true });
+      }
     } catch {
       /* best-effort */
     }
@@ -324,6 +395,9 @@ function parseInversePlan(raw: string): InversePlan {
       );
     }
   }
+  if (typeof p.apiKey !== "string" || p.apiKey.length === 0) {
+    throw new Error("grove migrate --rollback: inverse-plan.json missing apiKey");
+  }
   return {
     type: "namespace-migration",
     version: 1,
@@ -333,6 +407,7 @@ function parseInversePlan(raw: string): InversePlan {
     previousNamespace: p.previousNamespace,
     contributionCount: typeof p.contributionCount === "number" ? p.contributionCount : 0,
     claimCount: typeof p.claimCount === "number" ? p.claimCount : 0,
+    apiKey: p.apiKey,
   };
 }
 
@@ -357,9 +432,9 @@ async function executeRollback(groveDir: string, dbPath: string): Promise<void> 
   console.log(`  namespace was:  ${plan.namespace}`);
   console.log(`  reverting to:   ${plan.previousNamespace}`);
 
-  // Remove credential files. The whitelist + basename check prevents a
-  // tampered inverse-plan from deleting unrelated entries (e.g. grove.db,
-  // path-traversal targets outside .grove/).
+  // Remove migration-owned credential files. The allowlist + basename check
+  // prevents a tampered inverse-plan from deleting unrelated entries (e.g.
+  // grove.db, path-traversal targets outside .grove/).
   for (const file of plan.filesCreated) {
     if (!ALLOWED_FILES.has(file)) {
       console.warn(`  warning: skipping unrecognized entry '${file}' (not in allowlist)`);
@@ -376,6 +451,24 @@ async function executeRollback(groveDir: string, dbPath: string): Promise<void> 
     } catch (err) {
       console.warn(`  warning: could not remove .grove/${file}: ${(err as Error).message}`);
     }
+  }
+
+  // Surgical removal of OUR key from server-keys.yaml — preserves any other
+  // entries an operator may have added. Delete the file only if empty.
+  try {
+    const remaining = removeServerKey(groveDir, plan.apiKey);
+    if (remaining === 0) {
+      rmSync(join(groveDir, SERVER_KEYS_FILE), { force: true });
+      console.log(`  removed: .grove/${SERVER_KEYS_FILE} (empty after key removal)`);
+    } else {
+      console.log(
+        `  removed migrated key from .grove/${SERVER_KEYS_FILE} (${remaining} keys left)`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `  warning: could not surgically remove key from .grove/${SERVER_KEYS_FILE}: ${(err as Error).message}`,
+    );
   }
 
   // Restore previous namespace in the SQLite store.

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -10,7 +10,8 @@
  *   grove migrate --rollback   Reverse a previous migration
  */
 
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 
@@ -23,6 +24,13 @@ import {
 } from "../../core/project-key.js";
 import { initSqliteDb, readStoreNamespace, writeStoreNamespace } from "../../local/sqlite-store.js";
 import { resolveGroveDir } from "../utils/grove-dir.js";
+
+/**
+ * Files the migration is allowed to create or remove inside the grove dir.
+ * Used as a whitelist for rollback to prevent a tampered inverse-plan.json
+ * from deleting unrelated files (e.g. grove.db, grove.json).
+ */
+const ALLOWED_FILES = new Set(["project-id", "api-key", "server-keys.yaml", "namespace"]);
 
 // ---------------------------------------------------------------------------
 // Types
@@ -111,16 +119,34 @@ export async function handleMigrate(
     return;
   }
 
+  // Require an existing grove.db. We must NOT silently bootstrap one — that
+  // would mask a wrong --grove path or a lost database, then stamp identity
+  // onto an empty store. Legitimate fresh installs go through `grove init`.
+  if (!existsSync(dbPath)) {
+    throw new Error(
+      `grove migrate: ${dbPath} not found. Run \`grove init\` for a new grove, ` +
+        `or pass --grove pointing at an existing legacy install.`,
+    );
+  }
+
+  // Dry-run uses a read-only handle so planning never mutates the DB
+  // (including running schema migrations).
+  if (opts.dryRun) {
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const plan = buildPlan(db);
+      printPlan(plan);
+      console.log("\nDry run — no changes written.");
+    } finally {
+      db.close();
+    }
+    return;
+  }
+
   const db = initSqliteDb(dbPath);
   try {
-    const plan = buildPlan(groveDir, db);
+    const plan = buildPlan(db);
     printPlan(plan);
-
-    if (opts.dryRun) {
-      console.log("\nDry run — no changes written.");
-      return;
-    }
-
     applyMigration(plan, groveDir, db);
     console.log(`\nMigration complete. Namespace: ${plan.namespace}`);
   } finally {
@@ -132,7 +158,7 @@ export async function handleMigrate(
 // Plan
 // ---------------------------------------------------------------------------
 
-function buildPlan(_groveDir: string, db: ReturnType<typeof initSqliteDb>): MigrationPlan {
+function buildPlan(db: Database): MigrationPlan {
   const projectId = generateProjectId();
   const namespace = `${projectId}/${WORKTREE_NAME}`;
   const apiKey = generateApiKey();
@@ -166,51 +192,149 @@ function printPlan(plan: MigrationPlan): void {
 // Apply
 // ---------------------------------------------------------------------------
 
-function applyMigration(
-  plan: MigrationPlan,
-  groveDir: string,
-  db: ReturnType<typeof initSqliteDb>,
-): void {
+function applyMigration(plan: MigrationPlan, groveDir: string, db: Database): void {
+  // Order matters: project-id is written LAST as the "commit marker" — its
+  // absence is the fresh-install guard's signal that migration may safely
+  // retry. If anything before fails, we roll back partial state and the
+  // next `grove migrate` run can re-apply cleanly.
   const filesCreated: string[] = [];
-
-  // 1. Write project-id.
-  writeProjectId(groveDir, plan.projectId);
-  filesCreated.push("project-id");
-
-  // 2. Write credentials.
-  writeClientKey(groveDir, plan.apiKey);
-  filesCreated.push("api-key");
-  appendServerKey(groveDir, plan.apiKey, plan.namespace);
-  filesCreated.push("server-keys.yaml");
-  writeNamespace(groveDir, plan.namespace);
-  filesCreated.push("namespace");
-
-  // 3. Write namespace into the SQLite store so listEntities projects correctly.
-  writeStoreNamespace(db, plan.namespace);
-
-  // 4. Record inverse plan for rollback.
   const migrationsDir = join(groveDir, MIGRATIONS_DIR);
-  mkdirSync(migrationsDir, { recursive: true });
-  const inversePlan: InversePlan = {
-    type: "namespace-migration",
-    version: 1,
-    appliedAt: new Date().toISOString(),
-    namespace: plan.namespace,
-    filesCreated,
-    previousNamespace: plan.previousNamespace,
-    contributionCount: plan.contributionCount,
-    claimCount: plan.claimCount,
-  };
-  writeFileSync(
-    join(migrationsDir, INVERSE_PLAN_FILE),
-    `${JSON.stringify(inversePlan, null, 2)}\n`,
-    { encoding: "utf8", mode: 0o600 },
-  );
+  const inversePlanPath = join(migrationsDir, INVERSE_PLAN_FILE);
+  let dbNamespaceWritten = false;
+
+  try {
+    // 1. SQLite store namespace (idempotent via INSERT OR REPLACE).
+    writeStoreNamespace(db, plan.namespace);
+    dbNamespaceWritten = true;
+
+    // 2. Credential files.
+    writeClientKey(groveDir, plan.apiKey);
+    filesCreated.push("api-key");
+    appendServerKey(groveDir, plan.apiKey, plan.namespace);
+    filesCreated.push("server-keys.yaml");
+    writeNamespace(groveDir, plan.namespace);
+    filesCreated.push("namespace");
+
+    // 3. Inverse plan (must include project-id even though we write it last,
+    //    so rollback after a successful migration removes it).
+    mkdirSync(migrationsDir, { recursive: true });
+    const inversePlan: InversePlan = {
+      type: "namespace-migration",
+      version: 1,
+      appliedAt: new Date().toISOString(),
+      namespace: plan.namespace,
+      filesCreated: [...filesCreated, "project-id"],
+      previousNamespace: plan.previousNamespace,
+      contributionCount: plan.contributionCount,
+      claimCount: plan.claimCount,
+    };
+    writeFileSync(inversePlanPath, `${JSON.stringify(inversePlan, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+
+    // 4. Commit marker: project-id. Once this exists, subsequent migrate
+    //    runs hit the fresh-install guard and skip.
+    writeProjectId(groveDir, plan.projectId);
+  } catch (err) {
+    cleanupPartial(groveDir, db, filesCreated, dbNamespaceWritten, plan.previousNamespace);
+    rmSync(inversePlanPath, { force: true });
+    throw err;
+  }
+}
+
+/**
+ * Best-effort cleanup of partial migration state. Called only when a step
+ * AFTER the SQLite write fails — never after `writeProjectId` succeeds, since
+ * that marks the migration as durable.
+ */
+function cleanupPartial(
+  groveDir: string,
+  db: Database,
+  filesCreated: readonly string[],
+  dbNamespaceWritten: boolean,
+  previousNamespace: string,
+): void {
+  for (const name of filesCreated) {
+    if (!ALLOWED_FILES.has(name)) continue;
+    try {
+      rmSync(join(groveDir, name), { force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+  if (dbNamespaceWritten) {
+    try {
+      if (previousNamespace === "default") {
+        db.run("DELETE FROM project_settings WHERE key = 'namespace'");
+      } else {
+        writeStoreNamespace(db, previousNamespace);
+      }
+    } catch {
+      /* best-effort */
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Rollback
 // ---------------------------------------------------------------------------
+
+/**
+ * Strict-validate the parsed JSON against the InversePlan shape. Rejects
+ * unknown types, wrong versions, missing or non-string fields, and any
+ * filesCreated entry that escapes the allowlist or contains a path
+ * separator. A corrupt plan would otherwise let rollback delete arbitrary
+ * files inside .grove/ (or — via traversal — outside it).
+ */
+function parseInversePlan(raw: string): InversePlan {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`grove migrate --rollback: inverse-plan.json is not valid JSON: ${err}`);
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("grove migrate --rollback: inverse-plan.json is not an object");
+  }
+  const p = parsed as Record<string, unknown>;
+  if (p.type !== "namespace-migration") {
+    throw new Error(
+      `grove migrate --rollback: unrecognized inverse-plan type (type=${String(p.type)})`,
+    );
+  }
+  if (p.version !== 1) {
+    throw new Error(
+      `grove migrate --rollback: unsupported inverse-plan version (version=${String(p.version)})`,
+    );
+  }
+  if (typeof p.appliedAt !== "string" || typeof p.namespace !== "string") {
+    throw new Error("grove migrate --rollback: inverse-plan.json missing required string fields");
+  }
+  if (typeof p.previousNamespace !== "string") {
+    throw new Error("grove migrate --rollback: inverse-plan.json missing previousNamespace");
+  }
+  if (!Array.isArray(p.filesCreated)) {
+    throw new Error("grove migrate --rollback: inverse-plan.json filesCreated must be an array");
+  }
+  for (const f of p.filesCreated) {
+    if (typeof f !== "string" || !ALLOWED_FILES.has(f)) {
+      throw new Error(
+        `grove migrate --rollback: inverse-plan.json contains disallowed file '${String(f)}'`,
+      );
+    }
+  }
+  return {
+    type: "namespace-migration",
+    version: 1,
+    appliedAt: p.appliedAt,
+    namespace: p.namespace,
+    filesCreated: p.filesCreated as readonly string[],
+    previousNamespace: p.previousNamespace,
+    contributionCount: typeof p.contributionCount === "number" ? p.contributionCount : 0,
+    claimCount: typeof p.claimCount === "number" ? p.claimCount : 0,
+  };
+}
 
 async function executeRollback(groveDir: string, dbPath: string): Promise<void> {
   const inversePlanPath = join(groveDir, MIGRATIONS_DIR, INVERSE_PLAN_FILE);
@@ -227,20 +351,24 @@ async function executeRollback(groveDir: string, dbPath: string): Promise<void> 
     throw err;
   }
 
-  const plan = JSON.parse(raw) as InversePlan;
-
-  if (plan.type !== "namespace-migration" || plan.version !== 1) {
-    throw new Error(
-      `grove migrate --rollback: unrecognized inverse-plan format (type=${plan.type}, version=${plan.version})`,
-    );
-  }
+  const plan = parseInversePlan(raw);
 
   console.log(`grove migrate --rollback: reversing migration applied at ${plan.appliedAt}`);
   console.log(`  namespace was:  ${plan.namespace}`);
   console.log(`  reverting to:   ${plan.previousNamespace}`);
 
-  // Remove credential files.
+  // Remove credential files. The whitelist + basename check prevents a
+  // tampered inverse-plan from deleting unrelated entries (e.g. grove.db,
+  // path-traversal targets outside .grove/).
   for (const file of plan.filesCreated) {
+    if (!ALLOWED_FILES.has(file)) {
+      console.warn(`  warning: skipping unrecognized entry '${file}' (not in allowlist)`);
+      continue;
+    }
+    if (file.includes("/") || file.includes("\\") || file === "." || file === "..") {
+      console.warn(`  warning: skipping suspicious entry '${file}'`);
+      continue;
+    }
     const filePath = join(groveDir, file);
     try {
       rmSync(filePath, { force: true });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -369,6 +369,15 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "migrate",
+      description: "Migrate legacy grove to namespaced identity",
+      needsStore: false,
+      handler: async (args) => {
+        const { handleMigrate } = await import("./commands/migrate.js");
+        await handleMigrate(args, groveOverride);
+      },
+    },
+    {
       name: "up",
       description: "Start all grove services and TUI",
       needsStore: false,
@@ -537,6 +546,7 @@ function printUsage(): void {
 Getting Started:
   grove                                Launch TUI (default)
   grove init [--preset <name>] [name]  Create a new grove
+  grove migrate [--dry-run|--rollback] Migrate legacy grove to namespaced identity
   grove up [--headless] [--no-tui]     Start all services and TUI
   grove down                           Stop all services
 

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -43,6 +43,11 @@ export const COMMANDS: readonly CommandMeta[] = [
     ],
   },
   {
+    name: "migrate",
+    description: "Migrate legacy grove to namespaced identity",
+    flags: ["dry-run", "rollback", "grove", "help"],
+  },
+  {
     name: "up",
     description: "Start all grove services and TUI",
     flags: ["headless", "no-tui", "grove", "build", "nexus-source", "help"],

--- a/src/core/project-key.ts
+++ b/src/core/project-key.ts
@@ -134,28 +134,69 @@ export function appendServerKey(groveDir: string, key: string, namespace: string
   renameSync(tmp, filePath);
 }
 
+export interface RemoveServerKeyResult {
+  /** True iff a parseable version-1 registry was found on disk. */
+  readonly registryFound: boolean;
+  /** True iff the key was present and has now been removed. */
+  readonly removed: boolean;
+  /** Remaining key count after removal. 0 when registry absent. */
+  readonly remaining: number;
+}
+
 /**
  * Remove a single key from `<groveDir>/server-keys.yaml`.
  *
- * Returns the number of remaining keys after removal (so callers can decide
- * whether to delete the file entirely). If the file does not exist, returns
- * 0. Safe to call when the key is not present — it is a no-op in that case.
+ * Strict parse: throws if the file exists but is not a recognized
+ * version-1 registry (so we never silently treat a forward-version file as
+ * empty and let callers delete it). The returned result distinguishes the
+ * three cases: registry absent, key already absent, key removed.
  */
-export function removeServerKey(groveDir: string, key: string): number {
+export function removeServerKey(groveDir: string, key: string): RemoveServerKeyResult {
   const filePath = join(groveDir, SERVER_KEYS_FILE);
-  let existing: ServerKeysFile;
+  let raw: string;
   try {
-    const raw = readFileSync(filePath, "utf8");
-    const parsed = parseYaml(raw) as ServerKeysFile;
-    existing = parsed?.version === 1 && parsed.keys ? parsed : { version: 1, keys: {} };
+    raw = readFileSync(filePath, "utf8");
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { registryFound: false, removed: false, remaining: 0 };
+    }
     throw err;
   }
-  if (!(key in existing.keys)) return Object.keys(existing.keys).length;
-  delete existing.keys[key];
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    throw new Error(`server-keys.yaml is not valid YAML: ${(err as Error).message}`);
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("server-keys.yaml is not a YAML object");
+  }
+  const candidate = parsed as { version?: unknown; keys?: unknown };
+  if (candidate.version !== 1) {
+    throw new Error(
+      `server-keys.yaml has unsupported version=${String(candidate.version)}; refusing to mutate`,
+    );
+  }
+  if (typeof candidate.keys !== "object" || candidate.keys === null) {
+    throw new Error("server-keys.yaml is missing the 'keys' map; refusing to mutate");
+  }
+  const registry: ServerKeysFile = { version: 1, keys: candidate.keys as ServerKeysFile["keys"] };
+
+  if (!(key in registry.keys)) {
+    return {
+      registryFound: true,
+      removed: false,
+      remaining: Object.keys(registry.keys).length,
+    };
+  }
+  delete registry.keys[key];
   const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
-  writeFileSync(tmp, stringifyYaml(existing), { encoding: "utf8", mode: 0o600 });
+  writeFileSync(tmp, stringifyYaml(registry), { encoding: "utf8", mode: 0o600 });
   renameSync(tmp, filePath);
-  return Object.keys(existing.keys).length;
+  return {
+    registryFound: true,
+    removed: true,
+    remaining: Object.keys(registry.keys).length,
+  };
 }

--- a/src/core/project-key.ts
+++ b/src/core/project-key.ts
@@ -133,3 +133,29 @@ export function appendServerKey(groveDir: string, key: string, namespace: string
   writeFileSync(tmp, stringifyYaml(existing), { encoding: "utf8", mode: 0o600 });
   renameSync(tmp, filePath);
 }
+
+/**
+ * Remove a single key from `<groveDir>/server-keys.yaml`.
+ *
+ * Returns the number of remaining keys after removal (so callers can decide
+ * whether to delete the file entirely). If the file does not exist, returns
+ * 0. Safe to call when the key is not present — it is a no-op in that case.
+ */
+export function removeServerKey(groveDir: string, key: string): number {
+  const filePath = join(groveDir, SERVER_KEYS_FILE);
+  let existing: ServerKeysFile;
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    const parsed = parseYaml(raw) as ServerKeysFile;
+    existing = parsed?.version === 1 && parsed.keys ? parsed : { version: 1, keys: {} };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw err;
+  }
+  if (!(key in existing.keys)) return Object.keys(existing.keys).length;
+  delete existing.keys[key];
+  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, stringifyYaml(existing), { encoding: "utf8", mode: 0o600 });
+  renameSync(tmp, filePath);
+  return Object.keys(existing.keys).length;
+}

--- a/src/core/project-key.ts
+++ b/src/core/project-key.ts
@@ -115,19 +115,54 @@ export function readNamespace(groveDir: string): string | undefined {
   }
 }
 
-/** Append a key → namespace entry to `<groveDir>/server-keys.yaml`. */
+/**
+ * Strict-parse `<groveDir>/server-keys.yaml`.
+ *
+ * Returns `null` if the file does not exist. Throws on any other failure
+ * mode (unparseable YAML, non-object root, unsupported version, missing
+ * `keys` map). Callers must NEVER fall back to an empty registry on
+ * failure — doing so would silently overwrite forward-version files that
+ * may carry credentials this code base does not understand.
+ */
+export function parseServerKeys(groveDir: string): ServerKeysFile | null {
+  const filePath = join(groveDir, SERVER_KEYS_FILE);
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    throw new Error(`server-keys.yaml is not valid YAML: ${(err as Error).message}`);
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("server-keys.yaml is not a YAML object");
+  }
+  const candidate = parsed as { version?: unknown; keys?: unknown };
+  if (candidate.version !== 1) {
+    throw new Error(
+      `server-keys.yaml has unsupported version=${String(candidate.version)}; refusing to mutate`,
+    );
+  }
+  if (typeof candidate.keys !== "object" || candidate.keys === null) {
+    throw new Error("server-keys.yaml is missing the 'keys' map; refusing to mutate");
+  }
+  return { version: 1, keys: candidate.keys as ServerKeysFile["keys"] };
+}
+
+/**
+ * Append a key → namespace entry to `<groveDir>/server-keys.yaml`.
+ *
+ * Strict: throws if an existing file is not a recognized version-1
+ * registry (preserves forward-version data; never silently clobbers).
+ */
 export function appendServerKey(groveDir: string, key: string, namespace: string): void {
   const filePath = join(groveDir, SERVER_KEYS_FILE);
-  let existing: ServerKeysFile = { version: 1, keys: {} };
-  try {
-    const raw = readFileSync(filePath, "utf8");
-    const parsed = parseYaml(raw) as ServerKeysFile;
-    if (parsed?.version === 1 && parsed.keys) {
-      existing = parsed;
-    }
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-  }
+  const existing = parseServerKeys(groveDir) ?? { version: 1 as const, keys: {} };
   existing.keys[key] = { namespace, createdAt: new Date().toISOString() };
   const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
   writeFileSync(tmp, stringifyYaml(existing), { encoding: "utf8", mode: 0o600 });
@@ -152,51 +187,17 @@ export interface RemoveServerKeyResult {
  * three cases: registry absent, key already absent, key removed.
  */
 export function removeServerKey(groveDir: string, key: string): RemoveServerKeyResult {
-  const filePath = join(groveDir, SERVER_KEYS_FILE);
-  let raw: string;
-  try {
-    raw = readFileSync(filePath, "utf8");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return { registryFound: false, removed: false, remaining: 0 };
-    }
-    throw err;
+  const registry = parseServerKeys(groveDir);
+  if (registry === null) {
+    return { registryFound: false, removed: false, remaining: 0 };
   }
-
-  let parsed: unknown;
-  try {
-    parsed = parseYaml(raw);
-  } catch (err) {
-    throw new Error(`server-keys.yaml is not valid YAML: ${(err as Error).message}`);
-  }
-  if (typeof parsed !== "object" || parsed === null) {
-    throw new Error("server-keys.yaml is not a YAML object");
-  }
-  const candidate = parsed as { version?: unknown; keys?: unknown };
-  if (candidate.version !== 1) {
-    throw new Error(
-      `server-keys.yaml has unsupported version=${String(candidate.version)}; refusing to mutate`,
-    );
-  }
-  if (typeof candidate.keys !== "object" || candidate.keys === null) {
-    throw new Error("server-keys.yaml is missing the 'keys' map; refusing to mutate");
-  }
-  const registry: ServerKeysFile = { version: 1, keys: candidate.keys as ServerKeysFile["keys"] };
-
   if (!(key in registry.keys)) {
-    return {
-      registryFound: true,
-      removed: false,
-      remaining: Object.keys(registry.keys).length,
-    };
+    return { registryFound: true, removed: false, remaining: Object.keys(registry.keys).length };
   }
   delete registry.keys[key];
+  const filePath = join(groveDir, SERVER_KEYS_FILE);
   const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
   writeFileSync(tmp, stringifyYaml(registry), { encoding: "utf8", mode: 0o600 });
   renameSync(tmp, filePath);
-  return {
-    registryFound: true,
-    removed: true,
-    remaining: Object.keys(registry.keys).length,
-  };
+  return { registryFound: true, removed: true, remaining: Object.keys(registry.keys).length };
 }

--- a/src/local/sqlite-store.migration.test.ts
+++ b/src/local/sqlite-store.migration.test.ts
@@ -32,7 +32,7 @@ describe("schema migration", () => {
       db.close();
 
       expect(row).toBeDefined();
-      expect(row?.version).toBe(10);
+      expect(row?.version).toBe(11);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -173,7 +173,7 @@ describe("schema migration", () => {
       db.close();
 
       expect(rows.length).toBe(1);
-      expect(rows[0]?.version).toBe(10);
+      expect(rows[0]?.version).toBe(11);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -191,7 +191,7 @@ describe("schema migration", () => {
         .get() as {
         version: number;
       } | null;
-      expect(row?.version).toBe(10);
+      expect(row?.version).toBe(11);
 
       db.close();
     } finally {
@@ -534,7 +534,7 @@ describe("schema migration", () => {
           v: number | null;
         }
       ).v;
-      expect(version).toBe(10);
+      expect(version).toBe(11);
 
       db2.close();
     } finally {

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -51,7 +51,7 @@ import { claimToEntity, contributionToEntity } from "../core/entity.js";
 import { ClaimConflictError, NotFoundError, StateConflictError } from "../core/errors.js";
 import { toUtcIso } from "../core/time.js";
 
-const CURRENT_SCHEMA_VERSION = 10;
+const CURRENT_SCHEMA_VERSION = 11;
 const SQLITE_BIND_LIMIT = 900;
 
 // ---------------------------------------------------------------------------
@@ -169,6 +169,12 @@ const SCHEMA_DDL = `
     result_json TEXT NOT NULL DEFAULT '{}',
     status TEXT NOT NULL DEFAULT 'pending',
     stored_at INTEGER NOT NULL
+  );
+
+  -- Key-value store for per-grove settings (e.g. migrated namespace).
+  CREATE TABLE IF NOT EXISTS project_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
   );
 `;
 
@@ -447,6 +453,10 @@ export function initSqliteDb(dbPath: string): Database {
       }
     }
 
+    // Migration → v11: create project_settings table (key-value store for
+    // per-grove settings like the migrated namespace from `grove migrate`).
+    // Handled by SCHEMA_DDL CREATE TABLE IF NOT EXISTS — no ALTER needed.
+
     db.run("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)", [
       CURRENT_SCHEMA_VERSION,
       new Date().toISOString(),
@@ -478,6 +488,30 @@ export function initSqliteDb(dbPath: string): Database {
   initSchema.immediate();
 
   return db;
+}
+
+/**
+ * Read the effective namespace for this grove's SQLite store.
+ *
+ * Written by `grove migrate` when upgrading a legacy installation.
+ * Returns `"default"` if no migration has been applied yet.
+ */
+export function readStoreNamespace(db: Database): string {
+  const row = db.prepare("SELECT value FROM project_settings WHERE key = 'namespace'").get() as {
+    value: string;
+  } | null;
+  return row?.value ?? "default";
+}
+
+/**
+ * Persist the store namespace in project_settings (upsert).
+ * Used by `grove migrate` and `grove init` to wire the local store to
+ * the project's canonical `{uuid}/{worktree}` namespace.
+ */
+export function writeStoreNamespace(db: Database, namespace: string): void {
+  db.run("INSERT OR REPLACE INTO project_settings (key, value) VALUES ('namespace', ?)", [
+    namespace,
+  ]);
 }
 
 // ---------------------------------------------------------------------------
@@ -1235,7 +1269,8 @@ export class SqliteContributionStore implements ContributionStore {
 
   async listEntities(query?: ContributionQuery): Promise<readonly ContributionEntity[]> {
     const items = await this.list(query);
-    return items.map((c) => contributionToEntity(c, "default"));
+    const namespace = readStoreNamespace(this.db);
+    return items.map((c) => contributionToEntity(c, namespace));
   }
 
   /**

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -497,10 +497,17 @@ export function initSqliteDb(dbPath: string): Database {
  * Returns `"default"` if no migration has been applied yet.
  */
 export function readStoreNamespace(db: Database): string {
-  const row = db.prepare("SELECT value FROM project_settings WHERE key = 'namespace'").get() as {
-    value: string;
-  } | null;
-  return row?.value ?? "default";
+  // Tolerate missing table so callers (e.g. `grove migrate --dry-run` opening
+  // a legacy DB read-only) do not crash before schema migrations have run.
+  try {
+    const row = db.prepare("SELECT value FROM project_settings WHERE key = 'namespace'").get() as {
+      value: string;
+    } | null;
+    return row?.value ?? "default";
+  } catch (err) {
+    if ((err as Error).message?.includes("no such table")) return "default";
+    throw err;
+  }
 }
 
 /**
@@ -1743,7 +1750,8 @@ export class SqliteClaimStore implements ClaimStore {
     const baseQuery: ClaimQuery | undefined =
       query === undefined ? undefined : { ...query, status: undefined };
     const items = await this.listClaims(baseQuery);
-    const entities = items.map((c) => claimToEntity(c, () => Date.now()));
+    const namespace = readStoreNamespace(this.db);
+    const entities = items.map((c) => claimToEntity(c, () => Date.now(), namespace));
     if (query?.status === undefined) return entities;
     const wanted = Array.isArray(query.status) ? new Set(query.status) : new Set([query.status]);
     return entities.filter((e) => wanted.has(e.status.phase));


### PR DESCRIPTION
## Summary

- Adds `grove migrate` CLI command for upgrading pre-A2/A3 installations to the `{uuid}/main` namespace model
- Adds `project_settings` table (schema v11) to SQLite; `listEntities` now reads namespace from this table instead of hardcoding `"default"`
- Exports `readStoreNamespace` / `writeStoreNamespace` helpers from `sqlite-store.ts`

## Commands

```
grove migrate              # execute migration
grove migrate --dry-run    # print plan without writing
grove migrate --rollback   # reverse via .grove/migrations/inverse-plan.json
```

## Migration steps

1. Fresh-install guard: skips if `.grove/project-id` already exists
2. Generates project UUID → writes `.grove/project-id`
3. Generates API key → writes `.grove/api-key`, `.grove/server-keys.yaml`, `.grove/namespace`
4. Sets `project_settings.namespace = {uuid}/main` in SQLite so `listEntities` projects the correct namespace for all historical records
5. Records `.grove/migrations/inverse-plan.json` for rollback

## Test plan

- [ ] `bun test src/cli/commands/migrate.test.ts` — 19 tests: args, fresh-install guard, dry-run, execute, rollback
- [ ] `bun test src/local/sqlite-store.migration.test.ts` — schema v11 version assertions
- [ ] `bun test src/local/sqlite-store.test.ts` — no regressions in store

Closes #291