### PR TITLE
feat(watch): A6 stale-RV Expired path + compaction (#293)

### DIFF
--- a/docs/parity-matrix.md
+++ b/docs/parity-matrix.md
@@ -54,6 +54,7 @@ and their classification. All `shared` capabilities use the operations layer in
 | artifact download | - | - | Y | Y | transport-only |
 | diff | - | - | Y | Y | transport-only |
 | metadata | - | - | Y | - | transport-only |
+| watch retention | - | - | Y | Y | transport-only |
 
 ## Notes
 
@@ -68,6 +69,7 @@ and their classification. All `shared` capabilities use the operations layer in
   (delegates to the `@grove/ask-user` package). Neither goes through the operations layer;
   each surface implements its own strategy resolution.
 - **gossip**: Peer-to-peer sync, relevant for CLI daemon and HTTP server.
+- **watch retention**: Server-side ring buffer per `(namespace, kind)`. Retention controlled by `GROVE_WATCH_RETENTION_MS` (default 300000 ms) and `GROVE_WATCH_MAX_EVENTS` (default 1024). A stale `resumeFrom` returns SSE `event:ERROR data:{code:410, reason:"expired"}`; clients must re-list via the A5 handshake. Per-`(ns,kind)` compaction stats available at `GET /api/watch/metrics`. See `docs/superpowers/specs/2026-04-28-a6-stale-rv-compaction-design.md`.
 
 ## JSON Output
 

--- a/docs/superpowers/plans/2026-04-28-a6-stale-rv-compaction.md
+++ b/docs/superpowers/plans/2026-04-28-a6-stale-rv-compaction.md
@@ -1,0 +1,2187 @@
+# A6 Stale-RV + Compaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface configurable retention + compaction metrics on the watch protocol shipped in #292, and ship a `WatchClient` helper that handles 410 by relisting via the A5 list→watch handshake. Closes the silent-desync gap in long-lived watches.
+
+**Architecture:** Extend the existing in-memory `WatchHub` with monotonic eviction counters. Add a `GET /api/watch/metrics` JSON endpoint behind the existing `namespaceAuth`. Read `GROVE_WATCH_RETENTION_MS` / `GROVE_WATCH_MAX_EVENTS` at boot via a clamp utility. Build a thin (~150 LOC) `WatchClient` that drives the list→watch loop with backoff and a typed `RELIST` op so consumers can reconcile after a relist. Tests use `bun:test` and the existing `test-helpers.ts` factory.
+
+**Tech Stack:** Bun + TypeScript, Hono routes, `bun:test`, no new external deps. SSE via the existing `ReadableStream` route handler.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-a6-stale-rv-compaction-design.md`
+
+**Issue:** [#293](https://github.com/windoliver/grove/issues/293)
+
+---
+
+## File map
+
+**New:**
+- `src/core/clamp.ts` — `clampInt({raw, fallback, min, max, name})` for env-var parsing.
+- `src/core/clamp.test.ts`
+- `src/core/watch-client.ts` — list→watch loop with `RELIST`/`ADDED`/`MODIFIED`/`DELETED` ops, 410 relist, backoff.
+- `src/core/watch-client.test.ts`
+- `src/core/watch-hub.compaction.test.ts` — counter/`getCompactionStats()` unit tests.
+- `src/server/watch-hub-config.ts` — `resolveWatchHubConfig(env)` boot helper.
+- `src/server/watch-hub-config.test.ts`
+- `src/server/watch.compaction.test.ts` — sleep-past-retention + metrics endpoint integration.
+- `src/server/watch.relist.e2e.test.ts` — `WatchClient` against a real test server, the issue acceptance #2 test.
+
+**Modified:**
+- `src/core/watch-hub.ts` — add `evictedByAge` / `evictedByCapacity` counters in `KeyState`; promote `maxAgeMsPerKey` / `maxEventsPerKey` to public; add `getCompactionStats()`.
+- `src/server/routes/watch.ts` — add `GET /api/watch/metrics`.
+- `src/server/serve.ts` — call `resolveWatchHubConfig(process.env)` and pass to `WatchHub`.
+- `docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md` — resolve "Open questions deferred" compaction entry.
+- `docs/parity-matrix.md` — document retention env vars + metrics endpoint.
+
+---
+
+## Task 1: `clampInt` utility
+
+**Files:**
+- Create: `src/core/clamp.ts`
+- Test: `src/core/clamp.test.ts`
+
+**Why first:** Needed by `serve.ts` env-var wiring (Task 4). Pure logic, no deps — quickest red→green cycle to anchor the TDD rhythm.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/clamp.test.ts`:
+
+```typescript
+import { describe, expect, mock, test } from "bun:test";
+import { clampInt } from "./clamp.js";
+
+describe("clampInt", () => {
+  test("returns parsed value when within range", () => {
+    expect(
+      clampInt({ raw: "5000", fallback: 100, min: 1, max: 10_000, name: "X" }),
+    ).toBe(5000);
+  });
+
+  test("returns fallback when raw is undefined", () => {
+    const warn = mock(() => {});
+    expect(
+      clampInt({ raw: undefined, fallback: 42, min: 1, max: 100, name: "X", warn }),
+    ).toBe(42);
+    expect(warn.mock.calls.length).toBe(0); // unset is normal, no warn
+  });
+
+  test("returns fallback when raw is empty string", () => {
+    expect(
+      clampInt({ raw: "", fallback: 7, min: 1, max: 100, name: "X" }),
+    ).toBe(7);
+  });
+
+  test("warns and returns fallback when raw is unparseable", () => {
+    const warn = mock(() => {});
+    expect(
+      clampInt({ raw: "abc", fallback: 9, min: 1, max: 100, name: "Y", warn }),
+    ).toBe(9);
+    expect(warn.mock.calls.length).toBe(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain("Y");
+  });
+
+  test("warns and returns fallback when raw is below min", () => {
+    const warn = mock(() => {});
+    expect(
+      clampInt({ raw: "0", fallback: 10, min: 1, max: 100, name: "Z", warn }),
+    ).toBe(10);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  test("warns and returns fallback when raw is above max", () => {
+    const warn = mock(() => {});
+    expect(
+      clampInt({ raw: "999", fallback: 10, min: 1, max: 100, name: "Z", warn }),
+    ).toBe(10);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  test("rejects fractional input", () => {
+    const warn = mock(() => {});
+    expect(
+      clampInt({ raw: "1.5", fallback: 2, min: 1, max: 100, name: "F", warn }),
+    ).toBe(2);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  test("accepts boundary values", () => {
+    expect(
+      clampInt({ raw: "1", fallback: 5, min: 1, max: 100, name: "B" }),
+    ).toBe(1);
+    expect(
+      clampInt({ raw: "100", fallback: 5, min: 1, max: 100, name: "B" }),
+    ).toBe(100);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/clamp.test.ts`
+Expected: FAIL — `Cannot find module './clamp.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/core/clamp.ts`:
+
+```typescript
+/**
+ * Parse an integer env var with bounds. Used at server boot so a stray
+ * `GROVE_WATCH_RETENTION_MS=-5` falls back to the documented default
+ * instead of silently disabling retention.
+ */
+
+export interface ClampIntArgs {
+  readonly raw: string | undefined;
+  readonly fallback: number;
+  readonly min: number;
+  readonly max: number;
+  readonly name: string;
+  readonly warn?: (msg: string) => void;
+}
+
+export function clampInt({
+  raw,
+  fallback,
+  min,
+  max,
+  name,
+  warn = (msg) => console.warn(msg),
+}: ClampIntArgs): number {
+  if (raw === undefined || raw === "") return fallback;
+  if (!/^-?[0-9]+$/.test(raw)) {
+    warn(`${name}=${raw} is not an integer; using fallback ${fallback}`);
+    return fallback;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (n < min || n > max) {
+    warn(
+      `${name}=${n} is outside [${min}, ${max}]; using fallback ${fallback}`,
+    );
+    return fallback;
+  }
+  return n;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/clamp.test.ts`
+Expected: PASS — 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/clamp.ts src/core/clamp.test.ts
+git commit -m "feat(util): clampInt env-var parser for #293 retention bounds"
+```
+
+---
+
+## Task 2: WatchHub compaction counters + `getCompactionStats()`
+
+**Files:**
+- Modify: `src/core/watch-hub.ts`
+- Test: `src/core/watch-hub.compaction.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/watch-hub.compaction.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { contributionToEntity } from "./entity.js";
+import type { Contribution } from "./models.js";
+import { WatchHub } from "./watch-hub.js";
+
+function fixtureContribution(cid: string): Contribution {
+  return {
+    cid,
+    manifestVersion: 1,
+    kind: "work",
+    mode: "evaluation",
+    summary: "fixture",
+    artifacts: {},
+    relations: [],
+    tags: [],
+    agent: { agentId: "a-1" },
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function writeOne(hub: WatchHub, ns: string, cid: string): bigint {
+  const entity = contributionToEntity(fixtureContribution(cid), ns);
+  return hub.recordWrite({ kind: "Contribution", namespace: ns, op: "ADDED", entity });
+}
+
+describe("WatchHub compaction stats", () => {
+  test("evictedByCapacity increments when ring exceeds maxEventsPerKey", () => {
+    const hub = new WatchHub({ maxEventsPerKey: 3, maxAgeMsPerKey: 60_000 });
+    for (let i = 0; i < 5; i++) writeOne(hub, "ns", `cid-${i}`);
+
+    const stats = hub.getCompactionStats();
+    expect(stats.length).toBe(1);
+    expect(stats[0]?.namespace).toBe("ns");
+    expect(stats[0]?.kind).toBe("Contribution");
+    expect(stats[0]?.evictedByCapacity).toBe(2); // 5 writes, cap 3 → 2 evicted
+    expect(stats[0]?.evictedByAge).toBe(0);
+    expect(stats[0]?.currentRingSize).toBe(3);
+    expect(stats[0]?.currentRv).toBe("5");
+    expect(stats[0]?.oldestRv).toBe("3");
+  });
+
+  test("evictedByAge increments when events exceed maxAgeMsPerKey", () => {
+    let now = 1_000_000;
+    const hub = new WatchHub({
+      maxEventsPerKey: 100,
+      maxAgeMsPerKey: 100,
+      now: () => now,
+    });
+    writeOne(hub, "ns", "old-1");
+    writeOne(hub, "ns", "old-2");
+    now += 250; // past retention
+    writeOne(hub, "ns", "fresh-1");
+
+    const stats = hub.getCompactionStats();
+    expect(stats[0]?.evictedByAge).toBe(2);
+    expect(stats[0]?.evictedByCapacity).toBe(0);
+    expect(stats[0]?.currentRingSize).toBe(1);
+    expect(stats[0]?.oldestRv).toBe("3");
+    expect(stats[0]?.currentRv).toBe("3");
+  });
+
+  test("counters are monotonic across subscribe/unsubscribe", async () => {
+    const hub = new WatchHub({ maxEventsPerKey: 2, maxAgeMsPerKey: 60_000 });
+    for (let i = 0; i < 5; i++) writeOne(hub, "ns", `cid-${i}`);
+
+    const ac = new AbortController();
+    const iter = hub.subscribe("ns", "Contribution", 4n, ac.signal);
+    for await (const _ev of iter) break; // consume one
+    ac.abort();
+
+    writeOne(hub, "ns", "cid-after");
+    const stats = hub.getCompactionStats();
+    // 6 writes total, cap 2 → 4 evicted
+    expect(stats[0]?.evictedByCapacity).toBe(4);
+  });
+
+  test("getCompactionStats returns one entry per active (ns, kind)", () => {
+    const hub = new WatchHub({ maxEventsPerKey: 5, maxAgeMsPerKey: 60_000 });
+    writeOne(hub, "ns-a", "cid-a");
+    writeOne(hub, "ns-b", "cid-b");
+    const stats = hub.getCompactionStats();
+    expect(stats.length).toBe(2);
+    const namespaces = stats.map((s) => s.namespace).sort();
+    expect(namespaces).toEqual(["ns-a", "ns-b"]);
+  });
+
+  test("oldestRv is '0' when ring is empty after full eviction", () => {
+    let now = 1_000;
+    const hub = new WatchHub({
+      maxEventsPerKey: 100,
+      maxAgeMsPerKey: 100,
+      now: () => now,
+    });
+    writeOne(hub, "ns", "x");
+    now += 1000;
+    writeOne(hub, "ns", "y"); // triggers age eviction of x; y stays
+    expect(hub.getCompactionStats()[0]?.currentRingSize).toBe(1);
+    expect(hub.getCompactionStats()[0]?.oldestRv).toBe("2");
+  });
+
+  test("public maxAgeMsPerKey and maxEventsPerKey reflect constructor args", () => {
+    const hub = new WatchHub({ maxAgeMsPerKey: 7777, maxEventsPerKey: 12 });
+    expect(hub.maxAgeMsPerKey).toBe(7777);
+    expect(hub.maxEventsPerKey).toBe(12);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/watch-hub.compaction.test.ts`
+Expected: FAIL — `getCompactionStats` is not a function.
+
+- [ ] **Step 3: Modify `src/core/watch-hub.ts`**
+
+Replace the `KeyState` interface (around line 18) and counter-related members. Apply these edits:
+
+a. Update `KeyState` to add counters:
+
+```typescript
+interface KeyState {
+  counter: bigint;
+  ring: WatchEvent[];
+  insertedAt: number[];
+  evictedByAge: number;
+  evictedByCapacity: number;
+}
+```
+
+b. Add the public `CompactionStats` interface near the top of the file (after the imports, before `WatchHubOptions`):
+
+```typescript
+export interface CompactionStats {
+  readonly namespace: string;
+  readonly kind: WatchKind;
+  readonly evictedByAge: number;
+  readonly evictedByCapacity: number;
+  readonly currentRingSize: number;
+  readonly oldestRv: string;
+  readonly currentRv: string;
+}
+```
+
+c. Promote `maxAgeMsPerKey` and `maxEventsPerKey` to public readonly. The class field declarations near line 31 become:
+
+```typescript
+readonly maxEventsPerKey: number;
+readonly maxAgeMsPerKey: number;
+readonly bookmarkIntervalMs: number;
+readonly perClientOutboxCap: number;
+private readonly now: () => number;
+```
+
+d. Update `getOrCreate` (around line 169) to initialize counters:
+
+```typescript
+private getOrCreate(key: string): KeyState {
+  let s = this.state.get(key);
+  if (!s) {
+    s = {
+      counter: 0n,
+      ring: [],
+      insertedAt: [],
+      evictedByAge: 0,
+      evictedByCapacity: 0,
+    };
+    this.state.set(key, s);
+  }
+  return s;
+}
+```
+
+e. Update `trim()` (around line 178) to increment counters:
+
+```typescript
+private trim(s: KeyState): void {
+  while (s.ring.length > this.maxEventsPerKey) {
+    s.ring.shift();
+    s.insertedAt.shift();
+    s.evictedByCapacity += 1;
+  }
+  const cutoff = this.now() - this.maxAgeMsPerKey;
+  while (s.ring.length > 0 && (s.insertedAt[0] ?? 0) < cutoff) {
+    s.ring.shift();
+    s.insertedAt.shift();
+    s.evictedByAge += 1;
+  }
+}
+```
+
+f. Add `getCompactionStats()` as a new public method (after `snapshotRing` around line 163):
+
+```typescript
+/** Snapshot of compaction counters across all (ns, kind) keys. */
+getCompactionStats(): readonly CompactionStats[] {
+  const out: CompactionStats[] = [];
+  for (const [keyStr, s] of this.state.entries()) {
+    const sep = keyStr.indexOf("\x00");
+    const namespace = keyStr.slice(0, sep);
+    const kind = keyStr.slice(sep + 1) as WatchKind;
+    const oldestRv = s.ring.length > 0 ? (s.ring[0] as WatchEvent).rv : 0n;
+    out.push({
+      namespace,
+      kind,
+      evictedByAge: s.evictedByAge,
+      evictedByCapacity: s.evictedByCapacity,
+      currentRingSize: s.ring.length,
+      oldestRv: String(oldestRv),
+      currentRv: String(s.counter),
+    });
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/watch-hub.compaction.test.ts`
+Expected: PASS — 6 tests.
+
+Also run the existing watch-hub tests to make sure nothing regressed:
+
+Run: `bun test src/core/watch-hub.test.ts`
+Expected: PASS — all existing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/watch-hub.ts src/core/watch-hub.compaction.test.ts
+git commit -m "feat(watch): compaction counters and getCompactionStats() (#293)"
+```
+
+---
+
+## Task 3: `GET /api/watch/metrics` route
+
+**Files:**
+- Modify: `src/server/routes/watch.ts`
+- Test: `src/server/watch.compaction.test.ts` (new — partial; expanded in Task 10)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/server/watch.compaction.test.ts`:
+
+```typescript
+/**
+ * Acceptance tests for issue #293 — server-side compaction surface.
+ *   - GET /api/watch/metrics returns retention config and per-(ns,kind) counters
+ *   - Namespace isolation: caller only sees their own keys
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createTestApp, makeManifestBody, TEST_AUTH_HEADERS } from "./test-helpers.js";
+
+interface MetricsResponse {
+  retention: { maxAgeMs: number; maxEvents: number };
+  keys: Array<{
+    namespace: string;
+    kind: string;
+    evictedByAge: number;
+    evictedByCapacity: number;
+    currentRingSize: number;
+    oldestRv: string;
+    currentRv: string;
+  }>;
+}
+
+describe("GET /api/watch/metrics", () => {
+  test("returns retention config from WatchHub options", async () => {
+    const { app } = createTestApp({
+      watchHubOptions: { maxAgeMsPerKey: 1234, maxEventsPerKey: 56 },
+    });
+    const res = await app.request("/api/watch/metrics", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MetricsResponse;
+    expect(body.retention.maxAgeMs).toBe(1234);
+    expect(body.retention.maxEvents).toBe(56);
+  });
+
+  test("reports counters after writes within capacity", async () => {
+    const { app } = createTestApp({
+      watchHubOptions: { maxAgeMsPerKey: 60_000, maxEventsPerKey: 100 },
+    });
+    const writeRes = await app.request("/api/contributions", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify(makeManifestBody({ summary: "metrics-1" })),
+    });
+    expect(writeRes.status).toBe(201);
+
+    const res = await app.request("/api/watch/metrics", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const body = (await res.json()) as MetricsResponse;
+    const key = body.keys.find((k) => k.kind === "Contribution");
+    expect(key).toBeDefined();
+    expect(key?.evictedByAge).toBe(0);
+    expect(key?.evictedByCapacity).toBe(0);
+    expect(key?.currentRingSize).toBe(1);
+    expect(key?.currentRv).toBe("1");
+  });
+
+  test("requires authentication", async () => {
+    const { app } = createTestApp();
+    const res = await app.request("/api/watch/metrics");
+    expect([400, 401]).toContain(res.status);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/server/watch.compaction.test.ts`
+Expected: FAIL — route returns 404.
+
+- [ ] **Step 3: Add the route to `src/server/routes/watch.ts`**
+
+After the `watch.get("/watch", ...)` block (around line 285), insert the metrics route. It needs to be defined before the `export { watch }` line:
+
+```typescript
+/** GET /api/watch/metrics — retention config + per-(ns,kind) compaction stats. */
+watch.get("/metrics", async (c) => {
+  const namespace = c.get("namespace");
+  const hub: WatchHub = c.get("deps").watchHub;
+  const allStats = hub.getCompactionStats();
+  // Filter to caller's namespace so namespaces don't leak each other's
+  // traffic shape. The request is already authenticated by namespaceAuth.
+  const keys = allStats.filter((s) => s.namespace === namespace);
+  return c.json({
+    retention: {
+      maxAgeMs: hub.maxAgeMsPerKey,
+      maxEvents: hub.maxEventsPerKey,
+    },
+    keys,
+  });
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/server/watch.compaction.test.ts`
+Expected: PASS — 3 tests.
+
+Also confirm existing watch tests still pass:
+
+Run: `bun test src/server/watch`
+Expected: PASS — all sibling tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/routes/watch.ts src/server/watch.compaction.test.ts
+git commit -m "feat(watch): GET /api/watch/metrics endpoint (#293)"
+```
+
+---
+
+## Task 4: Wire `GROVE_WATCH_RETENTION_MS` / `GROVE_WATCH_MAX_EVENTS` in `serve.ts`
+
+Refactor the boot-time `WatchHub` construction into a small testable helper so the env-var → `WatchHubOptions` mapping is unit-tested in isolation. Then call it from `serve.ts`.
+
+**Files:**
+- Create: `src/server/watch-hub-config.ts`
+- Create: `src/server/watch-hub-config.test.ts`
+- Modify: `src/server/serve.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/server/watch-hub-config.test.ts`:
+
+```typescript
+import { describe, expect, mock, test } from "bun:test";
+import { resolveWatchHubConfig } from "./watch-hub-config.js";
+
+describe("resolveWatchHubConfig", () => {
+  test("returns defaults when no env vars set", () => {
+    const cfg = resolveWatchHubConfig({});
+    expect(cfg.maxAgeMsPerKey).toBe(300_000);
+    expect(cfg.maxEventsPerKey).toBe(1024);
+  });
+
+  test("reads GROVE_WATCH_RETENTION_MS when in range", () => {
+    const cfg = resolveWatchHubConfig({
+      GROVE_WATCH_RETENTION_MS: "30000",
+    });
+    expect(cfg.maxAgeMsPerKey).toBe(30_000);
+  });
+
+  test("reads GROVE_WATCH_MAX_EVENTS when in range", () => {
+    const cfg = resolveWatchHubConfig({
+      GROVE_WATCH_MAX_EVENTS: "256",
+    });
+    expect(cfg.maxEventsPerKey).toBe(256);
+  });
+
+  test("clamps GROVE_WATCH_RETENTION_MS below min to default", () => {
+    const warn = mock(() => {});
+    const cfg = resolveWatchHubConfig(
+      { GROVE_WATCH_RETENTION_MS: "0" },
+      { warn },
+    );
+    expect(cfg.maxAgeMsPerKey).toBe(300_000);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  test("clamps GROVE_WATCH_MAX_EVENTS above max to default", () => {
+    const warn = mock(() => {});
+    const cfg = resolveWatchHubConfig(
+      { GROVE_WATCH_MAX_EVENTS: "9999999999" },
+      { warn },
+    );
+    expect(cfg.maxEventsPerKey).toBe(1024);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  test("rejects negative GROVE_WATCH_RETENTION_MS", () => {
+    const warn = mock(() => {});
+    const cfg = resolveWatchHubConfig(
+      { GROVE_WATCH_RETENTION_MS: "-5" },
+      { warn },
+    );
+    expect(cfg.maxAgeMsPerKey).toBe(300_000);
+  });
+
+  test("accepts boundary values", () => {
+    const cfg = resolveWatchHubConfig({
+      GROVE_WATCH_RETENTION_MS: "1000",     // min
+      GROVE_WATCH_MAX_EVENTS: "1000000",    // max
+    });
+    expect(cfg.maxAgeMsPerKey).toBe(1000);
+    expect(cfg.maxEventsPerKey).toBe(1_000_000);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/server/watch-hub-config.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/server/watch-hub-config.ts`:
+
+```typescript
+/**
+ * Boot-time resolution of WatchHubOptions from environment variables.
+ * Extracted from serve.ts so the env→config mapping is unit-testable
+ * without standing up the full server (#293).
+ */
+
+import { clampInt } from "../core/clamp.js";
+import type { WatchHubOptions } from "../core/watch-hub.js";
+
+export interface ResolveOptions {
+  readonly warn?: (msg: string) => void;
+}
+
+export function resolveWatchHubConfig(
+  env: Readonly<Record<string, string | undefined>>,
+  opts: ResolveOptions = {},
+): Pick<WatchHubOptions, "maxAgeMsPerKey" | "maxEventsPerKey"> {
+  return {
+    maxAgeMsPerKey: clampInt({
+      raw: env.GROVE_WATCH_RETENTION_MS,
+      fallback: 300_000,
+      min: 1_000,
+      max: 86_400_000,
+      name: "GROVE_WATCH_RETENTION_MS",
+      ...(opts.warn ? { warn: opts.warn } : {}),
+    }),
+    maxEventsPerKey: clampInt({
+      raw: env.GROVE_WATCH_MAX_EVENTS,
+      fallback: 1024,
+      min: 16,
+      max: 1_000_000,
+      name: "GROVE_WATCH_MAX_EVENTS",
+      ...(opts.warn ? { warn: opts.warn } : {}),
+    }),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/server/watch-hub-config.test.ts`
+Expected: PASS — 7 tests.
+
+- [ ] **Step 5: Modify `src/server/serve.ts`**
+
+Add import at the top with the other `./` imports:
+
+```typescript
+import { resolveWatchHubConfig } from "./watch-hub-config.js";
+```
+
+Locate the `const watchHub = new WatchHub();` line (around line 217). Replace with:
+
+```typescript
+const watchHub = new WatchHub(resolveWatchHubConfig(process.env));
+```
+
+- [ ] **Step 6: Smoke-build**
+
+Run: `bun run build` (check `package.json` for the actual script — it may be `bun run build:dist` or `bun run typecheck`).
+Expected: PASS — no type errors.
+
+If no build script exists for typechecking, run: `bun build src/server/serve.ts --target=bun --outdir=/tmp/grove-build-check`
+Expected: builds without error.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/server/watch-hub-config.ts src/server/watch-hub-config.test.ts src/server/serve.ts
+git commit -m "feat(watch): GROVE_WATCH_RETENTION_MS/MAX_EVENTS env vars (#293)"
+```
+
+---
+
+## Task 5: `WatchClient` — happy path (list → RELIST → ADDED)
+
+**Files:**
+- Create: `src/core/watch-client.ts`
+- Test: `src/core/watch-client.test.ts`
+
+This task ships the minimal happy path. Subsequent tasks add 410 relist (Task 6), TCP-close fast resume (Task 7), sequential `onEvent` + abort (Task 8), and terminal errors (Task 9). Keeping each task focused makes the TDD red→green cycle short.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/watch-client.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { WatchClient, type WatchClientEvent } from "./watch-client.js";
+
+/** Mock fetch returning canned list and watch responses. */
+function makeFetch(
+  list: { items: unknown[]; listResourceVersion: string },
+  watchEvents: string[],
+): typeof fetch {
+  return (async (input, init) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.includes("/api/list")) {
+      return new Response(JSON.stringify(list), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url.includes("/api/watch")) {
+      const body = watchEvents.join("");
+      return new Response(body, {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }) as typeof fetch;
+}
+
+const ENTITY_A = {
+  envelope: { kind: "Contribution", id: "cid-a" },
+  data: { cid: "cid-a", summary: "a" },
+};
+const ENTITY_B = {
+  envelope: { kind: "Contribution", id: "cid-b" },
+  data: { cid: "cid-b", summary: "b" },
+};
+
+function sse(event: string, data: unknown, id?: string): string {
+  const idLine = id ? `id: ${id}\n` : "";
+  return `${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+describe("WatchClient happy path", () => {
+  test("emits RELIST for each list item then ADDED for streamed events", async () => {
+    const seen: WatchClientEvent[] = [];
+    const fetchImpl = makeFetch(
+      { items: [ENTITY_A], listResourceVersion: "5" },
+      [
+        sse("ADDED", { rv: "6", kind: "Contribution", entity: ENTITY_B }, "6"),
+      ],
+    );
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+    });
+    const ac = new AbortController();
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+        if (seen.length === 2) ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await running;
+
+    expect(seen.length).toBe(2);
+    expect(seen[0]?.op).toBe("RELIST");
+    expect(seen[0]?.rv).toBe(5n);
+    expect((seen[0]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-a");
+    expect(seen[1]?.op).toBe("ADDED");
+    expect(seen[1]?.rv).toBe(6n);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/watch-client.test.ts`
+Expected: FAIL — `Cannot find module './watch-client.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/core/watch-client.ts`:
+
+```typescript
+/**
+ * WatchClient — list→watch loop with relist on Expired (#293).
+ *
+ * Drives the A5 handshake (#292) and translates server SSE events into
+ * a typed callback. RELIST signals "snapshot, not delta" so consumers
+ * can run K8s-informer-style Replace() reconciliation.
+ */
+
+import type { WatchEntity, WatchKind } from "./watch-events.js";
+
+export type WatchClientOp = "ADDED" | "MODIFIED" | "DELETED" | "RELIST";
+
+export interface WatchClientEvent {
+  readonly op: WatchClientOp;
+  readonly rv: bigint;
+  readonly kind: WatchKind;
+  readonly entity: WatchEntity;
+}
+
+export interface WatchClientOptions {
+  readonly baseUrl: string;
+  readonly kind: WatchKind;
+  readonly authHeader: string;
+  readonly fetch?: typeof fetch;
+  readonly backoff?: {
+    readonly minMs: number;
+    readonly maxMs: number;
+    readonly jitter: number;
+  };
+}
+
+interface ListResponse {
+  readonly items: WatchEntity[];
+  readonly listResourceVersion: string;
+}
+
+interface SseFrame {
+  readonly id: string;
+  readonly event: string;
+  readonly data: unknown;
+}
+
+export class WatchClient {
+  private readonly baseUrl: string;
+  private readonly kind: WatchKind;
+  private readonly authHeader: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: WatchClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.kind = opts.kind;
+    this.authHeader = opts.authHeader;
+    this.fetchImpl = opts.fetch ?? fetch;
+  }
+
+  async run(opts: {
+    onEvent: (e: WatchClientEvent) => Promise<void> | void;
+    signal: AbortSignal;
+  }): Promise<void> {
+    const { onEvent, signal } = opts;
+    while (!signal.aborted) {
+      const list = await this.list(signal);
+      for (const item of list.items) {
+        if (signal.aborted) return;
+        await onEvent({
+          op: "RELIST",
+          rv: BigInt(list.listResourceVersion),
+          kind: this.kind,
+          entity: item,
+        });
+      }
+      const resumed = await this.streamWatch(
+        BigInt(list.listResourceVersion),
+        onEvent,
+        signal,
+      );
+      if (resumed === "abort") return;
+      // Future tasks: distinguish 410/503 (full relist, restart loop) from
+      // TCP close (fast resume). For now any non-abort exit restarts the loop.
+    }
+  }
+
+  private async list(signal: AbortSignal): Promise<ListResponse> {
+    const res = await this.fetchImpl(
+      `${this.baseUrl}/api/list?kind=${this.kind}`,
+      { headers: { Authorization: this.authHeader }, signal },
+    );
+    if (!res.ok) {
+      throw new Error(`list failed: ${res.status}`);
+    }
+    return (await res.json()) as ListResponse;
+  }
+
+  private async streamWatch(
+    fromRv: bigint,
+    onEvent: (e: WatchClientEvent) => Promise<void> | void,
+    signal: AbortSignal,
+  ): Promise<"abort" | "ended"> {
+    const url = `${this.baseUrl}/api/watch?kind=${this.kind}&resumeFrom=${fromRv}`;
+    const res = await this.fetchImpl(url, {
+      headers: { Authorization: this.authHeader, Accept: "text/event-stream" },
+      signal,
+    });
+    if (!res.ok || !res.body) return "ended";
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    try {
+      while (!signal.aborted) {
+        const { value, done } = await reader.read();
+        if (done) return "ended";
+        buf += decoder.decode(value, { stream: true });
+        let idx = buf.indexOf("\n\n");
+        while (idx >= 0) {
+          const block = buf.slice(0, idx);
+          buf = buf.slice(idx + 2);
+          const frame = parseSseFrame(block);
+          if (frame && isDataOp(frame.event)) {
+            const payload = frame.data as { rv: string; entity: WatchEntity };
+            await onEvent({
+              op: frame.event as WatchClientOp,
+              rv: BigInt(payload.rv),
+              kind: this.kind,
+              entity: payload.entity,
+            });
+          }
+          if (signal.aborted) return "abort";
+          idx = buf.indexOf("\n\n");
+        }
+      }
+      return "abort";
+    } finally {
+      try {
+        await reader.cancel();
+      } catch {
+        /* already cancelled */
+      }
+    }
+  }
+}
+
+function parseSseFrame(block: string): SseFrame | null {
+  const id = /^id: (.*)$/m.exec(block)?.[1] ?? "";
+  const event = /^event: (.*)$/m.exec(block)?.[1] ?? "";
+  const dataLine = /^data: (.*)$/m.exec(block)?.[1] ?? "null";
+  if (!event) return null;
+  let data: unknown = null;
+  try {
+    data = JSON.parse(dataLine);
+  } catch {
+    data = dataLine;
+  }
+  return { id, event, data };
+}
+
+function isDataOp(event: string): boolean {
+  return event === "ADDED" || event === "MODIFIED" || event === "DELETED";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/watch-client.test.ts`
+Expected: PASS — 1 test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/watch-client.ts src/core/watch-client.test.ts
+git commit -m "feat(watch): WatchClient happy path — list→RELIST→ADDED (#293)"
+```
+
+---
+
+## Task 6: `WatchClient` — 410/503 relist with backoff
+
+**Files:**
+- Modify: `src/core/watch-client.ts`
+- Modify: `src/core/watch-client.test.ts`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/core/watch-client.test.ts`:
+
+```typescript
+/**
+ * Helper: chained fetch that returns scripted responses in order. Each call
+ * matches a (urlPattern, body) pair. Throws if the script runs out.
+ */
+function scriptedFetch(
+  steps: Array<{ urlPattern: string; body: string; status?: number; json?: unknown }>,
+): typeof fetch {
+  let i = 0;
+  return (async (input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (i >= steps.length) {
+      throw new Error(`scripted fetch exhausted at ${url}`);
+    }
+    const step = steps[i] as (typeof steps)[number];
+    i += 1;
+    if (!url.includes(step.urlPattern)) {
+      throw new Error(
+        `expected url to contain ${step.urlPattern}, got ${url}`,
+      );
+    }
+    if (step.json !== undefined) {
+      return new Response(JSON.stringify(step.json), {
+        status: step.status ?? 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(step.body, {
+      status: step.status ?? 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  }) as typeof fetch;
+}
+
+describe("WatchClient relist on 410", () => {
+  test("ERROR{code:410} triggers relist + new RELIST events", async () => {
+    const seen: WatchClientEvent[] = [];
+    const fetchImpl = scriptedFetch([
+      // First list
+      { urlPattern: "/api/list", json: { items: [ENTITY_A], listResourceVersion: "5" } },
+      // First watch — emits 410 immediately
+      {
+        urlPattern: "/api/watch",
+        body: sse("ERROR", { code: 410, reason: "expired" }, "5"),
+      },
+      // Second list (relist)
+      { urlPattern: "/api/list", json: { items: [ENTITY_B], listResourceVersion: "10" } },
+      // Second watch — empty stream, then closes
+      { urlPattern: "/api/watch", body: "" },
+    ]);
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const ac = new AbortController();
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+        // Stop after we observe the second relist.
+        const relists = seen.filter((s) => s.op === "RELIST");
+        if (relists.length >= 2) ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await running;
+
+    const relists = seen.filter((s) => s.op === "RELIST");
+    expect(relists.length).toBe(2);
+    expect((relists[0]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-a");
+    expect((relists[1]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-b");
+    expect(relists[1]?.rv).toBe(10n);
+  });
+
+  test("ERROR{code:503} triggers relist same as 410", async () => {
+    const seen: WatchClientEvent[] = [];
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [ENTITY_A], listResourceVersion: "5" } },
+      {
+        urlPattern: "/api/watch",
+        body: sse("ERROR", { code: 503, reason: "buffer_overflow" }, "5"),
+      },
+      { urlPattern: "/api/list", json: { items: [ENTITY_B], listResourceVersion: "9" } },
+      { urlPattern: "/api/watch", body: "" },
+    ]);
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const ac = new AbortController();
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+        const relists = seen.filter((s) => s.op === "RELIST");
+        if (relists.length >= 2) ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await running;
+    expect(seen.filter((s) => s.op === "RELIST").length).toBe(2);
+  });
+
+  test("backoff sleeps between attempts when minMs > 0", async () => {
+    const sleeps: number[] = [];
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: sse("ERROR", { code: 410 }, "0") },
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: sse("ERROR", { code: 410 }, "0") },
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: sse("ERROR", { code: 410 }, "0") },
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: "" },
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 10, maxMs: 100, jitter: 0 },
+    });
+    // Hook the internal sleep via Bun's Date.now/setTimeout? Easier: snapshot
+    // wall-clock times around restarts. Use a custom sleep injection point:
+    // (handled by exposing onBackoff in implementation step below)
+    (client as unknown as { onBackoff?: (ms: number) => void }).onBackoff = (
+      ms: number,
+    ) => {
+      sleeps.push(ms);
+      if (sleeps.length >= 3) ac.abort();
+    };
+    await client.run({ onEvent: () => {}, signal: ac.signal });
+    expect(sleeps).toEqual([10, 20, 40]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/watch-client.test.ts`
+Expected: FAIL — relist tests see only one RELIST or hit "scripted fetch exhausted"; backoff test sees no sleeps.
+
+- [ ] **Step 3: Modify `src/core/watch-client.ts`**
+
+Add backoff state and the ERROR-frame branch. The full updated file:
+
+```typescript
+/**
+ * WatchClient — list→watch loop with relist on Expired (#293).
+ *
+ * Drives the A5 handshake (#292) and translates server SSE events into
+ * a typed callback. RELIST signals "snapshot, not delta" so consumers
+ * can run K8s-informer-style Replace() reconciliation.
+ */
+
+import type { WatchEntity, WatchKind } from "./watch-events.js";
+
+export type WatchClientOp = "ADDED" | "MODIFIED" | "DELETED" | "RELIST";
+
+export interface WatchClientEvent {
+  readonly op: WatchClientOp;
+  readonly rv: bigint;
+  readonly kind: WatchKind;
+  readonly entity: WatchEntity;
+}
+
+export interface WatchClientOptions {
+  readonly baseUrl: string;
+  readonly kind: WatchKind;
+  readonly authHeader: string;
+  readonly fetch?: typeof fetch;
+  readonly backoff?: {
+    readonly minMs: number;
+    readonly maxMs: number;
+    readonly jitter: number;
+  };
+}
+
+const DEFAULT_BACKOFF = { minMs: 100, maxMs: 30_000, jitter: 0.3 };
+
+interface ListResponse {
+  readonly items: WatchEntity[];
+  readonly listResourceVersion: string;
+}
+
+interface SseFrame {
+  readonly id: string;
+  readonly event: string;
+  readonly data: unknown;
+}
+
+type StreamExit =
+  | { kind: "abort" }
+  | { kind: "ended" }
+  | { kind: "relist" }; // 410/503 → full relist
+
+export class WatchClient {
+  private readonly baseUrl: string;
+  private readonly kind: WatchKind;
+  private readonly authHeader: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly backoffCfg: NonNullable<WatchClientOptions["backoff"]>;
+  /** Test-only hook called whenever the loop sleeps for `ms` after a failure. */
+  onBackoff?: (ms: number) => void;
+
+  constructor(opts: WatchClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.kind = opts.kind;
+    this.authHeader = opts.authHeader;
+    this.fetchImpl = opts.fetch ?? fetch;
+    this.backoffCfg = opts.backoff ?? DEFAULT_BACKOFF;
+  }
+
+  async run(opts: {
+    onEvent: (e: WatchClientEvent) => Promise<void> | void;
+    signal: AbortSignal;
+  }): Promise<void> {
+    const { onEvent, signal } = opts;
+    let nextDelay = this.backoffCfg.minMs;
+    while (!signal.aborted) {
+      const list = await this.list(signal);
+      for (const item of list.items) {
+        if (signal.aborted) return;
+        await onEvent({
+          op: "RELIST",
+          rv: BigInt(list.listResourceVersion),
+          kind: this.kind,
+          entity: item,
+        });
+      }
+      // Successful list → reset backoff.
+      nextDelay = this.backoffCfg.minMs;
+      const exit = await this.streamWatch(
+        BigInt(list.listResourceVersion),
+        onEvent,
+        signal,
+      );
+      if (exit.kind === "abort") return;
+      if (exit.kind === "relist") {
+        // 410/503 — backoff, then restart with a fresh list.
+        await this.sleep(nextDelay, signal);
+        nextDelay = this.advanceBackoff(nextDelay);
+        continue;
+      }
+      // exit.kind === "ended" — no error event, stream just closed. Reopen
+      // immediately with the same fromRv (no relist needed). For now restart
+      // the loop; Task 7 introduces fast-resume.
+      await this.sleep(nextDelay, signal);
+      nextDelay = this.advanceBackoff(nextDelay);
+    }
+  }
+
+  private async list(signal: AbortSignal): Promise<ListResponse> {
+    const res = await this.fetchImpl(
+      `${this.baseUrl}/api/list?kind=${this.kind}`,
+      { headers: { Authorization: this.authHeader }, signal },
+    );
+    if (!res.ok) {
+      throw new Error(`list failed: ${res.status}`);
+    }
+    return (await res.json()) as ListResponse;
+  }
+
+  private async streamWatch(
+    fromRv: bigint,
+    onEvent: (e: WatchClientEvent) => Promise<void> | void,
+    signal: AbortSignal,
+  ): Promise<StreamExit> {
+    const url = `${this.baseUrl}/api/watch?kind=${this.kind}&resumeFrom=${fromRv}`;
+    const res = await this.fetchImpl(url, {
+      headers: { Authorization: this.authHeader, Accept: "text/event-stream" },
+      signal,
+    });
+    if (!res.ok || !res.body) return { kind: "ended" };
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    try {
+      while (!signal.aborted) {
+        const { value, done } = await reader.read();
+        if (done) return { kind: "ended" };
+        buf += decoder.decode(value, { stream: true });
+        let idx = buf.indexOf("\n\n");
+        while (idx >= 0) {
+          const block = buf.slice(0, idx);
+          buf = buf.slice(idx + 2);
+          const frame = parseSseFrame(block);
+          if (!frame) {
+            idx = buf.indexOf("\n\n");
+            continue;
+          }
+          if (frame.event === "ERROR") {
+            const code = (frame.data as { code?: number })?.code;
+            if (code === 410 || code === 503) return { kind: "relist" };
+            throw new Error(`watch terminal error: code=${code}`);
+          }
+          if (isDataOp(frame.event)) {
+            const payload = frame.data as { rv: string; entity: WatchEntity };
+            await onEvent({
+              op: frame.event as WatchClientOp,
+              rv: BigInt(payload.rv),
+              kind: this.kind,
+              entity: payload.entity,
+            });
+          }
+          if (signal.aborted) return { kind: "abort" };
+          idx = buf.indexOf("\n\n");
+        }
+      }
+      return { kind: "abort" };
+    } finally {
+      try {
+        await reader.cancel();
+      } catch {
+        /* already cancelled */
+      }
+    }
+  }
+
+  private advanceBackoff(prev: number): number {
+    const doubled = Math.min(this.backoffCfg.maxMs, Math.max(this.backoffCfg.minMs, prev * 2));
+    return doubled;
+  }
+
+  private async sleep(ms: number, signal: AbortSignal): Promise<void> {
+    this.onBackoff?.(ms);
+    if (ms <= 0 || signal.aborted) return;
+    const jitter = this.backoffCfg.jitter;
+    const actual =
+      jitter > 0 ? ms * (1 + (Math.random() * 2 - 1) * jitter) : ms;
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, actual);
+      const onAbort = () => {
+        clearTimeout(t);
+        resolve();
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+}
+
+function parseSseFrame(block: string): SseFrame | null {
+  const id = /^id: (.*)$/m.exec(block)?.[1] ?? "";
+  const event = /^event: (.*)$/m.exec(block)?.[1] ?? "";
+  const dataLine = /^data: (.*)$/m.exec(block)?.[1] ?? "null";
+  if (!event) return null;
+  let data: unknown = null;
+  try {
+    data = JSON.parse(dataLine);
+  } catch {
+    data = dataLine;
+  }
+  return { id, event, data };
+}
+
+function isDataOp(event: string): boolean {
+  return event === "ADDED" || event === "MODIFIED" || event === "DELETED";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/watch-client.test.ts`
+Expected: PASS — 4 tests (1 from Task 5 + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/watch-client.ts src/core/watch-client.test.ts
+git commit -m "feat(watch): WatchClient relist on 410/503 with backoff (#293)"
+```
+
+---
+
+## Task 7: `WatchClient` — fast resume on TCP close
+
+**Files:**
+- Modify: `src/core/watch-client.ts`
+- Modify: `src/core/watch-client.test.ts`
+
+The "ended" exit path currently falls back to a full relist. Per spec, a TCP close without an ERROR event should fast-resume from the last-seen rv (or the listRv if no events were seen yet) — no fresh list needed.
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/core/watch-client.test.ts`:
+
+```typescript
+describe("WatchClient fast resume on TCP close", () => {
+  test("reopens watch from last-seen rv after stream ends without ERROR", async () => {
+    const seen: WatchClientEvent[] = [];
+    const watchUrls: string[] = [];
+    const ac = new AbortController();
+    const fetchImpl = ((async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/list")) {
+        return new Response(
+          JSON.stringify({ items: [], listResourceVersion: "5" }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("/api/watch")) {
+        watchUrls.push(url);
+        if (watchUrls.length === 1) {
+          // First watch: emit ADDED rv=6 then end.
+          return new Response(
+            sse("ADDED", { rv: "6", kind: "Contribution", entity: ENTITY_A }, "6"),
+            { headers: { "Content-Type": "text/event-stream" } },
+          );
+        }
+        // Second watch observed → fire abort so the loop unwinds. Returning
+        // an empty body would otherwise spin the loop forever (no onEvent
+        // fires to drive an in-callback abort).
+        ac.abort();
+        return new Response("", {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      throw new Error(`unexpected ${url}`);
+    }) as typeof fetch);
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+      },
+      signal: ac.signal,
+    });
+    await running;
+
+    expect(watchUrls.length).toBeGreaterThanOrEqual(2);
+    // First watch resumes from listRv=5; second resumes from last-seen rv=6.
+    expect(watchUrls[0]).toContain("resumeFrom=5");
+    expect(watchUrls[1]).toContain("resumeFrom=6");
+    expect(seen.filter((e) => e.op === "RELIST").length).toBe(0); // no relist
+  });
+
+  test("first ended-without-event uses listRv as resumeFrom", async () => {
+    const watchUrls: string[] = [];
+    const fetchImpl = ((async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/list")) {
+        return new Response(
+          JSON.stringify({ items: [], listResourceVersion: "5" }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("/api/watch")) {
+        watchUrls.push(url);
+        return new Response("", {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      throw new Error(`unexpected ${url}`);
+    }) as typeof fetch);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const running = client.run({
+      onEvent: () => {},
+      signal: ac.signal,
+    });
+    // Let it loop a few times then abort.
+    setTimeout(() => ac.abort(), 50);
+    await running;
+
+    expect(watchUrls.length).toBeGreaterThanOrEqual(2);
+    for (const u of watchUrls) {
+      expect(u).toContain("resumeFrom=5");
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/watch-client.test.ts`
+Expected: FAIL — first new test sees `resumeFrom=5` for both watches (no fast resume); RELIST count is non-zero because the loop currently re-lists on `ended`.
+
+- [ ] **Step 3: Modify the loop in `src/core/watch-client.ts`**
+
+Track `lastSeenRv` inside the `run()` loop. Replace the `run()` method body and `streamWatch()` signature so the watch reports the last rv it observed.
+
+a. Update `StreamExit`:
+
+```typescript
+type StreamExit =
+  | { kind: "abort" }
+  | { kind: "ended"; lastRv: bigint }
+  | { kind: "relist" };
+```
+
+b. Update `streamWatch` to track and return `lastRv`:
+
+```typescript
+private async streamWatch(
+  fromRv: bigint,
+  onEvent: (e: WatchClientEvent) => Promise<void> | void,
+  signal: AbortSignal,
+): Promise<StreamExit> {
+  let lastRv = fromRv;
+  const url = `${this.baseUrl}/api/watch?kind=${this.kind}&resumeFrom=${fromRv}`;
+  const res = await this.fetchImpl(url, {
+    headers: { Authorization: this.authHeader, Accept: "text/event-stream" },
+    signal,
+  });
+  if (!res.ok || !res.body) return { kind: "ended", lastRv };
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    while (!signal.aborted) {
+      const { value, done } = await reader.read();
+      if (done) return { kind: "ended", lastRv };
+      buf += decoder.decode(value, { stream: true });
+      let idx = buf.indexOf("\n\n");
+      while (idx >= 0) {
+        const block = buf.slice(0, idx);
+        buf = buf.slice(idx + 2);
+        const frame = parseSseFrame(block);
+        if (!frame) {
+          idx = buf.indexOf("\n\n");
+          continue;
+        }
+        if (frame.event === "ERROR") {
+          const code = (frame.data as { code?: number })?.code;
+          if (code === 410 || code === 503) return { kind: "relist" };
+          throw new Error(`watch terminal error: code=${code}`);
+        }
+        if (isDataOp(frame.event)) {
+          const payload = frame.data as { rv: string; entity: WatchEntity };
+          const rv = BigInt(payload.rv);
+          lastRv = rv;
+          await onEvent({
+            op: frame.event as WatchClientOp,
+            rv,
+            kind: this.kind,
+            entity: payload.entity,
+          });
+        } else if (frame.event === "BOOKMARK") {
+          // BOOKMARK advances resume cursor without firing onEvent.
+          const rv = (frame.data as { rv?: string })?.rv;
+          if (rv && /^[0-9]+$/.test(rv)) lastRv = BigInt(rv);
+        }
+        if (signal.aborted) return { kind: "abort" };
+        idx = buf.indexOf("\n\n");
+      }
+    }
+    return { kind: "abort" };
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      /* already cancelled */
+    }
+  }
+}
+```
+
+c. Replace the `run()` body to thread `lastRv` through fast-resume:
+
+```typescript
+async run(opts: {
+  onEvent: (e: WatchClientEvent) => Promise<void> | void;
+  signal: AbortSignal;
+}): Promise<void> {
+  const { onEvent, signal } = opts;
+  let nextDelay = this.backoffCfg.minMs;
+  let resumeFrom: bigint | null = null; // null → must (re)list
+
+  while (!signal.aborted) {
+    if (resumeFrom === null) {
+      const list = await this.list(signal);
+      for (const item of list.items) {
+        if (signal.aborted) return;
+        await onEvent({
+          op: "RELIST",
+          rv: BigInt(list.listResourceVersion),
+          kind: this.kind,
+          entity: item,
+        });
+      }
+      resumeFrom = BigInt(list.listResourceVersion);
+      nextDelay = this.backoffCfg.minMs;
+    }
+    const exit = await this.streamWatch(resumeFrom, onEvent, signal);
+    if (exit.kind === "abort") return;
+    if (exit.kind === "relist") {
+      // Full relist on next iteration.
+      resumeFrom = null;
+      await this.sleep(nextDelay, signal);
+      nextDelay = this.advanceBackoff(nextDelay);
+      continue;
+    }
+    // exit.kind === "ended" — fast resume from lastRv.
+    resumeFrom = exit.lastRv;
+    await this.sleep(nextDelay, signal);
+    nextDelay = this.advanceBackoff(nextDelay);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/watch-client.test.ts`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/watch-client.ts src/core/watch-client.test.ts
+git commit -m "feat(watch): WatchClient fast resume on TCP close (#293)"
+```
+
+---
+
+## Task 8: `WatchClient` — sequential `onEvent` + abort during in-flight callback
+
+**Files:**
+- Modify: `src/core/watch-client.test.ts` (only — implementation already satisfies these contracts; tests assert and lock them in)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/core/watch-client.test.ts`:
+
+```typescript
+describe("WatchClient onEvent semantics", () => {
+  test("awaits each onEvent before processing the next", async () => {
+    const order: string[] = [];
+    let resolveFirst: (() => void) | undefined;
+    const firstDone = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+    const fetchImpl = makeFetch(
+      { items: [], listResourceVersion: "5" },
+      [
+        sse("ADDED", { rv: "6", kind: "Contribution", entity: ENTITY_A }, "6"),
+        sse("ADDED", { rv: "7", kind: "Contribution", entity: ENTITY_B }, "7"),
+      ],
+    );
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const running = client.run({
+      onEvent: async (e) => {
+        order.push(`enter:${e.rv}`);
+        if (e.rv === 6n) await firstDone;
+        order.push(`exit:${e.rv}`);
+        if (e.rv === 7n) ac.abort();
+      },
+      signal: ac.signal,
+    });
+    // Give the loop a tick to enter onEvent for rv=6.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(order).toEqual(["enter:6"]);
+    resolveFirst?.();
+    await running;
+    expect(order).toEqual(["enter:6", "exit:6", "enter:7", "exit:7"]);
+  });
+
+  test("abort during in-flight onEvent waits for callback to settle", async () => {
+    let callbackResolved = false;
+    let onEventEntered = false;
+    const fetchImpl = makeFetch(
+      { items: [ENTITY_A], listResourceVersion: "5" },
+      [],
+    );
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const running = client.run({
+      onEvent: async () => {
+        onEventEntered = true;
+        ac.abort(); // abort while we are inside onEvent
+        await new Promise((r) => setTimeout(r, 20));
+        callbackResolved = true;
+      },
+      signal: ac.signal,
+    });
+    await running;
+    expect(onEventEntered).toBe(true);
+    expect(callbackResolved).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+The current `run()` already `await`s every `onEvent` before checking `signal.aborted`, so these tests should pass without code changes. Run: `bun test src/core/watch-client.test.ts`
+Expected: PASS — 8 tests.
+
+If any test fails, the `await onEvent(...)` call sites in `streamWatch` and the `RELIST` loop need a closer audit — but the implementation from Task 7 already awaits sequentially.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/watch-client.test.ts
+git commit -m "test(watch): WatchClient sequential onEvent + abort semantics (#293)"
+```
+
+---
+
+## Task 9: `WatchClient` — terminal errors (401/501/malformed SSE)
+
+**Files:**
+- Modify: `src/core/watch-client.ts`
+- Modify: `src/core/watch-client.test.ts`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/core/watch-client.test.ts`:
+
+```typescript
+describe("WatchClient terminal errors", () => {
+  test("rejects on HTTP 401 from list", async () => {
+    const fetchImpl = ((async () =>
+      new Response(JSON.stringify({ code: "UNAUTHENTICATED" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(
+      client.run({ onEvent: () => {}, signal: ac.signal }),
+    ).rejects.toThrow(/401|UNAUTHENTICATED|list failed/);
+  });
+
+  test("rejects on watch ERROR with non-410/503 code", async () => {
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      {
+        urlPattern: "/api/watch",
+        body: sse("ERROR", { code: 400, reason: "validation_error" }, "0"),
+      },
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(
+      client.run({ onEvent: () => {}, signal: ac.signal }),
+    ).rejects.toThrow(/400|terminal/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `bun test src/core/watch-client.test.ts`
+Expected: from the implementation in Task 6:
+  - The 401 test should already PASS (`list()` throws on `!res.ok`).
+  - The non-410/503 ERROR test should already PASS (the `streamWatch` ERROR branch throws).
+
+If both pass without changes, skip Step 3 and go straight to commit.
+
+- [ ] **Step 3: If a test fails, harden the relevant branch**
+
+For 401: confirm `this.list()` throws and that the throw bubbles out of `run()`. Already covered.
+
+For non-410 ERROR: confirm the `throw new Error("watch terminal error...")` in `streamWatch` propagates. Already covered.
+
+If both pass, no implementation change needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/watch-client.test.ts
+git commit -m "test(watch): WatchClient terminal error contracts (#293)"
+```
+
+---
+
+## Task 10: Server compaction integration test (sleep past retention)
+
+**Files:**
+- Modify: `src/server/watch.compaction.test.ts`
+
+- [ ] **Step 1: Append the sleep-past-retention test**
+
+Append to `src/server/watch.compaction.test.ts`:
+
+```typescript
+import { readSseEvents } from "./sse-test-utils.js";
+
+describe("compaction triggers Expired (issue #293 acceptance #1)", () => {
+  test("sleep past retention window → resume returns 410", async () => {
+    let now = 1_000_000;
+    const { app } = createTestApp({
+      watchHubOptions: {
+        maxAgeMsPerKey: 200,
+        maxEventsPerKey: 100,
+        now: () => now,
+      },
+    });
+
+    // Capture rv before any writes so it falls strictly below the post-
+    // eviction oldestRv. With earlyRv=0 and oldestRv=2 after eviction,
+    // the 410 trigger `fromRv < oldestRv - 1n` (0 < 1) holds.
+    const earlyRv = await listRv(app);
+    expect(earlyRv).toBe("0");
+
+    const writeRes1 = await app.request("/api/contributions", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify(makeManifestBody({ summary: "early" })),
+    });
+    expect(writeRes1.status).toBe(201);
+
+    // Advance clock past retention so the next write's trim evicts entry 1.
+    now += 1_000;
+
+    const writeRes2 = await app.request("/api/contributions", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify(makeManifestBody({ summary: "late" })),
+    });
+    expect(writeRes2.status).toBe(201);
+
+    // Resume from earlyRv=0. Ring oldestRv=2 → 410.
+    const watchRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${earlyRv}`,
+      { headers: TEST_AUTH_HEADERS },
+    );
+    const events = await readSseEvents(watchRes, 1, 1_000);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    const errorEvent = events.find((e) => e.event === "ERROR");
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { code: number }).code).toBe(410);
+    expect((errorEvent?.data as { reason: string }).reason).toBe("expired");
+
+    // Metrics endpoint reflects the eviction.
+    const metricsRes = await app.request("/api/watch/metrics", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const metrics = (await metricsRes.json()) as MetricsResponse;
+    const key = metrics.keys.find((k) => k.kind === "Contribution");
+    expect(key?.evictedByAge).toBeGreaterThanOrEqual(1);
+  });
+
+  test("capacity-based eviction also returns 410", async () => {
+    const { app } = createTestApp({
+      watchHubOptions: { maxAgeMsPerKey: 60_000, maxEventsPerKey: 4 },
+    });
+    const earlyRv = await listRv(app);
+    for (let i = 0; i < 10; i++) {
+      const r = await app.request("/api/contributions", {
+        method: "POST",
+        headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+        body: JSON.stringify(makeManifestBody({ summary: `cap-${i}` })),
+      });
+      expect(r.status).toBe(201);
+    }
+    const watchRes = await app.request(
+      `/api/watch?kind=Contribution&resumeFrom=${earlyRv}`,
+      { headers: TEST_AUTH_HEADERS },
+    );
+    const events = await readSseEvents(watchRes, 1, 1_000);
+    const errorEvent = events.find((e) => e.event === "ERROR");
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { code: number }).code).toBe(410);
+
+    const metricsRes = await app.request("/api/watch/metrics", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const metrics = (await metricsRes.json()) as MetricsResponse;
+    const key = metrics.keys.find((k) => k.kind === "Contribution");
+    expect(key?.evictedByCapacity).toBeGreaterThanOrEqual(1);
+  });
+});
+
+async function listRv(app: { request: (path: string, init?: RequestInit) => Promise<Response> }): Promise<string> {
+  const res = await app.request("/api/list?kind=Contribution", {
+    headers: TEST_AUTH_HEADERS,
+  });
+  const json = (await res.json()) as { listResourceVersion: string };
+  return json.listResourceVersion;
+}
+```
+
+Note: the new imports (`readSseEvents`) go alongside the existing imports at the top of the file. Drop the `contributionToEntity` import shown in the snippet above — it is not used by the test body.
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `bun test src/server/watch.compaction.test.ts`
+Expected: PASS — all tests including the new acceptance ones.
+
+If the sleep test fails because the server route is using `Date.now()` rather than the injected `now`, double-check that `WatchHub` constructor is being threaded with `opts.watchHubOptions.now` in `test-helpers.ts` (it already is, per existing source).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/server/watch.compaction.test.ts
+git commit -m "test(watch): sleep-past-retention + capacity eviction (#293 #1)"
+```
+
+---
+
+## Task 11: E2E relist test — `WatchClient` against in-process server
+
+**Files:**
+- Create: `src/server/watch.relist.e2e.test.ts`
+
+This is the issue acceptance criterion #2: client relists via A5 handshake automatically → no events missed across the gap.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/server/watch.relist.e2e.test.ts`:
+
+```typescript
+/**
+ * Acceptance test for issue #293 — criterion #2.
+ *
+ * A WatchClient driven against a real in-process grove-server that has
+ * a tiny ring buffer survives a simulated kill -9 + sleep past retention
+ * by relisting via the A5 handshake. Every contribution surfaces (via
+ * either RELIST or ADDED) with no missed entities.
+ *
+ * Sizing: maxEventsPerKey=2 + 5 writes during pause guarantees
+ * `oldestRv >= lastSeenRv + 2`, which is the condition the server uses to
+ * raise StaleResourceVersionError. (See WatchHub.subscribe: trigger is
+ * `fromRv < oldestRv - 1n`.)
+ */
+
+import { describe, expect, test } from "bun:test";
+import { WatchClient, type WatchClientEvent } from "../core/watch-client.js";
+import type { ContributionEntity } from "../core/entity.js";
+import { createTestApp, makeManifestBody, TEST_AUTH_HEADERS } from "./test-helpers.js";
+
+describe("WatchClient survives retention gap (issue #293 acceptance #2)", () => {
+  test("client relists across retention gap with no missed events", async () => {
+    let now = 1_000_000;
+    const { app } = createTestApp({
+      watchHubOptions: {
+        maxAgeMsPerKey: 60_000,  // age not the trigger; capacity is
+        maxEventsPerKey: 2,
+        now: () => now,
+      },
+    });
+
+    // app.request is a Hono helper that turns a path + RequestInit into a
+    // Response. WatchClient expects a base URL + WHATWG fetch. Adapt by
+    // intercepting the URL prefix and forwarding to app.request.
+    const adaptedFetch: typeof fetch = (async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const path = url.replace(/^http:\/\/test/, "");
+      return app.request(path, init);
+    }) as typeof fetch;
+
+    const seen: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    let paused = false;
+    const pauseGate: typeof fetch = (async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (paused && url.includes("/api/watch")) {
+        // Simulate disconnect: return 503 so streamWatch sees !res.ok and ends.
+        return new Response("", { status: 503 });
+      }
+      return adaptedFetch(input, init);
+    }) as typeof fetch;
+
+    const client = new WatchClient({
+      baseUrl: "http://test",
+      kind: "Contribution",
+      authHeader: TEST_AUTH_HEADERS.Authorization as string,
+      fetch: pauseGate,
+      backoff: { minMs: 5, maxMs: 50, jitter: 0 },
+    });
+
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+      },
+      signal: ac.signal,
+    });
+
+    // Helper to write a contribution with a known summary marker.
+    const post = async (marker: string): Promise<void> => {
+      const r = await app.request("/api/contributions", {
+        method: "POST",
+        headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+        body: JSON.stringify(makeManifestBody({ summary: marker })),
+      });
+      expect(r.status).toBe(201);
+    };
+
+    // Phase 1: write 3 events and wait for the watcher to ack all 3.
+    for (const m of ["m1", "m2", "m3"]) await post(m);
+    await waitFor(
+      () => seen.filter((e) => e.op === "ADDED").length >= 3,
+      2_000,
+    );
+
+    // Phase 2: pause + write 5 more so capacity eviction pushes
+    // oldestRv past the client's last-seen rv.
+    paused = true;
+    await sleep(50); // let the loop see 503 and enter backoff
+    for (const m of ["m4", "m5", "m6", "m7", "m8"]) await post(m);
+
+    // Phase 3: resume. Next watch attempt hits 410 (lastSeenRv=3 is
+    // outside the ring whose oldestRv is 7), which forces a relist.
+    paused = false;
+
+    await waitFor(() => {
+      const summaries = collectSummaries(seen);
+      return (
+        seen.some((e) => e.op === "RELIST") &&
+        ["m4", "m5", "m6", "m7", "m8"].some((m) => summaries.has(m))
+      );
+    }, 5_000);
+
+    ac.abort();
+    await running;
+
+    // Every marker is observed at least once across the run.
+    const observed = collectSummaries(seen);
+    for (const m of ["m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8"]) {
+      expect(observed.has(m)).toBe(true);
+    }
+    expect(seen.some((e) => e.op === "RELIST")).toBe(true);
+  }, 15_000);
+});
+
+function collectSummaries(events: readonly WatchClientEvent[]): Set<string> {
+  const out = new Set<string>();
+  for (const e of events) {
+    const summary = (e.entity as ContributionEntity).spec?.summary;
+    if (summary) out.add(summary);
+  }
+  return out;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+  throw new Error("waitFor timed out");
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `bun test src/server/watch.relist.e2e.test.ts`
+Expected: PASS — 1 test (within 15s timeout).
+
+If the test times out: log `seen.map(e => ({op: e.op, rv: e.rv.toString(), summary: (e.entity as ContributionEntity).spec?.summary}))` before the assertions to confirm the relist is happening. Common causes:
+- pause/unpause timing — increase `await sleep(50)` if the loop is still mid-list when `paused=true`.
+- `bigint` JSON serialization — the existing watch route already stringifies rv on the wire; only the client converts back via `BigInt(...)`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/server/watch.relist.e2e.test.ts
+git commit -m "test(watch): WatchClient relist E2E across retention gap (#293 #2)"
+```
+
+---
+
+## Task 12: Update docs
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md`
+- Modify: `docs/parity-matrix.md`
+
+- [ ] **Step 1: Update the A5 spec deferred-questions section**
+
+In `docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md`, find the "Open questions deferred" section near the end. Replace the bullet:
+
+```markdown
+- Compaction window for ring buffers when a kind sees a sustained burst >
+  cap. A6 (#293) addresses this; A5's behavior is "drop oldest, return 410
+  on stale resume."
+```
+
+with:
+
+```markdown
+- ~~Compaction window for ring buffers when a kind sees a sustained burst >
+  cap.~~ Addressed by A6 (#293) — see
+  `docs/superpowers/specs/2026-04-28-a6-stale-rv-compaction-design.md`.
+```
+
+- [ ] **Step 2: Add a row to `docs/parity-matrix.md`**
+
+Open `docs/parity-matrix.md` and add a new row to the appropriate table. The exact section depends on the matrix's current structure — read the file first. Add (or extend an existing "Watch" section with):
+
+```markdown
+| Watch retention | server-side ring buffer | `GROVE_WATCH_RETENTION_MS` (default 300000), `GROVE_WATCH_MAX_EVENTS` (default 1024). Stale resume returns SSE `event:ERROR data:{code:410, reason:"expired"}`. Clients re-list via A5 handshake. Per-`(ns,kind)` compaction stats at `GET /api/watch/metrics`. See `docs/superpowers/specs/2026-04-28-a6-stale-rv-compaction-design.md`. |
+```
+
+If the matrix is row-per-(capability, local, nexus) instead of free-form, populate columns to match. If unsure of the table format, read the existing rows first and follow the pattern.
+
+- [ ] **Step 3: Verify nothing else is missed**
+
+Run a quick grep to make sure no remaining placeholder language refers to compaction as deferred:
+
+```bash
+grep -rn "compaction.*A6\|compaction.*deferred\|compaction.*future\|TODO.*compaction" docs/
+```
+
+Expected: only matches in this design doc and the updated A5 spec entry pointing forward.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md docs/parity-matrix.md
+git commit -m "docs(watch): document #293 retention env vars + metrics endpoint"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full test suite**
+
+Run: `bun test`
+Expected: PASS — all suites green. If anything outside `src/core/watch-*` or `src/server/watch*` fails, revisit Task 4 (env-var wiring may have introduced a stray import that broke a sibling test).
+
+- [ ] **Manual smoke**
+
+If a working server-up command exists in the repo (e.g., `bun run dev` or `grove up`), do a manual sanity check:
+
+```bash
+GROVE_WATCH_RETENTION_MS=5000 bun run src/server/serve.ts &
+sleep 1
+# Substitute your auth token + URL.
+curl -s "http://localhost:8080/api/watch/metrics" -H "Authorization: Bearer $TOKEN" | jq .
+# Expected: {"retention":{"maxAgeMs":5000,"maxEvents":1024},"keys":[]}
+```
+
+If `bun run dev` doesn't exist or requires Nexus to be up, skip this step — the integration + E2E tests already cover the behavior.
+
+- [ ] **Self-review checklist**
+
+Before opening the PR, eyeball the diff:
+- All new files are under `src/core/` or `src/server/` and follow existing naming.
+- No `console.log` left over from debugging the E2E test.
+- The `WatchClient` import in the E2E test is from `../core/watch-client.js` (with `.js` extension — TypeScript NodeNext convention used in the repo).
+- The `getCompactionStats()` snapshot is non-mutating (returns a new array; callers can't push into hub state).
+
+---
+
+## Acceptance traceability
+
+| Issue criterion | Where covered |
+|-----------------|---------------|
+| Sleep past retention window → resume returns `Expired` | Task 10 (`watch.compaction.test.ts`) |
+| Client relists via A5 handshake automatically → no events missed | Task 11 (`watch.relist.e2e.test.ts`) |
+| Retention window configurable + documented | Tasks 4 + 12 |
+| Compaction metric exposed | Tasks 2 + 3 (`getCompactionStats()` + `/api/watch/metrics`) |

--- a/docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md
+++ b/docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md
@@ -405,8 +405,8 @@ test("handshake race: writes between list-return and watch-open all replayed", a
 ## Open questions deferred
 
 - Whether to expose watch over WebSocket as a future alternative (SSE-only for A5).
-- Compaction window for ring buffers when a kind sees a sustained burst >
-  cap. A6 (#293) addresses this; A5's behavior is "drop oldest, return 410
-  on stale resume."
+- ~~Compaction window for ring buffers when a kind sees a sustained burst >
+  cap.~~ Addressed by A6 (#293) — see
+  `docs/superpowers/specs/2026-04-28-a6-stale-rv-compaction-design.md`.
 - TUI informer cache shape, including whether informers share a single
   watch per kind across panels. A7 (#294).

--- a/docs/superpowers/specs/2026-04-28-a6-stale-rv-compaction-design.md
+++ b/docs/superpowers/specs/2026-04-28-a6-stale-rv-compaction-design.md
@@ -1,0 +1,524 @@
+# A6: Stale-RV (Expired) Error Path + Compaction Semantics — Design
+
+- **Issue**: [#293](https://github.com/windoliver/grove/issues/293)
+- **Epic**: [#282](https://github.com/windoliver/grove/issues/282) — Foundation: Entity Model + Watch Protocol
+- **Date**: 2026-04-28
+- **Depends on**: [#292](https://github.com/windoliver/grove/issues/292) (A5 watch protocol)
+- **Blocks**: [#294](https://github.com/windoliver/grove/issues/294) (A7 informer client)
+- **Reference**: `k8s.io/apimachinery/pkg/api/errors.NewResourceExpired`,
+  `k8s.io/apimachinery/pkg/watch`
+
+## Goal
+
+Close the retention/compaction gap on top of the watch protocol shipped in
+#292. When a client's `resumeFrom` falls outside the server's ring buffer,
+the server returns a typed `Expired` (HTTP 410) error and the client
+recovers by re-running the A5 list→watch handshake — no events lost, no
+silent skips. Retention window is configurable and observable; eviction is
+counted and surfaced via a metrics endpoint.
+
+The "silently skip past the gap" anti-pattern is the desync bug this design
+prevents. K8s informers solve it with `Replace()` after a relist; #293 ships
+the equivalent contract for grove's watch.
+
+## Non-goals
+
+- Persistent watch log across server restart. In-memory ring buffer only —
+  same constraint as #292. On restart, RV resets to 0 and clients must
+  re-list (#292 already returns 410 for `resumeFrom > currentRv`).
+- Full informer (`Map<id, Entity>` + handler fanout). That is #294.
+  #293 ships a thin `WatchClient` helper that #294 will wrap.
+- Polling retirement in the TUI. That is #295.
+- Prometheus / OpenMetrics format. JSON metrics endpoint only — promotable
+  later when there is broader demand for a `/metrics` scrape surface.
+- Multi-server retention coordination. Single grove-server per worktree
+  (same as #292).
+- Adaptive retention (sized by burst load). Fixed retention with operator-
+  set bounds; tuning is an ops decision, not a runtime adaptation.
+
+## Architecture
+
+```
+                      grove-server (single process)
+   ┌──────────────────────────────────────────────────────────────┐
+   │                                                              │
+   │  WatchHub                                                    │
+   │   ├── per-(ns,kind) RV counter                               │
+   │   ├── ring buffer (bounded by maxEvents AND maxAgeMs)        │
+   │   ├── compaction stats {evictedByAge, evictedByCapacity,    │
+   │   │                     currentRingSize, oldestRv}           │
+   │   └── trim() increments stats on each eviction               │
+   │                                                              │
+   │  GET /api/watch/metrics  ← new (#293)                        │
+   │     → JSON: per-(ns,kind) compaction stats + retention cfg   │
+   │                                                              │
+   │  GET /api/list?kind=X    ← from #292                         │
+   │  GET /api/watch?kind=X&resumeFrom=Y                          │
+   │     → on stale rv → SSE event:ERROR data:{code:410,          │
+   │                       reason:"expired"} → close              │
+   └──────────────────────────────────────────────────────────────┘
+                            ▲
+                            │  list → watch → on-410 relist
+                            │
+                ┌───────────┴───────────┐
+                │   WatchClient (new)   │
+                │  - run({onEvent})     │
+                │  - handles 410/503    │
+                │  - reconnect+backoff  │
+                └───────────────────────┘
+                            ▲
+                            │  wraps
+                            │
+                  Informer (future, #294)
+```
+
+### Boot config
+
+`serve.ts` reads two env vars and passes them to `new WatchHub(...)`:
+
+| Env var | Default | Range (clamped) | Meaning |
+|---------|---------|-----------------|---------|
+| `GROVE_WATCH_RETENTION_MS` | `300_000` (5 min) | `[1_000, 86_400_000]` | Max age of any event in the ring buffer |
+| `GROVE_WATCH_MAX_EVENTS` | `1024` | `[16, 1_000_000]` | Max events per `(ns, kind)` ring |
+
+Out-of-range or unparseable values fall back to default with a
+`console.warn`. Clamping protects against ops typos like
+`GROVE_WATCH_RETENTION_MS=-5` (silently disables retention) or
+`...=999999999999` (eats memory).
+
+### Data flow on Expired
+
+1. Client opens `GET /api/watch?resumeFrom=42`.
+2. Server's `WatchHub.subscribe` throws `StaleResourceVersionError` because
+   `oldestRv = 200` (or `currentRv < 42` after a server restart).
+3. Watch route catches the error and emits
+   `event: ERROR\ndata: {"code":410,"reason":"expired"}\n\n`, then closes.
+4. `WatchClient` parses the ERROR event, increments local `relistCount`,
+   awaits any in-flight `onEvent` callback, then re-issues
+   `GET /api/list?kind=X`.
+5. New `listResourceVersion` (e.g., 247) becomes the new `resumeFrom`. The
+   client fires `op:"RELIST"` events for every item in the snapshot, then
+   reopens the watch from `listRv`.
+6. The race-correctness invariant from #292 closes the gap: any write that
+   landed between "see 410" and "list returns" has `rv > listRv` and is
+   guaranteed to be in the ring on watch resume.
+
+### Why `RELIST` op tagging
+
+A consumer reading from `WatchClient` needs to know "your local cache is
+stale, here is the full state, replace it." Without an explicit signal, the
+consumer would treat a relist's events as deltas and double-insert.
+Kubernetes informers solve this with `Replace()` on the cache; our minimal
+client surfaces it as a typed callback signal so #294's informer (and any
+direct consumer in the meantime) can implement `Replace`-style reconciliation
+trivially.
+
+`RELIST` events all carry the same `rv` (the `listResourceVersion` returned
+by `/api/list`). A consumer can track "last RELIST rv seen" and clear any
+local entries whose last-seen rv is older — that is the standard informer
+reconcile loop.
+
+## Components
+
+### `src/core/watch-hub.ts` (modify)
+
+Extend internal state with compaction counters:
+
+```typescript
+interface KeyState {
+  counter: bigint;
+  ring: WatchEvent[];
+  insertedAt: number[];
+  evictedByAge: number;       // new
+  evictedByCapacity: number;  // new
+}
+```
+
+`trim()` increments the right counter on each shift. Pre-existing trim
+logic stays — we only add observability:
+
+```typescript
+private trim(s: KeyState): void {
+  while (s.ring.length > this.maxEventsPerKey) {
+    s.ring.shift();
+    s.insertedAt.shift();
+    s.evictedByCapacity += 1;
+  }
+  const cutoff = this.now() - this.maxAgeMsPerKey;
+  while (s.ring.length > 0 && (s.insertedAt[0] ?? 0) < cutoff) {
+    s.ring.shift();
+    s.insertedAt.shift();
+    s.evictedByAge += 1;
+  }
+}
+```
+
+Public API additions:
+
+```typescript
+export interface CompactionStats {
+  readonly namespace: string;
+  readonly kind: WatchKind;
+  readonly evictedByAge: number;
+  readonly evictedByCapacity: number;
+  readonly currentRingSize: number;
+  readonly oldestRv: string;   // bigint as decimal string
+  readonly currentRv: string;
+}
+
+export class WatchHub {
+  // ... existing members ...
+  readonly maxAgeMsPerKey: number;     // promote to public for /metrics
+  readonly maxEventsPerKey: number;    // promote to public for /metrics
+
+  /** Snapshot of compaction counters across all (ns, kind) keys. */
+  getCompactionStats(): readonly CompactionStats[];
+}
+```
+
+Counters are monotonic and never reset within a process lifetime. They
+survive `subscribe`/`unsubscribe` cycles; only the ring buffer entries
+change. No behavior change to `recordWrite` / `subscribe`.
+
+### `src/server/routes/watch.ts` (modify)
+
+Add a third route:
+
+```
+GET /api/watch/metrics
+  → 200 JSON
+    {
+      "retention": {
+        "maxAgeMs": 300000,
+        "maxEvents": 1024
+      },
+      "keys": [
+        {
+          "namespace": "abc-123",
+          "kind": "Contribution",
+          "evictedByAge": 12,
+          "evictedByCapacity": 0,
+          "currentRingSize": 87,
+          "oldestRv": "5",
+          "currentRv": "104"
+        },
+        ...
+      ]
+    }
+```
+
+`keys` is filtered to `c.get("namespace")` so namespaces don't leak each
+other's traffic shape. The route sits behind the same `namespaceAuth`
+middleware as the rest of `/api/*`. No query parameters.
+
+### `src/core/watch-client.ts` (new)
+
+Thin client. ~150 LOC. No dependencies beyond `fetch` + `EventSource`,
+both injectable for tests.
+
+```typescript
+export type WatchClientOp = "ADDED" | "MODIFIED" | "DELETED" | "RELIST";
+
+export interface WatchClientEvent {
+  readonly op: WatchClientOp;
+  readonly rv: bigint;
+  readonly kind: WatchKind;
+  readonly entity: WatchEntity;
+}
+
+export interface WatchClientOptions {
+  readonly baseUrl: string;
+  readonly kind: WatchKind;
+  readonly authHeader: string;
+  readonly fetch?: typeof fetch;
+  readonly EventSource?: typeof EventSource;
+  readonly backoff?: {
+    readonly minMs: number;     // default 100
+    readonly maxMs: number;     // default 30_000
+    readonly jitter: number;    // default 0.3 (multiplicative)
+  };
+}
+
+export class WatchClient {
+  constructor(opts: WatchClientOptions);
+
+  /**
+   * Runs list→watch loop until aborted. Calls onEvent for each delta
+   * (ADDED/MODIFIED/DELETED) and for relist replay (RELIST). Errors only
+   * on terminal misconfig (e.g., 401, 400, 501); 410/503/network blips
+   * trigger reconnect with backoff.
+   *
+   * onEvent is awaited sequentially — sequential delivery is contract.
+   */
+  run(opts: {
+    onEvent: (e: WatchClientEvent) => Promise<void> | void;
+    signal: AbortSignal;
+  }): Promise<void>;
+}
+```
+
+**Loop**:
+
+1. `GET /api/list?kind=X` → `{ items, listResourceVersion }`.
+2. For each item, fire `onEvent({op:"RELIST", rv:listRv, kind, entity})`.
+   RELIST signals "snapshot, not delta".
+3. Open `GET /api/watch?kind=X&resumeFrom=listRv` (SSE).
+4. For each `ADDED|MODIFIED|DELETED` event, await `onEvent`.
+5. On `event:ERROR` with `code:410` or `code:503`: backoff (with jitter),
+   goto 1 (full relist).
+6. On TCP close / non-410 network error: backoff, reopen watch with
+   last-seen `rv` as `resumeFrom` (fast resume — no relist). Initial value
+   is the `listRv` from step 1, so a TCP close before any events still
+   resumes correctly.
+7. On `event:ERROR` 4xx other than 410: terminal — `run()` rejects.
+8. Stop when `signal.aborted`.
+
+**Backoff state machine**:
+- `delay = max(minMs, min(maxMs, prevDelay × 2)) × (1 ± jitter)`
+- Reset to `minMs` on first successful SSE data event after reconnect.
+- Reset on 410/503 too — relist is a clean slate.
+
+**Sequential onEvent**: `run()` awaits each `onEvent` before processing the
+next event. Consumers (incl. future informer) need this for cache
+consistency. Callers wanting concurrency manage it themselves inside
+`onEvent`.
+
+**Abort semantics**: on `signal.abort()`, `run()` waits for any in-flight
+`onEvent` to settle, tears down the EventSource, and resolves cleanly. No
+dangling promises or zombie subscriptions.
+
+### `src/server/serve.ts` (modify)
+
+Read env vars at boot and pass to `WatchHub`:
+
+```typescript
+import { clampInt } from "../util/clamp.js";  // small new util
+
+const watchRetentionMs = clampInt({
+  raw: process.env.GROVE_WATCH_RETENTION_MS,
+  fallback: 300_000,
+  min: 1_000,
+  max: 86_400_000,
+  name: "GROVE_WATCH_RETENTION_MS",
+});
+const watchMaxEvents = clampInt({
+  raw: process.env.GROVE_WATCH_MAX_EVENTS,
+  fallback: 1024,
+  min: 16,
+  max: 1_000_000,
+  name: "GROVE_WATCH_MAX_EVENTS",
+});
+
+const watchHub = new WatchHub({
+  maxAgeMsPerKey: watchRetentionMs,
+  maxEventsPerKey: watchMaxEvents,
+});
+```
+
+`clampInt` lives in `src/util/clamp.ts`, logs `console.warn` on out-of-range
+or unparseable values, and falls back to `fallback`. Trivially unit-tested
+on its own.
+
+### Documentation
+
+- **`docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md`**: edit
+  the "Open questions deferred" section — strike the compaction line and
+  link to #293.
+- **`docs/parity-matrix.md`**: add a row documenting `GROVE_WATCH_RETENTION_MS`,
+  `GROVE_WATCH_MAX_EVENTS`, the 410/expired contract, and the metrics
+  endpoint.
+
+## Error handling
+
+| Condition | Server emits | `WatchClient` action |
+|-----------|--------------|----------------------|
+| `resumeFrom < oldestRv` (sleep past retention) | `event:ERROR data:{code:410, reason:"expired"}` then close | Relist via A5 → fire `RELIST` events → reopen from `listRv` |
+| `resumeFrom > currentRv` (server restart, RV reset) | `event:ERROR data:{code:410, reason:"expired"}` (existing #292 — `StaleResourceVersionError` covers both directions) | Same: relist |
+| Per-client outbox overflow | `event:ERROR data:{code:503, reason:"buffer_overflow"}` then close | Same as 410: relist (slow consumer is now fresh) |
+| Per-event >1 MiB | `event:ERROR data:{code:503, reason:"buffer_overflow"}` (existing #292) | Same: relist |
+| TCP close / network blip | (no event) | Reopen with last-seen `rv` as `resumeFrom`, exponential backoff, no relist |
+| HTTP 401 / 403 | JSON `{code:UNAUTHENTICATED}` | Terminal — `run()` rejects |
+| HTTP 400 (validation) | JSON `{code:VALIDATION_ERROR}` | Terminal — bug |
+| HTTP 501 (kind unsupported) | JSON `{code:NOT_CONFIGURED}` | Terminal — kind not yet wired |
+| Malformed SSE 5× consecutively | (parse error in client) | Terminal — `run()` rejects |
+
+**Race during relist**: between "see 410" and "list returns", new writes
+may land. Those are visible in the new `listRv`. The watch resumes from
+`listRv`, so the gap is closed by construction (same handshake guarantee
+as #292's `watch.race.test.ts`).
+
+## Testing strategy
+
+### Unit — `src/core/watch-hub.compaction.test.ts` (new)
+
+- `evictedByAge` increments when an event is trimmed via `now() > insertedAt + maxAgeMs` (inject fake `now`).
+- `evictedByCapacity` increments when ring exceeds `maxEventsPerKey`.
+- `getCompactionStats()` returns one entry per active `(ns, kind)`, with
+  correct `currentRingSize`, `oldestRv`, `currentRv`. Bigint serialized as
+  decimal string.
+- Stats persist across `subscribe`/`unsubscribe` cycles.
+- `currentRv` reflects total writes ever, not ring size.
+- Empty `(ns, kind)` (counter created but ring empty) reports `currentRingSize: 0` and `oldestRv: "0"`.
+
+### Unit — `src/core/watch-client.test.ts` (new)
+
+Inject mock `fetch` + mock `EventSource`. No real network.
+
+- **Happy path**: list returns 3 items → 3 `RELIST` events → watch streams
+  `ADDED` → forwarded as `op:"ADDED"` to `onEvent`.
+- **410 → relist**: watch emits `ERROR{code:410}` → client reissues
+  `GET /api/list` → fires fresh `RELIST` events → reopens watch.
+- **503 → relist**: same as 410.
+- **TCP close, no error event**: client reopens watch from last `rv` (no relist).
+- **Backoff schedule**: 3 consecutive failures → delays follow exponential
+  schedule (deterministic with seeded jitter).
+- **Backoff reset on success**: failure → success → next failure starts at `minMs`.
+- **Backoff reset on 410**: relist is a fresh start.
+- **`onEvent` awaited sequentially**: slow async `onEvent` blocks subsequent
+  dispatch until resolved.
+- **Abort during in-flight `onEvent`**: `signal.abort()` mid-callback →
+  `run()` resolves after callback settles, no events dispatched after abort.
+- **Terminal 401**: `run()` rejects; no relist loop.
+- **Terminal 501**: same.
+- **Malformed SSE 5×**: terminal error.
+
+### Unit — `src/util/clamp.test.ts` (new)
+
+- Unparseable returns fallback + warns.
+- Below min returns fallback + warns.
+- Above max returns fallback + warns.
+- Within range returns parsed.
+- Empty / undefined returns fallback (no warn — env unset is normal).
+
+### Integration — `src/server/watch.compaction.test.ts` (new)
+
+Real `WatchHub`, tiny config (`maxAgeMsPerKey: 200`, `maxEventsPerKey: 4`).
+
+- **Sleep past retention** (acceptance #1): write event at rv=1, advance
+  fake clock past retention, write more events → `GET /api/watch?resumeFrom=1`
+  → SSE `ERROR{code:410, reason:"expired"}`, stream closes.
+- **Capacity-based eviction**: write 10 events into a 4-event ring →
+  `resumeFrom=1` → 410.
+- **Metrics endpoint** (acceptance #4): after evictions,
+  `GET /api/watch/metrics` returns `evictedByAge` ≥ 1 and
+  `evictedByCapacity` ≥ 1, plus `retention.maxAgeMs` and
+  `retention.maxEvents` matching boot config.
+- **Metrics namespace isolation**: namespace A's metrics endpoint doesn't
+  see namespace B's keys.
+- **Env-var config**: with `GROVE_WATCH_RETENTION_MS=1000` set,
+  `GET /api/watch/metrics` reports `retention.maxAgeMs: 1000`.
+- **Env-var clamping**: `GROVE_WATCH_RETENTION_MS=-5` falls back to default
+  + logs warning.
+
+### E2E — `src/server/watch.relist.e2e.test.ts` (new) (acceptance #2)
+
+Real `WatchClient` against an in-process Hono test server.
+
+```typescript
+test("client relists across retention gap with no missed events", async () => {
+  const server = await startTestServer({
+    watchRetentionMs: 100,
+    watchMaxEvents: 4,
+  });
+  const seen: WatchClientEvent[] = [];
+  const client = new WatchClient({
+    baseUrl: server.url,
+    kind: "Contribution",
+    authHeader: server.authHeader,
+  });
+  const ac = new AbortController();
+  const running = client.run({
+    onEvent: async (e) => { seen.push(e); },
+    signal: ac.signal,
+  });
+
+  // Phase 1: write 3 events, observe via watch.
+  await postContribution(server, "a");
+  await postContribution(server, "b");
+  await postContribution(server, "c");
+  await waitFor(() => seen.filter(e => e.op === "ADDED").length === 3);
+
+  // Phase 2: simulate kill -9 + sleep past retention.
+  await server.pauseClient(client);  // intercept fetch with 503 mid-stream
+  await advanceClock(server, 500);   // > 100ms retention
+  await postContribution(server, "d");
+  await postContribution(server, "e");
+
+  // Phase 3: resume client → must relist + cover the gap.
+  await server.resumeClient(client);
+  await waitFor(() => seen.filter(e => e.entity.id === "e").length >= 1);
+
+  // Every contribution surfaced. RELIST may repeat ids that ADDED already
+  // delivered — consumer reconciles via id+rv.
+  const ids = new Set(seen.map(e => e.entity.id));
+  expect(ids).toEqual(new Set(["a","b","c","d","e"]));
+  expect(seen.some(e => e.op === "RELIST")).toBe(true);
+
+  ac.abort();
+  await running;
+});
+```
+
+Plumbing notes:
+- WatchHub's `now` is already injectable; bookmark interval is the real
+  timer. Test uses short bookmark (50ms) and short retention (100ms) so
+  wallclock time suffices — no fake `setInterval` needed.
+- `pauseClient` injects a fetch wrapper that returns 503 between
+  pause/resume to emulate disconnect.
+- Real Sqlite + real Hono. No mocked stores.
+
+### Manual smoke
+
+```sh
+GROVE_WATCH_RETENTION_MS=5000 grove-server start
+sleep 6
+curl -N "${GROVE_URL}/api/watch?kind=Contribution&resumeFrom=1" \
+  -H "Authorization: Bearer ${GROVE_TOKEN}"
+# → expects: event: ERROR\ndata: {"code":410,"reason":"expired"}
+```
+
+## File changes summary
+
+**New**:
+- `src/core/watch-client.ts`
+- `src/core/watch-client.test.ts`
+- `src/core/watch-hub.compaction.test.ts`
+- `src/server/watch.compaction.test.ts`
+- `src/server/watch.relist.e2e.test.ts`
+- `src/util/clamp.ts`
+- `src/util/clamp.test.ts`
+
+**Modified**:
+- `src/core/watch-hub.ts` — add compaction counters, `getCompactionStats()`,
+  promote `maxAgeMsPerKey` / `maxEventsPerKey` to public.
+- `src/core/watch-events.ts` — no change (`StaleResourceVersionError`
+  already covers both stale-low and stale-high cases).
+- `src/server/routes/watch.ts` — add `GET /api/watch/metrics`.
+- `src/server/serve.ts` — read `GROVE_WATCH_RETENTION_MS` /
+  `GROVE_WATCH_MAX_EVENTS`, clamp, pass to `WatchHub`.
+- `docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md` —
+  resolve "Open questions deferred" compaction entry.
+- `docs/parity-matrix.md` — document retention + metrics endpoint.
+
+## Acceptance traceability
+
+| Issue criterion | Where covered |
+|-----------------|---------------|
+| Sleep past retention window → resume returns `Expired` | `watch.compaction.test.ts` "sleep past retention" |
+| Client relists via A5 handshake automatically → no events missed | `watch.relist.e2e.test.ts` |
+| Retention window configurable + documented | env vars in `serve.ts`, `parity-matrix.md`, this design |
+| Compaction metric exposed | `GET /api/watch/metrics` + `getCompactionStats()` |
+
+## Open questions deferred
+
+- **Per-kind retention**: today `maxAgeMs` / `maxEvents` are global to the
+  `WatchHub`. If `Claim` watchers see 100× the rate of `Contribution`, the
+  Claim ring will evict aggressively while Contribution barely uses its
+  capacity. Per-kind tuning is a future ops knob — out of scope for #293.
+- **Retention SLO surfaced to clients**: `GET /api/watch/metrics` exposes
+  the configured retention but not a "how often did we evict in the last
+  N minutes" rate. A future histogram or rate counter would help ops alert
+  on chronic relist storms. Defer until #294 informers reveal the access
+  patterns.
+- **Prometheus scrape format**: defer until ops asks. JSON satisfies the
+  acceptance criterion today.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "nexus:up": "docker compose up nexus -d",
     "nexus:down": "docker compose down",
     "check": "biome check .",
-    "postinstall": "bun run --cwd packages/ask-user build && bun ./scripts/install-hooks.mjs"
+    "postinstall": "bun run --cwd packages/ask-user build && bun ./scripts/install-hooks.mjs",
+    "smoke:watch-relist": "bun run tests/e2e/watch-relist-tmux.ts"
   },
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.30.0",

--- a/src/core/clamp.test.ts
+++ b/src/core/clamp.test.ts
@@ -3,64 +3,46 @@ import { clampInt } from "./clamp.js";
 
 describe("clampInt", () => {
   test("returns parsed value when within range", () => {
-    expect(
-      clampInt({ raw: "5000", fallback: 100, min: 1, max: 10_000, name: "X" }),
-    ).toBe(5000);
+    expect(clampInt({ raw: "5000", fallback: 100, min: 1, max: 10_000, name: "X" })).toBe(5000);
   });
 
   test("returns fallback when raw is undefined", () => {
     const warn = mock(() => {});
-    expect(
-      clampInt({ raw: undefined, fallback: 42, min: 1, max: 100, name: "X", warn }),
-    ).toBe(42);
+    expect(clampInt({ raw: undefined, fallback: 42, min: 1, max: 100, name: "X", warn })).toBe(42);
     expect(warn.mock.calls.length).toBe(0); // unset is normal, no warn
   });
 
   test("returns fallback when raw is empty string", () => {
-    expect(
-      clampInt({ raw: "", fallback: 7, min: 1, max: 100, name: "X" }),
-    ).toBe(7);
+    expect(clampInt({ raw: "", fallback: 7, min: 1, max: 100, name: "X" })).toBe(7);
   });
 
   test("warns and returns fallback when raw is unparseable", () => {
     const warn = mock(() => {});
-    expect(
-      clampInt({ raw: "abc", fallback: 9, min: 1, max: 100, name: "Y", warn }),
-    ).toBe(9);
+    expect(clampInt({ raw: "abc", fallback: 9, min: 1, max: 100, name: "Y", warn })).toBe(9);
     expect(warn.mock.calls.length).toBe(1);
     expect(String(warn.mock.calls[0]?.[0])).toContain("Y");
   });
 
   test("warns and returns fallback when raw is below min", () => {
     const warn = mock(() => {});
-    expect(
-      clampInt({ raw: "0", fallback: 10, min: 1, max: 100, name: "Z", warn }),
-    ).toBe(10);
+    expect(clampInt({ raw: "0", fallback: 10, min: 1, max: 100, name: "Z", warn })).toBe(10);
     expect(warn.mock.calls.length).toBe(1);
   });
 
   test("warns and returns fallback when raw is above max", () => {
     const warn = mock(() => {});
-    expect(
-      clampInt({ raw: "999", fallback: 10, min: 1, max: 100, name: "Z", warn }),
-    ).toBe(10);
+    expect(clampInt({ raw: "999", fallback: 10, min: 1, max: 100, name: "Z", warn })).toBe(10);
     expect(warn.mock.calls.length).toBe(1);
   });
 
   test("rejects fractional input", () => {
     const warn = mock(() => {});
-    expect(
-      clampInt({ raw: "1.5", fallback: 2, min: 1, max: 100, name: "F", warn }),
-    ).toBe(2);
+    expect(clampInt({ raw: "1.5", fallback: 2, min: 1, max: 100, name: "F", warn })).toBe(2);
     expect(warn.mock.calls.length).toBe(1);
   });
 
   test("accepts boundary values", () => {
-    expect(
-      clampInt({ raw: "1", fallback: 5, min: 1, max: 100, name: "B" }),
-    ).toBe(1);
-    expect(
-      clampInt({ raw: "100", fallback: 5, min: 1, max: 100, name: "B" }),
-    ).toBe(100);
+    expect(clampInt({ raw: "1", fallback: 5, min: 1, max: 100, name: "B" })).toBe(1);
+    expect(clampInt({ raw: "100", fallback: 5, min: 1, max: 100, name: "B" })).toBe(100);
   });
 });

--- a/src/core/clamp.test.ts
+++ b/src/core/clamp.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, mock, test } from "bun:test";
+import { clampInt } from "./clamp.js";
+
+describe("clampInt", () => {
+  test("returns parsed value when within range", () => {
+    expect(
+      clampInt({ raw: "5000", fallback: 100, min: 1, max: 10_000, name: "X" }),
+    ).toBe(5000);
+  });
+
+  test("returns fallback when raw is undefined", () => {
+    const warn = mock(() => {});
+    expect(
+      clampInt({ raw: undefined, fallback: 42, min: 1, max: 100, name: "X", warn }),
+    ).toBe(42);
+    expect(warn.mock.calls.length).toBe(0); // unset is normal, no warn
+  });
+
+  test("returns fallback when raw is empty string", () => {
+    expect(
+      clampInt({ raw: "", fallback: 7, min: 1, max: 100, name: "X" }),
+    ).toBe(7);
+  });
+
+  test("warns and returns fallback when raw is unparseable", () => {
+    const warn = mock(() => {});
+    expect(
+      clampInt({ raw: "abc", fallback: 9, min: 1, max: 100, name: "Y", warn }),
+    ).toBe(9);
+    expect(warn.mock.calls.length).toBe(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain("Y");
+  });
+
+  test("warns and returns fallback when raw is below min", () => {
+    const warn = mock(() => {});
+    expect(
+      clampInt({ raw: "0", fallback: 10, min: 1, max: 100, name: "Z", warn }),
+    ).toBe(10);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  test("warns and returns fallback when raw is above max", () => {
+    const warn = mock(() => {});
+    expect(
+      clampInt({ raw: "999", fallback: 10, min: 1, max: 100, name: "Z", warn }),
+    ).toBe(10);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  test("rejects fractional input", () => {
+    const warn = mock(() => {});
+    expect(
+      clampInt({ raw: "1.5", fallback: 2, min: 1, max: 100, name: "F", warn }),
+    ).toBe(2);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  test("accepts boundary values", () => {
+    expect(
+      clampInt({ raw: "1", fallback: 5, min: 1, max: 100, name: "B" }),
+    ).toBe(1);
+    expect(
+      clampInt({ raw: "100", fallback: 5, min: 1, max: 100, name: "B" }),
+    ).toBe(100);
+  });
+});

--- a/src/core/clamp.test.ts
+++ b/src/core/clamp.test.ts
@@ -20,7 +20,7 @@ describe("clampInt", () => {
     const warn = mock(() => {});
     expect(clampInt({ raw: "abc", fallback: 9, min: 1, max: 100, name: "Y", warn })).toBe(9);
     expect(warn.mock.calls.length).toBe(1);
-    expect(String(warn.mock.calls[0]?.[0])).toContain("Y");
+    expect(String((warn.mock.calls as unknown as unknown[][])[0]?.[0])).toContain("Y");
   });
 
   test("warns and returns fallback when raw is below min", () => {

--- a/src/core/clamp.ts
+++ b/src/core/clamp.ts
@@ -1,0 +1,37 @@
+/**
+ * Parse an integer env var with bounds. Used at server boot so a stray
+ * `GROVE_WATCH_RETENTION_MS=-5` falls back to the documented default
+ * instead of silently disabling retention.
+ */
+
+export interface ClampIntArgs {
+  readonly raw: string | undefined;
+  readonly fallback: number;
+  readonly min: number;
+  readonly max: number;
+  readonly name: string;
+  readonly warn?: (msg: string) => void;
+}
+
+export function clampInt({
+  raw,
+  fallback,
+  min,
+  max,
+  name,
+  warn = (msg) => console.warn(msg),
+}: ClampIntArgs): number {
+  if (raw === undefined || raw === "") return fallback;
+  if (!/^-?[0-9]+$/.test(raw)) {
+    warn(`${name}=${raw} is not an integer; using fallback ${fallback}`);
+    return fallback;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (n < min || n > max) {
+    warn(
+      `${name}=${n} is outside [${min}, ${max}]; using fallback ${fallback}`,
+    );
+    return fallback;
+  }
+  return n;
+}

--- a/src/core/clamp.ts
+++ b/src/core/clamp.ts
@@ -28,9 +28,7 @@ export function clampInt({
   }
   const n = Number.parseInt(raw, 10);
   if (n < min || n > max) {
-    warn(
-      `${name}=${n} is outside [${min}, ${max}]; using fallback ${fallback}`,
-    );
+    warn(`${name}=${n} is outside [${min}, ${max}]; using fallback ${fallback}`);
     return fallback;
   }
   return n;

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -437,6 +437,176 @@ describe("WatchClient fast resume on TCP close", () => {
   });
 });
 
+describe("WatchClient snapshot dedup (list/watch race)", () => {
+  // The dedup uses entity.id + entity.resourceVersion (per ContributionEntity).
+  // Local fixtures shaped like real entities so the dedup keys exist.
+  const E_A = { id: "cid-a", resourceVersion: "0", spec: { summary: "a" } };
+  const E_B = { id: "cid-b", resourceVersion: "0", spec: { summary: "b" } };
+
+  /**
+   * Watch fetcher that returns one canned watch body, then aborts the run
+   * on the next watch call. This prevents the loop from spinning when the
+   * scripted fetch is exhausted (which would otherwise hammer the
+   * fast-resume path forever via the transport-error catch).
+   */
+  function singleWatchThenAbort(
+    listJson: unknown,
+    watchBody: string,
+    ac: AbortController,
+  ): typeof fetch {
+    let watchCalls = 0;
+    return (async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/list")) {
+        return new Response(JSON.stringify(listJson), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.includes("/api/watch")) {
+        watchCalls += 1;
+        if (watchCalls === 1) {
+          return new Response(watchBody, {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        }
+        // Subsequent watch attempts: signal end, abort the run.
+        ac.abort();
+        return new Response("", { headers: { "Content-Type": "text/event-stream" } });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+  }
+
+  test("ADDED with same (id, resourceVersion) as a snapshot item is suppressed", async () => {
+    const seen: WatchClientEvent[] = [];
+    // E_A is in the snapshot at listRv=5 with resourceVersion "0".
+    // The watch then replays an ADDED for the same entity at watch-rv=6
+    // (the race-window duplicate). It must not surface as ADDED.
+    const ac = new AbortController();
+    const fetchImpl = singleWatchThenAbort(
+      { items: [E_A], listResourceVersion: "5" },
+      sse("ADDED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
+      ac,
+    );
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+      },
+      signal: ac.signal,
+    });
+    await running;
+    // RELIST_BEGIN, RELIST(A), RELIST_END — and crucially NO ADDED for A.
+    const ops = seen.map((e) => e.op);
+    expect(ops).toEqual(["RELIST_BEGIN", "RELIST", "RELIST_END"]);
+    expect(seen.some((e) => e.op === "ADDED")).toBe(false);
+  });
+
+  test("MODIFIED with different resourceVersion (real update) is forwarded", async () => {
+    const seen: WatchClientEvent[] = [];
+    // Snapshot has E_A at resourceVersion "0". Watch sends a MODIFIED
+    // with resourceVersion "1" — a real update, NOT a snapshot replay.
+    const updatedA = { ...E_A, resourceVersion: "1" };
+    const ac = new AbortController();
+    const fetchImpl = singleWatchThenAbort(
+      { items: [E_A], listResourceVersion: "5" },
+      sse("MODIFIED", { rv: "6", kind: "Contribution", entity: updatedA }, "6"),
+      ac,
+    );
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await client.run({ onEvent: (e) => seen.push(e), signal: ac.signal });
+    const modified = seen.find((e) => e.op === "MODIFIED");
+    expect(modified).toBeDefined();
+    expect((modified?.entity as { resourceVersion: string }).resourceVersion).toBe("1");
+  });
+
+  test("DELETED for snapshot entity is forwarded (never deduped)", async () => {
+    const seen: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    const fetchImpl = singleWatchThenAbort(
+      { items: [E_A], listResourceVersion: "5" },
+      sse("DELETED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
+      ac,
+    );
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await client.run({ onEvent: (e) => seen.push(e), signal: ac.signal });
+    expect(seen.some((e) => e.op === "DELETED")).toBe(true);
+  });
+
+  test("dedup window is reset on every RELIST snapshot", async () => {
+    // Round 1: snapshot has A. Round 2 (after relist): snapshot has only B
+    // (A no longer present). A subsequent ADDED for A at the SAME
+    // resourceVersion must NOT be deduped — A is not in the new window.
+    const seen: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    let listCalls = 0;
+    let watchCalls = 0;
+    const fetchImpl: typeof fetch = (async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/list")) {
+        listCalls += 1;
+        const body =
+          listCalls === 1
+            ? { items: [E_A], listResourceVersion: "5" }
+            : { items: [E_B], listResourceVersion: "10" };
+        return new Response(JSON.stringify(body), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.includes("/api/watch")) {
+        watchCalls += 1;
+        if (watchCalls === 1) {
+          // First watch: 410 → triggers relist for round 2.
+          return new Response(sse("ERROR", { code: 410 }, "5"), {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        }
+        if (watchCalls === 2) {
+          // Second watch: ADDED for A. After round-2 relist, A is NOT in
+          // the snapshot window, so this must surface (no dedup).
+          return new Response(
+            sse("ADDED", { rv: "11", kind: "Contribution", entity: E_A }, "11"),
+            { headers: { "Content-Type": "text/event-stream" } },
+          );
+        }
+        ac.abort();
+        return new Response("", { headers: { "Content-Type": "text/event-stream" } });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await client.run({ onEvent: (e) => seen.push(e), signal: ac.signal });
+    const addedA = seen.find(
+      (e) => e.op === "ADDED" && (e.entity as { id: string } | null)?.id === "cid-a",
+    );
+    expect(addedA).toBeDefined();
+  });
+});
+
 describe("WatchClient terminal errors", () => {
   test("rejects on HTTP 401 from list", async () => {
     const fetchImpl = (async () =>

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -308,3 +308,66 @@ describe("WatchClient fast resume on TCP close", () => {
     }
   });
 });
+
+describe("WatchClient onEvent semantics", () => {
+  test("awaits each onEvent before processing the next", async () => {
+    const order: string[] = [];
+    let resolveFirst: (() => void) | undefined;
+    const firstDone = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+    const fetchImpl = makeFetch({ items: [], listResourceVersion: "5" }, [
+      sse("ADDED", { rv: "6", kind: "Contribution", entity: ENTITY_A }, "6"),
+      sse("ADDED", { rv: "7", kind: "Contribution", entity: ENTITY_B }, "7"),
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const running = client.run({
+      onEvent: async (e) => {
+        order.push(`enter:${e.rv}`);
+        if (e.rv === 6n) await firstDone;
+        order.push(`exit:${e.rv}`);
+        if (e.rv === 7n) ac.abort();
+      },
+      signal: ac.signal,
+    });
+    // Give the loop a tick to enter onEvent for rv=6.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(order).toEqual(["enter:6"]);
+    resolveFirst?.();
+    await running;
+    expect(order).toEqual(["enter:6", "exit:6", "enter:7", "exit:7"]);
+  });
+
+  test("abort during in-flight onEvent waits for callback to settle", async () => {
+    let callbackResolved = false;
+    let onEventEntered = false;
+    const fetchImpl = makeFetch({ items: [ENTITY_A], listResourceVersion: "5" }, []);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const running = client.run({
+      onEvent: async () => {
+        onEventEntered = true;
+        ac.abort(); // abort while we are inside onEvent
+        await new Promise((r) => setTimeout(r, 20));
+        callbackResolved = true;
+      },
+      signal: ac.signal,
+    });
+    await running;
+    expect(onEventEntered).toBe(true);
+    expect(callbackResolved).toBe(true);
+  });
+});

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -872,6 +872,40 @@ describe("WatchClient list-phase transient failures", () => {
     expect(listCalls).toBeGreaterThanOrEqual(3);
   });
 
+  test("HTTP 501 NOT_CONFIGURED on /api/list is terminal (not retried forever)", async () => {
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", body: "", status: 501 },
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(client.run({ onEvent: () => undefined, signal: ac.signal })).rejects.toThrow(
+      /501|list failed/,
+    );
+  });
+
+  test("HTTP 500 on /api/list is terminal (configuration/server bug)", async () => {
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", body: "", status: 500 },
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(client.run({ onEvent: () => undefined, signal: ac.signal })).rejects.toThrow(
+      /500|list failed/,
+    );
+  });
+
   test("HTTP 4xx on /api/list (other than auth-style) is still terminal", async () => {
     // 400 is a server contract error — retrying would loop forever.
     const fetchImpl = scriptedFetch([

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -166,13 +166,15 @@ describe("WatchClient relist on 410", () => {
 
   test("backoff sleeps between attempts when minMs > 0", async () => {
     const sleeps: number[] = [];
+    // Use TCP-close (empty SSE body, no ERROR frame) to drive the exponential
+    // ladder. The 410 path resets backoff per spec ("relist is a clean slate").
     const fetchImpl = scriptedFetch([
       { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
-      { urlPattern: "/api/watch", body: sse("ERROR", { code: 410 }, "0") },
+      { urlPattern: "/api/watch", body: "" },
       { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
-      { urlPattern: "/api/watch", body: sse("ERROR", { code: 410 }, "0") },
+      { urlPattern: "/api/watch", body: "" },
       { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
-      { urlPattern: "/api/watch", body: sse("ERROR", { code: 410 }, "0") },
+      { urlPattern: "/api/watch", body: "" },
       { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
       { urlPattern: "/api/watch", body: "" },
     ]);
@@ -190,5 +192,34 @@ describe("WatchClient relist on 410", () => {
     };
     await client.run({ onEvent: () => {}, signal: ac.signal });
     expect(sleeps).toEqual([10, 20, 40]);
+  });
+
+  test("ERROR{code:410} resets backoff (relist is a clean slate)", async () => {
+    const sleeps: number[] = [];
+    // Two TCP-close cycles climb backoff to 20ms, then a 410 should reset to 10ms.
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: "" }, // ended → sleep(10), advance to 20
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: "" }, // ended → sleep(20), advance to 40
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: sse("ERROR", { code: 410 }, "0") }, // 410 → reset, sleep(10)
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: "" }, // never reached
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 10, maxMs: 100, jitter: 0 },
+    });
+    (client as unknown as { onBackoff?: (ms: number) => void }).onBackoff = (ms: number) => {
+      sleeps.push(ms);
+      if (sleeps.length >= 3) ac.abort();
+    };
+    await client.run({ onEvent: () => {}, signal: ac.signal });
+    expect(sleeps).toEqual([10, 20, 10]);
   });
 });

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -167,16 +167,14 @@ describe("WatchClient relist on 410", () => {
   test("backoff sleeps between attempts when minMs > 0", async () => {
     const sleeps: number[] = [];
     // Use TCP-close (empty SSE body, no ERROR frame) to drive the exponential
-    // ladder. The 410 path resets backoff per spec ("relist is a clean slate").
+    // ladder. With fast-resume, ended cycles skip the list and go straight to
+    // the next watch. One initial list, then repeated watch-only cycles.
     const fetchImpl = scriptedFetch([
       { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
-      { urlPattern: "/api/watch", body: "" },
-      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
-      { urlPattern: "/api/watch", body: "" },
-      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
-      { urlPattern: "/api/watch", body: "" },
-      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
-      { urlPattern: "/api/watch", body: "" },
+      { urlPattern: "/api/watch", body: "" }, // ended → sleep(10), advance to 20
+      { urlPattern: "/api/watch", body: "" }, // ended → sleep(20), advance to 40
+      { urlPattern: "/api/watch", body: "" }, // ended → sleep(40), advance to 80
+      { urlPattern: "/api/watch", body: "" }, // never reached
     ]);
     const ac = new AbortController();
     const client = new WatchClient({
@@ -197,12 +195,11 @@ describe("WatchClient relist on 410", () => {
   test("ERROR{code:410} resets backoff (relist is a clean slate)", async () => {
     const sleeps: number[] = [];
     // Two TCP-close cycles climb backoff to 20ms, then a 410 should reset to 10ms.
+    // With fast-resume, ended cycles skip the list — only the 410 triggers a relist.
     const fetchImpl = scriptedFetch([
       { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
       { urlPattern: "/api/watch", body: "" }, // ended → sleep(10), advance to 20
-      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
       { urlPattern: "/api/watch", body: "" }, // ended → sleep(20), advance to 40
-      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
       { urlPattern: "/api/watch", body: sse("ERROR", { code: 410 }, "0") }, // 410 → reset, sleep(10)
       { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
       { urlPattern: "/api/watch", body: "" }, // never reached
@@ -221,5 +218,93 @@ describe("WatchClient relist on 410", () => {
     };
     await client.run({ onEvent: () => {}, signal: ac.signal });
     expect(sleeps).toEqual([10, 20, 10]);
+  });
+});
+
+describe("WatchClient fast resume on TCP close", () => {
+  test("reopens watch from last-seen rv after stream ends without ERROR", async () => {
+    const seen: WatchClientEvent[] = [];
+    const watchUrls: string[] = [];
+    const ac = new AbortController();
+    const fetchImpl = (async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/list")) {
+        return new Response(JSON.stringify({ items: [], listResourceVersion: "5" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.includes("/api/watch")) {
+        watchUrls.push(url);
+        if (watchUrls.length === 1) {
+          // First watch: emit ADDED rv=6 then end.
+          return new Response(
+            sse("ADDED", { rv: "6", kind: "Contribution", entity: ENTITY_A }, "6"),
+            { headers: { "Content-Type": "text/event-stream" } },
+          );
+        }
+        // Second watch observed → fire abort so the loop unwinds.
+        ac.abort();
+        return new Response("", {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      throw new Error(`unexpected ${url}`);
+    }) as typeof fetch;
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+      },
+      signal: ac.signal,
+    });
+    await running;
+
+    expect(watchUrls.length).toBeGreaterThanOrEqual(2);
+    // First watch resumes from listRv=5; second resumes from last-seen rv=6.
+    expect(watchUrls[0]).toContain("resumeFrom=5");
+    expect(watchUrls[1]).toContain("resumeFrom=6");
+    expect(seen.filter((e) => e.op === "RELIST").length).toBe(0); // no relist
+  });
+
+  test("first ended-without-event uses listRv as resumeFrom", async () => {
+    const ac = new AbortController();
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "5" } },
+      { urlPattern: "/api/watch", body: "" }, // ended → fast resume from rv=5
+      { urlPattern: "/api/watch", body: "" }, // ended → fast resume from rv=5 again
+      { urlPattern: "/api/watch", body: "" }, // third watch → abort
+    ]);
+    // Override: wrap scriptedFetch to capture urls and abort on third watch
+    const watchUrls: string[] = [];
+    const wrappedFetch: typeof fetch = (async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/watch")) {
+        watchUrls.push(url);
+        if (watchUrls.length >= 3) ac.abort();
+      }
+      return fetchImpl(input, init);
+    }) as typeof fetch;
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: wrappedFetch,
+      backoff: { minMs: 1, maxMs: 1, jitter: 0 },
+    });
+    await client.run({
+      onEvent: () => undefined,
+      signal: ac.signal,
+    });
+
+    expect(watchUrls.length).toBeGreaterThanOrEqual(2);
+    for (const u of watchUrls) {
+      expect(u).toContain("resumeFrom=5");
+    }
   });
 });

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -62,7 +62,7 @@ describe("WatchClient happy path", () => {
     expect(seen.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST", "RELIST_END", "ADDED"]);
     expect(seen[0]?.entity).toBeNull();
     expect(seen[0]?.rv).toBe(5n);
-    expect((seen[1]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-a");
+    expect((seen[1]?.entity as unknown as { envelope: { id: string } }).envelope.id).toBe("cid-a");
     expect(seen[1]?.rv).toBe(5n);
     expect(seen[2]?.entity).toBeNull();
     expect(seen[2]?.rv).toBe(5n);
@@ -153,8 +153,8 @@ describe("WatchClient relist on 410", () => {
 
     const relists = seen.filter((s) => s.op === "RELIST");
     expect(relists.length).toBe(2);
-    expect((relists[0]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-a");
-    expect((relists[1]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-b");
+    expect((relists[0]?.entity as unknown as { envelope: { id: string } }).envelope.id).toBe("cid-a");
+    expect((relists[1]?.entity as unknown as { envelope: { id: string } }).envelope.id).toBe("cid-b");
     expect(relists[1]?.rv).toBe(10n);
   });
 
@@ -306,7 +306,7 @@ describe("WatchClient relist on 410", () => {
     const running = client.run({
       onEvent: async (e) => {
         seen.push(e);
-        if (e.op === "RELIST" && (e.entity as { envelope: { id: string } }).envelope.id === "cid-b")
+        if (e.op === "RELIST" && (e.entity as unknown as { envelope: { id: string } }).envelope.id === "cid-b")
           ac.abort();
       },
       signal: ac.signal,
@@ -317,7 +317,7 @@ describe("WatchClient relist on 410", () => {
     expect(dataOps.length).toBe(0);
     const relists = seen.filter((e) => e.op === "RELIST");
     expect(relists.length).toBe(1);
-    expect((relists[0]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-b");
+    expect((relists[0]?.entity as unknown as { envelope: { id: string } }).envelope.id).toBe("cid-b");
   });
 
   test("ERROR{code:410} resets backoff (relist is a clean slate)", async () => {
@@ -677,7 +677,7 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
       fetch: fetchImpl,
       backoff: { minMs: 0, maxMs: 0, jitter: 0 },
     });
-    await client.run({ onEvent: (e) => seen.push(e), signal: ac.signal });
+    await client.run({ onEvent: (e) => { seen.push(e); }, signal: ac.signal });
     const modified = seen.find((e) => e.op === "MODIFIED");
     expect(modified).toBeDefined();
     expect((modified?.entity as { resourceVersion: string }).resourceVersion).toBe("1");
@@ -698,7 +698,7 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
       fetch: fetchImpl,
       backoff: { minMs: 0, maxMs: 0, jitter: 0 },
     });
-    await client.run({ onEvent: (e) => seen.push(e), signal: ac.signal });
+    await client.run({ onEvent: (e) => { seen.push(e); }, signal: ac.signal });
     expect(seen.some((e) => e.op === "DELETED")).toBe(true);
   });
 
@@ -730,7 +730,7 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
       fetch: fetchImpl,
       backoff: { minMs: 0, maxMs: 0, jitter: 0 },
     });
-    await client.run({ onEvent: (e) => seen.push(e), signal: ac.signal });
+    await client.run({ onEvent: (e) => { seen.push(e); }, signal: ac.signal });
     // Only the snapshot RELIST should surface for entity X. No ADDED
     // events for either the stale version-2 or duplicate version-3 frame.
     const dataOps = seen.filter((e) => e.op === "ADDED" || e.op === "MODIFIED");
@@ -757,7 +757,7 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
       fetch: fetchImpl,
       backoff: { minMs: 0, maxMs: 0, jitter: 0 },
     });
-    await client.run({ onEvent: (e) => seen.push(e), signal: ac.signal });
+    await client.run({ onEvent: (e) => { seen.push(e); }, signal: ac.signal });
     expect(seen.some((e) => e.op === "MODIFIED")).toBe(true);
   });
 
@@ -808,7 +808,7 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
       fetch: fetchImpl,
       backoff: { minMs: 0, maxMs: 0, jitter: 0 },
     });
-    await client.run({ onEvent: (e) => seen.push(e), signal: ac.signal });
+    await client.run({ onEvent: (e) => { seen.push(e); }, signal: ac.signal });
     const addedA = seen.find(
       (e) => e.op === "ADDED" && (e.entity as { id: string } | null)?.id === "cid-a",
     );
@@ -822,7 +822,7 @@ describe("WatchClient terminal errors", () => {
       new Response(JSON.stringify({ code: "UNAUTHENTICATED" }), {
         status: 401,
         headers: { "Content-Type": "application/json" },
-      })) as typeof fetch;
+      })) as unknown as typeof fetch;
     const ac = new AbortController();
     const client = new WatchClient({
       baseUrl: "http://t",

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -38,7 +38,7 @@ function sse(event: string, data: unknown, id?: string): string {
 }
 
 describe("WatchClient happy path", () => {
-  test("emits RELIST for each list item then ADDED for streamed events", async () => {
+  test("emits RELIST_BEGIN, RELIST per item, RELIST_END, then data ops", async () => {
     const seen: WatchClientEvent[] = [];
     const fetchImpl = makeFetch({ items: [ENTITY_A], listResourceVersion: "5" }, [
       sse("ADDED", { rv: "6", kind: "Contribution", entity: ENTITY_B }, "6"),
@@ -53,18 +53,43 @@ describe("WatchClient happy path", () => {
     const running = client.run({
       onEvent: async (e) => {
         seen.push(e);
-        if (seen.length === 2) ac.abort();
+        if (e.op === "ADDED") ac.abort();
       },
       signal: ac.signal,
     });
     await running;
 
-    expect(seen.length).toBe(2);
-    expect(seen[0]?.op).toBe("RELIST");
+    expect(seen.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST", "RELIST_END", "ADDED"]);
+    expect(seen[0]?.entity).toBeNull();
     expect(seen[0]?.rv).toBe(5n);
-    expect((seen[0]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-a");
-    expect(seen[1]?.op).toBe("ADDED");
-    expect(seen[1]?.rv).toBe(6n);
+    expect((seen[1]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-a");
+    expect(seen[1]?.rv).toBe(5n);
+    expect(seen[2]?.entity).toBeNull();
+    expect(seen[2]?.rv).toBe(5n);
+    expect(seen[3]?.op).toBe("ADDED");
+    expect(seen[3]?.rv).toBe(6n);
+  });
+
+  test("empty snapshot still emits RELIST_BEGIN + RELIST_END (no items in between)", async () => {
+    const seen: WatchClientEvent[] = [];
+    const fetchImpl = makeFetch({ items: [], listResourceVersion: "5" }, [
+      sse("ADDED", { rv: "6", kind: "Contribution", entity: ENTITY_A }, "6"),
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+    });
+    await client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+        if (e.op === "ADDED") ac.abort();
+      },
+      signal: ac.signal,
+    });
+    expect(seen.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST_END", "ADDED"]);
   });
 });
 
@@ -251,16 +276,23 @@ describe("WatchClient relist on 410", () => {
     expect(seen.filter((s) => s.op === "RELIST").length).toBe(2);
   });
 
-  test("malformed rv on data event is dropped, run continues", async () => {
+  test("malformed data frame forces relist (BOOKMARK cannot ack past skipped event)", async () => {
     const seen: WatchClientEvent[] = [];
+    // Stream 1: malformed ADDED (no rv) followed by BOOKMARK rv=99. Without
+    // the relist policy, BOOKMARK would silently advance lastRv past the
+    // dropped data event. The expected behavior is to relist immediately.
     const fetchImpl = scriptedFetch([
       { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
       {
         urlPattern: "/api/watch",
-        body:
-          sse("ADDED", { rv: "not-a-number", kind: "Contribution", entity: ENTITY_A }, "1") +
-          sse("ADDED", { rv: "2", kind: "Contribution", entity: ENTITY_B }, "2"),
+        body: `${sse(
+          "ADDED",
+          { rv: "not-a-number", kind: "Contribution", entity: ENTITY_A },
+          "1",
+        )}${sse("BOOKMARK", { rv: "99" }, "99")}`,
       },
+      // After relist, list returns ENTITY_B at rv=2 → assert this snapshot is delivered.
+      { urlPattern: "/api/list", json: { items: [ENTITY_B], listResourceVersion: "2" } },
       { urlPattern: "/api/watch", body: "" },
     ]);
     const ac = new AbortController();
@@ -274,14 +306,18 @@ describe("WatchClient relist on 410", () => {
     const running = client.run({
       onEvent: async (e) => {
         seen.push(e);
-        if (seen.length >= 1) ac.abort();
+        if (e.op === "RELIST" && (e.entity as { envelope: { id: string } }).envelope.id === "cid-b")
+          ac.abort();
       },
       signal: ac.signal,
     });
     await running;
-    // Only the well-formed event surfaced.
-    expect(seen.length).toBe(1);
-    expect(seen[0]?.rv).toBe(2n);
+    // The malformed ADDED is not delivered; the relist surfaces ENTITY_B.
+    const dataOps = seen.filter((e) => e.op === "ADDED");
+    expect(dataOps.length).toBe(0);
+    const relists = seen.filter((e) => e.op === "RELIST");
+    expect(relists.length).toBe(1);
+    expect((relists[0]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-b");
   });
 
   test("ERROR{code:410} resets backoff (relist is a clean slate)", async () => {
@@ -441,6 +477,108 @@ describe("WatchClient terminal errors", () => {
       /400|terminal/,
     );
   });
+
+  test("rejects on HTTP 401 from /api/watch (not infinite retry)", async () => {
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: "", status: 401 },
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(client.run({ onEvent: () => undefined, signal: ac.signal })).rejects.toThrow(
+      /401|watch failed/,
+    );
+  });
+
+  test("rejects on HTTP 500 from /api/watch (server bug, not retryable)", async () => {
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: "", status: 500 },
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(client.run({ onEvent: () => undefined, signal: ac.signal })).rejects.toThrow(
+      /500|watch failed/,
+    );
+  });
+});
+
+describe("WatchClient transport errors", () => {
+  test("fetch rejection mid-loop is recoverable (fast resume from lastRv)", async () => {
+    let watchCalls = 0;
+    const ac = new AbortController();
+    const fetchImpl = (async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/list")) {
+        return new Response(JSON.stringify({ items: [], listResourceVersion: "5" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      watchCalls += 1;
+      if (watchCalls === 1) throw new Error("ECONNRESET");
+      // Second watch must resume from rv=5, then end. Abort on third call.
+      if (watchCalls >= 3) ac.abort();
+      return new Response("", { headers: { "Content-Type": "text/event-stream" } });
+    }) as typeof fetch;
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    // Should NOT reject — transport error is fast-resumed.
+    await client.run({ onEvent: () => undefined, signal: ac.signal });
+    expect(watchCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  test("mid-stream reader.read rejection is recoverable", async () => {
+    let watchCalls = 0;
+    const ac = new AbortController();
+    const fetchImpl = (async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/list")) {
+        return new Response(JSON.stringify({ items: [], listResourceVersion: "5" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      watchCalls += 1;
+      if (watchCalls === 1) {
+        // Stream that errors mid-read.
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("event: BOOKMARK\ndata: {}\n\n"));
+            queueMicrotask(() => controller.error(new Error("RST")));
+          },
+        });
+        return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+      }
+      if (watchCalls >= 2) ac.abort();
+      return new Response("", { headers: { "Content-Type": "text/event-stream" } });
+    }) as typeof fetch;
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    // Should NOT reject — mid-stream read failure → fast resume.
+    await client.run({ onEvent: () => undefined, signal: ac.signal });
+    expect(watchCalls).toBeGreaterThanOrEqual(2);
+  });
 });
 
 describe("WatchClient onEvent semantics", () => {
@@ -464,6 +602,9 @@ describe("WatchClient onEvent semantics", () => {
     });
     const running = client.run({
       onEvent: async (e) => {
+        // Boundary events fire synchronously around the snapshot; only
+        // assert serialisation of the data ops.
+        if (e.op === "RELIST_BEGIN" || e.op === "RELIST_END") return;
         order.push(`enter:${e.rv}`);
         if (e.rv === 6n) await firstDone;
         order.push(`exit:${e.rv}`);

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -437,6 +437,90 @@ describe("WatchClient fast resume on TCP close", () => {
   });
 });
 
+describe("WatchClient relist boundary invariant", () => {
+  const E_X = { id: "cid-x", resourceVersion: "0", spec: { summary: "x" } };
+
+  test("abort during RELIST_BEGIN's onEvent still emits RELIST_END", async () => {
+    const seen: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    const fetchImpl = makeFetch({ items: [E_X], listResourceVersion: "5" }, []);
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+        if (e.op === "RELIST_BEGIN") ac.abort();
+      },
+      signal: ac.signal,
+    });
+    // BEGIN was delivered; END must follow even though the consumer aborted
+    // immediately. No RELIST item is emitted (loop short-circuits on
+    // signal.aborted before processing items).
+    expect(seen.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST_END"]);
+  });
+
+  test("abort during a RELIST item still emits RELIST_END", async () => {
+    const seen: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    const fetchImpl = makeFetch(
+      { items: [E_X, E_X, E_X], listResourceVersion: "5" },
+      [],
+    );
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+        if (e.op === "RELIST") ac.abort();
+      },
+      signal: ac.signal,
+    });
+    // BEGIN, one RELIST item (the one that triggered abort), then END.
+    // The remaining 2 items are skipped.
+    const ops = seen.map((e) => e.op);
+    expect(ops[0]).toBe("RELIST_BEGIN");
+    expect(ops[ops.length - 1]).toBe("RELIST_END");
+    expect(seen.filter((e) => e.op === "RELIST").length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("throw inside RELIST_BEGIN onEvent does NOT emit RELIST_END", async () => {
+    // If BEGIN failed to be delivered (handler threw), the consumer never
+    // entered replace mode — emitting END would invent a transition that
+    // never started.
+    const seen: WatchClientEvent[] = [];
+    const fetchImpl = makeFetch({ items: [E_X], listResourceVersion: "5" }, []);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(
+      client.run({
+        onEvent: async (e) => {
+          if (e.op === "RELIST_BEGIN") throw new Error("consumer rejected BEGIN");
+          seen.push(e);
+        },
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow(/consumer rejected BEGIN/);
+    // No END emitted because BEGIN never completed.
+    expect(seen.some((e) => e.op === "RELIST_END")).toBe(false);
+  });
+});
+
 describe("WatchClient snapshot dedup (list/watch race)", () => {
   // The dedup uses entity.id + entity.resourceVersion (per ContributionEntity).
   // Local fixtures shaped like real entities so the dedup keys exist.

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -708,6 +708,65 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
     expect(seen.some((e) => e.op === "DELETED")).toBe(true);
   });
 
+  test("multi-update race: stale replay older than snapshot rv is suppressed (high-water mark)", async () => {
+    // Race: snapshot captures listResourceVersion=5, then 3 writes for
+    // entity X land at rv=6,7,8 — entity goes resourceVersion 1→2→3
+    // during the list query. Snapshot returns X at rv=3. Watch replays
+    // ADDED at versions 2 then 3. The version-2 frame must be suppressed
+    // (older than snapshot's 3) and the version-3 frame must also be
+    // suppressed (equal to snapshot). Without the high-water-mark check
+    // the version-2 frame would deliver stale state to the consumer.
+    const seen: WatchClientEvent[] = [];
+    const X_at_3 = { id: "cid-x", resourceVersion: "3", spec: { summary: "x3" } };
+    const X_at_2 = { id: "cid-x", resourceVersion: "2", spec: { summary: "x2" } };
+    const ac = new AbortController();
+    const fetchImpl = singleWatchThenAbort(
+      { items: [X_at_3], listResourceVersion: "5" },
+      `${sse("ADDED", { rv: "6", kind: "Contribution", entity: X_at_2 }, "6")}${sse(
+        "ADDED",
+        { rv: "7", kind: "Contribution", entity: X_at_3 },
+        "7",
+      )}`,
+      ac,
+    );
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await client.run({ onEvent: (e) => seen.push(e), signal: ac.signal });
+    // Only the snapshot RELIST should surface for entity X. No ADDED
+    // events for either the stale version-2 or duplicate version-3 frame.
+    const dataOps = seen.filter((e) => e.op === "ADDED" || e.op === "MODIFIED");
+    expect(dataOps.length).toBe(0);
+  });
+
+  test("strictly-newer version after snapshot is forwarded (window cleared)", async () => {
+    // Snapshot has X at rv=3. Watch delivers MODIFIED at rv=4 — that's
+    // the post-snapshot real update. It MUST surface; the window entry
+    // is then cleared so any further events for X bypass dedup.
+    const seen: WatchClientEvent[] = [];
+    const X_at_3 = { id: "cid-x", resourceVersion: "3", spec: { summary: "x3" } };
+    const X_at_4 = { id: "cid-x", resourceVersion: "4", spec: { summary: "x4" } };
+    const ac = new AbortController();
+    const fetchImpl = singleWatchThenAbort(
+      { items: [X_at_3], listResourceVersion: "5" },
+      sse("MODIFIED", { rv: "6", kind: "Contribution", entity: X_at_4 }, "6"),
+      ac,
+    );
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await client.run({ onEvent: (e) => seen.push(e), signal: ac.signal });
+    expect(seen.some((e) => e.op === "MODIFIED")).toBe(true);
+  });
+
   test("dedup window is reset on every RELIST snapshot", async () => {
     // Round 1: snapshot has A. Round 2 (after relist): snapshot has only B
     // (A no longer present). A subsequent ADDED for A at the SAME

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { WatchClient, type WatchClientEvent } from "./watch-client.js";
+
+/** Mock fetch returning canned list and watch responses. */
+function makeFetch(
+  list: { items: unknown[]; listResourceVersion: string },
+  watchEvents: string[],
+): typeof fetch {
+  return (async (input, init) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.includes("/api/list")) {
+      return new Response(JSON.stringify(list), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url.includes("/api/watch")) {
+      const body = watchEvents.join("");
+      return new Response(body, {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }) as typeof fetch;
+}
+
+const ENTITY_A = {
+  envelope: { kind: "Contribution", id: "cid-a" },
+  data: { cid: "cid-a", summary: "a" },
+};
+const ENTITY_B = {
+  envelope: { kind: "Contribution", id: "cid-b" },
+  data: { cid: "cid-b", summary: "b" },
+};
+
+function sse(event: string, data: unknown, id?: string): string {
+  const idLine = id ? `id: ${id}\n` : "";
+  return `${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+describe("WatchClient happy path", () => {
+  test("emits RELIST for each list item then ADDED for streamed events", async () => {
+    const seen: WatchClientEvent[] = [];
+    const fetchImpl = makeFetch(
+      { items: [ENTITY_A], listResourceVersion: "5" },
+      [
+        sse("ADDED", { rv: "6", kind: "Contribution", entity: ENTITY_B }, "6"),
+      ],
+    );
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+    });
+    const ac = new AbortController();
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+        if (seen.length === 2) ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await running;
+
+    expect(seen.length).toBe(2);
+    expect(seen[0]?.op).toBe("RELIST");
+    expect(seen[0]?.rv).toBe(5n);
+    expect((seen[0]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-a");
+    expect(seen[1]?.op).toBe("ADDED");
+    expect(seen[1]?.rv).toBe(6n);
+  });
+});

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -309,6 +309,48 @@ describe("WatchClient fast resume on TCP close", () => {
   });
 });
 
+describe("WatchClient terminal errors", () => {
+  test("rejects on HTTP 401 from list", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ code: "UNAUTHENTICATED" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch;
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(client.run({ onEvent: () => undefined, signal: ac.signal })).rejects.toThrow(
+      /401|UNAUTHENTICATED|list failed/,
+    );
+  });
+
+  test("rejects on watch ERROR with non-410/503 code", async () => {
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      {
+        urlPattern: "/api/watch",
+        body: sse("ERROR", { code: 400, reason: "validation_error" }, "0"),
+      },
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(client.run({ onEvent: () => undefined, signal: ac.signal })).rejects.toThrow(
+      /400|terminal/,
+    );
+  });
+});
+
 describe("WatchClient onEvent semantics", () => {
   test("awaits each onEvent before processing the next", async () => {
     const order: string[] = [];

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -493,6 +493,52 @@ describe("WatchClient relist boundary invariant", () => {
     expect(seen.filter((e) => e.op === "RELIST").length).toBeGreaterThanOrEqual(1);
   });
 
+  test("RELIST_END handler failure (no abort, no prior error) propagates", async () => {
+    // RELIST_END is the consumer's commit barrier — a failure there means
+    // the snapshot replace is half-applied. The watcher must NOT silently
+    // advance to delta mode with a partially committed cache.
+    const fetchImpl = makeFetch({ items: [E_X], listResourceVersion: "5" }, []);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(
+      client.run({
+        onEvent: async (e) => {
+          if (e.op === "RELIST_END") throw new Error("commit failed");
+        },
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow(/commit failed/);
+  });
+
+  test("RELIST_END handler failure DURING abort is swallowed (teardown)", async () => {
+    // If the consumer is already shutting down (abort in flight), a noisy
+    // RELIST_END must not mask the abort.
+    const fetchImpl = makeFetch({ items: [E_X], listResourceVersion: "5" }, []);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    // Should resolve cleanly (not reject) — the END error is suppressed
+    // because abort is in flight.
+    await client.run({
+      onEvent: async (e) => {
+        if (e.op === "RELIST_BEGIN") ac.abort();
+        if (e.op === "RELIST_END") throw new Error("noisy teardown");
+      },
+      signal: ac.signal,
+    });
+  });
+
   test("throw inside RELIST_BEGIN onEvent does NOT emit RELIST_END", async () => {
     // If BEGIN failed to be delivered (handler threw), the consumer never
     // entered replace mode — emitting END would invent a transition that
@@ -765,6 +811,82 @@ describe("WatchClient terminal errors", () => {
     });
     await expect(client.run({ onEvent: () => undefined, signal: ac.signal })).rejects.toThrow(
       /500|watch failed/,
+    );
+  });
+});
+
+describe("WatchClient list-phase transient failures", () => {
+  test("transport reject on /api/list retries with backoff (does not kill loop)", async () => {
+    let listCalls = 0;
+    const ac = new AbortController();
+    const fetchImpl = (async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/list")) {
+        listCalls += 1;
+        if (listCalls < 3) throw new Error("ECONNRESET");
+        return new Response(JSON.stringify({ items: [], listResourceVersion: "0" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // First /api/watch we abort.
+      ac.abort();
+      return new Response("", { headers: { "Content-Type": "text/event-stream" } });
+    }) as typeof fetch;
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    // Should NOT reject — list transport failures are retried.
+    await client.run({ onEvent: () => undefined, signal: ac.signal });
+    expect(listCalls).toBeGreaterThanOrEqual(3);
+  });
+
+  test("HTTP 503 on /api/list retries with backoff", async () => {
+    let listCalls = 0;
+    const ac = new AbortController();
+    const fetchImpl = (async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/list")) {
+        listCalls += 1;
+        if (listCalls < 3) {
+          return new Response("", { status: 503 });
+        }
+        return new Response(JSON.stringify({ items: [], listResourceVersion: "0" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      ac.abort();
+      return new Response("", { headers: { "Content-Type": "text/event-stream" } });
+    }) as typeof fetch;
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await client.run({ onEvent: () => undefined, signal: ac.signal });
+    expect(listCalls).toBeGreaterThanOrEqual(3);
+  });
+
+  test("HTTP 4xx on /api/list (other than auth-style) is still terminal", async () => {
+    // 400 is a server contract error — retrying would loop forever.
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", body: "", status: 400 },
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(client.run({ onEvent: () => undefined, signal: ac.signal })).rejects.toThrow(
+      /400|list failed/,
     );
   });
 });

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -192,6 +192,98 @@ describe("WatchClient relist on 410", () => {
     expect(sleeps).toEqual([10, 20, 40]);
   });
 
+  test("ended after data delivery resets backoff", async () => {
+    const sleeps: number[] = [];
+    // Two empty-watch ended cycles climb to 20ms, then a watch that delivers
+    // one ADDED event before ending must reset backoff to 10ms.
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: "" }, // ended (no data) → sleep(10), advance to 20
+      { urlPattern: "/api/watch", body: "" }, // ended (no data) → sleep(20), advance to 40
+      {
+        urlPattern: "/api/watch",
+        body: sse("ADDED", { rv: "1", kind: "Contribution", entity: ENTITY_A }, "1"),
+      }, // ended after delivering data → reset, sleep(10)
+      { urlPattern: "/api/watch", body: "" },
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 10, maxMs: 100, jitter: 0 },
+    });
+    (client as unknown as { onBackoff?: (ms: number) => void }).onBackoff = (ms: number) => {
+      sleeps.push(ms);
+      if (sleeps.length >= 3) ac.abort();
+    };
+    await client.run({ onEvent: () => undefined, signal: ac.signal });
+    expect(sleeps).toEqual([10, 20, 10]);
+  });
+
+  test("HTTP 503 from watch triggers relist (not fast resume)", async () => {
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [ENTITY_A], listResourceVersion: "5" } },
+      { urlPattern: "/api/watch", body: "", status: 503 },
+      { urlPattern: "/api/list", json: { items: [ENTITY_B], listResourceVersion: "9" } },
+      { urlPattern: "/api/watch", body: "" },
+    ]);
+    const seen: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+        const relists = seen.filter((s) => s.op === "RELIST");
+        if (relists.length >= 2) ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await running;
+    // 2 RELIST events: one per list (the second after relist due to 503).
+    expect(seen.filter((s) => s.op === "RELIST").length).toBe(2);
+  });
+
+  test("malformed rv on data event is dropped, run continues", async () => {
+    const seen: WatchClientEvent[] = [];
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      {
+        urlPattern: "/api/watch",
+        body:
+          sse("ADDED", { rv: "not-a-number", kind: "Contribution", entity: ENTITY_A }, "1") +
+          sse("ADDED", { rv: "2", kind: "Contribution", entity: ENTITY_B }, "2"),
+      },
+      { urlPattern: "/api/watch", body: "" },
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+        if (seen.length >= 1) ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await running;
+    // Only the well-formed event surfaced.
+    expect(seen.length).toBe(1);
+    expect(seen[0]?.rv).toBe(2n);
+  });
+
   test("ERROR{code:410} resets backoff (relist is a clean slate)", async () => {
     const sleeps: number[] = [];
     // Two TCP-close cycles climb backoff to 20ms, then a 410 should reset to 10ms.

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -153,8 +153,12 @@ describe("WatchClient relist on 410", () => {
 
     const relists = seen.filter((s) => s.op === "RELIST");
     expect(relists.length).toBe(2);
-    expect((relists[0]?.entity as unknown as { envelope: { id: string } }).envelope.id).toBe("cid-a");
-    expect((relists[1]?.entity as unknown as { envelope: { id: string } }).envelope.id).toBe("cid-b");
+    expect((relists[0]?.entity as unknown as { envelope: { id: string } }).envelope.id).toBe(
+      "cid-a",
+    );
+    expect((relists[1]?.entity as unknown as { envelope: { id: string } }).envelope.id).toBe(
+      "cid-b",
+    );
     expect(relists[1]?.rv).toBe(10n);
   });
 
@@ -306,7 +310,10 @@ describe("WatchClient relist on 410", () => {
     const running = client.run({
       onEvent: async (e) => {
         seen.push(e);
-        if (e.op === "RELIST" && (e.entity as unknown as { envelope: { id: string } }).envelope.id === "cid-b")
+        if (
+          e.op === "RELIST" &&
+          (e.entity as unknown as { envelope: { id: string } }).envelope.id === "cid-b"
+        )
           ac.abort();
       },
       signal: ac.signal,
@@ -317,7 +324,9 @@ describe("WatchClient relist on 410", () => {
     expect(dataOps.length).toBe(0);
     const relists = seen.filter((e) => e.op === "RELIST");
     expect(relists.length).toBe(1);
-    expect((relists[0]?.entity as unknown as { envelope: { id: string } }).envelope.id).toBe("cid-b");
+    expect((relists[0]?.entity as unknown as { envelope: { id: string } }).envelope.id).toBe(
+      "cid-b",
+    );
   });
 
   test("ERROR{code:410} resets backoff (relist is a clean slate)", async () => {
@@ -677,7 +686,12 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
       fetch: fetchImpl,
       backoff: { minMs: 0, maxMs: 0, jitter: 0 },
     });
-    await client.run({ onEvent: (e) => { seen.push(e); }, signal: ac.signal });
+    await client.run({
+      onEvent: (e) => {
+        seen.push(e);
+      },
+      signal: ac.signal,
+    });
     const modified = seen.find((e) => e.op === "MODIFIED");
     expect(modified).toBeDefined();
     expect((modified?.entity as { resourceVersion: string }).resourceVersion).toBe("1");
@@ -698,7 +712,12 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
       fetch: fetchImpl,
       backoff: { minMs: 0, maxMs: 0, jitter: 0 },
     });
-    await client.run({ onEvent: (e) => { seen.push(e); }, signal: ac.signal });
+    await client.run({
+      onEvent: (e) => {
+        seen.push(e);
+      },
+      signal: ac.signal,
+    });
     expect(seen.some((e) => e.op === "DELETED")).toBe(true);
   });
 
@@ -730,7 +749,12 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
       fetch: fetchImpl,
       backoff: { minMs: 0, maxMs: 0, jitter: 0 },
     });
-    await client.run({ onEvent: (e) => { seen.push(e); }, signal: ac.signal });
+    await client.run({
+      onEvent: (e) => {
+        seen.push(e);
+      },
+      signal: ac.signal,
+    });
     // Only the snapshot RELIST should surface for entity X. No ADDED
     // events for either the stale version-2 or duplicate version-3 frame.
     const dataOps = seen.filter((e) => e.op === "ADDED" || e.op === "MODIFIED");
@@ -757,7 +781,12 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
       fetch: fetchImpl,
       backoff: { minMs: 0, maxMs: 0, jitter: 0 },
     });
-    await client.run({ onEvent: (e) => { seen.push(e); }, signal: ac.signal });
+    await client.run({
+      onEvent: (e) => {
+        seen.push(e);
+      },
+      signal: ac.signal,
+    });
     expect(seen.some((e) => e.op === "MODIFIED")).toBe(true);
   });
 
@@ -808,7 +837,12 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
       fetch: fetchImpl,
       backoff: { minMs: 0, maxMs: 0, jitter: 0 },
     });
-    await client.run({ onEvent: (e) => { seen.push(e); }, signal: ac.signal });
+    await client.run({
+      onEvent: (e) => {
+        seen.push(e);
+      },
+      signal: ac.signal,
+    });
     const addedA = seen.find(
       (e) => e.op === "ADDED" && (e.entity as { id: string } | null)?.id === "cid-a",
     );

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -440,7 +440,7 @@ describe("WatchClient fast resume on TCP close", () => {
 describe("WatchClient relist boundary invariant", () => {
   const E_X = { id: "cid-x", resourceVersion: "0", spec: { summary: "x" } };
 
-  test("abort during RELIST_BEGIN's onEvent still emits RELIST_END", async () => {
+  test("abort during RELIST_BEGIN's onEvent emits RELIST_ABORTED (not END)", async () => {
     const seen: WatchClientEvent[] = [];
     const ac = new AbortController();
     const fetchImpl = makeFetch({ items: [E_X], listResourceVersion: "5" }, []);
@@ -458,13 +458,13 @@ describe("WatchClient relist boundary invariant", () => {
       },
       signal: ac.signal,
     });
-    // BEGIN was delivered; END must follow even though the consumer aborted
-    // immediately. No RELIST item is emitted (loop short-circuits on
-    // signal.aborted before processing items).
-    expect(seen.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST_END"]);
+    // BEGIN delivered; consumer aborted; the snapshot is incomplete so the
+    // boundary closes with RELIST_ABORTED (NOT RELIST_END) — consumers
+    // must roll back staged replace instead of committing.
+    expect(seen.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST_ABORTED"]);
   });
 
-  test("abort during a RELIST item still emits RELIST_END", async () => {
+  test("abort during a RELIST item emits RELIST_ABORTED (not END)", async () => {
     const seen: WatchClientEvent[] = [];
     const ac = new AbortController();
     const fetchImpl = makeFetch(
@@ -485,12 +485,39 @@ describe("WatchClient relist boundary invariant", () => {
       },
       signal: ac.signal,
     });
-    // BEGIN, one RELIST item (the one that triggered abort), then END.
-    // The remaining 2 items are skipped.
     const ops = seen.map((e) => e.op);
     expect(ops[0]).toBe("RELIST_BEGIN");
-    expect(ops[ops.length - 1]).toBe("RELIST_END");
-    expect(seen.filter((e) => e.op === "RELIST").length).toBeGreaterThanOrEqual(1);
+    // Snapshot was interrupted mid-stream → ABORTED, not END.
+    expect(ops[ops.length - 1]).toBe("RELIST_ABORTED");
+    expect(seen.some((e) => e.op === "RELIST_END")).toBe(false);
+  });
+
+  test("throw inside a RELIST item emits RELIST_ABORTED", async () => {
+    const seen: WatchClientEvent[] = [];
+    const fetchImpl = makeFetch(
+      { items: [E_X, E_X], listResourceVersion: "5" },
+      [],
+    );
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    await expect(
+      client.run({
+        onEvent: async (e) => {
+          seen.push(e);
+          if (e.op === "RELIST") throw new Error("staging failed");
+        },
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow(/staging failed/);
+    // Boundary closes with ABORTED before the original error propagates.
+    expect(seen.some((e) => e.op === "RELIST_ABORTED")).toBe(true);
+    expect(seen.some((e) => e.op === "RELIST_END")).toBe(false);
   });
 
   test("RELIST_END handler failure (no abort, no prior error) propagates", async () => {
@@ -516,9 +543,9 @@ describe("WatchClient relist boundary invariant", () => {
     ).rejects.toThrow(/commit failed/);
   });
 
-  test("RELIST_END handler failure DURING abort is swallowed (teardown)", async () => {
-    // If the consumer is already shutting down (abort in flight), a noisy
-    // RELIST_END must not mask the abort.
+  test("RELIST_ABORTED handler failure during abort is swallowed (teardown)", async () => {
+    // After abort, the boundary closes with RELIST_ABORTED. Errors thrown
+    // by that handler must not mask the abort itself.
     const fetchImpl = makeFetch({ items: [E_X], listResourceVersion: "5" }, []);
     const ac = new AbortController();
     const client = new WatchClient({
@@ -528,12 +555,12 @@ describe("WatchClient relist boundary invariant", () => {
       fetch: fetchImpl,
       backoff: { minMs: 0, maxMs: 0, jitter: 0 },
     });
-    // Should resolve cleanly (not reject) — the END error is suppressed
-    // because abort is in flight.
+    // Should resolve cleanly (not reject) — error from ABORTED handler
+    // is suppressed because the abort already triggered teardown.
     await client.run({
       onEvent: async (e) => {
         if (e.op === "RELIST_BEGIN") ac.abort();
-        if (e.op === "RELIST_END") throw new Error("noisy teardown");
+        if (e.op === "RELIST_ABORTED") throw new Error("noisy teardown");
       },
       signal: ac.signal,
     });

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -67,3 +67,128 @@ describe("WatchClient happy path", () => {
     expect(seen[1]?.rv).toBe(6n);
   });
 });
+
+/**
+ * Helper: chained fetch that returns scripted responses in order. Each call
+ * matches a (urlPattern, body) pair. Throws if the script runs out.
+ */
+function scriptedFetch(
+  steps: Array<{ urlPattern: string; body?: string; status?: number; json?: unknown }>,
+): typeof fetch {
+  let i = 0;
+  return (async (input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (i >= steps.length) {
+      throw new Error(`scripted fetch exhausted at ${url}`);
+    }
+    const step = steps[i] as (typeof steps)[number];
+    i += 1;
+    if (!url.includes(step.urlPattern)) {
+      throw new Error(`expected url to contain ${step.urlPattern}, got ${url}`);
+    }
+    if (step.json !== undefined) {
+      return new Response(JSON.stringify(step.json), {
+        status: step.status ?? 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(step.body ?? "", {
+      status: step.status ?? 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  }) as typeof fetch;
+}
+
+describe("WatchClient relist on 410", () => {
+  test("ERROR{code:410} triggers relist + new RELIST events", async () => {
+    const seen: WatchClientEvent[] = [];
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [ENTITY_A], listResourceVersion: "5" } },
+      { urlPattern: "/api/watch", body: sse("ERROR", { code: 410, reason: "expired" }, "5") },
+      { urlPattern: "/api/list", json: { items: [ENTITY_B], listResourceVersion: "10" } },
+      { urlPattern: "/api/watch", body: "" },
+    ]);
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const ac = new AbortController();
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+        const relists = seen.filter((s) => s.op === "RELIST");
+        if (relists.length >= 2) ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await running;
+
+    const relists = seen.filter((s) => s.op === "RELIST");
+    expect(relists.length).toBe(2);
+    expect((relists[0]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-a");
+    expect((relists[1]?.entity as { envelope: { id: string } }).envelope.id).toBe("cid-b");
+    expect(relists[1]?.rv).toBe(10n);
+  });
+
+  test("ERROR{code:503} triggers relist same as 410", async () => {
+    const seen: WatchClientEvent[] = [];
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [ENTITY_A], listResourceVersion: "5" } },
+      {
+        urlPattern: "/api/watch",
+        body: sse("ERROR", { code: 503, reason: "buffer_overflow" }, "5"),
+      },
+      { urlPattern: "/api/list", json: { items: [ENTITY_B], listResourceVersion: "9" } },
+      { urlPattern: "/api/watch", body: "" },
+    ]);
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    const ac = new AbortController();
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+        const relists = seen.filter((s) => s.op === "RELIST");
+        if (relists.length >= 2) ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await running;
+    expect(seen.filter((s) => s.op === "RELIST").length).toBe(2);
+  });
+
+  test("backoff sleeps between attempts when minMs > 0", async () => {
+    const sleeps: number[] = [];
+    const fetchImpl = scriptedFetch([
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: sse("ERROR", { code: 410 }, "0") },
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: sse("ERROR", { code: 410 }, "0") },
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: sse("ERROR", { code: 410 }, "0") },
+      { urlPattern: "/api/list", json: { items: [], listResourceVersion: "0" } },
+      { urlPattern: "/api/watch", body: "" },
+    ]);
+    const ac = new AbortController();
+    const client = new WatchClient({
+      baseUrl: "http://t",
+      kind: "Contribution",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 10, maxMs: 100, jitter: 0 },
+    });
+    (client as unknown as { onBackoff?: (ms: number) => void }).onBackoff = (ms: number) => {
+      sleeps.push(ms);
+      if (sleeps.length >= 3) ac.abort();
+    };
+    await client.run({ onEvent: () => {}, signal: ac.signal });
+    expect(sleeps).toEqual([10, 20, 40]);
+  });
+});

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -6,7 +6,7 @@ function makeFetch(
   list: { items: unknown[]; listResourceVersion: string },
   watchEvents: string[],
 ): typeof fetch {
-  return (async (input, init) => {
+  return (async (input, _init) => {
     const url = typeof input === "string" ? input : (input as Request).url;
     if (url.includes("/api/list")) {
       return new Response(JSON.stringify(list), {
@@ -40,12 +40,9 @@ function sse(event: string, data: unknown, id?: string): string {
 describe("WatchClient happy path", () => {
   test("emits RELIST for each list item then ADDED for streamed events", async () => {
     const seen: WatchClientEvent[] = [];
-    const fetchImpl = makeFetch(
-      { items: [ENTITY_A], listResourceVersion: "5" },
-      [
-        sse("ADDED", { rv: "6", kind: "Contribution", entity: ENTITY_B }, "6"),
-      ],
-    );
+    const fetchImpl = makeFetch({ items: [ENTITY_A], listResourceVersion: "5" }, [
+      sse("ADDED", { rv: "6", kind: "Contribution", entity: ENTITY_B }, "6"),
+    ]);
     const client = new WatchClient({
       baseUrl: "http://t",
       kind: "Contribution",

--- a/src/core/watch-client.test.ts
+++ b/src/core/watch-client.test.ts
@@ -467,10 +467,7 @@ describe("WatchClient relist boundary invariant", () => {
   test("abort during a RELIST item emits RELIST_ABORTED (not END)", async () => {
     const seen: WatchClientEvent[] = [];
     const ac = new AbortController();
-    const fetchImpl = makeFetch(
-      { items: [E_X, E_X, E_X], listResourceVersion: "5" },
-      [],
-    );
+    const fetchImpl = makeFetch({ items: [E_X, E_X, E_X], listResourceVersion: "5" }, []);
     const client = new WatchClient({
       baseUrl: "http://t",
       kind: "Contribution",
@@ -494,10 +491,7 @@ describe("WatchClient relist boundary invariant", () => {
 
   test("throw inside a RELIST item emits RELIST_ABORTED", async () => {
     const seen: WatchClientEvent[] = [];
-    const fetchImpl = makeFetch(
-      { items: [E_X, E_X], listResourceVersion: "5" },
-      [],
-    );
+    const fetchImpl = makeFetch({ items: [E_X, E_X], listResourceVersion: "5" }, []);
     const ac = new AbortController();
     const client = new WatchClient({
       baseUrl: "http://t",
@@ -798,10 +792,9 @@ describe("WatchClient snapshot dedup (list/watch race)", () => {
         if (watchCalls === 2) {
           // Second watch: ADDED for A. After round-2 relist, A is NOT in
           // the snapshot window, so this must surface (no dedup).
-          return new Response(
-            sse("ADDED", { rv: "11", kind: "Contribution", entity: E_A }, "11"),
-            { headers: { "Content-Type": "text/event-stream" } },
-          );
+          return new Response(sse("ADDED", { rv: "11", kind: "Contribution", entity: E_A }, "11"), {
+            headers: { "Content-Type": "text/event-stream" },
+          });
         }
         ac.abort();
         return new Response("", { headers: { "Content-Type": "text/event-stream" } });
@@ -959,9 +952,7 @@ describe("WatchClient list-phase transient failures", () => {
   });
 
   test("HTTP 501 NOT_CONFIGURED on /api/list is terminal (not retried forever)", async () => {
-    const fetchImpl = scriptedFetch([
-      { urlPattern: "/api/list", body: "", status: 501 },
-    ]);
+    const fetchImpl = scriptedFetch([{ urlPattern: "/api/list", body: "", status: 501 }]);
     const ac = new AbortController();
     const client = new WatchClient({
       baseUrl: "http://t",
@@ -976,9 +967,7 @@ describe("WatchClient list-phase transient failures", () => {
   });
 
   test("HTTP 500 on /api/list is terminal (configuration/server bug)", async () => {
-    const fetchImpl = scriptedFetch([
-      { urlPattern: "/api/list", body: "", status: 500 },
-    ]);
+    const fetchImpl = scriptedFetch([{ urlPattern: "/api/list", body: "", status: 500 }]);
     const ac = new AbortController();
     const client = new WatchClient({
       baseUrl: "http://t",
@@ -994,9 +983,7 @@ describe("WatchClient list-phase transient failures", () => {
 
   test("HTTP 4xx on /api/list (other than auth-style) is still terminal", async () => {
     // 400 is a server contract error — retrying would loop forever.
-    const fetchImpl = scriptedFetch([
-      { urlPattern: "/api/list", body: "", status: 400 },
-    ]);
+    const fetchImpl = scriptedFetch([{ urlPattern: "/api/list", body: "", status: 400 }]);
     const ac = new AbortController();
     const client = new WatchClient({
       baseUrl: "http://t",

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -14,12 +14,23 @@ export type WatchClientOp =
   | "DELETED"
   | "RELIST"
   | "RELIST_BEGIN"
-  | "RELIST_END";
+  | "RELIST_END"
+  | "RELIST_ABORTED";
 
 /**
- * Boundary events RELIST_BEGIN/RELIST_END fire even for empty snapshots so
- * consumers can atomically replace local state after compaction (drop entries
- * not present between BEGIN and END). Their entity is null.
+ * Boundary events fire even for empty snapshots so consumers can atomically
+ * replace local state after compaction (drop entries not present between
+ * BEGIN and END). Their entity is null.
+ *
+ * The boundary contract is:
+ * - RELIST_BEGIN: enter replace mode.
+ * - RELIST_END: snapshot fully delivered → commit replace transaction.
+ * - RELIST_ABORTED: snapshot was interrupted (abort or onEvent throw mid-
+ *   snapshot) → roll back; do NOT commit a partial replace.
+ *
+ * Exactly one terminal event (RELIST_END or RELIST_ABORTED) follows every
+ * RELIST_BEGIN. Consumers can rely on receiving one or the other but
+ * never both.
  */
 export interface WatchClientEvent {
   readonly op: WatchClientOp;
@@ -112,13 +123,11 @@ export class WatchClient {
         }
         const rv = BigInt(list.listResourceVersion);
         const newWindow = new Map<string, string>();
-        // Boundary invariant: once RELIST_BEGIN has been delivered, the
-        // matching RELIST_END must always fire — including on abort or
-        // mid-snapshot throw — so consumers using BEGIN/END for atomic
-        // replace cannot get stuck in replace mode with a partial snapshot.
-        // Track the primary error separately so a throw inside the END
-        // handler can't mask an earlier failure, but a standalone END
-        // failure (the consumer's commit boundary) propagates.
+        // Boundary invariant: once RELIST_BEGIN has been delivered, exactly
+        // one terminal — RELIST_END (full snapshot delivered) or
+        // RELIST_ABORTED (interrupted) — always fires. Consumers can
+        // commit on RELIST_END and rollback on RELIST_ABORTED without
+        // ambiguity.
         let relistOpen = false;
         let primaryError: unknown = undefined;
         try {
@@ -133,14 +142,18 @@ export class WatchClient {
           primaryError = err;
         }
         if (relistOpen) {
+          // RELIST_END only when snapshot fully delivered AND no error/abort.
+          // Otherwise RELIST_ABORTED so consumers know to discard staged state
+          // instead of committing a partial replace.
+          const interrupted = primaryError !== undefined || signal.aborted;
+          const closeOp: WatchClientOp = interrupted ? "RELIST_ABORTED" : "RELIST_END";
           try {
-            await onEvent({ op: "RELIST_END", rv, kind: this.kind, entity: null });
+            await onEvent({ op: closeOp, rv, kind: this.kind, entity: null });
           } catch (err) {
-            // RELIST_END is the consumer's commit barrier for the snapshot.
-            // If it failed without a prior error or abort, the consumer's
-            // replace transaction is half-applied — propagate so the caller
-            // sees the failure instead of silently advancing past it.
-            if (primaryError === undefined && !signal.aborted) {
+            // Terminal-event handler failures: only propagate when this is
+            // a clean commit (RELIST_END) and no earlier error/abort
+            // already triggered teardown.
+            if (closeOp === "RELIST_END" && primaryError === undefined && !signal.aborted) {
               primaryError = err;
             }
           }

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -40,17 +40,25 @@ interface SseFrame {
   readonly data: unknown;
 }
 
+const DEFAULT_BACKOFF = { minMs: 100, maxMs: 30_000, jitter: 0.3 };
+
+type StreamExit = { kind: "abort" } | { kind: "ended" } | { kind: "relist" };
+
 export class WatchClient {
   private readonly baseUrl: string;
   private readonly kind: WatchKind;
   private readonly authHeader: string;
   private readonly fetchImpl: typeof fetch;
+  private readonly backoffCfg: NonNullable<WatchClientOptions["backoff"]>;
+  /** Test-only hook called whenever the loop sleeps for `ms` after a failure. */
+  onBackoff?: (ms: number) => void;
 
   constructor(opts: WatchClientOptions) {
     this.baseUrl = opts.baseUrl;
     this.kind = opts.kind;
     this.authHeader = opts.authHeader;
     this.fetchImpl = opts.fetch ?? fetch;
+    this.backoffCfg = opts.backoff ?? DEFAULT_BACKOFF;
   }
 
   async run(opts: {
@@ -58,6 +66,7 @@ export class WatchClient {
     signal: AbortSignal;
   }): Promise<void> {
     const { onEvent, signal } = opts;
+    let nextDelay = this.backoffCfg.minMs;
     while (!signal.aborted) {
       const list = await this.list(signal);
       for (const item of list.items) {
@@ -69,10 +78,19 @@ export class WatchClient {
           entity: item,
         });
       }
-      const resumed = await this.streamWatch(BigInt(list.listResourceVersion), onEvent, signal);
-      if (resumed === "abort") return;
-      // Future tasks: distinguish 410/503 (full relist, restart loop) from
-      // TCP close (fast resume). For now any non-abort exit restarts the loop.
+      const exit = await this.streamWatch(BigInt(list.listResourceVersion), onEvent, signal);
+      if (exit.kind === "abort") return;
+      if (exit.kind === "relist") {
+        await this.sleep(nextDelay, signal);
+        nextDelay = this.advanceBackoff(nextDelay);
+        continue;
+      }
+      // exit.kind === "ended" — Task 7 will introduce fast-resume here. For
+      // Task 6, just sleep + restart loop with a fresh list.
+      // Successful stream end: reset backoff.
+      nextDelay = this.backoffCfg.minMs;
+      await this.sleep(nextDelay, signal);
+      nextDelay = this.advanceBackoff(nextDelay);
     }
   }
 
@@ -91,13 +109,13 @@ export class WatchClient {
     fromRv: bigint,
     onEvent: (e: WatchClientEvent) => Promise<void> | void,
     signal: AbortSignal,
-  ): Promise<"abort" | "ended"> {
+  ): Promise<StreamExit> {
     const url = `${this.baseUrl}/api/watch?kind=${this.kind}&resumeFrom=${fromRv}`;
     const res = await this.fetchImpl(url, {
       headers: { Authorization: this.authHeader, Accept: "text/event-stream" },
       signal,
     });
-    if (!res.ok || !res.body) return "ended";
+    if (!res.ok || !res.body) return { kind: "ended" };
 
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
@@ -105,14 +123,23 @@ export class WatchClient {
     try {
       while (!signal.aborted) {
         const { value, done } = await reader.read();
-        if (done) return "ended";
+        if (done) return { kind: "ended" };
         buf += decoder.decode(value, { stream: true });
         let idx = buf.indexOf("\n\n");
         while (idx >= 0) {
           const block = buf.slice(0, idx);
           buf = buf.slice(idx + 2);
           const frame = parseSseFrame(block);
-          if (frame && isDataOp(frame.event)) {
+          if (!frame) {
+            idx = buf.indexOf("\n\n");
+            continue;
+          }
+          if (frame.event === "ERROR") {
+            const code = (frame.data as { code?: number })?.code;
+            if (code === 410 || code === 503) return { kind: "relist" };
+            throw new Error(`watch terminal error: code=${code}`);
+          }
+          if (isDataOp(frame.event)) {
             const payload = frame.data as { rv: string; entity: WatchEntity };
             await onEvent({
               op: frame.event as WatchClientOp,
@@ -121,11 +148,11 @@ export class WatchClient {
               entity: payload.entity,
             });
           }
-          if (signal.aborted) return "abort";
+          if (signal.aborted) return { kind: "abort" };
           idx = buf.indexOf("\n\n");
         }
       }
-      return "abort";
+      return { kind: "abort" };
     } finally {
       try {
         await reader.cancel();
@@ -133,6 +160,25 @@ export class WatchClient {
         /* already cancelled */
       }
     }
+  }
+
+  private advanceBackoff(prev: number): number {
+    return Math.min(this.backoffCfg.maxMs, Math.max(this.backoffCfg.minMs, prev * 2));
+  }
+
+  private async sleep(ms: number, signal: AbortSignal): Promise<void> {
+    this.onBackoff?.(ms);
+    if (ms <= 0 || signal.aborted) return;
+    const jitter = this.backoffCfg.jitter;
+    const actual = jitter > 0 ? ms * (1 + (Math.random() * 2 - 1) * jitter) : ms;
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, actual);
+      const onAbort = (): void => {
+        clearTimeout(t);
+        resolve();
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
   }
 }
 

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -129,7 +129,7 @@ export class WatchClient {
         // commit on RELIST_END and rollback on RELIST_ABORTED without
         // ambiguity.
         let relistOpen = false;
-        let primaryError: unknown = undefined;
+        let primaryError: unknown;
         try {
           await onEvent({ op: "RELIST_BEGIN", rv, kind: this.kind, entity: null });
           relistOpen = true;

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -81,14 +81,16 @@ export class WatchClient {
       const exit = await this.streamWatch(BigInt(list.listResourceVersion), onEvent, signal);
       if (exit.kind === "abort") return;
       if (exit.kind === "relist") {
+        // 410/503 means resumeFrom expired but the server is healthy — relist is
+        // a clean slate, so reset backoff per spec.
+        nextDelay = this.backoffCfg.minMs;
         await this.sleep(nextDelay, signal);
         nextDelay = this.advanceBackoff(nextDelay);
         continue;
       }
-      // exit.kind === "ended" — Task 7 will introduce fast-resume here. For
-      // Task 6, just sleep + restart loop with a fresh list.
-      // Successful stream end: reset backoff.
-      nextDelay = this.backoffCfg.minMs;
+      // exit.kind === "ended" — TCP-close without data; keep accumulating backoff
+      // because the server may actually be down. Task 7 will introduce a
+      // data-flowed-then-ended fast-resume path (reset only when data flowed).
       await this.sleep(nextDelay, signal);
       nextDelay = this.advanceBackoff(nextDelay);
     }
@@ -172,8 +174,12 @@ export class WatchClient {
     const jitter = this.backoffCfg.jitter;
     const actual = jitter > 0 ? ms * (1 + (Math.random() * 2 - 1) * jitter) : ms;
     await new Promise<void>((resolve) => {
-      const t = setTimeout(resolve, actual);
-      const onAbort = (): void => {
+      let onAbort: (() => void) | undefined;
+      const t = setTimeout(() => {
+        if (onAbort) signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, actual);
+      onAbort = (): void => {
         clearTimeout(t);
         resolve();
       };

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -279,24 +279,29 @@ export class WatchClient {
             }
             const rv = BigInt(payload.rv);
             const entity = payload.entity;
-            // Snapshot-dedup: an entity that appeared in the just-completed
-            // RELIST with the same resourceVersion must not be redelivered as
-            // ADDED/MODIFIED. The race comes from the server capturing
-            // listResourceVersion *before* querying the store; a write whose
-            // hub-rv lands during the list window appears in BOTH the
-            // snapshot and the watch replay. Suppress the duplicate but
-            // still advance lastRv so the cursor reflects what the server
-            // sent. Only one duplicate is possible per (entity, snapshot),
-            // so consume the entry on first match either way.
+            // Snapshot-dedup with high-water mark. The /api/list handshake
+            // captures listResourceVersion *before* querying the store, so
+            // a write whose hub-rv lands during the list window appears in
+            // BOTH the snapshot and the watch replay. Drop replay frames
+            // whose entity version is ≤ the snapshot's version for that
+            // id; forward strictly newer versions and DELETED. Treat the
+            // window as a high-water mark — never delete on a stale match,
+            // since further stale frames could still arrive in the same
+            // race window.
             const seenRv = this.snapshotWindow.get(entity.id);
-            if (seenRv !== undefined) {
-              this.snapshotWindow.delete(entity.id);
-              if (frame.event !== "DELETED" && seenRv === entity.resourceVersion) {
+            if (seenRv !== undefined && frame.event !== "DELETED") {
+              if (isStaleVersion(entity.resourceVersion, seenRv)) {
                 lastRv = rv;
                 observedData = true;
                 idx = buf.indexOf("\n\n");
                 continue;
               }
+              // Strictly newer real update — clear the entry so subsequent
+              // events for this entity bypass dedup entirely.
+              this.snapshotWindow.delete(entity.id);
+            } else if (seenRv !== undefined) {
+              // DELETED tombstone supersedes any prior snapshot version.
+              this.snapshotWindow.delete(entity.id);
             }
             lastRv = rv;
             observedData = true;
@@ -365,6 +370,28 @@ function parseSseFrame(block: string): SseFrame | null {
 
 function isDataOp(event: string): boolean {
   return event === "ADDED" || event === "MODIFIED" || event === "DELETED";
+}
+
+/**
+ * Compare two `entity.resourceVersion` values. Returns true when `eventRv`
+ * is older-or-equal to `snapshotRv` (i.e. should be treated as a stale
+ * replay during snapshot-dedup). Format is normally `String(rev)` but the
+ * Claim entity also encodes lease state as `${rev}-lease-expired` —
+ * extract the leading numeric prefix on both sides for a robust ordering.
+ * Falls back to exact string equality when no numeric prefix is present.
+ */
+function isStaleVersion(eventRv: string, snapshotRv: string): boolean {
+  const a = parseRvPrefix(snapshotRv);
+  const b = parseRvPrefix(eventRv);
+  if (a !== null && b !== null) return b <= a;
+  return eventRv === snapshotRv;
+}
+
+function parseRvPrefix(s: string): number | null {
+  const m = /^(\d+)/.exec(s);
+  if (!m) return null;
+  const n = Number.parseInt(m[1] ?? "", 10);
+  return Number.isFinite(n) ? n : null;
 }
 
 /**

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -69,11 +69,7 @@ export class WatchClient {
           entity: item,
         });
       }
-      const resumed = await this.streamWatch(
-        BigInt(list.listResourceVersion),
-        onEvent,
-        signal,
-      );
+      const resumed = await this.streamWatch(BigInt(list.listResourceVersion), onEvent, signal);
       if (resumed === "abort") return;
       // Future tasks: distinguish 410/503 (full relist, restart loop) from
       // TCP close (fast resume). For now any non-abort exit restarts the loop.
@@ -81,10 +77,10 @@ export class WatchClient {
   }
 
   private async list(signal: AbortSignal): Promise<ListResponse> {
-    const res = await this.fetchImpl(
-      `${this.baseUrl}/api/list?kind=${this.kind}`,
-      { headers: { Authorization: this.authHeader }, signal },
-    );
+    const res = await this.fetchImpl(`${this.baseUrl}/api/list?kind=${this.kind}`, {
+      headers: { Authorization: this.authHeader },
+      signal,
+    });
     if (!res.ok) {
       throw new Error(`list failed: ${res.status}`);
     }

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -242,7 +242,7 @@ export class WatchClient {
     let buf = "";
     try {
       while (!signal.aborted) {
-        let chunk: ReadableStreamReadResult<Uint8Array>;
+        let chunk: { done: boolean; value: Uint8Array | undefined };
         try {
           chunk = await reader.read();
         } catch (err) {

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -8,13 +8,24 @@
 
 import type { WatchEntity, WatchKind } from "./watch-events.js";
 
-export type WatchClientOp = "ADDED" | "MODIFIED" | "DELETED" | "RELIST";
+export type WatchClientOp =
+  | "ADDED"
+  | "MODIFIED"
+  | "DELETED"
+  | "RELIST"
+  | "RELIST_BEGIN"
+  | "RELIST_END";
 
+/**
+ * Boundary events RELIST_BEGIN/RELIST_END fire even for empty snapshots so
+ * consumers can atomically replace local state after compaction (drop entries
+ * not present between BEGIN and END). Their entity is null.
+ */
 export interface WatchClientEvent {
   readonly op: WatchClientOp;
   readonly rv: bigint;
   readonly kind: WatchKind;
-  readonly entity: WatchEntity;
+  readonly entity: WatchEntity | null;
 }
 
 export interface WatchClientOptions {
@@ -75,16 +86,15 @@ export class WatchClient {
     while (!signal.aborted) {
       if (resumeFrom === null) {
         const list = await this.list(signal);
+        const rv = BigInt(list.listResourceVersion);
+        await onEvent({ op: "RELIST_BEGIN", rv, kind: this.kind, entity: null });
         for (const item of list.items) {
           if (signal.aborted) return;
-          await onEvent({
-            op: "RELIST",
-            rv: BigInt(list.listResourceVersion),
-            kind: this.kind,
-            entity: item,
-          });
+          await onEvent({ op: "RELIST", rv, kind: this.kind, entity: item });
         }
-        resumeFrom = BigInt(list.listResourceVersion);
+        if (signal.aborted) return;
+        await onEvent({ op: "RELIST_END", rv, kind: this.kind, entity: null });
+        resumeFrom = rv;
       }
       const exit = await this.streamWatch(resumeFrom, onEvent, signal);
       if (exit.kind === "abort") return;
@@ -127,23 +137,47 @@ export class WatchClient {
     let lastRv = fromRv;
     let observedData = false;
     const url = `${this.baseUrl}/api/watch?kind=${this.kind}&resumeFrom=${fromRv}`;
-    const res = await this.fetchImpl(url, {
-      headers: { Authorization: this.authHeader, Accept: "text/event-stream" },
-      signal,
-    });
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, {
+        headers: { Authorization: this.authHeader, Accept: "text/event-stream" },
+        signal,
+      });
+    } catch (err) {
+      // Transport error (connection reset, DNS, TLS). If the caller aborted,
+      // unwind cleanly; otherwise treat as a transient close → fast resume.
+      if (signal.aborted) return { kind: "abort" };
+      console.warn(`watch: fetch failed (${(err as Error)?.message ?? err}); resuming`);
+      return { kind: "ended", lastRv, observedData };
+    }
     if (res.status === 410 || res.status === 503) {
       return { kind: "relist" };
     }
-    if (!res.ok || !res.body) return { kind: "ended", lastRv, observedData };
+    if (!res.ok) {
+      // 4xx/5xx other than 410/503 indicate the server is up and refusing
+      // (auth/config/server bug). Make terminal so the caller surfaces it
+      // instead of looping forever with a stale resumeFrom.
+      throw new Error(`watch failed: ${res.status}`);
+    }
+    if (!res.body) return { kind: "ended", lastRv, observedData };
 
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buf = "";
     try {
       while (!signal.aborted) {
-        const { value, done } = await reader.read();
-        if (done) return { kind: "ended", lastRv, observedData };
-        buf += decoder.decode(value, { stream: true });
+        let chunk: ReadableStreamReadResult<Uint8Array>;
+        try {
+          chunk = await reader.read();
+        } catch (err) {
+          // Mid-stream transport failure (RST, stream reset). Same policy as
+          // fetch reject: aborted → unwind, otherwise fast resume from lastRv.
+          if (signal.aborted) return { kind: "abort" };
+          console.warn(`watch: read failed (${(err as Error)?.message ?? err}); resuming`);
+          return { kind: "ended", lastRv, observedData };
+        }
+        if (chunk.done) return { kind: "ended", lastRv, observedData };
+        buf += decoder.decode(chunk.value, { stream: true });
         let idx = buf.indexOf("\n\n");
         while (idx >= 0) {
           const block = buf.slice(0, idx);
@@ -161,11 +195,11 @@ export class WatchClient {
           if (isDataOp(frame.event)) {
             const payload = frame.data as { rv?: string; entity?: WatchEntity };
             if (!payload.rv || !/^[0-9]+$/.test(payload.rv) || !payload.entity) {
-              // Malformed data event — server bug. Drop and continue rather than
-              // crashing the loop; the next BOOKMARK or event will resync the cursor.
-              console.warn(`watch: dropped malformed ${frame.event} frame`);
-              idx = buf.indexOf("\n\n");
-              continue;
+              // Malformed data frame: a subsequent BOOKMARK could otherwise
+              // ack past this rv and silently drop the event. Force a relist
+              // so the consumer atomically replaces state from a fresh snapshot.
+              console.warn(`watch: malformed ${frame.event} frame → forcing relist`);
+              return { kind: "relist" };
             }
             const rv = BigInt(payload.rv);
             lastRv = rv;

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -94,14 +94,33 @@ export class WatchClient {
 
     while (!signal.aborted) {
       if (resumeFrom === null) {
-        const list = await this.list(signal);
+        let list: ListResponse;
+        try {
+          list = await this.list(signal);
+        } catch (err) {
+          if (signal.aborted) return;
+          // Transient errors (network reject, 5xx) retry with backoff so a
+          // brief server restart during compaction recovery doesn't kill
+          // the watcher. HTTP 4xx (auth/config) stays terminal.
+          if (isTransientListError(err)) {
+            console.warn(`watch: list failed (${(err as Error)?.message ?? err}); retrying`);
+            await this.sleep(nextDelay, signal);
+            nextDelay = this.advanceBackoff(nextDelay);
+            continue;
+          }
+          throw err;
+        }
         const rv = BigInt(list.listResourceVersion);
         const newWindow = new Map<string, string>();
         // Boundary invariant: once RELIST_BEGIN has been delivered, the
         // matching RELIST_END must always fire — including on abort or
         // mid-snapshot throw — so consumers using BEGIN/END for atomic
         // replace cannot get stuck in replace mode with a partial snapshot.
+        // Track the primary error separately so a throw inside the END
+        // handler can't mask an earlier failure, but a standalone END
+        // failure (the consumer's commit boundary) propagates.
         let relistOpen = false;
+        let primaryError: unknown = undefined;
         try {
           await onEvent({ op: "RELIST_BEGIN", rv, kind: this.kind, entity: null });
           relistOpen = true;
@@ -110,16 +129,23 @@ export class WatchClient {
             newWindow.set(item.id, item.resourceVersion);
             await onEvent({ op: "RELIST", rv, kind: this.kind, entity: item });
           }
-        } finally {
-          if (relistOpen) {
-            try {
-              await onEvent({ op: "RELIST_END", rv, kind: this.kind, entity: null });
-            } catch {
-              // Best-effort close: a throw inside RELIST_END handling must
-              // not mask the original abort/throw that triggered teardown.
+        } catch (err) {
+          primaryError = err;
+        }
+        if (relistOpen) {
+          try {
+            await onEvent({ op: "RELIST_END", rv, kind: this.kind, entity: null });
+          } catch (err) {
+            // RELIST_END is the consumer's commit barrier for the snapshot.
+            // If it failed without a prior error or abort, the consumer's
+            // replace transaction is half-applied — propagate so the caller
+            // sees the failure instead of silently advancing past it.
+            if (primaryError === undefined && !signal.aborted) {
+              primaryError = err;
             }
           }
         }
+        if (primaryError !== undefined) throw primaryError;
         if (signal.aborted) return;
         // Install the dedup window AFTER RELIST_END so the snapshot itself
         // can't accidentally be deduped against itself by re-entrant code.
@@ -149,12 +175,19 @@ export class WatchClient {
   }
 
   private async list(signal: AbortSignal): Promise<ListResponse> {
-    const res = await this.fetchImpl(`${this.baseUrl}/api/list?kind=${this.kind}`, {
-      headers: { Authorization: this.authHeader },
-      signal,
-    });
+    let res: Response;
+    try {
+      res = await this.fetchImpl(`${this.baseUrl}/api/list?kind=${this.kind}`, {
+        headers: { Authorization: this.authHeader },
+        signal,
+      });
+    } catch (err) {
+      // Transport rejection — surface as transient via a marked error so
+      // run() can distinguish it from HTTP-level failures.
+      throw new TransientListTransportError((err as Error)?.message ?? String(err));
+    }
     if (!res.ok) {
-      throw new Error(`list failed: ${res.status}`);
+      throw new ListHttpError(res.status, `list failed: ${res.status}`);
     }
     return (await res.json()) as ListResponse;
   }
@@ -319,4 +352,34 @@ function parseSseFrame(block: string): SseFrame | null {
 
 function isDataOp(event: string): boolean {
   return event === "ADDED" || event === "MODIFIED" || event === "DELETED";
+}
+
+/**
+ * Marker for /api/list transport rejections (network reset, DNS, TLS).
+ * Always retryable.
+ */
+class TransientListTransportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TransientListTransportError";
+  }
+}
+
+/**
+ * Marker for /api/list non-OK HTTP responses. 5xx is retryable; 4xx is
+ * terminal (auth/config/server-side validation failure).
+ */
+class ListHttpError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ListHttpError";
+    this.status = status;
+  }
+}
+
+function isTransientListError(err: unknown): boolean {
+  if (err instanceof TransientListTransportError) return true;
+  if (err instanceof ListHttpError) return err.status >= 500;
+  return false;
 }

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -42,7 +42,7 @@ interface SseFrame {
 
 const DEFAULT_BACKOFF = { minMs: 100, maxMs: 30_000, jitter: 0.3 };
 
-type StreamExit = { kind: "abort" } | { kind: "ended" } | { kind: "relist" };
+type StreamExit = { kind: "abort" } | { kind: "ended"; lastRv: bigint } | { kind: "relist" };
 
 export class WatchClient {
   private readonly baseUrl: string;
@@ -67,30 +67,34 @@ export class WatchClient {
   }): Promise<void> {
     const { onEvent, signal } = opts;
     let nextDelay = this.backoffCfg.minMs;
+    let resumeFrom: bigint | null = null; // null → must (re)list
+
     while (!signal.aborted) {
-      const list = await this.list(signal);
-      for (const item of list.items) {
-        if (signal.aborted) return;
-        await onEvent({
-          op: "RELIST",
-          rv: BigInt(list.listResourceVersion),
-          kind: this.kind,
-          entity: item,
-        });
+      if (resumeFrom === null) {
+        const list = await this.list(signal);
+        for (const item of list.items) {
+          if (signal.aborted) return;
+          await onEvent({
+            op: "RELIST",
+            rv: BigInt(list.listResourceVersion),
+            kind: this.kind,
+            entity: item,
+          });
+        }
+        resumeFrom = BigInt(list.listResourceVersion);
       }
-      const exit = await this.streamWatch(BigInt(list.listResourceVersion), onEvent, signal);
+      const exit = await this.streamWatch(resumeFrom, onEvent, signal);
       if (exit.kind === "abort") return;
       if (exit.kind === "relist") {
-        // 410/503 means resumeFrom expired but the server is healthy — relist is
-        // a clean slate, so reset backoff per spec.
+        // Full relist on next iteration. Reset backoff (relist is a clean slate).
+        resumeFrom = null;
         nextDelay = this.backoffCfg.minMs;
         await this.sleep(nextDelay, signal);
         nextDelay = this.advanceBackoff(nextDelay);
         continue;
       }
-      // exit.kind === "ended" — TCP-close without data; keep accumulating backoff
-      // because the server may actually be down. Task 7 will introduce a
-      // data-flowed-then-ended fast-resume path (reset only when data flowed).
+      // exit.kind === "ended" — fast resume from lastRv (no relist).
+      resumeFrom = exit.lastRv;
       await this.sleep(nextDelay, signal);
       nextDelay = this.advanceBackoff(nextDelay);
     }
@@ -112,12 +116,13 @@ export class WatchClient {
     onEvent: (e: WatchClientEvent) => Promise<void> | void,
     signal: AbortSignal,
   ): Promise<StreamExit> {
+    let lastRv = fromRv;
     const url = `${this.baseUrl}/api/watch?kind=${this.kind}&resumeFrom=${fromRv}`;
     const res = await this.fetchImpl(url, {
       headers: { Authorization: this.authHeader, Accept: "text/event-stream" },
       signal,
     });
-    if (!res.ok || !res.body) return { kind: "ended" };
+    if (!res.ok || !res.body) return { kind: "ended", lastRv };
 
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
@@ -125,7 +130,7 @@ export class WatchClient {
     try {
       while (!signal.aborted) {
         const { value, done } = await reader.read();
-        if (done) return { kind: "ended" };
+        if (done) return { kind: "ended", lastRv };
         buf += decoder.decode(value, { stream: true });
         let idx = buf.indexOf("\n\n");
         while (idx >= 0) {
@@ -143,12 +148,18 @@ export class WatchClient {
           }
           if (isDataOp(frame.event)) {
             const payload = frame.data as { rv: string; entity: WatchEntity };
+            const rv = BigInt(payload.rv);
+            lastRv = rv;
             await onEvent({
               op: frame.event as WatchClientOp,
-              rv: BigInt(payload.rv),
+              rv,
               kind: this.kind,
               entity: payload.entity,
             });
+          } else if (frame.event === "BOOKMARK") {
+            // BOOKMARK advances resume cursor without firing onEvent.
+            const rv = (frame.data as { rv?: string })?.rv;
+            if (rv && /^[0-9]+$/.test(rv)) lastRv = BigInt(rv);
           }
           if (signal.aborted) return { kind: "abort" };
           idx = buf.indexOf("\n\n");

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -42,7 +42,10 @@ interface SseFrame {
 
 const DEFAULT_BACKOFF = { minMs: 100, maxMs: 30_000, jitter: 0.3 };
 
-type StreamExit = { kind: "abort" } | { kind: "ended"; lastRv: bigint } | { kind: "relist" };
+type StreamExit =
+  | { kind: "abort" }
+  | { kind: "ended"; lastRv: bigint; observedData: boolean }
+  | { kind: "relist" };
 
 export class WatchClient {
   private readonly baseUrl: string;
@@ -91,12 +94,17 @@ export class WatchClient {
         nextDelay = this.backoffCfg.minMs;
         await this.sleep(nextDelay, signal);
         nextDelay = this.advanceBackoff(nextDelay);
-        continue;
+      } else {
+        // exit.kind === "ended" — fast resume from lastRv (no relist).
+        resumeFrom = exit.lastRv;
+        // Reset backoff if the stream actually delivered events; otherwise keep
+        // accumulating so a flapping/empty server gets exponentially throttled.
+        if (exit.observedData) {
+          nextDelay = this.backoffCfg.minMs;
+        }
+        await this.sleep(nextDelay, signal);
+        nextDelay = this.advanceBackoff(nextDelay);
       }
-      // exit.kind === "ended" — fast resume from lastRv (no relist).
-      resumeFrom = exit.lastRv;
-      await this.sleep(nextDelay, signal);
-      nextDelay = this.advanceBackoff(nextDelay);
     }
   }
 
@@ -117,12 +125,16 @@ export class WatchClient {
     signal: AbortSignal,
   ): Promise<StreamExit> {
     let lastRv = fromRv;
+    let observedData = false;
     const url = `${this.baseUrl}/api/watch?kind=${this.kind}&resumeFrom=${fromRv}`;
     const res = await this.fetchImpl(url, {
       headers: { Authorization: this.authHeader, Accept: "text/event-stream" },
       signal,
     });
-    if (!res.ok || !res.body) return { kind: "ended", lastRv };
+    if (res.status === 410 || res.status === 503) {
+      return { kind: "relist" };
+    }
+    if (!res.ok || !res.body) return { kind: "ended", lastRv, observedData };
 
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
@@ -130,7 +142,7 @@ export class WatchClient {
     try {
       while (!signal.aborted) {
         const { value, done } = await reader.read();
-        if (done) return { kind: "ended", lastRv };
+        if (done) return { kind: "ended", lastRv, observedData };
         buf += decoder.decode(value, { stream: true });
         let idx = buf.indexOf("\n\n");
         while (idx >= 0) {
@@ -147,9 +159,17 @@ export class WatchClient {
             throw new Error(`watch terminal error: code=${code}`);
           }
           if (isDataOp(frame.event)) {
-            const payload = frame.data as { rv: string; entity: WatchEntity };
+            const payload = frame.data as { rv?: string; entity?: WatchEntity };
+            if (!payload.rv || !/^[0-9]+$/.test(payload.rv) || !payload.entity) {
+              // Malformed data event — server bug. Drop and continue rather than
+              // crashing the loop; the next BOOKMARK or event will resync the cursor.
+              console.warn(`watch: dropped malformed ${frame.event} frame`);
+              idx = buf.indexOf("\n\n");
+              continue;
+            }
             const rv = BigInt(payload.rv);
             lastRv = rv;
+            observedData = true;
             await onEvent({
               op: frame.event as WatchClientOp,
               rv,

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -97,14 +97,30 @@ export class WatchClient {
         const list = await this.list(signal);
         const rv = BigInt(list.listResourceVersion);
         const newWindow = new Map<string, string>();
-        await onEvent({ op: "RELIST_BEGIN", rv, kind: this.kind, entity: null });
-        for (const item of list.items) {
-          if (signal.aborted) return;
-          newWindow.set(item.id, item.resourceVersion);
-          await onEvent({ op: "RELIST", rv, kind: this.kind, entity: item });
+        // Boundary invariant: once RELIST_BEGIN has been delivered, the
+        // matching RELIST_END must always fire — including on abort or
+        // mid-snapshot throw — so consumers using BEGIN/END for atomic
+        // replace cannot get stuck in replace mode with a partial snapshot.
+        let relistOpen = false;
+        try {
+          await onEvent({ op: "RELIST_BEGIN", rv, kind: this.kind, entity: null });
+          relistOpen = true;
+          for (const item of list.items) {
+            if (signal.aborted) break;
+            newWindow.set(item.id, item.resourceVersion);
+            await onEvent({ op: "RELIST", rv, kind: this.kind, entity: item });
+          }
+        } finally {
+          if (relistOpen) {
+            try {
+              await onEvent({ op: "RELIST_END", rv, kind: this.kind, entity: null });
+            } catch {
+              // Best-effort close: a throw inside RELIST_END handling must
+              // not mask the original abort/throw that triggered teardown.
+            }
+          }
         }
         if (signal.aborted) return;
-        await onEvent({ op: "RELIST_END", rv, kind: this.kind, entity: null });
         // Install the dedup window AFTER RELIST_END so the snapshot itself
         // can't accidentally be deduped against itself by re-entrant code.
         this.snapshotWindow = newWindow;

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -64,6 +64,15 @@ export class WatchClient {
   private readonly authHeader: string;
   private readonly fetchImpl: typeof fetch;
   private readonly backoffCfg: NonNullable<WatchClientOptions["backoff"]>;
+  /**
+   * Snapshot dedup window. The /api/list handshake captures the watch RV
+   * before the store query, so a write that commits between rv-capture and
+   * list-return appears in BOTH the snapshot and the watch replay (rv >
+   * listResourceVersion). Track {entityId → resourceVersion} from the most
+   * recent RELIST so an immediately-following ADDED/MODIFIED with the same
+   * (id, rv) tuple is suppressed instead of double-delivered to the consumer.
+   */
+  private snapshotWindow = new Map<string, string>();
   /** Test-only hook called whenever the loop sleeps for `ms` after a failure. */
   onBackoff?: (ms: number) => void;
 
@@ -87,13 +96,18 @@ export class WatchClient {
       if (resumeFrom === null) {
         const list = await this.list(signal);
         const rv = BigInt(list.listResourceVersion);
+        const newWindow = new Map<string, string>();
         await onEvent({ op: "RELIST_BEGIN", rv, kind: this.kind, entity: null });
         for (const item of list.items) {
           if (signal.aborted) return;
+          newWindow.set(item.id, item.resourceVersion);
           await onEvent({ op: "RELIST", rv, kind: this.kind, entity: item });
         }
         if (signal.aborted) return;
         await onEvent({ op: "RELIST_END", rv, kind: this.kind, entity: null });
+        // Install the dedup window AFTER RELIST_END so the snapshot itself
+        // can't accidentally be deduped against itself by re-entrant code.
+        this.snapshotWindow = newWindow;
         resumeFrom = rv;
       }
       const exit = await this.streamWatch(resumeFrom, onEvent, signal);
@@ -202,13 +216,33 @@ export class WatchClient {
               return { kind: "relist" };
             }
             const rv = BigInt(payload.rv);
+            const entity = payload.entity;
+            // Snapshot-dedup: an entity that appeared in the just-completed
+            // RELIST with the same resourceVersion must not be redelivered as
+            // ADDED/MODIFIED. The race comes from the server capturing
+            // listResourceVersion *before* querying the store; a write whose
+            // hub-rv lands during the list window appears in BOTH the
+            // snapshot and the watch replay. Suppress the duplicate but
+            // still advance lastRv so the cursor reflects what the server
+            // sent. Only one duplicate is possible per (entity, snapshot),
+            // so consume the entry on first match either way.
+            const seenRv = this.snapshotWindow.get(entity.id);
+            if (seenRv !== undefined) {
+              this.snapshotWindow.delete(entity.id);
+              if (frame.event !== "DELETED" && seenRv === entity.resourceVersion) {
+                lastRv = rv;
+                observedData = true;
+                idx = buf.indexOf("\n\n");
+                continue;
+              }
+            }
             lastRv = rv;
             observedData = true;
             await onEvent({
               op: frame.event as WatchClientOp,
               rv,
               kind: this.kind,
-              entity: payload.entity,
+              entity,
             });
           } else if (frame.event === "BOOKMARK") {
             // BOOKMARK advances resume cursor without firing onEvent.

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -380,6 +380,11 @@ class ListHttpError extends Error {
 
 function isTransientListError(err: unknown): boolean {
   if (err instanceof TransientListTransportError) return true;
-  if (err instanceof ListHttpError) return err.status >= 500;
+  if (err instanceof ListHttpError) {
+    // Only retry on infrastructure-class transients. 500 (generic server
+    // error) and 501 (NOT_CONFIGURED — e.g. AgentSession watcher hits
+    // an unsupported kind) are permanent: retrying would loop forever.
+    return err.status === 502 || err.status === 503 || err.status === 504;
+  }
   return false;
 }

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -1,0 +1,159 @@
+/**
+ * WatchClient — list→watch loop with relist on Expired (#293).
+ *
+ * Drives the A5 handshake (#292) and translates server SSE events into
+ * a typed callback. RELIST signals "snapshot, not delta" so consumers
+ * can run K8s-informer-style Replace() reconciliation.
+ */
+
+import type { WatchEntity, WatchKind } from "./watch-events.js";
+
+export type WatchClientOp = "ADDED" | "MODIFIED" | "DELETED" | "RELIST";
+
+export interface WatchClientEvent {
+  readonly op: WatchClientOp;
+  readonly rv: bigint;
+  readonly kind: WatchKind;
+  readonly entity: WatchEntity;
+}
+
+export interface WatchClientOptions {
+  readonly baseUrl: string;
+  readonly kind: WatchKind;
+  readonly authHeader: string;
+  readonly fetch?: typeof fetch;
+  readonly backoff?: {
+    readonly minMs: number;
+    readonly maxMs: number;
+    readonly jitter: number;
+  };
+}
+
+interface ListResponse {
+  readonly items: WatchEntity[];
+  readonly listResourceVersion: string;
+}
+
+interface SseFrame {
+  readonly id: string;
+  readonly event: string;
+  readonly data: unknown;
+}
+
+export class WatchClient {
+  private readonly baseUrl: string;
+  private readonly kind: WatchKind;
+  private readonly authHeader: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: WatchClientOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.kind = opts.kind;
+    this.authHeader = opts.authHeader;
+    this.fetchImpl = opts.fetch ?? fetch;
+  }
+
+  async run(opts: {
+    onEvent: (e: WatchClientEvent) => Promise<void> | void;
+    signal: AbortSignal;
+  }): Promise<void> {
+    const { onEvent, signal } = opts;
+    while (!signal.aborted) {
+      const list = await this.list(signal);
+      for (const item of list.items) {
+        if (signal.aborted) return;
+        await onEvent({
+          op: "RELIST",
+          rv: BigInt(list.listResourceVersion),
+          kind: this.kind,
+          entity: item,
+        });
+      }
+      const resumed = await this.streamWatch(
+        BigInt(list.listResourceVersion),
+        onEvent,
+        signal,
+      );
+      if (resumed === "abort") return;
+      // Future tasks: distinguish 410/503 (full relist, restart loop) from
+      // TCP close (fast resume). For now any non-abort exit restarts the loop.
+    }
+  }
+
+  private async list(signal: AbortSignal): Promise<ListResponse> {
+    const res = await this.fetchImpl(
+      `${this.baseUrl}/api/list?kind=${this.kind}`,
+      { headers: { Authorization: this.authHeader }, signal },
+    );
+    if (!res.ok) {
+      throw new Error(`list failed: ${res.status}`);
+    }
+    return (await res.json()) as ListResponse;
+  }
+
+  private async streamWatch(
+    fromRv: bigint,
+    onEvent: (e: WatchClientEvent) => Promise<void> | void,
+    signal: AbortSignal,
+  ): Promise<"abort" | "ended"> {
+    const url = `${this.baseUrl}/api/watch?kind=${this.kind}&resumeFrom=${fromRv}`;
+    const res = await this.fetchImpl(url, {
+      headers: { Authorization: this.authHeader, Accept: "text/event-stream" },
+      signal,
+    });
+    if (!res.ok || !res.body) return "ended";
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    try {
+      while (!signal.aborted) {
+        const { value, done } = await reader.read();
+        if (done) return "ended";
+        buf += decoder.decode(value, { stream: true });
+        let idx = buf.indexOf("\n\n");
+        while (idx >= 0) {
+          const block = buf.slice(0, idx);
+          buf = buf.slice(idx + 2);
+          const frame = parseSseFrame(block);
+          if (frame && isDataOp(frame.event)) {
+            const payload = frame.data as { rv: string; entity: WatchEntity };
+            await onEvent({
+              op: frame.event as WatchClientOp,
+              rv: BigInt(payload.rv),
+              kind: this.kind,
+              entity: payload.entity,
+            });
+          }
+          if (signal.aborted) return "abort";
+          idx = buf.indexOf("\n\n");
+        }
+      }
+      return "abort";
+    } finally {
+      try {
+        await reader.cancel();
+      } catch {
+        /* already cancelled */
+      }
+    }
+  }
+}
+
+function parseSseFrame(block: string): SseFrame | null {
+  const id = /^id: (.*)$/m.exec(block)?.[1] ?? "";
+  const event = /^event: (.*)$/m.exec(block)?.[1] ?? "";
+  const dataLine = /^data: (.*)$/m.exec(block)?.[1] ?? "null";
+  if (!event) return null;
+  let data: unknown = null;
+  try {
+    data = JSON.parse(dataLine);
+  } catch {
+    data = dataLine;
+  }
+  return { id, event, data };
+}
+
+function isDataOp(event: string): boolean {
+  return event === "ADDED" || event === "MODIFIED" || event === "DELETED";
+}

--- a/src/core/watch-hub.compaction.test.ts
+++ b/src/core/watch-hub.compaction.test.ts
@@ -84,7 +84,7 @@ describe("WatchHub compaction stats", () => {
     expect(namespaces).toEqual(["ns-a", "ns-b"]);
   });
 
-  test("oldestRv is '0' when ring is empty after full eviction", () => {
+  test("oldestRv tracks the surviving event after age eviction", () => {
     let now = 1_000;
     const hub = new WatchHub({
       maxEventsPerKey: 100,
@@ -96,6 +96,22 @@ describe("WatchHub compaction stats", () => {
     writeOne(hub, "ns", "y"); // triggers age eviction of x; y stays
     expect(hub.getCompactionStats()[0]?.currentRingSize).toBe(1);
     expect(hub.getCompactionStats()[0]?.oldestRv).toBe("2");
+  });
+
+  test("oldestRv reports '0' for a key with no writes", async () => {
+    const hub = new WatchHub({ maxEventsPerKey: 5, maxAgeMsPerKey: 60_000 });
+    const ac = new AbortController();
+    // subscribe creates the key via getOrCreate without writing.
+    const iter = hub.subscribe("ns", "Contribution", 0n, ac.signal);
+    // Abort immediately — we just need the key to exist.
+    ac.abort();
+    // Drain the (already aborted) iterator to release resources.
+    for await (const _ev of iter) break;
+    const stats = hub.getCompactionStats();
+    expect(stats.length).toBe(1);
+    expect(stats[0]?.currentRingSize).toBe(0);
+    expect(stats[0]?.oldestRv).toBe("0");
+    expect(stats[0]?.currentRv).toBe("0");
   });
 
   test("public maxAgeMsPerKey and maxEventsPerKey reflect constructor args", () => {

--- a/src/core/watch-hub.compaction.test.ts
+++ b/src/core/watch-hub.compaction.test.ts
@@ -98,7 +98,7 @@ describe("WatchHub compaction stats", () => {
     expect(hub.getCompactionStats()[0]?.oldestRv).toBe("2");
   });
 
-  test("oldestRv reports '0' for a key with no writes", async () => {
+  test("oldestRv on empty ring reports floorRv+1 (first rv not yet evicted)", async () => {
     const hub = new WatchHub({ maxEventsPerKey: 5, maxAgeMsPerKey: 60_000 });
     const ac = new AbortController();
     // subscribe creates the key via getOrCreate without writing.
@@ -110,7 +110,10 @@ describe("WatchHub compaction stats", () => {
     const stats = hub.getCompactionStats();
     expect(stats.length).toBe(1);
     expect(stats[0]?.currentRingSize).toBe(0);
-    expect(stats[0]?.oldestRv).toBe("0");
+    // No writes ever happened: floorRv=0, so oldestRv reports "1" — the rv
+    // that the next write would receive. This semantic survives idle-key
+    // age compaction (full eviction), where oldestRv = counter + 1.
+    expect(stats[0]?.oldestRv).toBe("1");
     expect(stats[0]?.currentRv).toBe("0");
   });
 

--- a/src/core/watch-hub.compaction.test.ts
+++ b/src/core/watch-hub.compaction.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { contributionToEntity } from "./entity.js";
+import type { Contribution } from "./models.js";
+import { WatchHub } from "./watch-hub.js";
+
+function fixtureContribution(cid: string): Contribution {
+  return {
+    cid,
+    manifestVersion: 1,
+    kind: "work",
+    mode: "evaluation",
+    summary: "fixture",
+    artifacts: {},
+    relations: [],
+    tags: [],
+    agent: { agentId: "a-1" },
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function writeOne(hub: WatchHub, ns: string, cid: string): bigint {
+  const entity = contributionToEntity(fixtureContribution(cid), ns);
+  return hub.recordWrite({ kind: "Contribution", namespace: ns, op: "ADDED", entity });
+}
+
+describe("WatchHub compaction stats", () => {
+  test("evictedByCapacity increments when ring exceeds maxEventsPerKey", () => {
+    const hub = new WatchHub({ maxEventsPerKey: 3, maxAgeMsPerKey: 60_000 });
+    for (let i = 0; i < 5; i++) writeOne(hub, "ns", `cid-${i}`);
+
+    const stats = hub.getCompactionStats();
+    expect(stats.length).toBe(1);
+    expect(stats[0]?.namespace).toBe("ns");
+    expect(stats[0]?.kind).toBe("Contribution");
+    expect(stats[0]?.evictedByCapacity).toBe(2); // 5 writes, cap 3 → 2 evicted
+    expect(stats[0]?.evictedByAge).toBe(0);
+    expect(stats[0]?.currentRingSize).toBe(3);
+    expect(stats[0]?.currentRv).toBe("5");
+    expect(stats[0]?.oldestRv).toBe("3");
+  });
+
+  test("evictedByAge increments when events exceed maxAgeMsPerKey", () => {
+    let now = 1_000_000;
+    const hub = new WatchHub({
+      maxEventsPerKey: 100,
+      maxAgeMsPerKey: 100,
+      now: () => now,
+    });
+    writeOne(hub, "ns", "old-1");
+    writeOne(hub, "ns", "old-2");
+    now += 250; // past retention
+    writeOne(hub, "ns", "fresh-1");
+
+    const stats = hub.getCompactionStats();
+    expect(stats[0]?.evictedByAge).toBe(2);
+    expect(stats[0]?.evictedByCapacity).toBe(0);
+    expect(stats[0]?.currentRingSize).toBe(1);
+    expect(stats[0]?.oldestRv).toBe("3");
+    expect(stats[0]?.currentRv).toBe("3");
+  });
+
+  test("counters are monotonic across subscribe/unsubscribe", async () => {
+    const hub = new WatchHub({ maxEventsPerKey: 2, maxAgeMsPerKey: 60_000 });
+    for (let i = 0; i < 5; i++) writeOne(hub, "ns", `cid-${i}`);
+
+    const ac = new AbortController();
+    const iter = hub.subscribe("ns", "Contribution", 4n, ac.signal);
+    for await (const _ev of iter) break; // consume one
+    ac.abort();
+
+    writeOne(hub, "ns", "cid-after");
+    const stats = hub.getCompactionStats();
+    // 6 writes total, cap 2 → 4 evicted
+    expect(stats[0]?.evictedByCapacity).toBe(4);
+  });
+
+  test("getCompactionStats returns one entry per active (ns, kind)", () => {
+    const hub = new WatchHub({ maxEventsPerKey: 5, maxAgeMsPerKey: 60_000 });
+    writeOne(hub, "ns-a", "cid-a");
+    writeOne(hub, "ns-b", "cid-b");
+    const stats = hub.getCompactionStats();
+    expect(stats.length).toBe(2);
+    const namespaces = stats.map((s) => s.namespace).sort();
+    expect(namespaces).toEqual(["ns-a", "ns-b"]);
+  });
+
+  test("oldestRv is '0' when ring is empty after full eviction", () => {
+    let now = 1_000;
+    const hub = new WatchHub({
+      maxEventsPerKey: 100,
+      maxAgeMsPerKey: 100,
+      now: () => now,
+    });
+    writeOne(hub, "ns", "x");
+    now += 1000;
+    writeOne(hub, "ns", "y"); // triggers age eviction of x; y stays
+    expect(hub.getCompactionStats()[0]?.currentRingSize).toBe(1);
+    expect(hub.getCompactionStats()[0]?.oldestRv).toBe("2");
+  });
+
+  test("public maxAgeMsPerKey and maxEventsPerKey reflect constructor args", () => {
+    const hub = new WatchHub({ maxAgeMsPerKey: 7777, maxEventsPerKey: 12 });
+    expect(hub.maxAgeMsPerKey).toBe(7777);
+    expect(hub.maxEventsPerKey).toBe(12);
+  });
+});

--- a/src/core/watch-hub.test.ts
+++ b/src/core/watch-hub.test.ts
@@ -19,6 +19,39 @@ function fixtureContribution(cid: string): Contribution {
   };
 }
 
+describe("WatchHub.subscribe replay cap", () => {
+  test("replay > perClientOutboxCap fails immediately with BufferOverflowError", async () => {
+    // Without the cap, a slow reconnect from rv=0 against a large ring
+    // could allocate maxEventsPerKey events per subscriber on creation
+    // (configurable up to 1M), risking OOM under reconnect storms. With
+    // the cap, over-budget replay fails fast → 503 → client relists.
+    const hub = new WatchHub({ maxEventsPerKey: 100, perClientOutboxCap: 4 });
+    for (let i = 0; i < 10; i++) {
+      const ent = contributionToEntity(fixtureContribution(`cid-${i}`), "ns");
+      hub.recordWrite({ kind: "Contribution", namespace: "ns", op: "ADDED", entity: ent });
+    }
+    const ac = new AbortController();
+    const iter = hub.subscribe("ns", "Contribution", 0n, ac.signal);
+    // 10 events > cap of 4 → next() throws BufferOverflowError immediately.
+    await expect(iter[Symbol.asyncIterator]().next()).rejects.toBeInstanceOf(BufferOverflowError);
+  });
+
+  test("replay ≤ perClientOutboxCap is delivered normally", async () => {
+    const hub = new WatchHub({ maxEventsPerKey: 100, perClientOutboxCap: 10 });
+    for (let i = 0; i < 5; i++) {
+      const ent = contributionToEntity(fixtureContribution(`cid-${i}`), "ns");
+      hub.recordWrite({ kind: "Contribution", namespace: "ns", op: "ADDED", entity: ent });
+    }
+    const ac = new AbortController();
+    const iter = hub.subscribe("ns", "Contribution", 0n, ac.signal);
+    const it = iter[Symbol.asyncIterator]();
+    const r1 = await it.next();
+    expect(r1.done).toBe(false);
+    expect((r1.value as { rv: bigint }).rv).toBe(1n);
+    ac.abort();
+  });
+});
+
 describe("WatchHub.subscribe + AbortSignal", () => {
   test("pre-aborted signal does not register subscriber (no leak)", async () => {
     const hub = new WatchHub();

--- a/src/core/watch-hub.test.ts
+++ b/src/core/watch-hub.test.ts
@@ -19,6 +19,37 @@ function fixtureContribution(cid: string): Contribution {
   };
 }
 
+describe("WatchHub.subscribe + AbortSignal", () => {
+  test("pre-aborted signal does not register subscriber (no leak)", async () => {
+    const hub = new WatchHub();
+    const ac = new AbortController();
+    ac.abort(); // already aborted before subscribe
+    const iter = hub.subscribe("ns", "Contribution", 0n, ac.signal);
+    // Iterator must terminate immediately (subscriber.closed = true).
+    const r = await iter[Symbol.asyncIterator]().next();
+    expect(r.done).toBe(true);
+
+    // No subscriber should have been registered. Verify by writing —
+    // a leaked subscriber would still receive the fanout into a queue
+    // we'd never drain. We can't observe queue directly, but a fresh
+    // subscribe + drain proves the live set is clean.
+    const ent = contributionToEntity(fixtureContribution("cid-a"), "ns");
+    hub.recordWrite({ kind: "Contribution", namespace: "ns", op: "ADDED", entity: ent });
+
+    // Inspect subscribers via internal state (test-only access).
+    // (The hub doesn't expose this; we can at least assert the second
+    // subscribe returns and ends without leak.)
+    const ac2 = new AbortController();
+    const iter2 = hub.subscribe("ns", "Contribution", 0n, ac2.signal);
+    const next = iter2[Symbol.asyncIterator]().next();
+    // Replay should include rv=1.
+    const r2 = await next;
+    expect(r2.done).toBe(false);
+    expect((r2.value as { rv: bigint }).rv).toBe(1n);
+    ac2.abort();
+  });
+});
+
 describe("WatchHub.recordWrite", () => {
   test("returns strictly increasing rv for same (ns, kind)", () => {
     const hub = new WatchHub();

--- a/src/core/watch-hub.ts
+++ b/src/core/watch-hub.ts
@@ -116,12 +116,23 @@ export class WatchHub {
       kind,
       queue: [...replay],
       pending: null,
-      closed: false,
+      // Pre-aborted signals never fire their listener (AbortSignal does
+      // not invoke retroactively), so a subscriber registered against an
+      // already-aborted signal would be stuck in subscribersByKey forever
+      // and continue to consume fan-out from every future write. Set
+      // `closed` up front so the next() loop terminates immediately and
+      // the subscriber is never registered on the live set.
+      closed: signal.aborted,
       overflow: false,
     };
-    this.subscribersFor(key).add(subscriber);
-
-    signal.addEventListener("abort", () => this.closeSubscriber(key, subscriber));
+    if (!signal.aborted) {
+      this.subscribersFor(key).add(subscriber);
+      const onAbort = (): void => {
+        signal.removeEventListener("abort", onAbort);
+        this.closeSubscriber(key, subscriber);
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
 
     return {
       [Symbol.asyncIterator]: () => ({

--- a/src/core/watch-hub.ts
+++ b/src/core/watch-hub.ts
@@ -15,10 +15,22 @@ export interface WatchHubOptions {
   readonly now?: () => number;
 }
 
+export interface CompactionStats {
+  readonly namespace: string;
+  readonly kind: WatchKind;
+  readonly evictedByAge: number;
+  readonly evictedByCapacity: number;
+  readonly currentRingSize: number;
+  readonly oldestRv: string;
+  readonly currentRv: string;
+}
+
 interface KeyState {
   counter: bigint;
   ring: WatchEvent[];
   insertedAt: number[];
+  evictedByAge: number;
+  evictedByCapacity: number;
 }
 
 const DEFAULT_MAX_EVENTS = 1024;
@@ -28,8 +40,8 @@ const DEFAULT_OUTBOX_CAP = 256;
 
 export class WatchHub {
   private readonly state = new Map<string, KeyState>();
-  private readonly maxEventsPerKey: number;
-  private readonly maxAgeMsPerKey: number;
+  readonly maxEventsPerKey: number;
+  readonly maxAgeMsPerKey: number;
   readonly bookmarkIntervalMs: number;
   readonly perClientOutboxCap: number;
   private readonly now: () => number;
@@ -162,6 +174,27 @@ export class WatchHub {
     return s ? [...s.ring] : [];
   }
 
+  /** Snapshot of compaction counters across all (ns, kind) keys. */
+  getCompactionStats(): readonly CompactionStats[] {
+    const out: CompactionStats[] = [];
+    for (const [keyStr, s] of this.state.entries()) {
+      const sep = keyStr.indexOf("\x00");
+      const namespace = keyStr.slice(0, sep);
+      const kind = keyStr.slice(sep + 1) as WatchKind;
+      const oldestRv = s.ring.length > 0 ? (s.ring[0] as WatchEvent).rv : 0n;
+      out.push({
+        namespace,
+        kind,
+        evictedByAge: s.evictedByAge,
+        evictedByCapacity: s.evictedByCapacity,
+        currentRingSize: s.ring.length,
+        oldestRv: String(oldestRv),
+        currentRv: String(s.counter),
+      });
+    }
+    return out;
+  }
+
   private key(namespace: string, kind: WatchKind): string {
     return `${namespace}\x00${kind}`;
   }
@@ -169,7 +202,13 @@ export class WatchHub {
   private getOrCreate(key: string): KeyState {
     let s = this.state.get(key);
     if (!s) {
-      s = { counter: 0n, ring: [], insertedAt: [] };
+      s = {
+        counter: 0n,
+        ring: [],
+        insertedAt: [],
+        evictedByAge: 0,
+        evictedByCapacity: 0,
+      };
       this.state.set(key, s);
     }
     return s;
@@ -179,11 +218,13 @@ export class WatchHub {
     while (s.ring.length > this.maxEventsPerKey) {
       s.ring.shift();
       s.insertedAt.shift();
+      s.evictedByCapacity += 1;
     }
     const cutoff = this.now() - this.maxAgeMsPerKey;
     while (s.ring.length > 0 && (s.insertedAt[0] ?? 0) < cutoff) {
       s.ring.shift();
       s.insertedAt.shift();
+      s.evictedByAge += 1;
     }
   }
 }

--- a/src/core/watch-hub.ts
+++ b/src/core/watch-hub.ts
@@ -26,6 +26,8 @@ export interface CompactionStats {
 }
 
 interface KeyState {
+  readonly namespace: string;
+  readonly kind: WatchKind;
   counter: bigint;
   ring: WatchEvent[];
   insertedAt: number[];
@@ -55,8 +57,8 @@ export class WatchHub {
   }
 
   recordWrite(event: EntityWriteEvent): bigint {
+    const s = this.getOrCreate(event.namespace, event.kind);
     const key = this.key(event.namespace, event.kind);
-    const s = this.getOrCreate(key);
     s.counter += 1n;
     const watchEvent: WatchEvent = { ...event, rv: s.counter };
     s.ring.push(watchEvent);
@@ -77,7 +79,7 @@ export class WatchHub {
     signal: AbortSignal,
   ): AsyncIterable<WatchEvent> {
     const key = this.key(namespace, kind);
-    const s = this.getOrCreate(key);
+    const s = this.getOrCreate(namespace, kind);
 
     const oldestRv = s.ring.length > 0 ? (s.ring[0] as WatchEvent).rv : 0n;
     // Resume from rv == oldestRv - 1 means "I have everything through oldestRv-1,
@@ -177,14 +179,11 @@ export class WatchHub {
   /** Snapshot of compaction counters across all (ns, kind) keys. */
   getCompactionStats(): readonly CompactionStats[] {
     const out: CompactionStats[] = [];
-    for (const [keyStr, s] of this.state.entries()) {
-      const sep = keyStr.indexOf("\x00");
-      const namespace = keyStr.slice(0, sep);
-      const kind = keyStr.slice(sep + 1) as WatchKind;
+    for (const s of this.state.values()) {
       const oldestRv = s.ring.length > 0 ? (s.ring[0] as WatchEvent).rv : 0n;
       out.push({
-        namespace,
-        kind,
+        namespace: s.namespace,
+        kind: s.kind,
         evictedByAge: s.evictedByAge,
         evictedByCapacity: s.evictedByCapacity,
         currentRingSize: s.ring.length,
@@ -199,10 +198,13 @@ export class WatchHub {
     return `${namespace}\x00${kind}`;
   }
 
-  private getOrCreate(key: string): KeyState {
+  private getOrCreate(namespace: string, kind: WatchKind): KeyState {
+    const key = this.key(namespace, kind);
     let s = this.state.get(key);
     if (!s) {
       s = {
+        namespace,
+        kind,
         counter: 0n,
         ring: [],
         insertedAt: [],

--- a/src/core/watch-hub.ts
+++ b/src/core/watch-hub.ts
@@ -31,6 +31,13 @@ interface KeyState {
   counter: bigint;
   ring: WatchEvent[];
   insertedAt: number[];
+  /**
+   * Highest rv that has been evicted (by age or capacity). Any client
+   * resuming from `fromRv < floorRv` has missed at least one unrecoverable
+   * event and must relist. Survives full ring eviction so age-compaction
+   * of an idle key still triggers 410.
+   */
+  floorRv: bigint;
   evictedByAge: number;
   evictedByCapacity: number;
 }
@@ -81,10 +88,18 @@ export class WatchHub {
     const key = this.key(namespace, kind);
     const s = this.getOrCreate(namespace, kind);
 
-    const oldestRv = s.ring.length > 0 ? (s.ring[0] as WatchEvent).rv : 0n;
-    // Resume from rv == oldestRv - 1 means "I have everything through oldestRv-1,
-    // give me oldestRv onward." Anything strictly older is unrecoverable → 410.
-    if (fromRv < oldestRv - 1n) {
+    // Apply age compaction at subscribe time. Without this, an idle
+    // (namespace, kind) would keep events past maxAgeMs indefinitely and
+    // a resuming client could be replayed events the retention contract
+    // says are gone.
+    this.trim(s);
+
+    // floorRv is the highest evicted rv. Anything ≤ floorRv is unrecoverable;
+    // resuming from fromRv == floorRv means "I have everything through
+    // floorRv, give me floorRv+1 onward." Survives full ring eviction so
+    // age-compaction of idle keys still triggers 410.
+    if (fromRv < s.floorRv) {
+      const oldestRv = s.ring.length > 0 ? (s.ring[0] as WatchEvent).rv : s.floorRv + 1n;
       throw new StaleResourceVersionError(namespace, kind, fromRv, oldestRv);
     }
     // Reject future RVs. After a server restart the hub resets to 0; a client
@@ -180,7 +195,11 @@ export class WatchHub {
   getCompactionStats(): readonly CompactionStats[] {
     const out: CompactionStats[] = [];
     for (const s of this.state.values()) {
-      const oldestRv = s.ring.length > 0 ? (s.ring[0] as WatchEvent).rv : 0n;
+      // Reflect age compaction in metrics even when no writes have arrived
+      // since the events expired — otherwise the dashboard hides the fact
+      // that the ring is now empty.
+      this.trim(s);
+      const oldestRv = s.ring.length > 0 ? (s.ring[0] as WatchEvent).rv : s.floorRv + 1n;
       out.push({
         namespace: s.namespace,
         kind: s.kind,
@@ -208,6 +227,7 @@ export class WatchHub {
         counter: 0n,
         ring: [],
         insertedAt: [],
+        floorRv: 0n,
         evictedByAge: 0,
         evictedByCapacity: 0,
       };
@@ -218,14 +238,16 @@ export class WatchHub {
 
   private trim(s: KeyState): void {
     while (s.ring.length > this.maxEventsPerKey) {
-      s.ring.shift();
+      const evicted = s.ring.shift() as WatchEvent;
       s.insertedAt.shift();
+      if (evicted.rv > s.floorRv) s.floorRv = evicted.rv;
       s.evictedByCapacity += 1;
     }
     const cutoff = this.now() - this.maxAgeMsPerKey;
     while (s.ring.length > 0 && (s.insertedAt[0] ?? 0) < cutoff) {
-      s.ring.shift();
+      const evicted = s.ring.shift() as WatchEvent;
       s.insertedAt.shift();
+      if (evicted.rv > s.floorRv) s.floorRv = evicted.rv;
       s.evictedByAge += 1;
     }
   }

--- a/src/core/watch-hub.ts
+++ b/src/core/watch-hub.ts
@@ -110,11 +110,20 @@ export class WatchHub {
     }
 
     const replay: WatchEvent[] = s.ring.filter((e) => e.rv > fromRv);
+    // Cap replay at perClientOutboxCap. Without this, a slow consumer
+    // reconnecting from an old-but-valid rv could allocate up to
+    // maxEventsPerKey events per subscription on creation, and that cap
+    // can be configured up to 1M — multi-client reconnects would risk OOM
+    // before the route's byte-overflow path could trip. When replay exceeds
+    // the cap, fail closed: the subscriber starts in overflow state so
+    // next() throws BufferOverflowError → 503 → client relists from a
+    // fresh snapshot instead.
+    const replayOverflow = replay.length > this.perClientOutboxCap;
 
     const subscriber: Subscriber = {
       namespace,
       kind,
-      queue: [...replay],
+      queue: replayOverflow ? [] : [...replay],
       pending: null,
       // Pre-aborted signals never fire their listener (AbortSignal does
       // not invoke retroactively), so a subscriber registered against an
@@ -123,7 +132,7 @@ export class WatchHub {
       // `closed` up front so the next() loop terminates immediately and
       // the subscriber is never registered on the live set.
       closed: signal.aborted,
-      overflow: false,
+      overflow: replayOverflow,
     };
     if (!signal.aborted) {
       this.subscribersFor(key).add(subscriber);

--- a/src/nexus/nexus-claim-store.ts
+++ b/src/nexus/nexus-claim-store.ts
@@ -216,14 +216,11 @@ export class NexusClaimStore implements ClaimStore {
       }
       this.claimCache.set(renewed.claimId, renewed);
       this.invalidateActiveClaimsCache();
-      // Renew path always emits MODIFIED. Distinguishing pure heartbeat
-      // (no status change) from user-meaningful renews (intentSummary
-      // refresh, lease bump) would require comparing the prior claim
-      // contents — the cost of an extra read on every renew. The
-      // subscriber's (kind, id, generation) dedupe filters back-to-back
-      // duplicates, and the generation is monotonic on every revision
-      // bump above, so each renew is a distinct watch event.
-      this.publishWatch(renewed, "MODIFIED");
+      // Renewals do not change phase: status stays "active", and only the
+      // heartbeat/lease/intentSummary fields move. Suppress the watch
+      // event so renewal traffic doesn't burn watch RVs and ring slots.
+      // Status transitions (release / complete / expireStale) emit via
+      // their own paths; lease-bump-only events are not watch-worthy.
       return renewed;
     }
 
@@ -296,8 +293,10 @@ export class NexusClaimStore implements ClaimStore {
     await this.writeClaimCas(updated, etag);
     this.claimCache.set(updated.claimId, updated);
     this.invalidateActiveClaimsCache();
-    // Heartbeats are MODIFIED — same reasoning as the claimOrRenew renew path.
-    this.publishWatch(updated, "MODIFIED");
+    // Heartbeats are pure lease-bump operations: no phase change, no
+    // user-visible state mutation. Suppress watch fan-out (same rationale
+    // as the renew path); a flooded ring would force false 410s on
+    // legitimate watchers.
     return updated;
   }
 

--- a/src/nexus/nexus-claim-store.ts
+++ b/src/nexus/nexus-claim-store.ts
@@ -216,11 +216,11 @@ export class NexusClaimStore implements ClaimStore {
       }
       this.claimCache.set(renewed.claimId, renewed);
       this.invalidateActiveClaimsCache();
-      // Renewals do not change phase: status stays "active", and only the
-      // heartbeat/lease/intentSummary fields move. Suppress the watch
-      // event so renewal traffic doesn't burn watch RVs and ring slots.
-      // Status transitions (release / complete / expireStale) emit via
-      // their own paths; lease-bump-only events are not watch-worthy.
+      // Renewals advance heartbeatAt/leaseExpiresAt — fields Claim
+      // watchers depend on to reason about lease state. Emit MODIFIED
+      // even though status stays "active": suppressing would let a
+      // watcher conclude an actively-renewed claim has expired.
+      this.publishWatch(renewed, "MODIFIED");
       return renewed;
     }
 
@@ -293,10 +293,10 @@ export class NexusClaimStore implements ClaimStore {
     await this.writeClaimCas(updated, etag);
     this.claimCache.set(updated.claimId, updated);
     this.invalidateActiveClaimsCache();
-    // Heartbeats are pure lease-bump operations: no phase change, no
-    // user-visible state mutation. Suppress watch fan-out (same rationale
-    // as the renew path); a flooded ring would force false 410s on
-    // legitimate watchers.
+    // Heartbeats advance heartbeatAt/leaseExpiresAt and watchers depend
+    // on those fields for lease-aware decisions. Same rationale as the
+    // renew path — emit MODIFIED rather than risk stale-lease bugs.
+    this.publishWatch(updated, "MODIFIED");
     return updated;
   }
 

--- a/src/server/routes/claims.ts
+++ b/src/server/routes/claims.ts
@@ -80,29 +80,28 @@ claims.post("/", zValidator("json", createBodySchema), async (c) => {
   const result = await claimStore.claimOrRenew(claim);
 
   // Watch fan-out (#292). Direct store path bypasses the operations layer
-  // so we record + markSeen here. Only emit on the first create (revision
-  // === 1). claimOrRenew never changes status via this path — renewals
-  // (revision > 1) keep status "active" and would otherwise burn watch
-  // RVs and ring-buffer slots, forcing false 410s under normal lease
-  // renewal traffic. Status transitions (release/complete/expire) flow
-  // through their own handlers which emit independently.
-  const isCreate = (result.revision ?? 1) === 1;
-  if (isCreate) {
-    const entity = claimToEntity(result, () => Date.now(), namespace);
-    try {
-      watchHub.recordWrite({ kind: "Claim", namespace, op: "ADDED", entity });
-      watchSubscriber?.markSeen({
-        kind: "Claim",
-        entityId: result.claimId,
-        generation: entity.metadata.generation,
-      });
-    } catch (err) {
-      process.stderr.write(
-        `[grove] Warning: watch fan-out threw after POST /api/claims: ${
-          err instanceof Error ? err.message : String(err)
-        }\n`,
-      );
-    }
+  // so we record + markSeen here. Renewals must emit MODIFIED — they
+  // advance heartbeatAt/leaseExpiresAt which Claim watchers use to
+  // reason about lease state; suppressing them would let watchers
+  // declare an actively-renewed claim expired. Ring pressure under
+  // high renewal cadence is mitigated by sizing maxEventsPerKey to the
+  // expected renewal × active-claim load and by the WatchClient's
+  // relist-on-410 recovery path.
+  const op: "ADDED" | "MODIFIED" = (result.revision ?? 1) === 1 ? "ADDED" : "MODIFIED";
+  const entity = claimToEntity(result, () => Date.now(), namespace);
+  try {
+    watchHub.recordWrite({ kind: "Claim", namespace, op, entity });
+    watchSubscriber?.markSeen({
+      kind: "Claim",
+      entityId: result.claimId,
+      generation: entity.metadata.generation,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[grove] Warning: watch fan-out threw after POST /api/claims: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
   }
 
   return c.json(result, 201);

--- a/src/server/routes/claims.ts
+++ b/src/server/routes/claims.ts
@@ -80,27 +80,29 @@ claims.post("/", zValidator("json", createBodySchema), async (c) => {
   const result = await claimStore.claimOrRenew(claim);
 
   // Watch fan-out (#292). Direct store path bypasses the operations layer
-  // so we record + markSeen here. Derive ADDED vs MODIFIED from the
-  // store's atomic revision counter — pre-reading `existing` outside the
-  // store transaction is racy: two concurrent same-agent renewals can
-  // both observe no existing claim and both emit ADDED for one logical
-  // claim. The store guarantees revision === 1 on first create and
-  // revision > 1 on every renewal, regardless of concurrency.
-  const op: "ADDED" | "MODIFIED" = (result.revision ?? 1) === 1 ? "ADDED" : "MODIFIED";
-  const entity = claimToEntity(result, () => Date.now(), namespace);
-  try {
-    watchHub.recordWrite({ kind: "Claim", namespace, op, entity });
-    watchSubscriber?.markSeen({
-      kind: "Claim",
-      entityId: result.claimId,
-      generation: entity.metadata.generation,
-    });
-  } catch (err) {
-    process.stderr.write(
-      `[grove] Warning: watch fan-out threw after POST /api/claims: ${
-        err instanceof Error ? err.message : String(err)
-      }\n`,
-    );
+  // so we record + markSeen here. Only emit on the first create (revision
+  // === 1). claimOrRenew never changes status via this path — renewals
+  // (revision > 1) keep status "active" and would otherwise burn watch
+  // RVs and ring-buffer slots, forcing false 410s under normal lease
+  // renewal traffic. Status transitions (release/complete/expire) flow
+  // through their own handlers which emit independently.
+  const isCreate = (result.revision ?? 1) === 1;
+  if (isCreate) {
+    const entity = claimToEntity(result, () => Date.now(), namespace);
+    try {
+      watchHub.recordWrite({ kind: "Claim", namespace, op: "ADDED", entity });
+      watchSubscriber?.markSeen({
+        kind: "Claim",
+        entityId: result.claimId,
+        generation: entity.metadata.generation,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `[grove] Warning: watch fan-out threw after POST /api/claims: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+    }
   }
 
   return c.json(result, 201);

--- a/src/server/routes/claims.ts
+++ b/src/server/routes/claims.ts
@@ -114,8 +114,28 @@ claims.patch("/:id", zValidator("json", patchBodySchema), async (c) => {
 
   // Heartbeat stays as direct store call (no matching operation)
   if (action === "heartbeat") {
-    const { claimStore } = c.get("deps");
+    const deps = c.get("deps");
+    const { claimStore, watchHub, watchSubscriber } = deps;
+    const namespace = c.get("namespace");
     const result = await claimStore.heartbeat(claimId, leaseDurationMs);
+    // Heartbeats advance heartbeatAt/leaseExpiresAt — fields Claim watchers
+    // depend on for lease-aware decisions. Emit MODIFIED so a watcher's
+    // cached entity stays in sync with the new lease deadline.
+    const entity = claimToEntity(result, () => Date.now(), namespace);
+    try {
+      watchHub.recordWrite({ kind: "Claim", namespace, op: "MODIFIED", entity });
+      watchSubscriber?.markSeen({
+        kind: "Claim",
+        entityId: result.claimId,
+        generation: entity.metadata.generation,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `[grove] Warning: watch fan-out threw after PATCH heartbeat: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+    }
     return c.json(result);
   }
 

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -189,8 +189,25 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
         };
         teardown = cleanup;
 
+        // Terminal frames bypass the byte-overflow gate. send() refuses to
+        // enqueue when desiredSize is past ROUTE_BYTE_OVERFLOW_THRESHOLD —
+        // but the entire reason we're closing is overflow, and accepting
+        // one small ERROR frame on an over-budget queue is what the client
+        // depends on to receive the 503 signal (otherwise it sees plain EOF
+        // and fast-resumes into the same overflow loop).
+        const sendTerminal = (event: string, data: unknown): void => {
+          if (closed) return;
+          const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+          const bytes = encoder.encode(payload);
+          try {
+            controller.enqueue(bytes);
+          } catch {
+            /* already closed */
+          }
+        };
+
         const closeWithError = (code: number, reason: string): void => {
-          send("ERROR", { code, reason });
+          sendTerminal("ERROR", { code, reason });
           cleanup();
         };
 

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -284,6 +284,23 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
   });
 });
 
+/** GET /api/watch/metrics — retention config + per-(ns,kind) compaction stats. */
+watch.get("/watch/metrics", async (c) => {
+  const namespace = c.get("namespace");
+  const hub: WatchHub = c.get("deps").watchHub;
+  const allStats = hub.getCompactionStats();
+  // Filter to caller's namespace so namespaces don't leak each other's
+  // traffic shape. The request is already authenticated by namespaceAuth.
+  const keys = allStats.filter((s) => s.namespace === namespace);
+  return c.json({
+    retention: {
+      maxAgeMs: hub.maxAgeMsPerKey,
+      maxEvents: hub.maxEventsPerKey,
+    },
+    keys,
+  });
+});
+
 async function listForKind(
   deps: ServerDeps,
   namespace: string,

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -211,6 +211,23 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
           cleanup();
         };
 
+        // Wire up the request-disconnect listener BEFORE subscribing.
+        // AbortSignal listeners are not retroactive — registering after
+        // hub.subscribe() leaves a window where the client can disconnect
+        // and the subscription/timer would leak until later overflow or
+        // process exit.
+        const reqSignal = c.req.raw.signal;
+        if (reqSignal.aborted) {
+          // Already disconnected before we got here. Don't subscribe.
+          cleanup();
+          return;
+        }
+        const onReqAbort = (): void => {
+          reqSignal.removeEventListener("abort", onReqAbort);
+          cleanup();
+        };
+        reqSignal.addEventListener("abort", onReqAbort, { once: true });
+
         let iterable: AsyncIterable<WatchEvent>;
         try {
           iterable = hub.subscribe(namespace, kind as WatchKind, fromRv, ac.signal);
@@ -277,9 +294,6 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
             }
           }
         })();
-
-        // Abort when the client disconnects.
-        c.req.raw.signal.addEventListener("abort", cleanup);
       },
       cancel() {
         // Reader cancel (response body cancelled) — release the hub

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -292,13 +292,20 @@ watch.get("/watch/metrics", async (c) => {
   // Filter to caller's namespace so namespaces don't leak each other's
   // traffic shape. The request is already authenticated by namespaceAuth.
   const keys = allStats.filter((s) => s.namespace === namespace);
-  return c.json({
-    retention: {
-      maxAgeMs: hub.maxAgeMsPerKey,
-      maxEvents: hub.maxEventsPerKey,
+  return c.json(
+    {
+      retention: {
+        maxAgeMs: hub.maxAgeMsPerKey,
+        maxEvents: hub.maxEventsPerKey,
+      },
+      keys,
     },
-    keys,
-  });
+    200,
+    {
+      "Cache-Control": "private, no-store",
+      Vary: "Authorization",
+    },
+  );
 });
 
 async function listForKind(

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -35,8 +35,8 @@ import type { ServerDeps } from "./deps.js";
 import { loadKeyRegistry } from "./middleware/namespace-auth.js";
 import { SessionService } from "./session-service.js";
 import { memoizeContributionStoreForSession } from "./session-store-factory.js";
-import { createWsHandler } from "./ws-handler.js";
 import { resolveWatchHubConfig } from "./watch-hub-config.js";
+import { createWsHandler } from "./ws-handler.js";
 
 const GROVE_DIR = process.env.GROVE_DIR ?? join(process.cwd(), ".grove");
 const PORT = parsePort(process.env.PORT, 4515);

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -215,6 +215,15 @@ if (seedPeers.length > 0) {
 // envelopes; the publisher lives inside Nexus stores and the subscriber
 // lives here in the server. Even in pure-local mode we instantiate both
 // so the wiring is uniform — the bus is just idle when nothing publishes.
+//
+// KNOWN GAP (tracked separately from #293, see #294 informer client):
+// The bus is process-local. MCP/agent processes that share the same Nexus
+// VFS write through Nexus stores, but their `entity.changed` envelopes
+// publish to a *different* in-process bus and never reach this server's
+// watchSubscriber. Today the watch protocol covers writes performed
+// through grove-server's own routes plus the in-process onEntityWrite
+// fast path. Closing the gap requires routing entity.changed through
+// NexusEventBus (cross-process via Nexus IPC) on both sides.
 const watchHub = new WatchHub(resolveWatchHubConfig(process.env));
 const watchEventBus = new LocalEventBus();
 

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -36,6 +36,7 @@ import { loadKeyRegistry } from "./middleware/namespace-auth.js";
 import { SessionService } from "./session-service.js";
 import { memoizeContributionStoreForSession } from "./session-store-factory.js";
 import { createWsHandler } from "./ws-handler.js";
+import { resolveWatchHubConfig } from "./watch-hub-config.js";
 
 const GROVE_DIR = process.env.GROVE_DIR ?? join(process.cwd(), ".grove");
 const PORT = parsePort(process.env.PORT, 4515);
@@ -214,7 +215,7 @@ if (seedPeers.length > 0) {
 // envelopes; the publisher lives inside Nexus stores and the subscriber
 // lives here in the server. Even in pure-local mode we instantiate both
 // so the wiring is uniform — the bus is just idle when nothing publishes.
-const watchHub = new WatchHub();
+const watchHub = new WatchHub(resolveWatchHubConfig(process.env));
 const watchEventBus = new LocalEventBus();
 
 if (nexusUrl) {

--- a/src/server/test-helpers.ts
+++ b/src/server/test-helpers.ts
@@ -119,12 +119,16 @@ export class InMemoryClaimStore implements ClaimStore {
     for (const existing of this.claims.values()) {
       if (existing.targetRef === claim.targetRef && existing.status === "active") {
         if (existing.agent.agentId === claim.agent.agentId) {
-          // Renew: update lease
+          // Renew: update lease and bump revision (matches the conformance
+          // contract — SQLite + Nexus stores both increment revision on
+          // every renewal, and watch fan-out depends on it to distinguish
+          // create from renew).
           const renewed: Claim = {
             ...existing,
             heartbeatAt: claim.heartbeatAt,
             leaseExpiresAt: claim.leaseExpiresAt,
             intentSummary: claim.intentSummary,
+            revision: (existing.revision ?? 1) + 1,
           };
           this.claims.set(existing.claimId, renewed);
           return renewed;
@@ -136,8 +140,9 @@ export class InMemoryClaimStore implements ClaimStore {
         });
       }
     }
-    this.claims.set(claim.claimId, claim);
-    return claim;
+    const created: Claim = { ...claim, revision: 1 };
+    this.claims.set(claim.claimId, created);
+    return created;
   }
 
   async getClaim(claimId: string): Promise<Claim | undefined> {

--- a/src/server/test-helpers.ts
+++ b/src/server/test-helpers.ts
@@ -170,6 +170,7 @@ export class InMemoryClaimStore implements ClaimStore {
       ...claim,
       heartbeatAt: now.toISOString(),
       leaseExpiresAt: new Date(now.getTime() + (leaseDurationMs ?? 300_000)).toISOString(),
+      revision: (claim.revision ?? 1) + 1,
     };
     this.claims.set(claimId, updated);
     return updated;

--- a/src/server/watch-hub-config.test.ts
+++ b/src/server/watch-hub-config.test.ts
@@ -24,37 +24,28 @@ describe("resolveWatchHubConfig", () => {
 
   test("clamps GROVE_WATCH_RETENTION_MS below min to default", () => {
     const warn = mock(() => {});
-    const cfg = resolveWatchHubConfig(
-      { GROVE_WATCH_RETENTION_MS: "0" },
-      { warn },
-    );
+    const cfg = resolveWatchHubConfig({ GROVE_WATCH_RETENTION_MS: "0" }, { warn });
     expect(cfg.maxAgeMsPerKey).toBe(300_000);
     expect(warn.mock.calls.length).toBe(1);
   });
 
   test("clamps GROVE_WATCH_MAX_EVENTS above max to default", () => {
     const warn = mock(() => {});
-    const cfg = resolveWatchHubConfig(
-      { GROVE_WATCH_MAX_EVENTS: "9999999999" },
-      { warn },
-    );
+    const cfg = resolveWatchHubConfig({ GROVE_WATCH_MAX_EVENTS: "9999999999" }, { warn });
     expect(cfg.maxEventsPerKey).toBe(1024);
     expect(warn.mock.calls.length).toBe(1);
   });
 
   test("rejects negative GROVE_WATCH_RETENTION_MS", () => {
     const warn = mock(() => {});
-    const cfg = resolveWatchHubConfig(
-      { GROVE_WATCH_RETENTION_MS: "-5" },
-      { warn },
-    );
+    const cfg = resolveWatchHubConfig({ GROVE_WATCH_RETENTION_MS: "-5" }, { warn });
     expect(cfg.maxAgeMsPerKey).toBe(300_000);
   });
 
   test("accepts boundary values", () => {
     const cfg = resolveWatchHubConfig({
-      GROVE_WATCH_RETENTION_MS: "1000",     // min
-      GROVE_WATCH_MAX_EVENTS: "1000000",    // max
+      GROVE_WATCH_RETENTION_MS: "1000", // min
+      GROVE_WATCH_MAX_EVENTS: "1000000", // max
     });
     expect(cfg.maxAgeMsPerKey).toBe(1000);
     expect(cfg.maxEventsPerKey).toBe(1_000_000);

--- a/src/server/watch-hub-config.test.ts
+++ b/src/server/watch-hub-config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, mock, test } from "bun:test";
+import { resolveWatchHubConfig } from "./watch-hub-config.js";
+
+describe("resolveWatchHubConfig", () => {
+  test("returns defaults when no env vars set", () => {
+    const cfg = resolveWatchHubConfig({});
+    expect(cfg.maxAgeMsPerKey).toBe(300_000);
+    expect(cfg.maxEventsPerKey).toBe(1024);
+  });
+
+  test("reads GROVE_WATCH_RETENTION_MS when in range", () => {
+    const cfg = resolveWatchHubConfig({
+      GROVE_WATCH_RETENTION_MS: "30000",
+    });
+    expect(cfg.maxAgeMsPerKey).toBe(30_000);
+  });
+
+  test("reads GROVE_WATCH_MAX_EVENTS when in range", () => {
+    const cfg = resolveWatchHubConfig({
+      GROVE_WATCH_MAX_EVENTS: "256",
+    });
+    expect(cfg.maxEventsPerKey).toBe(256);
+  });
+
+  test("clamps GROVE_WATCH_RETENTION_MS below min to default", () => {
+    const warn = mock(() => {});
+    const cfg = resolveWatchHubConfig(
+      { GROVE_WATCH_RETENTION_MS: "0" },
+      { warn },
+    );
+    expect(cfg.maxAgeMsPerKey).toBe(300_000);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  test("clamps GROVE_WATCH_MAX_EVENTS above max to default", () => {
+    const warn = mock(() => {});
+    const cfg = resolveWatchHubConfig(
+      { GROVE_WATCH_MAX_EVENTS: "9999999999" },
+      { warn },
+    );
+    expect(cfg.maxEventsPerKey).toBe(1024);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  test("rejects negative GROVE_WATCH_RETENTION_MS", () => {
+    const warn = mock(() => {});
+    const cfg = resolveWatchHubConfig(
+      { GROVE_WATCH_RETENTION_MS: "-5" },
+      { warn },
+    );
+    expect(cfg.maxAgeMsPerKey).toBe(300_000);
+  });
+
+  test("accepts boundary values", () => {
+    const cfg = resolveWatchHubConfig({
+      GROVE_WATCH_RETENTION_MS: "1000",     // min
+      GROVE_WATCH_MAX_EVENTS: "1000000",    // max
+    });
+    expect(cfg.maxAgeMsPerKey).toBe(1000);
+    expect(cfg.maxEventsPerKey).toBe(1_000_000);
+  });
+});

--- a/src/server/watch-hub-config.ts
+++ b/src/server/watch-hub-config.ts
@@ -1,0 +1,36 @@
+/**
+ * Boot-time resolution of WatchHubOptions from environment variables.
+ * Extracted from serve.ts so the env→config mapping is unit-testable
+ * without standing up the full server (#293).
+ */
+
+import { clampInt } from "../core/clamp.js";
+import type { WatchHubOptions } from "../core/watch-hub.js";
+
+export interface ResolveOptions {
+  readonly warn?: (msg: string) => void;
+}
+
+export function resolveWatchHubConfig(
+  env: Readonly<Record<string, string | undefined>>,
+  opts: ResolveOptions = {},
+): Pick<WatchHubOptions, "maxAgeMsPerKey" | "maxEventsPerKey"> {
+  return {
+    maxAgeMsPerKey: clampInt({
+      raw: env.GROVE_WATCH_RETENTION_MS,
+      fallback: 300_000,
+      min: 1_000,
+      max: 86_400_000,
+      name: "GROVE_WATCH_RETENTION_MS",
+      ...(opts.warn ? { warn: opts.warn } : {}),
+    }),
+    maxEventsPerKey: clampInt({
+      raw: env.GROVE_WATCH_MAX_EVENTS,
+      fallback: 1024,
+      min: 16,
+      max: 1_000_000,
+      name: "GROVE_WATCH_MAX_EVENTS",
+      ...(opts.warn ? { warn: opts.warn } : {}),
+    }),
+  };
+}

--- a/src/server/watch.compaction.test.ts
+++ b/src/server/watch.compaction.test.ts
@@ -112,6 +112,7 @@ describe("compaction triggers Expired (issue #293 acceptance #1)", () => {
     expect(errorEvent).toBeDefined();
     expect((errorEvent?.data as { code: number }).code).toBe(410);
     expect((errorEvent?.data as { reason: string }).reason).toBe("expired");
+    expect(events[0]?.event).toBe("ERROR");
 
     // Metrics endpoint reflects the eviction.
     const metricsRes = await app.request("/api/watch/metrics", {
@@ -127,6 +128,7 @@ describe("compaction triggers Expired (issue #293 acceptance #1)", () => {
       watchHubOptions: { maxAgeMsPerKey: 60_000, maxEventsPerKey: 4 },
     });
     const earlyRv = await listRv(app);
+    expect(earlyRv).toBe("0");
     for (let i = 0; i < 10; i++) {
       const r = await app.request("/api/contributions", {
         method: "POST",
@@ -142,6 +144,7 @@ describe("compaction triggers Expired (issue #293 acceptance #1)", () => {
     const errorEvent = events.find((e) => e.event === "ERROR");
     expect(errorEvent).toBeDefined();
     expect((errorEvent?.data as { code: number }).code).toBe(410);
+    expect(events[0]?.event).toBe("ERROR");
 
     const metricsRes = await app.request("/api/watch/metrics", {
       headers: TEST_AUTH_HEADERS,

--- a/src/server/watch.compaction.test.ts
+++ b/src/server/watch.compaction.test.ts
@@ -236,9 +236,7 @@ describe("PATCH /api/claims/:id heartbeat watch fan-out", () => {
     const events = await readSseEvents(watchRes, 1, 1_000);
     const modified = events.find((e) => e.event === "MODIFIED");
     expect(modified).toBeDefined();
-    expect(
-      (modified?.data as { entity: { id: string } }).entity.id,
-    ).toBe(claimBody.claimId);
+    expect((modified?.data as { entity: { id: string } }).entity.id).toBe(claimBody.claimId);
   });
 });
 

--- a/src/server/watch.compaction.test.ts
+++ b/src/server/watch.compaction.test.ts
@@ -32,6 +32,9 @@ describe("GET /api/watch/metrics", () => {
     const body = (await res.json()) as MetricsResponse;
     expect(body.retention.maxAgeMs).toBe(1234);
     expect(body.retention.maxEvents).toBe(56);
+    expect(body.keys).toEqual([]);
+    expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(res.headers.get("Vary")).toBe("Authorization");
   });
 
   test("reports counters after writes within capacity", async () => {

--- a/src/server/watch.compaction.test.ts
+++ b/src/server/watch.compaction.test.ts
@@ -202,15 +202,13 @@ describe("compaction triggers Expired (issue #293 acceptance #1)", () => {
   });
 });
 
-describe("POST /api/claims watch fan-out (renewal suppression)", () => {
-  test("repeated same-agent renewals do not advance Claim watch RV", async () => {
-    // Regression: route used to emit MODIFIED on every renewal, so a tight
-    // loop of renewals burned the watch ring and forced false 410s for
-    // legitimate watchers. With suppression, only the initial create
-    // advances Claim RV; subsequent renewals are pure lease bumps and
-    // emit no watch event.
+describe("POST /api/claims watch fan-out", () => {
+  test("renewals emit MODIFIED so watchers see lease updates", async () => {
+    // Lease state (heartbeatAt / leaseExpiresAt) is part of the Claim
+    // entity surfaced to watchers. Suppressing renewal events would let
+    // a watcher conclude an actively-renewed claim had expired.
     const { app } = createTestApp({
-      watchHubOptions: { maxEventsPerKey: 2, maxAgeMsPerKey: 60_000 },
+      watchHubOptions: { maxEventsPerKey: 100, maxAgeMsPerKey: 60_000 },
     });
     const claimBody = {
       claimId: "claim-renew-1",
@@ -218,7 +216,6 @@ describe("POST /api/claims watch fan-out (renewal suppression)", () => {
       agent: { agentId: "agent-1" },
       intentSummary: "renewal stress",
     };
-    // Helper to POST and wait for 201.
     const post = async () => {
       const r = await app.request("/api/claims", {
         method: "POST",
@@ -227,22 +224,17 @@ describe("POST /api/claims watch fan-out (renewal suppression)", () => {
       });
       expect(r.status).toBe(201);
     };
-    // First create + 4 renewals.
     await post();
     await post();
     await post();
-    await post();
-    await post();
-    // Watch metrics should show Claim RV advanced exactly once (the create).
     const metricsRes = await app.request("/api/watch/metrics", {
       headers: TEST_AUTH_HEADERS,
     });
     const metrics = (await metricsRes.json()) as MetricsResponse;
     const claimKey = metrics.keys.find((k) => k.kind === "Claim");
     expect(claimKey).toBeDefined();
-    expect(claimKey?.currentRv).toBe("1");
-    // No capacity eviction even though the per-kind cap is 2.
-    expect(claimKey?.evictedByCapacity).toBe(0);
+    // First create (revision=1) → ADDED + 2 renewals → MODIFIED. RV=3.
+    expect(claimKey?.currentRv).toBe("3");
   });
 });
 

--- a/src/server/watch.compaction.test.ts
+++ b/src/server/watch.compaction.test.ts
@@ -202,6 +202,50 @@ describe("compaction triggers Expired (issue #293 acceptance #1)", () => {
   });
 });
 
+describe("POST /api/claims watch fan-out (renewal suppression)", () => {
+  test("repeated same-agent renewals do not advance Claim watch RV", async () => {
+    // Regression: route used to emit MODIFIED on every renewal, so a tight
+    // loop of renewals burned the watch ring and forced false 410s for
+    // legitimate watchers. With suppression, only the initial create
+    // advances Claim RV; subsequent renewals are pure lease bumps and
+    // emit no watch event.
+    const { app } = createTestApp({
+      watchHubOptions: { maxEventsPerKey: 2, maxAgeMsPerKey: 60_000 },
+    });
+    const claimBody = {
+      claimId: "claim-renew-1",
+      targetRef: "task-x",
+      agent: { agentId: "agent-1" },
+      intentSummary: "renewal stress",
+    };
+    // Helper to POST and wait for 201.
+    const post = async () => {
+      const r = await app.request("/api/claims", {
+        method: "POST",
+        headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+        body: JSON.stringify(claimBody),
+      });
+      expect(r.status).toBe(201);
+    };
+    // First create + 4 renewals.
+    await post();
+    await post();
+    await post();
+    await post();
+    await post();
+    // Watch metrics should show Claim RV advanced exactly once (the create).
+    const metricsRes = await app.request("/api/watch/metrics", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const metrics = (await metricsRes.json()) as MetricsResponse;
+    const claimKey = metrics.keys.find((k) => k.kind === "Claim");
+    expect(claimKey).toBeDefined();
+    expect(claimKey?.currentRv).toBe("1");
+    // No capacity eviction even though the per-kind cap is 2.
+    expect(claimKey?.evictedByCapacity).toBe(0);
+  });
+});
+
 describe("watch route overflow path delivers terminal ERROR", () => {
   test("byte-overflow at route level still emits ERROR{code:503} (regression)", async () => {
     // Regression: closeWithError() previously routed through send() which

--- a/src/server/watch.compaction.test.ts
+++ b/src/server/watch.compaction.test.ts
@@ -202,6 +202,46 @@ describe("compaction triggers Expired (issue #293 acceptance #1)", () => {
   });
 });
 
+describe("PATCH /api/claims/:id heartbeat watch fan-out", () => {
+  test("heartbeat emits MODIFIED with updated lease fields", async () => {
+    // Heartbeats update heartbeatAt + leaseExpiresAt. Watchers must see
+    // these so they don't conclude an actively heartbeated claim has
+    // expired. Regression: heartbeat used to return without recordWrite.
+    const { app } = createTestApp({
+      watchHubOptions: { maxEventsPerKey: 100, maxAgeMsPerKey: 60_000 },
+    });
+    const claimBody = {
+      claimId: "claim-hb-1",
+      targetRef: "task-hb",
+      agent: { agentId: "agent-1" },
+      intentSummary: "heartbeat test",
+    };
+    const post = await app.request("/api/claims", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify(claimBody),
+    });
+    expect(post.status).toBe(201);
+
+    // Open watch from current rv=1 so the heartbeat shows up as the next event.
+    const watchRes = await app.request("/api/watch?kind=Claim&resumeFrom=1", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const hb = await app.request(`/api/claims/${claimBody.claimId}`, {
+      method: "PATCH",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "heartbeat" }),
+    });
+    expect(hb.status).toBe(200);
+    const events = await readSseEvents(watchRes, 1, 1_000);
+    const modified = events.find((e) => e.event === "MODIFIED");
+    expect(modified).toBeDefined();
+    expect(
+      (modified?.data as { entity: { id: string } }).entity.id,
+    ).toBe(claimBody.claimId);
+  });
+});
+
 describe("POST /api/claims watch fan-out", () => {
   test("renewals emit MODIFIED so watchers see lease updates", async () => {
     // Lease state (heartbeatAt / leaseExpiresAt) is part of the Claim

--- a/src/server/watch.compaction.test.ts
+++ b/src/server/watch.compaction.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Acceptance tests for issue #293 — server-side compaction surface.
+ *   - GET /api/watch/metrics returns retention config and per-(ns,kind) counters
+ *   - Namespace isolation: caller only sees their own keys
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createTestApp, makeManifestBody, TEST_AUTH_HEADERS } from "./test-helpers.js";
+
+interface MetricsResponse {
+  retention: { maxAgeMs: number; maxEvents: number };
+  keys: Array<{
+    namespace: string;
+    kind: string;
+    evictedByAge: number;
+    evictedByCapacity: number;
+    currentRingSize: number;
+    oldestRv: string;
+    currentRv: string;
+  }>;
+}
+
+describe("GET /api/watch/metrics", () => {
+  test("returns retention config from WatchHub options", async () => {
+    const { app } = createTestApp({
+      watchHubOptions: { maxAgeMsPerKey: 1234, maxEventsPerKey: 56 },
+    });
+    const res = await app.request("/api/watch/metrics", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MetricsResponse;
+    expect(body.retention.maxAgeMs).toBe(1234);
+    expect(body.retention.maxEvents).toBe(56);
+  });
+
+  test("reports counters after writes within capacity", async () => {
+    const { app } = createTestApp({
+      watchHubOptions: { maxAgeMsPerKey: 60_000, maxEventsPerKey: 100 },
+    });
+    const writeRes = await app.request("/api/contributions", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify(makeManifestBody({ summary: "metrics-1" })),
+    });
+    expect(writeRes.status).toBe(201);
+
+    const res = await app.request("/api/watch/metrics", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const body = (await res.json()) as MetricsResponse;
+    const key = body.keys.find((k) => k.kind === "Contribution");
+    expect(key).toBeDefined();
+    expect(key?.evictedByAge).toBe(0);
+    expect(key?.evictedByCapacity).toBe(0);
+    expect(key?.currentRingSize).toBe(1);
+    expect(key?.currentRv).toBe("1");
+  });
+
+  test("requires authentication", async () => {
+    const { app } = createTestApp();
+    const res = await app.request("/api/watch/metrics");
+    expect([400, 401]).toContain(res.status);
+  });
+});

--- a/src/server/watch.compaction.test.ts
+++ b/src/server/watch.compaction.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { readSseEvents } from "./sse-test-utils.js";
 import { createTestApp, makeManifestBody, TEST_AUTH_HEADERS } from "./test-helpers.js";
 
 interface MetricsResponse {
@@ -66,3 +67,97 @@ describe("GET /api/watch/metrics", () => {
     expect([400, 401]).toContain(res.status);
   });
 });
+
+describe("compaction triggers Expired (issue #293 acceptance #1)", () => {
+  test("sleep past retention window → resume returns 410", async () => {
+    let now = 1_000_000;
+    const { app } = createTestApp({
+      watchHubOptions: {
+        maxAgeMsPerKey: 200,
+        maxEventsPerKey: 100,
+        now: () => now,
+      },
+    });
+
+    // Capture rv before any writes so it falls strictly below the post-
+    // eviction oldestRv. With earlyRv=0 and oldestRv=2 after eviction,
+    // the 410 trigger `fromRv < oldestRv - 1n` (0 < 1) holds.
+    const earlyRv = await listRv(app);
+    expect(earlyRv).toBe("0");
+
+    const writeRes1 = await app.request("/api/contributions", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify(makeManifestBody({ summary: "early" })),
+    });
+    expect(writeRes1.status).toBe(201);
+
+    // Advance clock past retention so the next write's trim evicts entry 1.
+    now += 1_000;
+
+    const writeRes2 = await app.request("/api/contributions", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify(makeManifestBody({ summary: "late" })),
+    });
+    expect(writeRes2.status).toBe(201);
+
+    // Resume from earlyRv=0. Ring oldestRv=2 → 410.
+    const watchRes = await app.request(`/api/watch?kind=Contribution&resumeFrom=${earlyRv}`, {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const events = await readSseEvents(watchRes, 1, 1_000);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    const errorEvent = events.find((e) => e.event === "ERROR");
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { code: number }).code).toBe(410);
+    expect((errorEvent?.data as { reason: string }).reason).toBe("expired");
+
+    // Metrics endpoint reflects the eviction.
+    const metricsRes = await app.request("/api/watch/metrics", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const metrics = (await metricsRes.json()) as MetricsResponse;
+    const key = metrics.keys.find((k) => k.kind === "Contribution");
+    expect(key?.evictedByAge).toBeGreaterThanOrEqual(1);
+  });
+
+  test("capacity-based eviction also returns 410", async () => {
+    const { app } = createTestApp({
+      watchHubOptions: { maxAgeMsPerKey: 60_000, maxEventsPerKey: 4 },
+    });
+    const earlyRv = await listRv(app);
+    for (let i = 0; i < 10; i++) {
+      const r = await app.request("/api/contributions", {
+        method: "POST",
+        headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+        body: JSON.stringify(makeManifestBody({ summary: `cap-${i}` })),
+      });
+      expect(r.status).toBe(201);
+    }
+    const watchRes = await app.request(`/api/watch?kind=Contribution&resumeFrom=${earlyRv}`, {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const events = await readSseEvents(watchRes, 1, 1_000);
+    const errorEvent = events.find((e) => e.event === "ERROR");
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { code: number }).code).toBe(410);
+
+    const metricsRes = await app.request("/api/watch/metrics", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const metrics = (await metricsRes.json()) as MetricsResponse;
+    const key = metrics.keys.find((k) => k.kind === "Contribution");
+    expect(key?.evictedByCapacity).toBeGreaterThanOrEqual(1);
+  });
+});
+
+async function listRv(app: {
+  request: (path: string, init?: RequestInit) => Promise<Response>;
+}): Promise<string> {
+  const res = await app.request("/api/list?kind=Contribution", {
+    headers: TEST_AUTH_HEADERS,
+  });
+  const json = (await res.json()) as { listResourceVersion: string };
+  return json.listResourceVersion;
+}

--- a/src/server/watch.compaction.test.ts
+++ b/src/server/watch.compaction.test.ts
@@ -310,7 +310,7 @@ describe("watch route overflow path delivers terminal ERROR", () => {
 });
 
 async function listRv(app: {
-  request: (path: string, init?: RequestInit) => Promise<Response>;
+  request: (path: string, init?: RequestInit) => Response | Promise<Response>;
 }): Promise<string> {
   const res = await app.request("/api/list?kind=Contribution", {
     headers: TEST_AUTH_HEADERS,

--- a/src/server/watch.compaction.test.ts
+++ b/src/server/watch.compaction.test.ts
@@ -123,6 +123,53 @@ describe("compaction triggers Expired (issue #293 acceptance #1)", () => {
     expect(key?.evictedByAge).toBeGreaterThanOrEqual(1);
   });
 
+  test("idle key past retention window → resume returns 410 (no further writes)", async () => {
+    // Regression: trim() used to run only on recordWrite(), so an idle
+    // (namespace, kind) key kept events past maxAgeMs forever. A client
+    // resuming after the documented retention window would receive
+    // expired replay instead of ERROR 410, defeating the contract.
+    let now = 1_000_000;
+    const { app } = createTestApp({
+      watchHubOptions: {
+        maxAgeMsPerKey: 200,
+        maxEventsPerKey: 100,
+        now: () => now,
+      },
+    });
+
+    const earlyRv = await listRv(app);
+    expect(earlyRv).toBe("0");
+
+    const wr = await app.request("/api/contributions", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify(makeManifestBody({ summary: "alone" })),
+    });
+    expect(wr.status).toBe(201);
+
+    // Advance clock past retention WITHOUT another write. Compaction must
+    // happen at subscribe time even though no write triggers trim().
+    now += 1_000;
+
+    const watchRes = await app.request(`/api/watch?kind=Contribution&resumeFrom=${earlyRv}`, {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const events = await readSseEvents(watchRes, 1, 1_000);
+    const errorEvent = events.find((e) => e.event === "ERROR");
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { code: number }).code).toBe(410);
+    expect(events[0]?.event).toBe("ERROR");
+
+    // Metrics also reflect the eviction without a write triggering it.
+    const metricsRes = await app.request("/api/watch/metrics", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    const metrics = (await metricsRes.json()) as MetricsResponse;
+    const key = metrics.keys.find((k) => k.kind === "Contribution");
+    expect(key?.evictedByAge).toBe(1);
+    expect(key?.currentRingSize).toBe(0);
+  });
+
   test("capacity-based eviction also returns 410", async () => {
     const { app } = createTestApp({
       watchHubOptions: { maxAgeMsPerKey: 60_000, maxEventsPerKey: 4 },
@@ -153,6 +200,39 @@ describe("compaction triggers Expired (issue #293 acceptance #1)", () => {
     const key = metrics.keys.find((k) => k.kind === "Contribution");
     expect(key?.evictedByCapacity).toBeGreaterThanOrEqual(1);
   });
+});
+
+describe("watch route overflow path delivers terminal ERROR", () => {
+  test("byte-overflow at route level still emits ERROR{code:503} (regression)", async () => {
+    // Regression: closeWithError() previously routed through send() which
+    // refuses frames whose enqueue would push desiredSize past the route's
+    // overflow threshold. Once isOverflowed() fired, closeWithError(503)
+    // would silently drop the terminal ERROR frame and the client would
+    // see plain EOF → fast-resume → loop. This test forces the route
+    // queue past the threshold and asserts the ERROR frame is delivered.
+    const { app } = createTestApp();
+    const watchRes = await app.request("/api/watch?kind=Contribution&resumeFrom=0", {
+      headers: TEST_AUTH_HEADERS,
+    });
+    // ROUTE_BYTE_OVERFLOW_THRESHOLD = -3 MiB; HWM = +1 MiB. ~600 KiB
+    // events × 8 = ~4.7 MiB, pushing desiredSize to -3.7 MiB. Each event
+    // sits below the 1 MiB per-event cap.
+    const bigSummary = "x".repeat(600 * 1024);
+    for (let i = 0; i < 8; i++) {
+      const r = await app.request("/api/contributions", {
+        method: "POST",
+        headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+        body: JSON.stringify(makeManifestBody({ summary: bigSummary })),
+      });
+      expect(r.status).toBe(201);
+    }
+    // Drain. Whatever arrives, the terminal ERROR{503} must be among it.
+    const events = await readSseEvents(watchRes, 200, 5_000);
+    const error = events.find((e) => e.event === "ERROR");
+    expect(error).toBeDefined();
+    expect((error?.data as { code: number }).code).toBe(503);
+    expect((error?.data as { reason: string }).reason).toBe("buffer_overflow");
+  }, 10_000);
 });
 
 async function listRv(app: {

--- a/src/server/watch.relist.e2e.test.ts
+++ b/src/server/watch.relist.e2e.test.ts
@@ -157,6 +157,7 @@ describe("WatchClient survives retention gap (issue #293 acceptance #2)", () => 
 function collectSummaries(events: readonly WatchClientEvent[]): Set<string> {
   const out = new Set<string>();
   for (const e of events) {
+    if (!e.entity) continue; // RELIST_BEGIN/END have no entity
     const summary = (e.entity as ContributionEntity).spec?.summary;
     if (summary) out.add(summary);
   }

--- a/src/server/watch.relist.e2e.test.ts
+++ b/src/server/watch.relist.e2e.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Acceptance test for issue #293 — criterion #2.
+ *
+ * A WatchClient driven against a real in-process grove-server that has
+ * a tiny ring buffer survives a simulated kill -9 + sleep past retention
+ * by relisting via the A5 handshake. Every contribution surfaces (via
+ * either RELIST or ADDED) with no missed entities.
+ *
+ * Sizing: maxEventsPerKey=2 + 5 writes during pause guarantees
+ * `oldestRv >= lastSeenRv + 2`, which is the condition the server uses to
+ * raise StaleResourceVersionError. (See WatchHub.subscribe: trigger is
+ * `fromRv < oldestRv - 1n`.)
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ContributionEntity } from "../core/entity.js";
+import { WatchClient, type WatchClientEvent } from "../core/watch-client.js";
+import { createTestApp, makeManifestBody, TEST_AUTH_HEADERS } from "./test-helpers.js";
+
+describe("WatchClient survives retention gap (issue #293 acceptance #2)", () => {
+  test("client relists across retention gap with no missed events", async () => {
+    const now = 1_000_000;
+    const { app } = createTestApp({
+      watchHubOptions: {
+        maxAgeMsPerKey: 60_000, // age not the trigger; capacity is
+        maxEventsPerKey: 2,
+        now: () => now,
+      },
+    });
+
+    // app.request is a Hono helper that turns a path + RequestInit into a
+    // Response. WatchClient expects a base URL + WHATWG fetch. Adapt by
+    // intercepting the URL prefix and forwarding to app.request.
+    const adaptedFetch: typeof fetch = (async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const path = url.replace(/^http:\/\/test/, "");
+      return app.request(path, init);
+    }) as typeof fetch;
+
+    const seen: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    let paused = false;
+    // Track per-watch-request abort controllers so we can cancel the current
+    // SSE stream when paused=true is set.
+    const activeWatchAcs = new Set<AbortController>();
+    const pauseGate: typeof fetch = (async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/watch") && !url.includes("/api/watch/metrics")) {
+        if (paused) {
+          // Simulate disconnect: return 503 so streamWatch sees !res.ok and ends.
+          return new Response("", { status: 503 });
+        }
+        // Wrap with a per-request abort controller so we can kill the open
+        // SSE stream when we transition to paused.
+        const watchAc = new AbortController();
+        activeWatchAcs.add(watchAc);
+        // Chain outer abort signal into this per-watch controller.
+        ac.signal.addEventListener("abort", () => watchAc.abort(), { once: true });
+        const combinedInit = { ...init, signal: watchAc.signal };
+        const res = await adaptedFetch(input, combinedInit);
+        // Wrap the body so we know when the consumer is done (and can clean up
+        // the ac from the active set). We don't need strict cleanup here since
+        // killActiveWatches() just iterates the set and aborts.
+        if (res.body) {
+          const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+          void res.body
+            .pipeTo(writable)
+            .catch(() => {
+              /* stream aborted — expected when we kill active watches */
+            })
+            .finally(() => {
+              activeWatchAcs.delete(watchAc);
+            });
+          return new Response(readable, {
+            status: res.status,
+            headers: res.headers,
+          });
+        }
+        activeWatchAcs.delete(watchAc);
+        return res;
+      }
+      return adaptedFetch(input, init);
+    }) as typeof fetch;
+
+    // Abort all active watch streams (simulates network kill).
+    const killActiveWatches = (): void => {
+      for (const watchAc of [...activeWatchAcs]) {
+        watchAc.abort();
+      }
+    };
+
+    const client = new WatchClient({
+      baseUrl: "http://test",
+      kind: "Contribution",
+      authHeader: TEST_AUTH_HEADERS.Authorization as string,
+      fetch: pauseGate,
+      backoff: { minMs: 5, maxMs: 50, jitter: 0 },
+    });
+
+    const running = client.run({
+      onEvent: async (e) => {
+        seen.push(e);
+      },
+      signal: ac.signal,
+    });
+
+    // Helper to write a contribution with a known summary marker.
+    const post = async (marker: string): Promise<void> => {
+      const r = await app.request("/api/contributions", {
+        method: "POST",
+        headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+        body: JSON.stringify(makeManifestBody({ summary: marker })),
+      });
+      expect(r.status).toBe(201);
+    };
+
+    // Phase 1: write 3 events and wait for the watcher to surface all 3.
+    // Depending on timing the client may list before or after the writes,
+    // so m1/m2/m3 can arrive as either RELIST or ADDED — accept either.
+    for (const m of ["m1", "m2", "m3"]) await post(m);
+    await waitFor(() => {
+      const summaries = collectSummaries(seen);
+      return summaries.has("m1") && summaries.has("m2") && summaries.has("m3");
+    }, 3_000);
+
+    // Phase 2: pause + write 5 more so capacity eviction pushes
+    // oldestRv past the client's last-seen rv.
+    paused = true;
+    killActiveWatches(); // abort the currently open SSE stream immediately
+    await sleep(50); // let the aborted watch loop return and enter backoff
+    for (const m of ["m4", "m5", "m6", "m7", "m8"]) await post(m);
+
+    // Phase 3: resume. Next watch attempt hits 410 (lastSeenRv=3 is
+    // outside the ring whose oldestRv is 7), which forces a relist.
+    paused = false;
+
+    await waitFor(() => {
+      const summaries = collectSummaries(seen);
+      return (
+        seen.some((e) => e.op === "RELIST") &&
+        ["m4", "m5", "m6", "m7", "m8"].some((m) => summaries.has(m))
+      );
+    }, 5_000);
+
+    ac.abort();
+    await running;
+
+    // Every marker is observed at least once across the run.
+    const observed = collectSummaries(seen);
+    for (const m of ["m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8"]) {
+      expect(observed.has(m)).toBe(true);
+    }
+    expect(seen.some((e) => e.op === "RELIST")).toBe(true);
+  }, 15_000);
+});
+
+function collectSummaries(events: readonly WatchClientEvent[]): Set<string> {
+  const out = new Set<string>();
+  for (const e of events) {
+    const summary = (e.entity as ContributionEntity).spec?.summary;
+    if (summary) out.add(summary);
+  }
+  return out;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+  throw new Error("waitFor timed out");
+}

--- a/tests/e2e/watch-relist-tmux.ts
+++ b/tests/e2e/watch-relist-tmux.ts
@@ -1,0 +1,524 @@
+/**
+ * Tmux-driven E2E smoke test for WatchClient relist on stale-rv (#293).
+ *
+ * Starts a real grove-server with tight ring-buffer retention (2000 ms,
+ * max 2 events), then drives a WatchClient through the A5 handshake and
+ * forces a stale-rv condition by pausing the watcher while 3 writes push
+ * events past the ring boundary.  Asserts the watcher re-lists via a 410
+ * response and surfaces all 5 markers.
+ *
+ * NOT wired into `bun test` — run as:
+ *   bun run tests/e2e/watch-relist-tmux.ts
+ *
+ * Flags:
+ *   --keep          Leave tmux session + workdir for inspection
+ *   --attach        Print `tmux attach` command and wait
+ *   --timeout <ms>  Overall budget (default 60000)
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { parse as parseYaml } from "yaml";
+
+// ─── Paths ────────────────────────────────────────────────────────────────────
+
+const SOCKET = "grove-watch-relist-e2e";
+const SESSION = "grove-watch-relist-e2e";
+const PROJECT_ROOT = join(import.meta.dir, "..", "..");
+const SERVER_PORT = 12793;
+
+// ─── Args ─────────────────────────────────────────────────────────────────────
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    keep: { type: "boolean", default: false },
+    attach: { type: "boolean", default: false },
+    timeout: { type: "string", default: "60000" },
+  },
+});
+const KEEP = values.keep;
+const ATTACH = values.attach;
+const BUDGET_MS = Number.parseInt(values.timeout as string, 10);
+
+// ─── tmux helpers ─────────────────────────────────────────────────────────────
+
+function tmux(cmd: string, opts: { check?: boolean } = {}): string {
+  const args = cmd.split(" ").filter(Boolean);
+  const out = spawnSync("tmux", ["-L", SOCKET, ...args], { encoding: "utf-8" });
+  if (opts.check !== false && out.status !== 0) {
+    throw new Error(`tmux ${cmd} failed (${out.status}): ${out.stderr}`);
+  }
+  return out.stdout.trim();
+}
+
+function capturePane(target = SESSION): string {
+  const out = spawnSync("tmux", ["-L", SOCKET, "capture-pane", "-t", target, "-p", "-S", "-5000"], {
+    encoding: "utf-8",
+  });
+  return out.stdout;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitForPane(
+  predicate: (pane: string) => boolean,
+  phase: string,
+  maxMs = 30000,
+  target = SESSION,
+): Promise<string> {
+  const deadline = Date.now() + maxMs;
+  let last = "";
+  while (Date.now() < deadline) {
+    last = capturePane(target);
+    if (predicate(last)) {
+      console.log(`[${phase}] matched`);
+      return last;
+    }
+    await sleep(500);
+  }
+  console.error(`\n──── pane dump (${phase}) ────`);
+  console.error(last);
+  console.error("──── end pane dump ────\n");
+  throw new Error(`[${phase}] predicate did not match within ${maxMs}ms`);
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+const workDir = mkdtempSync(join(tmpdir(), "grove-watch-relist-"));
+const groveDir = join(workDir, ".grove");
+console.log(`[setup] workDir=${workDir}`);
+
+function cleanup() {
+  try {
+    execSync(`tmux -L ${SOCKET} kill-server 2>/dev/null`, { stdio: "ignore" });
+  } catch {
+    /* already dead */
+  }
+  if (!KEEP && existsSync(workDir)) {
+    rmSync(workDir, { recursive: true, force: true });
+  } else if (KEEP) {
+    console.log(`[cleanup] kept workDir=${workDir} (--keep)`);
+  }
+}
+
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+
+// ─── Watcher script (written to a temp .ts file) ──────────────────────────────
+
+function makeWatcherScript(projectRoot: string): string {
+  // Language: TypeScript (run via bun). Receives env vars:
+  //   GROVE_BASE_URL, GROVE_TOKEN, GROVE_PID_FILE
+  //
+  // Pause mechanism mirrors the unit test in watch.relist.e2e.test.ts:
+  //   SIGUSR1 → set paused=true + killActiveWatches() (aborts open SSE stream)
+  //             next watch request gets 503 so WatchClient loops in backoff
+  //   SIGUSR2 → set paused=false; WatchClient retries from old lastSeenRv
+  //             which is now stale → server SSE sends ERROR/410 → RELIST
+  return `
+import { WatchClient } from "${projectRoot}/src/core/watch-client.js";
+import { writeFileSync } from "node:fs";
+
+const baseUrl = process.env.GROVE_BASE_URL ?? "http://localhost:${SERVER_PORT}";
+const token   = process.env.GROVE_TOKEN ?? "";
+const pidFile = process.env.GROVE_PID_FILE ?? "/tmp/watcher.pid";
+
+// Write our PID so the driver can send signals
+writeFileSync(pidFile, String(process.pid));
+
+let paused = false;
+// Track active-watch stream close functions so we can terminate the SSE
+// body cleanly (done=true) without throwing AbortError into WatchClient.
+const killFns: (() => void)[] = [];
+
+function killActiveWatches(): void {
+  const fns = killFns.splice(0);
+  for (const fn of fns) fn();
+}
+
+process.on("SIGUSR1", () => {
+  paused = true;
+  killActiveWatches(); // close currently open SSE streams cleanly
+  console.log("[watcher] paused");
+});
+process.on("SIGUSR2", () => {
+  paused = false;
+  console.log("[watcher] resumed");
+});
+
+const outerAc = new AbortController();
+process.on("SIGTERM", () => outerAc.abort());
+process.on("SIGINT",  () => { outerAc.abort(); process.exit(0); });
+
+// Proxied fetch — mirrors pauseGate from watch.relist.e2e.test.ts.
+// When paused: returns 503 immediately so WatchClient triggers relist path.
+// When live: wraps the response body through a manual ReadableStream that
+// we can close early (cleanly, without AbortError) by calling its stored
+// controller.close(). WatchClient's reader.read() returns done=true,
+// streamWatch returns {kind:"ended"}, then the next request hits 503 and
+// triggers relist (since paused is still true at that point, old lastSeenRv
+// is now stale).
+const proxiedFetch: typeof fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = typeof input === "string" ? input : (input as Request).url;
+  if (url.includes("/api/watch")) {
+    if (paused) {
+      return new Response("", { status: 503 });
+    }
+    const res = await fetch(input as RequestInfo, init as RequestInit);
+    if (!res.body) return res;
+
+    // Wrap body in a manually-controlled ReadableStream so we can close it
+    // cleanly (done=true) without throwing AbortError.
+    let innerReader: ReadableStreamDefaultReader<Uint8Array> | null = res.body.getReader();
+    let killed = false;
+
+    const wrapped = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        if (!innerReader || killed) { controller.close(); return; }
+        try {
+          const { value, done } = await innerReader.read();
+          if (done || killed) {
+            controller.close();
+            try { await innerReader.cancel(); } catch { /* ignore */ }
+            innerReader = null;
+          } else {
+            controller.enqueue(value);
+          }
+        } catch {
+          controller.close();
+          innerReader = null;
+        }
+      },
+      cancel() {
+        killed = true;
+        try { innerReader?.cancel(); } catch { /* ignore */ }
+        innerReader = null;
+      },
+    });
+
+    const killFn = (): void => {
+      killed = true;
+      try { innerReader?.cancel(); } catch { /* ignore */ }
+      innerReader = null;
+    };
+    killFns.push(killFn);
+
+    return new Response(wrapped, { status: res.status, headers: res.headers });
+  }
+  return fetch(input as RequestInfo, init as RequestInit);
+}) as typeof fetch;
+
+const client = new WatchClient({
+  baseUrl,
+  kind: "Contribution",
+  authHeader: \`Bearer \${token}\`,
+  fetch: proxiedFetch,
+  backoff: { minMs: 50, maxMs: 500, jitter: 0 },
+});
+
+console.log("[watcher] starting");
+
+client
+  .run({
+    onEvent(e) {
+      const summary = (e.entity as { spec?: { summary?: string } })?.spec?.summary ?? "";
+      console.log(\`[EVENT] op=\${e.op} rv=\${e.rv} summary=\${summary}\`);
+    },
+    signal: outerAc.signal,
+  })
+  .then(() => {
+    console.log("[watcher] done");
+  })
+  .catch((err: unknown) => {
+    if (outerAc.signal.aborted) return;
+    console.error("[watcher] error:", err);
+    process.exit(1);
+  });
+`;
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  // Kill any leftover tmux socket
+  try {
+    execSync(`tmux -L ${SOCKET} kill-server 2>/dev/null`, { stdio: "ignore" });
+  } catch {
+    /* already dead */
+  }
+
+  // 1. Init grove inside workDir (creates .grove/server-keys.yaml, api-key, project-id)
+  console.log("[setup] grove init --preset review-loop");
+  mkdirSync(workDir, { recursive: true });
+  execSync(
+    `GROVE_DIR=${groveDir} bun run ${join(PROJECT_ROOT, "src/cli/main.ts")} init --preset review-loop --force watch-smoke`,
+    { cwd: workDir, stdio: "inherit" },
+  );
+
+  // 2. Read bearer token from .grove/server-keys.yaml
+  const serverKeysPath = join(groveDir, "server-keys.yaml");
+  if (!existsSync(serverKeysPath)) {
+    throw new Error(`server-keys.yaml not found at ${serverKeysPath}`);
+  }
+  const rawYaml = readFileSync(serverKeysPath, "utf8");
+  const keysFile = parseYaml(rawYaml) as {
+    version: number;
+    keys: Record<string, { namespace: string; createdAt: string }>;
+  };
+  const token = Object.keys(keysFile.keys)[0];
+  if (!token) throw new Error("No bearer token found in server-keys.yaml");
+  console.log(`[setup] token=${token.slice(0, 8)}... (first 8 chars)`);
+
+  const baseUrl = `http://localhost:${SERVER_PORT}`;
+  console.log(`[setup] baseUrl=${baseUrl}`);
+
+  // 3. Write watcher script to workDir
+  const watcherScriptPath = join(workDir, "watcher.ts");
+  writeFileSync(watcherScriptPath, makeWatcherScript(PROJECT_ROOT));
+
+  const pidFile = join(workDir, "watcher.pid");
+  const serverLogFile = join(workDir, "server.log");
+
+  // 4. Create tmux session (server pane)
+  spawnSync(
+    "tmux",
+    [
+      "-L", SOCKET,
+      "new-session", "-d",
+      "-s", SESSION,
+      "-x", "220",
+      "-y", "50",
+      "sh", "-c",
+      // GROVE_WATCH_MAX_EVENTS=2 matches the unit test sizing:
+      // after 2 events in the ring, a write evicts the oldest.
+      // Writing 5 events while paused guarantees oldestRv > lastSeenRv.
+      [
+        `GROVE_DIR=${groveDir}`,
+        `PORT=${SERVER_PORT}`,
+        `GROVE_WATCH_RETENTION_MS=60000`,
+        `GROVE_WATCH_MAX_EVENTS=2`,
+        `bun run ${join(PROJECT_ROOT, "src/server/serve.ts")} 2>&1 | tee ${serverLogFile}`,
+      ].join(" ") + "; cat",
+    ],
+    { stdio: "inherit" },
+  );
+  console.log(`[tmux] server pane started. Attach: tmux -L ${SOCKET} attach -t ${SESSION}`);
+
+  if (ATTACH) {
+    console.log(`\nAttach in another terminal:\n  tmux -L ${SOCKET} attach -t ${SESSION}\n`);
+    await sleep(BUDGET_MS);
+    return;
+  }
+
+  // 5. Wait for server to be listening
+  await waitForPane((p) => /listening/.test(p), "server-ready", 30000);
+  console.log("[phase 1] server listening");
+
+  // 6. Split pane — watcher pane (pane 1)
+  spawnSync(
+    "tmux",
+    [
+      "-L", SOCKET,
+      "split-window", "-t", SESSION,
+      "-h",
+      "sh", "-c",
+      [
+        `GROVE_BASE_URL=${baseUrl}`,
+        `GROVE_TOKEN=${token}`,
+        `GROVE_PID_FILE=${pidFile}`,
+        `bun run ${watcherScriptPath}`,
+      ].join(" ") + "; cat",
+    ],
+    { stdio: "inherit" },
+  );
+  console.log("[tmux] watcher pane started");
+
+  // Helper: capture watcher pane (pane 1)
+  const watcherTarget = `${SESSION}.1`;
+  const waitWatcher = (pred: (p: string) => boolean, phase: string, maxMs?: number) =>
+    waitForPane(pred, phase, maxMs, watcherTarget);
+
+  // 7. Wait for initial RELIST (empty list is fine — client prints [watcher] starting first)
+  await waitWatcher((p) => /\[watcher\] starting/.test(p), "watcher-started", 15000);
+  console.log("[phase 2] watcher started");
+
+  // Wait for at least one [EVENT] line (initial RELIST may fire immediately even with 0 items)
+  // Give it a moment to connect
+  await sleep(2000);
+
+  // Helper: POST a contribution using plain JSON body (server supports both multipart and JSON)
+  async function postContribution(summary: string) {
+    const body = {
+      kind: "work",
+      mode: "evaluation",
+      summary,
+      agent: {
+        agentId: "smoke-agent-001",
+        agentName: "Smoke Agent",
+        provider: "test",
+        model: "test-model",
+      },
+      tags: [],
+      relations: [],
+      createdAt: new Date().toISOString(),
+    };
+
+    const res = await fetch(`${baseUrl}/api/contributions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`POST /api/contributions failed (${res.status}): ${text}`);
+    }
+    const json = await res.json();
+    console.log(`[driver] posted ${summary} → cid=${(json as { cid?: string }).cid?.slice(0, 16)}...`);
+  }
+
+  // 8. POST m1
+  await postContribution("m1");
+  await waitWatcher((p) => /summary=m1/.test(p), "event-m1", 15000);
+  console.log("[phase 3] m1 observed");
+
+  // 9. POST m2
+  await postContribution("m2");
+  await waitWatcher((p) => /summary=m2/.test(p), "event-m2", 15000);
+  console.log("[phase 4] m2 observed");
+
+  // 10. Read watcher PID (wait for it to be written)
+  let watcherPid: number | undefined;
+  const pidDeadline = Date.now() + 10000;
+  while (Date.now() < pidDeadline) {
+    if (existsSync(pidFile)) {
+      watcherPid = Number.parseInt(readFileSync(pidFile, "utf8").trim(), 10);
+      break;
+    }
+    await sleep(200);
+  }
+  if (!watcherPid) throw new Error("Watcher PID file not written");
+  console.log(`[driver] watcher PID=${watcherPid}`);
+
+  // 11. Pause watcher via SIGUSR1
+  //     killActiveWatches() inside the watcher aborts the current SSE stream.
+  process.kill(watcherPid, "SIGUSR1");
+  console.log("[driver] sent SIGUSR1 (pause)");
+  // Wait briefly so the signal handler runs and the SSE stream is aborted
+  // before we start writing.
+  await sleep(200);
+
+  // 12. POST m3, m4, m5 while watcher is paused.
+  //     With GROVE_WATCH_MAX_EVENTS=2, writing 5 events pushes oldestRv past
+  //     lastSeenRv (which was 2 after m1+m2), matching the unit test sizing.
+  for (let i = 3; i <= 7; i++) {
+    await postContribution(`m${i}`);
+  }
+  console.log("[driver] 5 filler writes done (ring evicted m1/m2 rv)");
+
+  // 14. Capture pre-resume RELIST count BEFORE sending SIGUSR2, so we can
+  //     detect new RELISTs that appear after the resume.
+  const preResumeContent = capturePane(watcherTarget);
+  const preResumeRelistCount = (preResumeContent.match(/op=RELIST/g) ?? []).length;
+  console.log(`[driver] pre-resume RELIST count=${preResumeRelistCount}`);
+
+  // 13. Resume watcher via SIGUSR2
+  process.kill(watcherPid, "SIGUSR2");
+  console.log("[driver] sent SIGUSR2 (resume)");
+
+  // Wait for RELIST after pause (the stale-rv relist).
+  // The watcher will list → get 410/relist path → emit RELIST events at rv=7.
+  await waitWatcher(
+    (p) => {
+      const curCount = (p.match(/op=RELIST/g) ?? []).length;
+      return curCount > preResumeRelistCount;
+    },
+    "relist-after-stale",
+    20000,
+  );
+  console.log("[phase 5] RELIST after stale-rv observed");
+
+  // 15. Wait for post-pause markers to appear via RELIST snapshot
+  await waitWatcher((p) => /summary=m5/.test(p), "event-m5-via-relist", 20000);
+  console.log("[phase 6] m5 observed via relist");
+  await waitWatcher((p) => /summary=m6/.test(p), "event-m6-via-relist", 20000);
+  console.log("[phase 7] m6 observed via relist");
+
+  // 16. Final assertions
+  const finalPane = capturePane(watcherTarget);
+
+  // All 7 markers must appear (m1-m7, whether via ADDED or RELIST)
+  const allMarkers = ["m1", "m2", "m3", "m4", "m5", "m6", "m7"];
+  const missingMarkers = allMarkers.filter((m) => !new RegExp(`summary=${m}\\b`).test(finalPane));
+  const relistCount = (finalPane.match(/op=RELIST/g) ?? []).length;
+
+  console.log("\n──── watcher pane (final) ────");
+  console.log(finalPane);
+  console.log("──── end watcher pane ────\n");
+
+  if (missingMarkers.length > 0) {
+    console.error(`[FAIL] Missing markers in watcher output: ${missingMarkers.join(", ")}`);
+    console.error("──── server log tail ────");
+    try {
+      console.error(execSync(`tail -50 ${serverLogFile}`, { encoding: "utf-8" }));
+    } catch {
+      /* no log */
+    }
+    process.exit(1);
+  }
+
+  if (relistCount < 2) {
+    console.error(`[FAIL] Expected at least 2 RELIST events, got ${relistCount}`);
+    console.error("──── server log tail ────");
+    try {
+      console.error(execSync(`tail -50 ${serverLogFile}`, { encoding: "utf-8" }));
+    } catch {
+      /* no log */
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `[smoke] OK — RELIST after stale rv observed, all markers surfaced. (relistCount=${relistCount})`,
+  );
+}
+
+main()
+  .then(() => {
+    cleanup();
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("[FAIL]", err);
+    console.error("\n──── watcher pane (error) ────");
+    try {
+      console.error(capturePane(`${SESSION}.1`));
+    } catch {
+      /* tmux already dead */
+    }
+    console.error("──── server pane (error) ────");
+    try {
+      console.error(capturePane(SESSION));
+    } catch {
+      /* tmux already dead */
+    }
+    cleanup();
+    process.exit(1);
+  });

--- a/tests/e2e/watch-relist-tmux.ts
+++ b/tests/e2e/watch-relist-tmux.ts
@@ -46,15 +46,6 @@ const BUDGET_MS = Number.parseInt(values.timeout as string, 10);
 
 // ─── tmux helpers ─────────────────────────────────────────────────────────────
 
-function tmux(cmd: string, opts: { check?: boolean } = {}): string {
-  const args = cmd.split(" ").filter(Boolean);
-  const out = spawnSync("tmux", ["-L", SOCKET, ...args], { encoding: "utf-8" });
-  if (opts.check !== false && out.status !== 0) {
-    throw new Error(`tmux ${cmd} failed (${out.status}): ${out.stderr}`);
-  }
-  return out.stdout.trim();
-}
-
 function capturePane(target = SESSION): string {
   const out = spawnSync("tmux", ["-L", SOCKET, "capture-pane", "-t", target, "-p", "-S", "-5000"], {
     encoding: "utf-8",

--- a/tests/e2e/watch-relist-tmux.ts
+++ b/tests/e2e/watch-relist-tmux.ts
@@ -236,7 +236,9 @@ console.log("[watcher] starting");
 client
   .run({
     onEvent(e) {
-      const summary = (e.entity as { spec?: { summary?: string } })?.spec?.summary ?? "";
+      const summary = e.entity
+        ? ((e.entity as { spec?: { summary?: string } }).spec?.summary ?? "")
+        : "";
       console.log(\`[EVENT] op=\${e.op} rv=\${e.rv} summary=\${summary}\`);
     },
     signal: outerAc.signal,

--- a/tests/e2e/watch-relist-tmux.ts
+++ b/tests/e2e/watch-relist-tmux.ts
@@ -17,14 +17,7 @@
  */
 
 import { execSync, spawnSync } from "node:child_process";
-import {
-  existsSync,
-  mkdtempSync,
-  mkdirSync,
-  rmSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
@@ -300,12 +293,18 @@ async function main() {
   spawnSync(
     "tmux",
     [
-      "-L", SOCKET,
-      "new-session", "-d",
-      "-s", SESSION,
-      "-x", "220",
-      "-y", "50",
-      "sh", "-c",
+      "-L",
+      SOCKET,
+      "new-session",
+      "-d",
+      "-s",
+      SESSION,
+      "-x",
+      "220",
+      "-y",
+      "50",
+      "sh",
+      "-c",
       // GROVE_WATCH_MAX_EVENTS=2 matches the unit test sizing:
       // after 2 events in the ring, a write evicts the oldest.
       // Writing 5 events while paused guarantees oldestRv > lastSeenRv.
@@ -335,10 +334,14 @@ async function main() {
   spawnSync(
     "tmux",
     [
-      "-L", SOCKET,
-      "split-window", "-t", SESSION,
+      "-L",
+      SOCKET,
+      "split-window",
+      "-t",
+      SESSION,
       "-h",
-      "sh", "-c",
+      "sh",
+      "-c",
       [
         `GROVE_BASE_URL=${baseUrl}`,
         `GROVE_TOKEN=${token}`,
@@ -393,7 +396,9 @@ async function main() {
       throw new Error(`POST /api/contributions failed (${res.status}): ${text}`);
     }
     const json = await res.json();
-    console.log(`[driver] posted ${summary} → cid=${(json as { cid?: string }).cid?.slice(0, 16)}...`);
+    console.log(
+      `[driver] posted ${summary} → cid=${(json as { cid?: string }).cid?.slice(0, 16)}...`,
+    );
   }
 
   // 8. POST m1


### PR DESCRIPTION
## Summary
- Surface configurable retention + compaction metrics on the watch protocol from #292; add `WatchClient` helper that relists on 410/503 via the A5 handshake.
- New env vars `GROVE_WATCH_RETENTION_MS` (default 300000) and `GROVE_WATCH_MAX_EVENTS` (default 1024); new `GET /api/watch/metrics` endpoint exposing per-`(ns,kind)` eviction counters; new `WatchClient` with RELIST op, fast resume on TCP close, exponential backoff with jitter, and explicit terminal-error rejection.
- Closes #293.

## Acceptance traceability
| Criterion | Test |
|-----------|------|
| Sleep past retention → resume returns Expired | `src/server/watch.compaction.test.ts` "sleep past retention window → resume returns 410" |
| Client relists via A5 handshake automatically → no events missed | `src/server/watch.relist.e2e.test.ts` |
| Retention window configurable + documented | `src/server/watch-hub-config.{ts,test.ts}` + `docs/parity-matrix.md` |
| Compaction metric exposed | `WatchHub.getCompactionStats()` + `GET /api/watch/metrics` |

## Design / plan
- Spec: `docs/superpowers/specs/2026-04-28-a6-stale-rv-compaction-design.md`
- Plan: `docs/superpowers/plans/2026-04-28-a6-stale-rv-compaction.md`

## Test plan
- [x] `bun test src/core/clamp` (8 pass)
- [x] `bun test src/core/watch-hub` (16 pass — 9 pre-existing + 7 compaction)
- [x] `bun test src/core/watch-client` (14 pass — happy path + relist + fast resume + sequential + terminal errors + backoff reset on data + HTTP 503 relist + malformed-rv guard)
- [x] `bun test src/server/watch-hub-config` (7 pass)
- [x] `bun test src/server/watch.compaction` (5 pass — metrics endpoint + sleep-past-retention + capacity eviction)
- [x] `bun test src/server/watch.relist` (1 E2E pass)
- [x] `bun test src/server/watch` (25 pass total — no regressions to #292 watch tests)
- [ ] CI green
- [ ] Smoke: `GROVE_WATCH_RETENTION_MS=5000 grove-server start; sleep 6; curl /api/watch?resumeFrom=1` → expects SSE ERROR{code:410}