### PR TITLE
[codex] fix server route validation and handoff conflicts

### DIFF
--- a/src/server/middleware/error-handler.test.ts
+++ b/src/server/middleware/error-handler.test.ts
@@ -12,6 +12,7 @@ import {
   RetryExhaustedError,
   StateConflictError,
 } from "../../core/errors.js";
+import { HandoffStatus, InvalidTransitionError } from "../../core/handoff.js";
 import { handleError } from "./error-handler.js";
 
 // biome-ignore lint/suspicious/noExplicitAny: test file — JSON responses are dynamically shaped
@@ -145,6 +146,18 @@ describe("error handler", () => {
     expect(res.status).toBe(409);
     const data = (await res.json()) as Json;
     expect(data.error.code).toBe("STATE_CONFLICT");
+  });
+
+  it("maps handoff InvalidTransitionError to 409", async () => {
+    const app = appThatThrows(
+      new InvalidTransitionError("handoff-1", HandoffStatus.Replied, HandoffStatus.Delivered),
+    );
+
+    const res = await app.request("/test");
+    expect(res.status).toBe(409);
+    const data = (await res.json()) as Json;
+    expect(data.error.code).toBe("STATE_CONFLICT");
+    expect(data.error.message).toContain("Invalid handoff transition");
   });
 
   it("maps unknown errors to 500 without leaking details", async () => {

--- a/src/server/middleware/error-handler.ts
+++ b/src/server/middleware/error-handler.ts
@@ -8,6 +8,7 @@
 import type { Context } from "hono";
 import { ZodError } from "zod";
 import { GroveError, RateLimitError } from "../../core/errors.js";
+import { InvalidTransitionError } from "../../core/handoff.js";
 
 // NotFoundError and StateConflictError are resolved via ERROR_MAP by name.
 
@@ -46,6 +47,11 @@ export function handleError(err: Error, c: Context): Response {
   if (err instanceof ZodError) {
     const messages = err.issues.map((i) => `${i.path.join(".")}: ${i.message}`);
     return c.json(errorBody("VALIDATION_ERROR", messages.join("; ")), 400);
+  }
+
+  // Handoff state machine errors are plain Error subclasses, not GroveError.
+  if (err instanceof InvalidTransitionError) {
+    return c.json(errorBody("STATE_CONFLICT", err.message), 409);
   }
 
   // Grove typed errors → mapped status code

--- a/src/server/routes/bounties.ts
+++ b/src/server/routes/bounties.ts
@@ -4,11 +4,30 @@
  * GET /api/bounties — List bounties with optional status/creator filters.
  */
 
+import { zValidator } from "@hono/zod-validator";
 import type { Hono as HonoType } from "hono";
 import { Hono } from "hono";
-import type { BountyStatus } from "../../core/bounty.js";
+import { z } from "zod";
+import { BountyStatus } from "../../core/bounty.js";
 import type { BountyQuery } from "../../core/bounty-store.js";
 import type { ServerEnv } from "../deps.js";
+
+const listQuerySchema = z.object({
+  status: z
+    .enum([
+      BountyStatus.Draft,
+      BountyStatus.Open,
+      BountyStatus.Claimed,
+      BountyStatus.PendingSettlement,
+      BountyStatus.Completed,
+      BountyStatus.Settled,
+      BountyStatus.Expired,
+      BountyStatus.Cancelled,
+    ])
+    .optional(),
+  creatorAgentId: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
 
 // ---------------------------------------------------------------------------
 // Routes
@@ -17,7 +36,7 @@ import type { ServerEnv } from "../deps.js";
 const bounties: HonoType<ServerEnv> = new Hono<ServerEnv>();
 
 /** GET /api/bounties — List bounties. */
-bounties.get("/", async (c) => {
+bounties.get("/", zValidator("query", listQuerySchema), async (c) => {
   const { bountyStore } = c.get("deps");
   if (!bountyStore) {
     return c.json(
@@ -26,14 +45,12 @@ bounties.get("/", async (c) => {
     );
   }
 
-  const status = c.req.query("status");
-  const creatorAgentId = c.req.query("creatorAgentId");
-  const limit = c.req.query("limit");
+  const { status, creatorAgentId, limit } = c.req.valid("query");
 
   const query: BountyQuery = {
-    ...(status ? { status: status as BountyStatus } : {}),
-    ...(creatorAgentId ? { creatorAgentId } : {}),
-    ...(limit ? { limit: Number(limit) } : {}),
+    ...(status !== undefined ? { status } : {}),
+    ...(creatorAgentId !== undefined ? { creatorAgentId } : {}),
+    ...(limit !== undefined ? { limit } : {}),
   };
 
   const results = await bountyStore.listBounties(query);

--- a/src/server/routes/handoffs.ts
+++ b/src/server/routes/handoffs.ts
@@ -10,12 +10,33 @@
  * unauthenticated. See comments below for rationale.
  */
 
+import { zValidator } from "@hono/zod-validator";
 import type { Context, Hono as HonoType } from "hono";
 import { Hono } from "hono";
-import type { HandoffStatus, HandoffStore } from "../../core/handoff.js";
+import { z } from "zod";
+import type { HandoffStore } from "../../core/handoff.js";
+import { HandoffStatus as HandoffStatusValue } from "../../core/handoff.js";
 import type { ServerEnv } from "../deps.js";
 
 const handoffs: HonoType<ServerEnv> = new Hono<ServerEnv>();
+
+const listQuerySchema = z.object({
+  toRole: z.string().optional(),
+  fromRole: z.string().optional(),
+  status: z
+    .enum([
+      HandoffStatusValue.PendingPickup,
+      HandoffStatusValue.Delivered,
+      HandoffStatusValue.Processed,
+      HandoffStatusValue.Replied,
+      HandoffStatusValue.Expired,
+      HandoffStatusValue.DeadLettered,
+    ])
+    .optional(),
+  sourceCid: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  sessionId: z.string().optional(),
+});
 
 /**
  * Middleware: require handoffStore to be configured.
@@ -59,19 +80,14 @@ function resolveStore(c: Context<ServerEnv>): HandoffStore | undefined {
 }
 
 /** GET /api/handoffs — List handoffs with optional filters. */
-handoffs.get("/", async (c) => {
+handoffs.get("/", zValidator("query", listQuerySchema), async (c) => {
   const store = resolveStore(c);
   if (store === undefined) return c.json({ error: "unreachable" }, 500);
 
   // Expire stale handoffs before listing so callers always see fresh status.
   await store.expireStale();
 
-  const toRole = c.req.query("toRole");
-  const fromRole = c.req.query("fromRole");
-  const status = c.req.query("status") as HandoffStatus | undefined;
-  const sourceCid = c.req.query("sourceCid");
-  const limitRaw = c.req.query("limit");
-  const limit = limitRaw !== undefined ? Math.min(parseInt(limitRaw, 10) || 50, 200) : 50;
+  const { toRole, fromRole, status, sourceCid, limit } = c.req.valid("query");
 
   const results = await store.list({
     ...(toRole !== undefined ? { toRole } : {}),
@@ -130,16 +146,12 @@ handoffs.post("/:id/delivered", async (c) => {
     return c.json({ error: { code: "BAD_REQUEST", message: "Missing handoff id" } }, 400);
   }
 
-  try {
-    await store.markDelivered(id);
-    const updated = await store.get(id);
-    if (updated === undefined) {
-      return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
-    }
-    return c.json(updated);
-  } catch {
+  await store.markDelivered(id);
+  const updated = await store.get(id);
+  if (updated === undefined) {
     return c.json({ error: { code: "NOT_FOUND", message: "Handoff not found" } }, 404);
   }
+  return c.json(updated);
 });
 
 export { handoffs };

--- a/tests/server/routes-extended.test.ts
+++ b/tests/server/routes-extended.test.ts
@@ -21,8 +21,17 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { HandoffStatus } from "../../src/core/handoff.js";
+import { InMemoryHandoffStore } from "../../src/core/in-memory-handoff-store.js";
+import { createApp } from "../../src/server/app.js";
 import type { TestContext } from "./helpers.js";
-import { createTestContext, postContribution, TEST_AUTH_HEADERS } from "./helpers.js";
+import {
+  createTestContext,
+  postContribution,
+  TEST_AUTH_HEADERS,
+  TEST_KEY,
+  TEST_NAMESPACE,
+} from "./helpers.js";
 
 const FAKE_CID = `blake3:${"0".repeat(64)}`;
 
@@ -259,5 +268,59 @@ describe("routes — /api/bounties", () => {
     expect(res.status).toBe(501);
     const data = (await res.json()) as { error: { code: string } };
     expect(data.error.code).toBe("NOT_CONFIGURED");
+  });
+
+  test("GET / rejects invalid limit before hitting storage", async () => {
+    const res = await ctx.app.request("/api/bounties?limit=-1", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ===================================================================
+// 5. Handoffs route (/api/handoffs)
+// ===================================================================
+
+describe("routes — /api/handoffs", () => {
+  let ctx: TestContext;
+  let handoffStore: InMemoryHandoffStore;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    ctx = await createTestContext();
+    handoffStore = new InMemoryHandoffStore();
+    app = createApp({ ...ctx.deps, handoffStore }, new Map([[TEST_KEY, TEST_NAMESPACE]]));
+  });
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  test("GET / rejects negative limit", async () => {
+    const res = await app.request("/api/handoffs?limit=-1", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("POST /:id/delivered returns 409 when the handoff cannot transition", async () => {
+    const handoff = await handoffStore.create({
+      sourceCid: FAKE_CID,
+      fromRole: "coder",
+      toRole: "reviewer",
+      requiresReply: true,
+    });
+    await handoffStore.markDelivered(handoff.handoffId);
+    await handoffStore.markReplied(handoff.handoffId, FAKE_CID);
+
+    const res = await app.request(`/api/handoffs/${handoff.handoffId}/delivered`, {
+      method: "POST",
+      headers: TEST_AUTH_HEADERS,
+    });
+
+    expect(res.status).toBe(409);
+    const data = (await res.json()) as { error: { code: string; message: string } };
+    expect(data.error.code).toBe("STATE_CONFLICT");
+    expect(data.error.message).toContain(HandoffStatus.Replied);
   });
 });


### PR DESCRIPTION
## Summary

- Validate bounty and handoff list query parameters before they reach storage.
- Preserve handoff state-machine conflicts as 409 responses instead of masking them as 404s.
- Add regression coverage for invalid handoff delivery transitions and invalid list limits.

## Root cause

The handoff delivered route caught every store error and returned NOT_FOUND, so invalid terminal-state transitions were reported as missing records. The handoff and bounty list routes also accepted raw query values, allowing invalid limits to reach downstream storage or produce inconsistent behavior.

## Validation

- `bun test /Users/tafeng/.codex/worktrees/c10d/grove/src/server/*.test.ts /Users/tafeng/.codex/worktrees/c10d/grove/src/server/middleware/*.test.ts /Users/tafeng/.codex/worktrees/c10d/grove/tests/server` from `/tmp`: 248 pass, 0 fail
- `bunx biome check src/server/middleware/error-handler.ts src/server/routes/bounties.ts src/server/routes/handoffs.ts src/server/middleware/error-handler.test.ts tests/server/routes-extended.test.ts`
- `git diff --check`
- `bun --bun run typecheck`
- `bun --bun run build`
