### PR TITLE
feat(watch): A5 list→watch RV handshake (#292)

### DIFF
--- a/docs/superpowers/plans/2026-04-27-a5-watch-protocol.md
+++ b/docs/superpowers/plans/2026-04-27-a5-watch-protocol.md
@@ -1,0 +1,2425 @@
+# A5 Watch Protocol — list→watch RV Handshake — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a Kubernetes-style reactive watch protocol that lets TUI clients list Entities, then resume an SSE watch from the exact `listResourceVersion` and receive every subsequent event without gaps.
+
+**Architecture:** A grove-server-local `WatchHub` holds a per-(namespace, kind) monotonic RV counter and a per-key ring buffer. Writes feed the hub from two paths: (1) an in-process `onEntityWrite` operations hook for HTTP-mediated writes, and (2) a Nexus event-bus `entity.changed` subscription for cross-process writes from MCP agents. New endpoints `GET /api/list?kind=X` and `GET /api/watch?kind=X&resumeFrom=Y` (SSE) sit behind the existing namespace-auth middleware.
+
+**Tech Stack:** Bun 1.3.9, TypeScript, Hono, Zod, `bun:test`, Biome. Reference spec: `docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md`. Reference upstream: `kubernetes/staging/src/k8s.io/apimachinery/pkg/watch/watch.go`.
+
+**Working directory:** Run all commands from `/Users/tafeng/grove/.claude/worktrees/tidy-hatching-wadler`.
+
+**Test runner:** `bun test <path>` for a file, `bun test <path> -t "<test name>"` for a single test. The repo uses `bun:test` (`describe`, `test`, `expect`).
+
+**Lint / typecheck:** `bunx biome check --write src/` for style, `bunx tsc --noEmit` for typecheck.
+
+---
+
+## File Structure
+
+### New files
+
+| Path | Responsibility |
+|------|---------------|
+| `src/core/watch-hub.ts` | Pure WatchHub: RV counter, ring buffer, subscribe API. No HTTP, no I/O. |
+| `src/core/watch-hub.test.ts` | Unit tests for WatchHub (monotonicity, isolation, ring caps, replay, bookmark, overflow). |
+| `src/core/watch-events.ts` | Shared types: `WatchKind`, `WatchOp`, `WatchEvent`, `EntityWriteEvent`, `StaleResourceVersionError`. |
+| `src/server/routes/watch.ts` | Hono route module for `GET /api/list` and `GET /api/watch` (SSE). |
+| `src/server/watch.integration.test.ts` | Integration test: list returns RV, watch streams writes, 410 on stale. |
+| `src/server/watch.race.test.ts` | Acceptance test: handshake-race (writes between list-return and watch-open all replayed). |
+| `src/server/watch.kill.test.ts` | Acceptance test: kill-9 mid-stream resume with stored RV → zero missed events. |
+| `src/server/watch.bookmark.test.ts` | Acceptance test: BOOKMARK arrives within 31s on quiescent kind. |
+| `src/nexus/nexus-watch-publisher.ts` | Publishes `entity.changed` envelopes to the Nexus event-bus on writes through Nexus stores. |
+| `src/nexus/nexus-watch-subscriber.ts` | grove-server subscribes to `entity.changed`, dedupes against in-process fast path, calls `hub.recordWrite()`. |
+
+### Modified files
+
+| Path | Change |
+|------|--------|
+| `src/core/operations/deps.ts` | Add `onEntityWrite?: (event: EntityWriteEvent) => void` to `OperationDeps`. |
+| `src/core/operations/contribute.ts:1207` | Fire `onEntityWrite` for the committed contribution alongside existing hooks. |
+| `src/core/operations/claim.ts` | Fire `onEntityWrite` after `claimOrRenew`, `complete`, `release` when phase changes. |
+| `src/server/deps.ts` | Add `watchHub: WatchHub` to `ServerDeps`. |
+| `src/server/app.ts` | Mount `/api/list` and `/api/watch` routes; bypass routes from any unrelated middleware. |
+| `src/server/serve.ts` | Instantiate WatchHub, wire `onEntityWrite`, start NexusWatchSubscriber when Nexus is configured. |
+| `src/nexus/nexus-contribution-store.ts` | Call `nexusWatchPublisher.publish` after every commit. |
+| `src/nexus/nexus-claim-store.ts` | Call `nexusWatchPublisher.publish` after every state change. |
+
+### Out of scope for this plan
+
+- TUI informer (A7, #294)
+- Polling retirement (A8, #295)
+- Compaction/Expired RV recovery (A6, #293)
+- Outcome/Bounty/Handoff watch — extend later
+- AgentSession watch — extend in a follow-up plan once session-orchestrator emits clean phase-change events
+
+---
+
+## Phase 1 — Core WatchHub (pure logic)
+
+### Task 1: Define shared watch-event types
+
+**Files:**
+- Create: `src/core/watch-events.ts`
+
+- [ ] **Step 1: Write the file**
+
+```typescript
+/**
+ * Shared types for the watch protocol (#292).
+ *
+ * The watch RV is a monotonic per-(namespace, kind) sequence held by the
+ * server's WatchHub. It is distinct from Entity.resourceVersion (per-row
+ * revision) — see docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md.
+ */
+
+import type {
+  AgentSessionEntity,
+  ClaimEntity,
+  ContributionEntity,
+} from "./entity.js";
+
+export type WatchKind = "Contribution" | "Claim" | "AgentSession";
+
+export type WatchOp = "ADDED" | "MODIFIED" | "DELETED";
+
+export type WatchEntity = ContributionEntity | ClaimEntity | AgentSessionEntity;
+
+/** A watch-stream event emitted by the hub to subscribers. */
+export interface WatchEvent {
+  readonly rv: bigint;
+  readonly op: WatchOp;
+  readonly kind: WatchKind;
+  readonly namespace: string;
+  readonly entity: WatchEntity;
+}
+
+/** Argument shape for `WatchHub.recordWrite` / `OperationDeps.onEntityWrite`. */
+export type EntityWriteEvent = Omit<WatchEvent, "rv">;
+
+/** Thrown by `WatchHub.subscribe` when `fromRv` falls outside the ring buffer. */
+export class StaleResourceVersionError extends Error {
+  readonly code = 410;
+  constructor(
+    public readonly namespace: string,
+    public readonly kind: WatchKind,
+    public readonly fromRv: bigint,
+    public readonly oldestRv: bigint,
+  ) {
+    super(
+      `resourceVersion ${fromRv} is older than the oldest buffered event ${oldestRv} for ${namespace}/${kind}`,
+    );
+    this.name = "StaleResourceVersionError";
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bunx tsc --noEmit src/core/watch-events.ts`
+Expected: PASS (no output).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/watch-events.ts
+git commit -m "feat(watch): shared watch-event types (#292)"
+```
+
+---
+
+### Task 2: WatchHub skeleton + RV monotonicity
+
+**Files:**
+- Create: `src/core/watch-hub.ts`
+- Create: `src/core/watch-hub.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/core/watch-hub.test.ts
+import { describe, expect, test } from "bun:test";
+import { contributionToEntity } from "./entity.js";
+import type { Contribution } from "./models.js";
+import { WatchHub } from "./watch-hub.js";
+
+function fixtureContribution(cid: string): Contribution {
+  return {
+    cid,
+    kind: "work",
+    mode: "evaluation",
+    summary: "fixture",
+    artifacts: {},
+    relations: [],
+    tags: [],
+    agent: { agentId: "a-1" },
+    createdAt: new Date().toISOString(),
+  } as Contribution;
+}
+
+describe("WatchHub.recordWrite", () => {
+  test("returns strictly increasing rv for same (ns, kind)", () => {
+    const hub = new WatchHub();
+    const ent1 = contributionToEntity(fixtureContribution("cid-a"), "ns/wt");
+    const ent2 = contributionToEntity(fixtureContribution("cid-b"), "ns/wt");
+    const rv1 = hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: ent1,
+    });
+    const rv2 = hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: ent2,
+    });
+    expect(rv2 > rv1).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/watch-hub.test.ts`
+Expected: FAIL with "Cannot find module './watch-hub.js'".
+
+- [ ] **Step 3: Write minimal WatchHub implementation**
+
+```typescript
+// src/core/watch-hub.ts
+/**
+ * WatchHub — per-(namespace, kind) monotonic resourceVersion authority,
+ * ring buffer, and subscriber fan-out for the watch protocol (#292).
+ *
+ * No HTTP, no I/O. Pure in-memory state. See
+ * docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md.
+ */
+
+import type { EntityWriteEvent, WatchKind } from "./watch-events.js";
+
+export class WatchHub {
+  private readonly counters = new Map<string, bigint>();
+
+  recordWrite(event: EntityWriteEvent): bigint {
+    const key = `${event.namespace}\x00${event.kind}`;
+    const next = (this.counters.get(key) ?? 0n) + 1n;
+    this.counters.set(key, next);
+    return next;
+  }
+
+  currentRv(namespace: string, kind: WatchKind): bigint {
+    return this.counters.get(`${namespace}\x00${kind}`) ?? 0n;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/watch-hub.test.ts`
+Expected: PASS — 1 test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/watch-hub.ts src/core/watch-hub.test.ts
+git commit -m "feat(watch): WatchHub recordWrite + currentRv (#292)"
+```
+
+---
+
+### Task 3: Namespace and kind isolation
+
+**Files:**
+- Modify: `src/core/watch-hub.test.ts`
+
+- [ ] **Step 1: Append the failing test**
+
+Add to the existing `describe("WatchHub.recordWrite", ...)` block:
+
+```typescript
+  test("namespaces and kinds maintain independent counters", () => {
+    const hub = new WatchHub();
+    const ent = contributionToEntity(fixtureContribution("cid-a"), "ns/wt");
+    const rvNsA = hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/A",
+      op: "ADDED",
+      entity: ent,
+    });
+    const rvNsB = hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/B",
+      op: "ADDED",
+      entity: ent,
+    });
+    const rvKindClaim = hub.recordWrite({
+      kind: "Claim",
+      namespace: "ns/A",
+      op: "ADDED",
+      // Claim entity reuse for shape only; type system accepts it because
+      // WatchEntity is a union and the test does not exercise claim semantics.
+      entity: ent as unknown as never,
+    });
+    expect(rvNsA).toBe(1n);
+    expect(rvNsB).toBe(1n);
+    expect(rvKindClaim).toBe(1n);
+    expect(hub.currentRv("ns/A", "Contribution")).toBe(1n);
+    expect(hub.currentRv("ns/B", "Contribution")).toBe(1n);
+    expect(hub.currentRv("ns/A", "Claim")).toBe(1n);
+    expect(hub.currentRv("ns/A", "AgentSession")).toBe(0n);
+  });
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test src/core/watch-hub.test.ts`
+Expected: PASS — 2 tests. The implementation already supports this because the key includes both namespace and kind.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/watch-hub.test.ts
+git commit -m "test(watch): namespace+kind isolation in counters (#292)"
+```
+
+---
+
+### Task 4: Ring buffer with count cap
+
+**Files:**
+- Modify: `src/core/watch-hub.ts`
+- Modify: `src/core/watch-hub.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new describe block at the bottom of `watch-hub.test.ts`:
+
+```typescript
+describe("WatchHub ring buffer", () => {
+  test("retains last maxEventsPerKey events per (ns, kind)", () => {
+    const hub = new WatchHub({ maxEventsPerKey: 3 });
+    for (let i = 0; i < 5; i++) {
+      hub.recordWrite({
+        kind: "Contribution",
+        namespace: "ns/wt",
+        op: "ADDED",
+        entity: contributionToEntity(fixtureContribution(`cid-${i}`), "ns/wt"),
+      });
+    }
+    const buffered = hub.snapshotRing("ns/wt", "Contribution");
+    expect(buffered.length).toBe(3);
+    expect(buffered.map((e) => e.rv)).toEqual([3n, 4n, 5n]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `bun test src/core/watch-hub.test.ts -t "retains last"`
+Expected: FAIL with `hub.snapshotRing is not a function` or constructor type error.
+
+- [ ] **Step 3: Extend WatchHub**
+
+Replace the contents of `src/core/watch-hub.ts` with:
+
+```typescript
+/**
+ * WatchHub — per-(namespace, kind) monotonic resourceVersion authority,
+ * ring buffer, and subscriber fan-out for the watch protocol (#292).
+ *
+ * No HTTP, no I/O. Pure in-memory state. See
+ * docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md.
+ */
+
+import type { EntityWriteEvent, WatchEvent, WatchKind } from "./watch-events.js";
+
+export interface WatchHubOptions {
+  readonly maxEventsPerKey?: number;
+  readonly maxAgeMsPerKey?: number;
+  readonly bookmarkIntervalMs?: number;
+  readonly perClientOutboxCap?: number;
+  readonly now?: () => number;
+}
+
+interface KeyState {
+  counter: bigint;
+  ring: WatchEvent[];
+  insertedAt: number[];
+}
+
+const DEFAULT_MAX_EVENTS = 1024;
+const DEFAULT_MAX_AGE_MS = 5 * 60_000;
+const DEFAULT_BOOKMARK_INTERVAL_MS = 30_000;
+const DEFAULT_OUTBOX_CAP = 256;
+
+export class WatchHub {
+  private readonly state = new Map<string, KeyState>();
+  private readonly maxEventsPerKey: number;
+  private readonly maxAgeMsPerKey: number;
+  readonly bookmarkIntervalMs: number;
+  readonly perClientOutboxCap: number;
+  private readonly now: () => number;
+
+  constructor(opts: WatchHubOptions = {}) {
+    this.maxEventsPerKey = opts.maxEventsPerKey ?? DEFAULT_MAX_EVENTS;
+    this.maxAgeMsPerKey = opts.maxAgeMsPerKey ?? DEFAULT_MAX_AGE_MS;
+    this.bookmarkIntervalMs = opts.bookmarkIntervalMs ?? DEFAULT_BOOKMARK_INTERVAL_MS;
+    this.perClientOutboxCap = opts.perClientOutboxCap ?? DEFAULT_OUTBOX_CAP;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  recordWrite(event: EntityWriteEvent): bigint {
+    const key = this.key(event.namespace, event.kind);
+    const s = this.getOrCreate(key);
+    s.counter += 1n;
+    const watchEvent: WatchEvent = { ...event, rv: s.counter };
+    s.ring.push(watchEvent);
+    s.insertedAt.push(this.now());
+    this.trim(s);
+    return s.counter;
+  }
+
+  currentRv(namespace: string, kind: WatchKind): bigint {
+    return this.state.get(this.key(namespace, kind))?.counter ?? 0n;
+  }
+
+  /** Test-only inspector. Returns a copy. */
+  snapshotRing(namespace: string, kind: WatchKind): readonly WatchEvent[] {
+    const s = this.state.get(this.key(namespace, kind));
+    return s ? [...s.ring] : [];
+  }
+
+  private key(namespace: string, kind: WatchKind): string {
+    return `${namespace}\x00${kind}`;
+  }
+
+  private getOrCreate(key: string): KeyState {
+    let s = this.state.get(key);
+    if (!s) {
+      s = { counter: 0n, ring: [], insertedAt: [] };
+      this.state.set(key, s);
+    }
+    return s;
+  }
+
+  private trim(s: KeyState): void {
+    while (s.ring.length > this.maxEventsPerKey) {
+      s.ring.shift();
+      s.insertedAt.shift();
+    }
+    const cutoff = this.now() - this.maxAgeMsPerKey;
+    while (s.ring.length > 0 && (s.insertedAt[0] ?? 0) < cutoff) {
+      s.ring.shift();
+      s.insertedAt.shift();
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/watch-hub.test.ts`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/watch-hub.ts src/core/watch-hub.test.ts
+git commit -m "feat(watch): WatchHub ring buffer with count cap (#292)"
+```
+
+---
+
+### Task 5: Ring buffer age cap
+
+**Files:**
+- Modify: `src/core/watch-hub.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `describe("WatchHub ring buffer", ...)` block:
+
+```typescript
+  test("evicts events older than maxAgeMsPerKey", () => {
+    let clock = 1_000_000;
+    const hub = new WatchHub({
+      maxEventsPerKey: 1024,
+      maxAgeMsPerKey: 1_000,
+      now: () => clock,
+    });
+    hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: contributionToEntity(fixtureContribution("cid-old"), "ns/wt"),
+    });
+    clock += 5_000; // advance 5s past the 1s cap
+    hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: contributionToEntity(fixtureContribution("cid-new"), "ns/wt"),
+    });
+    const buffered = hub.snapshotRing("ns/wt", "Contribution");
+    expect(buffered.length).toBe(1);
+    expect(buffered[0]?.entity.id).toBe("cid-new");
+  });
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `bun test src/core/watch-hub.test.ts -t "evicts events older"`
+Expected: PASS — `trim()` already evicts by age. If FAIL, the implementation in Task 4 is incomplete; re-read it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/watch-hub.test.ts
+git commit -m "test(watch): ring buffer evicts by age (#292)"
+```
+
+---
+
+### Task 6: Subscribe with replay + StaleResourceVersionError
+
+**Files:**
+- Modify: `src/core/watch-hub.ts`
+- Modify: `src/core/watch-hub.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `watch-hub.test.ts`:
+
+```typescript
+describe("WatchHub.subscribe", () => {
+  test("replays events with rv > fromRv then tails new writes", async () => {
+    const hub = new WatchHub();
+    const ent = (cid: string) =>
+      contributionToEntity(fixtureContribution(cid), "ns/wt");
+    const rv1 = hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: ent("cid-1"),
+    });
+    hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: ent("cid-2"),
+    });
+
+    const ac = new AbortController();
+    const seen: bigint[] = [];
+    const stream = hub.subscribe("ns/wt", "Contribution", rv1, ac.signal);
+
+    const drain = (async () => {
+      for await (const ev of stream) {
+        seen.push(ev.rv);
+        if (seen.length === 2) ac.abort();
+      }
+    })();
+
+    // Tail event posted after subscribe
+    queueMicrotask(() => {
+      hub.recordWrite({
+        kind: "Contribution",
+        namespace: "ns/wt",
+        op: "ADDED",
+        entity: ent("cid-3"),
+      });
+    });
+
+    await drain;
+    expect(seen).toEqual([2n, 3n]);
+  });
+
+  test("throws StaleResourceVersionError when fromRv < ring.oldestRv", () => {
+    const hub = new WatchHub({ maxEventsPerKey: 2 });
+    const ent = (cid: string) =>
+      contributionToEntity(fixtureContribution(cid), "ns/wt");
+    for (const cid of ["a", "b", "c"]) {
+      hub.recordWrite({
+        kind: "Contribution",
+        namespace: "ns/wt",
+        op: "ADDED",
+        entity: ent(cid),
+      });
+    }
+    expect(() => {
+      const ac = new AbortController();
+      hub.subscribe("ns/wt", "Contribution", 0n, ac.signal);
+    }).toThrow("resourceVersion 0 is older than");
+  });
+});
+```
+
+Update the import line at the top of `watch-hub.test.ts`:
+```typescript
+import { StaleResourceVersionError, WatchHub } from "./watch-hub.js";
+```
+
+…wait — `StaleResourceVersionError` is exported from `watch-events.ts`. Use:
+```typescript
+import { WatchHub } from "./watch-hub.js";
+import { StaleResourceVersionError } from "./watch-events.js";
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `bun test src/core/watch-hub.test.ts -t "subscribe"`
+Expected: FAIL with `hub.subscribe is not a function`.
+
+- [ ] **Step 3: Implement subscribe**
+
+Add these imports at the top of `src/core/watch-hub.ts`:
+```typescript
+import { StaleResourceVersionError } from "./watch-events.js";
+```
+
+Add a private `Subscriber` type and `subscribe` method. Append inside the `WatchHub` class:
+
+```typescript
+  subscribe(
+    namespace: string,
+    kind: WatchKind,
+    fromRv: bigint,
+    signal: AbortSignal,
+  ): AsyncIterable<WatchEvent> {
+    const key = this.key(namespace, kind);
+    const s = this.getOrCreate(key);
+
+    // Determine oldest RV in the ring
+    const oldestRv = s.ring.length > 0 ? (s.ring[0] as WatchEvent).rv : 0n;
+    if (fromRv < oldestRv - 1n) {
+      // Subscribers are allowed to resume from rv == oldestRv - 1; that means
+      // "I have everything up through (oldestRv-1), give me oldestRv onward."
+      // Anything strictly older is unrecoverable — raise 410.
+      throw new StaleResourceVersionError(namespace, kind, fromRv, oldestRv);
+    }
+
+    const replay: WatchEvent[] = s.ring.filter((e) => e.rv > fromRv);
+
+    const subscriber: Subscriber = {
+      namespace,
+      kind,
+      queue: [...replay],
+      pending: null,
+      closed: false,
+      overflow: false,
+    };
+    this.subscribersFor(key).add(subscriber);
+
+    signal.addEventListener("abort", () => this.closeSubscriber(key, subscriber));
+
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => {
+          while (true) {
+            if (subscriber.overflow) {
+              this.closeSubscriber(key, subscriber);
+              throw new BufferOverflowError(namespace, kind);
+            }
+            if (subscriber.queue.length > 0) {
+              const value = subscriber.queue.shift() as WatchEvent;
+              return { value, done: false };
+            }
+            if (subscriber.closed) {
+              return { value: undefined as unknown as WatchEvent, done: true };
+            }
+            await new Promise<void>((resolve) => {
+              subscriber.pending = resolve;
+            });
+          }
+        },
+        return: async () => {
+          this.closeSubscriber(key, subscriber);
+          return { value: undefined as unknown as WatchEvent, done: true };
+        },
+      }),
+    };
+  }
+
+  private subscribersByKey = new Map<string, Set<Subscriber>>();
+
+  private subscribersFor(key: string): Set<Subscriber> {
+    let set = this.subscribersByKey.get(key);
+    if (!set) {
+      set = new Set();
+      this.subscribersByKey.set(key, set);
+    }
+    return set;
+  }
+
+  private fanout(key: string, event: WatchEvent): void {
+    const set = this.subscribersByKey.get(key);
+    if (!set) return;
+    for (const sub of set) {
+      if (sub.queue.length >= this.perClientOutboxCap) {
+        sub.overflow = true;
+      } else {
+        sub.queue.push(event);
+      }
+      sub.pending?.();
+      sub.pending = null;
+    }
+  }
+
+  private closeSubscriber(key: string, sub: Subscriber): void {
+    sub.closed = true;
+    sub.pending?.();
+    sub.pending = null;
+    this.subscribersByKey.get(key)?.delete(sub);
+  }
+```
+
+Update `recordWrite` to fan out:
+```typescript
+  recordWrite(event: EntityWriteEvent): bigint {
+    const key = this.key(event.namespace, event.kind);
+    const s = this.getOrCreate(key);
+    s.counter += 1n;
+    const watchEvent: WatchEvent = { ...event, rv: s.counter };
+    s.ring.push(watchEvent);
+    s.insertedAt.push(this.now());
+    this.trim(s);
+    this.fanout(key, watchEvent);
+    return s.counter;
+  }
+```
+
+Add at the bottom of the file:
+```typescript
+interface Subscriber {
+  readonly namespace: string;
+  readonly kind: WatchKind;
+  queue: WatchEvent[];
+  pending: (() => void) | null;
+  closed: boolean;
+  overflow: boolean;
+}
+
+export class BufferOverflowError extends Error {
+  readonly code = 503;
+  constructor(
+    public readonly namespace: string,
+    public readonly kind: WatchKind,
+  ) {
+    super(`watch outbox overflowed for ${namespace}/${kind}`);
+    this.name = "BufferOverflowError";
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/watch-hub.test.ts`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/watch-hub.ts src/core/watch-hub.test.ts
+git commit -m "feat(watch): subscribe with replay + stale-RV 410 (#292)"
+```
+
+---
+
+### Task 7: Per-client outbox overflow
+
+**Files:**
+- Modify: `src/core/watch-hub.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `watch-hub.test.ts`:
+
+```typescript
+describe("WatchHub overflow", () => {
+  test("slow consumer triggers BufferOverflowError after outbox cap exceeded", async () => {
+    const hub = new WatchHub({ perClientOutboxCap: 2 });
+    const ent = (cid: string) =>
+      contributionToEntity(fixtureContribution(cid), "ns/wt");
+
+    const ac = new AbortController();
+    const stream = hub.subscribe("ns/wt", "Contribution", 0n, ac.signal);
+
+    // Don't drain — let the queue fill up
+    for (let i = 0; i < 5; i++) {
+      hub.recordWrite({
+        kind: "Contribution",
+        namespace: "ns/wt",
+        op: "ADDED",
+        entity: ent(`cid-${i}`),
+      });
+    }
+
+    const it = stream[Symbol.asyncIterator]();
+    // First two reads return queued events
+    expect((await it.next()).value.rv).toBe(1n);
+    expect((await it.next()).value.rv).toBe(2n);
+    // Third read raises overflow because the producer has set the flag
+    await expect(it.next()).rejects.toThrow("watch outbox overflowed");
+  });
+});
+```
+
+Update import in test file:
+```typescript
+import { BufferOverflowError } from "./watch-hub.js";
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `bun test src/core/watch-hub.test.ts -t "overflow"`
+Expected: PASS — the overflow flag is set whenever `queue.length >= perClientOutboxCap` and a new event arrives, so the third event sets the flag, and the next `it.next()` throws.
+
+If it fails because the test sees three values instead of throwing, re-read the `fanout` method: events should be DROPPED (overflow true, no push) once the cap is reached, not appended.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/watch-hub.test.ts
+git commit -m "test(watch): outbox overflow raises BufferOverflowError (#292)"
+```
+
+---
+
+### Task 8: Bookmark cadence (timer-driven)
+
+**Files:**
+- Modify: `src/core/watch-hub.ts`
+- Modify: `src/core/watch-hub.test.ts`
+
+The hub itself does not own bookmark timers — those are per-stream and live in the SSE handler. But the hub exposes `bookmarkIntervalMs` so route code reads the policy from one place. Verify the option round-trips:
+
+- [ ] **Step 1: Write the test**
+
+Append to `watch-hub.test.ts`:
+
+```typescript
+describe("WatchHub config", () => {
+  test("exposes bookmarkIntervalMs and perClientOutboxCap from options", () => {
+    const hub = new WatchHub({ bookmarkIntervalMs: 5_000, perClientOutboxCap: 16 });
+    expect(hub.bookmarkIntervalMs).toBe(5_000);
+    expect(hub.perClientOutboxCap).toBe(16);
+  });
+
+  test("defaults bookmarkIntervalMs to 30000", () => {
+    const hub = new WatchHub();
+    expect(hub.bookmarkIntervalMs).toBe(30_000);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test src/core/watch-hub.test.ts -t "config"`
+Expected: PASS — both fields are public readonly on the class from Task 4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/watch-hub.test.ts
+git commit -m "test(watch): expose bookmarkIntervalMs config (#292)"
+```
+
+---
+
+## Phase 2 — Wire `onEntityWrite` for Contribution
+
+### Task 9: Add `onEntityWrite` field to OperationDeps
+
+**Files:**
+- Modify: `src/core/operations/deps.ts`
+
+- [ ] **Step 1: Edit the interface**
+
+Use Edit to change `src/core/operations/deps.ts`:
+
+Replace this comment + field block:
+```typescript
+  /** Called after a contribution is written, receiving the CID. Used for session tagging. */
+  readonly onContributionWritten?: ((cid: string) => void) | undefined;
+```
+
+With:
+```typescript
+  /** Called after a contribution is written, receiving the CID. Used for session tagging. */
+  readonly onContributionWritten?: ((cid: string) => void) | undefined;
+  /**
+   * Called after any Entity (#287) write, with the kind, namespace, op, and
+   * projected envelope. Drives the watch protocol (#292) — grove-server wires
+   * this into WatchHub.recordWrite. Heartbeat-only Claim writes that change
+   * neither status nor the lease-expiry boundary do not fire this hook.
+   */
+  readonly onEntityWrite?:
+    | ((event: import("../watch-events.js").EntityWriteEvent) => void)
+    | undefined;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/operations/deps.ts
+git commit -m "feat(watch): add onEntityWrite hook to OperationDeps (#292)"
+```
+
+---
+
+### Task 10: Fire `onEntityWrite` from contribute operation
+
+**Files:**
+- Modify: `src/core/operations/contribute.ts`
+
+- [ ] **Step 1: Locate the existing fire site**
+
+Open `src/core/operations/contribute.ts` and find lines 1204–1216 (the `try { deps.onContributionWrite?.(); deps.onContributionWritten?.(...) } catch {...}` block).
+
+- [ ] **Step 2: Locate the namespace source**
+
+Find where `namespace` is available in the operation. Search for `namespace` in `contribute.ts`. The operation does not currently take a namespace — it is a per-server concept set by middleware. The cleanest source is `deps.onEntityWriteNamespace` or a new field. Use this approach: add a `deps.namespace?: string` lookup at the call site, and only fire `onEntityWrite` when both `onEntityWrite` and a namespace are available.
+
+In the same file, add a helper near the top (after imports):
+
+```typescript
+import { contributionToEntity } from "../entity.js";
+```
+
+- [ ] **Step 3: Replace the post-write callback block**
+
+Replace:
+```typescript
+    try {
+      deps.onContributionWrite?.();
+      deps.onContributionWritten?.(contribution.cid);
+    } catch (callbackErr) {
+      process.stderr.write(
+        `[grove] Warning: onContributionWrite* callback threw after commit: ${
+          callbackErr instanceof Error ? callbackErr.message : String(callbackErr)
+        }\n`,
+      );
+    }
+```
+
+With:
+```typescript
+    try {
+      deps.onContributionWrite?.();
+      deps.onContributionWritten?.(contribution.cid);
+      if (deps.onEntityWrite && deps.namespace) {
+        deps.onEntityWrite({
+          kind: "Contribution",
+          namespace: deps.namespace,
+          op: "ADDED",
+          entity: contributionToEntity(contribution, deps.namespace),
+        });
+      }
+    } catch (callbackErr) {
+      process.stderr.write(
+        `[grove] Warning: post-commit callback threw after contribution commit: ${
+          callbackErr instanceof Error ? callbackErr.message : String(callbackErr)
+        }\n`,
+      );
+    }
+```
+
+- [ ] **Step 4: Add `namespace` to OperationDeps**
+
+In `src/core/operations/deps.ts`, append after the `onEntityWrite` field:
+
+```typescript
+  /**
+   * Namespace under which this operation runs. Required to fire
+   * `onEntityWrite` (the watch protocol scopes events per-namespace). When
+   * absent (e.g. legacy callers without auth context), the watch hook is
+   * skipped — operations remain functional.
+   */
+  readonly namespace?: string | undefined;
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 6: Run existing contribute tests to confirm no regression**
+
+Run: `bun test src/core/operations/contribute.test.ts`
+Expected: All tests still pass — the new branch only fires when both `onEntityWrite` and `namespace` are set, and existing tests set neither.
+
+- [ ] **Step 7: Add a focused test**
+
+Append to `src/core/operations/contribute.test.ts` inside the most appropriate `describe` block (look for a "post-write" or "callbacks" group; if none, add one at the end of the file):
+
+```typescript
+describe("contribute → onEntityWrite", () => {
+  test("fires onEntityWrite with the projected ContributionEntity", async () => {
+    const events: Array<{ kind: string; op: string; cid: string }> = [];
+    const deps = makeContributeTestDeps({
+      onEntityWrite: (e) =>
+        events.push({ kind: e.kind, op: e.op, cid: e.entity.id }),
+      namespace: "ns/wt",
+    });
+    const result = await contributeOperation(makeContributeInput(), deps);
+    expect(result.ok).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: "Contribution", op: "ADDED" });
+  });
+
+  test("skips onEntityWrite when namespace is missing", async () => {
+    const events: unknown[] = [];
+    const deps = makeContributeTestDeps({
+      onEntityWrite: (e) => events.push(e),
+      // no namespace
+    });
+    const result = await contributeOperation(makeContributeInput(), deps);
+    expect(result.ok).toBe(true);
+    expect(events).toHaveLength(0);
+  });
+});
+```
+
+You will need `makeContributeTestDeps` and `makeContributeInput` helpers — these likely exist already in `src/core/operations/test-helpers.ts` or `contribute.test.ts`. If a similar helper exists under a different name, use that instead. If neither exists, define minimal versions inline using the patterns already in `contribute.test.ts`.
+
+- [ ] **Step 8: Run the new test**
+
+Run: `bun test src/core/operations/contribute.test.ts -t "onEntityWrite"`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/core/operations/contribute.ts src/core/operations/deps.ts src/core/operations/contribute.test.ts
+git commit -m "feat(watch): contribute fires onEntityWrite for Contribution (#292)"
+```
+
+---
+
+## Phase 3 — HTTP routes
+
+### Task 11: ServerDeps + watch route scaffold
+
+**Files:**
+- Modify: `src/server/deps.ts`
+- Create: `src/server/routes/watch.ts`
+- Modify: `src/server/app.ts`
+
+- [ ] **Step 1: Add `watchHub` to ServerDeps**
+
+In `src/server/deps.ts`, add the import:
+```typescript
+import type { WatchHub } from "../core/watch-hub.js";
+```
+
+Add the field at the end of the `ServerDeps` interface:
+```typescript
+  /** Watch hub for list→watch handshake (#292). */
+  readonly watchHub: WatchHub;
+```
+
+- [ ] **Step 2: Add `watchHub` to all server-construction sites**
+
+Run: `grep -rn "ServerDeps\b" src/ test/ tests/`
+
+Every constructor or test helper that builds a `ServerDeps` literal will now fail typecheck because `watchHub` is required. For each match, add `watchHub: new WatchHub()` (importing from `"../core/watch-hub.js"` adjusted to the file's path). The most likely sites are:
+- `src/server/serve.ts`
+- `src/server/test-helpers.ts`
+- `src/server/e2e.test.ts`
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS. Fix any remaining missing-`watchHub` literals.
+
+- [ ] **Step 4: Create watch route file**
+
+Create `src/server/routes/watch.ts`:
+
+```typescript
+/**
+ * Watch protocol endpoints (#292).
+ *
+ * GET /api/list?kind=<kind>      — list snapshot with listResourceVersion
+ * GET /api/watch?kind=<kind>&resumeFrom=<rv> — SSE stream
+ *
+ * Both endpoints sit behind the existing /api/* namespaceAuth middleware
+ * (#290), so namespace is always read from `c.get("namespace")` — never
+ * from query or path params.
+ */
+
+import { zValidator } from "@hono/zod-validator";
+import type { Hono as HonoType } from "hono";
+import { Hono } from "hono";
+import { z } from "zod";
+import type { WatchKind } from "../../core/watch-events.js";
+import {
+  BufferOverflowError,
+  type WatchHub,
+} from "../../core/watch-hub.js";
+import { StaleResourceVersionError } from "../../core/watch-events.js";
+import type { ServerEnv } from "../deps.js";
+
+const KIND_VALUES = ["Contribution", "Claim", "AgentSession"] as const;
+
+const listQuerySchema = z.object({
+  kind: z.enum(KIND_VALUES),
+});
+
+const watchQuerySchema = z.object({
+  kind: z.enum(KIND_VALUES),
+  resumeFrom: z.string().regex(/^[0-9]+$/, "resumeFrom must be a non-negative integer"),
+});
+
+const watch: HonoType<ServerEnv> = new Hono<ServerEnv>();
+
+/** GET /api/list?kind=X */
+watch.get("/list", zValidator("query", listQuerySchema), async (c) => {
+  const namespace = c.get("namespace");
+  const { kind } = c.req.valid("query");
+  const deps = c.get("deps");
+  const hub: WatchHub = deps.watchHub;
+
+  // Race-correctness invariant: capture RV BEFORE the list query.
+  const listRv = hub.currentRv(namespace, kind as WatchKind);
+  const items = await listForKind(deps, namespace, kind as WatchKind);
+
+  return c.json({ items, listResourceVersion: String(listRv) });
+});
+
+/** GET /api/watch?kind=X&resumeFrom=Y — SSE stream. */
+watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
+  const namespace = c.get("namespace");
+  const { kind, resumeFrom } = c.req.valid("query");
+  const lastEventId = c.req.header("last-event-id");
+  const fromRv = BigInt(lastEventId ?? resumeFrom);
+  const hub: WatchHub = c.get("deps").watchHub;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      const ac = new AbortController();
+      let bookmarkTimer: ReturnType<typeof setInterval> | null = null;
+
+      const send = (event: string, data: unknown, id?: string) => {
+        const payload = `id: ${id ?? ""}\nevent: ${event}\ndata: ${JSON.stringify(
+          data,
+        )}\n\n`;
+        controller.enqueue(encoder.encode(payload));
+      };
+
+      const closeWithError = (code: number, reason: string) => {
+        send("ERROR", { code, reason });
+        cleanup();
+      };
+
+      const cleanup = () => {
+        if (bookmarkTimer) clearInterval(bookmarkTimer);
+        bookmarkTimer = null;
+        ac.abort();
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+      };
+
+      let iterable: AsyncIterable<import("../../core/watch-events.js").WatchEvent>;
+      try {
+        iterable = hub.subscribe(namespace, kind as WatchKind, fromRv, ac.signal);
+      } catch (err) {
+        if (err instanceof StaleResourceVersionError) {
+          closeWithError(410, "expired");
+          return;
+        }
+        throw err;
+      }
+
+      bookmarkTimer = setInterval(() => {
+        send("BOOKMARK", { rv: String(hub.currentRv(namespace, kind as WatchKind)) });
+      }, hub.bookmarkIntervalMs);
+      // Allow the process to exit when only this timer is pending
+      (bookmarkTimer as unknown as { unref?: () => void }).unref?.();
+
+      (async () => {
+        try {
+          for await (const ev of iterable) {
+            send(ev.op, { kind: ev.kind, entity: ev.entity }, String(ev.rv));
+          }
+          cleanup();
+        } catch (err) {
+          if (err instanceof BufferOverflowError) {
+            closeWithError(503, "buffer_overflow");
+          } else {
+            closeWithError(500, "internal_error");
+          }
+        }
+      })();
+
+      // Abort when the client disconnects.
+      c.req.raw.signal.addEventListener("abort", cleanup);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+});
+
+async function listForKind(
+  deps: ServerEnv["Variables"]["deps"],
+  namespace: string,
+  kind: WatchKind,
+): Promise<readonly unknown[]> {
+  switch (kind) {
+    case "Contribution":
+      return deps.contributionStore.listEntities();
+    case "Claim":
+      return deps.claimStore.listEntities();
+    case "AgentSession":
+      // AgentSession listing is not yet a Store API. Return empty until the
+      // session-orchestrator integration lands (out of scope for #292).
+      return [];
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      void namespace;
+      return [];
+    }
+  }
+}
+
+export { watch };
+```
+
+- [ ] **Step 5: Verify Claim store has listEntities**
+
+Run: `grep -n "listEntities" src/core/store.ts`
+Expected: matches at lines 197 (Contribution) and 333 (Claim). Both return Entity-projected arrays. If Claim is missing, this plan needs an upstream fix — pause and report.
+
+- [ ] **Step 6: Mount the route**
+
+In `src/server/app.ts`, add the import:
+```typescript
+import { watch } from "./routes/watch.js";
+```
+
+Add a mount after `app.route("/api/handoffs", handoffs);`:
+```typescript
+  app.route("/api", watch);
+```
+
+This mounts `/api/list` and `/api/watch` (the route module uses absolute sub-paths).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS. Address any remaining `ServerDeps` literals missing `watchHub`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/server/deps.ts src/server/app.ts src/server/routes/watch.ts src/server/serve.ts src/server/test-helpers.ts
+git commit -m "feat(watch): /api/list and /api/watch SSE routes (#292)"
+```
+
+---
+
+### Task 12: Server-side WatchHub instantiation + onEntityWrite wiring
+
+**Files:**
+- Modify: `src/server/serve.ts`
+
+- [ ] **Step 1: Import WatchHub**
+
+Add to the imports at the top of `src/server/serve.ts`:
+```typescript
+import { WatchHub } from "../core/watch-hub.js";
+```
+
+- [ ] **Step 2: Construct the hub at startup**
+
+After `const runtime = createLocalRuntime(...)` and before stores are constructed, add:
+```typescript
+const watchHub = new WatchHub();
+```
+
+- [ ] **Step 3: Pass `watchHub` into `ServerDeps`**
+
+Find the `ServerDeps` literal in `serve.ts` and add `watchHub` to it.
+
+- [ ] **Step 4: Wire `onEntityWrite` into operations deps**
+
+Find where `OperationDeps` is constructed for HTTP requests. The current pattern lives in `src/server/operation-adapter.ts`. Open it, locate `toOperationDeps(serverDeps)`, and append two fields to the returned object:
+```typescript
+    onEntityWrite: (event) => serverDeps.watchHub.recordWrite(event),
+    // namespace is set per-request by the route handler — see watch.ts
+    // and contributions.ts. operation-adapter only fills the static fields.
+```
+
+- [ ] **Step 5: Inject namespace per-request in contribute route**
+
+In `src/server/routes/contributions.ts`, find the `contributeOperation(input, opDeps)` call. Modify the `opDeps` construction to include the namespace:
+```typescript
+  let opDeps = toOperationDeps(serverDeps);
+  opDeps = { ...opDeps, namespace: c.get("namespace") };
+```
+
+- [ ] **Step 6: Typecheck and run server tests**
+
+Run: `bunx tsc --noEmit && bun test src/server/`
+Expected: All pre-existing server tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/server/serve.ts src/server/operation-adapter.ts src/server/routes/contributions.ts
+git commit -m "feat(watch): wire WatchHub + onEntityWrite in serve (#292)"
+```
+
+---
+
+## Phase 4 — Integration tests
+
+### Task 13: List endpoint integration test
+
+**Files:**
+- Create: `src/server/watch.integration.test.ts`
+
+- [ ] **Step 1: Inspect existing test helpers**
+
+Open `src/server/test-helpers.ts` and look for a function like `createTestApp(deps)` or similar that builds a Hono app with auth bypassed or with a known bearer token. Use whichever pattern is established. If the helpers already support contribution submission, reuse them.
+
+- [ ] **Step 2: Write the test**
+
+```typescript
+// src/server/watch.integration.test.ts
+import { describe, expect, test } from "bun:test";
+import { createTestApp, postContribution, withAuth } from "./test-helpers.js";
+
+describe("GET /api/list", () => {
+  test("returns items with listResourceVersion = 0 for an empty namespace", async () => {
+    const { app } = await createTestApp();
+    const res = await app.request("/api/list?kind=Contribution", {
+      headers: withAuth(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items).toEqual([]);
+    expect(body.listResourceVersion).toBe("0");
+  });
+
+  test("listResourceVersion advances after a write", async () => {
+    const { app } = await createTestApp();
+    await postContribution(app, { summary: "first" });
+    const res = await app.request("/api/list?kind=Contribution", {
+      headers: withAuth(),
+    });
+    const body = await res.json();
+    expect(body.items.length).toBe(1);
+    expect(BigInt(body.listResourceVersion)).toBeGreaterThan(0n);
+  });
+
+  test("400 on missing kind", async () => {
+    const { app } = await createTestApp();
+    const res = await app.request("/api/list", { headers: withAuth() });
+    expect(res.status).toBe(400);
+  });
+
+  test("401 without auth", async () => {
+    const { app } = await createTestApp();
+    const res = await app.request("/api/list?kind=Contribution");
+    expect([400, 401]).toContain(res.status);
+  });
+});
+```
+
+If `createTestApp`, `postContribution`, or `withAuth` is not present under those exact names, adapt to the actual helpers. The patterns to follow are visible in `src/server/e2e.test.ts` and `src/server/namespace-isolation.test.ts`.
+
+- [ ] **Step 3: Run test**
+
+Run: `bun test src/server/watch.integration.test.ts`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/watch.integration.test.ts
+git commit -m "test(watch): list endpoint integration (#292)"
+```
+
+---
+
+### Task 14: Watch endpoint streams writes
+
+**Files:**
+- Modify: `src/server/watch.integration.test.ts`
+
+- [ ] **Step 1: Add a streaming helper**
+
+At the top of the test file, add a helper that drains an SSE stream into structured events:
+
+```typescript
+async function readSseEvents(
+  res: Response,
+  stopAfter: number,
+  timeoutMs = 2_000,
+): Promise<Array<{ id: string; event: string; data: unknown }>> {
+  const events: Array<{ id: string; event: string; data: unknown }> = [];
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  const deadline = Date.now() + timeoutMs;
+  while (events.length < stopAfter && Date.now() < deadline) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf("\n\n")) >= 0) {
+      const block = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+      const id = /^id: (.*)$/m.exec(block)?.[1] ?? "";
+      const event = /^event: (.*)$/m.exec(block)?.[1] ?? "";
+      const dataLine = /^data: (.*)$/m.exec(block)?.[1] ?? "null";
+      events.push({ id, event, data: JSON.parse(dataLine) });
+    }
+  }
+  await reader.cancel();
+  return events;
+}
+```
+
+- [ ] **Step 2: Write the streaming test**
+
+```typescript
+describe("GET /api/watch", () => {
+  test("streams ADDED events for writes after subscribe", async () => {
+    const { app } = await createTestApp();
+    const list = await app
+      .request("/api/list?kind=Contribution", { headers: withAuth() })
+      .then((r) => r.json());
+    const watchRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+      { headers: withAuth() },
+    );
+    expect(watchRes.status).toBe(200);
+    expect(watchRes.headers.get("content-type")).toMatch(/text\/event-stream/);
+
+    const writePromise = postContribution(app, { summary: "live-1" });
+    const events = await readSseEvents(watchRes, 1);
+    await writePromise;
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events[0]?.event).toBe("ADDED");
+  });
+});
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `bun test src/server/watch.integration.test.ts -t "streams ADDED"`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/watch.integration.test.ts
+git commit -m "test(watch): SSE streams ADDED events post-subscribe (#292)"
+```
+
+---
+
+### Task 15: Watch endpoint emits 410 on stale RV
+
+**Files:**
+- Modify: `src/server/watch.integration.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+  test("ERROR 410 when resumeFrom is older than ring oldestRv", async () => {
+    // Hub is constructed by serve.ts with default cap 1024. We simulate stale
+    // by forcing the ring to evict via a custom hub. The cleanest way is for
+    // createTestApp to accept a `watchHub` override.
+    const { app, watchHub } = await createTestApp({
+      watchHubOptions: { maxEventsPerKey: 2 },
+    });
+    await postContribution(app, { summary: "a" });
+    await postContribution(app, { summary: "b" });
+    await postContribution(app, { summary: "c" }); // evicts a
+    const res = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=0`,
+      { headers: withAuth() },
+    );
+    const events = await readSseEvents(res, 1);
+    expect(events[0]?.event).toBe("ERROR");
+    expect((events[0]?.data as { code: number }).code).toBe(410);
+    void watchHub; // reference so the option-override branch is exercised
+  });
+```
+
+- [ ] **Step 2: Extend `createTestApp` to accept `watchHubOptions`**
+
+Edit `src/server/test-helpers.ts`. Find the `createTestApp` function (or equivalent). Add a `watchHubOptions?: WatchHubOptions` parameter that constructs a custom `WatchHub` and exposes it on the return value.
+
+```typescript
+import { WatchHub, type WatchHubOptions } from "../core/watch-hub.js";
+
+export async function createTestApp(
+  opts: { watchHubOptions?: WatchHubOptions } = {},
+): Promise<{ app: Hono<ServerEnv>; watchHub: WatchHub /* ...existing fields */ }> {
+  // ...
+  const watchHub = new WatchHub(opts.watchHubOptions);
+  // ...
+  return { app, watchHub /* ...existing fields */ };
+}
+```
+
+If `createTestApp` is named differently or has a different shape, adapt accordingly — keep the option additive.
+
+- [ ] **Step 3: Run test**
+
+Run: `bun test src/server/watch.integration.test.ts -t "ERROR 410"`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/watch.integration.test.ts src/server/test-helpers.ts
+git commit -m "test(watch): 410 on stale resumeFrom (#292)"
+```
+
+---
+
+## Phase 5 — Acceptance tests
+
+### Task 16: Handshake-race acceptance test (issue criterion #2)
+
+**Files:**
+- Create: `src/server/watch.race.test.ts`
+- Modify: `src/server/routes/watch.ts` (add a test-only injection point)
+
+- [ ] **Step 1: Add an injection point on the watch route**
+
+The race test needs to inject a delay between `hub.currentRv()` and `store.listEntities()` to widen the handshake window. Add an env-gated hook to `src/server/routes/watch.ts`:
+
+In the `/list` handler, replace:
+```typescript
+  const listRv = hub.currentRv(namespace, kind as WatchKind);
+  const items = await listForKind(deps, namespace, kind as WatchKind);
+```
+
+With:
+```typescript
+  const listRv = hub.currentRv(namespace, kind as WatchKind);
+  const delayMs = Number(process.env.GROVE_WATCH_LIST_DELAY_MS);
+  if (Number.isFinite(delayMs) && delayMs > 0) {
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  const items = await listForKind(deps, namespace, kind as WatchKind);
+```
+
+`GROVE_WATCH_LIST_DELAY_MS` is a test-only knob, set only in this acceptance test. The delay defaults to 0 in production.
+
+- [ ] **Step 2: Write the test**
+
+```typescript
+// src/server/watch.race.test.ts
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createTestApp, postContribution, withAuth } from "./test-helpers.js";
+
+describe("watch handshake-race (issue #292 acceptance #2)", () => {
+  beforeEach(() => {
+    process.env.GROVE_WATCH_LIST_DELAY_MS = "100";
+  });
+  afterEach(() => {
+    delete process.env.GROVE_WATCH_LIST_DELAY_MS;
+  });
+
+  test("writes between list-return and watch-open are all replayed", async () => {
+    const { app } = await createTestApp();
+
+    // Begin list (will block 100ms inside the handler)
+    const listPromise = app
+      .request("/api/list?kind=Contribution", { headers: withAuth() })
+      .then((r) => r.json());
+
+    // Inject 50 concurrent writes during the list delay window
+    await new Promise((r) => setTimeout(r, 10)); // ensure list is mid-flight
+    const N = 50;
+    const writes = await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        postContribution(app, { summary: `race-${i}` }),
+      ),
+    );
+    const list = await listPromise;
+    const writtenIds = new Set(writes.map((w) => w.cid));
+
+    // Open watch from the listResourceVersion
+    const watchRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+      { headers: withAuth() },
+    );
+    const events = await readSseEvents(watchRes, N, 5_000);
+    const watchedIds = new Set(
+      events
+        .filter((e) => e.event === "ADDED")
+        .map((e) => (e.data as { entity: { id: string } }).entity.id),
+    );
+    for (const id of writtenIds) {
+      expect(watchedIds.has(id)).toBe(true);
+    }
+  });
+});
+
+// (readSseEvents helper defined in watch.integration.test.ts; copy or
+// extract to a shared util — see Task 14 step 1.)
+```
+
+If the helper extraction is preferred (it is — DRY), do this Step 2.5:
+
+- [ ] **Step 2.5: Extract `readSseEvents` to `src/server/sse-test-utils.ts`**
+
+Create `src/server/sse-test-utils.ts` with the helper from Task 14, then import it in both `watch.integration.test.ts` and `watch.race.test.ts`.
+
+- [ ] **Step 3: Run the race test**
+
+Run: `bun test src/server/watch.race.test.ts`
+Expected: PASS — every cid in the write set surfaces on the watch stream.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/watch.race.test.ts src/server/routes/watch.ts src/server/sse-test-utils.ts src/server/watch.integration.test.ts
+git commit -m "test(watch): handshake-race acceptance — writes between list and watch all replayed (#292)"
+```
+
+---
+
+### Task 17: Kill-9 mid-stream resume test (issue criterion #1)
+
+**Files:**
+- Create: `src/server/watch.kill.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+// src/server/watch.kill.test.ts
+import { describe, expect, test } from "bun:test";
+import { createTestApp, postContribution, withAuth } from "./test-helpers.js";
+import { readSseEvents } from "./sse-test-utils.js";
+
+describe("watch kill-9 resume (issue #292 acceptance #1)", () => {
+  test("reconnect with stored RV → zero missed events", async () => {
+    const { app } = await createTestApp();
+    const list = await app
+      .request("/api/list?kind=Contribution", { headers: withAuth() })
+      .then((r) => r.json());
+
+    // First connection: read one BOOKMARK, then abort to simulate kill-9
+    const ac = new AbortController();
+    const firstRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+      { headers: withAuth(), signal: ac.signal },
+    );
+
+    // Force one BOOKMARK by emitting at a fast cadence is server-side, so
+    // we instead capture the implicit fromRv the client would store: the
+    // listResourceVersion already represents the checkpoint. Abort now.
+    ac.abort();
+    void firstRes;
+
+    // Write 20 events while disconnected
+    const writes = await Promise.all(
+      Array.from({ length: 20 }, (_, i) =>
+        postContribution(app, { summary: `kill-${i}` }),
+      ),
+    );
+    const writtenIds = new Set(writes.map((w) => w.cid));
+
+    // Reconnect with the same resumeFrom
+    const secondRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+      { headers: withAuth() },
+    );
+    const events = await readSseEvents(secondRes, 20, 3_000);
+    const watchedIds = new Set(
+      events
+        .filter((e) => e.event === "ADDED")
+        .map((e) => (e.data as { entity: { id: string } }).entity.id),
+    );
+    for (const id of writtenIds) {
+      expect(watchedIds.has(id)).toBe(true);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/watch.kill.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/server/watch.kill.test.ts
+git commit -m "test(watch): kill-9 resume — zero missed events (#292)"
+```
+
+---
+
+### Task 18: Bookmark cadence test (issue criterion #3)
+
+**Files:**
+- Create: `src/server/watch.bookmark.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+// src/server/watch.bookmark.test.ts
+import { describe, expect, test } from "bun:test";
+import { createTestApp, withAuth } from "./test-helpers.js";
+import { readSseEvents } from "./sse-test-utils.js";
+
+describe("watch BOOKMARK cadence (issue #292 acceptance #3)", () => {
+  test("emits BOOKMARK at least once within bookmarkInterval", async () => {
+    const { app } = await createTestApp({
+      watchHubOptions: { bookmarkIntervalMs: 200 },
+    });
+    const list = await app
+      .request("/api/list?kind=Contribution", { headers: withAuth() })
+      .then((r) => r.json());
+    const res = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+      { headers: withAuth() },
+    );
+    const events = await readSseEvents(res, 1, 1_000);
+    expect(events[0]?.event).toBe("BOOKMARK");
+    expect(typeof (events[0]?.data as { rv: string }).rv).toBe("string");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/watch.bookmark.test.ts`
+Expected: PASS within ~200–250ms.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/server/watch.bookmark.test.ts
+git commit -m "test(watch): BOOKMARK cadence acceptance (#292)"
+```
+
+---
+
+## Phase 6 — Wire Claim operations
+
+### Task 19: Fire `onEntityWrite` from claim operation (status changes only)
+
+**Files:**
+- Modify: `src/core/operations/claim.ts`
+- Modify: `src/core/operations/claim.test.ts`
+
+- [ ] **Step 1: Read the current claim operation**
+
+Run: `grep -n "claimOrRenew\|export async function" src/core/operations/claim.ts`
+
+Identify the post-commit point — typically after `await deps.claimStore.claimOrRenew(...)` returns.
+
+- [ ] **Step 2: Add status-change tracking**
+
+After the claim is created/renewed, capture the prior persisted phase (if any) and project the new claim to its Entity. Fire `onEntityWrite` only when the persisted phase changed OR this is a fresh claim (`prior === undefined`). Skip when only `heartbeatAt` / `leaseExpiresAt` advanced — those are noise.
+
+Add the import:
+```typescript
+import { claimToEntity } from "../entity.js";
+```
+
+Replace the relevant section (sketch — adapt to actual code):
+```typescript
+  const prior = await deps.claimStore.getClaim(claim.claimId);
+  const result = await deps.claimStore.claimOrRenew(claim);
+  const phaseChanged = !prior || prior.status !== result.status;
+  if (phaseChanged && deps.onEntityWrite && deps.namespace) {
+    deps.onEntityWrite({
+      kind: "Claim",
+      namespace: deps.namespace,
+      op: prior ? "MODIFIED" : "ADDED",
+      entity: claimToEntity(result, () => Date.now(), deps.namespace),
+    });
+  }
+```
+
+- [ ] **Step 3: Add the test**
+
+Append to `src/core/operations/claim.test.ts`:
+
+```typescript
+describe("claimOrRenew → onEntityWrite", () => {
+  test("fires ADDED on first claim, MODIFIED on status change", async () => {
+    const events: Array<{ op: string; phase: string }> = [];
+    const deps = makeClaimTestDeps({
+      onEntityWrite: (e) =>
+        events.push({
+          op: e.op,
+          phase: (e.entity as { status: { phase: string } }).status.phase,
+        }),
+      namespace: "ns/wt",
+    });
+
+    await claimOperation({ targetRef: "t1", agent: { agentId: "a" } }, deps);
+    await deps.claimStore.complete((await deps.claimStore.activeClaims())[0]!.claimId);
+    // Re-emit by calling the operation again with a fresh claim
+    await claimOperation({ targetRef: "t1", agent: { agentId: "a" } }, deps);
+
+    expect(events.map((e) => e.op)).toEqual(["ADDED", /* complete fires via store, not op */ "ADDED"]);
+  });
+
+  test("does NOT fire when only heartbeat advances", async () => {
+    const events: unknown[] = [];
+    const deps = makeClaimTestDeps({
+      onEntityWrite: (e) => events.push(e),
+      namespace: "ns/wt",
+    });
+    await claimOperation({ targetRef: "t1", agent: { agentId: "a" } }, deps);
+    const before = events.length;
+    // Direct heartbeat — bypasses the operation, so no hook fires
+    await deps.claimStore.heartbeat((await deps.claimStore.activeClaims())[0]!.claimId);
+    expect(events.length).toBe(before);
+  });
+});
+```
+
+`makeClaimTestDeps` follows the same pattern as `makeContributeTestDeps` from Task 10. Reuse if it exists; define inline if not.
+
+> Note: `complete` and `release` are direct store calls, not part of `claimOperation`. To fire `onEntityWrite` for those transitions in this MVP, the simplest path is to subscribe at the store wrapper layer — covered by Phase 7 (Nexus catch-all). Local-only flows that bypass Nexus will not see Claim MODIFIED/DELETED events until a follow-up. This is documented in the spec's "future work" section.
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/operations/claim.test.ts -t "onEntityWrite"`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/operations/claim.ts src/core/operations/claim.test.ts
+git commit -m "feat(watch): claim operation fires onEntityWrite on phase change (#292)"
+```
+
+---
+
+## Phase 7 — Nexus catch-all (cross-process writes)
+
+### Task 20: NexusWatchPublisher
+
+**Files:**
+- Create: `src/nexus/nexus-watch-publisher.ts`
+
+- [ ] **Step 1: Write the file**
+
+```typescript
+/**
+ * NexusWatchPublisher — publishes lightweight `entity.changed` envelopes to
+ * the Nexus event-bus when entities are written through Nexus stores.
+ *
+ * The grove-server's NexusWatchSubscriber consumes these, dedupes against
+ * the in-process onEntityWrite fast path, fetches the full entity, and
+ * calls WatchHub.recordWrite. See spec §RV authority.
+ */
+
+import type { EventBus } from "../core/event-bus.js";
+import type { WatchKind, WatchOp } from "../core/watch-events.js";
+
+const ENTITY_CHANGED_TOPIC = "entity.changed";
+
+export interface EntityChangedEnvelope {
+  readonly kind: WatchKind;
+  readonly namespace: string;
+  readonly op: WatchOp;
+  readonly entityId: string;
+  readonly generation: number;
+  readonly emittedAt: string;
+}
+
+export class NexusWatchPublisher {
+  constructor(private readonly bus: EventBus) {}
+
+  async publish(envelope: EntityChangedEnvelope): Promise<void> {
+    await this.bus.publish({
+      type: ENTITY_CHANGED_TOPIC,
+      sourceRole: "grove-store",
+      targetRole: "*",
+      payload: { ...envelope },
+      timestamp: envelope.emittedAt,
+    });
+  }
+}
+
+export const ENTITY_CHANGED = ENTITY_CHANGED_TOPIC;
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/nexus/nexus-watch-publisher.ts
+git commit -m "feat(watch): NexusWatchPublisher for entity.changed envelopes (#292)"
+```
+
+---
+
+### Task 21: NexusWatchSubscriber
+
+**Files:**
+- Create: `src/nexus/nexus-watch-subscriber.ts`
+- Create: `src/nexus/nexus-watch-subscriber.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/nexus/nexus-watch-subscriber.test.ts
+import { describe, expect, test } from "bun:test";
+import { LocalEventBus } from "../core/local-event-bus.js";
+import { WatchHub } from "../core/watch-hub.js";
+import {
+  ENTITY_CHANGED,
+  NexusWatchPublisher,
+} from "./nexus-watch-publisher.js";
+import { NexusWatchSubscriber } from "./nexus-watch-subscriber.js";
+
+describe("NexusWatchSubscriber", () => {
+  test("forwards entity.changed envelopes to WatchHub", async () => {
+    const bus = new LocalEventBus();
+    const hub = new WatchHub();
+    const fetcher = async (kind: string, ns: string, id: string) => ({
+      kind,
+      namespace: ns,
+      id,
+      spec: {},
+      status: {},
+      conditions: [],
+      observedGeneration: 0,
+      resourceVersion: "1",
+      metadata: { generation: 1 },
+    });
+    const sub = new NexusWatchSubscriber({ bus, hub, fetchEntity: fetcher });
+    sub.start();
+
+    const pub = new NexusWatchPublisher(bus);
+    await pub.publish({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entityId: "cid-1",
+      generation: 1,
+      emittedAt: new Date().toISOString(),
+    });
+
+    // Allow microtask flush
+    await new Promise((r) => setImmediate(r));
+    expect(hub.currentRv("ns/wt", "Contribution")).toBe(1n);
+  });
+
+  test("dedupes within window when (kind, id, generation) repeats", async () => {
+    const bus = new LocalEventBus();
+    const hub = new WatchHub();
+    let fetched = 0;
+    const fetcher = async (kind: string, ns: string, id: string) => {
+      fetched += 1;
+      return {
+        kind,
+        namespace: ns,
+        id,
+        spec: {},
+        status: {},
+        conditions: [],
+        observedGeneration: 0,
+        resourceVersion: "1",
+        metadata: { generation: 1 },
+      };
+    };
+    const sub = new NexusWatchSubscriber({
+      bus,
+      hub,
+      fetchEntity: fetcher,
+      dedupWindowMs: 1_000,
+    });
+    sub.start();
+
+    const env = {
+      kind: "Contribution" as const,
+      namespace: "ns/wt",
+      op: "ADDED" as const,
+      entityId: "cid-1",
+      generation: 1,
+      emittedAt: new Date().toISOString(),
+    };
+
+    // Mark seen via the fast-path API
+    sub.markSeen(env);
+
+    const pub = new NexusWatchPublisher(bus);
+    await pub.publish(env);
+
+    await new Promise((r) => setImmediate(r));
+    expect(hub.currentRv("ns/wt", "Contribution")).toBe(0n);
+    expect(fetched).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `bun test src/nexus/nexus-watch-subscriber.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/nexus/nexus-watch-subscriber.ts
+import type { EventBus } from "../core/event-bus.js";
+import type {
+  EntityWriteEvent,
+  WatchEntity,
+  WatchKind,
+  WatchOp,
+} from "../core/watch-events.js";
+import type { WatchHub } from "../core/watch-hub.js";
+import {
+  ENTITY_CHANGED,
+  type EntityChangedEnvelope,
+} from "./nexus-watch-publisher.js";
+
+export interface NexusWatchSubscriberOptions {
+  readonly bus: EventBus;
+  readonly hub: WatchHub;
+  /** Fetch the full entity on receipt — keeps the wire format minimal. */
+  readonly fetchEntity: (
+    kind: WatchKind,
+    namespace: string,
+    id: string,
+  ) => Promise<WatchEntity>;
+  /** Dedupe window for in-process fast-path replays. Default 5_000ms. */
+  readonly dedupWindowMs?: number;
+}
+
+interface SeenKey {
+  readonly key: string;
+  readonly seenAt: number;
+}
+
+const DEFAULT_DEDUP_WINDOW = 5_000;
+
+export class NexusWatchSubscriber {
+  private readonly opts: NexusWatchSubscriberOptions;
+  private readonly seen: SeenKey[] = [];
+  private readonly handler = (event: { payload: Record<string, unknown> }) => {
+    void this.onEnvelope(event.payload as unknown as EntityChangedEnvelope);
+  };
+  private started = false;
+
+  constructor(opts: NexusWatchSubscriberOptions) {
+    this.opts = opts;
+  }
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.opts.bus.subscribe(ENTITY_CHANGED, this.handler);
+  }
+
+  stop(): void {
+    if (!this.started) return;
+    this.opts.bus.unsubscribe(ENTITY_CHANGED, this.handler);
+    this.started = false;
+  }
+
+  /**
+   * Record that the in-process fast path already handled this write. The
+   * subscriber will then ignore the matching cross-process envelope.
+   */
+  markSeen(envelope: {
+    kind: WatchKind;
+    entityId: string;
+    generation: number;
+  }): void {
+    this.seen.push({
+      key: this.dedupKey(envelope),
+      seenAt: Date.now(),
+    });
+    this.expire();
+  }
+
+  private async onEnvelope(env: EntityChangedEnvelope): Promise<void> {
+    if (!env || !env.kind || !env.namespace || !env.entityId) return;
+    this.expire();
+    const k = this.dedupKey(env);
+    if (this.seen.some((s) => s.key === k)) return;
+    const entity = await this.opts.fetchEntity(env.kind, env.namespace, env.entityId);
+    const e: EntityWriteEvent = {
+      kind: env.kind,
+      namespace: env.namespace,
+      op: env.op as WatchOp,
+      entity,
+    };
+    this.opts.hub.recordWrite(e);
+  }
+
+  private dedupKey(env: {
+    kind: WatchKind;
+    entityId: string;
+    generation: number;
+  }): string {
+    return `${env.kind}\x00${env.entityId}\x00${env.generation}`;
+  }
+
+  private expire(): void {
+    const cutoff = Date.now() - (this.opts.dedupWindowMs ?? DEFAULT_DEDUP_WINDOW);
+    while (this.seen.length > 0 && this.seen[0]!.seenAt < cutoff) {
+      this.seen.shift();
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/nexus/nexus-watch-subscriber.test.ts`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/nexus-watch-subscriber.ts src/nexus/nexus-watch-subscriber.test.ts
+git commit -m "feat(watch): NexusWatchSubscriber forwards entity.changed → hub (#292)"
+```
+
+---
+
+### Task 22: Wire Nexus stores to publish on writes
+
+**Files:**
+- Modify: `src/nexus/nexus-contribution-store.ts`
+- Modify: `src/nexus/nexus-claim-store.ts`
+
+- [ ] **Step 1: Add an optional publisher on each store**
+
+Both stores currently take a constructor-options object. Add an optional `watchPublisher?: NexusWatchPublisher` field to each.
+
+Edit `src/nexus/nexus-contribution-store.ts`. Add the import:
+```typescript
+import type { NexusWatchPublisher } from "./nexus-watch-publisher.js";
+```
+
+Add to the constructor options interface and to the class.
+
+Find the post-commit point inside `submit` / `put`. After the contribution is durably written, call:
+```typescript
+    await this.watchPublisher?.publish({
+      kind: "Contribution",
+      namespace: this.namespace,
+      op: "ADDED",
+      entityId: contribution.cid,
+      generation: 1,
+      emittedAt: new Date().toISOString(),
+    });
+```
+
+Repeat the equivalent change for `nexus-claim-store.ts`, calling `publish` after `createClaim`, `claimOrRenew`, `complete`, `release`. For each, derive `op` from the operation:
+- `createClaim` / first `claimOrRenew` → `ADDED`
+- subsequent renew → skip (no phase change unless status flips, which `claimOrRenew` does not do)
+- `complete` / `release` → `MODIFIED`
+- `cleanCompleted` → `DELETED` (per row)
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS. Add `watchPublisher` to all instantiation sites the typechecker complains about (or default it to `undefined` in the options, which is fine since the field is optional).
+
+- [ ] **Step 3: Wire the publisher into `serve.ts`**
+
+In `src/server/serve.ts`, after the Nexus event-bus is constructed and `WatchHub` is constructed:
+```typescript
+const watchPublisher =
+  nexusEventBus !== undefined
+    ? new NexusWatchPublisher(nexusEventBus)
+    : undefined;
+```
+
+Pass `watchPublisher` into the Nexus store constructor calls.
+
+If `nexusEventBus` is undefined, the publisher is undefined; the stores fall back to no-op, and the in-process fast path remains the only RV source — correct behavior for local-only mode.
+
+- [ ] **Step 4: Wire the subscriber into `serve.ts`**
+
+After the publisher and the WatchHub:
+```typescript
+const watchSubscriber =
+  nexusEventBus !== undefined
+    ? new NexusWatchSubscriber({
+        bus: nexusEventBus,
+        hub: watchHub,
+        fetchEntity: makeWatchEntityFetcher(deps),
+      })
+    : undefined;
+watchSubscriber?.start();
+```
+
+`makeWatchEntityFetcher` returns a function that, given (kind, namespace, id), fetches the row from the right store and projects to Entity:
+```typescript
+function makeWatchEntityFetcher(deps: ServerDeps) {
+  return async (kind: WatchKind, namespace: string, id: string): Promise<WatchEntity> => {
+    if (kind === "Contribution") {
+      const c = await deps.contributionStore.get(id);
+      if (!c) throw new Error(`Contribution ${id} not found`);
+      return contributionToEntity(c, namespace);
+    }
+    if (kind === "Claim") {
+      const c = await deps.claimStore.getClaim(id);
+      if (!c) throw new Error(`Claim ${id} not found`);
+      return claimToEntity(c, () => Date.now(), namespace);
+    }
+    throw new Error(`Unsupported kind for watch fetcher: ${kind}`);
+  };
+}
+```
+
+Place this helper at the bottom of `serve.ts` (or a new `src/server/watch-fetcher.ts` if `serve.ts` is becoming unwieldy).
+
+- [ ] **Step 5: markSeen integration**
+
+Update the `onEntityWrite` callback in `operation-adapter.ts` (Task 12) to also call `watchSubscriber?.markSeen` so the in-process fast path suppresses the cross-process duplicate:
+```typescript
+    onEntityWrite: (event) => {
+      serverDeps.watchHub.recordWrite(event);
+      serverDeps.watchSubscriber?.markSeen({
+        kind: event.kind,
+        entityId: event.entity.id,
+        generation: event.entity.metadata.generation,
+      });
+    },
+```
+
+This requires adding `watchSubscriber?: NexusWatchSubscriber` to `ServerDeps`. Add it.
+
+- [ ] **Step 6: Typecheck and run all tests**
+
+Run: `bunx tsc --noEmit && bun test src/server/ src/core/watch-hub.test.ts src/nexus/nexus-watch-subscriber.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/nexus/nexus-contribution-store.ts src/nexus/nexus-claim-store.ts src/server/serve.ts src/server/deps.ts src/server/operation-adapter.ts src/server/watch-fetcher.ts
+git commit -m "feat(watch): publish entity.changed from Nexus stores; subscriber feeds hub (#292)"
+```
+
+---
+
+### Task 23: Cross-process integration smoke test
+
+**Files:**
+- Create: `src/server/watch.cross-process.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+// src/server/watch.cross-process.test.ts
+import { describe, expect, test } from "bun:test";
+import { LocalEventBus } from "../core/local-event-bus.js";
+import { NexusWatchPublisher } from "../nexus/nexus-watch-publisher.js";
+import { createTestApp, withAuth } from "./test-helpers.js";
+import { readSseEvents } from "./sse-test-utils.js";
+
+describe("watch cross-process via Nexus event-bus", () => {
+  test("envelope from a different process surfaces on a watch stream", async () => {
+    const bus = new LocalEventBus();
+    const { app, contributionStore } = await createTestApp({
+      eventBus: bus,
+    });
+
+    const list = await app
+      .request("/api/list?kind=Contribution", { headers: withAuth() })
+      .then((r) => r.json());
+
+    const watchRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+      { headers: withAuth() },
+    );
+
+    // Simulate an out-of-band write: write to the store directly, then
+    // publish on the bus the way another process would.
+    const cid = await contributionStore.put({
+      kind: "work",
+      mode: "evaluation",
+      summary: "cross-proc",
+      artifacts: {},
+      relations: [],
+      tags: [],
+      agent: { agentId: "ext" },
+      createdAt: new Date().toISOString(),
+    } as never);
+
+    const pub = new NexusWatchPublisher(bus);
+    await pub.publish({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entityId: cid,
+      generation: 1,
+      emittedAt: new Date().toISOString(),
+    });
+
+    const events = await readSseEvents(watchRes, 1, 2_000);
+    expect(events[0]?.event).toBe("ADDED");
+    expect((events[0]?.data as { entity: { id: string } }).entity.id).toBe(cid);
+  });
+});
+```
+
+`createTestApp` may need an `eventBus` option to share the bus between the publisher and the subscriber. Add it analogously to `watchHubOptions`. If `contributionStore.put` does not match the actual API, use the existing API to insert a contribution directly (whatever the local store helper provides).
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/server/watch.cross-process.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/server/watch.cross-process.test.ts src/server/test-helpers.ts
+git commit -m "test(watch): cross-process write surfaces on watch stream (#292)"
+```
+
+---
+
+## Phase 8 — Polish + final verification
+
+### Task 24: Lint, typecheck, full test sweep
+
+- [ ] **Step 1: Biome**
+
+Run: `bunx biome check --write src/`
+Expected: Clean.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `bun test`
+Expected: PASS. If any pre-existing test regressed, investigate and fix before commit. Do not skip or weaken assertions.
+
+- [ ] **Step 4: Acceptance recap**
+
+Confirm by running the named files explicitly:
+
+```
+bun test src/server/watch.race.test.ts
+bun test src/server/watch.kill.test.ts
+bun test src/server/watch.bookmark.test.ts
+```
+
+All three should pass — they correspond to the three issue acceptance criteria.
+
+- [ ] **Step 5: Commit any final cleanup**
+
+```bash
+git add -A
+git commit -m "chore(watch): biome cleanup post-A5 (#292)" || echo "nothing to clean"
+```
+
+---
+
+### Task 25: Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin worktree-tidy-hatching-wadler
+```
+
+- [ ] **Step 2: Open PR via gh**
+
+```bash
+gh pr create --title "feat(watch): A5 list→watch RV handshake (#292)" --body "$(cat <<'EOF'
+## Summary
+- New `WatchHub` holds a per-(namespace, kind) monotonic resourceVersion plus a ring buffer (1024 events / 5 min).
+- New endpoints: `GET /api/list?kind=X` returns `{items, listResourceVersion}`; `GET /api/watch?kind=X&resumeFrom=Y` is SSE with mandatory `resumeFrom`.
+- Writes feed the hub from two paths: the in-process `onEntityWrite` operations hook for HTTP-mediated writes, and a Nexus event-bus `entity.changed` subscription for cross-process writes from MCP agents.
+- Acceptance tests cover the handshake race, kill-9 resume, and bookmark cadence (issue criteria #2, #1, #3).
+
+## Spec
+docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md
+
+## Test plan
+- [ ] `bun test src/core/watch-hub.test.ts`
+- [ ] `bun test src/server/watch.integration.test.ts`
+- [ ] `bun test src/server/watch.race.test.ts`
+- [ ] `bun test src/server/watch.kill.test.ts`
+- [ ] `bun test src/server/watch.bookmark.test.ts`
+- [ ] `bun test src/server/watch.cross-process.test.ts`
+- [ ] `bun test src/nexus/nexus-watch-subscriber.test.ts`
+- [ ] Full suite `bun test`
+- [ ] `bunx tsc --noEmit`
+- [ ] `bunx biome check src/`
+
+Closes #292
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+After execution, audit against these items before declaring done:
+
+- **Spec coverage**:
+  - Per-(namespace, kind) monotonic RV → Tasks 2, 3 (WatchHub).
+  - List returns `{items, listResourceVersion}` → Task 11.
+  - Watch resumes from `resumeFrom`, NEVER "latest" → Task 11 (zod requires the field).
+  - Replay between list-return and watch-establish → Task 11 + Task 16 race test.
+  - BOOKMARK ≥1/30s → Task 11 timer + Task 18.
+  - 410 on stale RV → Task 6 (hub) + Task 15 (HTTP).
+  - Kill-9 resume → Task 17.
+  - Three Entity kinds covered: Contribution (Phase 2), Claim (Phase 6). AgentSession deferred — documented in spec non-goals; full A5 closure does not require it because Claim + Contribution exercise every code path.
+
+- **Type consistency**: `WatchKind`, `WatchOp`, `WatchEvent`, `EntityWriteEvent` defined once in `watch-events.ts` and imported everywhere.
+
+- **No placeholders**: every step shows code or an exact command. No "implement appropriately" wording.
+
+- **Frequent commits**: every task ends with a `git commit`. Each commit message is `<type>(watch): <summary> (#292)`.
+
+- **Test discipline**: every implementation step is preceded by a failing test, then made green.
+
+---
+
+## Risks / open follow-ups
+
+These are explicitly OUT of scope for the A5 plan but should be tracked:
+
+1. **AgentSession write hook**: session lifecycle transitions live in `session-orchestrator.ts` / `acp-runtime.ts`, not in the operations layer. Wiring `onEntityWrite` for these requires a small refactor — track as a follow-up issue once A7 informer needs it.
+2. **Compaction**: when the ring is full and a slow watcher wakes, it gets 410. A6 (#293) replaces this with smarter recovery. Until then, clients re-list — acceptable per spec.
+3. **Single-server scope**: multi-grove-server consensus is out of scope; one server per worktree is the deployment shape.

--- a/docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md
+++ b/docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md
@@ -1,0 +1,412 @@
+# A5: Watch Protocol — list→watch RV Handshake — Design
+
+- **Issue**: [#292](https://github.com/windoliver/grove/issues/292)
+- **Epic**: [#282](https://github.com/windoliver/grove/issues/282) — Foundation: Entity Model + Watch Protocol
+- **Date**: 2026-04-27
+- **Depends on**: #287 (Entity envelope), #290 (Namespace enforcement)
+- **Reference**: `kubernetes/staging/src/k8s.io/apimachinery/pkg/watch/watch.go`
+
+## Goal
+
+Provide a reactive watch protocol with a strict list→watch resourceVersion (RV)
+handshake so that TUI clients can list a kind, then resume a watch from the
+exact RV the list snapshot was taken at, and receive every subsequent event
+without gaps. This is the foundation that retires polling reactive paths in
+the TUI (#295) and that the informer cache (#294) builds on.
+
+The "list-from-listRv then watch-from-latest" anti-pattern is the silent
+desync bug this design exists to prevent: any event written between
+list-return and watch-establishment must be guaranteed to land on the
+watcher's stream.
+
+## Non-goals
+
+- Persistent watch log across server restart. In-memory ring buffers only;
+  on restart, watchers must re-list. K8s informers handle this transparently.
+- Multi-grove-server consensus. Grove deploys one server per worktree, so a
+  single in-memory RV authority is sufficient. Cross-server agreement is a
+  future concern (and out of scope for the foundation epic).
+- Field or label selectors. Only `kind` and namespace (auth-derived) filter
+  the watch. Label filtering is client-side post-watch — labels live for
+  intra-namespace filtering only per #290.
+- TUI consumer integration. A7 (#294) wires informer clients; A5 ships the
+  server protocol and a thin internal subscribe API.
+- Polling retirement. A8 (#295) deletes the polling timers once watch lands.
+- Compaction / Expired RV recovery. A6 (#293) adds smarter handling of stale
+  RVs; A5 simply emits a 410-equivalent error event when `resumeFrom` falls
+  outside the ring buffer.
+- Outcome / Bounty / Handoff watch. Future kinds extend the same hub, but
+  A5 ships only the three Entity kinds defined in #287.
+
+## RV authority
+
+A per-(namespace, kind) monotonic counter lives in grove-server memory inside
+a new `WatchHub`. Writes feed the counter from two paths:
+
+1. **Fast path — in-process**: the operations layer (`contribute`, `claim`,
+   etc.) calls `onEntityWrite` post-commit. The server's deps wire this to
+   `hub.recordWrite()`.
+2. **Catch-all — Nexus event-bus**: writes from a different process (e.g. an
+   MCP agent calling `grove_contribute` from a separate Bun process) reach
+   grove-server via a new `entity.changed` Nexus topic. grove-server
+   subscribes and feeds the same hub.
+
+Duplicate suppression is keyed on `(kind, id, generation)`: if both paths fire
+for the same write, the second is a no-op.
+
+This is the C-lite option from brainstorming. Server-local-only (A) silently
+misses cross-process writes; pure Nexus-derived (B) requires a new Nexus
+brick that exposes a per-(ns,kind) sequence which Nexus does not natively
+provide. C-lite ships A5 with what we have and treats the brick as a future
+optimization.
+
+### Two RV namespaces (do not conflate)
+
+| RV | Lives on | Monotonic over | Used for |
+|----|----------|----------------|----------|
+| `entity.resourceVersion` (existing, #287) | Each Entity row | A single entity's revision history | Optimistic concurrency on writes |
+| Watch RV (new) | WatchHub `(ns, kind)` counter | The kind in a namespace | list→watch handshake, SSE event ids |
+
+The watch event payload carries the per-row `entity.resourceVersion` for the
+client's downstream use; the SSE event id and `listResourceVersion` are the
+watch RV. They look similar (numeric strings) but are independent.
+
+## Architecture
+
+```
+                ┌──────────────────────────────────────────┐
+                │            grove-server                  │
+                │                                          │
+   write op ──► │  WatchHub                                │
+   (operations  │   ├── per-(ns,kind) RV counters         │
+    layer,      │   ├── ring buffers (1024 events / 5min) │
+    in-process) │   └── active SSE subscribers             │
+                │                                          │
+   Nexus ──►    │  GET /api/list?kind=X                    │
+   event-bus    │  GET /api/watch?kind=X&resumeFrom=Y      │
+   subscription │                                          │
+   (cross-proc) │                                          │
+                └──────────────────────────────────────────┘
+                                ▲
+                       TUI informer (A7, #294)
+```
+
+## Endpoint shape
+
+Two new endpoints, both behind the existing `namespaceAuth` middleware. The
+namespace is auth-derived (#290); never accepted as a query parameter.
+
+### `GET /api/list?kind=<kind>`
+
+Response:
+```json
+{
+  "items": [ /* Entity<...>[] */ ],
+  "listResourceVersion": "42"
+}
+```
+
+Implementation must capture the watch RV **before** invoking
+`store.listEntities()`. This is the race-correctness invariant: any write
+that lands during the list query has rv > listRv, so it is guaranteed to be
+in the ring buffer when the watch resumes.
+
+```typescript
+// server/routes/watch.ts
+const namespace = c.get("namespace");
+const kind = parseKind(c.req.valid("query").kind);
+const listRv = hub.currentRv(namespace, kind);  // BEFORE list
+const items = await store.listEntities({ namespace });
+return c.json({ items, listResourceVersion: String(listRv) });
+```
+
+Reverse order would silently miss writes interleaved with list — that is the
+specific bug this design exists to prevent.
+
+### `GET /api/watch?kind=<kind>&resumeFrom=<rv>`
+
+Returns `Content-Type: text/event-stream`. `resumeFrom` is required and is
+NEVER `"latest"`. The server replays all events with `rv > resumeFrom` from
+the ring buffer, then tails new events on the same stream.
+
+`Last-Event-ID` (set automatically by browser EventSource on auto-reconnect)
+overrides `resumeFrom` if present, so reconnect after a network blip is
+transparent to the client.
+
+Event types:
+
+| Type | Payload | Meaning |
+|------|---------|---------|
+| `ADDED` | `{rv, kind, entity}` | New entity appeared |
+| `MODIFIED` | `{rv, kind, entity}` | Existing entity changed |
+| `DELETED` | `{rv, kind, entity}` | Entity removed (snapshot at deletion) |
+| `BOOKMARK` | `{rv}` | Periodic checkpoint, no entity change |
+| `ERROR` | `{code, reason}` | Terminal — stream closes after this event |
+
+Each event carries an SSE `id:` field equal to its `rv`, and an `event:`
+field naming the type. Bookmarks are emitted at minimum once per 30s per
+active stream (acceptance criterion #3).
+
+## Components
+
+### `src/core/watch-hub.ts` (new)
+
+Pure-logic, no HTTP. Lives in core because both server route handlers and
+test helpers (race test) need to inject hooks.
+
+```typescript
+export type WatchKind = "Contribution" | "Claim" | "AgentSession";
+export type WatchOp = "ADDED" | "MODIFIED" | "DELETED";
+
+export interface WatchEvent {
+  readonly rv: bigint;
+  readonly op: WatchOp;
+  readonly kind: WatchKind;
+  readonly namespace: string;
+  readonly entity:
+    | ContributionEntity
+    | ClaimEntity
+    | AgentSessionEntity;
+}
+
+export interface WatchHubOptions {
+  readonly maxEventsPerKey?: number;       // default 1024
+  readonly maxAgeMsPerKey?: number;        // default 5 * 60_000
+  readonly bookmarkIntervalMs?: number;    // default 30_000
+  readonly perClientOutboxCap?: number;    // default 256
+}
+
+export class WatchHub {
+  constructor(opts?: WatchHubOptions);
+
+  /** Record a write. Bumps the (ns, kind) counter and emits to subscribers.
+   *  Returns the new watch RV. */
+  recordWrite(event: Omit<WatchEvent, "rv">): bigint;
+
+  /** Read the current watch RV without bumping. Captured by the list
+   *  endpoint BEFORE store.listEntities() to prevent the handshake race. */
+  currentRv(namespace: string, kind: WatchKind): bigint;
+
+  /** Subscribe with replay-from semantics. Throws StaleResourceVersionError
+   *  if fromRv < ringBuffer.oldestRv for that (ns, kind). The iterable
+   *  yields replay events first, then tails until aborted. */
+  subscribe(
+    namespace: string,
+    kind: WatchKind,
+    fromRv: bigint,
+    signal: AbortSignal,
+  ): AsyncIterable<WatchEvent>;
+}
+
+export class StaleResourceVersionError extends Error {
+  readonly code = 410;
+}
+```
+
+Internal state:
+```typescript
+type KeyState = {
+  counter: bigint;                  // monotonic per (ns, kind)
+  ring: WatchEvent[];               // bounded by maxEvents AND maxAgeMs
+  ringInsertedAt: number[];         // parallel to ring, for age trim
+  subscribers: Set<Subscriber>;     // active SSE clients
+};
+private readonly state = new Map<string /* "ns/kind" */, KeyState>();
+```
+
+Per-subscriber outbox is a bounded `AsyncQueue` with a hard cap. On overflow,
+the subscriber is closed with a `BufferOverflowError` so the SSE handler can
+emit the terminal `ERROR` event.
+
+### `src/core/operations/deps.ts` (modify)
+
+Extend `OperationDeps` with:
+```typescript
+readonly onEntityWrite?:
+  | ((event: {
+      kind: WatchKind;
+      namespace: string;
+      op: WatchOp;
+      entity:
+        | ContributionEntity
+        | ClaimEntity
+        | AgentSessionEntity;
+    }) => void)
+  | undefined;
+```
+
+The hook fires post-commit, in addition to the existing
+`onContributionWrite` / `onContributionWritten` callbacks (they remain — they
+are used by other consumers and have different semantics: write-side
+flush coordination, not watch fan-out).
+
+### `src/core/operations/contribute.ts` (modify)
+
+After successful commit, project the contribution to its Entity envelope and
+fire `onEntityWrite({kind: "Contribution", namespace, op: "ADDED", entity})`.
+The contribute operation has no MODIFIED path (contributions are immutable);
+DELETED is reserved for compaction and out of scope here.
+
+Equivalent hooks land in any operation that writes a Claim or AgentSession.
+Claim emits ADDED on `createClaim` / `claimOrRenew` (first write), MODIFIED
+on lease renewal and status transition, DELETED on `cleanCompleted` for
+terminal-state rows. **Heartbeat MODIFIED events are filtered**: a heartbeat
+that does not change `status` or cross the lease-expiry boundary in
+`claimToEntity` is suppressed at the hook site, because heartbeats arrive
+several times per second per active claim and would flood the ring buffer
+with no semantic change for watchers. The lease-expiry-crossed boundary
+(when `resourceVersion` flips to `"<rev>-lease-expired"`) DOES emit, since
+that is a logical state change observable by consumers.
+
+AgentSession emits ADDED on first appearance, MODIFIED on phase change
+(`running` ↔ `idle` ↔ `stopped` ↔ `crashed`). DELETED is not used in A5 —
+sessions are retained for history; future cleanup pathways will emit DELETED
+when they land.
+
+### `src/server/routes/watch.ts` (new)
+
+Hono route module for `/api/list` and `/api/watch`. Mounts behind the
+existing `namespaceAuth` middleware — namespace flows from `c.get("namespace")`,
+never query params.
+
+The watch handler uses Bun's stream-friendly `Response` with
+`Content-Type: text/event-stream`. Bookmark timer is a per-stream
+`setInterval(bookmarkIntervalMs)`. Stream lifecycle is bound to an
+`AbortController` so client disconnect / server shutdown cleanly removes the
+subscription from `WatchHub`.
+
+### `src/nexus/nexus-watch-publisher.ts` (new)
+
+Called by Nexus stores after a write. Publishes a structured event to the
+`entity.changed` Nexus topic carrying `{kind, namespace, op, entityId,
+generation}`. Lightweight payload — full entity is re-fetched on the
+subscriber side so the wire format does not bake in entity shape.
+
+### `src/nexus/nexus-watch-subscriber.ts` (new)
+
+grove-server subscribes to `entity.changed` at startup. On receipt:
+1. De-duplicate: if `(kind, id, generation)` was already recorded by the
+   in-process fast path within the last N ms, drop.
+2. Otherwise fetch the full entity from the appropriate store and call
+   `hub.recordWrite()`.
+
+Dedup window: 5s — long enough to absorb event-bus latency, short enough that
+genuine subsequent writes at the same generation (which shouldn't happen but
+defense-in-depth) aren't masked.
+
+### `src/server/serve.ts` (modify)
+
+- Instantiate `WatchHub` at startup.
+- Wire `onEntityWrite` into the operations deps factory.
+- If Nexus is configured, start `NexusWatchSubscriber`.
+- Pass `hub` into ServerEnv deps so route handlers can access it.
+
+### `src/server/deps.ts` (modify)
+
+Add `watchHub: WatchHub` to `ServerDeps`.
+
+### `src/server/app.ts` (modify)
+
+Mount `watch` routes under `/api`. Routes are gated by the existing
+namespace-auth middleware automatically.
+
+### `src/nexus/nexus-contribution-store.ts` and peers (modify)
+
+After every write, call `nexusWatchPublisher.publish({...})`. Same for
+`nexus-claim-store.ts`, `nexus-session-store.ts`. This is the cross-process
+catch-all path.
+
+## Error handling
+
+| Condition | Server response | Client action |
+|-----------|-----------------|---------------|
+| Missing `kind` query param | HTTP 400 `{code: VALIDATION_ERROR}` | Fix request |
+| Missing/invalid auth | HTTP 401/400 (existing #290 middleware) | Re-auth |
+| `resumeFrom < ring.oldestRv` | SSE `event: ERROR data: {code: 410, reason: "expired"}`, then close | Re-list, restart watch |
+| Per-client outbox overflow | SSE `event: ERROR data: {code: 503, reason: "buffer_overflow"}`, then close | Re-list, restart watch |
+| Server restart | TCP close | Reconnect → fresh list |
+| Network blip | TCP close | EventSource auto-reconnects with `Last-Event-ID` header → server uses as `resumeFrom` |
+
+## Testing strategy
+
+### Unit — `src/core/watch-hub.test.ts`
+
+- RV monotonicity: `recordWrite` returns strictly increasing rv per (ns, kind), independent across pairs.
+- Ring buffer cap: at `maxEventsPerKey`, oldest is evicted; subscribe with rv < oldest throws `StaleResourceVersionError`.
+- Ring buffer age cap: events older than `maxAgeMsPerKey` are evicted on read.
+- Replay correctness: subscribe(fromRv=N) yields exactly events with rv > N then tails new.
+- Bookmark cadence: ≥1 emit per `bookmarkIntervalMs` per active subscription.
+- Per-client outbox overflow: slow consumer triggers bounded-queue close with `BufferOverflowError`.
+- Namespace isolation: writes to ns=A do not appear in subscribe(ns=B).
+- Kind isolation: writes to kind=Contribution do not appear in subscribe(kind=Claim) for the same ns.
+
+### Integration — `src/server/watch.test.ts`
+
+- `GET /api/list?kind=Contribution` returns `{items, listResourceVersion}` with auth; 401 without; 400 without `kind`.
+- `GET /api/watch` opens SSE, emits `ADDED` after a `POST /api/contributions`.
+- Stale RV: write past ring cap, `resumeFrom=stale` → `ERROR` event with `code: 410`, then close.
+- Cross-process via Nexus subscriber: a write into the Nexus VFS by a separate test client surfaces on a watch opened against the server.
+
+### Acceptance — `src/server/watch.race.test.ts` (issue criterion #2)
+
+```typescript
+test("handshake race: writes between list-return and watch-open all replayed", async () => {
+  // Test-only hook: WatchHub takes an injectable beforeListHook so the test
+  // can inject a 100ms delay between hub.currentRv() and store.listEntities().
+  const N = 50;
+  const listRv = await beginList();
+  const writes = await Promise.all(
+    Array.from({ length: N }, (_, i) => writeContribution(i)),
+  );
+  const items = await endList();
+  const events = await collectWatch(listRv, { timeoutMs: 1_000 });
+  expect(events.length).toBe(N);
+  expect(events.map(e => e.entity.id).sort()).toEqual(
+    writes.map(w => w.cid).sort()
+  );
+});
+```
+
+### Acceptance — `src/server/watch.kill.test.ts` (issue criterion #1)
+
+- Open watch, receive bookmark `rv=K`.
+- Force-close client by aborting the underlying stream (simulates `kill -9`).
+- Write M=20 events while disconnected (well under the 1024 ring cap).
+- Reconnect with `resumeFrom=K` → assert all M events replayed in order, no duplicates.
+
+### Acceptance — bookmark cadence (issue criterion #3)
+
+- Open watch on a quiescent (ns, kind), no writes.
+- Assert at least one BOOKMARK event arrives within `bookmarkIntervalMs + slack` (33s).
+- Carry-current-RV: payload `rv` matches `hub.currentRv()` at emit time.
+
+## File changes summary
+
+**New**:
+- `src/core/watch-hub.ts`
+- `src/core/watch-hub.test.ts`
+- `src/server/routes/watch.ts`
+- `src/server/watch.test.ts`
+- `src/server/watch.race.test.ts`
+- `src/server/watch.kill.test.ts`
+- `src/nexus/nexus-watch-publisher.ts`
+- `src/nexus/nexus-watch-subscriber.ts`
+
+**Modified**:
+- `src/core/operations/deps.ts` — add `onEntityWrite` hook field
+- `src/core/operations/contribute.ts` — fire `onEntityWrite` post-commit
+- Operations that mutate Claim or AgentSession — same fire site
+- `src/server/serve.ts` — instantiate WatchHub, wire callback + Nexus subscriber
+- `src/server/deps.ts` — add `watchHub`
+- `src/server/app.ts` — mount `/api/list`, `/api/watch`
+- `src/nexus/nexus-contribution-store.ts`, `nexus-claim-store.ts`,
+  `nexus-session-store.ts` — call publisher after writes
+
+## Open questions deferred
+
+- Whether to expose watch over WebSocket as a future alternative (SSE-only for A5).
+- Compaction window for ring buffers when a kind sees a sustained burst >
+  cap. A6 (#293) addresses this; A5's behavior is "drop oldest, return 410
+  on stale resume."
+- TUI informer cache shape, including whether informers share a single
+  watch per kind across panels. A7 (#294).

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -246,6 +246,7 @@ export async function executeInit(
     }),
   );
 
+  let namespace: string;
   try {
     // Generate namespace key for this worktree (inside rollback-protected block).
     {
@@ -257,7 +258,7 @@ export async function executeInit(
         writeNamespace,
       } = await import("../../core/project-key.js");
       const worktreeName = await detectWorktreeName();
-      const namespace = `${projectId}/${worktreeName}`;
+      namespace = `${projectId}/${worktreeName}`;
       const apiKey = generateApiKey();
       writeClientKey(grovePath, apiKey);
       appendServerKey(grovePath, apiKey, namespace);
@@ -266,8 +267,12 @@ export async function executeInit(
     }
     progress(2, "Initializing database");
     const dbPath = join(grovePath, "grove.db");
-    const { initSqliteDb } = await import("../../local/sqlite-store.js");
+    const { initSqliteDb, writeStoreNamespace } = await import("../../local/sqlite-store.js");
     const db = initSqliteDb(dbPath);
+    // Persist the same namespace into the SQLite store so listEntities()
+    // tags rows with the auth-derived namespace instead of falling back to
+    // "default", matching what the watch route emits via `c.get("namespace")`.
+    writeStoreNamespace(db, namespace);
     // Everything below runs under try/finally so db.close() always fires — a
     // failure writing GROVE.md, grove.json, or seeding must not leak the DB.
     try {

--- a/src/core/operations/claim.test.ts
+++ b/src/core/operations/claim.test.ts
@@ -275,3 +275,118 @@ describe("listClaimsOperation", () => {
     if (releasedResult.ok) expect(releasedResult.value.count).toBe(1);
   });
 });
+
+describe("claim → onEntityWrite", () => {
+  let testDeps: TestOperationDeps;
+
+  beforeEach(async () => {
+    testDeps = await createTestOperationDeps();
+  });
+
+  afterEach(async () => {
+    await testDeps.cleanup();
+  });
+
+  test("claimOperation fires ADDED on first claim", async () => {
+    const events: Array<{
+      kind: string;
+      op: string;
+      phase: string;
+      namespace: string;
+    }> = [];
+    const deps: OperationDeps = {
+      ...testDeps.deps,
+      onEntityWrite: (e) =>
+        events.push({
+          kind: e.kind,
+          op: e.op,
+          phase: (e.entity as { status: { phase: string } }).status.phase,
+          namespace: e.namespace,
+        }),
+      namespace: "ns/wt",
+    };
+
+    const result = await claimOperation(
+      { targetRef: "t1", agent: { agentId: "a-1" }, intentSummary: "first" },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: "Claim",
+      op: "ADDED",
+      namespace: "ns/wt",
+    });
+    expect(events[0]?.phase).toBe("active");
+  });
+
+  test("claimOperation suppresses event on heartbeat-like renewal (no phase change)", async () => {
+    const events: Array<{ op: string }> = [];
+    const deps: OperationDeps = {
+      ...testDeps.deps,
+      onEntityWrite: (e) => events.push({ op: e.op }),
+      namespace: "ns/wt",
+    };
+
+    const first = await claimOperation(
+      { targetRef: "t1", agent: { agentId: "a-1" }, intentSummary: "first" },
+      deps,
+    );
+    expect(first.ok).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.op).toBe("ADDED");
+
+    // Renew — same agent, same target, still active. No phase transition,
+    // so no event should fire.
+    const renewed = await claimOperation(
+      { targetRef: "t1", agent: { agentId: "a-1" }, intentSummary: "renewed" },
+      deps,
+    );
+    expect(renewed.ok).toBe(true);
+    expect(events).toHaveLength(1);
+  });
+
+  test("releaseOperation fires MODIFIED with the released phase", async () => {
+    const events: Array<{ op: string; phase: string }> = [];
+    const deps: OperationDeps = {
+      ...testDeps.deps,
+      onEntityWrite: (e) =>
+        events.push({
+          op: e.op,
+          phase: (e.entity as { status: { phase: string } }).status.phase,
+        }),
+      namespace: "ns/wt",
+    };
+
+    const created = await claimOperation(
+      { targetRef: "t1", agent: { agentId: "a-1" }, intentSummary: "first" },
+      deps,
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    events.length = 0; // reset to focus on the release event
+    const released = await releaseOperation(
+      { claimId: created.value.claimId, action: "release" },
+      deps,
+    );
+    expect(released.ok).toBe(true);
+    expect(events.some((e) => e.op === "MODIFIED")).toBe(true);
+    expect(events.some((e) => e.phase === "released")).toBe(true);
+  });
+
+  test("skips onEntityWrite when namespace is missing", async () => {
+    const events: unknown[] = [];
+    const deps: OperationDeps = {
+      ...testDeps.deps,
+      onEntityWrite: (e: unknown) => events.push(e),
+      namespace: undefined, // explicit override of helper's default
+    };
+    const result = await claimOperation(
+      { targetRef: "t1", agent: { agentId: "a-1" }, intentSummary: "first" },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(events).toHaveLength(0);
+  });
+});

--- a/src/core/operations/claim.ts
+++ b/src/core/operations/claim.ts
@@ -6,12 +6,35 @@
  * listClaimsOperation — List claims with filters
  */
 
+import { claimToEntity } from "../entity.js";
 import type { Claim, ClaimStatus, JsonValue } from "../models.js";
+import type { EntityWriteEvent } from "../watch-events.js";
 import type { AgentOverrides } from "./agent.js";
 import { resolveAgent } from "./agent.js";
 import type { OperationDeps } from "./deps.js";
 import type { OperationResult } from "./result.js";
 import { fromGroveError, notFound, ok, validationErr } from "./result.js";
+
+/**
+ * Fire `onEntityWrite` for a claim transition, swallowing any throw so a
+ * watcher hook cannot escape and roll back the commit from the caller's
+ * perspective. Mirrors the post-commit pattern in `contribute.ts`.
+ *
+ * The hook is suppressed when `namespace` is absent — the watch protocol
+ * scopes events per-namespace, so without it the event has no destination.
+ */
+function fireClaimEntityWrite(deps: OperationDeps, event: EntityWriteEvent): void {
+  if (!deps.onEntityWrite || !deps.namespace) return;
+  try {
+    deps.onEntityWrite(event);
+  } catch (err) {
+    process.stderr.write(
+      `[grove] Warning: post-commit callback threw after claim commit: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Result types
@@ -118,6 +141,18 @@ export async function claimOperation(
 
     const result = await deps.claimStore.claimOrRenew(claim);
 
+    // Fire watch hook on phase change. Renewal that does not change status
+    // is suppressed — heartbeat-only updates would otherwise flood watchers.
+    const phaseChanged = !existing || existing.status !== result.status;
+    if (phaseChanged && deps.namespace) {
+      fireClaimEntityWrite(deps, {
+        kind: "Claim",
+        namespace: deps.namespace,
+        op: existing ? "MODIFIED" : "ADDED",
+        entity: claimToEntity(result, () => Date.now(), deps.namespace),
+      });
+    }
+
     return ok({
       claimId: result.claimId,
       targetRef: result.targetRef,
@@ -153,6 +188,17 @@ export async function releaseOperation(
       result = await deps.claimStore.release(input.claimId);
     } else {
       result = await deps.claimStore.complete(input.claimId);
+    }
+
+    // Release / complete are by-definition status transitions, so always
+    // fire the watch hook (when namespace + onEntityWrite are wired).
+    if (deps.namespace) {
+      fireClaimEntityWrite(deps, {
+        kind: "Claim",
+        namespace: deps.namespace,
+        op: "MODIFIED",
+        entity: claimToEntity(result, () => Date.now(), deps.namespace),
+      });
     }
 
     return ok({

--- a/src/core/operations/contribute.test.ts
+++ b/src/core/operations/contribute.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import { LocalEventBus } from "../local-event-bus.js";
 import { ROUTING_SIGNATURE_CONTEXT_KEY } from "../routing-provenance.js";
+import type { EntityWriteEvent } from "../watch-events.js";
 import type { AgentTopology } from "../topology.js";
 import { TopologyRouter } from "../topology-router.js";
 import {
@@ -1495,5 +1496,73 @@ describe("writeSerial: best-effort handoff failure paths", () => {
     expect(warnedAboutCreate).toBe(true);
 
     warnSpy.mockRestore();
+  });
+});
+
+describe("contribute → onEntityWrite", () => {
+  let testDeps: TestOperationDeps;
+
+  beforeEach(async () => {
+    testDeps = await createTestOperationDeps();
+  });
+
+  afterEach(async () => {
+    await testDeps.cleanup();
+  });
+
+  test("fires onEntityWrite with the projected ContributionEntity", async () => {
+    const events: EntityWriteEvent[] = [];
+    const deps: OperationDeps = {
+      ...testDeps.deps,
+      onEntityWrite: (e: EntityWriteEvent) => {
+        events.push(e);
+      },
+      namespace: "ns/wt",
+    };
+
+    const result = await contributeOperation(
+      {
+        kind: "work",
+        summary: "watch-fire test",
+        agent: { agentId: "a1" },
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev?.kind).toBe("Contribution");
+    expect(ev?.op).toBe("ADDED");
+    expect(ev?.namespace).toBe("ns/wt");
+    expect(ev?.entity.namespace).toBe("ns/wt");
+    expect(ev?.entity.id).toBe(result.value.cid);
+    expect(ev?.entity.id).toMatch(/^blake3:/);
+  });
+
+  test("skips onEntityWrite when namespace is missing", async () => {
+    const events: EntityWriteEvent[] = [];
+    // Override the helper-supplied namespace with undefined so the gate trips.
+    const deps: OperationDeps = {
+      ...testDeps.deps,
+      onEntityWrite: (e: EntityWriteEvent) => {
+        events.push(e);
+      },
+      namespace: undefined,
+    };
+
+    const result = await contributeOperation(
+      {
+        kind: "work",
+        summary: "no-namespace test",
+        agent: { agentId: "a1" },
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(events).toHaveLength(0);
   });
 });

--- a/src/core/operations/contribute.test.ts
+++ b/src/core/operations/contribute.test.ts
@@ -6,9 +6,9 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import { LocalEventBus } from "../local-event-bus.js";
 import { ROUTING_SIGNATURE_CONTEXT_KEY } from "../routing-provenance.js";
-import type { EntityWriteEvent } from "../watch-events.js";
 import type { AgentTopology } from "../topology.js";
 import { TopologyRouter } from "../topology-router.js";
+import type { EntityWriteEvent } from "../watch-events.js";
 import {
   _resetIdempotencyCacheForTests,
   contributeOperation,

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1123,6 +1123,15 @@ export async function contributeOperation(
           }
         : undefined;
 
+    // Watch fan-out should only fire for true inserts (#292). The store
+    // uses INSERT OR IGNORE for idempotency, so a duplicate-CID submit is
+    // a no-op in storage — emitting ADDED for it would advance the watch
+    // RV with a phantom event. Pre-checking with `get(cid)` is racy under
+    // concurrent re-submit, but contributions are content-addressed so
+    // any race produces identical content; the worst case is one extra
+    // benign event vs. a stream of phantom events for every retry.
+    const existedBefore = (await deps.contributionStore.get(contribution.cid)) !== undefined;
+
     const handoffIds = await writeContributionWithHandoffs(
       contribution,
       handoffsRoutedTo,
@@ -1207,7 +1216,7 @@ export async function contributeOperation(
     try {
       deps.onContributionWrite?.();
       deps.onContributionWritten?.(contribution.cid);
-      if (deps.onEntityWrite && deps.namespace) {
+      if (deps.onEntityWrite && deps.namespace && !existedBefore) {
         deps.onEntityWrite({
           kind: "Contribution",
           namespace: deps.namespace,

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -9,6 +9,7 @@
 
 import { fireAndForget } from "../../shared/fire-and-forget.js";
 import { pickDefined } from "../../shared/pick-defined.js";
+import { contributionToEntity } from "../entity.js";
 import { type HandoffInput, HandoffStatus, type HandoffStore } from "../handoff.js";
 import { createContribution } from "../manifest.js";
 import {
@@ -1206,9 +1207,17 @@ export async function contributeOperation(
     try {
       deps.onContributionWrite?.();
       deps.onContributionWritten?.(contribution.cid);
+      if (deps.onEntityWrite && deps.namespace) {
+        deps.onEntityWrite({
+          kind: "Contribution",
+          namespace: deps.namespace,
+          op: "ADDED",
+          entity: contributionToEntity(contribution, deps.namespace),
+        });
+      }
     } catch (callbackErr) {
       process.stderr.write(
-        `[grove] Warning: onContributionWrite* callback threw after commit: ${
+        `[grove] Warning: post-commit callback threw after contribution commit: ${
           callbackErr instanceof Error ? callbackErr.message : String(callbackErr)
         }\n`,
       );

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -762,6 +762,15 @@ async function writeContributionWithHandoffs(
 // Operations
 // ---------------------------------------------------------------------------
 
+/**
+ * Per-CID in-flight write tracker. Concurrent same-CID submits must serialize
+ * here so the second-arriving call observes the first's commit when it does
+ * its existedBefore check. Without this, two racing identical submits would
+ * both see the row absent, both fire onEntityWrite, and the watch RV would
+ * advance by 2 for a logical single-insert (#292 round 5).
+ */
+const inFlightContributionWrites = new Map<string, Promise<void>>();
+
 /** Create and store a contribution. */
 export async function contributeOperation(
   input: ContributeInput,
@@ -1123,24 +1132,52 @@ export async function contributeOperation(
           }
         : undefined;
 
-    // Watch fan-out should only fire for true inserts (#292). The store
-    // uses INSERT OR IGNORE for idempotency, so a duplicate-CID submit is
-    // a no-op in storage — emitting ADDED for it would advance the watch
-    // RV with a phantom event. Pre-checking with `get(cid)` is racy under
-    // concurrent re-submit, but contributions are content-addressed so
-    // any race produces identical content; the worst case is one extra
-    // benign event vs. a stream of phantom events for every retry.
-    const existedBefore = (await deps.contributionStore.get(contribution.cid)) !== undefined;
+    // Watch fan-out must fire only for true inserts (#292). The store uses
+    // INSERT OR IGNORE for idempotency, so a duplicate-CID submit is a
+    // no-op in storage — emitting ADDED for it would advance the watch RV
+    // with a phantom event.
+    //
+    // Concurrent same-CID submits are serialized through
+    // `inFlightContributionWrites`: the second-arriving caller waits on
+    // the first's write promise, so its `existedBefore` check observes
+    // the prior commit and skips its own ADDED. Without this, two racing
+    // identical submits would both see `existedBefore=false` and the
+    // watch RV would advance by 2 for a logical single insert.
+    const cidKey = contribution.cid;
+    const priorInFlight = inFlightContributionWrites.get(cidKey);
+    if (priorInFlight !== undefined) {
+      await priorInFlight;
+    }
 
-    const handoffIds = await writeContributionWithHandoffs(
-      contribution,
-      handoffsRoutedTo,
-      agentRole,
-      deps.contributionStore,
-      deps.handoffStore,
-      idempotencyOnCommit,
-      replyTimeouts,
-    );
+    let resolveInFlight: () => void = () => {};
+    const inFlightPromise = new Promise<void>((r) => {
+      resolveInFlight = r;
+    });
+    inFlightContributionWrites.set(cidKey, inFlightPromise);
+
+    let existedBefore = false;
+    let handoffIds: readonly string[] = [];
+    try {
+      existedBefore = (await deps.contributionStore.get(cidKey)) !== undefined;
+
+      handoffIds = await writeContributionWithHandoffs(
+        contribution,
+        handoffsRoutedTo,
+        agentRole,
+        deps.contributionStore,
+        deps.handoffStore,
+        idempotencyOnCommit,
+        replyTimeouts,
+      );
+    } finally {
+      // Release the lock as soon as the durable write resolves — the next
+      // waiter must observe the row in `get()`. Post-commit callbacks run
+      // outside the lock; they don't change store visibility.
+      if (inFlightContributionWrites.get(cidKey) === inFlightPromise) {
+        inFlightContributionWrites.delete(cidKey);
+      }
+      resolveInFlight();
+    }
 
     if (process.env.GROVE_DEBUG === "1" && handoffIds.length > 0) {
       process.stderr.write(

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1149,7 +1149,10 @@ export async function contributeOperation(
       await priorInFlight;
     }
 
-    let resolveInFlight: () => void = () => {};
+    // Promise constructor runs the executor synchronously, so the
+    // definite-assignment assertion is safe and avoids the empty-arrow
+    // dummy initializer (lint/suspicious/noEmptyBlockStatements).
+    let resolveInFlight!: () => void;
     const inFlightPromise = new Promise<void>((r) => {
       resolveInFlight = r;
     });

--- a/src/core/operations/deps.ts
+++ b/src/core/operations/deps.ts
@@ -75,6 +75,22 @@ export interface OperationDeps {
   readonly onContributionWrite?: (() => void) | undefined;
   /** Called after a contribution is written, receiving the CID. Used for session tagging. */
   readonly onContributionWritten?: ((cid: string) => void) | undefined;
+  /**
+   * Called after any Entity (#287) write, with the kind, namespace, op, and
+   * projected envelope. Drives the watch protocol (#292) — grove-server wires
+   * this into WatchHub.recordWrite. Heartbeat-only Claim writes that change
+   * neither status nor the lease-expiry boundary do not fire this hook.
+   */
+  readonly onEntityWrite?:
+    | ((event: import("../watch-events.js").EntityWriteEvent) => void)
+    | undefined;
+  /**
+   * Namespace under which this operation runs. Required to fire
+   * `onEntityWrite` (the watch protocol scopes events per-namespace). When
+   * absent (e.g. legacy callers without auth context), the watch hook is
+   * skipped — operations remain functional.
+   */
+  readonly namespace?: string | undefined;
   /** Optional event bus for agent notifications. */
   readonly eventBus?: EventBus | undefined;
   /** Optional topology router for routing contribution events to downstream agents. */

--- a/src/core/operations/test-helpers.ts
+++ b/src/core/operations/test-helpers.ts
@@ -155,6 +155,10 @@ export async function createTestOperationDeps(): Promise<TestOperationDeps> {
     onContributionWritten: () => {
       /* no-op for tests */
     },
+    onEntityWrite: () => {
+      /* no-op for tests */
+    },
+    namespace: "test",
     eventBus: undefined as unknown as NonNullable<OperationDeps["eventBus"]>,
     topologyRouter: undefined as unknown as NonNullable<OperationDeps["topologyRouter"]>,
     hookRunner: undefined as unknown as NonNullable<OperationDeps["hookRunner"]>,

--- a/src/core/watch-events.ts
+++ b/src/core/watch-events.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared types for the watch protocol (#292).
+ *
+ * The watch RV is a monotonic per-(namespace, kind) sequence held by the
+ * server's WatchHub. It is distinct from Entity.resourceVersion (per-row
+ * revision) — see docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md.
+ */
+
+import type {
+  AgentSessionEntity,
+  ClaimEntity,
+  ContributionEntity,
+} from "./entity.js";
+
+export type WatchKind = "Contribution" | "Claim" | "AgentSession";
+
+export type WatchOp = "ADDED" | "MODIFIED" | "DELETED";
+
+export type WatchEntity = ContributionEntity | ClaimEntity | AgentSessionEntity;
+
+/** A watch-stream event emitted by the hub to subscribers. */
+export interface WatchEvent {
+  readonly rv: bigint;
+  readonly op: WatchOp;
+  readonly kind: WatchKind;
+  readonly namespace: string;
+  readonly entity: WatchEntity;
+}
+
+/** Argument shape for `WatchHub.recordWrite` / `OperationDeps.onEntityWrite`. */
+export type EntityWriteEvent = Omit<WatchEvent, "rv">;
+
+/** Thrown by `WatchHub.subscribe` when `fromRv` falls outside the ring buffer. */
+export class StaleResourceVersionError extends Error {
+  readonly code = 410;
+  readonly namespace: string;
+  readonly kind: WatchKind;
+  readonly fromRv: bigint;
+  readonly oldestRv: bigint;
+
+  constructor(namespace: string, kind: WatchKind, fromRv: bigint, oldestRv: bigint) {
+    super(
+      `resourceVersion ${fromRv} is older than the oldest buffered event ${oldestRv} for ${namespace}/${kind}`,
+    );
+    this.name = "StaleResourceVersionError";
+    this.namespace = namespace;
+    this.kind = kind;
+    this.fromRv = fromRv;
+    this.oldestRv = oldestRv;
+  }
+}

--- a/src/core/watch-events.ts
+++ b/src/core/watch-events.ts
@@ -6,11 +6,7 @@
  * revision) — see docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md.
  */
 
-import type {
-  AgentSessionEntity,
-  ClaimEntity,
-  ContributionEntity,
-} from "./entity.js";
+import type { AgentSessionEntity, ClaimEntity, ContributionEntity } from "./entity.js";
 
 export type WatchKind = "Contribution" | "Claim" | "AgentSession";
 

--- a/src/core/watch-hub.test.ts
+++ b/src/core/watch-hub.test.ts
@@ -117,8 +117,7 @@ describe("WatchHub ring buffer", () => {
 describe("WatchHub.subscribe", () => {
   test("replays events with rv > fromRv then tails new writes", async () => {
     const hub = new WatchHub();
-    const ent = (cid: string) =>
-      contributionToEntity(fixtureContribution(cid), "ns/wt");
+    const ent = (cid: string) => contributionToEntity(fixtureContribution(cid), "ns/wt");
     const rv1 = hub.recordWrite({
       kind: "Contribution",
       namespace: "ns/wt",
@@ -158,8 +157,7 @@ describe("WatchHub.subscribe", () => {
 
   test("throws StaleResourceVersionError when fromRv < ring.oldestRv", () => {
     const hub = new WatchHub({ maxEventsPerKey: 2 });
-    const ent = (cid: string) =>
-      contributionToEntity(fixtureContribution(cid), "ns/wt");
+    const ent = (cid: string) => contributionToEntity(fixtureContribution(cid), "ns/wt");
     for (const cid of ["a", "b", "c"]) {
       hub.recordWrite({
         kind: "Contribution",
@@ -178,8 +176,7 @@ describe("WatchHub.subscribe", () => {
 describe("WatchHub overflow", () => {
   test("slow consumer triggers BufferOverflowError after outbox cap exceeded", async () => {
     const hub = new WatchHub({ perClientOutboxCap: 2 });
-    const ent = (cid: string) =>
-      contributionToEntity(fixtureContribution(cid), "ns/wt");
+    const ent = (cid: string) => contributionToEntity(fixtureContribution(cid), "ns/wt");
 
     const ac = new AbortController();
     const stream = hub.subscribe("ns/wt", "Contribution", 0n, ac.signal);

--- a/src/core/watch-hub.test.ts
+++ b/src/core/watch-hub.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { contributionToEntity } from "./entity.js";
 import type { Contribution } from "./models.js";
 import { StaleResourceVersionError } from "./watch-events.js";
-import { WatchHub } from "./watch-hub.js";
+import { BufferOverflowError, WatchHub } from "./watch-hub.js";
 
 function fixtureContribution(cid: string): Contribution {
   return {
@@ -172,5 +172,33 @@ describe("WatchHub.subscribe", () => {
       const ac = new AbortController();
       hub.subscribe("ns/wt", "Contribution", 0n, ac.signal);
     }).toThrow(StaleResourceVersionError);
+  });
+});
+
+describe("WatchHub overflow", () => {
+  test("slow consumer triggers BufferOverflowError after outbox cap exceeded", async () => {
+    const hub = new WatchHub({ perClientOutboxCap: 2 });
+    const ent = (cid: string) =>
+      contributionToEntity(fixtureContribution(cid), "ns/wt");
+
+    const ac = new AbortController();
+    const stream = hub.subscribe("ns/wt", "Contribution", 0n, ac.signal);
+
+    // Don't drain — let the queue fill up
+    for (let i = 0; i < 5; i++) {
+      hub.recordWrite({
+        kind: "Contribution",
+        namespace: "ns/wt",
+        op: "ADDED",
+        entity: ent(`cid-${i}`),
+      });
+    }
+
+    const it = stream[Symbol.asyncIterator]();
+    expect((await it.next()).value.rv).toBe(1n);
+    expect((await it.next()).value.rv).toBe(2n);
+    const rejection = it.next();
+    await expect(rejection).rejects.toThrow("watch outbox overflowed");
+    await expect(rejection).rejects.toBeInstanceOf(BufferOverflowError);
   });
 });

--- a/src/core/watch-hub.test.ts
+++ b/src/core/watch-hub.test.ts
@@ -202,3 +202,16 @@ describe("WatchHub overflow", () => {
     await expect(rejection).rejects.toBeInstanceOf(BufferOverflowError);
   });
 });
+
+describe("WatchHub config", () => {
+  test("exposes bookmarkIntervalMs and perClientOutboxCap from options", () => {
+    const hub = new WatchHub({ bookmarkIntervalMs: 5_000, perClientOutboxCap: 16 });
+    expect(hub.bookmarkIntervalMs).toBe(5_000);
+    expect(hub.perClientOutboxCap).toBe(16);
+  });
+
+  test("defaults bookmarkIntervalMs to 30000", () => {
+    const hub = new WatchHub();
+    expect(hub.bookmarkIntervalMs).toBe(30_000);
+  });
+});

--- a/src/core/watch-hub.test.ts
+++ b/src/core/watch-hub.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { contributionToEntity } from "./entity.js";
 import type { Contribution } from "./models.js";
+import { StaleResourceVersionError } from "./watch-events.js";
 import { WatchHub } from "./watch-hub.js";
 
 function fixtureContribution(cid: string): Contribution {
@@ -110,5 +111,66 @@ describe("WatchHub ring buffer", () => {
     const buffered = hub.snapshotRing("ns/wt", "Contribution");
     expect(buffered.length).toBe(1);
     expect(buffered[0]?.entity.id).toBe("cid-new");
+  });
+});
+
+describe("WatchHub.subscribe", () => {
+  test("replays events with rv > fromRv then tails new writes", async () => {
+    const hub = new WatchHub();
+    const ent = (cid: string) =>
+      contributionToEntity(fixtureContribution(cid), "ns/wt");
+    const rv1 = hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: ent("cid-1"),
+    });
+    hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: ent("cid-2"),
+    });
+
+    const ac = new AbortController();
+    const seen: bigint[] = [];
+    const stream = hub.subscribe("ns/wt", "Contribution", rv1, ac.signal);
+
+    const drain = (async () => {
+      for await (const ev of stream) {
+        seen.push(ev.rv);
+        if (seen.length === 2) ac.abort();
+      }
+    })();
+
+    queueMicrotask(() => {
+      hub.recordWrite({
+        kind: "Contribution",
+        namespace: "ns/wt",
+        op: "ADDED",
+        entity: ent("cid-3"),
+      });
+    });
+
+    await drain;
+    expect(seen).toEqual([2n, 3n]);
+  });
+
+  test("throws StaleResourceVersionError when fromRv < ring.oldestRv", () => {
+    const hub = new WatchHub({ maxEventsPerKey: 2 });
+    const ent = (cid: string) =>
+      contributionToEntity(fixtureContribution(cid), "ns/wt");
+    for (const cid of ["a", "b", "c"]) {
+      hub.recordWrite({
+        kind: "Contribution",
+        namespace: "ns/wt",
+        op: "ADDED",
+        entity: ent(cid),
+      });
+    }
+    expect(() => {
+      const ac = new AbortController();
+      hub.subscribe("ns/wt", "Contribution", 0n, ac.signal);
+    }).toThrow(StaleResourceVersionError);
   });
 });

--- a/src/core/watch-hub.test.ts
+++ b/src/core/watch-hub.test.ts
@@ -6,6 +6,7 @@ import { WatchHub } from "./watch-hub.js";
 function fixtureContribution(cid: string): Contribution {
   return {
     cid,
+    manifestVersion: 1,
     kind: "work",
     mode: "evaluation",
     summary: "fixture",
@@ -14,7 +15,7 @@ function fixtureContribution(cid: string): Contribution {
     tags: [],
     agent: { agentId: "a-1" },
     createdAt: new Date().toISOString(),
-  } as Contribution;
+  };
 }
 
 describe("WatchHub.recordWrite", () => {

--- a/src/core/watch-hub.test.ts
+++ b/src/core/watch-hub.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { contributionToEntity } from "./entity.js";
+import type { Contribution } from "./models.js";
+import { WatchHub } from "./watch-hub.js";
+
+function fixtureContribution(cid: string): Contribution {
+  return {
+    cid,
+    kind: "work",
+    mode: "evaluation",
+    summary: "fixture",
+    artifacts: {},
+    relations: [],
+    tags: [],
+    agent: { agentId: "a-1" },
+    createdAt: new Date().toISOString(),
+  } as Contribution;
+}
+
+describe("WatchHub.recordWrite", () => {
+  test("returns strictly increasing rv for same (ns, kind)", () => {
+    const hub = new WatchHub();
+    const ent1 = contributionToEntity(fixtureContribution("cid-a"), "ns/wt");
+    const ent2 = contributionToEntity(fixtureContribution("cid-b"), "ns/wt");
+    const rv1 = hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: ent1,
+    });
+    const rv2 = hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: ent2,
+    });
+    expect(rv2 > rv1).toBe(true);
+  });
+});

--- a/src/core/watch-hub.test.ts
+++ b/src/core/watch-hub.test.ts
@@ -37,4 +37,36 @@ describe("WatchHub.recordWrite", () => {
     });
     expect(rv2 > rv1).toBe(true);
   });
+
+  test("namespaces and kinds maintain independent counters", () => {
+    const hub = new WatchHub();
+    const ent = contributionToEntity(fixtureContribution("cid-a"), "ns/wt");
+    const rvNsA = hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/A",
+      op: "ADDED",
+      entity: ent,
+    });
+    const rvNsB = hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/B",
+      op: "ADDED",
+      entity: ent,
+    });
+    const rvKindClaim = hub.recordWrite({
+      kind: "Claim",
+      namespace: "ns/A",
+      op: "ADDED",
+      // Reusing the Contribution entity for shape only; the WatchEvent
+      // union accepts it because the test does not exercise claim semantics.
+      entity: ent as unknown as never,
+    });
+    expect(rvNsA).toBe(1n);
+    expect(rvNsB).toBe(1n);
+    expect(rvKindClaim).toBe(1n);
+    expect(hub.currentRv("ns/A", "Contribution")).toBe(1n);
+    expect(hub.currentRv("ns/B", "Contribution")).toBe(1n);
+    expect(hub.currentRv("ns/A", "Claim")).toBe(1n);
+    expect(hub.currentRv("ns/A", "AgentSession")).toBe(0n);
+  });
 });

--- a/src/core/watch-hub.test.ts
+++ b/src/core/watch-hub.test.ts
@@ -70,3 +70,20 @@ describe("WatchHub.recordWrite", () => {
     expect(hub.currentRv("ns/A", "AgentSession")).toBe(0n);
   });
 });
+
+describe("WatchHub ring buffer", () => {
+  test("retains last maxEventsPerKey events per (ns, kind)", () => {
+    const hub = new WatchHub({ maxEventsPerKey: 3 });
+    for (let i = 0; i < 5; i++) {
+      hub.recordWrite({
+        kind: "Contribution",
+        namespace: "ns/wt",
+        op: "ADDED",
+        entity: contributionToEntity(fixtureContribution(`cid-${i}`), "ns/wt"),
+      });
+    }
+    const buffered = hub.snapshotRing("ns/wt", "Contribution");
+    expect(buffered.length).toBe(3);
+    expect(buffered.map((e) => e.rv)).toEqual([3n, 4n, 5n]);
+  });
+});

--- a/src/core/watch-hub.test.ts
+++ b/src/core/watch-hub.test.ts
@@ -86,4 +86,29 @@ describe("WatchHub ring buffer", () => {
     expect(buffered.length).toBe(3);
     expect(buffered.map((e) => e.rv)).toEqual([3n, 4n, 5n]);
   });
+
+  test("evicts events older than maxAgeMsPerKey", () => {
+    let clock = 1_000_000;
+    const hub = new WatchHub({
+      maxEventsPerKey: 1024,
+      maxAgeMsPerKey: 1_000,
+      now: () => clock,
+    });
+    hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: contributionToEntity(fixtureContribution("cid-old"), "ns/wt"),
+    });
+    clock += 5_000;
+    hub.recordWrite({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: contributionToEntity(fixtureContribution("cid-new"), "ns/wt"),
+    });
+    const buffered = hub.snapshotRing("ns/wt", "Contribution");
+    expect(buffered.length).toBe(1);
+    expect(buffered[0]?.entity.id).toBe("cid-new");
+  });
 });

--- a/src/core/watch-hub.ts
+++ b/src/core/watch-hub.ts
@@ -5,6 +5,7 @@
  */
 
 import type { EntityWriteEvent, WatchEvent, WatchKind } from "./watch-events.js";
+import { StaleResourceVersionError } from "./watch-events.js";
 
 export interface WatchHubOptions {
   readonly maxEventsPerKey?: number;
@@ -49,11 +50,102 @@ export class WatchHub {
     s.ring.push(watchEvent);
     s.insertedAt.push(this.now());
     this.trim(s);
+    this.fanout(key, watchEvent);
     return s.counter;
   }
 
   currentRv(namespace: string, kind: WatchKind): bigint {
     return this.state.get(this.key(namespace, kind))?.counter ?? 0n;
+  }
+
+  subscribe(
+    namespace: string,
+    kind: WatchKind,
+    fromRv: bigint,
+    signal: AbortSignal,
+  ): AsyncIterable<WatchEvent> {
+    const key = this.key(namespace, kind);
+    const s = this.getOrCreate(key);
+
+    const oldestRv = s.ring.length > 0 ? (s.ring[0] as WatchEvent).rv : 0n;
+    // Resume from rv == oldestRv - 1 means "I have everything through oldestRv-1,
+    // give me oldestRv onward." Anything strictly older is unrecoverable → 410.
+    if (fromRv < oldestRv - 1n) {
+      throw new StaleResourceVersionError(namespace, kind, fromRv, oldestRv);
+    }
+
+    const replay: WatchEvent[] = s.ring.filter((e) => e.rv > fromRv);
+
+    const subscriber: Subscriber = {
+      namespace,
+      kind,
+      queue: [...replay],
+      pending: null,
+      closed: false,
+      overflow: false,
+    };
+    this.subscribersFor(key).add(subscriber);
+
+    signal.addEventListener("abort", () => this.closeSubscriber(key, subscriber));
+
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => {
+          while (true) {
+            if (subscriber.overflow) {
+              this.closeSubscriber(key, subscriber);
+              throw new BufferOverflowError(namespace, kind);
+            }
+            if (subscriber.queue.length > 0) {
+              const value = subscriber.queue.shift() as WatchEvent;
+              return { value, done: false };
+            }
+            if (subscriber.closed) {
+              return { value: undefined as unknown as WatchEvent, done: true };
+            }
+            await new Promise<void>((resolve) => {
+              subscriber.pending = resolve;
+            });
+          }
+        },
+        return: async () => {
+          this.closeSubscriber(key, subscriber);
+          return { value: undefined as unknown as WatchEvent, done: true };
+        },
+      }),
+    };
+  }
+
+  private subscribersByKey = new Map<string, Set<Subscriber>>();
+
+  private subscribersFor(key: string): Set<Subscriber> {
+    let set = this.subscribersByKey.get(key);
+    if (!set) {
+      set = new Set();
+      this.subscribersByKey.set(key, set);
+    }
+    return set;
+  }
+
+  private fanout(key: string, event: WatchEvent): void {
+    const set = this.subscribersByKey.get(key);
+    if (!set) return;
+    for (const sub of set) {
+      if (sub.queue.length >= this.perClientOutboxCap) {
+        sub.overflow = true;
+      } else {
+        sub.queue.push(event);
+      }
+      sub.pending?.();
+      sub.pending = null;
+    }
+  }
+
+  private closeSubscriber(key: string, sub: Subscriber): void {
+    sub.closed = true;
+    sub.pending?.();
+    sub.pending = null;
+    this.subscribersByKey.get(key)?.delete(sub);
   }
 
   /** Test-only inspector. Returns a copy. */
@@ -85,5 +177,27 @@ export class WatchHub {
       s.ring.shift();
       s.insertedAt.shift();
     }
+  }
+}
+
+interface Subscriber {
+  readonly namespace: string;
+  readonly kind: WatchKind;
+  queue: WatchEvent[];
+  pending: (() => void) | null;
+  closed: boolean;
+  overflow: boolean;
+}
+
+export class BufferOverflowError extends Error {
+  readonly code = 503;
+  readonly namespace: string;
+  readonly kind: WatchKind;
+
+  constructor(namespace: string, kind: WatchKind) {
+    super(`watch outbox overflowed for ${namespace}/${kind}`);
+    this.name = "BufferOverflowError";
+    this.namespace = namespace;
+    this.kind = kind;
   }
 }

--- a/src/core/watch-hub.ts
+++ b/src/core/watch-hub.ts
@@ -1,9 +1,6 @@
 /**
- * WatchHub — per-(namespace, kind) monotonic resourceVersion authority,
- * ring buffer, and subscriber fan-out for the watch protocol (#292).
- *
- * No HTTP, no I/O. Pure in-memory state. See
- * docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md.
+ * WatchHub — per-(namespace, kind) monotonic resourceVersion counter (#292).
+ * See docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md.
  */
 
 import type { EntityWriteEvent, WatchKind } from "./watch-events.js";

--- a/src/core/watch-hub.ts
+++ b/src/core/watch-hub.ts
@@ -1,21 +1,89 @@
 /**
- * WatchHub — per-(namespace, kind) monotonic resourceVersion counter (#292).
+ * WatchHub — per-(namespace, kind) monotonic resourceVersion counter and
+ * ring buffer for the watch protocol (#292).
  * See docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md.
  */
 
-import type { EntityWriteEvent, WatchKind } from "./watch-events.js";
+import type { EntityWriteEvent, WatchEvent, WatchKind } from "./watch-events.js";
+
+export interface WatchHubOptions {
+  readonly maxEventsPerKey?: number;
+  readonly maxAgeMsPerKey?: number;
+  readonly bookmarkIntervalMs?: number;
+  readonly perClientOutboxCap?: number;
+  readonly now?: () => number;
+}
+
+interface KeyState {
+  counter: bigint;
+  ring: WatchEvent[];
+  insertedAt: number[];
+}
+
+const DEFAULT_MAX_EVENTS = 1024;
+const DEFAULT_MAX_AGE_MS = 5 * 60_000;
+const DEFAULT_BOOKMARK_INTERVAL_MS = 30_000;
+const DEFAULT_OUTBOX_CAP = 256;
 
 export class WatchHub {
-  private readonly counters = new Map<string, bigint>();
+  private readonly state = new Map<string, KeyState>();
+  private readonly maxEventsPerKey: number;
+  private readonly maxAgeMsPerKey: number;
+  readonly bookmarkIntervalMs: number;
+  readonly perClientOutboxCap: number;
+  private readonly now: () => number;
+
+  constructor(opts: WatchHubOptions = {}) {
+    this.maxEventsPerKey = opts.maxEventsPerKey ?? DEFAULT_MAX_EVENTS;
+    this.maxAgeMsPerKey = opts.maxAgeMsPerKey ?? DEFAULT_MAX_AGE_MS;
+    this.bookmarkIntervalMs = opts.bookmarkIntervalMs ?? DEFAULT_BOOKMARK_INTERVAL_MS;
+    this.perClientOutboxCap = opts.perClientOutboxCap ?? DEFAULT_OUTBOX_CAP;
+    this.now = opts.now ?? (() => Date.now());
+  }
 
   recordWrite(event: EntityWriteEvent): bigint {
-    const key = `${event.namespace}\x00${event.kind}`;
-    const next = (this.counters.get(key) ?? 0n) + 1n;
-    this.counters.set(key, next);
-    return next;
+    const key = this.key(event.namespace, event.kind);
+    const s = this.getOrCreate(key);
+    s.counter += 1n;
+    const watchEvent: WatchEvent = { ...event, rv: s.counter };
+    s.ring.push(watchEvent);
+    s.insertedAt.push(this.now());
+    this.trim(s);
+    return s.counter;
   }
 
   currentRv(namespace: string, kind: WatchKind): bigint {
-    return this.counters.get(`${namespace}\x00${kind}`) ?? 0n;
+    return this.state.get(this.key(namespace, kind))?.counter ?? 0n;
+  }
+
+  /** Test-only inspector. Returns a copy. */
+  snapshotRing(namespace: string, kind: WatchKind): readonly WatchEvent[] {
+    const s = this.state.get(this.key(namespace, kind));
+    return s ? [...s.ring] : [];
+  }
+
+  private key(namespace: string, kind: WatchKind): string {
+    return `${namespace}\x00${kind}`;
+  }
+
+  private getOrCreate(key: string): KeyState {
+    let s = this.state.get(key);
+    if (!s) {
+      s = { counter: 0n, ring: [], insertedAt: [] };
+      this.state.set(key, s);
+    }
+    return s;
+  }
+
+  private trim(s: KeyState): void {
+    while (s.ring.length > this.maxEventsPerKey) {
+      s.ring.shift();
+      s.insertedAt.shift();
+    }
+    const cutoff = this.now() - this.maxAgeMsPerKey;
+    while (s.ring.length > 0 && (s.insertedAt[0] ?? 0) < cutoff) {
+      s.ring.shift();
+      s.insertedAt.shift();
+    }
   }
 }

--- a/src/core/watch-hub.ts
+++ b/src/core/watch-hub.ts
@@ -92,13 +92,15 @@ export class WatchHub {
       [Symbol.asyncIterator]: () => ({
         next: async () => {
           while (true) {
-            if (subscriber.overflow) {
-              this.closeSubscriber(key, subscriber);
-              throw new BufferOverflowError(namespace, kind);
-            }
+            // Drain already-queued events first; only signal overflow once
+            // the consumer has caught up with what was successfully buffered.
             if (subscriber.queue.length > 0) {
               const value = subscriber.queue.shift() as WatchEvent;
               return { value, done: false };
+            }
+            if (subscriber.overflow) {
+              this.closeSubscriber(key, subscriber);
+              throw new BufferOverflowError(namespace, kind);
             }
             if (subscriber.closed) {
               return { value: undefined as unknown as WatchEvent, done: true };

--- a/src/core/watch-hub.ts
+++ b/src/core/watch-hub.ts
@@ -1,0 +1,24 @@
+/**
+ * WatchHub — per-(namespace, kind) monotonic resourceVersion authority,
+ * ring buffer, and subscriber fan-out for the watch protocol (#292).
+ *
+ * No HTTP, no I/O. Pure in-memory state. See
+ * docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md.
+ */
+
+import type { EntityWriteEvent, WatchKind } from "./watch-events.js";
+
+export class WatchHub {
+  private readonly counters = new Map<string, bigint>();
+
+  recordWrite(event: EntityWriteEvent): bigint {
+    const key = `${event.namespace}\x00${event.kind}`;
+    const next = (this.counters.get(key) ?? 0n) + 1n;
+    this.counters.set(key, next);
+    return next;
+  }
+
+  currentRv(namespace: string, kind: WatchKind): bigint {
+    return this.counters.get(`${namespace}\x00${kind}`) ?? 0n;
+  }
+}

--- a/src/core/watch-hub.ts
+++ b/src/core/watch-hub.ts
@@ -73,6 +73,12 @@ export class WatchHub {
     if (fromRv < oldestRv - 1n) {
       throw new StaleResourceVersionError(namespace, kind, fromRv, oldestRv);
     }
+    // Reject future RVs. After a server restart the hub resets to 0; a client
+    // resuming from rv=100 must re-list rather than receive id=1 next and
+    // silently violate watch-RV monotonicity.
+    if (fromRv > s.counter) {
+      throw new StaleResourceVersionError(namespace, kind, fromRv, s.counter);
+    }
 
     const replay: WatchEvent[] = s.ring.filter((e) => e.rv > fromRv);
 

--- a/src/mcp/deps-parity.test.ts
+++ b/src/mcp/deps-parity.test.ts
@@ -11,6 +11,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { WatchHub } from "../core/watch-hub.js";
 import { createLocalRuntime, type LocalRuntime } from "../local/runtime.js";
 import type { McpDeps } from "./deps.js";
 
@@ -54,6 +55,7 @@ describe("MCP deps parity with LocalRuntime", () => {
       workspaceBoundary: runtime.groveRoot,
       goalSessionStore: runtime.goalSessionStore,
       handoffStore: runtime.handoffStore,
+      watchHub: new WatchHub(),
     };
 
     expect(deps.goalSessionStore).toBeDefined();
@@ -73,6 +75,7 @@ describe("MCP deps parity with LocalRuntime", () => {
       onContributionWrite: runtime.onContributionWrite,
       workspaceBoundary: runtime.groveRoot,
       goalSessionStore: runtime.goalSessionStore,
+      watchHub: new WatchHub(),
     };
 
     expect(deps.goalSessionStore).toBeDefined();

--- a/src/mcp/serve-http.ts
+++ b/src/mcp/serve-http.ts
@@ -29,6 +29,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { findGroveDir } from "../cli/context.js";
 import { StateConflictError } from "../core/errors.js";
 import { TopologyRouter } from "../core/topology-router.js";
+import { WatchHub } from "../core/watch-hub.js";
 import { createLocalRuntime } from "../local/runtime.js";
 import { parsePort } from "../shared/env.js";
 import { safeCleanup } from "../shared/safe-cleanup.js";
@@ -687,6 +688,7 @@ async function buildScopedDeps(sessionId: string | undefined): Promise<ScopedDep
     idempotencyStore,
     ...(handoffExpiryManaged ? { handoffExpiryManaged: true } : {}),
     ...(deadlineWatcher ? { deadlineWatcher } : {}),
+    watchHub: new WatchHub(),
   };
   const deactivate = () => {
     mutationGuard.deactivate();

--- a/src/mcp/serve.ts
+++ b/src/mcp/serve.ts
@@ -15,6 +15,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 
 import { findGroveDir } from "../cli/context.js";
 import { TopologyRouter } from "../core/topology-router.js";
+import { WatchHub } from "../core/watch-hub.js";
 import { createLocalRuntime } from "../local/runtime.js";
 import type { McpDeps } from "./deps.js";
 import { createMcpServer } from "./server.js";
@@ -532,6 +533,7 @@ try {
     idempotencyStore: runtime.idempotencyStore,
     ...(handoffExpiryManaged ? { handoffExpiryManaged: true } : {}),
     ...(deadlineWatcher ? { deadlineWatcher } : {}),
+    watchHub: new WatchHub(),
   };
   // Derive MCP tool preset from contract mode — #11 MCP Tool Surface + #12 Concept Usage
   const contractMode = loadedContract?.mode ?? "exploration";

--- a/src/mcp/test-helpers.ts
+++ b/src/mcp/test-helpers.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import type { ContentStore } from "../core/cas.js";
 import { DefaultFrontierCalculator } from "../core/frontier.js";
 import { InMemoryCreditsService } from "../core/in-memory-credits.js";
+import { WatchHub } from "../core/watch-hub.js";
 import { FsCas } from "../local/fs-cas.js";
 import { SqliteBountyStore } from "../local/sqlite-bounty-store.js";
 import { initSqliteDb, SqliteClaimStore, SqliteContributionStore } from "../local/sqlite-store.js";
@@ -57,6 +58,7 @@ export async function createTestMcpDeps(): Promise<TestMcpDeps> {
     frontier,
     workspace,
     workspaceBoundary: tempDir,
+    watchHub: new WatchHub(),
   };
 
   return {

--- a/src/nexus/config.ts
+++ b/src/nexus/config.ts
@@ -3,6 +3,7 @@
  */
 
 import type { NexusClient } from "./client.js";
+import type { NexusWatchPublisher } from "./nexus-watch-publisher.js";
 
 /** Configuration for Nexus-backed Grove adapters. */
 export interface NexusConfig {
@@ -16,6 +17,18 @@ export interface NexusConfig {
    *  are stored under /zones/{zoneId}/sessions/{sessionId}/ instead of the zone root.
    *  This prevents N+1 VFS reads from scanning all historical contributions. */
   readonly sessionId?: string | undefined;
+
+  /**
+   * Optional publisher for cross-process watch fan-out (#292).
+   *
+   * When set, store mutations also publish lightweight `entity.changed`
+   * envelopes onto the in-process event-bus so that NexusWatchSubscriber
+   * (running in the grove-server) can hydrate the WatchHub for any process
+   * that wrote through Nexus, regardless of which process holds the watcher.
+   *
+   * Optional so existing test code (and pure-local mode) can omit it.
+   */
+  readonly watchPublisher?: NexusWatchPublisher | undefined;
 
   /** Maximum concurrent requests to Nexus. Defaults to 20. */
   readonly maxConcurrency?: number | undefined;
@@ -51,6 +64,7 @@ export interface ResolvedNexusConfig {
   readonly retryMaxAttempts: number;
   readonly retryBaseDelayMs: number;
   readonly retryMaxDelayMs: number;
+  readonly watchPublisher: NexusWatchPublisher | undefined;
 }
 
 /** Apply defaults to a NexusConfig. */
@@ -65,5 +79,6 @@ export function resolveConfig(config: NexusConfig): ResolvedNexusConfig {
     retryMaxAttempts: config.retryMaxAttempts ?? 3,
     retryBaseDelayMs: config.retryBaseDelayMs ?? 100,
     retryMaxDelayMs: config.retryMaxDelayMs ?? 5_000,
+    watchPublisher: config.watchPublisher,
   };
 }

--- a/src/nexus/nexus-claim-store.ts
+++ b/src/nexus/nexus-claim-store.ts
@@ -38,6 +38,7 @@ import { resolveConfig } from "./config.js";
 import { NexusConflictError } from "./errors.js";
 import { listAllPages } from "./list-pages.js";
 import { LruCache } from "./lru-cache.js";
+import type { NexusWatchPublisher } from "./nexus-watch-publisher.js";
 import { withRetry, withSemaphore } from "./retry.js";
 import { Semaphore } from "./semaphore.js";
 import {
@@ -77,6 +78,7 @@ export class NexusClaimStore implements ClaimStore {
   private readonly semaphore: Semaphore;
   private readonly zoneId: string;
   private readonly claimCache: LruCache<Claim>;
+  private readonly watchPublisher: NexusWatchPublisher | undefined;
   /** Cached activeClaims result with TTL. */
   private activeClaimsCache:
     | { readonly claims: readonly Claim[]; readonly expiresAt: number }
@@ -87,9 +89,27 @@ export class NexusClaimStore implements ClaimStore {
     this.config = resolveConfig(config);
     this.client = this.config.client;
     this.zoneId = this.config.zoneId;
+    this.watchPublisher = this.config.watchPublisher;
     this.storeIdentity = `nexus:${this.zoneId}:claims`;
     this.semaphore = new Semaphore(this.config.maxConcurrency);
     this.claimCache = new LruCache(this.config.cacheMaxEntries);
+  }
+
+  /** Publish a watch fan-out envelope (#292). No-op when publisher not configured. */
+  private publishWatch(claim: Claim, op: "ADDED" | "MODIFIED" | "DELETED"): void {
+    if (!this.watchPublisher) return;
+    // Generation tracks per-row revision (1-based). Same field used by
+    // claimToEntity to populate metadata.generation, so subscriber dedupe
+    // keys agree across processes.
+    const generation = claim.revision ?? 1;
+    void this.watchPublisher.publish({
+      kind: "Claim",
+      namespace: this.zoneId,
+      op,
+      entityId: claim.claimId,
+      generation,
+      emittedAt: new Date().toISOString(),
+    });
   }
 
   /** Invalidate the activeClaims cache (called on mutations). */
@@ -152,6 +172,7 @@ export class NexusClaimStore implements ClaimStore {
 
     this.claimCache.set(createdClaim.claimId, createdClaim);
     this.invalidateActiveClaimsCache();
+    this.publishWatch(createdClaim, "ADDED");
     return createdClaim;
   }
 
@@ -190,6 +211,14 @@ export class NexusClaimStore implements ClaimStore {
       }
       this.claimCache.set(renewed.claimId, renewed);
       this.invalidateActiveClaimsCache();
+      // Renew path always emits MODIFIED. Distinguishing pure heartbeat
+      // (no status change) from user-meaningful renews (intentSummary
+      // refresh, lease bump) would require comparing the prior claim
+      // contents — the cost of an extra read on every renew. The
+      // subscriber's (kind, id, generation) dedupe filters back-to-back
+      // duplicates, and the generation is monotonic on every revision
+      // bump above, so each renew is a distinct watch event.
+      this.publishWatch(renewed, "MODIFIED");
       return renewed;
     }
 
@@ -231,6 +260,7 @@ export class NexusClaimStore implements ClaimStore {
 
     this.claimCache.set(createdClaim.claimId, createdClaim);
     this.invalidateActiveClaimsCache();
+    this.publishWatch(createdClaim, "ADDED");
     return createdClaim;
   }
 
@@ -261,6 +291,8 @@ export class NexusClaimStore implements ClaimStore {
     await this.writeClaimCas(updated, etag);
     this.claimCache.set(updated.claimId, updated);
     this.invalidateActiveClaimsCache();
+    // Heartbeats are MODIFIED — same reasoning as the claimOrRenew renew path.
+    this.publishWatch(updated, "MODIFIED");
     return updated;
   }
 
@@ -324,6 +356,7 @@ export class NexusClaimStore implements ClaimStore {
         await this.writeClaimCas(expired, etag);
         await this.deleteActiveIndex(expired);
         this.claimCache.set(expired.claimId, expired);
+        this.publishWatch(expired, "MODIFIED");
         results.push({ claim: expired, reason });
       }
     }
@@ -410,6 +443,11 @@ export class NexusClaimStore implements ClaimStore {
             this.config,
           );
           this.claimCache.delete(claim.claimId);
+          // The row is gone — surface DELETED so watchers can drop their
+          // local copy. Subscribers that have not yet seen this claim
+          // will simply ignore the event (their fetchEntity returns
+          // not-found and the subscriber logs + skips).
+          this.publishWatch(claim, "DELETED");
           deleted++;
         }
       }
@@ -495,6 +533,10 @@ export class NexusClaimStore implements ClaimStore {
     }
     this.claimCache.set(updated.claimId, updated);
     this.invalidateActiveClaimsCache();
+    // release / complete / expire all surface as MODIFIED — the row still
+    // exists, only its phase changed. Subscribers project the new effective
+    // phase via claimToEntity and route accordingly.
+    this.publishWatch(updated, "MODIFIED");
     return updated;
   }
 

--- a/src/nexus/nexus-claim-store.ts
+++ b/src/nexus/nexus-claim-store.ts
@@ -102,6 +102,10 @@ export class NexusClaimStore implements ClaimStore {
     // claimToEntity to populate metadata.generation, so subscriber dedupe
     // keys agree across processes.
     const generation = claim.revision ?? 1;
+    // Include the entity snapshot for DELETED — the row is removed before
+    // (or alongside) publish, so subscribers can't fetchEntity. Including
+    // it for ADDED/MODIFIED is also a free latency win.
+    const entity: ClaimEntity = claimToEntity(claim, () => Date.now(), this.zoneId);
     void this.watchPublisher.publish({
       kind: "Claim",
       namespace: this.zoneId,
@@ -109,6 +113,7 @@ export class NexusClaimStore implements ClaimStore {
       entityId: claim.claimId,
       generation,
       emittedAt: new Date().toISOString(),
+      entity,
     });
   }
 

--- a/src/nexus/nexus-contribution-store.ts
+++ b/src/nexus/nexus-contribution-store.ts
@@ -36,6 +36,7 @@ import type { NexusConfig, ResolvedNexusConfig } from "./config.js";
 import { resolveConfig } from "./config.js";
 import { listAllPages } from "./list-pages.js";
 import { LruCache } from "./lru-cache.js";
+import type { NexusWatchPublisher } from "./nexus-watch-publisher.js";
 import { withRetry, withSemaphore } from "./retry.js";
 import { Semaphore } from "./semaphore.js";
 import {
@@ -69,6 +70,7 @@ export class NexusContributionStore implements ContributionStore {
   private readonly cache: LruCache<Contribution>;
   private readonly zoneId: string;
   private readonly sessionId: string | undefined;
+  private readonly watchPublisher: NexusWatchPublisher | undefined;
   // TTL cache for list() — avoids the N+1 VFS read storm (1 list + N FTS + N manifest)
   // that exhausts Nexus's 300/min rate limit when multiple callers poll independently.
   // TTL is short (2s) so SSE-triggered refreshes (running-view bumps refreshSignal
@@ -129,6 +131,7 @@ export class NexusContributionStore implements ContributionStore {
     this.client = this.config.client;
     this.zoneId = this.config.zoneId;
     this.sessionId = this.config.sessionId;
+    this.watchPublisher = this.config.watchPublisher;
     this.storeIdentity = `nexus:${this.zoneId}:contributions`;
     this.semaphore = new Semaphore(this.config.maxConcurrency);
     this.cache = new LruCache(this.config.cacheMaxEntries);
@@ -198,6 +201,21 @@ export class NexusContributionStore implements ContributionStore {
       "store.put",
       `cid=${contribution.cid.slice(0, 16)} sessionId=${this.sessionId ?? "none"} path=${manifestPath}`,
     );
+
+    // Cross-process watch fan-out (#292). Contributions are content-addressed
+    // and immutable, so every successful put is logically an ADDED event.
+    // Errors are swallowed by `void` — losing a fan-out envelope must never
+    // fail the underlying write.
+    if (this.watchPublisher) {
+      void this.watchPublisher.publish({
+        kind: "Contribution",
+        namespace: this.zoneId,
+        op: "ADDED",
+        entityId: contribution.cid,
+        generation: 1,
+        emittedAt: new Date().toISOString(),
+      });
+    }
   }
 
   async putMany(contributions: readonly Contribution[]): Promise<void> {

--- a/src/nexus/nexus-watch-publisher.ts
+++ b/src/nexus/nexus-watch-publisher.ts
@@ -1,0 +1,40 @@
+/**
+ * NexusWatchPublisher — publishes lightweight `entity.changed` envelopes to
+ * the Nexus event-bus when entities are written through Nexus stores.
+ *
+ * The grove-server's NexusWatchSubscriber consumes these, dedupes against
+ * the in-process onEntityWrite fast path, fetches the full entity, and
+ * calls WatchHub.recordWrite. See spec §RV authority.
+ */
+
+import type { EventBus } from "../core/event-bus.js";
+import type { WatchKind, WatchOp } from "../core/watch-events.js";
+
+export const ENTITY_CHANGED = "entity.changed";
+
+export interface EntityChangedEnvelope {
+  readonly kind: WatchKind;
+  readonly namespace: string;
+  readonly op: WatchOp;
+  readonly entityId: string;
+  readonly generation: number;
+  readonly emittedAt: string;
+}
+
+export class NexusWatchPublisher {
+  private readonly bus: EventBus;
+
+  constructor(bus: EventBus) {
+    this.bus = bus;
+  }
+
+  async publish(envelope: EntityChangedEnvelope): Promise<void> {
+    await this.bus.publish({
+      type: ENTITY_CHANGED,
+      sourceRole: "grove-store",
+      targetRole: "*",
+      payload: { ...envelope },
+      timestamp: envelope.emittedAt,
+    });
+  }
+}

--- a/src/nexus/nexus-watch-publisher.ts
+++ b/src/nexus/nexus-watch-publisher.ts
@@ -9,7 +9,7 @@
 
 import type { EventBus } from "../core/event-bus.js";
 import { getProcessInstanceId } from "../core/process-instance.js";
-import type { WatchKind, WatchOp } from "../core/watch-events.js";
+import type { WatchEntity, WatchKind, WatchOp } from "../core/watch-events.js";
 
 export const ENTITY_CHANGED = "entity.changed";
 
@@ -27,6 +27,13 @@ export interface EntityChangedEnvelope {
    * and accepting both would double-count the RV.
    */
   readonly sourceInstanceId: string;
+  /**
+   * Optional entity snapshot. Required on DELETED so the subscriber can
+   * record the event without fetching a row that has already been removed
+   * from the store. Producers MAY also include it for ADDED/MODIFIED to
+   * skip the subscriber's hydration round-trip.
+   */
+  readonly entity?: WatchEntity;
 }
 
 export class NexusWatchPublisher {

--- a/src/nexus/nexus-watch-publisher.ts
+++ b/src/nexus/nexus-watch-publisher.ts
@@ -45,9 +45,7 @@ export class NexusWatchPublisher {
     this.instanceId = instanceId ?? getProcessInstanceId();
   }
 
-  async publish(
-    envelope: Omit<EntityChangedEnvelope, "sourceInstanceId">,
-  ): Promise<void> {
+  async publish(envelope: Omit<EntityChangedEnvelope, "sourceInstanceId">): Promise<void> {
     const stamped: EntityChangedEnvelope = {
       ...envelope,
       sourceInstanceId: this.instanceId,

--- a/src/nexus/nexus-watch-publisher.ts
+++ b/src/nexus/nexus-watch-publisher.ts
@@ -8,6 +8,7 @@
  */
 
 import type { EventBus } from "../core/event-bus.js";
+import { getProcessInstanceId } from "../core/process-instance.js";
 import type { WatchKind, WatchOp } from "../core/watch-events.js";
 
 export const ENTITY_CHANGED = "entity.changed";
@@ -19,21 +20,36 @@ export interface EntityChangedEnvelope {
   readonly entityId: string;
   readonly generation: number;
   readonly emittedAt: string;
+  /**
+   * Stable per-process identifier of the writer. Subscribers running in the
+   * same process drop envelopes whose `sourceInstanceId` matches their own —
+   * that path is already covered by the in-process onEntityWrite fast path,
+   * and accepting both would double-count the RV.
+   */
+  readonly sourceInstanceId: string;
 }
 
 export class NexusWatchPublisher {
   private readonly bus: EventBus;
+  private readonly instanceId: string;
 
-  constructor(bus: EventBus) {
+  constructor(bus: EventBus, instanceId?: string) {
     this.bus = bus;
+    this.instanceId = instanceId ?? getProcessInstanceId();
   }
 
-  async publish(envelope: EntityChangedEnvelope): Promise<void> {
+  async publish(
+    envelope: Omit<EntityChangedEnvelope, "sourceInstanceId">,
+  ): Promise<void> {
+    const stamped: EntityChangedEnvelope = {
+      ...envelope,
+      sourceInstanceId: this.instanceId,
+    };
     await this.bus.publish({
       type: ENTITY_CHANGED,
       sourceRole: "grove-store",
       targetRole: "*",
-      payload: { ...envelope },
+      payload: { ...stamped },
       timestamp: envelope.emittedAt,
     });
   }

--- a/src/nexus/nexus-watch-subscriber.test.ts
+++ b/src/nexus/nexus-watch-subscriber.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import { LocalEventBus } from "../core/local-event-bus.js";
+import type { ContributionEntity } from "../core/entity.js";
+import type { WatchEntity } from "../core/watch-events.js";
+import { WatchHub } from "../core/watch-hub.js";
+import { NexusWatchPublisher } from "./nexus-watch-publisher.js";
+import { NexusWatchSubscriber } from "./nexus-watch-subscriber.js";
+
+function fakeContributionEntity(id: string, namespace: string): ContributionEntity {
+  return {
+    kind: "Contribution",
+    namespace,
+    id,
+    spec: {
+      contributionKind: "work",
+      mode: "evaluation",
+      summary: "fixture",
+      artifacts: {},
+      relations: [],
+      tags: [],
+      agent: { agentId: "test-a" },
+    },
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: "1",
+    metadata: { generation: 1 },
+  };
+}
+
+describe("NexusWatchSubscriber", () => {
+  test("forwards entity.changed envelopes to WatchHub", async () => {
+    const bus = new LocalEventBus();
+    const hub = new WatchHub();
+    let fetched = 0;
+    const fetchEntity = async (
+      kind: string,
+      ns: string,
+      id: string,
+    ): Promise<WatchEntity> => {
+      fetched += 1;
+      void kind;
+      return fakeContributionEntity(id, ns);
+    };
+    const sub = new NexusWatchSubscriber({ bus, hub, fetchEntity });
+    sub.start();
+
+    const pub = new NexusWatchPublisher(bus);
+    await pub.publish({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entityId: "cid-1",
+      generation: 1,
+      emittedAt: new Date().toISOString(),
+    });
+
+    // Allow microtask flush for the void this.onEnvelope() inside handler
+    await new Promise((r) => setImmediate(r));
+    expect(hub.currentRv("ns/wt", "Contribution")).toBe(1n);
+    expect(fetched).toBe(1);
+    sub.stop();
+  });
+
+  test("dedupes within window when (kind, id, generation) already seen via fast-path", async () => {
+    const bus = new LocalEventBus();
+    const hub = new WatchHub();
+    let fetched = 0;
+    const fetchEntity = async (
+      kind: string,
+      ns: string,
+      id: string,
+    ): Promise<WatchEntity> => {
+      fetched += 1;
+      void kind;
+      return fakeContributionEntity(id, ns);
+    };
+    const sub = new NexusWatchSubscriber({
+      bus,
+      hub,
+      fetchEntity,
+      dedupWindowMs: 1_000,
+    });
+    sub.start();
+
+    sub.markSeen({ kind: "Contribution", entityId: "cid-1", generation: 1 });
+
+    const pub = new NexusWatchPublisher(bus);
+    await pub.publish({
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entityId: "cid-1",
+      generation: 1,
+      emittedAt: new Date().toISOString(),
+    });
+
+    await new Promise((r) => setImmediate(r));
+    expect(hub.currentRv("ns/wt", "Contribution")).toBe(0n);
+    expect(fetched).toBe(0);
+    sub.stop();
+  });
+
+  test("ignores non-entity.changed events on the same role", async () => {
+    const bus = new LocalEventBus();
+    const hub = new WatchHub();
+    const fetchEntity = async (
+      kind: string,
+      ns: string,
+      id: string,
+    ): Promise<WatchEntity> => fakeContributionEntity(id, ns);
+    const sub = new NexusWatchSubscriber({ bus, hub, fetchEntity });
+    sub.start();
+
+    await bus.publish({
+      type: "some.other.topic",
+      sourceRole: "x",
+      targetRole: "*",
+      payload: { ignored: true },
+      timestamp: new Date().toISOString(),
+    });
+
+    await new Promise((r) => setImmediate(r));
+    expect(hub.currentRv("ns/wt", "Contribution")).toBe(0n);
+    sub.stop();
+  });
+});

--- a/src/nexus/nexus-watch-subscriber.test.ts
+++ b/src/nexus/nexus-watch-subscriber.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { LocalEventBus } from "../core/local-event-bus.js";
 import type { ContributionEntity } from "../core/entity.js";
+import { LocalEventBus } from "../core/local-event-bus.js";
 import type { WatchEntity } from "../core/watch-events.js";
 import { WatchHub } from "../core/watch-hub.js";
 import { NexusWatchPublisher } from "./nexus-watch-publisher.js";
@@ -33,11 +33,7 @@ describe("NexusWatchSubscriber", () => {
     const bus = new LocalEventBus();
     const hub = new WatchHub();
     let fetched = 0;
-    const fetchEntity = async (
-      kind: string,
-      ns: string,
-      id: string,
-    ): Promise<WatchEntity> => {
+    const fetchEntity = async (kind: string, ns: string, id: string): Promise<WatchEntity> => {
       fetched += 1;
       void kind;
       return fakeContributionEntity(id, ns);
@@ -66,11 +62,7 @@ describe("NexusWatchSubscriber", () => {
     const bus = new LocalEventBus();
     const hub = new WatchHub();
     let fetched = 0;
-    const fetchEntity = async (
-      kind: string,
-      ns: string,
-      id: string,
-    ): Promise<WatchEntity> => {
+    const fetchEntity = async (kind: string, ns: string, id: string): Promise<WatchEntity> => {
       fetched += 1;
       void kind;
       return fakeContributionEntity(id, ns);
@@ -104,11 +96,8 @@ describe("NexusWatchSubscriber", () => {
   test("ignores non-entity.changed events on the same role", async () => {
     const bus = new LocalEventBus();
     const hub = new WatchHub();
-    const fetchEntity = async (
-      kind: string,
-      ns: string,
-      id: string,
-    ): Promise<WatchEntity> => fakeContributionEntity(id, ns);
+    const fetchEntity = async (_kind: string, ns: string, id: string): Promise<WatchEntity> =>
+      fakeContributionEntity(id, ns);
     const sub = new NexusWatchSubscriber({ bus, hub, fetchEntity });
     sub.start();
 

--- a/src/nexus/nexus-watch-subscriber.test.ts
+++ b/src/nexus/nexus-watch-subscriber.test.ts
@@ -38,10 +38,10 @@ describe("NexusWatchSubscriber", () => {
       void kind;
       return fakeContributionEntity(id, ns);
     };
-    const sub = new NexusWatchSubscriber({ bus, hub, fetchEntity });
+    const sub = new NexusWatchSubscriber({ bus, hub, fetchEntity, instanceId: "sub-proc" });
     sub.start();
 
-    const pub = new NexusWatchPublisher(bus);
+    const pub = new NexusWatchPublisher(bus, "writer-proc");
     await pub.publish({
       kind: "Contribution",
       namespace: "ns/wt",
@@ -72,6 +72,7 @@ describe("NexusWatchSubscriber", () => {
       hub,
       fetchEntity,
       dedupWindowMs: 1_000,
+      instanceId: "sub-proc",
     });
     sub.start();
 

--- a/src/nexus/nexus-watch-subscriber.ts
+++ b/src/nexus/nexus-watch-subscriber.ts
@@ -9,17 +9,9 @@
  */
 
 import type { EventBus, EventHandler } from "../core/event-bus.js";
-import type {
-  EntityWriteEvent,
-  WatchEntity,
-  WatchKind,
-  WatchOp,
-} from "../core/watch-events.js";
+import type { EntityWriteEvent, WatchEntity, WatchKind, WatchOp } from "../core/watch-events.js";
 import type { WatchHub } from "../core/watch-hub.js";
-import {
-  ENTITY_CHANGED,
-  type EntityChangedEnvelope,
-} from "./nexus-watch-publisher.js";
+import { ENTITY_CHANGED, type EntityChangedEnvelope } from "./nexus-watch-publisher.js";
 
 const SUBSCRIBE_ROLE = "*";
 const DEFAULT_DEDUP_WINDOW_MS = 5_000;
@@ -28,11 +20,7 @@ export interface NexusWatchSubscriberOptions {
   readonly bus: EventBus;
   readonly hub: WatchHub;
   /** Fetch the full entity for an envelope — keeps the wire format minimal. */
-  readonly fetchEntity: (
-    kind: WatchKind,
-    namespace: string,
-    id: string,
-  ) => Promise<WatchEntity>;
+  readonly fetchEntity: (kind: WatchKind, namespace: string, id: string) => Promise<WatchEntity>;
   /** Dedupe window for in-process fast-path replays. Default 5_000ms. */
   readonly dedupWindowMs?: number;
 }
@@ -73,11 +61,7 @@ export class NexusWatchSubscriber {
    * subscriber will then ignore the matching cross-process envelope that
    * arrives shortly after via the Nexus event-bus.
    */
-  markSeen(envelope: {
-    kind: WatchKind;
-    entityId: string;
-    generation: number;
-  }): void {
+  markSeen(envelope: { kind: WatchKind; entityId: string; generation: number }): void {
     this.seen.push({
       key: this.dedupKey(envelope),
       seenAt: Date.now(),
@@ -112,11 +96,7 @@ export class NexusWatchSubscriber {
     this.opts.hub.recordWrite(e);
   }
 
-  private dedupKey(env: {
-    kind: WatchKind;
-    entityId: string;
-    generation: number;
-  }): string {
+  private dedupKey(env: { kind: WatchKind; entityId: string; generation: number }): string {
     return `${env.kind}\x00${env.entityId}\x00${env.generation}`;
   }
 

--- a/src/nexus/nexus-watch-subscriber.ts
+++ b/src/nexus/nexus-watch-subscriber.ts
@@ -89,21 +89,35 @@ export class NexusWatchSubscriber {
     if (this.seen.some((s) => s.key === k)) return;
 
     let entity: WatchEntity;
-    try {
-      entity = await this.opts.fetchEntity(env.kind, env.namespace, env.entityId);
-    } catch (err) {
+    if (env.entity !== undefined) {
+      // Producer-supplied snapshot — required for DELETED (the row is gone
+      // from the store at publish time) and an optimization for the rest.
+      entity = env.entity;
+    } else if (env.op === "DELETED") {
+      // No snapshot for a DELETED claim/contribution means the watcher has
+      // no way to learn that the row is gone — fetchEntity would 404. Log
+      // and skip; the producer must be patched to include the snapshot.
       process.stderr.write(
-        `[grove] NexusWatchSubscriber: fetchEntity failed for ${env.kind}/${env.entityId}: ${
-          err instanceof Error ? err.message : String(err)
-        }\n`,
+        `[grove] NexusWatchSubscriber: DELETED envelope without entity snapshot for ${env.kind}/${env.entityId}; dropping\n`,
       );
       return;
-    }
+    } else {
+      try {
+        entity = await this.opts.fetchEntity(env.kind, env.namespace, env.entityId);
+      } catch (err) {
+        process.stderr.write(
+          `[grove] NexusWatchSubscriber: fetchEntity failed for ${env.kind}/${env.entityId}: ${
+            err instanceof Error ? err.message : String(err)
+          }\n`,
+        );
+        return;
+      }
 
-    // Re-check dedup AFTER the fetch — the in-process fast path may have
-    // recorded between our first check and now (the publisher races the
-    // operation post-commit hook).
-    if (this.seen.some((s) => s.key === k)) return;
+      // Re-check dedup AFTER the fetch — the in-process fast path may have
+      // recorded between our first check and now (the publisher races the
+      // operation post-commit hook).
+      if (this.seen.some((s) => s.key === k)) return;
+    }
 
     const e: EntityWriteEvent = {
       kind: env.kind,

--- a/src/nexus/nexus-watch-subscriber.ts
+++ b/src/nexus/nexus-watch-subscriber.ts
@@ -9,6 +9,7 @@
  */
 
 import type { EventBus, EventHandler } from "../core/event-bus.js";
+import { getProcessInstanceId } from "../core/process-instance.js";
 import type { EntityWriteEvent, WatchEntity, WatchKind, WatchOp } from "../core/watch-events.js";
 import type { WatchHub } from "../core/watch-hub.js";
 import { ENTITY_CHANGED, type EntityChangedEnvelope } from "./nexus-watch-publisher.js";
@@ -23,6 +24,12 @@ export interface NexusWatchSubscriberOptions {
   readonly fetchEntity: (kind: WatchKind, namespace: string, id: string) => Promise<WatchEntity>;
   /** Dedupe window for in-process fast-path replays. Default 5_000ms. */
   readonly dedupWindowMs?: number;
+  /**
+   * Stable per-process identifier of THIS subscriber. Envelopes carrying a
+   * matching `sourceInstanceId` are dropped — they originated in this process
+   * and the in-process onEntityWrite fast path already advanced the hub.
+   */
+  readonly instanceId?: string;
 }
 
 interface SeenKey {
@@ -32,16 +39,22 @@ interface SeenKey {
 
 export class NexusWatchSubscriber {
   private readonly opts: NexusWatchSubscriberOptions;
+  private readonly instanceId: string;
   private readonly seen: SeenKey[] = [];
   private readonly handler: EventHandler = (event) => {
     if (event.type !== ENTITY_CHANGED) return;
     const env = event.payload as unknown as EntityChangedEnvelope;
+    // Self-emitted envelopes are duplicates of the in-process fast path and
+    // would advance the hub a second time. Drop before the dedup window even
+    // gets a chance to race against fetchEntity latency.
+    if (env.sourceInstanceId && env.sourceInstanceId === this.instanceId) return;
     void this.onEnvelope(env);
   };
   private started = false;
 
   constructor(opts: NexusWatchSubscriberOptions) {
     this.opts = opts;
+    this.instanceId = opts.instanceId ?? getProcessInstanceId();
   }
 
   start(): void {
@@ -86,6 +99,11 @@ export class NexusWatchSubscriber {
       );
       return;
     }
+
+    // Re-check dedup AFTER the fetch — the in-process fast path may have
+    // recorded between our first check and now (the publisher races the
+    // operation post-commit hook).
+    if (this.seen.some((s) => s.key === k)) return;
 
     const e: EntityWriteEvent = {
       kind: env.kind,

--- a/src/nexus/nexus-watch-subscriber.ts
+++ b/src/nexus/nexus-watch-subscriber.ts
@@ -1,0 +1,129 @@
+/**
+ * NexusWatchSubscriber — consumes `entity.changed` envelopes from the Nexus
+ * event-bus, dedupes against in-process onEntityWrite fast-path writes,
+ * fetches the full entity, and calls WatchHub.recordWrite (#292).
+ *
+ * The bus is role-based; the publisher emits with targetRole "*" and
+ * type "entity.changed", so this subscriber listens on role "*" and
+ * filters by event.type.
+ */
+
+import type { EventBus, EventHandler } from "../core/event-bus.js";
+import type {
+  EntityWriteEvent,
+  WatchEntity,
+  WatchKind,
+  WatchOp,
+} from "../core/watch-events.js";
+import type { WatchHub } from "../core/watch-hub.js";
+import {
+  ENTITY_CHANGED,
+  type EntityChangedEnvelope,
+} from "./nexus-watch-publisher.js";
+
+const SUBSCRIBE_ROLE = "*";
+const DEFAULT_DEDUP_WINDOW_MS = 5_000;
+
+export interface NexusWatchSubscriberOptions {
+  readonly bus: EventBus;
+  readonly hub: WatchHub;
+  /** Fetch the full entity for an envelope — keeps the wire format minimal. */
+  readonly fetchEntity: (
+    kind: WatchKind,
+    namespace: string,
+    id: string,
+  ) => Promise<WatchEntity>;
+  /** Dedupe window for in-process fast-path replays. Default 5_000ms. */
+  readonly dedupWindowMs?: number;
+}
+
+interface SeenKey {
+  readonly key: string;
+  readonly seenAt: number;
+}
+
+export class NexusWatchSubscriber {
+  private readonly opts: NexusWatchSubscriberOptions;
+  private readonly seen: SeenKey[] = [];
+  private readonly handler: EventHandler = (event) => {
+    if (event.type !== ENTITY_CHANGED) return;
+    const env = event.payload as unknown as EntityChangedEnvelope;
+    void this.onEnvelope(env);
+  };
+  private started = false;
+
+  constructor(opts: NexusWatchSubscriberOptions) {
+    this.opts = opts;
+  }
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.opts.bus.subscribe(SUBSCRIBE_ROLE, this.handler);
+  }
+
+  stop(): void {
+    if (!this.started) return;
+    this.opts.bus.unsubscribe(SUBSCRIBE_ROLE, this.handler);
+    this.started = false;
+  }
+
+  /**
+   * Record that the in-process fast path already handled this write. The
+   * subscriber will then ignore the matching cross-process envelope that
+   * arrives shortly after via the Nexus event-bus.
+   */
+  markSeen(envelope: {
+    kind: WatchKind;
+    entityId: string;
+    generation: number;
+  }): void {
+    this.seen.push({
+      key: this.dedupKey(envelope),
+      seenAt: Date.now(),
+    });
+    this.expire();
+  }
+
+  private async onEnvelope(env: EntityChangedEnvelope): Promise<void> {
+    if (!env || !env.kind || !env.namespace || !env.entityId) return;
+    this.expire();
+    const k = this.dedupKey(env);
+    if (this.seen.some((s) => s.key === k)) return;
+
+    let entity: WatchEntity;
+    try {
+      entity = await this.opts.fetchEntity(env.kind, env.namespace, env.entityId);
+    } catch (err) {
+      process.stderr.write(
+        `[grove] NexusWatchSubscriber: fetchEntity failed for ${env.kind}/${env.entityId}: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+      return;
+    }
+
+    const e: EntityWriteEvent = {
+      kind: env.kind,
+      namespace: env.namespace,
+      op: env.op as WatchOp,
+      entity,
+    };
+    this.opts.hub.recordWrite(e);
+  }
+
+  private dedupKey(env: {
+    kind: WatchKind;
+    entityId: string;
+    generation: number;
+  }): string {
+    return `${env.kind}\x00${env.entityId}\x00${env.generation}`;
+  }
+
+  private expire(): void {
+    const cutoff = Date.now() - (this.opts.dedupWindowMs ?? DEFAULT_DEDUP_WINDOW_MS);
+    while (this.seen.length > 0 && (this.seen[0]?.seenAt ?? Infinity) < cutoff) {
+      this.seen.shift();
+    }
+  }
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -33,6 +33,7 @@ import { outcomes } from "./routes/outcomes.js";
 import { search } from "./routes/search.js";
 import { sessions } from "./routes/sessions.js";
 import { threads } from "./routes/threads.js";
+import { watch } from "./routes/watch.js";
 
 /**
  * Create a Hono application with all grove-server routes.
@@ -119,6 +120,7 @@ export function createApp(deps: ServerDeps, registry: KeyRegistry): Hono<ServerE
   app.route("/api/session", goals);
   app.route("/api/sessions", sessions);
   app.route("/api/handoffs", handoffs);
+  app.route("/api", watch);
 
   // Centralized error handling
   app.onError(handleError);

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -17,6 +17,7 @@ import type { ClaimStore, ContributionStore } from "../core/store.js";
 import type { AgentTopology } from "../core/topology.js";
 import type { WatchHub } from "../core/watch-hub.js";
 import type { GoalSessionStore } from "../local/sqlite-goal-session-store.js";
+import type { NexusWatchSubscriber } from "../nexus/nexus-watch-subscriber.js";
 
 /** Dependencies injected into the Hono application. */
 export interface ServerDeps {
@@ -66,6 +67,16 @@ export interface ServerDeps {
   readonly idempotencyStore?: IdempotencyStore | undefined;
   /** Watch hub for list→watch handshake (#292). */
   readonly watchHub: WatchHub;
+  /**
+   * Optional cross-process watch subscriber (#292). When present, the
+   * operation-adapter calls `markSeen` on it after each in-process write
+   * so that the matching cross-process envelope (published by the same
+   * write through Nexus → NexusWatchPublisher) is suppressed at the
+   * subscriber instead of being replayed back into the WatchHub.
+   *
+   * Optional so test harnesses that build ServerDeps inline can omit it.
+   */
+  readonly watchSubscriber?: NexusWatchSubscriber | undefined;
 }
 
 /** Hono environment type carrying injected dependencies. */

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -15,6 +15,7 @@ import type { IdempotencyStore } from "../core/operations/deps.js";
 import type { OutcomeStore } from "../core/outcome.js";
 import type { ClaimStore, ContributionStore } from "../core/store.js";
 import type { AgentTopology } from "../core/topology.js";
+import type { WatchHub } from "../core/watch-hub.js";
 import type { GoalSessionStore } from "../local/sqlite-goal-session-store.js";
 
 /** Dependencies injected into the Hono application. */
@@ -63,6 +64,8 @@ export interface ServerDeps {
   readonly handoffStoreForSession?: (sessionId: string) => HandoffStore | undefined;
   /** Optional idempotency store for cross-process deduplication. */
   readonly idempotencyStore?: IdempotencyStore | undefined;
+  /** Watch hub for list→watch handshake (#292). */
+  readonly watchHub: WatchHub;
 }
 
 /** Hono environment type carrying injected dependencies. */

--- a/src/server/e2e.test.ts
+++ b/src/server/e2e.test.ts
@@ -10,6 +10,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import { DefaultFrontierCalculator } from "../core/frontier.js";
 import { _resetIdempotencyCacheForTests } from "../core/operations/contribute.js";
 import { InMemoryContributionStore } from "../core/testing.js";
+import { WatchHub } from "../core/watch-hub.js";
 import { createApp } from "./app.js";
 import type { ServerDeps } from "./deps.js";
 import type { KeyRegistry } from "./middleware/namespace-auth.js";
@@ -36,7 +37,13 @@ beforeAll(() => {
   const cas = new InMemoryContentStore();
   const frontier = new DefaultFrontierCalculator(contributionStore);
 
-  const deps: ServerDeps = { contributionStore, claimStore, cas, frontier };
+  const deps: ServerDeps = {
+    contributionStore,
+    claimStore,
+    cas,
+    frontier,
+    watchHub: new WatchHub(),
+  };
   const registry: KeyRegistry = new Map([[TEST_KEY, TEST_NAMESPACE]]);
   const app = createApp(deps, registry);
 

--- a/src/server/operation-adapter.ts
+++ b/src/server/operation-adapter.ts
@@ -17,6 +17,12 @@ import type { ServerDeps } from "./deps.js";
  * ServerDeps is a structural subset of OperationDeps — this function
  * selects the fields that operations require, dropping transport-specific
  * dependencies (gossip, topology).
+ *
+ * The `onEntityWrite` hook is wired here to forward Entity-write events
+ * (#287/#292) into the WatchHub on `deps.watchHub`. The per-request
+ * `namespace` field is NOT set here — route handlers must inject it from
+ * the auth context (`c.get("namespace")`) before invoking an operation,
+ * since the watch protocol scopes events per-namespace.
  */
 export function toOperationDeps(deps: ServerDeps): OperationDeps {
   return {
@@ -27,6 +33,7 @@ export function toOperationDeps(deps: ServerDeps): OperationDeps {
     ...(deps.outcomeStore !== undefined ? { outcomeStore: deps.outcomeStore } : {}),
     ...(deps.contract !== undefined ? { contract: deps.contract } : {}),
     ...(deps.idempotencyStore !== undefined ? { idempotencyStore: deps.idempotencyStore } : {}),
+    onEntityWrite: (event) => deps.watchHub.recordWrite(event),
   };
 }
 

--- a/src/server/operation-adapter.ts
+++ b/src/server/operation-adapter.ts
@@ -33,7 +33,20 @@ export function toOperationDeps(deps: ServerDeps): OperationDeps {
     ...(deps.outcomeStore !== undefined ? { outcomeStore: deps.outcomeStore } : {}),
     ...(deps.contract !== undefined ? { contract: deps.contract } : {}),
     ...(deps.idempotencyStore !== undefined ? { idempotencyStore: deps.idempotencyStore } : {}),
-    onEntityWrite: (event) => deps.watchHub.recordWrite(event),
+    onEntityWrite: (event) => {
+      deps.watchHub.recordWrite(event);
+      // Cross-process dedupe (#292): record this write so the matching
+      // `entity.changed` envelope (published by the Nexus store at write
+      // time) is suppressed when it lands on the subscriber. Without
+      // this, the same write would record twice — once via the in-process
+      // fast path, once via the bus — and the WatchHub RV would advance
+      // by 2 instead of 1 per logical write.
+      deps.watchSubscriber?.markSeen({
+        kind: event.kind,
+        entityId: event.entity.id,
+        generation: event.entity.metadata.generation,
+      });
+    },
   };
 }
 

--- a/src/server/routes/agents.ts
+++ b/src/server/routes/agents.ts
@@ -12,6 +12,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { claimToEntity } from "../../core/entity.js";
 import type { ServerEnv } from "../deps.js";
 
 // ---------------------------------------------------------------------------
@@ -41,6 +42,8 @@ agents.post("/spawn", zValidator("json", spawnBodySchema), async (c) => {
   const deps = c.get("deps");
   const claimStore = deps.claimStore;
   const topology = deps.topology;
+  const namespace = c.get("namespace");
+  const { watchHub, watchSubscriber } = deps;
 
   const body = c.req.valid("json");
 
@@ -81,6 +84,25 @@ agents.post("/spawn", zValidator("json", spawnBodySchema), async (c) => {
         }
       : {}),
   });
+
+  // Watch fan-out (#292). Direct store path bypasses the operations layer
+  // and the Nexus same-process publisher is filtered by sourceInstanceId,
+  // so this would otherwise be invisible to /api/watch clients.
+  try {
+    const entity = claimToEntity(claim, () => Date.now(), namespace);
+    watchHub.recordWrite({ kind: "Claim", namespace, op: "ADDED", entity });
+    watchSubscriber?.markSeen({
+      kind: "Claim",
+      entityId: claim.claimId,
+      generation: entity.metadata.generation,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[grove] Warning: watch fan-out threw after POST /api/agents/spawn: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+  }
 
   return c.json({
     claimId: claim.claimId,

--- a/src/server/routes/boardroom.ts
+++ b/src/server/routes/boardroom.ts
@@ -14,6 +14,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { contributionToEntity } from "../../core/entity.js";
 import { computeCid } from "../../core/manifest.js";
 import { ContributionKind, RelationType } from "../../core/models.js";
 import { answerQuestion } from "../../core/operations/ask-user-bus.js";
@@ -211,6 +212,8 @@ boardroom.get("/summary", zValidator("query", summaryQuerySchema), async (c) => 
  */
 boardroom.post("/answer", zValidator("json", answerBodySchema), async (c) => {
   const deps = c.get("deps");
+  const namespace = c.get("namespace");
+  const { watchHub, watchSubscriber } = deps;
   const body = c.req.valid("json");
   const store = contributionStoreForSession(deps, body.sessionId);
 
@@ -220,6 +223,25 @@ boardroom.post("/answer", zValidator("json", answerBodySchema), async (c) => {
     { questionCid: body.questionCid, answer: body.answer, operator },
     computeCid,
   );
+
+  // Watch fan-out (#292). answerQuestion writes the contribution directly to
+  // the store, bypassing the operations layer's onEntityWrite hook, so we
+  // advance the WatchHub manually.
+  try {
+    const entity = contributionToEntity(contribution, namespace);
+    watchHub.recordWrite({ kind: "Contribution", namespace, op: "ADDED", entity });
+    watchSubscriber?.markSeen({
+      kind: "Contribution",
+      entityId: entity.id,
+      generation: entity.metadata.generation,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[grove] Warning: watch fan-out threw after POST /api/boardroom/answer: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+  }
 
   // Link the answer contribution to the session so it is visible in scoped reads
   if (body.sessionId && deps.goalSessionStore) {
@@ -241,9 +263,13 @@ boardroom.post("/answer", zValidator("json", answerBodySchema), async (c) => {
  */
 boardroom.post("/message", zValidator("json", messageBodySchema), async (c) => {
   const deps = c.get("deps");
+  const namespace = c.get("namespace");
   const body = c.req.valid("json");
   const store = contributionStoreForSession(deps, body.sessionId);
 
+  // Inject namespace so contributeOperation fires onEntityWrite into the
+  // WatchHub (#292) — without it, this HTTP write is invisible to watchers.
+  const opDeps = { ...toOperationDeps({ ...deps, contributionStore: store }), namespace };
   const result = await sendMessageAsDiscussion(
     {
       agent: { agentId: "tui-operator", agentName: "operator" },
@@ -251,7 +277,7 @@ boardroom.post("/message", zValidator("json", messageBodySchema), async (c) => {
       recipients: body.recipients,
       ...(body.inReplyTo !== undefined ? { inReplyTo: body.inReplyTo } : {}),
     },
-    toOperationDeps({ ...deps, contributionStore: store }),
+    opDeps,
   );
 
   if (!result.ok) {

--- a/src/server/routes/boardroom.ts
+++ b/src/server/routes/boardroom.ts
@@ -227,20 +227,28 @@ boardroom.post("/answer", zValidator("json", answerBodySchema), async (c) => {
   // Watch fan-out (#292). answerQuestion writes the contribution directly to
   // the store, bypassing the operations layer's onEntityWrite hook, so we
   // advance the WatchHub manually.
-  try {
-    const entity = contributionToEntity(contribution, namespace);
-    watchHub.recordWrite({ kind: "Contribution", namespace, op: "ADDED", entity });
-    watchSubscriber?.markSeen({
-      kind: "Contribution",
-      entityId: entity.id,
-      generation: entity.metadata.generation,
-    });
-  } catch (err) {
-    process.stderr.write(
-      `[grove] Warning: watch fan-out threw after POST /api/boardroom/answer: ${
-        err instanceof Error ? err.message : String(err)
-      }\n`,
-    );
+  //
+  // Only fan out for non-session writes. When `sessionId` is set, the
+  // write lands in the session-scoped store but `/api/list` reads the
+  // process-global store, so emitting a watch event the lister can't
+  // mirror would break the list→watch RV invariant. Session-scoped
+  // watch is tracked as a follow-up.
+  if (body.sessionId === undefined) {
+    try {
+      const entity = contributionToEntity(contribution, namespace);
+      watchHub.recordWrite({ kind: "Contribution", namespace, op: "ADDED", entity });
+      watchSubscriber?.markSeen({
+        kind: "Contribution",
+        entityId: entity.id,
+        generation: entity.metadata.generation,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `[grove] Warning: watch fan-out threw after POST /api/boardroom/answer: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+    }
   }
 
   // Link the answer contribution to the session so it is visible in scoped reads
@@ -267,9 +275,13 @@ boardroom.post("/message", zValidator("json", messageBodySchema), async (c) => {
   const body = c.req.valid("json");
   const store = contributionStoreForSession(deps, body.sessionId);
 
-  // Inject namespace so contributeOperation fires onEntityWrite into the
-  // WatchHub (#292) — without it, this HTTP write is invisible to watchers.
-  const opDeps = { ...toOperationDeps({ ...deps, contributionStore: store }), namespace };
+  // Inject namespace only for non-session writes (#292). When `sessionId`
+  // is set, the write lands in the session-scoped store but `/api/list`
+  // reads the process-global store, so firing a watch event the lister
+  // can't mirror would violate the list→watch RV invariant. Session-scoped
+  // watch is tracked as a follow-up.
+  const baseOpDeps = toOperationDeps({ ...deps, contributionStore: store });
+  const opDeps = body.sessionId === undefined ? { ...baseOpDeps, namespace } : baseOpDeps;
   const result = await sendMessageAsDiscussion(
     {
       agent: { agentId: "tui-operator", agentName: "operator" },

--- a/src/server/routes/claims.ts
+++ b/src/server/routes/claims.ts
@@ -11,6 +11,7 @@ import type { Hono as HonoType } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import { DEFAULT_LEASE_MS } from "../../core/constants.js";
+import { claimToEntity } from "../../core/entity.js";
 import type { AgentIdentity, Claim, JsonValue } from "../../core/models.js";
 import { listClaimsOperation, releaseOperation } from "../../core/operations/index.js";
 import type { ServerEnv } from "../deps.js";
@@ -55,7 +56,9 @@ const claims: HonoType<ServerEnv> = new Hono<ServerEnv>();
  * agent identity in the request body rather than using resolveAgent().
  */
 claims.post("/", zValidator("json", createBodySchema), async (c) => {
-  const { claimStore } = c.get("deps");
+  const deps = c.get("deps");
+  const { claimStore, watchHub, watchSubscriber } = deps;
+  const namespace = c.get("namespace");
   const body = c.req.valid("json");
   const now = new Date();
   const leaseDurationMs = body.leaseDurationMs ?? DEFAULT_LEASE_MS;
@@ -74,7 +77,39 @@ claims.post("/", zValidator("json", createBodySchema), async (c) => {
       : {}),
   };
 
+  // Detect renew vs create so the watch event carries the right op.
+  const prior = await claimStore.activeClaims(body.targetRef);
+  const existing = prior.find((p) => p.agent.agentId === claim.agent.agentId);
+
   const result = await claimStore.claimOrRenew(claim);
+
+  // Watch fan-out (#292). Direct store path bypasses the operations layer
+  // so we record + markSeen here. Phase change is implicit on first create;
+  // renewal that did not change phase is suppressed to avoid heartbeat-noise.
+  const phaseChanged = !existing || existing.status !== result.status;
+  if (phaseChanged) {
+    const entity = claimToEntity(result, () => Date.now(), namespace);
+    try {
+      watchHub.recordWrite({
+        kind: "Claim",
+        namespace,
+        op: existing ? "MODIFIED" : "ADDED",
+        entity,
+      });
+      watchSubscriber?.markSeen({
+        kind: "Claim",
+        entityId: result.claimId,
+        generation: entity.metadata.generation,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `[grove] Warning: watch fan-out threw after POST /api/claims: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+    }
+  }
+
   return c.json(result, 201);
 });
 

--- a/src/server/routes/claims.ts
+++ b/src/server/routes/claims.ts
@@ -84,10 +84,17 @@ claims.post("/", zValidator("json", createBodySchema), async (c) => {
   const result = await claimStore.claimOrRenew(claim);
 
   // Watch fan-out (#292). Direct store path bypasses the operations layer
-  // so we record + markSeen here. Phase change is implicit on first create;
-  // renewal that did not change phase is suppressed to avoid heartbeat-noise.
-  const phaseChanged = !existing || existing.status !== result.status;
-  if (phaseChanged) {
+  // so we record + markSeen here. Emit ADDED on first create, MODIFIED when
+  // any semantic field changed (status, intent, lease, revision). Pure
+  // heartbeat-only renewals (where every observable field is unchanged) are
+  // suppressed to avoid noise on quiet keep-alives.
+  const semanticChange =
+    !existing ||
+    existing.status !== result.status ||
+    existing.intentSummary !== result.intentSummary ||
+    existing.leaseExpiresAt !== result.leaseExpiresAt ||
+    (existing.revision ?? 1) !== (result.revision ?? 1);
+  if (semanticChange) {
     const entity = claimToEntity(result, () => Date.now(), namespace);
     try {
       watchHub.recordWrite({

--- a/src/server/routes/claims.ts
+++ b/src/server/routes/claims.ts
@@ -91,7 +91,8 @@ claims.patch("/:id", zValidator("json", patchBodySchema), async (c) => {
   }
 
   // Release / complete via shared operation
-  const deps = toOperationDeps(c.get("deps"));
+  let deps = toOperationDeps(c.get("deps"));
+  deps = { ...deps, namespace: c.get("namespace") };
   const result = await releaseOperation({ claimId, action }, deps);
 
   const { data, status } = toHttpResult(result);

--- a/src/server/routes/claims.ts
+++ b/src/server/routes/claims.ts
@@ -77,44 +77,30 @@ claims.post("/", zValidator("json", createBodySchema), async (c) => {
       : {}),
   };
 
-  // Detect renew vs create so the watch event carries the right op.
-  const prior = await claimStore.activeClaims(body.targetRef);
-  const existing = prior.find((p) => p.agent.agentId === claim.agent.agentId);
-
   const result = await claimStore.claimOrRenew(claim);
 
   // Watch fan-out (#292). Direct store path bypasses the operations layer
-  // so we record + markSeen here. Emit ADDED on first create, MODIFIED when
-  // any semantic field changed (status, intent, lease, revision). Pure
-  // heartbeat-only renewals (where every observable field is unchanged) are
-  // suppressed to avoid noise on quiet keep-alives.
-  const semanticChange =
-    !existing ||
-    existing.status !== result.status ||
-    existing.intentSummary !== result.intentSummary ||
-    existing.leaseExpiresAt !== result.leaseExpiresAt ||
-    (existing.revision ?? 1) !== (result.revision ?? 1);
-  if (semanticChange) {
-    const entity = claimToEntity(result, () => Date.now(), namespace);
-    try {
-      watchHub.recordWrite({
-        kind: "Claim",
-        namespace,
-        op: existing ? "MODIFIED" : "ADDED",
-        entity,
-      });
-      watchSubscriber?.markSeen({
-        kind: "Claim",
-        entityId: result.claimId,
-        generation: entity.metadata.generation,
-      });
-    } catch (err) {
-      process.stderr.write(
-        `[grove] Warning: watch fan-out threw after POST /api/claims: ${
-          err instanceof Error ? err.message : String(err)
-        }\n`,
-      );
-    }
+  // so we record + markSeen here. Derive ADDED vs MODIFIED from the
+  // store's atomic revision counter — pre-reading `existing` outside the
+  // store transaction is racy: two concurrent same-agent renewals can
+  // both observe no existing claim and both emit ADDED for one logical
+  // claim. The store guarantees revision === 1 on first create and
+  // revision > 1 on every renewal, regardless of concurrency.
+  const op: "ADDED" | "MODIFIED" = (result.revision ?? 1) === 1 ? "ADDED" : "MODIFIED";
+  const entity = claimToEntity(result, () => Date.now(), namespace);
+  try {
+    watchHub.recordWrite({ kind: "Claim", namespace, op, entity });
+    watchSubscriber?.markSeen({
+      kind: "Claim",
+      entityId: result.claimId,
+      generation: entity.metadata.generation,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[grove] Warning: watch fan-out threw after POST /api/claims: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
   }
 
   return c.json(result, 201);

--- a/src/server/routes/contributions.ts
+++ b/src/server/routes/contributions.ts
@@ -261,6 +261,7 @@ contributions.post("/", async (c) => {
   };
 
   let opDeps = toOperationDeps(serverDeps);
+  opDeps = { ...opDeps, namespace: c.get("namespace") };
 
   // Session-scoped store: when sessionId is present and a factory is wired
   // (Nexus mode), swap the contribution store so writes land at the

--- a/src/server/routes/contributions.ts
+++ b/src/server/routes/contributions.ts
@@ -261,7 +261,14 @@ contributions.post("/", async (c) => {
   };
 
   let opDeps = toOperationDeps(serverDeps);
-  opDeps = { ...opDeps, namespace: c.get("namespace") };
+  // Inject namespace only for non-session writes (#292). When sessionId
+  // is set, the write lands in the session-scoped store but /api/list
+  // reads the process-global store, so emitting a watch event the lister
+  // can't mirror would violate the list→watch RV invariant. Session-scoped
+  // watch is tracked as a follow-up.
+  if (parsed.sessionId === undefined) {
+    opDeps = { ...opDeps, namespace: c.get("namespace") };
+  }
 
   // Session-scoped store: when sessionId is present and a factory is wired
   // (Nexus mode), swap the contribution store so writes land at the

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -1,0 +1,171 @@
+/**
+ * Watch protocol endpoints (#292).
+ *
+ * GET /api/list?kind=<kind>      — list snapshot with listResourceVersion
+ * GET /api/watch?kind=<kind>&resumeFrom=<rv> — SSE stream
+ *
+ * Both endpoints sit behind the existing /api/* namespaceAuth middleware
+ * (#290), so namespace is always read from `c.get("namespace")` — never
+ * from query or path params.
+ */
+
+import { zValidator } from "@hono/zod-validator";
+import type { Hono as HonoType } from "hono";
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  StaleResourceVersionError,
+  type WatchEvent,
+  type WatchKind,
+} from "../../core/watch-events.js";
+import { BufferOverflowError, type WatchHub } from "../../core/watch-hub.js";
+import type { ServerDeps, ServerEnv } from "../deps.js";
+
+const KIND_VALUES = ["Contribution", "Claim", "AgentSession"] as const;
+
+const listQuerySchema = z.object({
+  kind: z.enum(KIND_VALUES),
+});
+
+const watchQuerySchema = z.object({
+  kind: z.enum(KIND_VALUES),
+  resumeFrom: z.string().regex(/^[0-9]+$/, "resumeFrom must be a non-negative integer"),
+});
+
+const watch: HonoType<ServerEnv> = new Hono<ServerEnv>();
+
+/** GET /api/list?kind=X — list snapshot with listResourceVersion. */
+watch.get("/list", zValidator("query", listQuerySchema), async (c) => {
+  const namespace = c.get("namespace");
+  const { kind } = c.req.valid("query");
+  const deps = c.get("deps");
+  const hub: WatchHub = deps.watchHub;
+
+  // Race-correctness invariant (spec §Critical path): capture RV BEFORE the
+  // list query. Any write that lands during the list has rv > listRv and is
+  // therefore guaranteed to be replayed when the watch resumes.
+  const listRv = hub.currentRv(namespace, kind as WatchKind);
+  const items = await listForKind(deps, namespace, kind as WatchKind);
+
+  return c.json({ items, listResourceVersion: String(listRv) });
+});
+
+/** GET /api/watch?kind=X&resumeFrom=Y — SSE stream. */
+watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
+  const namespace = c.get("namespace");
+  const { kind, resumeFrom } = c.req.valid("query");
+  const lastEventId = c.req.header("last-event-id");
+  // Last-Event-ID overrides resumeFrom on auto-reconnect (browser EventSource).
+  const fromRv = BigInt(lastEventId ?? resumeFrom);
+  const hub: WatchHub = c.get("deps").watchHub;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      const ac = new AbortController();
+      let bookmarkTimer: ReturnType<typeof setInterval> | null = null;
+      let closed = false;
+
+      const send = (event: string, data: unknown, id?: string): void => {
+        if (closed) return;
+        const payload = `id: ${id ?? ""}\nevent: ${event}\ndata: ${JSON.stringify(
+          data,
+        )}\n\n`;
+        try {
+          controller.enqueue(encoder.encode(payload));
+        } catch {
+          /* controller already closed */
+        }
+      };
+
+      const cleanup = (): void => {
+        if (closed) return;
+        closed = true;
+        if (bookmarkTimer) clearInterval(bookmarkTimer);
+        bookmarkTimer = null;
+        ac.abort();
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+      };
+
+      const closeWithError = (code: number, reason: string): void => {
+        send("ERROR", { code, reason });
+        cleanup();
+      };
+
+      let iterable: AsyncIterable<WatchEvent>;
+      try {
+        iterable = hub.subscribe(namespace, kind as WatchKind, fromRv, ac.signal);
+      } catch (err) {
+        if (err instanceof StaleResourceVersionError) {
+          closeWithError(410, "expired");
+          return;
+        }
+        throw err;
+      }
+
+      bookmarkTimer = setInterval(() => {
+        send("BOOKMARK", {
+          rv: String(hub.currentRv(namespace, kind as WatchKind)),
+        });
+      }, hub.bookmarkIntervalMs);
+      // Don't hold the event loop open just for this timer.
+      (bookmarkTimer as unknown as { unref?: () => void }).unref?.();
+
+      void (async () => {
+        try {
+          for await (const ev of iterable) {
+            send(ev.op, { kind: ev.kind, entity: ev.entity }, String(ev.rv));
+          }
+          cleanup();
+        } catch (err) {
+          if (err instanceof BufferOverflowError) {
+            closeWithError(503, "buffer_overflow");
+          } else {
+            closeWithError(500, "internal_error");
+          }
+        }
+      })();
+
+      // Abort when the client disconnects.
+      c.req.raw.signal.addEventListener("abort", cleanup);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+});
+
+async function listForKind(
+  deps: ServerDeps,
+  namespace: string,
+  kind: WatchKind,
+): Promise<readonly unknown[]> {
+  void namespace;
+  switch (kind) {
+    case "Contribution":
+      return deps.contributionStore.listEntities();
+    case "Claim":
+      return deps.claimStore.listEntities();
+    case "AgentSession":
+      // AgentSession listing is not yet a Store API. Return empty until the
+      // session-orchestrator integration lands (out of scope for #292).
+      return [];
+    default: {
+      const _exhaustive: never = kind;
+      void _exhaustive;
+      return [];
+    }
+  }
+}
+
+export { watch };

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -73,15 +73,18 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
   const fromRv = BigInt(lastEventId ?? resumeFrom);
   const hub: WatchHub = c.get("deps").watchHub;
 
-  // SSE-route per-connection queue cap. The WatchHub already bounds its
+  // SSE-route per-connection byte cap. The WatchHub already bounds its
   // per-subscriber queue, but once a hub event is drained into the route's
   // ReadableStream, only the stream's own backpressure stops the route from
-  // accumulating bytes for a stalled TCP client. Setting an explicit
-  // highWaterMark + a hard overflow threshold lets us close the stream with
-  // 503 buffer_overflow before the process holds unbounded bytes for one
-  // client. K8s' watch http2 path uses a similar bounded write window.
-  const ROUTE_HIGH_WATER_MARK = 64;
-  const ROUTE_OVERFLOW_THRESHOLD = -ROUTE_HIGH_WATER_MARK * 4; // ~256 chunks queued
+  // accumulating bytes for a stalled TCP client. Per-event payload size is
+  // unbounded (large entities), so a chunk-count threshold could still let
+  // tens-to-hundreds of MB queue per client; use ByteLengthQueuingStrategy
+  // so desiredSize is measured in bytes instead of chunks. K8s' watch http2
+  // path uses a similar bounded write window.
+  const ROUTE_BYTE_HIGH_WATER_MARK = 1 * 1024 * 1024; // 1 MiB
+  // desiredSize can go negative when overshooting; cap at -3 MiB so total
+  // queued bytes stay under ~4 MiB per client before we 503.
+  const ROUTE_BYTE_OVERFLOW_THRESHOLD = -3 * 1024 * 1024;
 
   const stream = new ReadableStream<Uint8Array>(
     {
@@ -93,7 +96,7 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
 
       const isOverflowed = (): boolean => {
         const ds = controller.desiredSize;
-        return ds !== null && ds <= ROUTE_OVERFLOW_THRESHOLD;
+        return ds !== null && ds <= ROUTE_BYTE_OVERFLOW_THRESHOLD;
       };
 
       const send = (event: string, data: unknown, id?: string): void => {
@@ -184,7 +187,7 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
       c.req.raw.signal.addEventListener("abort", cleanup);
     },
   },
-    new CountQueuingStrategy({ highWaterMark: ROUTE_HIGH_WATER_MARK }),
+    new ByteLengthQueuingStrategy({ highWaterMark: ROUTE_BYTE_HIGH_WATER_MARK }),
   );
 
   return new Response(stream, {

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -45,6 +45,11 @@ watch.get("/list", zValidator("query", listQuerySchema), async (c) => {
   // list query. Any write that lands during the list has rv > listRv and is
   // therefore guaranteed to be replayed when the watch resumes.
   const listRv = hub.currentRv(namespace, kind as WatchKind);
+  // Test-only widening of the handshake window. See watch.race.test.ts (#292).
+  const delayMs = Number(process.env.GROVE_WATCH_LIST_DELAY_MS);
+  if (Number.isFinite(delayMs) && delayMs > 0) {
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
   const items = await listForKind(deps, namespace, kind as WatchKind);
 
   return c.json({ items, listResourceVersion: String(listRv) });

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -164,7 +164,11 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
               closeWithError(503, "buffer_overflow");
               return;
             }
-            send(ev.op, { kind: ev.kind, entity: ev.entity }, String(ev.rv));
+            const rv = String(ev.rv);
+            // Include rv in the JSON body so clients that only parse `data`
+            // (no SSE `lastEventId` access) can still resume. Matches the
+            // BOOKMARK shape and the A5 contract.
+            send(ev.op, { rv, kind: ev.kind, entity: ev.entity }, rv);
           }
           cleanup();
         } catch (err) {

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -61,11 +61,16 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
   const { kind, resumeFrom } = c.req.valid("query");
   const lastEventId = c.req.header("last-event-id");
   // Last-Event-ID overrides resumeFrom on auto-reconnect (browser EventSource).
-  // Reject blank/non-decimal values defensively — `BigInt("")` is 0n, which
-  // would silently rewind the watch to genesis and 410 once the ring evicts.
-  const validLastEventId =
-    lastEventId && /^[0-9]+$/.test(lastEventId) ? lastEventId : undefined;
-  const fromRv = BigInt(validLastEventId ?? resumeFrom);
+  // If present but malformed, fail fast with 400 — silently falling back to
+  // the URL's resumeFrom would let a stale URL rewind the client past
+  // recently-seen events, causing duplicate replay or stale 410.
+  if (lastEventId !== undefined && !/^[0-9]+$/.test(lastEventId)) {
+    return c.json(
+      { error: { code: "VALIDATION_ERROR", message: "Last-Event-ID must be a non-negative decimal integer" } },
+      400,
+    );
+  }
+  const fromRv = BigInt(lastEventId ?? resumeFrom);
   const hub: WatchHub = c.get("deps").watchHub;
 
   // SSE-route per-connection queue cap. The WatchHub already bounds its
@@ -135,6 +140,14 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
       }
 
       bookmarkTimer = setInterval(() => {
+        // A stalled reader on a quiescent watch would otherwise let
+        // BOOKMARK frames pile up forever — they don't trip the
+        // data-event overflow check below. Reuse the same threshold so
+        // both code paths cap memory identically.
+        if (isOverflowed()) {
+          closeWithError(503, "buffer_overflow");
+          return;
+        }
         // Tag the BOOKMARK with the RV as the SSE id so EventSource auto-
         // reconnect picks up Last-Event-ID = currentRv. Without this, a
         // BOOKMARK after a real event would not advance the resume cursor.

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -99,18 +99,36 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
         return ds !== null && ds <= ROUTE_BYTE_OVERFLOW_THRESHOLD;
       };
 
-      const send = (event: string, data: unknown, id?: string): void => {
-        if (closed) return;
+      // Per-event hard cap. Even within byte budget, a single huge frame
+      // would force the queue into deep-negative desiredSize between
+      // overflow checks. Watch consumers that produce >1 MiB events should
+      // chunk through the entity store, not the watch stream.
+      const ROUTE_MAX_EVENT_BYTES = 1 * 1024 * 1024;
+
+      const send = (event: string, data: unknown, id?: string): boolean => {
+        if (closed) return false;
         // Only emit `id:` when we have one. A blank `id:` line tells SSE
         // clients to clear Last-Event-ID, which would silently rewind the
         // watch on reconnect.
         const idLine = id ? `id: ${id}\n` : "";
         const payload = `${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+        const bytes = encoder.encode(payload);
+        // Reject oversized single events before they overshoot the queue.
+        // The terminal ERROR/cleanup path may still call send() inside this
+        // guard — that path uses small fixed payloads and is not affected.
+        if (bytes.byteLength > ROUTE_MAX_EVENT_BYTES) return false;
+        // If this single event would push the queue into hard-overflow
+        // before the next iteration's check, treat it as overflow now.
+        const ds = controller.desiredSize;
+        if (ds !== null && ds - bytes.byteLength <= ROUTE_BYTE_OVERFLOW_THRESHOLD) {
+          return false;
+        }
         try {
-          controller.enqueue(encoder.encode(payload));
+          controller.enqueue(bytes);
         } catch {
           /* controller already closed */
         }
+        return true;
       };
 
       const cleanup = (): void => {
@@ -171,7 +189,14 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
             // Include rv in the JSON body so clients that only parse `data`
             // (no SSE `lastEventId` access) can still resume. Matches the
             // BOOKMARK shape and the A5 contract.
-            send(ev.op, { rv, kind: ev.kind, entity: ev.entity }, rv);
+            const sent = send(ev.op, { rv, kind: ev.kind, entity: ev.entity }, rv);
+            // send() refuses oversized events or events that would push the
+            // queue past the overflow threshold. Either case is terminal —
+            // skipping the event silently would let the client miss writes.
+            if (!sent) {
+              closeWithError(503, "buffer_overflow");
+              return;
+            }
           }
           cleanup();
         } catch (err) {

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -22,6 +22,14 @@ import { BufferOverflowError, type WatchHub } from "../../core/watch-hub.js";
 import type { ServerDeps, ServerEnv } from "../deps.js";
 
 const KIND_VALUES = ["Contribution", "Claim", "AgentSession"] as const;
+// Subset of KIND_VALUES for which list+watch are actually backed by
+// stores and fan-out hooks. AgentSession remains in KIND_VALUES so the
+// type narrowing stays exhaustive, but watching it returns 501 until
+// the session-orchestrator integration lands (out of scope for #292).
+const SUPPORTED_KINDS: ReadonlySet<(typeof KIND_VALUES)[number]> = new Set([
+  "Contribution",
+  "Claim",
+]);
 
 const listQuerySchema = z.object({
   kind: z.enum(KIND_VALUES),
@@ -38,6 +46,12 @@ const watch: HonoType<ServerEnv> = new Hono<ServerEnv>();
 watch.get("/list", zValidator("query", listQuerySchema), async (c) => {
   const namespace = c.get("namespace");
   const { kind } = c.req.valid("query");
+  if (!SUPPORTED_KINDS.has(kind)) {
+    return c.json(
+      { error: { code: "NOT_CONFIGURED", message: `kind '${kind}' is accepted by the schema but not yet backed by a store; list is unavailable` } },
+      501,
+    );
+  }
   const deps = c.get("deps");
   const hub: WatchHub = deps.watchHub;
 
@@ -59,6 +73,12 @@ watch.get("/list", zValidator("query", listQuerySchema), async (c) => {
 watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
   const namespace = c.get("namespace");
   const { kind, resumeFrom } = c.req.valid("query");
+  if (!SUPPORTED_KINDS.has(kind)) {
+    return c.json(
+      { error: { code: "NOT_CONFIGURED", message: `kind '${kind}' is accepted by the schema but not yet backed by fan-out hooks; watch would silently miss events` } },
+      501,
+    );
+  }
   const lastEventId = c.req.header("last-event-id");
   // Last-Event-ID overrides resumeFrom on auto-reconnect (browser EventSource).
   // If present but malformed, fail fast with 400 — silently falling back to

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -106,6 +106,12 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
   // queued bytes stay under ~4 MiB per client before we 503.
   const ROUTE_BYTE_OVERFLOW_THRESHOLD = -3 * 1024 * 1024;
 
+  // Hoisted out of start() so the stream's cancel() handler can fire the
+  // same teardown when the consumer cancels the response body without
+  // routing through the request abort signal (some HTTP/2 proxies and
+  // body.cancel() callers do this).
+  let teardown: (() => void) | undefined;
+
   const stream = new ReadableStream<Uint8Array>(
     {
     start(controller) {
@@ -146,7 +152,10 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
         try {
           controller.enqueue(bytes);
         } catch {
-          /* controller already closed */
+          // Controller already closed — treat as send failure so callers
+          // can run their terminal path (close/cleanup) instead of
+          // silently dropping the frame.
+          return false;
         }
         return true;
       };
@@ -163,6 +172,7 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
           /* already closed */
         }
       };
+      teardown = cleanup;
 
       const closeWithError = (code: number, reason: string): void => {
         send("ERROR", { code, reason });
@@ -193,7 +203,15 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
         // reconnect picks up Last-Event-ID = currentRv. Without this, a
         // BOOKMARK after a real event would not advance the resume cursor.
         const rv = String(hub.currentRv(namespace, kind as WatchKind));
-        send("BOOKMARK", { rv }, rv);
+        // send() returns false when the queue can't accept another frame
+        // (overflow headroom, oversized payload, controller already closed).
+        // Treat this exactly like a data-path overflow so the watcher is
+        // closed and the hub subscription is released — silently dropping
+        // a bookmark would leave the timer + subscription alive forever
+        // on a stalled idle client.
+        if (!send("BOOKMARK", { rv }, rv)) {
+          closeWithError(503, "buffer_overflow");
+        }
       }, hub.bookmarkIntervalMs);
       // Don't hold the event loop open just for this timer.
       (bookmarkTimer as unknown as { unref?: () => void }).unref?.();
@@ -230,6 +248,12 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
 
       // Abort when the client disconnects.
       c.req.raw.signal.addEventListener("abort", cleanup);
+    },
+    cancel() {
+      // Reader cancel (response body cancelled) — release the hub
+      // subscription and bookmark timer even when the request abort
+      // signal didn't fire.
+      teardown?.();
     },
   },
     new ByteLengthQueuingStrategy({ highWaterMark: ROUTE_BYTE_HIGH_WATER_MARK }),

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -73,9 +73,7 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
 
       const send = (event: string, data: unknown, id?: string): void => {
         if (closed) return;
-        const payload = `id: ${id ?? ""}\nevent: ${event}\ndata: ${JSON.stringify(
-          data,
-        )}\n\n`;
+        const payload = `id: ${id ?? ""}\nevent: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
         try {
           controller.enqueue(encoder.encode(payload));
         } catch {

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -61,7 +61,11 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
   const { kind, resumeFrom } = c.req.valid("query");
   const lastEventId = c.req.header("last-event-id");
   // Last-Event-ID overrides resumeFrom on auto-reconnect (browser EventSource).
-  const fromRv = BigInt(lastEventId ?? resumeFrom);
+  // Reject blank/non-decimal values defensively — `BigInt("")` is 0n, which
+  // would silently rewind the watch to genesis and 410 once the ring evicts.
+  const validLastEventId =
+    lastEventId && /^[0-9]+$/.test(lastEventId) ? lastEventId : undefined;
+  const fromRv = BigInt(validLastEventId ?? resumeFrom);
   const hub: WatchHub = c.get("deps").watchHub;
 
   // SSE-route per-connection queue cap. The WatchHub already bounds its
@@ -89,7 +93,11 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
 
       const send = (event: string, data: unknown, id?: string): void => {
         if (closed) return;
-        const payload = `id: ${id ?? ""}\nevent: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+        // Only emit `id:` when we have one. A blank `id:` line tells SSE
+        // clients to clear Last-Event-ID, which would silently rewind the
+        // watch on reconnect.
+        const idLine = id ? `id: ${id}\n` : "";
+        const payload = `${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
         try {
           controller.enqueue(encoder.encode(payload));
         } catch {
@@ -127,9 +135,11 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
       }
 
       bookmarkTimer = setInterval(() => {
-        send("BOOKMARK", {
-          rv: String(hub.currentRv(namespace, kind as WatchKind)),
-        });
+        // Tag the BOOKMARK with the RV as the SSE id so EventSource auto-
+        // reconnect picks up Last-Event-ID = currentRv. Without this, a
+        // BOOKMARK after a real event would not advance the resume cursor.
+        const rv = String(hub.currentRv(namespace, kind as WatchKind));
+        send("BOOKMARK", { rv }, rv);
       }, hub.bookmarkIntervalMs);
       // Don't hold the event loop open just for this timer.
       (bookmarkTimer as unknown as { unref?: () => void }).unref?.();

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -64,12 +64,28 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
   const fromRv = BigInt(lastEventId ?? resumeFrom);
   const hub: WatchHub = c.get("deps").watchHub;
 
-  const stream = new ReadableStream<Uint8Array>({
+  // SSE-route per-connection queue cap. The WatchHub already bounds its
+  // per-subscriber queue, but once a hub event is drained into the route's
+  // ReadableStream, only the stream's own backpressure stops the route from
+  // accumulating bytes for a stalled TCP client. Setting an explicit
+  // highWaterMark + a hard overflow threshold lets us close the stream with
+  // 503 buffer_overflow before the process holds unbounded bytes for one
+  // client. K8s' watch http2 path uses a similar bounded write window.
+  const ROUTE_HIGH_WATER_MARK = 64;
+  const ROUTE_OVERFLOW_THRESHOLD = -ROUTE_HIGH_WATER_MARK * 4; // ~256 chunks queued
+
+  const stream = new ReadableStream<Uint8Array>(
+    {
     start(controller) {
       const encoder = new TextEncoder();
       const ac = new AbortController();
       let bookmarkTimer: ReturnType<typeof setInterval> | null = null;
       let closed = false;
+
+      const isOverflowed = (): boolean => {
+        const ds = controller.desiredSize;
+        return ds !== null && ds <= ROUTE_OVERFLOW_THRESHOLD;
+      };
 
       const send = (event: string, data: unknown, id?: string): void => {
         if (closed) return;
@@ -121,6 +137,10 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
       void (async () => {
         try {
           for await (const ev of iterable) {
+            if (isOverflowed()) {
+              closeWithError(503, "buffer_overflow");
+              return;
+            }
             send(ev.op, { kind: ev.kind, entity: ev.entity }, String(ev.rv));
           }
           cleanup();
@@ -136,7 +156,9 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
       // Abort when the client disconnects.
       c.req.raw.signal.addEventListener("abort", cleanup);
     },
-  });
+  },
+    new CountQueuingStrategy({ highWaterMark: ROUTE_HIGH_WATER_MARK }),
+  );
 
   return new Response(stream, {
     headers: {

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -48,7 +48,12 @@ watch.get("/list", zValidator("query", listQuerySchema), async (c) => {
   const { kind } = c.req.valid("query");
   if (!SUPPORTED_KINDS.has(kind)) {
     return c.json(
-      { error: { code: "NOT_CONFIGURED", message: `kind '${kind}' is accepted by the schema but not yet backed by a store; list is unavailable` } },
+      {
+        error: {
+          code: "NOT_CONFIGURED",
+          message: `kind '${kind}' is accepted by the schema but not yet backed by a store; list is unavailable`,
+        },
+      },
       501,
     );
   }
@@ -75,7 +80,12 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
   const { kind, resumeFrom } = c.req.valid("query");
   if (!SUPPORTED_KINDS.has(kind)) {
     return c.json(
-      { error: { code: "NOT_CONFIGURED", message: `kind '${kind}' is accepted by the schema but not yet backed by fan-out hooks; watch would silently miss events` } },
+      {
+        error: {
+          code: "NOT_CONFIGURED",
+          message: `kind '${kind}' is accepted by the schema but not yet backed by fan-out hooks; watch would silently miss events`,
+        },
+      },
       501,
     );
   }
@@ -86,7 +96,12 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
   // recently-seen events, causing duplicate replay or stale 410.
   if (lastEventId !== undefined && !/^[0-9]+$/.test(lastEventId)) {
     return c.json(
-      { error: { code: "VALIDATION_ERROR", message: "Last-Event-ID must be a non-negative decimal integer" } },
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Last-Event-ID must be a non-negative decimal integer",
+        },
+      },
       400,
     );
   }
@@ -114,148 +129,148 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
 
   const stream = new ReadableStream<Uint8Array>(
     {
-    start(controller) {
-      const encoder = new TextEncoder();
-      const ac = new AbortController();
-      let bookmarkTimer: ReturnType<typeof setInterval> | null = null;
-      let closed = false;
+      start(controller) {
+        const encoder = new TextEncoder();
+        const ac = new AbortController();
+        let bookmarkTimer: ReturnType<typeof setInterval> | null = null;
+        let closed = false;
 
-      const isOverflowed = (): boolean => {
-        const ds = controller.desiredSize;
-        return ds !== null && ds <= ROUTE_BYTE_OVERFLOW_THRESHOLD;
-      };
+        const isOverflowed = (): boolean => {
+          const ds = controller.desiredSize;
+          return ds !== null && ds <= ROUTE_BYTE_OVERFLOW_THRESHOLD;
+        };
 
-      // Per-event hard cap. Even within byte budget, a single huge frame
-      // would force the queue into deep-negative desiredSize between
-      // overflow checks. Watch consumers that produce >1 MiB events should
-      // chunk through the entity store, not the watch stream.
-      const ROUTE_MAX_EVENT_BYTES = 1 * 1024 * 1024;
+        // Per-event hard cap. Even within byte budget, a single huge frame
+        // would force the queue into deep-negative desiredSize between
+        // overflow checks. Watch consumers that produce >1 MiB events should
+        // chunk through the entity store, not the watch stream.
+        const ROUTE_MAX_EVENT_BYTES = 1 * 1024 * 1024;
 
-      const send = (event: string, data: unknown, id?: string): boolean => {
-        if (closed) return false;
-        // Only emit `id:` when we have one. A blank `id:` line tells SSE
-        // clients to clear Last-Event-ID, which would silently rewind the
-        // watch on reconnect.
-        const idLine = id ? `id: ${id}\n` : "";
-        const payload = `${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-        const bytes = encoder.encode(payload);
-        // Reject oversized single events before they overshoot the queue.
-        // The terminal ERROR/cleanup path may still call send() inside this
-        // guard — that path uses small fixed payloads and is not affected.
-        if (bytes.byteLength > ROUTE_MAX_EVENT_BYTES) return false;
-        // If this single event would push the queue into hard-overflow
-        // before the next iteration's check, treat it as overflow now.
-        const ds = controller.desiredSize;
-        if (ds !== null && ds - bytes.byteLength <= ROUTE_BYTE_OVERFLOW_THRESHOLD) {
-          return false;
-        }
-        try {
-          controller.enqueue(bytes);
-        } catch {
-          // Controller already closed — treat as send failure so callers
-          // can run their terminal path (close/cleanup) instead of
-          // silently dropping the frame.
-          return false;
-        }
-        return true;
-      };
-
-      const cleanup = (): void => {
-        if (closed) return;
-        closed = true;
-        if (bookmarkTimer) clearInterval(bookmarkTimer);
-        bookmarkTimer = null;
-        ac.abort();
-        try {
-          controller.close();
-        } catch {
-          /* already closed */
-        }
-      };
-      teardown = cleanup;
-
-      const closeWithError = (code: number, reason: string): void => {
-        send("ERROR", { code, reason });
-        cleanup();
-      };
-
-      let iterable: AsyncIterable<WatchEvent>;
-      try {
-        iterable = hub.subscribe(namespace, kind as WatchKind, fromRv, ac.signal);
-      } catch (err) {
-        if (err instanceof StaleResourceVersionError) {
-          closeWithError(410, "expired");
-          return;
-        }
-        throw err;
-      }
-
-      bookmarkTimer = setInterval(() => {
-        // A stalled reader on a quiescent watch would otherwise let
-        // BOOKMARK frames pile up forever — they don't trip the
-        // data-event overflow check below. Reuse the same threshold so
-        // both code paths cap memory identically.
-        if (isOverflowed()) {
-          closeWithError(503, "buffer_overflow");
-          return;
-        }
-        // Tag the BOOKMARK with the RV as the SSE id so EventSource auto-
-        // reconnect picks up Last-Event-ID = currentRv. Without this, a
-        // BOOKMARK after a real event would not advance the resume cursor.
-        const rv = String(hub.currentRv(namespace, kind as WatchKind));
-        // send() returns false when the queue can't accept another frame
-        // (overflow headroom, oversized payload, controller already closed).
-        // Treat this exactly like a data-path overflow so the watcher is
-        // closed and the hub subscription is released — silently dropping
-        // a bookmark would leave the timer + subscription alive forever
-        // on a stalled idle client.
-        if (!send("BOOKMARK", { rv }, rv)) {
-          closeWithError(503, "buffer_overflow");
-        }
-      }, hub.bookmarkIntervalMs);
-      // Don't hold the event loop open just for this timer.
-      (bookmarkTimer as unknown as { unref?: () => void }).unref?.();
-
-      void (async () => {
-        try {
-          for await (const ev of iterable) {
-            if (isOverflowed()) {
-              closeWithError(503, "buffer_overflow");
-              return;
-            }
-            const rv = String(ev.rv);
-            // Include rv in the JSON body so clients that only parse `data`
-            // (no SSE `lastEventId` access) can still resume. Matches the
-            // BOOKMARK shape and the A5 contract.
-            const sent = send(ev.op, { rv, kind: ev.kind, entity: ev.entity }, rv);
-            // send() refuses oversized events or events that would push the
-            // queue past the overflow threshold. Either case is terminal —
-            // skipping the event silently would let the client miss writes.
-            if (!sent) {
-              closeWithError(503, "buffer_overflow");
-              return;
-            }
+        const send = (event: string, data: unknown, id?: string): boolean => {
+          if (closed) return false;
+          // Only emit `id:` when we have one. A blank `id:` line tells SSE
+          // clients to clear Last-Event-ID, which would silently rewind the
+          // watch on reconnect.
+          const idLine = id ? `id: ${id}\n` : "";
+          const payload = `${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+          const bytes = encoder.encode(payload);
+          // Reject oversized single events before they overshoot the queue.
+          // The terminal ERROR/cleanup path may still call send() inside this
+          // guard — that path uses small fixed payloads and is not affected.
+          if (bytes.byteLength > ROUTE_MAX_EVENT_BYTES) return false;
+          // If this single event would push the queue into hard-overflow
+          // before the next iteration's check, treat it as overflow now.
+          const ds = controller.desiredSize;
+          if (ds !== null && ds - bytes.byteLength <= ROUTE_BYTE_OVERFLOW_THRESHOLD) {
+            return false;
           }
+          try {
+            controller.enqueue(bytes);
+          } catch {
+            // Controller already closed — treat as send failure so callers
+            // can run their terminal path (close/cleanup) instead of
+            // silently dropping the frame.
+            return false;
+          }
+          return true;
+        };
+
+        const cleanup = (): void => {
+          if (closed) return;
+          closed = true;
+          if (bookmarkTimer) clearInterval(bookmarkTimer);
+          bookmarkTimer = null;
+          ac.abort();
+          try {
+            controller.close();
+          } catch {
+            /* already closed */
+          }
+        };
+        teardown = cleanup;
+
+        const closeWithError = (code: number, reason: string): void => {
+          send("ERROR", { code, reason });
           cleanup();
-        } catch (err) {
-          if (err instanceof BufferOverflowError) {
-            closeWithError(503, "buffer_overflow");
-          } else {
-            closeWithError(500, "internal_error");
-          }
-        }
-      })();
+        };
 
-      // Abort when the client disconnects.
-      c.req.raw.signal.addEventListener("abort", cleanup);
+        let iterable: AsyncIterable<WatchEvent>;
+        try {
+          iterable = hub.subscribe(namespace, kind as WatchKind, fromRv, ac.signal);
+        } catch (err) {
+          if (err instanceof StaleResourceVersionError) {
+            closeWithError(410, "expired");
+            return;
+          }
+          throw err;
+        }
+
+        bookmarkTimer = setInterval(() => {
+          // A stalled reader on a quiescent watch would otherwise let
+          // BOOKMARK frames pile up forever — they don't trip the
+          // data-event overflow check below. Reuse the same threshold so
+          // both code paths cap memory identically.
+          if (isOverflowed()) {
+            closeWithError(503, "buffer_overflow");
+            return;
+          }
+          // Tag the BOOKMARK with the RV as the SSE id so EventSource auto-
+          // reconnect picks up Last-Event-ID = currentRv. Without this, a
+          // BOOKMARK after a real event would not advance the resume cursor.
+          const rv = String(hub.currentRv(namespace, kind as WatchKind));
+          // send() returns false when the queue can't accept another frame
+          // (overflow headroom, oversized payload, controller already closed).
+          // Treat this exactly like a data-path overflow so the watcher is
+          // closed and the hub subscription is released — silently dropping
+          // a bookmark would leave the timer + subscription alive forever
+          // on a stalled idle client.
+          if (!send("BOOKMARK", { rv }, rv)) {
+            closeWithError(503, "buffer_overflow");
+          }
+        }, hub.bookmarkIntervalMs);
+        // Don't hold the event loop open just for this timer.
+        (bookmarkTimer as unknown as { unref?: () => void }).unref?.();
+
+        void (async () => {
+          try {
+            for await (const ev of iterable) {
+              if (isOverflowed()) {
+                closeWithError(503, "buffer_overflow");
+                return;
+              }
+              const rv = String(ev.rv);
+              // Include rv in the JSON body so clients that only parse `data`
+              // (no SSE `lastEventId` access) can still resume. Matches the
+              // BOOKMARK shape and the A5 contract.
+              const sent = send(ev.op, { rv, kind: ev.kind, entity: ev.entity }, rv);
+              // send() refuses oversized events or events that would push the
+              // queue past the overflow threshold. Either case is terminal —
+              // skipping the event silently would let the client miss writes.
+              if (!sent) {
+                closeWithError(503, "buffer_overflow");
+                return;
+              }
+            }
+            cleanup();
+          } catch (err) {
+            if (err instanceof BufferOverflowError) {
+              closeWithError(503, "buffer_overflow");
+            } else {
+              closeWithError(500, "internal_error");
+            }
+          }
+        })();
+
+        // Abort when the client disconnects.
+        c.req.raw.signal.addEventListener("abort", cleanup);
+      },
+      cancel() {
+        // Reader cancel (response body cancelled) — release the hub
+        // subscription and bookmark timer even when the request abort
+        // signal didn't fire.
+        teardown?.();
+      },
     },
-    cancel() {
-      // Reader cancel (response body cancelled) — release the hub
-      // subscription and bookmark timer even when the request abort
-      // signal didn't fire.
-      teardown?.();
-    },
-  },
     new ByteLengthQueuingStrategy({ highWaterMark: ROUTE_BYTE_HIGH_WATER_MARK }),
   );
 

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -10,6 +10,7 @@
  */
 
 import { join } from "node:path";
+import { claimToEntity, contributionToEntity } from "../core/entity.js";
 import type { GossipService } from "../core/gossip/types.js";
 import { LocalEventBus } from "../core/local-event-bus.js";
 import { readProjectId } from "../core/project-id.js";
@@ -22,10 +23,12 @@ import {
   writeNamespace,
 } from "../core/project-key.js";
 import { TmuxRuntime } from "../core/tmux-runtime.js";
+import type { WatchEntity, WatchKind } from "../core/watch-events.js";
 import { WatchHub } from "../core/watch-hub.js";
 import { HttpGossipTransport } from "../gossip/http-transport.js";
 import { DefaultGossipService } from "../gossip/protocol.js";
 import { createLocalRuntime } from "../local/runtime.js";
+import { NexusWatchSubscriber } from "../nexus/nexus-watch-subscriber.js";
 import { parseGossipSeeds, parsePort } from "../shared/env.js";
 import { createApp } from "./app.js";
 import type { ServerDeps } from "./deps.js";
@@ -203,6 +206,17 @@ if (seedPeers.length > 0) {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Watch protocol (#292)
+// ---------------------------------------------------------------------------
+// `watchHub` holds per-(namespace, kind) RV counters and the replay ring.
+// `watchEventBus` is the in-process fan-out channel for `entity.changed`
+// envelopes; the publisher lives inside Nexus stores and the subscriber
+// lives here in the server. Even in pure-local mode we instantiate both
+// so the wiring is uniform — the bus is just idle when nothing publishes.
+const watchHub = new WatchHub();
+const watchEventBus = new LocalEventBus();
+
 if (nexusUrl) {
   const { NexusHttpClient } = await import("../nexus/nexus-http-client.js");
   const { NexusContributionStore } = await import("../nexus/nexus-contribution-store.js");
@@ -210,11 +224,19 @@ if (nexusUrl) {
   const { NexusBountyStore } = await import("../nexus/nexus-bounty-store.js");
   const { NexusOutcomeStore } = await import("../nexus/nexus-outcome-store.js");
   const { NexusCas } = await import("../nexus/nexus-cas.js");
+  const { NexusWatchPublisher } = await import("../nexus/nexus-watch-publisher.js");
 
   const nexusClient = new NexusHttpClient({
     url: nexusUrl,
     ...(nexusApiKey ? { apiKey: nexusApiKey } : {}),
   });
+
+  // Publisher fans out `entity.changed` envelopes from store mutations
+  // onto the local event-bus, where the subscriber (instantiated below
+  // after the stores) hydrates them into the WatchHub. This closes the
+  // cross-process loop: writes from MCP / other grove processes that
+  // share the same Nexus VFS reach this server's watchers.
+  const watchPublisher = new NexusWatchPublisher(watchEventBus);
 
   // Retry health check — during `grove up` Nexus may briefly be unavailable.
   // Matches the MCP server's retry window so both processes either come up
@@ -246,13 +268,23 @@ if (nexusUrl) {
     process.exit(1);
   }
 
-  serverContributionStore = new NexusContributionStore({ client: nexusClient, zoneId });
-  serverClaimStore = new NexusClaimStore({ client: nexusClient, zoneId });
+  serverContributionStore = new NexusContributionStore({
+    client: nexusClient,
+    zoneId,
+    watchPublisher,
+  });
+  serverClaimStore = new NexusClaimStore({ client: nexusClient, zoneId, watchPublisher });
   serverBountyStore = new NexusBountyStore({ client: nexusClient, zoneId });
   serverOutcomeStore = new NexusOutcomeStore({ client: nexusClient, zoneId });
   serverCas = new NexusCas({ client: nexusClient, zoneId });
   contributionStoreForSessionFactory = memoizeContributionStoreForSession(
-    (sessionId: string) => new NexusContributionStore({ client: nexusClient, zoneId, sessionId }),
+    (sessionId: string) =>
+      new NexusContributionStore({
+        client: nexusClient,
+        zoneId,
+        sessionId,
+        watchPublisher,
+      }),
   );
   console.log(`grove-server: using Nexus stores at ${nexusUrl} (zone=${zoneId})`);
 }
@@ -266,6 +298,19 @@ const { SqliteHandoffStore: _SqliteHandoffStore } = await import(
 );
 const handoffStoreForSession = (sessionId: string) =>
   new _SqliteHandoffStore(runtime.db, sessionId) as import("../core/handoff.js").HandoffStore;
+
+// Subscribe to cross-process `entity.changed` envelopes (#292). Started in
+// every mode so future bus-publishers (Nexus-backed bus, other processes)
+// fan in uniformly; idle no-op when nothing publishes (pure local).
+const watchSubscriber = new NexusWatchSubscriber({
+  bus: watchEventBus,
+  hub: watchHub,
+  fetchEntity: makeWatchEntityFetcher({
+    contributionStore: serverContributionStore,
+    claimStore: serverClaimStore,
+  }),
+});
+watchSubscriber.start();
 
 const deps: ServerDeps = {
   contributionStore: serverContributionStore,
@@ -283,7 +328,8 @@ const deps: ServerDeps = {
   topology: runtime.contract?.topology,
   contract: runtime.contract,
   idempotencyStore: runtime.idempotencyStore,
-  watchHub: new WatchHub(),
+  watchHub,
+  watchSubscriber,
 };
 
 const app = createApp(deps, registry);
@@ -461,6 +507,7 @@ async function shutdown(): Promise<void> {
   if (gossipService) {
     await gossipService.stop();
   }
+  watchSubscriber.stop();
   server.stop();
   runtime.close();
   process.exit(0);
@@ -468,3 +515,31 @@ async function shutdown(): Promise<void> {
 
 process.on("SIGTERM", () => void shutdown());
 process.on("SIGINT", () => void shutdown());
+
+// ---------------------------------------------------------------------------
+// Watch entity fetcher (#292)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fetcher used by NexusWatchSubscriber to hydrate `entity.changed`
+ * envelopes into full WatchEntity payloads via the same stores the server
+ * uses for HTTP reads — keeping the wire format minimal.
+ */
+function makeWatchEntityFetcher(stores: {
+  contributionStore: import("../core/store.js").ContributionStore;
+  claimStore: import("../core/store.js").ClaimStore;
+}): (kind: WatchKind, namespace: string, id: string) => Promise<WatchEntity> {
+  return async (kind, namespace, id) => {
+    if (kind === "Contribution") {
+      const c = await stores.contributionStore.get(id);
+      if (!c) throw new Error(`Contribution ${id} not found`);
+      return contributionToEntity(c, namespace);
+    }
+    if (kind === "Claim") {
+      const c = await stores.claimStore.getClaim(id);
+      if (!c) throw new Error(`Claim ${id} not found`);
+      return claimToEntity(c, () => Date.now(), namespace);
+    }
+    throw new Error(`Unsupported kind for watch fetcher: ${kind}`);
+  };
+}

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -22,6 +22,7 @@ import {
   writeNamespace,
 } from "../core/project-key.js";
 import { TmuxRuntime } from "../core/tmux-runtime.js";
+import { WatchHub } from "../core/watch-hub.js";
 import { HttpGossipTransport } from "../gossip/http-transport.js";
 import { DefaultGossipService } from "../gossip/protocol.js";
 import { createLocalRuntime } from "../local/runtime.js";
@@ -282,6 +283,7 @@ const deps: ServerDeps = {
   topology: runtime.contract?.topology,
   contract: runtime.contract,
   idempotencyStore: runtime.idempotencyStore,
+  watchHub: new WatchHub(),
 };
 
 const app = createApp(deps, registry);

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -367,6 +367,47 @@ if (serverBountyStore) {
 }
 
 // ---------------------------------------------------------------------------
+// Claim expiry sweep — drives lease-derived state changes into the watch log
+// ---------------------------------------------------------------------------
+//
+// expireStale() flips active claims past their lease to `expired` and bumps
+// revision, but it does not on its own emit a watch event in SQLite mode and
+// the Nexus mode publisher can be self-filtered by sourceInstanceId. Without
+// this sweep, /api/watch?kind=Claim clients would never observe a lease-only
+// expiry — they'd see the claim as active until another write touched it.
+const CLAIM_EXPIRY_INTERVAL_MS = 30_000;
+const claimExpiryTimer = setInterval(async () => {
+  try {
+    const expired = await serverClaimStore.expireStale();
+    for (const { claim } of expired) {
+      const entity = claimToEntity(claim, () => Date.now(), zoneId);
+      try {
+        watchHub.recordWrite({ kind: "Claim", namespace: zoneId, op: "MODIFIED", entity });
+        watchSubscriber.markSeen({
+          kind: "Claim",
+          entityId: claim.claimId,
+          generation: entity.metadata.generation,
+        });
+      } catch (err) {
+        process.stderr.write(
+          `[grove] Warning: claim-expiry watch fan-out threw: ${
+            err instanceof Error ? err.message : String(err)
+          }\n`,
+        );
+      }
+    }
+  } catch (err) {
+    process.stderr.write(
+      `[grove] Warning: claim-expiry sweep failed: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+  }
+}, CLAIM_EXPIRY_INTERVAL_MS);
+// Don't hold the event loop open just for this timer.
+(claimExpiryTimer as unknown as { unref?: () => void }).unref?.();
+
+// ---------------------------------------------------------------------------
 // Optional SessionService + WebSocket push
 // ---------------------------------------------------------------------------
 

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -434,10 +434,17 @@ if (HOST && !LOCALHOST_ADDRESSES.has(HOST)) {
 function startServer() {
   const hostnameOpts = HOST ? { hostname: HOST } : {};
 
+  // SSE watch streams (#292) hold connections idle for up to bookmarkIntervalMs
+  // (default 30s) plus replay drift. Bun's default idleTimeout is 10s — without
+  // raising it, the watcher's TCP connection is closed before the next BOOKMARK
+  // fires and clients see silent disconnects. 255 is Bun's max.
+  const idleTimeout = 255;
+
   if (wsHandler !== undefined) {
     const wsh = wsHandler;
     return Bun.serve({
       port: PORT,
+      idleTimeout,
       ...hostnameOpts,
       fetch(req, server) {
         const url = new URL(req.url);
@@ -480,6 +487,7 @@ function startServer() {
 
   return Bun.serve({
     port: PORT,
+    idleTimeout,
     ...hostnameOpts,
     fetch: app.fetch,
   });

--- a/src/server/sse-test-utils.ts
+++ b/src/server/sse-test-utils.ts
@@ -1,0 +1,72 @@
+/**
+ * Test-only utilities for draining text/event-stream responses into structured
+ * events. Used by watch.integration.test.ts and sibling acceptance tests (#292).
+ */
+
+export interface SseEvent {
+  readonly id: string;
+  readonly event: string;
+  readonly data: unknown;
+}
+
+/**
+ * Drain an SSE response body until either `stopAfter` events have been seen
+ * or `timeoutMs` has elapsed. Cancels the underlying reader on return.
+ */
+export async function readSseEvents(
+  res: Response,
+  stopAfter: number,
+  timeoutMs = 2_000,
+): Promise<SseEvent[]> {
+  const events: SseEvent[] = [];
+  const body = res.body;
+  if (!body) return events;
+  const reader = body.getReader();
+  type ReadResult = Awaited<ReturnType<typeof reader.read>>;
+  const decoder = new TextDecoder();
+  let buf = "";
+  const deadline = Date.now() + timeoutMs;
+
+  while (events.length < stopAfter && Date.now() < deadline) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
+    let result: ReadResult;
+    try {
+      result = await Promise.race([
+        reader.read(),
+        new Promise<ReadResult>((resolve) =>
+          setTimeout(
+            () => resolve({ value: undefined, done: false } as ReadResult),
+            remainingMs,
+          ),
+        ),
+      ]);
+    } catch {
+      break;
+    }
+    if (result.done) break;
+    if (result.value === undefined) continue; // timed out this read
+    buf += decoder.decode(result.value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf("\n\n")) >= 0) {
+      const block = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+      const id = /^id: (.*)$/m.exec(block)?.[1] ?? "";
+      const event = /^event: (.*)$/m.exec(block)?.[1] ?? "";
+      const dataLine = /^data: (.*)$/m.exec(block)?.[1] ?? "null";
+      let data: unknown = null;
+      try {
+        data = JSON.parse(dataLine);
+      } catch {
+        data = dataLine;
+      }
+      events.push({ id, event, data });
+    }
+  }
+  try {
+    await reader.cancel();
+  } catch {
+    /* already cancelled */
+  }
+  return events;
+}

--- a/src/server/sse-test-utils.ts
+++ b/src/server/sse-test-utils.ts
@@ -35,10 +35,7 @@ export async function readSseEvents(
       result = await Promise.race([
         reader.read(),
         new Promise<ReadResult>((resolve) =>
-          setTimeout(
-            () => resolve({ value: undefined, done: false } as ReadResult),
-            remainingMs,
-          ),
+          setTimeout(() => resolve({ value: undefined, done: false } as ReadResult), remainingMs),
         ),
       ]);
     } catch {
@@ -47,8 +44,8 @@ export async function readSseEvents(
     if (result.done) break;
     if (result.value === undefined) continue; // timed out this read
     buf += decoder.decode(result.value, { stream: true });
-    let idx;
-    while ((idx = buf.indexOf("\n\n")) >= 0) {
+    let idx = buf.indexOf("\n\n");
+    while (idx >= 0) {
       const block = buf.slice(0, idx);
       buf = buf.slice(idx + 2);
       const id = /^id: (.*)$/m.exec(block)?.[1] ?? "";
@@ -61,6 +58,7 @@ export async function readSseEvents(
         data = dataLine;
       }
       events.push({ id, event, data });
+      idx = buf.indexOf("\n\n");
     }
   }
   try {

--- a/src/server/test-helpers.ts
+++ b/src/server/test-helpers.ts
@@ -8,9 +8,11 @@
 import type { Hono } from "hono";
 import type { ContentStore, PutOptions } from "../core/cas.js";
 import type { ClaimEntity } from "../core/entity.js";
-import { claimToEntity } from "../core/entity.js";
+import { claimToEntity, contributionToEntity } from "../core/entity.js";
 import { NotFoundError, StateConflictError } from "../core/errors.js";
+import type { EventBus } from "../core/event-bus.js";
 import { DefaultFrontierCalculator } from "../core/frontier.js";
+import { LocalEventBus } from "../core/local-event-bus.js";
 import type { AgentIdentity, Artifact, Claim, ContributionInput } from "../core/models.js";
 import type {
   ActiveClaimFilter,
@@ -21,6 +23,7 @@ import type {
 } from "../core/store.js";
 import { InMemoryContributionStore } from "../core/testing.js";
 import { WatchHub, type WatchHubOptions } from "../core/watch-hub.js";
+import { NexusWatchSubscriber } from "../nexus/nexus-watch-subscriber.js";
 import { createApp } from "./app.js";
 import type { ServerDeps, ServerEnv } from "./deps.js";
 import type { KeyRegistry } from "./middleware/namespace-auth.js";
@@ -295,10 +298,12 @@ export interface TestContext {
   claimStore: InMemoryClaimStore;
   cas: InMemoryContentStore;
   watchHub: WatchHub;
+  watchEventBus: EventBus;
 }
 
 export interface CreateTestAppOptions {
   readonly watchHubOptions?: WatchHubOptions;
+  readonly eventBus?: EventBus;
 }
 
 /** Create a test app with fresh in-memory stores. */
@@ -309,17 +314,41 @@ export function createTestApp(opts: CreateTestAppOptions = {}): TestContext {
   const frontier = new DefaultFrontierCalculator(contributionStore);
   const watchHub = new WatchHub(opts.watchHubOptions);
 
+  // Cross-process subscriber that fans `entity.changed` envelopes from the
+  // shared event-bus into the WatchHub. fetchEntity uses the same in-memory
+  // stores so tests can simulate out-of-band writes (#292 T23).
+  const watchEventBus = opts.eventBus ?? new LocalEventBus();
+  const watchSubscriber = new NexusWatchSubscriber({
+    bus: watchEventBus,
+    hub: watchHub,
+    fetchEntity: async (kind, namespace, id) => {
+      if (kind === "Contribution") {
+        const c = await contributionStore.get(id);
+        if (!c) throw new Error(`Contribution ${id} not found`);
+        return contributionToEntity(c, namespace);
+      }
+      if (kind === "Claim") {
+        const c = await claimStore.getClaim(id);
+        if (!c) throw new Error(`Claim ${id} not found`);
+        return claimToEntity(c, () => Date.now(), namespace);
+      }
+      throw new Error(`Unsupported kind: ${kind}`);
+    },
+  });
+  watchSubscriber.start();
+
   const deps: ServerDeps = {
     contributionStore,
     claimStore,
     cas,
     frontier,
     watchHub,
+    watchSubscriber,
   };
   const registry: KeyRegistry = new Map([[TEST_NAMESPACE_KEY, TEST_NAMESPACE]]);
   const app = createApp(deps, registry);
 
-  return { app, deps, contributionStore, claimStore, cas, watchHub };
+  return { app, deps, contributionStore, claimStore, cas, watchHub, watchEventBus };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/test-helpers.ts
+++ b/src/server/test-helpers.ts
@@ -20,6 +20,7 @@ import type {
   ExpireStaleOptions,
 } from "../core/store.js";
 import { InMemoryContributionStore } from "../core/testing.js";
+import { WatchHub } from "../core/watch-hub.js";
 import { createApp } from "./app.js";
 import type { ServerDeps, ServerEnv } from "./deps.js";
 import type { KeyRegistry } from "./middleware/namespace-auth.js";
@@ -302,7 +303,13 @@ export function createTestApp(): TestContext {
   const cas = new InMemoryContentStore();
   const frontier = new DefaultFrontierCalculator(contributionStore);
 
-  const deps: ServerDeps = { contributionStore, claimStore, cas, frontier };
+  const deps: ServerDeps = {
+    contributionStore,
+    claimStore,
+    cas,
+    frontier,
+    watchHub: new WatchHub(),
+  };
   const registry: KeyRegistry = new Map([[TEST_NAMESPACE_KEY, TEST_NAMESPACE]]);
   const app = createApp(deps, registry);
 

--- a/src/server/test-helpers.ts
+++ b/src/server/test-helpers.ts
@@ -321,6 +321,11 @@ export function createTestApp(opts: CreateTestAppOptions = {}): TestContext {
   const watchSubscriber = new NexusWatchSubscriber({
     bus: watchEventBus,
     hub: watchHub,
+    // Pin a stable instanceId distinct from the default process id so the
+    // cross-process integration test (#292 T23) can publish with a different
+    // id and exercise the cross-process branch — instead of being filtered
+    // out as a self-emitted envelope.
+    instanceId: "test-server-proc",
     fetchEntity: async (kind, namespace, id) => {
       if (kind === "Contribution") {
         const c = await contributionStore.get(id);

--- a/src/server/test-helpers.ts
+++ b/src/server/test-helpers.ts
@@ -20,7 +20,7 @@ import type {
   ExpireStaleOptions,
 } from "../core/store.js";
 import { InMemoryContributionStore } from "../core/testing.js";
-import { WatchHub } from "../core/watch-hub.js";
+import { WatchHub, type WatchHubOptions } from "../core/watch-hub.js";
 import { createApp } from "./app.js";
 import type { ServerDeps, ServerEnv } from "./deps.js";
 import type { KeyRegistry } from "./middleware/namespace-auth.js";
@@ -294,26 +294,32 @@ export interface TestContext {
   contributionStore: InMemoryContributionStore;
   claimStore: InMemoryClaimStore;
   cas: InMemoryContentStore;
+  watchHub: WatchHub;
+}
+
+export interface CreateTestAppOptions {
+  readonly watchHubOptions?: WatchHubOptions;
 }
 
 /** Create a test app with fresh in-memory stores. */
-export function createTestApp(): TestContext {
+export function createTestApp(opts: CreateTestAppOptions = {}): TestContext {
   const contributionStore = new InMemoryContributionStore();
   const claimStore = new InMemoryClaimStore();
   const cas = new InMemoryContentStore();
   const frontier = new DefaultFrontierCalculator(contributionStore);
+  const watchHub = new WatchHub(opts.watchHubOptions);
 
   const deps: ServerDeps = {
     contributionStore,
     claimStore,
     cas,
     frontier,
-    watchHub: new WatchHub(),
+    watchHub,
   };
   const registry: KeyRegistry = new Map([[TEST_NAMESPACE_KEY, TEST_NAMESPACE]]);
   const app = createApp(deps, registry);
 
-  return { app, deps, contributionStore, claimStore, cas };
+  return { app, deps, contributionStore, claimStore, cas, watchHub };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/watch-wiring.test.ts
+++ b/src/server/watch-wiring.test.ts
@@ -1,0 +1,80 @@
+/**
+ * T12 — Verify the operation-adapter wires `onEntityWrite` into the
+ * WatchHub and that the contributions HTTP route injects the
+ * per-request namespace into OperationDeps.
+ *
+ * Two layers of confidence:
+ *   1. Direct: `toOperationDeps(deps)` returns a function that bumps
+ *      `deps.watchHub.currentRv` when invoked. Proves the adapter wiring
+ *      independent of any route.
+ *   2. End-to-end: POSTing /api/contributions with the test auth header
+ *      bumps the namespace+kind RV. Proves the namespace is being
+ *      injected from `c.get("namespace")` and that contribute fires the
+ *      hook with the right namespace.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { contributionToEntity } from "../core/entity.js";
+import type { Contribution } from "../core/models.js";
+import type { EntityWriteEvent } from "../core/watch-events.js";
+import { toOperationDeps } from "./operation-adapter.js";
+import {
+  createTestApp,
+  makeManifestBody,
+  TEST_AUTH_HEADERS,
+  TEST_NAMESPACE,
+} from "./test-helpers.js";
+
+describe("watch wiring (T12)", () => {
+  test("toOperationDeps forwards onEntityWrite into watchHub.recordWrite", () => {
+    const { deps } = createTestApp();
+    const opDeps = toOperationDeps(deps);
+
+    expect(typeof opDeps.onEntityWrite).toBe("function");
+
+    const before = deps.watchHub.currentRv("ns/wt", "Contribution");
+
+    const fakeContribution: Contribution = {
+      cid: `blake3:${"a".repeat(64)}`,
+      manifestVersion: 1,
+      kind: "work",
+      mode: "evaluation",
+      summary: "wiring-probe",
+      artifacts: {},
+      relations: [],
+      tags: [],
+      agent: { agentId: "probe", agentName: "probe", provider: "test", model: "test" },
+      createdAt: new Date().toISOString(),
+    };
+    const event: EntityWriteEvent = {
+      kind: "Contribution",
+      namespace: "ns/wt",
+      op: "ADDED",
+      entity: contributionToEntity(fakeContribution, "ns/wt"),
+    };
+
+    if (opDeps.onEntityWrite === undefined) {
+      throw new Error("onEntityWrite must be wired by toOperationDeps");
+    }
+    opDeps.onEntityWrite(event);
+
+    const after = deps.watchHub.currentRv("ns/wt", "Contribution");
+    expect(after).toBeGreaterThan(before);
+  });
+
+  test("HTTP contribute increments watchHub RV for the namespace", async () => {
+    const { app, deps } = createTestApp();
+    const before = deps.watchHub.currentRv(TEST_NAMESPACE, "Contribution");
+
+    const res = await app.request("/api/contributions", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify(makeManifestBody({ summary: "T12 watch wiring test" })),
+    });
+
+    expect(res.status).toBe(201);
+
+    const after = deps.watchHub.currentRv(TEST_NAMESPACE, "Contribution");
+    expect(after).toBeGreaterThan(before);
+  });
+});

--- a/src/server/watch.bookmark.test.ts
+++ b/src/server/watch.bookmark.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { readSseEvents } from "./sse-test-utils.js";
-import { TEST_AUTH_HEADERS, createTestApp } from "./test-helpers.js";
+import { createTestApp, TEST_AUTH_HEADERS } from "./test-helpers.js";
 
 describe("watch BOOKMARK cadence (issue #292 acceptance #3)", () => {
   test("emits BOOKMARK at least once within bookmarkIntervalMs on idle stream", async () => {

--- a/src/server/watch.bookmark.test.ts
+++ b/src/server/watch.bookmark.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Acceptance test for issue #292 — criterion #3.
+ * BOOKMARK events are emitted at minimum once per bookmarkIntervalMs per
+ * active watch stream, even on a quiescent (ns, kind).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readSseEvents } from "./sse-test-utils.js";
+import { TEST_AUTH_HEADERS, createTestApp } from "./test-helpers.js";
+
+describe("watch BOOKMARK cadence (issue #292 acceptance #3)", () => {
+  test("emits BOOKMARK at least once within bookmarkIntervalMs on idle stream", async () => {
+    const { app } = createTestApp({
+      watchHubOptions: { bookmarkIntervalMs: 200 },
+    });
+
+    const listRes = await app.request("/api/list?kind=Contribution", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const list = (await listRes.json()) as { listResourceVersion: string };
+
+    const watchRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+      { headers: TEST_AUTH_HEADERS },
+    );
+
+    const events = await readSseEvents(watchRes, 1, 1_000);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events[0]?.event).toBe("BOOKMARK");
+    const data = events[0]?.data as { rv: string };
+    expect(typeof data.rv).toBe("string");
+    expect(/^[0-9]+$/.test(data.rv)).toBe(true);
+  }, 5_000);
+});

--- a/src/server/watch.cross-process.test.ts
+++ b/src/server/watch.cross-process.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Cross-process integration smoke test (#292).
+ *
+ * Simulates a write performed by a separate process: writes directly to the
+ * contribution store (bypassing the HTTP route) and then publishes an
+ * `entity.changed` envelope on the shared event-bus. The grove-server's
+ * NexusWatchSubscriber picks it up, fetches the entity, bumps the WatchHub,
+ * and the open SSE watch stream receives the ADDED event.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { NexusWatchPublisher } from "../nexus/nexus-watch-publisher.js";
+import { readSseEvents } from "./sse-test-utils.js";
+import { TEST_AUTH_HEADERS, TEST_NAMESPACE, createTestApp } from "./test-helpers.js";
+
+describe("watch cross-process via event-bus", () => {
+  test("an entity.changed envelope from another writer surfaces on the watch stream", async () => {
+    const { app, contributionStore, watchEventBus } = createTestApp();
+
+    const listRes = await app.request("/api/list?kind=Contribution", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const list = (await listRes.json()) as { listResourceVersion: string };
+
+    const watchRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+      { headers: TEST_AUTH_HEADERS },
+    );
+
+    // Simulate an out-of-band write: write directly to the store. Build a
+    // minimal Contribution that conforms to the Contribution interface.
+    const cid = "blake3:" + "ab".repeat(32);
+    await contributionStore.put({
+      cid,
+      manifestVersion: 1,
+      kind: "work",
+      mode: "evaluation",
+      summary: "cross-proc",
+      artifacts: {},
+      relations: [],
+      tags: [],
+      agent: { agentId: "external-writer" },
+      createdAt: new Date().toISOString(),
+    });
+
+    // Now publish the envelope as if a separate-process publisher had fired.
+    const pub = new NexusWatchPublisher(watchEventBus);
+    await pub.publish({
+      kind: "Contribution",
+      namespace: TEST_NAMESPACE,
+      op: "ADDED",
+      entityId: cid,
+      generation: 1,
+      emittedAt: new Date().toISOString(),
+    });
+
+    const events = await readSseEvents(watchRes, 1, 2_000);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events[0]?.event).toBe("ADDED");
+    const entity = (events[0]?.data as { entity: { id: string } }).entity;
+    expect(entity.id).toBe(cid);
+  }, 5_000);
+});

--- a/src/server/watch.cross-process.test.ts
+++ b/src/server/watch.cross-process.test.ts
@@ -11,7 +11,7 @@
 import { describe, expect, test } from "bun:test";
 import { NexusWatchPublisher } from "../nexus/nexus-watch-publisher.js";
 import { readSseEvents } from "./sse-test-utils.js";
-import { TEST_AUTH_HEADERS, TEST_NAMESPACE, createTestApp } from "./test-helpers.js";
+import { createTestApp, TEST_AUTH_HEADERS, TEST_NAMESPACE } from "./test-helpers.js";
 
 describe("watch cross-process via event-bus", () => {
   test("an entity.changed envelope from another writer surfaces on the watch stream", async () => {
@@ -29,7 +29,7 @@ describe("watch cross-process via event-bus", () => {
 
     // Simulate an out-of-band write: write directly to the store. Build a
     // minimal Contribution that conforms to the Contribution interface.
-    const cid = "blake3:" + "ab".repeat(32);
+    const cid = `blake3:${"ab".repeat(32)}`;
     await contributionStore.put({
       cid,
       manifestVersion: 1,

--- a/src/server/watch.integration.test.ts
+++ b/src/server/watch.integration.test.ts
@@ -1,0 +1,61 @@
+/**
+ * T13 — Integration tests for the GET /api/list watch snapshot endpoint
+ * (#292).
+ *
+ * Verifies the contract documented in `src/server/routes/watch.ts`:
+ *   - empty namespace returns `items: []` and `listResourceVersion: "0"`
+ *   - the listResourceVersion advances after a write through the
+ *     /api/contributions HTTP route (proves the watchHub captured
+ *     in T12 is the same hub queried by /api/list)
+ *   - missing `kind` query param → 400 (zod validator)
+ *   - missing Authorization header → 400 NAMESPACE_MISSING (per
+ *     `namespace-auth.ts`); 401 is accepted as well to keep the test
+ *     resilient to future auth changes.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createTestApp, makeManifestBody, TEST_AUTH_HEADERS } from "./test-helpers.js";
+
+describe("GET /api/list", () => {
+  test("returns items: [] and listResourceVersion '0' for an empty namespace", async () => {
+    const { app } = createTestApp();
+    const res = await app.request("/api/list?kind=Contribution", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[]; listResourceVersion: string };
+    expect(body.items).toEqual([]);
+    expect(body.listResourceVersion).toBe("0");
+  });
+
+  test("listResourceVersion advances after a contribution write", async () => {
+    const { app } = createTestApp();
+
+    const postRes = await app.request("/api/contributions", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify(makeManifestBody({ summary: "T13 list-after-write" })),
+    });
+    expect(postRes.status).toBe(201);
+
+    const res = await app.request("/api/list?kind=Contribution", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[]; listResourceVersion: string };
+    expect(body.items.length).toBe(1);
+    expect(BigInt(body.listResourceVersion)).toBeGreaterThan(0n);
+  });
+
+  test("returns 400 when kind query param is missing", async () => {
+    const { app } = createTestApp();
+    const res = await app.request("/api/list", { headers: TEST_AUTH_HEADERS });
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 or 401 when Authorization header is missing", async () => {
+    const { app } = createTestApp();
+    const res = await app.request("/api/list?kind=Contribution");
+    expect([400, 401]).toContain(res.status);
+  });
+});

--- a/src/server/watch.integration.test.ts
+++ b/src/server/watch.integration.test.ts
@@ -107,10 +107,9 @@ describe("GET /api/watch", () => {
       expect(res.status).toBe(201);
     }
 
-    const watchRes = await app.request(
-      `/api/watch?kind=Contribution&resumeFrom=0`,
-      { headers: TEST_AUTH_HEADERS },
-    );
+    const watchRes = await app.request(`/api/watch?kind=Contribution&resumeFrom=0`, {
+      headers: TEST_AUTH_HEADERS,
+    });
     const events = await readSseEvents(watchRes, 1, 2_000);
     expect(events[0]?.event).toBe("ERROR");
     expect((events[0]?.data as { code: number }).code).toBe(410);

--- a/src/server/watch.integration.test.ts
+++ b/src/server/watch.integration.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { readSseEvents } from "./sse-test-utils.js";
 import { createTestApp, makeManifestBody, TEST_AUTH_HEADERS } from "./test-helpers.js";
 
 describe("GET /api/list", () => {
@@ -57,5 +58,39 @@ describe("GET /api/list", () => {
     const { app } = createTestApp();
     const res = await app.request("/api/list?kind=Contribution");
     expect([400, 401]).toContain(res.status);
+  });
+});
+
+describe("GET /api/watch", () => {
+  test("streams ADDED events for writes after subscribe", async () => {
+    const { app } = createTestApp();
+    const listRes = await app.request("/api/list?kind=Contribution", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const list = (await listRes.json()) as { listResourceVersion: string };
+
+    const watchRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+      { headers: TEST_AUTH_HEADERS },
+    );
+    expect(watchRes.status).toBe(200);
+    expect(watchRes.headers.get("content-type")).toMatch(/text\/event-stream/);
+
+    // POST a contribution AFTER opening the watch. Reuse the existing
+    // contribution-POST pattern from watch-wiring.test.ts (T12 commit 8703e68)
+    // / watch.integration.test.ts (T13 commit 2fb87ea).
+    const writePromise = app.request("/api/contributions", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify(makeManifestBody({ summary: "live-1" })),
+    });
+
+    const events = await readSseEvents(watchRes, 1, 2_000);
+    await writePromise;
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events[0]?.event).toBe("ADDED");
+    // Verify the SSE event id equals the rv (a stringified bigint)
+    expect(events[0]?.id).toMatch(/^[0-9]+$/);
   });
 });

--- a/src/server/watch.integration.test.ts
+++ b/src/server/watch.integration.test.ts
@@ -93,4 +93,27 @@ describe("GET /api/watch", () => {
     // Verify the SSE event id equals the rv (a stringified bigint)
     expect(events[0]?.id).toMatch(/^[0-9]+$/);
   });
+
+  test("ERROR 410 when resumeFrom is older than the ring's oldest rv", async () => {
+    const { app } = createTestApp({ watchHubOptions: { maxEventsPerKey: 2 } });
+
+    // Three writes evict the first one from the ring (cap=2).
+    for (const summary of ["a", "b", "c"]) {
+      const res = await app.request("/api/contributions", {
+        method: "POST",
+        headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+        body: JSON.stringify(makeManifestBody({ summary })),
+      });
+      expect(res.status).toBe(201);
+    }
+
+    const watchRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=0`,
+      { headers: TEST_AUTH_HEADERS },
+    );
+    const events = await readSseEvents(watchRes, 1, 2_000);
+    expect(events[0]?.event).toBe("ERROR");
+    expect((events[0]?.data as { code: number }).code).toBe(410);
+    expect((events[0]?.data as { reason: string }).reason).toBe("expired");
+  });
 });

--- a/src/server/watch.kill.test.ts
+++ b/src/server/watch.kill.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Acceptance test for issue #292 — criterion #1.
+ * After abrupt disconnect (simulates kill -9), reconnect with the stored RV
+ * must replay every event written during the disconnect window.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readSseEvents } from "./sse-test-utils.js";
+import {
+  TEST_AUTH_HEADERS,
+  createTestApp,
+  makeManifestBody,
+} from "./test-helpers.js";
+
+describe("watch kill-9 resume (issue #292 acceptance #1)", () => {
+  test("reconnect with stored RV → zero missed events", async () => {
+    const { app } = createTestApp();
+
+    // Initial list captures the RV checkpoint the client would store.
+    const listRes = await app.request("/api/list?kind=Contribution", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const list = (await listRes.json()) as { listResourceVersion: string };
+
+    // First connection: open the watch, then immediately abort to simulate kill -9.
+    const ac = new AbortController();
+    try {
+      await app.request(
+        `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+        { headers: TEST_AUTH_HEADERS, signal: ac.signal },
+      );
+    } catch {
+      /* signal abort can throw on some Bun versions; ignore */
+    }
+    ac.abort();
+
+    // Write M=20 events while disconnected.
+    const M = 20;
+    const writeResponses = await Promise.all(
+      Array.from({ length: M }, (_, i) =>
+        app.request("/api/contributions", {
+          method: "POST",
+          headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+          body: JSON.stringify(makeManifestBody({ summary: `kill-${i}` })),
+        }),
+      ),
+    );
+    for (const res of writeResponses) {
+      expect(res.status).toBe(201);
+    }
+    const writtenIds = new Set(
+      (
+        await Promise.all(
+          writeResponses.map((r) => r.json() as Promise<{ cid: string }>),
+        )
+      ).map((c) => c.cid),
+    );
+
+    // Reconnect with the same resumeFrom.
+    const secondRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+      { headers: TEST_AUTH_HEADERS },
+    );
+    const events = await readSseEvents(secondRes, M, 5_000);
+    const seenIds = new Set(
+      events
+        .filter((e) => e.event === "ADDED")
+        .map((e) => (e.data as { entity: { id: string } }).entity.id),
+    );
+
+    for (const id of writtenIds) {
+      expect(seenIds.has(id)).toBe(true);
+    }
+
+    // No duplicates: the count of ADDED events with our CIDs should equal M.
+    const addedFromOurWrites = events.filter(
+      (e) =>
+        e.event === "ADDED" &&
+        writtenIds.has((e.data as { entity: { id: string } }).entity.id),
+    );
+    expect(addedFromOurWrites.length).toBe(M);
+  }, 10_000);
+});

--- a/src/server/watch.kill.test.ts
+++ b/src/server/watch.kill.test.ts
@@ -6,11 +6,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { readSseEvents } from "./sse-test-utils.js";
-import {
-  TEST_AUTH_HEADERS,
-  createTestApp,
-  makeManifestBody,
-} from "./test-helpers.js";
+import { createTestApp, makeManifestBody, TEST_AUTH_HEADERS } from "./test-helpers.js";
 
 describe("watch kill-9 resume (issue #292 acceptance #1)", () => {
   test("reconnect with stored RV → zero missed events", async () => {
@@ -25,10 +21,10 @@ describe("watch kill-9 resume (issue #292 acceptance #1)", () => {
     // First connection: open the watch, then immediately abort to simulate kill -9.
     const ac = new AbortController();
     try {
-      await app.request(
-        `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
-        { headers: TEST_AUTH_HEADERS, signal: ac.signal },
-      );
+      await app.request(`/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`, {
+        headers: TEST_AUTH_HEADERS,
+        signal: ac.signal,
+      });
     } catch {
       /* signal abort can throw on some Bun versions; ignore */
     }
@@ -49,11 +45,9 @@ describe("watch kill-9 resume (issue #292 acceptance #1)", () => {
       expect(res.status).toBe(201);
     }
     const writtenIds = new Set(
-      (
-        await Promise.all(
-          writeResponses.map((r) => r.json() as Promise<{ cid: string }>),
-        )
-      ).map((c) => c.cid),
+      (await Promise.all(writeResponses.map((r) => r.json() as Promise<{ cid: string }>))).map(
+        (c) => c.cid,
+      ),
     );
 
     // Reconnect with the same resumeFrom.
@@ -75,8 +69,7 @@ describe("watch kill-9 resume (issue #292 acceptance #1)", () => {
     // No duplicates: the count of ADDED events with our CIDs should equal M.
     const addedFromOurWrites = events.filter(
       (e) =>
-        e.event === "ADDED" &&
-        writtenIds.has((e.data as { entity: { id: string } }).entity.id),
+        e.event === "ADDED" && writtenIds.has((e.data as { entity: { id: string } }).entity.id),
     );
     expect(addedFromOurWrites.length).toBe(M);
   }, 10_000);

--- a/src/server/watch.race.test.ts
+++ b/src/server/watch.race.test.ts
@@ -6,11 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { readSseEvents } from "./sse-test-utils.js";
-import {
-  TEST_AUTH_HEADERS,
-  createTestApp,
-  makeManifestBody,
-} from "./test-helpers.js";
+import { createTestApp, makeManifestBody, TEST_AUTH_HEADERS } from "./test-helpers.js";
 
 describe("watch handshake-race (issue #292 acceptance #2)", () => {
   beforeEach(() => {
@@ -25,12 +21,9 @@ describe("watch handshake-race (issue #292 acceptance #2)", () => {
     const N = 25;
 
     // Begin list (will block 150ms inside the handler)
-    const listPromise: Promise<{ items: unknown[]; listResourceVersion: string }> =
-      Promise.resolve(
-        app.request("/api/list?kind=Contribution", { headers: TEST_AUTH_HEADERS }),
-      ).then(
-        (r) => r.json() as Promise<{ items: unknown[]; listResourceVersion: string }>,
-      );
+    const listPromise: Promise<{ items: unknown[]; listResourceVersion: string }> = Promise.resolve(
+      app.request("/api/list?kind=Contribution", { headers: TEST_AUTH_HEADERS }),
+    ).then((r) => r.json() as Promise<{ items: unknown[]; listResourceVersion: string }>);
 
     // Inject N concurrent writes during the list delay window
     await new Promise((r) => setTimeout(r, 20)); // ensure list is mid-flight

--- a/src/server/watch.race.test.ts
+++ b/src/server/watch.race.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Acceptance test for issue #292 — criterion #2.
+ * Writes that arrive between list-return and watch-open must all be replayed
+ * once the watcher resumes from listResourceVersion.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readSseEvents } from "./sse-test-utils.js";
+import {
+  TEST_AUTH_HEADERS,
+  createTestApp,
+  makeManifestBody,
+} from "./test-helpers.js";
+
+describe("watch handshake-race (issue #292 acceptance #2)", () => {
+  beforeEach(() => {
+    process.env.GROVE_WATCH_LIST_DELAY_MS = "150";
+  });
+  afterEach(() => {
+    delete process.env.GROVE_WATCH_LIST_DELAY_MS;
+  });
+
+  test("writes between list-return and watch-open are all replayed", async () => {
+    const { app } = createTestApp();
+    const N = 25;
+
+    // Begin list (will block 150ms inside the handler)
+    const listPromise: Promise<{ items: unknown[]; listResourceVersion: string }> =
+      Promise.resolve(
+        app.request("/api/list?kind=Contribution", { headers: TEST_AUTH_HEADERS }),
+      ).then(
+        (r) => r.json() as Promise<{ items: unknown[]; listResourceVersion: string }>,
+      );
+
+    // Inject N concurrent writes during the list delay window
+    await new Promise((r) => setTimeout(r, 20)); // ensure list is mid-flight
+    const writeResponses = await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        app.request("/api/contributions", {
+          method: "POST",
+          headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+          body: JSON.stringify(makeManifestBody({ summary: `race-${i}` })),
+        }),
+      ),
+    );
+    for (const res of writeResponses) {
+      expect(res.status).toBe(201);
+    }
+    const writtenCids = await Promise.all(
+      writeResponses.map(async (r) => (await r.json()) as { cid: string }),
+    );
+    const writtenIdSet = new Set(writtenCids.map((c) => c.cid));
+
+    const list = await listPromise;
+
+    // Open watch from the listResourceVersion. Race-correctness requires
+    // that every event with rv > listResourceVersion is replayed.
+    const watchRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${list.listResourceVersion}`,
+      { headers: TEST_AUTH_HEADERS },
+    );
+    const events = await readSseEvents(watchRes, N, 5_000);
+    const watchedIds = new Set(
+      events
+        .filter((e) => e.event === "ADDED")
+        .map((e) => (e.data as { entity: { id: string } }).entity.id),
+    );
+
+    for (const id of writtenIdSet) {
+      expect(watchedIds.has(id)).toBe(true);
+    }
+  }, 10_000);
+});

--- a/tests/gossip/routes.test.ts
+++ b/tests/gossip/routes.test.ts
@@ -15,6 +15,7 @@ import type {
   ShuffleResponse,
 } from "../../src/core/gossip/types.js";
 import { InMemoryContributionStore } from "../../src/core/testing.js";
+import { WatchHub } from "../../src/core/watch-hub.js";
 import { DefaultGossipService, signPayload } from "../../src/gossip/protocol.js";
 import { createApp } from "../../src/server/app.js";
 import type { ServerDeps } from "../../src/server/deps.js";
@@ -90,6 +91,7 @@ beforeAll(() => {
     frontier,
     gossip: gossipService,
     gossipHmacSecret: TEST_HMAC_SECRET,
+    watchHub: new WatchHub(),
   };
   const app = createApp(deps, TEST_REGISTRY);
 
@@ -115,7 +117,13 @@ describe("gossip routes: not configured", () => {
     const cas = new InMemoryContentStore();
     const frontier = new DefaultFrontierCalculator(contributionStore);
 
-    const deps: ServerDeps = { contributionStore, claimStore, cas, frontier };
+    const deps: ServerDeps = {
+      contributionStore,
+      claimStore,
+      cas,
+      frontier,
+      watchHub: new WatchHub(),
+    };
     const app = createApp(deps, TEST_REGISTRY);
     noGossipServer = Bun.serve({ port: 0, fetch: app.fetch });
     noGossipUrl = `http://localhost:${noGossipServer.port}`;

--- a/tests/server/goals-sessions.test.ts
+++ b/tests/server/goals-sessions.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Hono } from "hono";
 import { DefaultFrontierCalculator } from "../../src/core/frontier.js";
+import { WatchHub } from "../../src/core/watch-hub.js";
 import { FsCas } from "../../src/local/fs-cas.js";
 import { createSqliteStores } from "../../src/local/sqlite-store.js";
 import { createApp } from "../../src/server/app.js";
@@ -53,6 +54,7 @@ async function createGoalSessionContext(): Promise<GoalSessionTestContext> {
     frontier,
     goalSessionStore: stores.goalSessionStore,
     contract: { contractVersion: 3, name: "test-contract" },
+    watchHub: new WatchHub(),
   };
 
   const app = createApp(deps, GS_TEST_REGISTRY);
@@ -578,6 +580,7 @@ describe("POST /api/sessions (config snapshot)", () => {
       frontier: frontier2,
       goalSessionStore: stores2.goalSessionStore,
       // No contract!
+      watchHub: new WatchHub(),
     };
     const app2 = createApp(deps2, GS_TEST_REGISTRY);
 
@@ -615,6 +618,7 @@ describe("POST /api/sessions (config snapshot)", () => {
       claimStore: stores3.claimStore,
       cas: cas3,
       frontier: frontier3,
+      watchHub: new WatchHub(),
     };
     const app3 = createApp(deps3, GS_TEST_REGISTRY);
 

--- a/tests/server/helpers.ts
+++ b/tests/server/helpers.ts
@@ -14,6 +14,7 @@ import type { FrontierCalculator } from "../../src/core/frontier.js";
 import { DefaultFrontierCalculator } from "../../src/core/frontier.js";
 import type { OutcomeStore } from "../../src/core/outcome.js";
 import type { ClaimStore, ContributionStore } from "../../src/core/store.js";
+import { WatchHub } from "../../src/core/watch-hub.js";
 import { FsCas } from "../../src/local/fs-cas.js";
 import { createSqliteStores } from "../../src/local/sqlite-store.js";
 import { createApp } from "../../src/server/app.js";
@@ -53,6 +54,7 @@ export async function createTestContext(): Promise<TestContext> {
     outcomeStore: stores.outcomeStore,
     cas,
     frontier,
+    watchHub: new WatchHub(),
   };
 
   const app = createApp(deps, TEST_REGISTRY);

--- a/tests/server/routes/sessions-no-contract.test.ts
+++ b/tests/server/routes/sessions-no-contract.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { WatchHub } from "../../../src/core/watch-hub.js";
 import { SqliteGoalSessionStore } from "../../../src/local/sqlite-goal-session-store.js";
 import { initSqliteDb } from "../../../src/local/sqlite-store.js";
 import { createApp } from "../../../src/server/app.js";
@@ -38,6 +39,7 @@ function makeDepsWithoutContract(): NoContractFixture {
     topology: undefined,
     contract: undefined,
     idempotencyStore: {} as never,
+    watchHub: new WatchHub(),
   } as ServerDeps;
 
   return {


### PR DESCRIPTION
## Summary
- Implements **A5 watch protocol** with strict list→watch resourceVersion handshake — the foundation for retiring TUI polling (#295) and the informer cache (#294).
- New `WatchHub` holds a per-(namespace, kind) monotonic RV plus a ring buffer (1024 events / 5 min defaults).
- New endpoints: `GET /api/list?kind=X` returns `{ items, listResourceVersion }`; `GET /api/watch?kind=X&resumeFrom=Y` is SSE with mandatory `resumeFrom`.
- Writes feed the hub from two paths: in-process `onEntityWrite` operations hook (HTTP-mediated) + Nexus event-bus `entity.changed` subscription (cross-process, e.g. MCP agents).
- Three Entity kinds covered: `Contribution`, `Claim`. `AgentSession` deferred to a follow-up — session lifecycle transitions are not yet routed through the operations layer.
- All three issue acceptance criteria proven by dedicated tests:
  - **Race** (`watch.race.test.ts`): 25 concurrent writes injected during a 150ms list→watch gap — every CID surfaces on the watch.
  - **Kill-9** (`watch.kill.test.ts`): abrupt disconnect, 20 writes during the gap, reconnect with stored RV → all 20 replayed, no duplicates.
  - **Bookmark** (`watch.bookmark.test.ts`): idle stream emits BOOKMARK within `bookmarkIntervalMs`.

## Spec & plan
- Spec: `docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-a5-watch-protocol.md`

## Architecture
```
                ┌──────────────────────────────────────────┐
                │            grove-server                  │
   write op ──► │  WatchHub                                │
   (operations  │   ├── per-(ns,kind) RV counters         │
    layer)      │   ├── ring buffers (1024 events / 5min) │
                │   └── active SSE subscribers             │
   Nexus ──►    │                                          │
   event-bus    │  GET /api/list?kind=X                    │
   subscription │  GET /api/watch?kind=X&resumeFrom=Y      │
   (cross-proc) │                                          │
                └──────────────────────────────────────────┘
                                ▲
                       TUI informer (A7, #294)
```

## Test plan
- [ ] `bun test src/core/watch-hub.test.ts` (9 unit tests — RV monotonicity, namespace/kind isolation, ring caps, replay, stale-RV, overflow, bookmark config)
- [ ] `bun test src/server/watch.integration.test.ts` (6 integration tests — list + watch + 410)
- [ ] `bun test src/server/watch.race.test.ts` (acceptance #2)
- [ ] `bun test src/server/watch.kill.test.ts` (acceptance #1)
- [ ] `bun test src/server/watch.bookmark.test.ts` (acceptance #3)
- [ ] `bun test src/server/watch.cross-process.test.ts` (cross-process loop)
- [ ] `bun test src/server/watch-wiring.test.ts` (operation-adapter wiring smoke)
- [ ] `bun test src/nexus/nexus-watch-subscriber.test.ts` (3 subscriber tests)
- [ ] Full suite: `bun test` — 6264 pass / 0 fail at HEAD
- [ ] `bunx tsc --noEmit` — clean
- [ ] `bunx biome check src/` on the watch-protocol files — clean

## Out of scope (tracked)
- A6 (#293) — Stale-RV recovery / compaction
- A7 (#294) — TUI informer client
- A8 (#295) — Polling retirement
- AgentSession `onEntityWrite` — needs session-orchestrator refactor first
- HTTP `POST /api/claims` direct-store path — bypasses `claimOperation`; will be covered when the Nexus catch-all path lands or that route is refactored

Closes #292