### PR TITLE
Fix duplicate content submissions

### DIFF
--- a/src/cli/commands/contribute.test.ts
+++ b/src/cli/commands/contribute.test.ts
@@ -821,15 +821,13 @@ describe("executeContribute", () => {
         cwd: dir,
       });
 
-      // The CID will differ because createdAt changes, but if we fix it...
-      // For true idempotency, we'd need the same createdAt. Let's just
-      // verify two contributions with different timestamps don't error.
+      // Identical logical payloads dedup at the store boundary even though
+      // executeContribute generates a fresh timestamp on each call.
       const r1 = await executeContribute(opts);
       const r2 = await executeContribute(opts);
 
-      // Different CIDs (different createdAt) but both succeed
       expect(r1.cid).toMatch(/^blake3:[0-9a-f]{64}$/);
-      expect(r2.cid).toMatch(/^blake3:[0-9a-f]{64}$/);
+      expect(r2.cid).toBe(r1.cid);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -1349,7 +1347,7 @@ describe("executeContribute: idempotencyKey", () => {
     }
   });
 
-  test("no idempotency key produces distinct contributions", async () => {
+  test("no idempotency key dedups identical logical contributions", async () => {
     const dir = await createTempDir();
     try {
       await executeInit(makeInitOptions(dir));
@@ -1363,8 +1361,7 @@ describe("executeContribute: idempotencyKey", () => {
       const second = await executeContribute(opts);
 
       expect(first.cid).toMatch(/^blake3:/);
-      expect(second.cid).toMatch(/^blake3:/);
-      expect(second.cid).not.toBe(first.cid);
+      expect(second.cid).toBe(first.cid);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/core/content-dedup.ts
+++ b/src/core/content-dedup.ts
@@ -1,0 +1,153 @@
+/**
+ * Content-hash helpers for retry-safe store-boundary deduplication.
+ *
+ * These hashes intentionally exclude generated identifiers and timestamps.
+ * They represent the caller's logical payload, not the persisted row identity.
+ */
+
+import { createHash } from "node:crypto";
+import type { Bounty } from "./bounty.js";
+import type { Contribution } from "./models.js";
+import type { OutcomeInput, OutcomeRecord } from "./outcome.js";
+
+const BOUNTY_CONTENT_HASH_PROPERTY = "__groveContentHash";
+
+type BountyWithProvidedContentHash = Bounty & {
+  readonly [BOUNTY_CONTENT_HASH_PROPERTY]?: string | undefined;
+};
+
+function canonicalize(value: unknown): string {
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) throw new Error("NaN is not allowed in canonical JSON");
+    if (!Number.isFinite(value)) throw new Error("Infinity is not allowed in canonical JSON");
+    return JSON.stringify(value);
+  }
+
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalize(item === undefined ? null : item)).join(",")}]`;
+  }
+
+  const obj = value as Record<string, unknown>;
+  const entries = Object.keys(obj)
+    .sort()
+    .reduce<string[]>((acc, key) => {
+      const item = obj[key];
+      if (item !== undefined && typeof item !== "symbol") {
+        acc.push(`${JSON.stringify(key)}:${canonicalize(item)}`);
+      }
+      return acc;
+    }, []);
+  return `{${entries.join(",")}}`;
+}
+
+function sha256Canonical(value: unknown): string {
+  return `sha256:${createHash("sha256").update(canonicalize(value)).digest("hex")}`;
+}
+
+function sortedTags(tags: readonly string[]): readonly string[] {
+  return [...tags].sort();
+}
+
+function sortedRelations(contribution: Contribution): readonly unknown[] {
+  return [...contribution.relations]
+    .map((relation) => ({
+      targetCid: relation.targetCid,
+      relationType: relation.relationType,
+      metadata: relation.metadata,
+    }))
+    .sort((a, b) => {
+      if (a.targetCid !== b.targetCid) return a.targetCid < b.targetCid ? -1 : 1;
+      if (a.relationType !== b.relationType) return a.relationType < b.relationType ? -1 : 1;
+      const aMeta = canonicalize(a.metadata ?? null);
+      const bMeta = canonicalize(b.metadata ?? null);
+      return aMeta < bMeta ? -1 : aMeta > bMeta ? 1 : 0;
+    });
+}
+
+/** Compute the implicit dedup key for a contribution payload. */
+export function computeContributionContentHash(contribution: Contribution): string {
+  return sha256Canonical({
+    entity: "contribution",
+    user: contribution.agent.agentId,
+    category: contribution.kind,
+    payload: {
+      mode: contribution.mode,
+      summary: contribution.summary,
+      description: contribution.description,
+      artifacts: contribution.artifacts,
+      commitHash: contribution.commitHash,
+      relations: sortedRelations(contribution),
+      scores: contribution.scores,
+      tags: sortedTags(contribution.tags),
+      context: contribution.context,
+    },
+  });
+}
+
+/** Compute the implicit dedup key for a bounty create payload. */
+export function computeBountyContentHash(bounty: Bounty): string {
+  return sha256Canonical({
+    entity: "bounty",
+    user: bounty.creator.agentId,
+    category: "bounty",
+    payload: {
+      title: bounty.title,
+      description: bounty.description,
+      amount: bounty.amount,
+      criteria: bounty.criteria,
+      zoneId: bounty.zoneId,
+      context: bounty.context,
+    },
+  });
+}
+
+/** Attach a non-serialized bounty create payload hash for store-boundary deduplication. */
+export function withBountyContentHash(
+  bounty: Bounty,
+  contentHash: string = computeBountyContentHash(bounty),
+): Bounty {
+  const marked = { ...bounty };
+  Object.defineProperty(marked, BOUNTY_CONTENT_HASH_PROPERTY, {
+    value: contentHash,
+    enumerable: false,
+  });
+  return marked;
+}
+
+function computeBountyRecordContentHash(bounty: Bounty): string {
+  return sha256Canonical({
+    entity: "bounty-record",
+    bountyId: bounty.bountyId,
+    logicalHash: computeBountyContentHash(bounty),
+  });
+}
+
+/** Compute the hash stored by bounty backends, honoring operation-level dedup hints. */
+export function computeBountyStorageContentHash(bounty: Bounty): string {
+  return (
+    (bounty as BountyWithProvidedContentHash)[BOUNTY_CONTENT_HASH_PROPERTY] ??
+    computeBountyRecordContentHash(bounty)
+  );
+}
+
+/** Compute the implicit dedup key for an outcome set payload. */
+export function computeOutcomeContentHash(
+  cid: string,
+  input: OutcomeInput | OutcomeRecord,
+): string {
+  return sha256Canonical({
+    entity: "outcome",
+    user: input.evaluatedBy,
+    category: "outcome",
+    payload: {
+      cid,
+      status: input.status,
+      reason: input.reason,
+      baselineCid: input.baselineCid,
+    },
+  });
+}

--- a/src/core/enforcing-store.ts
+++ b/src/core/enforcing-store.ts
@@ -28,6 +28,8 @@ import type {
   ActiveClaimFilter,
   ClaimQuery,
   ClaimStore,
+  ContributionPutManyOutcome,
+  ContributionPutOutcome,
   ContributionQuery,
   ContributionStore,
   ExpiredClaim,
@@ -166,7 +168,7 @@ export class EnforcingContributionStore implements ContributionStore {
     this.writeMutex = getMutexForStore(inner);
   }
 
-  put = async (contribution: Contribution): Promise<void> => {
+  put = async (contribution: Contribution): Promise<ContributionPutOutcome> => {
     return this.writeMutex.runExclusive(async () => {
       // Idempotent: if CID already exists, skip enforcement and delegate (no-op)
       const existing = await this.inner.get(contribution.cid);
@@ -208,13 +210,16 @@ export class EnforcingContributionStore implements ContributionStore {
    * cowrite callback itself is sync (runs inside the inner transaction).
    * Callers (`writeContributionWithHandoffs`) must handle the Promise.
    */
-  putWithCowrite = async (contribution: Contribution, cowriteFn: () => void): Promise<void> => {
+  putWithCowrite = async (
+    contribution: Contribution,
+    cowriteFn: () => void,
+  ): Promise<ContributionPutOutcome> => {
     return this.writeMutex.runExclusive(async () => {
       const existing = await this.inner.get(contribution.cid);
       if (existing !== undefined) {
         // Idempotent: contribution already present, skip enforcement and
         // the cowrite (no handoffs to insert for an existing row).
-        return;
+        return { cid: existing.cid, isNew: false, contribution: existing };
       }
 
       await this.enforceContributionLimits(contribution, 0, []);
@@ -226,22 +231,26 @@ export class EnforcingContributionStore implements ContributionStore {
 
       const innerCowrite = (
         this.inner as unknown as {
-          putWithCowrite?: (c: Contribution, fn: () => void) => void;
+          putWithCowrite?: (
+            c: Contribution,
+            fn: () => void,
+          ) => ContributionPutOutcome | Promise<ContributionPutOutcome>;
         }
       ).putWithCowrite;
       if (innerCowrite !== undefined) {
-        innerCowrite.call(this.inner, contribution, cowriteFn);
+        return innerCowrite.call(this.inner, contribution, cowriteFn);
       } else {
         // Defensive fallback — inner store does not support atomic cowrite.
         // Do the best we can: put the contribution, then run the cowrite fn
         // serially. This loses atomicity but matches the serial write path.
-        await this.inner.put(contribution);
-        cowriteFn();
+        const result = await this.inner.put(contribution);
+        if (result === undefined || result.isNew) cowriteFn();
+        return result;
       }
     });
   };
 
-  putMany = async (contributions: readonly Contribution[]): Promise<void> => {
+  putMany = async (contributions: readonly Contribution[]): Promise<ContributionPutManyOutcome> => {
     return this.writeMutex.runExclusive(async () => {
       // Filter out already-existing CIDs and intra-batch duplicates.
       // Idempotent puts should not be rate-limited, and putMany([c, c])
@@ -276,6 +285,8 @@ export class EnforcingContributionStore implements ContributionStore {
 
   // Read operations — direct delegation
   get = (cid: string): Promise<Contribution | undefined> => this.inner.get(cid);
+  getByContentHash = (contentHash: string): Promise<Contribution | undefined> =>
+    this.inner.getByContentHash?.(contentHash) ?? Promise.resolve(undefined);
   getMany = (cids: readonly string[]): Promise<ReadonlyMap<string, Contribution>> =>
     this.inner.getMany(cids);
   list = (query?: ContributionQuery): Promise<readonly Contribution[]> => this.inner.list(query);

--- a/src/core/operations/bounty.test.ts
+++ b/src/core/operations/bounty.test.ts
@@ -78,6 +78,66 @@ describe("createBountyOperation", () => {
     expect(result.value.reservationId).toBeUndefined();
   });
 
+  test("dedups repeated identical bounty creates by content hash", async () => {
+    const depsNoCredits: OperationDeps = {
+      contributionStore: deps.contributionStore,
+      claimStore: deps.claimStore,
+      cas: deps.cas,
+      frontier: deps.frontier,
+      bountyStore: deps.bountyStore,
+    };
+
+    const input = {
+      title: "Retry-safe bounty",
+      amount: 50,
+      criteria: { description: "Do one specific task" },
+      agent: { agentId: "agent-1" },
+    };
+
+    const first = await createBountyOperation(input, depsNoCredits);
+    const second = await createBountyOperation(input, depsNoCredits);
+    const third = await createBountyOperation(input, depsNoCredits);
+
+    expect(first.ok && second.ok && third.ok).toBe(true);
+    if (!first.ok || !second.ok || !third.ok) return;
+    expect(first.value.accepted).toBe(1);
+    expect(first.value.duplicate).toBe(0);
+    expect(second.value.accepted).toBe(0);
+    expect(second.value.duplicate).toBe(1);
+    expect(third.value.accepted).toBe(0);
+    expect(third.value.duplicate).toBe(1);
+    expect(second.value.bountyId).toBe(first.value.bountyId);
+    expect(third.value.bountyId).toBe(first.value.bountyId);
+
+    const listed = await listBountiesOperation({}, depsNoCredits);
+    expect(listed.ok).toBe(true);
+    if (listed.ok) expect(listed.value.count).toBe(1);
+  });
+
+  test("voids fresh credit reservations for duplicate bounty creates", async () => {
+    (deps.creditsService as InMemoryCreditsService).seed("agent-1", 1000);
+
+    const input = {
+      title: "Retry-safe funded bounty",
+      amount: 100,
+      criteria: { description: "Do one funded task" },
+      agent: { agentId: "agent-1" },
+    };
+
+    const first = await createBountyOperation(input, deps);
+    const second = await createBountyOperation(input, deps);
+
+    expect(first.ok && second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    expect(second.value.accepted).toBe(0);
+    expect(second.value.duplicate).toBe(1);
+    expect(second.value.bountyId).toBe(first.value.bountyId);
+
+    const balance = await (deps.creditsService as InMemoryCreditsService).balance("agent-1");
+    expect(balance.available).toBe(900);
+    expect(balance.reserved).toBe(100);
+  });
+
   test("returns VALIDATION_ERROR when bountyStore not configured", async () => {
     const depsNoBounty: OperationDeps = {
       contributionStore: deps.contributionStore,

--- a/src/core/operations/bounty.ts
+++ b/src/core/operations/bounty.ts
@@ -10,6 +10,7 @@
 import type { Bounty, BountyCriteria, BountyStatus } from "../bounty.js";
 import { BountyStatus as BS } from "../bounty.js";
 import { evaluateBountyCriteria } from "../bounty-logic.js";
+import { withBountyContentHash } from "../content-dedup.js";
 import type { JsonValue } from "../models.js";
 import type { AgentOverrides } from "./agent.js";
 import { resolveAgent } from "./agent.js";
@@ -29,6 +30,8 @@ export interface CreateBountyResult {
   readonly status: BountyStatus;
   readonly deadline: string;
   readonly reservationId?: string | undefined;
+  readonly accepted: number;
+  readonly duplicate: number;
 }
 
 /** Summary for list responses. */
@@ -166,7 +169,12 @@ export async function createBountyOperation(
       ...(input.context !== undefined ? { context: input.context } : {}),
     };
 
-    const result = await deps.bountyStore.createBounty(bounty);
+    const result = await deps.bountyStore.createBounty(withBountyContentHash(bounty));
+    const writeMeta = result as Bounty & { readonly isNew?: boolean | undefined };
+    const isNew = writeMeta.isNew !== false;
+    if (!isNew && reservationId !== undefined && deps.creditsService !== undefined) {
+      await deps.creditsService.void(reservationId);
+    }
 
     return ok({
       bountyId: result.bountyId,
@@ -175,6 +183,8 @@ export async function createBountyOperation(
       status: result.status,
       deadline: result.deadline,
       reservationId: result.reservationId,
+      accepted: isNew ? 1 : 0,
+      duplicate: isNew ? 0 : 1,
     });
   } catch (error) {
     return fromGroveError(error);

--- a/src/core/operations/contribute.test.ts
+++ b/src/core/operations/contribute.test.ts
@@ -743,7 +743,7 @@ describe("contributeOperation: idempotencyKey", () => {
     expect(result.ok).toBe(true);
   });
 
-  test("no idempotencyKey means no dedup", async () => {
+  test("identical payloads without idempotencyKey dedup by content hash", async () => {
     const first = await contributeOperation(
       { kind: "work", summary: "duplicate", agent: { agentId: "a1" } },
       deps,
@@ -752,13 +752,55 @@ describe("contributeOperation: idempotencyKey", () => {
       { kind: "work", summary: "duplicate", agent: { agentId: "a1" } },
       deps,
     );
+    const third = await contributeOperation(
+      { kind: "work", summary: "duplicate", agent: { agentId: "a1" } },
+      deps,
+    );
+    expect(first.ok && second.ok && third.ok).toBe(true);
+    if (!first.ok || !second.ok || !third.ok) return;
+
+    expect(first.value.accepted).toBe(1);
+    expect(first.value.duplicate).toBe(0);
+    expect(second.value.accepted).toBe(0);
+    expect(second.value.duplicate).toBe(1);
+    expect(third.value.accepted).toBe(0);
+    expect(third.value.duplicate).toBe(1);
+    expect(second.value.cid).toBe(first.value.cid);
+    expect(third.value.cid).toBe(first.value.cid);
+
+    const stored = await deps.contributionStore.list({ limit: 20 });
+    const matching = stored.filter((c) => c.summary === "duplicate");
+    expect(matching).toHaveLength(1);
+  });
+
+  test("identical gated payloads dedup before metric gate rejection", async () => {
+    const gatedDeps: OperationDeps = {
+      ...deps,
+      contract: {
+        contractVersion: 3,
+        name: "gated",
+        mode: "evaluation",
+        metrics: { val_bpb: { direction: "minimize" } },
+        gates: [{ type: "metric_improves", metric: "val_bpb" }],
+      },
+    };
+    const input = {
+      kind: "work" as const,
+      summary: "gated duplicate",
+      scores: { val_bpb: { value: 0.99, direction: "minimize" as const } },
+      agent: { agentId: "a1" },
+    };
+
+    const first = await contributeOperation(input, gatedDeps);
+    const second = await contributeOperation(input, gatedDeps);
+
     expect(first.ok && second.ok).toBe(true);
     if (!first.ok || !second.ok) return;
-    // Without an idempotency key, two identical contributions are produced.
-    // (CIDs may collide if the timestamps round to the same millisecond,
-    // but conceptually each call is a separate contribution.)
-    expect(first.value.cid).toBeTruthy();
-    expect(second.value.cid).toBeTruthy();
+    expect(first.value.accepted).toBe(1);
+    expect(first.value.duplicate).toBe(0);
+    expect(second.value.accepted).toBe(0);
+    expect(second.value.duplicate).toBe(1);
+    expect(second.value.cid).toBe(first.value.cid);
   });
 });
 

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -9,6 +9,8 @@
 
 import { fireAndForget } from "../../shared/fire-and-forget.js";
 import { pickDefined } from "../../shared/pick-defined.js";
+import { computeContributionContentHash } from "../content-dedup.js";
+import { PolicyViolationError } from "../errors.js";
 import { type HandoffInput, HandoffStatus, type HandoffStore } from "../handoff.js";
 import { createContribution } from "../manifest.js";
 import {
@@ -26,7 +28,7 @@ import {
 import type { PolicyEnforcementResult } from "../policy-enforcer.js";
 import { PolicyEnforcer } from "../policy-enforcer.js";
 import { attachRoutingSignatureToInput } from "../routing-provenance.js";
-import type { ContributionStore } from "../store.js";
+import type { ContributionPutOutcome, ContributionPutResult, ContributionStore } from "../store.js";
 import { toUtcIso } from "../time.js";
 import type { AgentOverrides } from "./agent.js";
 import { resolveAgent } from "./agent.js";
@@ -44,6 +46,8 @@ export interface BaseContributionResult {
   readonly cid: string;
   readonly summary: string;
   readonly createdAt: string;
+  readonly accepted: number;
+  readonly duplicate: number;
 }
 
 /** Result of a contribute operation. */
@@ -545,6 +549,67 @@ export function _resetIdempotencyCacheForTests(): void {
   idempotencyCache.clear();
 }
 
+interface ContributionWriteOutcome {
+  readonly putResult: ContributionPutResult;
+  readonly handoffIds: readonly string[];
+}
+
+function normalizePutResult(
+  contribution: Contribution,
+  result: ContributionPutOutcome,
+): ContributionPutResult {
+  return (
+    result ?? {
+      cid: contribution.cid,
+      isNew: true,
+      contribution,
+    }
+  );
+}
+
+function resultFromContribution(
+  contribution: Contribution,
+  opts: {
+    readonly storedCid?: string | undefined;
+    readonly accepted: number;
+    readonly duplicate: number;
+    readonly routedTo?: readonly string[] | undefined;
+    readonly handoffIds?: readonly string[] | undefined;
+    readonly policy?: PolicyEnforcementResult | undefined;
+  },
+): ContributeResult {
+  return {
+    cid: opts.storedCid ?? contribution.cid,
+    kind: contribution.kind,
+    mode: contribution.mode,
+    summary: contribution.summary,
+    artifactCount: Object.keys(contribution.artifacts).length,
+    relationCount: contribution.relations.length,
+    createdAt: contribution.createdAt,
+    accepted: opts.accepted,
+    duplicate: opts.duplicate,
+    ...(opts.routedTo !== undefined ? { routedTo: opts.routedTo } : {}),
+    ...(opts.handoffIds !== undefined && opts.handoffIds.length > 0
+      ? { handoffIds: opts.handoffIds }
+      : {}),
+    ...(opts.policy !== undefined ? { policy: opts.policy } : {}),
+  };
+}
+
+async function findStoredDuplicateByContentHash(
+  store: ContributionStore,
+  contribution: Contribution,
+): Promise<Contribution | undefined> {
+  if (store.getByContentHash === undefined) return undefined;
+  try {
+    return await store.getByContentHash(computeContributionContentHash(contribution));
+  } catch {
+    // Best-effort fast path. If the lookup fails, continue through the normal
+    // validation/write path so callers receive the original error surface.
+    return undefined;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Contribution write paths
 // ---------------------------------------------------------------------------
@@ -564,11 +629,14 @@ async function writeAtomic(
   contribution: Contribution,
   routedTo: readonly string[],
   agentRole: string,
-  putWithCowrite: (c: Contribution, fn: () => void) => void | Promise<void>,
+  putWithCowrite: (
+    c: Contribution,
+    fn: () => void,
+  ) => ContributionPutOutcome | Promise<ContributionPutOutcome>,
   insertSync: (input: HandoffInput) => string,
   onCommit?: () => void,
   replyTimeouts?: ReadonlyMap<string, number> | undefined,
-): Promise<readonly string[]> {
+): Promise<ContributionWriteOutcome> {
   const handoffIds: string[] = [];
   const maybePromise = putWithCowrite(contribution, () => {
     for (const targetRole of routedTo) {
@@ -590,13 +658,8 @@ async function writeAtomic(
     // record.
     onCommit?.();
   });
-  if (
-    maybePromise !== undefined &&
-    typeof (maybePromise as { then?: unknown }).then === "function"
-  ) {
-    await maybePromise;
-  }
-  return handoffIds;
+  const putResult = await maybePromise;
+  return { putResult: normalizePutResult(contribution, putResult), handoffIds };
 }
 
 /**
@@ -620,8 +683,11 @@ async function writeSerial(
   handoffStore: HandoffStore | undefined,
   onCommit?: () => void,
   replyTimeouts?: ReadonlyMap<string, number> | undefined,
-): Promise<readonly string[]> {
-  await store.put(contribution);
+): Promise<ContributionWriteOutcome> {
+  const putResult = normalizePutResult(contribution, await store.put(contribution));
+  if (!putResult.isNew) {
+    return { putResult, handoffIds: [] };
+  }
   // For non-atomic stores (Nexus, in-memory), write the idempotency row
   // immediately after the contribution commit. Not fully crash-safe (the
   // contribution and idempotency row are separate writes), but the window
@@ -630,7 +696,7 @@ async function writeSerial(
 
   const handoffIds: string[] = [];
   if (handoffStore === undefined || routedTo === undefined || agentRole === undefined) {
-    return handoffIds;
+    return { putResult, handoffIds };
   }
 
   const inputs: HandoffInput[] = routedTo.map((targetRole) => {
@@ -658,7 +724,7 @@ async function writeSerial(
         err,
       );
     }
-    return handoffIds;
+    return { putResult, handoffIds };
   }
 
   // Fallback for stores without createMany: fan out in parallel so N handoffs
@@ -681,7 +747,7 @@ async function writeSerial(
       );
     }
   }
-  return handoffIds;
+  return { putResult, handoffIds };
 }
 
 /**
@@ -697,7 +763,7 @@ async function writeContributionWithHandoffs(
   handoffStore: HandoffStore | undefined,
   onCommit?: () => void,
   replyTimeouts?: ReadonlyMap<string, number> | undefined,
-): Promise<readonly string[]> {
+): Promise<ContributionWriteOutcome> {
   const needsHandoffs =
     handoffStore !== undefined &&
     routedTo !== undefined &&
@@ -705,7 +771,10 @@ async function writeContributionWithHandoffs(
     agentRole !== undefined;
 
   const cowriteStore = store as {
-    putWithCowrite?: (c: Contribution, fn: () => void) => void | Promise<void>;
+    putWithCowrite?: (
+      c: Contribution,
+      fn: () => void,
+    ) => ContributionPutOutcome | Promise<ContributionPutOutcome>;
   };
 
   if (needsHandoffs) {
@@ -965,6 +1034,43 @@ export async function contributeOperation(
       return errResult;
     }
 
+    const returnDuplicate = (
+      storedContribution: Contribution,
+    ): OperationResult<ContributeResult> => {
+      const duplicateResult = resultFromContribution(storedContribution, {
+        storedCid: storedContribution.cid,
+        accepted: 0,
+        duplicate: 1,
+      });
+      const duplicateOk = ok(duplicateResult);
+      idempotencySlot?.resolve(duplicateOk);
+      idempotencySlot = undefined;
+      if (
+        deps.idempotencyStore !== undefined &&
+        idempotencyCacheLookupKey !== undefined &&
+        idempotencyFingerprint !== undefined
+      ) {
+        try {
+          deps.idempotencyStore.store(
+            idempotencyCacheLookupKey,
+            idempotencyFingerprint,
+            JSON.stringify(duplicateResult),
+          );
+        } catch {
+          // Best-effort; the store-level content hash already prevents duplicates.
+        }
+      }
+      return duplicateOk;
+    };
+
+    const existingDuplicate = await findStoredDuplicateByContentHash(
+      deps.contributionStore,
+      contribution,
+    );
+    if (existingDuplicate !== undefined) {
+      return returnDuplicate(existingDuplicate);
+    }
+
     // --- Routing classification ---
     // Plans are coordination metadata (not progress). Done markers
     // (kind=discussion + context.done=true, written by grove_done) signal
@@ -1035,7 +1141,18 @@ export async function contributeOperation(
         // Not the write-mutex hot path that motivated skipExpensiveStopChecks,
         // so keep full evaluation — the post-write recheck is best-effort and
         // should not be the sole detector here.
-        policyResult = await enforcer.enforce(contribution, true, { skipStopConditions });
+        try {
+          policyResult = await enforcer.enforce(contribution, true, { skipStopConditions });
+        } catch (policyErr) {
+          if (policyErr instanceof PolicyViolationError) {
+            const duplicate = await findStoredDuplicateByContentHash(
+              deps.contributionStore,
+              contribution,
+            );
+            if (duplicate !== undefined) return returnDuplicate(duplicate);
+          }
+          throw policyErr;
+        }
       }
     }
 
@@ -1098,15 +1215,10 @@ export async function contributeOperation(
             // Build a minimal result from the contribution (routedTo and
             // handoffIds are populated later, but the CID is the critical
             // dedup signal — retries just need to know the write happened).
-            const earlyResult: ContributeResult = {
-              cid: contribution.cid,
-              kind: contribution.kind,
-              mode: contribution.mode,
-              summary: contribution.summary,
-              artifactCount: Object.keys(contribution.artifacts).length,
-              relationCount: contribution.relations.length,
-              createdAt: contribution.createdAt,
-            };
+            const earlyResult = resultFromContribution(contribution, {
+              accepted: 1,
+              duplicate: 0,
+            });
             // Guarded above by idempotencyCacheLookupKey/idempotencyFingerprint
             // both being defined — non-null assertions here are safe.
             const key = idempotencyCacheLookupKey as string;
@@ -1115,15 +1227,33 @@ export async function contributeOperation(
           }
         : undefined;
 
-    const handoffIds = await writeContributionWithHandoffs(
-      contribution,
-      handoffsRoutedTo,
-      agentRole,
-      deps.contributionStore,
-      deps.handoffStore,
-      idempotencyOnCommit,
-      replyTimeouts,
-    );
+    let writeOutcome: ContributionWriteOutcome;
+    try {
+      writeOutcome = await writeContributionWithHandoffs(
+        contribution,
+        handoffsRoutedTo,
+        agentRole,
+        deps.contributionStore,
+        deps.handoffStore,
+        idempotencyOnCommit,
+        replyTimeouts,
+      );
+    } catch (writeErr) {
+      if (writeErr instanceof PolicyViolationError) {
+        const duplicate = await findStoredDuplicateByContentHash(
+          deps.contributionStore,
+          contribution,
+        );
+        if (duplicate !== undefined) return returnDuplicate(duplicate);
+      }
+      throw writeErr;
+    }
+    const { handoffIds, putResult } = writeOutcome;
+
+    if (!putResult.isNew) {
+      const storedContribution = putResult.contribution ?? contribution;
+      return returnDuplicate({ ...storedContribution, cid: putResult.cid });
+    }
 
     if (process.env.GROVE_DEBUG === "1" && handoffIds.length > 0) {
       process.stderr.write(
@@ -1152,18 +1282,13 @@ export async function contributeOperation(
     // │ snapshot, which is still correct (the contribution is the      │
     // │ same, only the advisory stop signal differs).                  │
     // └──────────────────────────────────────────────────────────────────┘
-    const committedResult: ContributeResult = {
-      cid: contribution.cid,
-      kind: contribution.kind,
-      mode: contribution.mode,
-      summary: contribution.summary,
-      artifactCount: Object.keys(contribution.artifacts).length,
-      relationCount: contribution.relations.length,
-      createdAt: contribution.createdAt,
-      ...(routedTo !== undefined ? { routedTo } : {}),
-      ...(handoffIds.length > 0 ? { handoffIds } : {}),
-      ...(policyResult !== undefined ? { policy: policyResult } : {}),
-    };
+    const committedResult = resultFromContribution(contribution, {
+      accepted: 1,
+      duplicate: 0,
+      routedTo,
+      handoffIds,
+      policy: policyResult,
+    });
 
     if (idempotencySlot !== undefined) {
       idempotencySlot.resolve(ok(committedResult));
@@ -1507,18 +1632,13 @@ export async function contributeOperation(
     // Build the final result returned to the DIRECT caller. This includes
     // any post-write updates to policyResult (e.g., stop-condition recheck
     // detecting a threshold crossing).
-    const result: ContributeResult = {
-      cid: contribution.cid,
-      kind: contribution.kind,
-      mode: contribution.mode,
-      summary: contribution.summary,
-      artifactCount: Object.keys(contribution.artifacts).length,
-      relationCount: contribution.relations.length,
-      createdAt: contribution.createdAt,
-      ...(routedTo !== undefined ? { routedTo } : {}),
-      ...(handoffIds.length > 0 ? { handoffIds } : {}),
-      ...(policyResult !== undefined ? { policy: policyResult } : {}),
-    };
+    const result = resultFromContribution(contribution, {
+      accepted: 1,
+      duplicate: 0,
+      routedTo,
+      handoffIds,
+      policy: policyResult,
+    });
 
     // Refresh BOTH the in-memory idempotency cache AND the durable row with
     // the final result so same-process retries and cross-process lookups
@@ -1656,6 +1776,8 @@ export async function reviewOperation(
     targetCid: input.targetCid,
     summary: result.value.summary,
     createdAt: result.value.createdAt,
+    accepted: result.value.accepted,
+    duplicate: result.value.duplicate,
   });
 }
 
@@ -1706,6 +1828,8 @@ export async function reproduceOperation(
     result: reproResult,
     summary: result.value.summary,
     createdAt: result.value.createdAt,
+    accepted: result.value.accepted,
+    duplicate: result.value.duplicate,
   });
 }
 
@@ -1746,6 +1870,8 @@ export async function discussOperation(
     ...(input.targetCid !== undefined ? { targetCid: input.targetCid } : {}),
     summary: result.value.summary,
     createdAt: result.value.createdAt,
+    accepted: result.value.accepted,
+    duplicate: result.value.duplicate,
   });
 }
 
@@ -1785,5 +1911,7 @@ export async function adoptOperation(
     targetCid: input.targetCid,
     summary: result.value.summary,
     createdAt: result.value.createdAt,
+    accepted: result.value.accepted,
+    duplicate: result.value.duplicate,
   });
 }

--- a/src/core/operations/outcome.test.ts
+++ b/src/core/operations/outcome.test.ts
@@ -98,6 +98,32 @@ describe("setOutcomeOperation", () => {
     expect(result.value.baselineCid).toBe("blake3:baseline000");
   });
 
+  test("dedups repeated identical outcome sets by content hash", async () => {
+    const input = {
+      cid: "blake3:duplicate-outcome",
+      status: "accepted" as const,
+      reason: "Same evaluator decision",
+      agent: { agentId: "evaluator-1" },
+    };
+
+    const first = await setOutcomeOperation(input, deps);
+    const second = await setOutcomeOperation(input, deps);
+    const third = await setOutcomeOperation(input, deps);
+
+    expect(first.ok && second.ok && third.ok).toBe(true);
+    if (!first.ok || !second.ok || !third.ok) return;
+    expect(first.value.accepted).toBe(1);
+    expect(first.value.duplicate).toBe(0);
+    expect(second.value.accepted).toBe(0);
+    expect(second.value.duplicate).toBe(1);
+    expect(third.value.accepted).toBe(0);
+    expect(third.value.duplicate).toBe(1);
+
+    const listed = await listOutcomesOperation({}, deps);
+    expect(listed.ok).toBe(true);
+    if (listed.ok) expect(listed.value).toHaveLength(1);
+  });
+
   test("returns VALIDATION_ERROR when outcomeStore not configured", async () => {
     const depsNoOutcome: OperationDeps = {
       contributionStore: deps.contributionStore,

--- a/src/core/operations/outcome.ts
+++ b/src/core/operations/outcome.ts
@@ -67,8 +67,14 @@ export async function setOutcomeOperation(
       ...(input.reason !== undefined ? { reason: input.reason } : {}),
       ...(input.baselineCid !== undefined ? { baselineCid: input.baselineCid } : {}),
     });
+    const writeMeta = record as OutcomeRecord & { readonly isNew?: boolean | undefined };
+    const isNew = writeMeta.isNew !== false;
 
-    return ok(record);
+    return ok({
+      ...record,
+      accepted: isNew ? 1 : 0,
+      duplicate: isNew ? 0 : 1,
+    });
   } catch (error) {
     return fromGroveError(error);
   }

--- a/src/core/outcome.ts
+++ b/src/core/outcome.ts
@@ -34,6 +34,8 @@ export interface OutcomeRecord {
   readonly baselineCid?: string | undefined;
   readonly evaluatedAt: string;
   readonly evaluatedBy: string;
+  readonly accepted?: number | undefined;
+  readonly duplicate?: number | undefined;
 }
 
 /** Input for creating/updating an outcome (cid is separate). */

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -59,6 +59,24 @@ export interface ContributionQuery {
   readonly sessionId?: string | undefined;
 }
 
+/** Result of a store-boundary contribution insert attempt. */
+export interface ContributionPutResult {
+  /** CID of the stored row. For duplicates this is the existing row CID. */
+  readonly cid: string;
+  /** True when this call inserted a new row; false when it matched existing content. */
+  readonly isNew: boolean;
+  /** Stored contribution snapshot, when the backend can return it without extra cost. */
+  readonly contribution?: Contribution | undefined;
+}
+
+// Existing in-memory and test stores historically return Promise<void>. Backends
+// that can detect content-hash duplicates return metadata instead.
+// biome-ignore lint/suspicious/noConfusingVoidType: preserves ContributionStore compatibility.
+export type ContributionPutOutcome = void | ContributionPutResult;
+
+// biome-ignore lint/suspicious/noConfusingVoidType: preserves ContributionStore compatibility.
+export type ContributionPutManyOutcome = void | readonly ContributionPutResult[];
+
 /** Store for immutable contributions and their typed relations. */
 export interface ContributionStore {
   /**
@@ -75,13 +93,16 @@ export interface ContributionStore {
    */
   readonly storeIdentity?: string | undefined;
   /** Store a contribution (idempotent — same CID is a no-op). */
-  put(contribution: Contribution): Promise<void>;
+  put(contribution: Contribution): Promise<ContributionPutOutcome>;
 
   /** Store multiple contributions in a single transaction. Idempotent per CID. */
-  putMany(contributions: readonly Contribution[]): Promise<void>;
+  putMany(contributions: readonly Contribution[]): Promise<ContributionPutManyOutcome>;
 
   /** Retrieve a contribution by CID. */
   get(cid: string): Promise<Contribution | undefined>;
+
+  /** Retrieve a contribution by its logical content hash, when the backend indexes it. */
+  getByContentHash?(contentHash: string): Promise<Contribution | undefined>;
 
   /** Retrieve multiple contributions by CID. Returns a map of CID → Contribution for found CIDs. */
   getMany(cids: readonly string[]): Promise<ReadonlyMap<string, Contribution>>;

--- a/src/local/sqlite-bounty-store.ts
+++ b/src/local/sqlite-bounty-store.ts
@@ -12,6 +12,7 @@ import { BountyStatus } from "../core/bounty.js";
 import { BountyStateError } from "../core/bounty-errors.js";
 import { validateBountyTransition } from "../core/bounty-logic.js";
 import type { BountyQuery, BountyStore, RewardQuery } from "../core/bounty-store.js";
+import { computeBountyStorageContentHash } from "../core/content-dedup.js";
 import { StateConflictError } from "../core/errors.js";
 import type { AgentIdentity, JsonValue } from "../core/models.js";
 
@@ -41,6 +42,7 @@ export const BOUNTY_DDL = `
     fulfilled_by_cid TEXT,
     reservation_id TEXT,
     context_json TEXT,
+    content_hash TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
   );
@@ -152,6 +154,46 @@ function rowToReward(row: RewardRow): RewardRecord {
   };
 }
 
+export function migrateBountyContentHash(db: Database): void {
+  const cols = db.prepare("PRAGMA table_info(bounties)").all() as readonly { name: string }[];
+  if (cols.length === 0) return;
+  const colNames = new Set(cols.map((c) => c.name));
+  if (!colNames.has("content_hash")) {
+    db.run("ALTER TABLE bounties ADD COLUMN content_hash TEXT");
+  }
+
+  const rows = db
+    .prepare("SELECT * FROM bounties WHERE content_hash IS NULL OR content_hash = ''")
+    .all() as BountyRow[];
+  const updateHash = db.prepare("UPDATE bounties SET content_hash = ? WHERE bounty_id = ?");
+  for (const row of rows) {
+    const bounty = rowToBounty(row);
+    updateHash.run(computeBountyStorageContentHash(bounty), bounty.bountyId);
+  }
+
+  const duplicateRows = db
+    .prepare(
+      `
+      WITH ranked AS (
+        SELECT bounty_id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY content_hash
+                 ORDER BY created_at ASC, rowid ASC
+               ) AS rn
+        FROM bounties
+        WHERE content_hash IS NOT NULL AND content_hash <> ''
+      )
+      SELECT bounty_id FROM ranked WHERE rn > 1
+    `,
+    )
+    .all() as readonly { bounty_id: string }[];
+  for (const row of duplicateRows) {
+    db.run("DELETE FROM bounties WHERE bounty_id = ?", [row.bounty_id]);
+  }
+
+  db.run("CREATE UNIQUE INDEX IF NOT EXISTS idx_bounties_content_hash ON bounties(content_hash)");
+}
+
 // ---------------------------------------------------------------------------
 // SqliteBountyStore
 // ---------------------------------------------------------------------------
@@ -169,6 +211,7 @@ export class SqliteBountyStore implements BountyStore {
   constructor(db: Database) {
     this.db = db;
     this.storeIdentity = (db as { filename?: string }).filename;
+    migrateBountyContentHash(db);
   }
 
   // -----------------------------------------------------------------------
@@ -177,15 +220,16 @@ export class SqliteBountyStore implements BountyStore {
 
   createBounty = async (bounty: Bounty): Promise<Bounty> => {
     this.stmtInsertBounty ??= this.db.prepare(`
-      INSERT INTO bounties (
+      INSERT OR IGNORE INTO bounties (
         bounty_id, title, description, status, creator_agent_id, creator_json,
         amount, criteria_json, zone_id, deadline, claimed_by_json, claim_id,
-        fulfilled_by_cid, reservation_id, context_json, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        fulfilled_by_cid, reservation_id, context_json, content_hash, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
+    const contentHash = computeBountyStorageContentHash(bounty);
     try {
-      this.stmtInsertBounty.run(
+      const result = this.stmtInsertBounty.run(
         bounty.bountyId,
         bounty.title,
         bounty.description,
@@ -201,9 +245,28 @@ export class SqliteBountyStore implements BountyStore {
         bounty.fulfilledByCid ?? null,
         bounty.reservationId ?? null,
         bounty.context !== undefined ? JSON.stringify(bounty.context) : null,
+        contentHash,
         bounty.createdAt,
         bounty.updatedAt,
       );
+      if (result.changes === 0) {
+        const idConflict = this.db
+          .prepare("SELECT bounty_id FROM bounties WHERE bounty_id = ?")
+          .get(bounty.bountyId) as { bounty_id: string } | null;
+        if (idConflict !== null) {
+          throw new StateConflictError({
+            resource: "Bounty",
+            reason: "already exists",
+            message: `Bounty '${bounty.bountyId}' already exists`,
+          });
+        }
+        const duplicate = this.db
+          .prepare("SELECT * FROM bounties WHERE content_hash = ?")
+          .get(contentHash) as BountyRow | null;
+        if (duplicate !== null) {
+          return { ...rowToBounty(duplicate), isNew: false } as Bounty & { readonly isNew: false };
+        }
+      }
     } catch (err) {
       if (err instanceof Error && err.message.includes("UNIQUE constraint")) {
         throw new StateConflictError({
@@ -215,7 +278,7 @@ export class SqliteBountyStore implements BountyStore {
       throw err;
     }
 
-    return bounty;
+    return { ...bounty, isNew: true } as Bounty & { readonly isNew: true };
   };
 
   getBounty = async (bountyId: string): Promise<Bounty | undefined> => {

--- a/src/local/sqlite-outcome-store.ts
+++ b/src/local/sqlite-outcome-store.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Database, Statement } from "bun:sqlite";
+import { computeOutcomeContentHash } from "../core/content-dedup.js";
 import type {
   OutcomeInput,
   OutcomeQuery,
@@ -21,6 +22,7 @@ export const OUTCOME_DDL = `
     status TEXT NOT NULL,
     reason TEXT,
     baseline_cid TEXT,
+    content_hash TEXT,
     evaluated_at TEXT NOT NULL,
     evaluated_by TEXT NOT NULL
   );
@@ -36,24 +38,28 @@ export class SqliteOutcomeStore implements OutcomeStore {
   private readonly db: Database;
   private readonly stmtUpsert: Statement;
   private readonly stmtGet: Statement;
+  private readonly stmtGetByContentHash: Statement;
   private readonly stmtStats: Statement;
 
   constructor(db: Database) {
     this.db = db;
     db.exec(OUTCOME_DDL);
+    this.migrateContentHash();
 
     this.stmtUpsert = db.prepare(`
-      INSERT INTO outcomes (cid, status, reason, baseline_cid, evaluated_at, evaluated_by)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO outcomes (cid, status, reason, baseline_cid, content_hash, evaluated_at, evaluated_by)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(cid) DO UPDATE SET
         status = excluded.status,
         reason = excluded.reason,
         baseline_cid = excluded.baseline_cid,
+        content_hash = excluded.content_hash,
         evaluated_at = excluded.evaluated_at,
         evaluated_by = excluded.evaluated_by
     `);
 
     this.stmtGet = db.prepare("SELECT * FROM outcomes WHERE cid = ?");
+    this.stmtGetByContentHash = db.prepare("SELECT * FROM outcomes WHERE content_hash = ?");
 
     this.stmtStats = db.prepare(`
       SELECT
@@ -66,13 +72,45 @@ export class SqliteOutcomeStore implements OutcomeStore {
     `);
   }
 
+  private migrateContentHash(): void {
+    const cols = this.db.prepare("PRAGMA table_info(outcomes)").all() as readonly {
+      name: string;
+    }[];
+    const colNames = new Set(cols.map((c) => c.name));
+    if (!colNames.has("content_hash")) {
+      this.db.run("ALTER TABLE outcomes ADD COLUMN content_hash TEXT");
+    }
+
+    const rows = this.db
+      .prepare("SELECT * FROM outcomes WHERE content_hash IS NULL OR content_hash = ''")
+      .all() as OutcomeRow[];
+    const updateHash = this.db.prepare("UPDATE outcomes SET content_hash = ? WHERE cid = ?");
+    for (const row of rows) {
+      const record = rowToRecord(row);
+      updateHash.run(computeOutcomeContentHash(record.cid, record), record.cid);
+    }
+
+    this.db.run(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_outcomes_content_hash ON outcomes(content_hash)",
+    );
+  }
+
   async set(cid: string, input: OutcomeInput): Promise<OutcomeRecord> {
+    const contentHash = computeOutcomeContentHash(cid, input);
+    const duplicate = this.stmtGetByContentHash.get(contentHash) as OutcomeRow | null;
+    if (duplicate !== null) {
+      return { ...rowToRecord(duplicate), isNew: false } as OutcomeRecord & {
+        readonly isNew: false;
+      };
+    }
+
     const evaluatedAt = new Date().toISOString();
     this.stmtUpsert.run(
       cid,
       input.status,
       input.reason ?? null,
       input.baselineCid ?? null,
+      contentHash,
       evaluatedAt,
       input.evaluatedBy,
     );
@@ -84,7 +122,8 @@ export class SqliteOutcomeStore implements OutcomeStore {
       baselineCid: input.baselineCid,
       evaluatedAt,
       evaluatedBy: input.evaluatedBy,
-    };
+      isNew: true,
+    } as OutcomeRecord & { readonly isNew: true };
   }
 
   async get(cid: string): Promise<OutcomeRecord | undefined> {

--- a/src/local/sqlite-store.migration.test.ts
+++ b/src/local/sqlite-store.migration.test.ts
@@ -2,7 +2,7 @@
  * Schema migration smoke tests for SQLite store.
  *
  * Validates that:
- * - Fresh DB creates schema v1
+ * - Fresh DB records the current schema version
  * - Re-opening existing DB doesn't corrupt data
  * - Schema migrations table is correctly populated
  */
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { toManifest } from "../core/manifest.js";
 import { makeClaim, makeContribution } from "../core/test-helpers.js";
-import { initSqliteDb, SqliteStore } from "./sqlite-store.js";
+import { CURRENT_SCHEMA_VERSION, initSqliteDb, SqliteStore } from "./sqlite-store.js";
 
 describe("schema migration", () => {
   test("fresh DB creates schema_migrations with current version", async () => {
@@ -32,7 +32,7 @@ describe("schema migration", () => {
       db.close();
 
       expect(row).toBeDefined();
-      expect(row?.version).toBe(10);
+      expect(row?.version).toBe(CURRENT_SCHEMA_VERSION);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -173,7 +173,7 @@ describe("schema migration", () => {
       db.close();
 
       expect(rows.length).toBe(1);
-      expect(rows[0]?.version).toBe(10);
+      expect(rows[0]?.version).toBe(CURRENT_SCHEMA_VERSION);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -191,7 +191,7 @@ describe("schema migration", () => {
         .get() as {
         version: number;
       } | null;
-      expect(row?.version).toBe(10);
+      expect(row?.version).toBe(CURRENT_SCHEMA_VERSION);
 
       db.close();
     } finally {
@@ -534,7 +534,7 @@ describe("schema migration", () => {
           v: number | null;
         }
       ).v;
-      expect(version).toBe(10);
+      expect(version).toBe(CURRENT_SCHEMA_VERSION);
 
       db2.close();
     } finally {

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -27,6 +27,7 @@ import type {
   ActiveClaimFilter,
   ClaimQuery,
   ClaimStore,
+  ContributionPutResult,
   ContributionQuery,
   ContributionStore,
   ExpiredClaim,
@@ -46,12 +47,13 @@ import { SqliteOutcomeStore } from "./sqlite-outcome-store.js";
 // ---------------------------------------------------------------------------
 
 import { DEFAULT_LEASE_DURATION_MS } from "../core/claim-logic.js";
+import { computeContributionContentHash } from "../core/content-dedup.js";
 import type { ClaimEntity, ContributionEntity } from "../core/entity.js";
 import { claimToEntity, contributionToEntity } from "../core/entity.js";
 import { ClaimConflictError, NotFoundError, StateConflictError } from "../core/errors.js";
 import { toUtcIso } from "../core/time.js";
 
-const CURRENT_SCHEMA_VERSION = 10;
+export const CURRENT_SCHEMA_VERSION = 11;
 const SQLITE_BIND_LIMIT = 900;
 
 // ---------------------------------------------------------------------------
@@ -76,6 +78,7 @@ const SCHEMA_DDL = `
     agent_name TEXT,
     created_at TEXT NOT NULL,
     tags_json TEXT NOT NULL DEFAULT '[]',
+    content_hash TEXT NOT NULL,
     manifest_json TEXT NOT NULL
   );
 
@@ -304,6 +307,60 @@ export function initSqliteDb(dbPath: string): Database {
     db.run(
       "CREATE INDEX IF NOT EXISTS idx_contributions_agent_created ON contributions(agent_id, created_at)",
     );
+
+    // Migration → v11: add implicit content-hash dedup for contributions.
+    // Existing duplicate rows are pruned before the UNIQUE index is created,
+    // keeping the earliest created_at row for each logical payload.
+    {
+      const contributionCols = db.prepare("PRAGMA table_info(contributions)").all() as readonly {
+        name: string;
+      }[];
+      const contributionColNames = new Set(contributionCols.map((c) => c.name));
+      if (!contributionColNames.has("content_hash")) {
+        db.run("ALTER TABLE contributions ADD COLUMN content_hash TEXT");
+      }
+
+      const rows = db
+        .prepare(
+          "SELECT cid, manifest_json FROM contributions WHERE content_hash IS NULL OR content_hash = ''",
+        )
+        .all() as readonly { cid: string; manifest_json: string }[];
+      const updateContentHash = db.prepare(
+        "UPDATE contributions SET content_hash = ? WHERE cid = ?",
+      );
+      for (const row of rows) {
+        const contribution = rowToContribution(row);
+        updateContentHash.run(computeContributionContentHash(contribution), row.cid);
+      }
+
+      const duplicateRows = db
+        .prepare(
+          `
+          WITH ranked AS (
+            SELECT cid,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY content_hash
+                     ORDER BY created_at ASC, rowid ASC
+                   ) AS rn
+            FROM contributions
+            WHERE content_hash IS NOT NULL AND content_hash <> ''
+          )
+          SELECT cid FROM ranked WHERE rn > 1
+        `,
+        )
+        .all() as readonly { cid: string }[];
+      for (const row of duplicateRows) {
+        db.run("DELETE FROM contributions_fts WHERE cid = ?", [row.cid]);
+        db.run("DELETE FROM contribution_tags WHERE cid = ?", [row.cid]);
+        db.run("DELETE FROM artifacts WHERE contribution_cid = ?", [row.cid]);
+        db.run("DELETE FROM relations WHERE source_cid = ?", [row.cid]);
+        db.run("DELETE FROM contributions WHERE cid = ?", [row.cid]);
+      }
+
+      db.run(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_contributions_content_hash ON contributions(content_hash)",
+      );
+    }
 
     // Version-gated destructive migration: recreate workspaces with per-agent PK
     if (currentVersion !== null && currentVersion < 4 && currentVersion >= 3) {
@@ -765,6 +822,7 @@ export class SqliteContributionStore implements ContributionStore {
 
   // Cached prepared statements for fixed queries
   private readonly stmtGetByCid: Statement;
+  private readonly stmtGetByContentHash: Statement;
   private readonly stmtInsertContribution: Statement;
   private readonly stmtInsertRelation: Statement;
   private readonly stmtInsertFts: Statement;
@@ -778,10 +836,13 @@ export class SqliteContributionStore implements ContributionStore {
     this.storeIdentity = db.filename;
 
     this.stmtGetByCid = db.query("SELECT manifest_json FROM contributions WHERE cid = ?");
+    this.stmtGetByContentHash = db.query(
+      "SELECT cid, manifest_json FROM contributions WHERE content_hash = ?",
+    );
     this.stmtInsertContribution = db.query(
       `INSERT OR IGNORE INTO contributions (cid, kind, mode, summary, description,
-       agent_id, agent_name, created_at, tags_json, manifest_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       agent_id, agent_name, created_at, tags_json, content_hash, manifest_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     this.stmtInsertRelation = db.query(
       `INSERT INTO relations (source_cid, target_cid, relation_type, metadata_json)
@@ -806,9 +867,10 @@ export class SqliteContributionStore implements ContributionStore {
     `);
   }
 
-  put = async (contribution: Contribution): Promise<void> => {
-    this.putSync(contribution);
-    this.onWrite?.();
+  put = async (contribution: Contribution): Promise<ContributionPutResult> => {
+    const result = this.putSync(contribution);
+    if (result.isNew) this.onWrite?.();
+    return result;
   };
 
   /**
@@ -825,98 +887,35 @@ export class SqliteContributionStore implements ContributionStore {
    * handoffs). Implementing stores must not add this method unless they can actually
    * satisfy the synchronous-cowrite contract.
    */
-  putWithCowrite(contribution: Contribution, cowriteFn: () => void): void {
-    this.putSync(contribution, cowriteFn);
-    this.onWrite?.();
+  putWithCowrite(contribution: Contribution, cowriteFn: () => void): ContributionPutResult {
+    const result = this.putSync(contribution, cowriteFn);
+    if (result.isNew) this.onWrite?.();
+    return result;
   }
 
-  putMany = async (contributions: readonly Contribution[]): Promise<void> => {
-    if (contributions.length === 0) return;
-    // Small batches use the single-put path (cached statements are optimal).
-    if (contributions.length <= 3) {
-      const tx = this.db.transaction(() => {
-        for (const c of contributions) {
-          this.putSync(c);
-        }
-      });
-      tx();
-      this.onWrite?.();
-      return;
-    }
-
-    // Larger batches: insert contributions individually (need per-row duplicate
-    // detection), then batch junction-table rows with multi-row INSERTs.
+  putMany = async (
+    contributions: readonly Contribution[],
+  ): Promise<readonly ContributionPutResult[]> => {
+    if (contributions.length === 0) return [];
+    const results: ContributionPutResult[] = [];
     const tx = this.db.transaction(() => {
-      const pendingRelations: SQLQueryBindings[][] = [];
-      const pendingTags: SQLQueryBindings[][] = [];
-      const pendingArtifacts: SQLQueryBindings[][] = [];
-      const pendingFts: SQLQueryBindings[][] = [];
-
       for (const c of contributions) {
-        if (!verifyCid(c)) {
-          throw new Error(
-            `CID integrity check failed for '${c.cid}': CID does not match manifest content`,
-          );
-        }
-        const manifestJson = JSON.stringify(toManifest(c));
-        const tagsJson = JSON.stringify(c.tags);
-        const createdAtUtc = toUtcIso(c.createdAt);
-
-        const result = this.stmtInsertContribution.run(
-          c.cid,
-          c.kind,
-          c.mode,
-          c.summary,
-          c.description ?? null,
-          c.agent.agentId,
-          c.agent.agentName ?? null,
-          createdAtUtc,
-          tagsJson,
-          manifestJson,
-        );
-        if (result.changes === 0) continue;
-
-        for (const rel of c.relations) {
-          pendingRelations.push([
-            c.cid,
-            rel.targetCid,
-            rel.relationType,
-            rel.metadata !== undefined ? JSON.stringify(rel.metadata) : null,
-          ]);
-        }
-        pendingFts.push([c.cid, c.summary, c.description ?? ""]);
-        for (const tag of c.tags) {
-          pendingTags.push([c.cid, tag]);
-        }
-        for (const [name, contentHash] of Object.entries(c.artifacts)) {
-          pendingArtifacts.push([c.cid, name, contentHash]);
-        }
+        results.push(this.insertContributionInCurrentTransaction(c));
       }
-
-      // Batch junction-table inserts (chunk to stay under SQLITE_MAX_VARIABLE_NUMBER=999)
-      this.batchInsert(
-        "INSERT INTO relations (source_cid, target_cid, relation_type, metadata_json) VALUES",
-        4,
-        pendingRelations,
-      );
-      this.batchInsert(
-        "INSERT INTO contributions_fts (cid, summary, description) VALUES",
-        3,
-        pendingFts,
-      );
-      this.batchInsert("INSERT INTO contribution_tags (cid, tag) VALUES", 2, pendingTags);
-      this.batchInsert(
-        "INSERT INTO artifacts (contribution_cid, name, content_hash) VALUES",
-        3,
-        pendingArtifacts,
-      );
     });
     tx();
-    this.onWrite?.();
+    if (results.some((result) => result.isNew)) this.onWrite?.();
+    return results;
   };
 
   get = async (cid: string): Promise<Contribution | undefined> => {
     const row = this.stmtGetByCid.get(cid) as { manifest_json: string } | null;
+    if (row === null) return undefined;
+    return rowToContribution(row);
+  };
+
+  getByContentHash = async (contentHash: string): Promise<Contribution | undefined> => {
+    const row = this.stmtGetByContentHash.get(contentHash) as { manifest_json: string } | null;
     if (row === null) return undefined;
     return rowToContribution(row);
   };
@@ -1253,7 +1252,17 @@ export class SqliteContributionStore implements ContributionStore {
   /** Synchronous put — uses INSERT OR IGNORE for atomic idempotency.
    *  @param cowrite — optional function run inside the same SQLite transaction after the insert.
    */
-  public putSync(contribution: Contribution, cowrite?: () => void): void {
+  public putSync(contribution: Contribution, cowrite?: () => void): ContributionPutResult {
+    const tx = this.db.transaction(() =>
+      this.insertContributionInCurrentTransaction(contribution, cowrite),
+    );
+    return tx();
+  }
+
+  private insertContributionInCurrentTransaction(
+    contribution: Contribution,
+    cowrite?: () => void,
+  ): ContributionPutResult {
     // Verify CID integrity before persisting
     if (!verifyCid(contribution)) {
       throw new Error(
@@ -1266,69 +1275,65 @@ export class SqliteContributionStore implements ContributionStore {
     // Normalize to UTC for reliable lexicographic ORDER BY on the indexed column.
     // The manifest_json keeps the original value for CID integrity.
     const createdAtUtc = toUtcIso(contribution.createdAt);
+    const contentHash = computeContributionContentHash(contribution);
 
-    const tx = this.db.transaction(() => {
-      // INSERT OR IGNORE: if CID already exists, this is a no-op
-      const result = this.stmtInsertContribution.run(
-        contribution.cid,
-        contribution.kind,
-        contribution.mode,
-        contribution.summary,
-        contribution.description ?? null,
-        contribution.agent.agentId,
-        contribution.agent.agentName ?? null,
-        createdAtUtc,
-        tagsJson,
-        manifestJson,
-      );
+    // INSERT OR IGNORE: if CID or content_hash already exists, this is a no-op.
+    const result = this.stmtInsertContribution.run(
+      contribution.cid,
+      contribution.kind,
+      contribution.mode,
+      contribution.summary,
+      contribution.description ?? null,
+      contribution.agent.agentId,
+      contribution.agent.agentName ?? null,
+      createdAtUtc,
+      tagsJson,
+      contentHash,
+      manifestJson,
+    );
 
-      // If no row was inserted (duplicate CID), skip relations/FTS/tags/artifacts
-      if (result.changes === 0) return;
-
-      // Insert relations
-      for (const rel of contribution.relations) {
-        this.stmtInsertRelation.run(
-          contribution.cid,
-          rel.targetCid,
-          rel.relationType,
-          rel.metadata !== undefined ? JSON.stringify(rel.metadata) : null,
-        );
+    // If no row was inserted, return the existing row selected by content hash.
+    if (result.changes === 0) {
+      const existing = this.stmtGetByContentHash.get(contentHash) as {
+        cid: string;
+        manifest_json: string;
+      } | null;
+      if (existing !== null) {
+        return {
+          cid: existing.cid,
+          isNew: false,
+          contribution: rowToContribution(existing),
+        };
       }
-
-      // Insert into FTS index
-      this.stmtInsertFts.run(
-        contribution.cid,
-        contribution.summary,
-        contribution.description ?? "",
-      );
-
-      // Insert tags into junction table
-      for (const tag of contribution.tags) {
-        this.stmtInsertTag.run(contribution.cid, tag);
-      }
-
-      // Insert artifact references into junction table
-      for (const [name, contentHash] of Object.entries(contribution.artifacts)) {
-        this.stmtInsertArtifact.run(contribution.cid, name, contentHash);
-      }
-
-      // Optional cowrite: runs inside the same transaction (used for atomic handoff creation)
-      cowrite?.();
-    });
-    tx();
-  }
-
-  /** Multi-row INSERT helper. Chunks rows to stay under SQLITE_MAX_VARIABLE_NUMBER (999). */
-  private batchInsert(prefix: string, cols: number, rows: SQLQueryBindings[][]): void {
-    if (rows.length === 0) return;
-    const chunkSize = Math.floor(SQLITE_BIND_LIMIT / cols);
-    for (let i = 0; i < rows.length; i += chunkSize) {
-      const chunk = rows.slice(i, i + chunkSize);
-      const placeholderRow = `(${Array(cols).fill("?").join(", ")})`;
-      const sql = `${prefix} ${chunk.map(() => placeholderRow).join(", ")}`;
-      const params = chunk.flat();
-      this.db.prepare(sql).run(...params);
+      return { cid: contribution.cid, isNew: false };
     }
+
+    // Insert relations
+    for (const rel of contribution.relations) {
+      this.stmtInsertRelation.run(
+        contribution.cid,
+        rel.targetCid,
+        rel.relationType,
+        rel.metadata !== undefined ? JSON.stringify(rel.metadata) : null,
+      );
+    }
+
+    // Insert into FTS index
+    this.stmtInsertFts.run(contribution.cid, contribution.summary, contribution.description ?? "");
+
+    // Insert tags into junction table
+    for (const tag of contribution.tags) {
+      this.stmtInsertTag.run(contribution.cid, tag);
+    }
+
+    // Insert artifact references into junction table
+    for (const [name, artifactContentHash] of Object.entries(contribution.artifacts)) {
+      this.stmtInsertArtifact.run(contribution.cid, name, artifactContentHash);
+    }
+
+    // Optional cowrite: runs inside the same transaction (used for atomic handoff creation)
+    cowrite?.();
+    return { cid: contribution.cid, isNew: true, contribution };
   }
 
   /**
@@ -1867,10 +1872,13 @@ export class SqliteStore implements ContributionStore {
   }
 
   // ContributionStore delegation
-  put = (contribution: Contribution): Promise<void> => this.contributions.put(contribution);
-  putMany = (contributions: readonly Contribution[]): Promise<void> =>
+  put = (contribution: Contribution): Promise<ContributionPutResult> =>
+    this.contributions.put(contribution);
+  putMany = (contributions: readonly Contribution[]): Promise<readonly ContributionPutResult[]> =>
     this.contributions.putMany(contributions);
   get = (cid: string): Promise<Contribution | undefined> => this.contributions.get(cid);
+  getByContentHash = (contentHash: string): Promise<Contribution | undefined> =>
+    this.contributions.getByContentHash(contentHash);
   getMany = (cids: readonly string[]): Promise<ReadonlyMap<string, Contribution>> =>
     this.contributions.getMany(cids);
   list = (query?: ContributionQuery): Promise<readonly Contribution[]> =>

--- a/src/mcp/tools/bounties.test.ts
+++ b/src/mcp/tools/bounties.test.ts
@@ -123,6 +123,32 @@ describe("grove_bounty_create", () => {
     expect(data.reservationId).toBeDefined();
   });
 
+  test("reports accepted and duplicate counts for repeated identical bounties", async () => {
+    const args = {
+      title: "Retry-safe MCP bounty",
+      amount: 100,
+      criteria: { description: "Do one MCP task" },
+      agent: { agentId: "agent-1" },
+    };
+
+    const first = await callTool(server, "grove_bounty_create", args);
+    const second = await callTool(server, "grove_bounty_create", args);
+
+    expect(first.isError).toBeUndefined();
+    expect(second.isError).toBeUndefined();
+    const firstData = JSON.parse(first.text);
+    const secondData = JSON.parse(second.text);
+    expect(firstData.accepted).toBe(1);
+    expect(firstData.duplicate).toBe(0);
+    expect(secondData.accepted).toBe(0);
+    expect(secondData.duplicate).toBe(1);
+    expect(secondData.bountyId).toBe(firstData.bountyId);
+
+    const balance = await (deps.creditsService as InMemoryCreditsService).balance("agent-1");
+    expect(balance.available).toBe(900);
+    expect(balance.reserved).toBe(100);
+  });
+
   test("returns error when bountyStore is missing", async () => {
     const noBountyDeps = { ...deps, bountyStore: undefined } as unknown as McpDeps;
     const s = new McpServer({ name: "test", version: "0.0.1" }, { capabilities: { tools: {} } });

--- a/src/mcp/tools/contributions.test.ts
+++ b/src/mcp/tools/contributions.test.ts
@@ -135,6 +135,37 @@ describe("grove_submit_work", () => {
     expect(data.artifactCount).toBe(1);
   });
 
+  test("reports accepted and duplicate counts for repeated identical work payloads", async () => {
+    const payload = {
+      summary: "Retry-safe upload",
+      artifacts: {},
+      agent: { agentId: "coder-1", role: "coder" },
+    };
+
+    const first = await callTool(server, "grove_submit_work", payload);
+    const second = await callTool(server, "grove_submit_work", payload);
+    const third = await callTool(server, "grove_submit_work", payload);
+
+    expect(first.isError).toBeUndefined();
+    expect(second.isError).toBeUndefined();
+    expect(third.isError).toBeUndefined();
+    const firstData = JSON.parse(first.text);
+    const secondData = JSON.parse(second.text);
+    const thirdData = JSON.parse(third.text);
+    expect(firstData.accepted).toBe(1);
+    expect(firstData.duplicate).toBe(0);
+    expect(secondData.accepted).toBe(0);
+    expect(secondData.duplicate).toBe(1);
+    expect(thirdData.accepted).toBe(0);
+    expect(thirdData.duplicate).toBe(1);
+    expect(secondData.cid).toBe(firstData.cid);
+    expect(thirdData.cid).toBe(firstData.cid);
+
+    const stored = await deps.contributionStore.list({ limit: 20 });
+    const matching = stored.filter((c) => c.summary === "Retry-safe upload");
+    expect(matching).toHaveLength(1);
+  });
+
   test("accepts empty artifacts with warning", async () => {
     const result = await callTool(server, "grove_submit_work", {
       summary: "Configured CI pipeline",

--- a/src/nexus/nexus-bounty-store.ts
+++ b/src/nexus/nexus-bounty-store.ts
@@ -12,6 +12,7 @@
 import type { Bounty, BountyStatus, RewardRecord } from "../core/bounty.js";
 import { validateBountyTransition } from "../core/bounty-logic.js";
 import type { BountyQuery, BountyStore, RewardQuery } from "../core/bounty-store.js";
+import { computeBountyStorageContentHash } from "../core/content-dedup.js";
 import { NotFoundError, StateConflictError } from "../core/errors.js";
 import type { AgentIdentity } from "../core/models.js";
 import { safeCleanup } from "../shared/safe-cleanup.js";
@@ -25,6 +26,7 @@ import { withRetry, withSemaphore } from "./retry.js";
 import { Semaphore } from "./semaphore.js";
 import {
   bountiesDir,
+  bountyContentHashIndexPath,
   bountyPath,
   bountyStatusIndexDir,
   bountyStatusIndexPath,
@@ -71,14 +73,66 @@ export class NexusBountyStore implements BountyStore {
   }
 
   async createBounty(bounty: Bounty): Promise<Bounty> {
+    const idConflict = await this.getBounty(bounty.bountyId);
+    if (idConflict !== undefined) {
+      throw new StateConflictError({
+        resource: "Bounty",
+        reason: "already exists",
+        message: `Bounty with id '${bounty.bountyId}' already exists`,
+      });
+    }
+
     const now = new Date().toISOString();
     const created: Bounty = {
       ...bounty,
       createdAt: bounty.createdAt || now,
       updatedAt: now,
     };
+    const contentHash = computeBountyStorageContentHash(bounty);
+    const contentHashPath = bountyContentHashIndexPath(this.zoneId, contentHash);
+    const existingIdData = await withRetry(
+      () => withSemaphore(this.semaphore, () => this.client.read(contentHashPath)),
+      "createBounty:contentHashLookup",
+      this.config,
+    );
+    if (existingIdData !== undefined) {
+      const existingId = decoder.decode(existingIdData);
+      const existing = await this.getBounty(existingId);
+      if (existing !== undefined) {
+        return { ...existing, isNew: false } as Bounty & { readonly isNew: false };
+      }
+    }
 
     try {
+      try {
+        await withRetry(
+          () =>
+            withSemaphore(this.semaphore, () =>
+              this.client.write(contentHashPath, encoder.encode(created.bountyId), {
+                ifNoneMatch: "*",
+              }),
+            ),
+          "createBounty:contentHashReserve",
+          this.config,
+        );
+      } catch (err) {
+        if (err instanceof NexusConflictError) {
+          const existing = await withRetry(
+            () => withSemaphore(this.semaphore, () => this.client.read(contentHashPath)),
+            "createBounty:contentHashConflictLookup",
+            this.config,
+          );
+          if (existing !== undefined) {
+            const existingId = decoder.decode(existing);
+            const existingBounty = await this.getBounty(existingId);
+            if (existingBounty !== undefined) {
+              return { ...existingBounty, isNew: false } as Bounty & { readonly isNew: false };
+            }
+          }
+        }
+        throw err;
+      }
+
       await withRetry(
         () =>
           withSemaphore(this.semaphore, () =>
@@ -101,7 +155,7 @@ export class NexusBountyStore implements BountyStore {
     }
 
     await this.writeStatusIndex(created);
-    return created;
+    return { ...created, isNew: true } as Bounty & { readonly isNew: true };
   }
 
   async getBounty(bountyId: string): Promise<Bounty | undefined> {

--- a/src/nexus/nexus-contribution-store.ts
+++ b/src/nexus/nexus-contribution-store.ts
@@ -11,6 +11,7 @@
  * - FTS:        /zones/{zoneId}/indexes/fts/{cid}.json
  */
 
+import { computeContributionContentHash } from "../core/content-dedup.js";
 import type { ContributionEntity } from "../core/entity.js";
 import { contributionToEntity } from "../core/entity.js";
 import { fromManifest, toManifest, verifyCid } from "../core/manifest.js";
@@ -22,6 +23,7 @@ import type {
   RelationType,
 } from "../core/models.js";
 import type {
+  ContributionPutResult,
   ContributionQuery,
   ContributionStore,
   HotThreadsOptions,
@@ -34,11 +36,13 @@ import { batchParallel } from "./batch.js";
 import type { NexusClient } from "./client.js";
 import type { NexusConfig, ResolvedNexusConfig } from "./config.js";
 import { resolveConfig } from "./config.js";
+import { NexusConflictError } from "./errors.js";
 import { listAllPages } from "./list-pages.js";
 import { LruCache } from "./lru-cache.js";
 import { withRetry, withSemaphore } from "./retry.js";
 import { Semaphore } from "./semaphore.js";
 import {
+  contributionContentHashIndexPath,
   contributionPath,
   ftsIndexDir,
   ftsIndexPath,
@@ -134,7 +138,7 @@ export class NexusContributionStore implements ContributionStore {
     this.cache = new LruCache(this.config.cacheMaxEntries);
   }
 
-  async put(contribution: Contribution): Promise<void> {
+  async put(contribution: Contribution): Promise<ContributionPutResult> {
     if (!verifyCid(contribution)) {
       throw new Error(
         `CID integrity check failed for '${contribution.cid}': CID does not match manifest content`,
@@ -142,6 +146,58 @@ export class NexusContributionStore implements ContributionStore {
     }
 
     const manifestPath = contributionPath(this.zoneId, contribution.cid, this.sessionId);
+    const contentHash = computeContributionContentHash(contribution);
+    const contentHashPath = contributionContentHashIndexPath(
+      this.zoneId,
+      contentHash,
+      this.sessionId,
+    );
+
+    const existingCidData = await withRetry(
+      () => withSemaphore(this.semaphore, () => this.client.read(contentHashPath)),
+      "put:contentHashLookup",
+      this.config,
+    );
+    if (existingCidData !== undefined) {
+      const existingCid = decoder.decode(existingCidData);
+      const existing = await this.get(existingCid);
+      return {
+        cid: existingCid,
+        isNew: false,
+        ...(existing !== undefined ? { contribution: existing } : {}),
+      };
+    }
+
+    try {
+      await withRetry(
+        () =>
+          withSemaphore(this.semaphore, () =>
+            this.client.write(contentHashPath, encoder.encode(contribution.cid), {
+              ifNoneMatch: "*",
+            }),
+          ),
+        "put:contentHashReserve",
+        this.config,
+      );
+    } catch (err) {
+      if (err instanceof NexusConflictError) {
+        const existing = await withRetry(
+          () => withSemaphore(this.semaphore, () => this.client.read(contentHashPath)),
+          "put:contentHashConflictLookup",
+          this.config,
+        );
+        if (existing !== undefined) {
+          const existingCid = decoder.decode(existing);
+          const existingContribution = await this.get(existingCid);
+          return {
+            cid: existingCid,
+            isNew: false,
+            ...(existingContribution !== undefined ? { contribution: existingContribution } : {}),
+          };
+        }
+      }
+      throw err;
+    }
 
     await withRetry(
       async () => {
@@ -198,14 +254,15 @@ export class NexusContributionStore implements ContributionStore {
       "store.put",
       `cid=${contribution.cid.slice(0, 16)} sessionId=${this.sessionId ?? "none"} path=${manifestPath}`,
     );
+    return { cid: contribution.cid, isNew: true, contribution };
   }
 
-  async putMany(contributions: readonly Contribution[]): Promise<void> {
+  async putMany(contributions: readonly Contribution[]): Promise<readonly ContributionPutResult[]> {
     const unique = new Map<string, Contribution>();
     for (const c of contributions) {
       unique.set(c.cid, c);
     }
-    await batchParallel([...unique.values()], (c) => this.put(c));
+    return batchParallel([...unique.values()], (c) => this.put(c));
   }
 
   async getMany(cids: readonly string[]): Promise<ReadonlyMap<string, Contribution>> {
@@ -236,6 +293,21 @@ export class NexusContributionStore implements ContributionStore {
     const contribution = fromManifest(manifest, { verify: false });
     this.cache.set(cid, contribution);
     return contribution;
+  }
+
+  async getByContentHash(contentHash: string): Promise<Contribution | undefined> {
+    const contentHashPath = contributionContentHashIndexPath(
+      this.zoneId,
+      contentHash,
+      this.sessionId,
+    );
+    const existingCidData = await withRetry(
+      () => withSemaphore(this.semaphore, () => this.client.read(contentHashPath)),
+      "getByContentHash",
+      this.config,
+    );
+    if (existingCidData === undefined) return undefined;
+    return this.get(decoder.decode(existingCidData));
   }
 
   async list(query?: ContributionQuery): Promise<readonly Contribution[]> {

--- a/src/nexus/nexus-outcome-store.ts
+++ b/src/nexus/nexus-outcome-store.ts
@@ -9,6 +9,7 @@
  * - Status index:   /zones/{zoneId}/indexes/outcomes/status/{status}/{cid}
  */
 
+import { computeOutcomeContentHash } from "../core/content-dedup.js";
 import type {
   OutcomeInput,
   OutcomeQuery,
@@ -67,6 +68,12 @@ export class NexusOutcomeStore implements OutcomeStore {
   async set(cid: string, input: OutcomeInput): Promise<OutcomeRecord> {
     // Read existing record to detect status change for index cleanup
     const existing = await this.get(cid);
+    if (
+      existing !== undefined &&
+      computeOutcomeContentHash(existing.cid, existing) === computeOutcomeContentHash(cid, input)
+    ) {
+      return { ...existing, isNew: false } as OutcomeRecord & { readonly isNew: false };
+    }
 
     const record: OutcomeRecord = {
       cid,
@@ -111,7 +118,7 @@ export class NexusOutcomeStore implements OutcomeStore {
       this.config,
     );
 
-    return record;
+    return { ...record, isNew: true } as OutcomeRecord & { readonly isNew: true };
   }
 
   async get(cid: string): Promise<OutcomeRecord | undefined> {

--- a/src/nexus/nexus-stores.test.ts
+++ b/src/nexus/nexus-stores.test.ts
@@ -6,13 +6,17 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Bounty } from "../core/bounty.js";
+import { withBountyContentHash } from "../core/content-dedup.js";
 import type { Contribution } from "../core/models.js";
 import { type ClaimStatus, ContributionKind, RelationType } from "../core/models.js";
 import { makeClaim, makeContribution } from "../core/test-helpers.js";
 import { MockNexusClient } from "./mock-client.js";
+import { NexusBountyStore } from "./nexus-bounty-store.js";
 import { NexusCas } from "./nexus-cas.js";
 import { NexusClaimStore } from "./nexus-claim-store.js";
 import { NexusContributionStore } from "./nexus-contribution-store.js";
+import { NexusOutcomeStore } from "./nexus-outcome-store.js";
 
 // ---------------------------------------------------------------------------
 // NexusContributionStore tests
@@ -60,6 +64,27 @@ describe("NexusContributionStore", () => {
       const retrieved = await store.get(c.cid);
       expect(retrieved).toBeDefined();
       expect(retrieved?.summary).toBe("idempotent put");
+    });
+
+    test("same logical payload with different timestamps dedups by content hash", async () => {
+      const first = makeContribution({
+        summary: "content dedup",
+        agent: { agentId: "agent-1" },
+        createdAt: "2026-01-01T00:00:00Z",
+      });
+      const second = makeContribution({
+        summary: "content dedup",
+        agent: { agentId: "agent-1" },
+        createdAt: "2026-01-01T00:00:01Z",
+      });
+
+      const firstResult = await store.put(first);
+      const secondResult = await store.put(second);
+
+      expect(firstResult.isNew).toBe(true);
+      expect(secondResult.isNew).toBe(false);
+      expect(secondResult.cid).toBe(first.cid);
+      expect(await store.count()).toBe(1);
     });
 
     test("put with invalid CID throws", async () => {
@@ -205,6 +230,95 @@ describe("NexusContributionStore", () => {
       await store.put(c2);
       expect(await store.count()).toBe(2);
     });
+  });
+});
+
+describe("NexusBountyStore", () => {
+  let client: MockNexusClient;
+  let store: NexusBountyStore;
+
+  beforeEach(() => {
+    client = new MockNexusClient();
+    store = new NexusBountyStore({
+      client,
+      zoneId: "test-zone",
+      retryMaxAttempts: 1,
+    });
+  });
+
+  afterEach(async () => {
+    store.close();
+    await client.close();
+  });
+
+  function bounty(overrides?: Partial<Bounty>): Bounty {
+    return {
+      bountyId: overrides?.bountyId ?? crypto.randomUUID(),
+      title: overrides?.title ?? "Retry-safe bounty",
+      description: overrides?.description ?? "Retry-safe bounty",
+      status: overrides?.status ?? "open",
+      creator: overrides?.creator ?? { agentId: "agent-1" },
+      amount: overrides?.amount ?? 10,
+      criteria: overrides?.criteria ?? { description: "Do one thing" },
+      deadline: overrides?.deadline ?? "2026-02-01T00:00:00Z",
+      createdAt: overrides?.createdAt ?? "2026-01-01T00:00:00Z",
+      updatedAt: overrides?.updatedAt ?? "2026-01-01T00:00:00Z",
+      ...(overrides?.zoneId !== undefined ? { zoneId: overrides.zoneId } : {}),
+      ...(overrides?.context !== undefined ? { context: overrides.context } : {}),
+    };
+  }
+
+  test("same logical create payload dedups by content hash", async () => {
+    const first = bounty({ bountyId: "bounty-1", createdAt: "2026-01-01T00:00:00Z" });
+    const second = bounty({ bountyId: "bounty-2", createdAt: "2026-01-01T00:00:01Z" });
+
+    const firstResult = (await store.createBounty(withBountyContentHash(first))) as Bounty & {
+      readonly isNew?: boolean;
+    };
+    const secondResult = (await store.createBounty(withBountyContentHash(second))) as Bounty & {
+      readonly isNew?: boolean;
+    };
+
+    expect(firstResult.isNew).toBe(true);
+    expect(secondResult.isNew).toBe(false);
+    expect(secondResult.bountyId).toBe(first.bountyId);
+    expect(await store.countBounties()).toBe(1);
+  });
+});
+
+describe("NexusOutcomeStore", () => {
+  let client: MockNexusClient;
+  let store: NexusOutcomeStore;
+
+  beforeEach(() => {
+    client = new MockNexusClient();
+    store = new NexusOutcomeStore({
+      client,
+      zoneId: "test-zone",
+      retryMaxAttempts: 1,
+    });
+  });
+
+  afterEach(async () => {
+    store.close();
+    await client.close();
+  });
+
+  test("same logical outcome set reports duplicate", async () => {
+    const first = await store.set("cid-1", {
+      status: "accepted",
+      reason: "Looks good",
+      evaluatedBy: "agent-1",
+    });
+    const second = (await store.set("cid-1", {
+      status: "accepted",
+      reason: "Looks good",
+      evaluatedBy: "agent-1",
+    })) as typeof first & { readonly isNew?: boolean };
+
+    expect((first as typeof first & { readonly isNew?: boolean }).isNew).toBe(true);
+    expect(second.isNew).toBe(false);
+    expect(await store.getStats()).toMatchObject({ total: 1, accepted: 1 });
   });
 });
 

--- a/src/nexus/vfs-paths.ts
+++ b/src/nexus/vfs-paths.ts
@@ -86,6 +86,18 @@ export function ftsIndexDir(zoneId: string, sessionId?: string): string {
   return `${base}/indexes/fts`;
 }
 
+/** Path to a contribution content-hash dedup index marker. */
+export function contributionContentHashIndexPath(
+  zoneId: string,
+  contentHash: string,
+  sessionId?: string,
+): string {
+  const base = sessionId
+    ? `/zones/${encodeSegment(zoneId)}/sessions/${encodeSegment(sessionId)}`
+    : `/zones/${encodeSegment(zoneId)}`;
+  return `${base}/indexes/contributions/content-hash/${encodeSegment(contentHash)}`;
+}
+
 /** Path to a relation index entry (from source pointing to target). */
 export function relationIndexPath(zoneId: string, targetCid: string, sourceCid: string): string {
   return `/zones/${encodeSegment(zoneId)}/indexes/relations/${encodeSegment(targetCid)}/${encodeSegment(sourceCid)}.json`;
@@ -155,6 +167,11 @@ export function bountyStatusIndexPath(zoneId: string, status: string, bountyId: 
 /** Directory for a specific bounty status index. */
 export function bountyStatusIndexDir(zoneId: string, status: string): string {
   return `/zones/${encodeSegment(zoneId)}/indexes/bounties/status/${encodeSegment(status)}`;
+}
+
+/** Path to a bounty content-hash dedup index marker. */
+export function bountyContentHashIndexPath(zoneId: string, contentHash: string): string {
+  return `/zones/${encodeSegment(zoneId)}/indexes/bounties/content-hash/${encodeSegment(contentHash)}`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #338.

## Summary
- add canonical content-hash deduplication for repeated contribution, bounty, and outcome payloads
- return accepted/duplicate counts through operations and MCP responses
- persist dedup indexes in SQLite and Nexus stores with migration coverage

## Verification
- bun run typecheck
- bun run check
- bun test reported 6178 pass, 6 skip, 0 fail; Bun exited 1 after coverage reporting due to repository coverage threshold behavior