### PR TITLE
A8.1: WatchStream contract + informer hooks (infra, ships dark)

### DIFF
--- a/docs/superpowers/plans/2026-04-30-retire-polling-a8-pr1-infra.md
+++ b/docs/superpowers/plans/2026-04-30-retire-polling-a8-pr1-infra.md
@@ -1,0 +1,1651 @@
+# A8 — PR1 (Infra) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the infrastructure that lets `src/tui` views consume the informer cache reactively (no polling), without changing any call site. Ship dark — every existing `usePolledData` caller keeps working unchanged.
+
+**Architecture:** Extract a `WatchStream` interface implemented by both the existing remote `WatchClient` (HTTP/SSE) and a new in-process `LocalWatchClient` (subscribes to a process-local `WatchHub`). Refactor `Informer`/`InformerFactory` to take a `WatchStream` and add a discriminated-union option shape selecting remote vs. local. Add a React `InformerProvider` plus three hooks (`useEntities`, `useEntity`, `useDerived`). A contract-test fixture proves both `WatchStream` backends produce the same event sequence. `main.ts` wires the factory and provider but no view uses the new hooks yet — call-site migration is PR2-PR4.
+
+**Tech Stack:** TypeScript (strict, `exactOptionalPropertyTypes`), Bun test runner (`bun:test`), React (OpenTUI, no DOM), existing `WatchHub` / `WatchClient` / `Informer` from `src/core/`.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-retire-polling-a8-design.md`. Issue #295. Depends on #294 (closed).
+
+**Out of scope for PR1:**
+- Any `usePolledData` call-site swap (PR2-PR4).
+- Local-store → `WatchHub.recordWrite` wiring (PR2 lands this when the first kind needs it).
+- `setInterval` removal in `src/tui/main.ts` (PR5).
+- Producer-side events for vfs / terminal (PR4).
+
+---
+
+## File structure
+
+**New files:**
+
+| Path | Responsibility |
+|---|---|
+| `src/core/watch-stream.ts` | `WatchStream` interface + re-exports of `WatchClientEvent` for callers. |
+| `src/core/local-watch-client.ts` | `LocalWatchClient` class — implements `WatchStream` over a process-local `WatchHub` and a snapshot `listFn`. |
+| `src/core/local-watch-client.test.ts` | Unit tests for `LocalWatchClient` against a hand-rolled fake hub. |
+| `src/core/watch-stream.contract.test.ts` | Parameterized contract suite — same assertions over `WatchClient` (with fake fetch) and `LocalWatchClient` (with fake hub). |
+| `src/tui/hooks/informer-context.tsx` | `<InformerProvider>` + `useInformer<K>(kind)` accessor. |
+| `src/tui/hooks/use-entities.ts` | `useEntities(kind, predicate?)` hook + pure `computeFilteredEntities` and `shallowArraysEqual` helpers. |
+| `src/tui/hooks/use-entities.test.ts` | Tests for the pure helpers. |
+| `src/tui/hooks/use-entity.ts` | `useEntity(kind, id)` hook + pure `selectEntityById` helper. |
+| `src/tui/hooks/use-entity.test.ts` | Tests for the pure helper. |
+| `src/tui/hooks/use-derived.ts` | `useDerived(compute, kinds, equals?)` hook + pure `derivedReducer` helper. |
+| `src/tui/hooks/use-derived.test.ts` | Tests for the pure helper. |
+| `src/tui/hooks/refresh-context.tsx` | New `RefreshProvider` wired to `factory.relist()`. Replaces the old `useRefreshSignal` for new callers; old signal stays in tree for PR1. |
+
+**Modified files:**
+
+| Path | Change |
+|---|---|
+| `src/core/informer.ts` | `Informer` constructor takes a `WatchStream`. `InformerFactory` becomes a discriminated-union of `{ mode: "remote", ... }` / `{ mode: "local", ... }`. Add `factory.relist(kind?)`. Public `informerFor(kind)` API unchanged. |
+| `src/core/informer.test.ts` | Update test setup to construct `WatchClient` explicitly and pass it to `Informer`, OR continue to construct via the remote factory. |
+| `src/core/watch-client.ts` | Implement `WatchStream` interface (declarative — already has the `run({ onEvent, signal })` shape; just add `implements WatchStream`). |
+| `src/tui/main.ts` | At boot: build `InformerFactory` from env (remote or local), eagerly start all 3 informers, render `<InformerProvider>` and `<RefreshProvider>` around the React tree. **No** view changes. **No** `setInterval` changes. |
+
+**Untouched in PR1:**
+
+- `src/tui/hooks/use-polled-data.ts`, `use-panel-state.ts`, `use-refresh-context.ts` — stay; PR5 deletes them.
+- All view files (`src/tui/views/`, `src/tui/screens/`, `src/tui/panels/`) — untouched. Call-site migration is PR2-PR4.
+- `src/tui/main.ts` `setInterval`s — stay; PR5 moves them.
+
+---
+
+## Tasks
+
+### Task 1: Define the `WatchStream` interface
+
+**Files:**
+- Create: `src/core/watch-stream.ts`
+
+- [ ] **Step 1: Write `watch-stream.ts`**
+
+```ts
+/**
+ * WatchStream — common contract implemented by remote (HTTP/SSE) and
+ * in-process watch clients. Consumed by Informer (#294) so the cache
+ * layer can be backend-agnostic.
+ */
+
+import type { WatchClientEvent } from "./watch-client.js";
+
+export interface WatchStream {
+  run(opts: {
+    onEvent: (e: WatchClientEvent) => void | Promise<void>;
+    signal: AbortSignal;
+  }): Promise<void>;
+}
+
+export type { WatchClientEvent };
+```
+
+- [ ] **Step 2: Add `implements WatchStream` to `WatchClient`**
+
+In `src/core/watch-client.ts`, change:
+
+```ts
+export class WatchClient {
+```
+
+to:
+
+```ts
+import type { WatchStream } from "./watch-stream.js";
+// ...
+export class WatchClient implements WatchStream {
+```
+
+(`WatchClient.run` already has the matching signature — this is purely declarative.)
+
+- [ ] **Step 3: Verify typecheck passes**
+
+Run: `bun run typecheck`
+Expected: clean (no new errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/watch-stream.ts src/core/watch-client.ts
+git commit -m "feat(core): extract WatchStream interface, implement on WatchClient"
+```
+
+---
+
+### Task 2: Build `LocalWatchClient` (TDD)
+
+**Files:**
+- Create: `src/core/local-watch-client.ts`
+- Create: `src/core/local-watch-client.test.ts`
+
+`LocalWatchClient` mimics `WatchClient.run`'s event sequence but reads from an in-process `WatchHub` instead of HTTP/SSE. Sequence per `run()` invocation:
+
+1. Capture `currentRv` from the hub (the snapshot boundary).
+2. Subscribe to the hub from `currentRv` (live deltas; arrives async via `AsyncIterable<WatchEvent>`).
+3. Emit `RELIST_BEGIN { rv: currentRv }`.
+4. For each entity from `listFn()`, emit `RELIST { rv: currentRv, entity }`.
+5. Emit `RELIST_END { rv: currentRv }`.
+6. Loop the subscription; for each `WatchEvent`, emit `{ op: e.op, rv: e.rv, kind: e.kind, entity: e.entity }` to `onEvent`.
+7. On abort: stop the loop, return.
+
+Note: `WatchHub.subscribe` rejects `fromRv > currentRv`. We capture `currentRv` first, then subscribe from that exact value, so we get only events strictly after the snapshot.
+
+Boundary events have `entity: null` to match remote `WatchClient` semantics.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/core/local-watch-client.test.ts
+import { describe, expect, test } from "bun:test";
+import { LocalWatchClient } from "./local-watch-client.js";
+import { WatchHub } from "./watch-hub.js";
+import type { WatchClientEvent } from "./watch-client.js";
+import type { WatchEntity } from "./watch-events.js";
+
+const NS = "default";
+
+function mkContribution(id: string, rv: string): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: id,
+      artifacts: {},
+      relations: [],
+      tags: [],
+    },
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: rv,
+    metadata: { generation: 1 },
+  } as unknown as WatchEntity;
+}
+
+describe("LocalWatchClient", () => {
+  test("emits RELIST_BEGIN, one RELIST per snapshot entity, then RELIST_END", async () => {
+    const hub = new WatchHub();
+    const e1 = mkContribution("a", "1");
+    const e2 = mkContribution("b", "1");
+    const events: WatchClientEvent[] = [];
+    const ac = new AbortController();
+
+    const client = new LocalWatchClient({
+      hub,
+      kind: "Contribution",
+      namespace: NS,
+      listFn: () => [e1, e2],
+    });
+
+    const runPromise = client.run({
+      onEvent: (e) => {
+        events.push(e);
+        if (e.op === "RELIST_END") ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await runPromise;
+
+    expect(events.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST", "RELIST", "RELIST_END"]);
+    expect(events[1]?.entity?.id).toBe("a");
+    expect(events[2]?.entity?.id).toBe("b");
+    expect(events[0]?.entity).toBeNull();
+    expect(events[3]?.entity).toBeNull();
+  });
+
+  test("emits live deltas after RELIST_END", async () => {
+    const hub = new WatchHub();
+    const events: WatchClientEvent[] = [];
+    const ac = new AbortController();
+
+    const client = new LocalWatchClient({
+      hub,
+      kind: "Contribution",
+      namespace: NS,
+      listFn: () => [],
+    });
+
+    const runPromise = client.run({
+      onEvent: (e) => {
+        events.push(e);
+        if (e.op === "ADDED") ac.abort();
+      },
+      signal: ac.signal,
+    });
+
+    // Wait one microtask so the client has emitted RELIST_BEGIN/END before we publish.
+    await Promise.resolve();
+    await Promise.resolve();
+    hub.recordWrite({
+      op: "ADDED",
+      kind: "Contribution",
+      namespace: NS,
+      entity: mkContribution("a", "1"),
+    });
+    await runPromise;
+
+    const ops = events.map((e) => e.op);
+    expect(ops).toEqual(["RELIST_BEGIN", "RELIST_END", "ADDED"]);
+    expect(events[2]?.entity?.id).toBe("a");
+  });
+
+  test("respects pre-aborted signal — no events emitted", async () => {
+    const hub = new WatchHub();
+    const events: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    ac.abort();
+
+    const client = new LocalWatchClient({
+      hub,
+      kind: "Contribution",
+      namespace: NS,
+      listFn: () => [mkContribution("a", "1")],
+    });
+
+    await client.run({
+      onEvent: (e) => events.push(e),
+      signal: ac.signal,
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  test("captures currentRv before listing — events written between capture and subscribe replay correctly", async () => {
+    const hub = new WatchHub();
+    // Pre-existing event in hub before run() starts.
+    hub.recordWrite({
+      op: "ADDED",
+      kind: "Contribution",
+      namespace: NS,
+      entity: mkContribution("pre", "1"),
+    });
+
+    const events: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    const client = new LocalWatchClient({
+      hub,
+      kind: "Contribution",
+      namespace: NS,
+      listFn: () => [mkContribution("a", "1")],
+    });
+
+    const runPromise = client.run({
+      onEvent: (e) => {
+        events.push(e);
+        if (e.op === "RELIST_END") ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await runPromise;
+
+    // No replay of the pre-snapshot event — listFn is the source of truth at snapshot time.
+    expect(events.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST", "RELIST_END"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/local-watch-client.test.ts`
+Expected: FAIL with "Cannot find module './local-watch-client.js'" or similar.
+
+- [ ] **Step 3: Implement `LocalWatchClient`**
+
+```ts
+// src/core/local-watch-client.ts
+/**
+ * LocalWatchClient — in-process WatchStream backend (#295).
+ *
+ * Reads a snapshot from `listFn` and subscribes to a process-local
+ * WatchHub for deltas. Emits the same RELIST_BEGIN → RELIST* → RELIST_END
+ * → live-delta sequence as the remote WatchClient so consumers (Informer)
+ * can be backend-agnostic.
+ *
+ * Local mode (no Nexus) wires this against per-store snapshots; the stores
+ * themselves call `hub.recordWrite` on each write. Remote mode keeps using
+ * the HTTP-based WatchClient.
+ */
+
+import type { WatchClientEvent } from "./watch-client.js";
+import { WatchHub } from "./watch-hub.js";
+import type { WatchEntity, WatchKind } from "./watch-events.js";
+import type { WatchStream } from "./watch-stream.js";
+
+export interface LocalWatchClientOptions {
+  readonly hub: WatchHub;
+  readonly kind: WatchKind;
+  readonly namespace: string;
+  readonly listFn: () => readonly WatchEntity[];
+}
+
+export class LocalWatchClient implements WatchStream {
+  private readonly hub: WatchHub;
+  private readonly kind: WatchKind;
+  private readonly namespace: string;
+  private readonly listFn: () => readonly WatchEntity[];
+
+  constructor(opts: LocalWatchClientOptions) {
+    this.hub = opts.hub;
+    this.kind = opts.kind;
+    this.namespace = opts.namespace;
+    this.listFn = opts.listFn;
+  }
+
+  async run(opts: {
+    onEvent: (e: WatchClientEvent) => void | Promise<void>;
+    signal: AbortSignal;
+  }): Promise<void> {
+    const { onEvent, signal } = opts;
+    if (signal.aborted) return;
+
+    // Capture the watch RV at the snapshot boundary, BEFORE listFn executes.
+    // The hub's subscribe() will replay everything strictly after this RV,
+    // so any write that happens after capture is delivered as a live delta.
+    const snapshotRv = this.hub.currentRv(this.namespace, this.kind);
+
+    // Subscribe BEFORE emitting RELIST events so we don't miss writes that
+    // race the snapshot. The hub buffers events into the subscriber's queue
+    // until the consumer iterates.
+    const stream = this.hub.subscribe(this.namespace, this.kind, snapshotRv, signal);
+
+    // Emit the snapshot.
+    await onEvent({
+      op: "RELIST_BEGIN",
+      rv: snapshotRv,
+      kind: this.kind,
+      entity: null,
+    });
+    if (signal.aborted) return;
+
+    for (const entity of this.listFn()) {
+      await onEvent({
+        op: "RELIST",
+        rv: snapshotRv,
+        kind: this.kind,
+        entity,
+      });
+      if (signal.aborted) return;
+    }
+
+    await onEvent({
+      op: "RELIST_END",
+      rv: snapshotRv,
+      kind: this.kind,
+      entity: null,
+    });
+    if (signal.aborted) return;
+
+    // Drain live deltas. The async iterator returns when the abort signal fires.
+    try {
+      for await (const event of stream) {
+        if (signal.aborted) return;
+        await onEvent({
+          op: event.op,
+          rv: event.rv,
+          kind: event.kind,
+          entity: event.entity,
+        });
+      }
+    } catch (err) {
+      // Hub buffer overflow (unlikely in-process) — surface as RELIST_ABORTED so
+      // the Informer can drop the snapshot in flight; not relevant here since
+      // we're already past RELIST_END, so just rethrow for the caller's run loop.
+      if (!signal.aborted) throw err;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/local-watch-client.test.ts`
+Expected: 4 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/local-watch-client.ts src/core/local-watch-client.test.ts
+git commit -m "feat(core): add LocalWatchClient — in-process WatchStream over WatchHub"
+```
+
+---
+
+### Task 3: Refactor `Informer` to accept a `WatchStream`
+
+**Files:**
+- Modify: `src/core/informer.ts`
+- Modify: `src/core/informer.test.ts`
+
+Currently `Informer` takes `WatchClientOptions` and constructs its own `WatchClient`. Decouple it so callers inject any `WatchStream`. Keep `InformerFactory` working with the same public `informerFor(kind)` API.
+
+- [ ] **Step 1: Change `Informer` constructor to take a `WatchStream`**
+
+In `src/core/informer.ts`, replace the existing class header and constructor:
+
+```ts
+import type { WatchStream } from "./watch-stream.js";
+// ... existing imports remain
+
+export class Informer<K extends WatchKind = WatchKind> {
+  private readonly stream: WatchStream;
+  private readonly store = new Map<string, EntityForKind<K>>();
+  private readonly handlers: Array<EventHandlerFn<K>> = [];
+  private _synced = false;
+  private staging: Map<string, EntityForKind<K>> | null = null;
+  private _running = false;
+  private _signal: AbortSignal | null = null;
+
+  constructor(stream: WatchStream) {
+    this.stream = stream;
+  }
+
+  // ... addEventHandler, hasSynced, getById, list unchanged
+```
+
+Replace the existing `run()`:
+
+```ts
+async run(signal: AbortSignal): Promise<void> {
+  if (this._running) {
+    throw new Error(
+      "Informer.run() called while already running; only one concurrent run is allowed",
+    );
+  }
+  this._running = true;
+  this._signal = signal;
+  try {
+    await this.stream.run({ onEvent: (e) => this.onEvent(e), signal });
+  } finally {
+    this._signal = null;
+    this._running = false;
+  }
+}
+```
+
+Delete the import of `WatchClient` from `informer.ts` (no longer used inside the class).
+
+- [ ] **Step 2: Update `InformerFactory` to a discriminated-union options shape**
+
+Replace the existing `InformerFactoryOptions` and `InformerFactory` class:
+
+```ts
+import { WatchClient, type WatchClientOptions } from "./watch-client.js";
+import { LocalWatchClient } from "./local-watch-client.js";
+import type { WatchHub } from "./watch-hub.js";
+
+export type Backoff = NonNullable<WatchClientOptions["backoff"]>;
+
+export type InformerFactoryOptions =
+  | {
+      readonly mode: "remote";
+      readonly baseUrl: string;
+      readonly authHeader: string;
+      readonly fetch?: typeof fetch;
+      readonly backoff?: Backoff;
+    }
+  | {
+      readonly mode: "local";
+      readonly hub: WatchHub;
+      readonly namespace: string;
+      readonly listFn: (kind: WatchKind) => readonly WatchEntity[];
+      readonly backoff?: Backoff;
+    };
+
+interface RunningInformer {
+  readonly informer: Informer;
+  controller: AbortController;
+  runPromise: Promise<void> | null;
+}
+
+export class InformerFactory {
+  private readonly opts: InformerFactoryOptions;
+  private readonly running = new Map<string, RunningInformer>();
+
+  constructor(opts: InformerFactoryOptions) {
+    this.opts = opts;
+  }
+
+  /**
+   * Returns the Informer for a kind. Lazily constructs it on first call,
+   * but does NOT start `run()` — call `startAll()` (or rely on it being
+   * called by the app's boot sequence) to start watching.
+   */
+  informerFor<K extends WatchKind>(kind: K): Informer<K> {
+    const existing = this.running.get(kind);
+    if (existing) return existing.informer as Informer<K>;
+    const stream = this.makeStream(kind);
+    const informer = new Informer<K>(stream);
+    this.running.set(kind, {
+      informer: informer as Informer,
+      controller: new AbortController(),
+      runPromise: null,
+    });
+    return informer;
+  }
+
+  /**
+   * Start `run()` on all 3 known kinds. Idempotent — calling on an already-
+   * started kind is a no-op. Caller is responsible for calling `stop()`
+   * (or aborting the parent signal) on shutdown.
+   */
+  startAll(): void {
+    for (const kind of ALL_KINDS) {
+      this.startKind(kind);
+    }
+  }
+
+  /**
+   * Abort all running informers. After this returns, the run() promises have
+   * settled and the factory is reusable (caller can startAll() again).
+   */
+  async stopAll(): Promise<void> {
+    const promises: Promise<void>[] = [];
+    for (const r of this.running.values()) {
+      r.controller.abort();
+      if (r.runPromise) promises.push(r.runPromise.catch(() => undefined));
+    }
+    await Promise.all(promises);
+  }
+
+  /**
+   * Force a relist on a single kind (or all kinds when undefined). Aborts the
+   * current run, awaits its settlement, then starts a new run with a fresh
+   * AbortController. Intended for the global `r`-key refresh.
+   */
+  async relist(kind?: WatchKind): Promise<void> {
+    const kinds: WatchKind[] = kind ? [kind] : [...ALL_KINDS];
+    for (const k of kinds) {
+      const r = this.running.get(k);
+      if (!r) continue;
+      r.controller.abort();
+      if (r.runPromise) await r.runPromise.catch(() => undefined);
+      r.controller = new AbortController();
+      r.runPromise = null;
+      this.startKind(k);
+    }
+  }
+
+  private startKind(kind: WatchKind): void {
+    const r = this.running.get(kind) ?? this.bootKind(kind);
+    if (r.runPromise) return; // already running
+    r.runPromise = r.informer.run(r.controller.signal);
+  }
+
+  private bootKind(kind: WatchKind): RunningInformer {
+    this.informerFor(kind);
+    const r = this.running.get(kind);
+    if (!r) throw new Error(`unreachable: informerFor(${kind}) did not register a running entry`);
+    return r;
+  }
+
+  private makeStream(kind: WatchKind): WatchStream {
+    if (this.opts.mode === "remote") {
+      const clientOpts: WatchClientOptions = {
+        baseUrl: this.opts.baseUrl,
+        kind,
+        authHeader: this.opts.authHeader,
+        ...(this.opts.fetch !== undefined ? { fetch: this.opts.fetch } : {}),
+        ...(this.opts.backoff !== undefined ? { backoff: this.opts.backoff } : {}),
+      };
+      return new WatchClient(clientOpts);
+    }
+    return new LocalWatchClient({
+      hub: this.opts.hub,
+      kind,
+      namespace: this.opts.namespace,
+      listFn: () => this.opts.listFn(kind),
+    });
+  }
+}
+
+const ALL_KINDS: readonly WatchKind[] = ["Contribution", "Claim", "AgentSession"];
+```
+
+- [ ] **Step 3: Update existing `informer.test.ts` to construct streams explicitly**
+
+The existing tests construct `Informer` with `WatchClientOptions`. Update each construction site to create a `WatchClient` and pass it:
+
+Find blocks like:
+
+```ts
+const informer = new Informer({
+  baseUrl: "http://t",
+  kind: "Contribution",
+  authHeader: "Bearer x",
+  fetch: fetchImpl,
+  backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+});
+```
+
+Replace with:
+
+```ts
+const informer = new Informer(
+  new WatchClient({
+    baseUrl: "http://t",
+    kind: "Contribution",
+    authHeader: "Bearer x",
+    fetch: fetchImpl,
+    backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+  }),
+);
+```
+
+Add `import { WatchClient } from "./watch-client.js";` at the top of `informer.test.ts`.
+
+For tests that exercise `InformerFactory`, update the construction:
+
+```ts
+// Before:
+const factory = new InformerFactory({ baseUrl: "...", authHeader: "..." });
+
+// After:
+const factory = new InformerFactory({ mode: "remote", baseUrl: "...", authHeader: "..." });
+```
+
+- [ ] **Step 4: Run informer tests to verify they pass**
+
+Run: `bun test src/core/informer.test.ts`
+Expected: all existing tests pass.
+
+- [ ] **Step 5: Run full typecheck**
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/informer.ts src/core/informer.test.ts
+git commit -m "refactor(core): Informer takes WatchStream; InformerFactory gains mode + relist"
+```
+
+---
+
+### Task 4: Contract test fixture for `WatchStream`
+
+**Files:**
+- Create: `src/core/watch-stream.contract.test.ts`
+
+Same assertions over both backends. Catches drift between `WatchClient` and `LocalWatchClient`.
+
+- [ ] **Step 1: Write the contract test**
+
+```ts
+// src/core/watch-stream.contract.test.ts
+import { describe, expect, test } from "bun:test";
+import type { WatchClientEvent } from "./watch-client.js";
+import { WatchClient } from "./watch-client.js";
+import { LocalWatchClient } from "./local-watch-client.js";
+import { WatchHub } from "./watch-hub.js";
+import type { WatchEntity, WatchKind } from "./watch-events.js";
+import type { WatchStream } from "./watch-stream.js";
+
+const NS = "default";
+const KIND: WatchKind = "Contribution";
+
+function mkEntity(id: string, rv: string): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: id,
+      artifacts: {},
+      relations: [],
+      tags: [],
+    },
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: rv,
+    metadata: { generation: 1 },
+  } as unknown as WatchEntity;
+}
+
+interface Backend {
+  readonly name: string;
+  readonly stream: WatchStream;
+  readonly publishLive: (entity: WatchEntity) => void;
+}
+
+function localBackend(snapshot: readonly WatchEntity[]): Backend {
+  const hub = new WatchHub();
+  const stream = new LocalWatchClient({
+    hub,
+    kind: KIND,
+    namespace: NS,
+    listFn: () => snapshot,
+  });
+  return {
+    name: "LocalWatchClient",
+    stream,
+    publishLive: (entity) => {
+      hub.recordWrite({ op: "ADDED", kind: KIND, namespace: NS, entity });
+    },
+  };
+}
+
+function sse(event: string, data: unknown, id?: string): string {
+  const idLine = id ? `id: ${id}\n` : "";
+  return `${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function remoteBackend(snapshot: readonly WatchEntity[], live: readonly WatchEntity[]): Backend {
+  const list = { items: [...snapshot], listResourceVersion: "0" };
+  let body = "";
+  let rv = 1n;
+  for (const e of live) {
+    body += sse("ADDED", { rv: String(rv), op: "ADDED", kind: KIND, entity: e }, String(rv));
+    rv += 1n;
+  }
+  const ac = new AbortController();
+  let watchCalls = 0;
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.includes("/api/list")) {
+      return new Response(JSON.stringify(list), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url.includes("/api/watch")) {
+      watchCalls += 1;
+      if (watchCalls === 1) {
+        return new Response(body, { headers: { "Content-Type": "text/event-stream" } });
+      }
+      ac.abort();
+      return new Response("", { headers: { "Content-Type": "text/event-stream" } });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }) as typeof fetch;
+  const stream = new WatchClient({
+    baseUrl: "http://t",
+    kind: KIND,
+    authHeader: "Bearer x",
+    fetch: fetchImpl,
+    backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+  });
+  return {
+    name: "WatchClient (remote, fake fetch)",
+    stream,
+    publishLive: () => {
+      throw new Error("remote backend's live events are pre-baked into the SSE body");
+    },
+  };
+}
+
+describe("WatchStream contract", () => {
+  for (const make of [
+    () => localBackend([mkEntity("a", "1"), mkEntity("b", "1")]),
+    () => remoteBackend([mkEntity("a", "1"), mkEntity("b", "1")], []),
+  ]) {
+    const backend = make();
+
+    test(`${backend.name}: snapshot order = BEGIN, RELIST*, END`, async () => {
+      const events: WatchClientEvent[] = [];
+      const ac = new AbortController();
+      const runPromise = backend.stream.run({
+        onEvent: (e) => {
+          events.push(e);
+          if (e.op === "RELIST_END") ac.abort();
+        },
+        signal: ac.signal,
+      });
+      await runPromise.catch(() => undefined);
+
+      expect(events.map((e) => e.op)).toEqual([
+        "RELIST_BEGIN",
+        "RELIST",
+        "RELIST",
+        "RELIST_END",
+      ]);
+      expect(events[0]?.entity).toBeNull();
+      expect(events[3]?.entity).toBeNull();
+    });
+  }
+
+  test("LocalWatchClient: live ADDED arrives after RELIST_END", async () => {
+    const backend = localBackend([]);
+    const events: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    const run = backend.stream.run({
+      onEvent: (e) => {
+        events.push(e);
+        if (e.op === "ADDED") ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    backend.publishLive(mkEntity("live-a", "1"));
+    await run;
+    expect(events.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST_END", "ADDED"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the contract test**
+
+Run: `bun test src/core/watch-stream.contract.test.ts`
+Expected: all tests pass for both backends.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/watch-stream.contract.test.ts
+git commit -m "test(core): contract suite proves WatchStream parity for remote and local"
+```
+
+---
+
+### Task 5: `InformerProvider` + `useInformer`
+
+**Files:**
+- Create: `src/tui/hooks/informer-context.tsx`
+
+- [ ] **Step 1: Write `informer-context.tsx`**
+
+```tsx
+/**
+ * InformerProvider — supplies an InformerFactory to React subscribers.
+ *
+ * Eager startAll() at provider mount, stopAll() on unmount. All hooks
+ * (useEntities, useEntity, useDerived) consume the factory through this
+ * context. Throws when used outside the provider.
+ */
+
+import { createContext, useContext, useEffect, type ReactNode } from "react";
+import type { InformerFactory } from "../../core/informer.js";
+import type { Informer } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+
+const InformerContext = createContext<InformerFactory | null>(null);
+
+export interface InformerProviderProps {
+  readonly value: InformerFactory;
+  readonly children: ReactNode;
+}
+
+export function InformerProvider(props: InformerProviderProps): ReactNode {
+  const { value, children } = props;
+  useEffect(() => {
+    value.startAll();
+    return () => {
+      void value.stopAll();
+    };
+  }, [value]);
+  return <InformerContext.Provider value={value}>{children}</InformerContext.Provider>;
+}
+
+export function useInformerFactory(): InformerFactory {
+  const factory = useContext(InformerContext);
+  if (!factory) {
+    throw new Error("useInformer*: must be called inside <InformerProvider>");
+  }
+  return factory;
+}
+
+export function useInformer<K extends WatchKind>(kind: K): Informer<K> {
+  return useInformerFactory().informerFor(kind);
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/hooks/informer-context.tsx
+git commit -m "feat(tui): InformerProvider + useInformer context"
+```
+
+---
+
+### Task 6: `useEntities` hook + pure helpers
+
+**Files:**
+- Create: `src/tui/hooks/use-entities.ts`
+- Create: `src/tui/hooks/use-entities.test.ts`
+
+Hook tests in this codebase test pure logic (no React renderer). Extract two helpers into the module: `computeFilteredEntities` (apply optional predicate, return identity-stable array if predicate is undefined) and `shallowArraysEqual` (length + per-index `Object.is`). Test those. The hook itself is a thin wrapper.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/tui/hooks/use-entities.test.ts
+import { describe, expect, test } from "bun:test";
+import { computeFilteredEntities, shallowArraysEqual } from "./use-entities.js";
+
+describe("shallowArraysEqual", () => {
+  test("identical references → true", () => {
+    const a = [1, 2, 3];
+    expect(shallowArraysEqual(a, a)).toBe(true);
+  });
+
+  test("different lengths → false", () => {
+    expect(shallowArraysEqual([1, 2], [1, 2, 3])).toBe(false);
+  });
+
+  test("same elements in same order → true", () => {
+    const a = { id: "a" };
+    const b = { id: "b" };
+    expect(shallowArraysEqual([a, b], [a, b])).toBe(true);
+  });
+
+  test("same length, different element identity → false", () => {
+    expect(shallowArraysEqual([{ id: "a" }], [{ id: "a" }])).toBe(false);
+  });
+
+  test("NaN handled by Object.is", () => {
+    expect(shallowArraysEqual([Number.NaN], [Number.NaN])).toBe(true);
+  });
+});
+
+describe("computeFilteredEntities", () => {
+  const e1 = { id: "a" } as unknown as { id: string };
+  const e2 = { id: "b" } as unknown as { id: string };
+
+  test("undefined predicate returns the input array reference", () => {
+    const list = [e1, e2];
+    expect(computeFilteredEntities(list, undefined)).toBe(list);
+  });
+
+  test("predicate filters", () => {
+    const out = computeFilteredEntities([e1, e2], (e) => e.id === "a");
+    expect(out).toEqual([e1]);
+  });
+
+  test("predicate that throws is propagated to caller", () => {
+    const boom = (): boolean => {
+      throw new Error("boom");
+    };
+    expect(() => computeFilteredEntities([e1], boom)).toThrow("boom");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/tui/hooks/use-entities.test.ts`
+Expected: FAIL with "Cannot find module" / "is not a function".
+
+- [ ] **Step 3: Implement helpers + hook**
+
+```ts
+// src/tui/hooks/use-entities.ts
+/**
+ * useEntities — reactive filtered list view over the informer cache.
+ *
+ * Subscribes to the named kind's informer once per consumer; recomputes
+ * the filtered list on every event; commits a new array reference only
+ * when the filtered slice actually changed (shallow equality).
+ *
+ * Pure helpers below are exported for unit tests; the React hook is a
+ * thin wrapper around them.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Informer } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+import { useInformer } from "./informer-context.js";
+
+type EntityFor<I extends Informer> = I extends Informer<infer K>
+  ? ReturnType<I["list"]>[number]
+  : never;
+
+export function shallowArraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (!Object.is(a[i], b[i])) return false;
+  }
+  return true;
+}
+
+export function computeFilteredEntities<E>(
+  list: readonly E[],
+  predicate: ((e: E) => boolean) | undefined,
+): readonly E[] {
+  if (!predicate) return list;
+  return list.filter(predicate);
+}
+
+export interface UseEntitiesResult<E> {
+  readonly data: readonly E[];
+  readonly hasSynced: boolean;
+  readonly error: Error | null;
+}
+
+export function useEntities<K extends WatchKind>(
+  kind: K,
+  predicate?: (e: ReturnType<Informer<K>["list"]>[number]) => boolean,
+): UseEntitiesResult<ReturnType<Informer<K>["list"]>[number]> {
+  type E = ReturnType<Informer<K>["list"]>[number];
+  const informer = useInformer(kind);
+  const predicateRef = useRef(predicate);
+  predicateRef.current = predicate;
+
+  const initial = useMemo<readonly E[]>(() => {
+    try {
+      return computeFilteredEntities(informer.list() as readonly E[], predicateRef.current);
+    } catch {
+      return [];
+    }
+  }, [informer]);
+
+  const [data, setData] = useState<readonly E[]>(initial);
+  const [hasSynced, setHasSynced] = useState<boolean>(informer.hasSynced());
+  const [error, setError] = useState<Error | null>(null);
+  const dataRef = useRef<readonly E[]>(initial);
+  dataRef.current = data;
+
+  useEffect(() => {
+    const unsub = informer.addEventHandler(() => {
+      try {
+        const next = computeFilteredEntities(informer.list() as readonly E[], predicateRef.current);
+        if (!shallowArraysEqual(dataRef.current, next)) {
+          setData(next);
+        }
+        if (!hasSynced && informer.hasSynced()) setHasSynced(true);
+        if (error) setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+    return unsub;
+  }, [informer, hasSynced, error]);
+
+  return { data, hasSynced, error };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/tui/hooks/use-entities.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/hooks/use-entities.ts src/tui/hooks/use-entities.test.ts
+git commit -m "feat(tui): useEntities hook with shallow-equal output memo"
+```
+
+---
+
+### Task 7: `useEntity` hook + pure helper
+
+**Files:**
+- Create: `src/tui/hooks/use-entity.ts`
+- Create: `src/tui/hooks/use-entity.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/tui/hooks/use-entity.test.ts
+import { describe, expect, test } from "bun:test";
+import { selectEntityById } from "./use-entity.js";
+import type { Informer } from "../../core/informer.js";
+
+function fakeInformer<E extends { id: string }>(items: readonly E[]): Informer {
+  return {
+    list: () => items,
+    getById: (id: string) => items.find((i) => i.id === id),
+    hasSynced: () => true,
+    addEventHandler: () => () => undefined,
+  } as unknown as Informer;
+}
+
+describe("selectEntityById", () => {
+  test("undefined id returns undefined and never calls getById", () => {
+    let calls = 0;
+    const inf = {
+      ...fakeInformer([{ id: "a" }]),
+      getById: (id: string) => {
+        calls += 1;
+        return undefined;
+      },
+    } as unknown as Informer;
+    expect(selectEntityById(inf, undefined)).toBeUndefined();
+    expect(calls).toBe(0);
+  });
+
+  test("id present in cache returns the entity", () => {
+    const a = { id: "a" };
+    const inf = fakeInformer([a]);
+    expect(selectEntityById(inf, "a")).toBe(a);
+  });
+
+  test("id absent returns undefined", () => {
+    const inf = fakeInformer<{ id: string }>([{ id: "a" }]);
+    expect(selectEntityById(inf, "missing")).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/tui/hooks/use-entity.test.ts`
+Expected: FAIL with module not found.
+
+- [ ] **Step 3: Implement helper + hook**
+
+```ts
+// src/tui/hooks/use-entity.ts
+/**
+ * useEntity — reactive single-record subscription over the informer cache.
+ *
+ * Subscribes to the named kind, but the handler ignores events whose
+ * entity id ≠ id, avoiding re-render churn for unrelated changes.
+ */
+
+import { useEffect, useState } from "react";
+import type { Informer } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+import { useInformer } from "./informer-context.js";
+
+export function selectEntityById<I extends Informer>(
+  informer: I,
+  id: string | undefined,
+): ReturnType<I["getById"]> | undefined {
+  if (id === undefined) return undefined;
+  return informer.getById(id) as ReturnType<I["getById"]>;
+}
+
+export interface UseEntityResult<E> {
+  readonly data: E | undefined;
+  readonly hasSynced: boolean;
+}
+
+export function useEntity<K extends WatchKind>(
+  kind: K,
+  id: string | undefined,
+): UseEntityResult<ReturnType<Informer<K>["getById"]> & ({} | undefined)> {
+  type E = NonNullable<ReturnType<Informer<K>["getById"]>>;
+  const informer = useInformer(kind);
+  const [data, setData] = useState<E | undefined>(
+    () => selectEntityById(informer, id) as E | undefined,
+  );
+  const [hasSynced, setHasSynced] = useState<boolean>(informer.hasSynced());
+
+  useEffect(() => {
+    if (id === undefined) {
+      setData(undefined);
+      return;
+    }
+    setData(selectEntityById(informer, id) as E | undefined);
+    const unsub = informer.addEventHandler((_op, entity) => {
+      if (entity.id !== id) return;
+      setData(selectEntityById(informer, id) as E | undefined);
+      if (!hasSynced && informer.hasSynced()) setHasSynced(true);
+    });
+    return unsub;
+  }, [informer, id, hasSynced]);
+
+  return { data, hasSynced };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/tui/hooks/use-entity.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/hooks/use-entity.ts src/tui/hooks/use-entity.test.ts
+git commit -m "feat(tui): useEntity hook for single-record subscription"
+```
+
+---
+
+### Task 8: `useDerived` hook + pure helper
+
+**Files:**
+- Create: `src/tui/hooks/use-derived.ts`
+- Create: `src/tui/hooks/use-derived.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/tui/hooks/use-derived.test.ts
+import { describe, expect, test } from "bun:test";
+import { stepDerived } from "./use-derived.js";
+
+describe("stepDerived", () => {
+  test("first compute success → data set, error null", () => {
+    const next = stepDerived({ data: undefined, error: null }, () => 42);
+    expect(next.data).toBe(42);
+    expect(next.error).toBeNull();
+    expect(next.committed).toBe(true);
+  });
+
+  test("compute returns same value (Object.is) → no commit", () => {
+    const obj = { a: 1 };
+    const next = stepDerived({ data: obj, error: null }, () => obj);
+    expect(next.committed).toBe(false);
+  });
+
+  test("custom equals comparator → no commit when equal", () => {
+    const next = stepDerived(
+      { data: { a: 1 }, error: null },
+      () => ({ a: 1 }),
+      (a, b) => a.a === b.a,
+    );
+    expect(next.committed).toBe(false);
+  });
+
+  test("compute throws → error set, last data preserved", () => {
+    const next = stepDerived({ data: 7, error: null }, () => {
+      throw new Error("boom");
+    });
+    expect(next.data).toBe(7);
+    expect(next.error?.message).toBe("boom");
+    expect(next.committed).toBe(true); // error state changed
+  });
+
+  test("recovery: previous error cleared on success", () => {
+    const next = stepDerived({ data: 7, error: new Error("old") }, () => 8);
+    expect(next.data).toBe(8);
+    expect(next.error).toBeNull();
+    expect(next.committed).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/tui/hooks/use-derived.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement helper + hook**
+
+```ts
+// src/tui/hooks/use-derived.ts
+/**
+ * useDerived — reactive projection over one or more informers.
+ *
+ * Subscribes to every listed kind; recomputes `compute()` on any event
+ * from any of them; commits a new state only when the output changed
+ * (Object.is by default, caller-provided `equals` for non-trivial
+ * shapes). Exceptions in `compute` set `error`; last-good `data`
+ * is preserved.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { useInformerFactory } from "./informer-context.js";
+import type { WatchKind } from "../../core/watch-events.js";
+
+export interface DerivedState<T> {
+  readonly data: T | undefined;
+  readonly error: Error | null;
+}
+
+export interface DerivedStep<T> extends DerivedState<T> {
+  readonly committed: boolean;
+}
+
+export function stepDerived<T>(
+  prev: DerivedState<T>,
+  compute: () => T,
+  equals: (a: T, b: T) => boolean = Object.is,
+): DerivedStep<T> {
+  try {
+    const next = compute();
+    if (prev.data !== undefined && equals(prev.data, next)) {
+      if (prev.error === null) {
+        return { data: prev.data, error: null, committed: false };
+      }
+      return { data: prev.data, error: null, committed: true };
+    }
+    return { data: next, error: null, committed: true };
+  } catch (err) {
+    return {
+      data: prev.data,
+      error: err instanceof Error ? err : new Error(String(err)),
+      committed: true,
+    };
+  }
+}
+
+export interface UseDerivedResult<T> {
+  readonly data: T | undefined;
+  readonly hasSynced: boolean;
+  readonly error: Error | null;
+}
+
+export function useDerived<T>(
+  compute: () => T,
+  kinds: readonly WatchKind[],
+  equals: (a: T, b: T) => boolean = Object.is,
+): UseDerivedResult<T> {
+  const factory = useInformerFactory();
+  const computeRef = useRef(compute);
+  computeRef.current = compute;
+  const equalsRef = useRef(equals);
+  equalsRef.current = equals;
+
+  const [state, setState] = useState<DerivedState<T>>(() =>
+    stepDerived<T>({ data: undefined, error: null }, () => computeRef.current()),
+  );
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const informers = kinds.map((k) => factory.informerFor(k));
+  const [hasSynced, setHasSynced] = useState<boolean>(() => informers.every((i) => i.hasSynced()));
+
+  useEffect(() => {
+    const tick = (): void => {
+      const next = stepDerived<T>(
+        stateRef.current,
+        () => computeRef.current(),
+        equalsRef.current,
+      );
+      if (next.committed) setState({ data: next.data, error: next.error });
+      if (!hasSynced && informers.every((i) => i.hasSynced())) setHasSynced(true);
+    };
+    const unsubs = informers.map((i) => i.addEventHandler(tick));
+    return () => {
+      for (const u of unsubs) u();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [factory, kinds.join(","), hasSynced]);
+
+  return { data: state.data, hasSynced, error: state.error };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/tui/hooks/use-derived.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/hooks/use-derived.ts src/tui/hooks/use-derived.test.ts
+git commit -m "feat(tui): useDerived hook for cross-kind aggregates"
+```
+
+---
+
+### Task 9: New `RefreshProvider` over `factory.relist`
+
+**Files:**
+- Create: `src/tui/hooks/refresh-context.tsx`
+
+The existing `use-refresh-context.ts` broadcasts a numeric signal that `usePolledData` consumers listen to. New `RefreshProvider` wraps `factory.relist()` so the global `r`-key triggers a single relist across all kinds. The old context stays in PR1; PR5 deletes it.
+
+- [ ] **Step 1: Write `refresh-context.tsx`**
+
+```tsx
+/**
+ * RefreshProvider — wires the global refresh trigger (r-key) to
+ * factory.relist(). Replaces use-refresh-context.ts's numeric-signal
+ * approach for informer-backed hooks. The old context stays in tree
+ * during the migration; PR5 deletes it.
+ */
+
+import { createContext, useCallback, useContext, type ReactNode } from "react";
+import type { InformerFactory } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+
+type RefreshFn = (kind?: WatchKind) => void;
+
+const RefreshContext = createContext<RefreshFn | null>(null);
+
+export interface RefreshProviderProps {
+  readonly factory: InformerFactory;
+  readonly children: ReactNode;
+}
+
+export function RefreshProvider(props: RefreshProviderProps): ReactNode {
+  const { factory, children } = props;
+  const refresh = useCallback<RefreshFn>(
+    (kind) => {
+      void factory.relist(kind);
+    },
+    [factory],
+  );
+  return <RefreshContext.Provider value={refresh}>{children}</RefreshContext.Provider>;
+}
+
+export function useRelistTrigger(): RefreshFn {
+  const fn = useContext(RefreshContext);
+  if (!fn) throw new Error("useRelistTrigger: must be inside <RefreshProvider>");
+  return fn;
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/hooks/refresh-context.tsx
+git commit -m "feat(tui): RefreshProvider wired to factory.relist()"
+```
+
+---
+
+### Task 10: Wire factory and providers in `main.ts`
+
+**Files:**
+- Modify: `src/tui/main.ts`
+
+`main.ts` constructs the factory at boot, mounts `<InformerProvider>` and `<RefreshProvider>` around the React tree, and registers a stop callback. **No** view migration. **No** `setInterval` removal. Existing data flow continues to work via `usePolledData`.
+
+In **local mode**, the factory is constructed but the local stores don't yet publish to a `WatchHub` (PR2 wires that). `LocalWatchClient.run()` will list the snapshot, emit `RELIST_END`, and then sit idle waiting for hub events that never arrive. That's intentional and harmless: no view consumes the cache yet.
+
+- [ ] **Step 1: Read `src/tui/main.ts` and find the React-render call site**
+
+Run: `grep -n "render\|<App" src/tui/main.ts | head -20`
+
+Identify the line that renders `<App ... />` (or similar). Insert the providers as wrappers around it.
+
+- [ ] **Step 2: Add factory construction near the boot/auth logic**
+
+Locate the section that determines `nexusUrl` / `apiKey` (around line 437 per the existing `eventBus` boot block). Add factory construction next to it. Sketch:
+
+```ts
+import { InformerFactory } from "../core/informer.js";
+import { WatchHub } from "../core/watch-hub.js";
+import { contributionToEntity, claimToEntity, agentSessionToEntity } from "../core/entity.js";
+
+// ... inside main(), after eventBus / cleanupRuntime setup ...
+
+let informerFactory: InformerFactory;
+const namespace = projectId ?? "default"; // use whatever the existing project-id resolution returns
+
+if (nexusUrl && apiKey) {
+  informerFactory = new InformerFactory({
+    mode: "remote",
+    baseUrl: nexusUrl,
+    authHeader: `Bearer ${apiKey}`,
+  });
+} else if (groveDir && cleanupRuntime) {
+  // Local mode: factory uses a local WatchHub. PR2 wires stores → hub.recordWrite.
+  // Until then, snapshots are static and live deltas don't arrive — no view consumes
+  // the cache in PR1 so this is harmless.
+  const localHub = new WatchHub();
+  informerFactory = new InformerFactory({
+    mode: "local",
+    hub: localHub,
+    namespace,
+    listFn: (kind) => {
+      switch (kind) {
+        case "Contribution":
+          return cleanupRuntime.contributionStore
+            .listAll()
+            .map((c) => contributionToEntity(c, namespace));
+        case "Claim":
+          return cleanupRuntime.claimStore.listAll().map((c) => claimToEntity(c));
+        case "AgentSession":
+          // Sessions live in goalSessionStore; project to AgentSession entities here.
+          // Confirm the listing API on goalSessionStore — adapt as needed for PR1's
+          // dark ship.
+          return [];
+      }
+    },
+  });
+} else {
+  // Headless / non-grove-dir startup — factory is unused. Construct an empty remote
+  // stub against an unreachable URL only if the React tree needs to mount; otherwise
+  // skip the provider entirely.
+  informerFactory = new InformerFactory({
+    mode: "remote",
+    baseUrl: "http://127.0.0.1:0",
+    authHeader: "",
+  });
+}
+
+stopCallbacks.push(() => {
+  void informerFactory.stopAll();
+});
+```
+
+> **Confirmation note for the implementer:** verify the actual store APIs (`contributionStore.listAll()` etc.) before pasting — adapt the `listFn` to whatever the local stores expose. PR1's correctness only requires the factory to be constructible; the snapshots being empty is acceptable (no view consumes them yet).
+
+- [ ] **Step 3: Wrap the React render with the providers**
+
+Find the existing `render(<App ... />)` (or the equivalent OpenTUI render call) and wrap:
+
+```tsx
+import { InformerProvider } from "./hooks/informer-context.js";
+import { RefreshProvider } from "./hooks/refresh-context.js";
+
+// ... existing render call ...
+render(
+  <InformerProvider value={informerFactory}>
+    <RefreshProvider factory={informerFactory}>
+      <App {...existingProps} />
+    </RefreshProvider>
+  </InformerProvider>,
+);
+```
+
+The exact prop shape on `<App>` is unchanged.
+
+- [ ] **Step 4: Typecheck and run the full test suite**
+
+Run: `bun run typecheck && bun test`
+Expected: typecheck clean, all existing tests still pass, new tests added in this PR pass.
+
+- [ ] **Step 5: Smoke-run the TUI in local mode**
+
+Run: `bun run src/tui/main.ts` (or the existing dev command — check `package.json scripts` if unsure)
+Expected: TUI launches, no runtime errors, all existing screens render. The new informer factory is alive but unused by views.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui/main.ts
+git commit -m "feat(tui): wire InformerFactory + InformerProvider at app root"
+```
+
+---
+
+### Task 11: Verify acceptance for PR1
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm PR1's scope is met**
+
+PR1 ships dark — no view migrated. Verify:
+
+- `grep -n usePolledData src/tui` matches the same set of files as before PR1 (no removals).
+- `grep -n useEntities\\\|useEntity\\\|useDerived src/tui` matches only the new hook source/test files (no view consumers).
+- `grep -n setInterval src/tui` matches only the existing 3 sites in `main.ts` (PR5's job to remove).
+
+Run all three greps, paste their output into the PR description.
+
+- [ ] **Step 2: Run the full test suite one more time**
+
+Run: `bun test`
+Expected: all tests pass.
+
+- [ ] **Step 3: Run lint**
+
+Run: `bun run lint`
+Expected: clean (or only pre-existing warnings unrelated to PR1).
+
+- [ ] **Step 4: Confirm commit log is clean and informative**
+
+Run: `git log --oneline main..HEAD`
+Expected: ~10 commits, each scoped to one task. Commit messages match the conventional-commit style of the repo.
+
+- [ ] **Step 5: Open the PR**
+
+Use `gh pr create` with title and body referencing issue #295 and labeling this as PR1 of 5.
+
+```bash
+gh pr create --title "A8 PR1: WatchStream contract + informer hooks (infra, ships dark)" --body "$(cat <<'EOF'
+## Summary
+
+PR1 of 5 for issue #295 (A8 — Retire all polling reactive paths).
+
+- Extracts a `WatchStream` interface implemented by both the existing remote `WatchClient` and a new in-process `LocalWatchClient`.
+- Refactors `Informer` to take a `WatchStream`; `InformerFactory` becomes a discriminated-union of `{ mode: "remote" }` / `{ mode: "local" }` and gains `factory.relist(kind?)` for the global r-key.
+- Adds `<InformerProvider>`, `<RefreshProvider>`, and the new view hooks `useEntities`, `useEntity`, `useDerived` (with pure helpers covered by unit tests).
+- `main.ts` constructs the factory and mounts the providers around the React tree.
+
+**Ships dark.** No `usePolledData` call site is changed; no `setInterval` is removed. Spec: `docs/superpowers/specs/2026-04-30-retire-polling-a8-design.md`.
+
+## Test plan
+
+- [ ] `bun test` passes (existing + new unit tests + WatchStream contract suite)
+- [ ] `bun run typecheck` clean
+- [ ] `bun run lint` clean
+- [ ] TUI launches in local mode, all existing screens render, no regressions
+- [ ] TUI launches in remote (Nexus) mode, all existing screens render, no regressions
+
+## Acceptance grep status
+
+- `grep -r setInterval src/tui` — still 3 matches in `main.ts` (PR5 job).
+- `grep -r usePolledData src/tui` — unchanged from main (PR2-PR4 job).
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- ✅ §1 Architecture (WatchStream contract, two backends): Tasks 1, 2, 4.
+- ✅ §2 Components / new files: Tasks 1-9 cover all PR1 new files; PR2-5 plans cover remaining files.
+- ✅ §2 Components / modified files: Task 3 (`informer.ts`), Task 10 (`main.ts`), Task 1 (`watch-client.ts` adds `implements`).
+- ✅ §3 Data flow / boot: Task 10.
+- ✅ §3 Data flow / read path: Tasks 6-8.
+- ✅ §3 Data flow / refresh: Task 9 (`RefreshProvider`).
+- ✅ §3 Data flow / local-mode write fanout: noted explicitly as PR2 work in Task 10.
+- ✅ §3 Data flow / non-Entity sources: out of PR1 scope (PR4).
+- ✅ §4 Error handling / hook predicate throws: covered in Tasks 6, 8 helpers and tests.
+- ✅ §4 Error handling / hook outside provider: Task 5 throws.
+- ✅ §5 Testing / unit suites: Tasks 2, 4, 6, 7, 8.
+- ✅ §5 Testing / contract fixture: Task 4.
+- 🟡 §5 Testing / migration regression smoke tests: deferred to PR2-PR4 plans (no migrated views in PR1).
+- 🟡 §5 Testing / kill-restart E2E: deferred to a later PR (probably PR5 or after).
+- 🟡 PR2-PR5 plans: not written here. Each will be authored after its predecessor lands and the implementer can grep concrete signatures.
+
+**Placeholder scan:** No "TBD", "TODO", "implement later" content in any task. The note in Task 10 about "verify the actual store APIs" is a real verification step the implementer must do, with explicit guidance on what's acceptable; not a placeholder.
+
+**Type consistency:**
+- `WatchStream` shape: `run({ onEvent, signal }) → Promise<void>` — consistent across Tasks 1, 2, 3.
+- `InformerFactory.relist(kind?)` and `startAll`/`stopAll` — defined in Task 3, consumed by Tasks 5, 9, 10.
+- `useInformer<K>(kind)` returns `Informer<K>` — consistent across Tasks 5, 6, 7, 8.
+- Pure helpers (`stepDerived`, `shallowArraysEqual`, `computeFilteredEntities`, `selectEntityById`) — names and signatures are consistent between their definition tasks and the tests that exercise them.

--- a/docs/superpowers/specs/2026-04-30-retire-polling-a8-design.md
+++ b/docs/superpowers/specs/2026-04-30-retire-polling-a8-design.md
@@ -1,0 +1,308 @@
+# A8 — Retire All Polling Reactive Paths
+
+**Issue:** [#295](https://github.com/windoliver/grove/issues/295)
+**Parent epic:** [#282](https://github.com/windoliver/grove/issues/282) — Foundation: Entity Model + Watch Protocol
+**Depends on:** #294 (Informer client, closed)
+**Date:** 2026-04-30
+
+---
+
+## Goal
+
+Eliminate polling from the Grove TUI. After A8, every reactive view in `src/tui/` is driven by SSE → informer cache → React hook. The literal acceptance check `grep -r setInterval src/tui` returns zero.
+
+## Acceptance criteria (from #295)
+
+1. `grep -r setInterval src/tui` returns zero.
+2. Single reactive path: SSE → informer → store → hook.
+3. E2E suite validates against Nexus stores.
+
+## Non-goals
+
+- Expanding the Entity model. The watch protocol stays at three kinds: `Contribution`, `Claim`, `AgentSession`. Non-Entity sources (GitHub PR, vfs, terminal output, gossip, etc.) keep their existing fetchers and migrate to event-driven re-fetch via the already-built `useEventDrivenData`.
+- Redesigning the watch protocol or informer (#292, #293, #294 already shipped).
+- New visual regressions / golden snapshots.
+- Load-burst testing (covered by #294).
+
+---
+
+## Architecture
+
+One reactive path:
+
+```
+[ source of truth ]
+        │
+        ▼
+   WatchHub  ──────────► (remote) WatchClient ──┐
+                                                ├──► Informer<K> ──► React hook ──► view
+              (in-process) LocalWatchClient ────┘
+```
+
+Two transport backends behind a single `WatchStream` contract:
+
+- **Remote mode** (Nexus available): existing `WatchClient` over HTTP/SSE.
+- **Local mode** (no Nexus): new `LocalWatchClient` subscribes directly to a process-local `WatchHub` over local stores. Same `WatchClientEvent` stream, same RELIST handshake, same RV semantics.
+
+`InformerFactory` is constructed with the appropriate transport at boot and provided through React context at the app root. It eagerly starts one informer per kind on mount; aborts all on unmount.
+
+Three view-layer hooks consume this:
+
+- `useEntities(kind, predicate?)` — filtered list view from `informer.list()`.
+- `useEntity(kind, id)` — single-record subscription.
+- `useDerived(deps, kinds, equals?)` — pure projection over informer caches for cross-kind aggregates.
+
+Existing `useEventDrivenData` (already polling-free) covers non-Entity sources.
+
+The three `setInterval`-driven cleanup loops in `src/tui/main.ts` (claim cleanup, blob GC, session GC) are not reactive UI; they move out of `src/tui/` to `src/local/cleanup-scheduler.ts` so the acceptance grep is literally zero. Semantics unchanged.
+
+## Components
+
+### New files
+
+- `src/core/watch-stream.ts` — extracted interface
+
+  ```ts
+  export interface WatchStream {
+    run(opts: { onEvent: (e: WatchClientEvent) => void | Promise<void>; signal: AbortSignal }): Promise<void>;
+  }
+  ```
+
+  Implemented by both `WatchClient` and `LocalWatchClient`.
+
+- `src/core/local-watch-client.ts` — `LocalWatchClient` class. Constructor:
+
+  ```ts
+  new LocalWatchClient({
+    hub: WatchHub,
+    kind: WatchKind,
+    listFn: () => readonly WatchEntity[],
+    backoff?: WatchClientOptions["backoff"],  // same shape as remote: { minMs, maxMs, jitter }
+  })
+  ```
+
+  Behavior on `run({ onEvent, signal })`:
+  1. Subscribe to `hub` for `kind` (buffer events while listing).
+  2. Emit `RELIST_BEGIN`.
+  3. For each entity from `listFn()`, emit `RELIST` events.
+  4. Emit `RELIST_END`.
+  5. Drain buffered live events; from then on emit live `ADDED/MODIFIED/DELETED` from the hub subscription.
+  6. On abort: detach the hub subscription, return.
+
+  No HTTP, no socket. Same `WatchClientEvent` shape and ordering as remote.
+
+- `src/tui/hooks/informer-context.tsx` —
+
+  ```ts
+  <InformerProvider value={factory}>{children}</InformerProvider>
+  function useInformer<K extends WatchKind>(kind: K): {
+    list(): readonly EntityForKind<K>[];
+    getById(id: string): EntityForKind<K> | undefined;
+    hasSynced(): boolean;
+    addEventHandler(fn: EventHandlerFn<K>): () => void;
+  }
+  ```
+
+  Throws when used outside the provider.
+
+- `src/tui/hooks/use-entities.ts` —
+
+  ```ts
+  function useEntities<K extends WatchKind>(
+    kind: K,
+    predicate?: (e: EntityForKind<K>) => boolean,
+  ): { data: readonly EntityForKind<K>[]; hasSynced: boolean; error: Error | null };
+  ```
+
+  Subscribes via `informer.addEventHandler`. On any event, recomputes the filtered list and shallow-compares against the previous output (length + per-index `Object.is`); only commits new state when the array actually changed. Predicate exceptions are caught: error is set, last-good data preserved.
+
+- `src/tui/hooks/use-entity.ts` —
+
+  ```ts
+  function useEntity<K extends WatchKind>(
+    kind: K,
+    id: string | undefined,
+  ): { data: EntityForKind<K> | undefined; hasSynced: boolean };
+  ```
+
+  Subscribes, but the handler ignores events with `entity.id !== id`. Returns `informer.getById(id)`. `undefined` id returns `undefined` data without subscribing.
+
+- `src/tui/hooks/use-derived.ts` —
+
+  ```ts
+  function useDerived<T>(
+    compute: () => T,
+    kinds: readonly WatchKind[],
+    equals?: (a: T, b: T) => boolean,
+  ): { data: T; hasSynced: boolean; error: Error | null };
+  ```
+
+  Subscribes to every listed kind. Recomputes on any event. `equals` defaults to `Object.is`. Caller is responsible for keeping `compute` referentially stable (or accepting the recompute on every render).
+
+- `src/local/cleanup-scheduler.ts` —
+
+  ```ts
+  function startCleanupScheduler(opts: {
+    cleanupRuntime: LocalCleanupRuntime;
+  }): { stop(): void };
+  ```
+
+  Owns the three `setInterval` timers (claim cleanup 60s, blob GC 10min, session GC 5min). Returns one `stop()` that clears all and closes the runtime. Caller (main.ts) keeps a single stop callback in `stopCallbacks`.
+
+### Modified files
+
+- `src/core/informer.ts` — `Informer` constructor takes a `WatchStream` (`{ run({ onEvent, signal }) }`) instead of `WatchClientOptions`. `InformerFactory` gains a discriminated-union options shape:
+
+  ```ts
+  type Backoff = { minMs: number; maxMs: number; jitter: number };
+  type InformerFactoryOptions =
+    | {
+        mode: "remote";
+        baseUrl: string;
+        authHeader: string;
+        fetch?: typeof fetch;
+        backoff?: Backoff;
+      }
+    | {
+        mode: "local";
+        hub: WatchHub;
+        listFn: (k: WatchKind) => readonly WatchEntity[];
+        backoff?: Backoff;
+      };
+  ```
+
+  Public `informerFor(kind)` API unchanged. Internally constructs the right `WatchStream` for the mode.
+
+  New: `factory.relist(kind?: WatchKind)` aborts the current `run()` for the given kind (or all) and starts a new one. Used by the global `r`-key refresh.
+
+- `src/tui/main.ts` —
+  - At boot: select mode from `GROVE_NEXUS_URL + NEXUS_API_KEY`. Construct factory.
+  - Eagerly start all three informers under one `AbortController`.
+  - Render `<InformerProvider value={factory}><App /></InformerProvider>`.
+  - Replace the three inline `setInterval`s with `startCleanupScheduler(...)`.
+
+- ~30 view/hook/screen files — call sites swap `usePolledData` → `useEntities` / `useEntity` / `useDerived` / `useEventDrivenData` per the per-source table below.
+
+### Deleted (after PR5 lands)
+
+- `src/tui/hooks/use-polled-data.ts` and `.test.ts`
+- `src/tui/hooks/use-panel-state.ts` (a thin wrapper over `usePolledData`; replace with inline `useEntities` calls or a new tiny wrapper if a use case survives).
+- `src/tui/hooks/use-refresh-context.ts` — replaced by a smaller `RefreshProvider` that calls `factory.relist()` instead of broadcasting a poll-poke signal.
+
+### Per-source migration table
+
+A view may pull from multiple sources; in that case it appears in multiple rows and migrates piece-by-piece across the PRs in the migration plan.
+
+| Source | New hook |
+|---|---|
+| Active claims, claim lists; the `Claim` portion of `agent-list` and `pipeline-view` | `useEntities("Claim", predicate)` |
+| Contribution feeds; the `Contribution` portion of `panel-manager` detail; contribution detail by id | `useEntities("Contribution", predicate)` / `useEntity("Contribution", id)` |
+| Agent sessions (`AgentSession` entities); the session portion of `agent-list` / `pipeline-view` / `agent-graph` | `useEntities("AgentSession", predicate)` |
+| Cross-kind aggregates: dashboard counts, dag layout, frontier projections, agent-graph layout | `useDerived(...)` over `Claim` / `AgentSession` / `Contribution` |
+| Cost rollups, agent profiles, palette sessions list, gossip peers, GitHub PR summary, threads, bounties, outcomes, decisions, handoffs, search results, full-text search beyond cache | `useEventDrivenData` — these read from non-Entity stores or external sources and are not projected through the watch protocol |
+| VFS browser entries, artifact preview, terminal output buffers, tmux capture, the tmux/session-output portion of `agent-list` and `pipeline-view` | `useEventDrivenData` — requires PR4 to add a coarse-grained event from the producer (file watcher or ACP stream listener) so the existing hook re-fetches without a timer |
+
+## Data flow
+
+### Boot sequence (`main.ts`)
+
+1. Determine mode from env.
+2. Construct factory:
+   - Remote: `createInformerFactory({ mode: "remote", baseUrl, authHeader })`.
+   - Local: open local stores, construct `WatchHub`, `createInformerFactory({ mode: "local", hub, listFn })` where `listFn(kind)` returns the current snapshot from the appropriate store.
+3. Eagerly start all 3 informers under one `AbortController`. `signal.addEventListener("abort", ...)` aborts on shutdown.
+4. Render `<InformerProvider value={factory}><App /></InformerProvider>`.
+5. `startCleanupScheduler(...)`, push its `stop` into `stopCallbacks`.
+
+### Read path (typical view)
+
+- `useEntities("Claim", c => c.status.phase === "active")` resolves the kind's `Informer` from context.
+- On mount: subscribes via `addEventHandler`, computes initial `list().filter(...)`, returns `{ data, hasSynced }`.
+- On event: predicate re-runs; output is shallow-compared with previous; React commits only when changed.
+- `useEntity("Claim", id)` ignores events whose `entity.id !== id`.
+
+### `useDerived` for aggregates
+
+`useDerived(() => buildDag(claimsInformer.list(), sessionsInformer.list()), ["Claim", "AgentSession"])` subscribes to both informers, recomputes on any event from either kind, returns memoized output via `equals`.
+
+### First-render gating
+
+Per-kind `hasSynced` is read off the factory; views render their own placeholder until `true`. The informer doesn't surface the cache until `RELIST_END` lands (existing #294 behavior) — no empty-flash.
+
+### Refresh (`r` key)
+
+`RefreshProvider` is reimplemented over the factory. Global `r` calls `factory.relist()`; `WatchClient` / `LocalWatchClient` re-issue `/api/list` (or re-snapshot) → atomic Replace.
+
+### Local-mode write fanout
+
+Local stores write → `WatchHub.publish(kind, event)` → `LocalWatchClient.onEvent` → informer dispatch → React subscribers. For kinds where the local store does not yet publish to `WatchHub`, PR1 adds the publish call (this is small and was likely missed when remote-only was the focus).
+
+### Non-Entity sources
+
+`useEventDrivenData` re-fetches when an `EventBus` event arrives. For sources that don't currently emit:
+
+- **VFS**: file watcher in `src/local/` emits a coarse `vfs.changed` event when the workspace tree changes; the hook re-fetches.
+- **Terminal buffers**: ACP stream listener emits `agent.output` events; the hook re-fetches the captured buffer.
+- **GitHub PR**: server-side webhook or periodic cron at the *producer* layer (out of TUI) publishes a `github.pr.changed` event; client just re-fetches on event. (Producer-side polling is acceptable — the acceptance criterion is `src/tui`.)
+
+## Error handling
+
+- **Watch stream failures (transient):** `WatchClient` already handles backoff + reconnect with `RELIST_BEGIN/END` Replace on resume (existing #292/#293). Views see only post-Replace state — no torn intermediate. `LocalWatchClient` mirrors the contract (logs + retries on backing-store error).
+- **Stale RV** (server-side compaction, #293): `WatchClient` raises `StaleResourceVersionError` internally → triggers full relist. Same path on local for symmetry.
+- **Predicate / projection throws in hooks:** wrapped in try/catch. Caught error sets `error` state and logs via `console.error`; last-good `data` preserved.
+- **Hook used outside `InformerProvider`:** `useInformer(kind)` throws synchronously with a clear message.
+- **Local-mode boot when stores aren't ready:** factory constructor doesn't throw; informer's `run()` surfaces the error. Main.ts treats that as fatal — same as remote startup failure.
+- **Cleanup scheduler errors:** non-fatal, swallowed + logged to stderr (preserves current behavior).
+- **`r`-key relist failure:** `factory.relist(kind)` aborts and restarts. If the new run immediately fails, `WatchClient`'s reconnect/backoff loop takes over. UI shows last-good cache.
+- **Hot-reload / unmount during dispatch:** `Informer.dispatch` already races handlers against the abort signal (existing implementation).
+
+## Testing
+
+### Unit tests
+
+- `local-watch-client.test.ts` — fake `WatchHub`, verifies `RELIST_BEGIN/RELIST*/RELIST_END` ordering, abort, error path.
+- `informer-context.test.tsx` — provider mount/unmount, `useInformer` outside provider throws.
+- `use-entities.test.tsx` — predicate filtering, shallow-equal output memo, `hasSynced` gating, predicate-throw → `error` state.
+- `use-entity.test.tsx` — single-id subscription, no re-render on unrelated id, `null` when id absent.
+- `use-derived.test.tsx` — recomputes on any listed kind, custom `equals` honored, throw in `compute` sets `error`.
+- `cleanup-scheduler.test.ts` — three timers fire on cadence, `stop()` clears all, errors don't crash the scheduler.
+
+### Contract test fixture
+
+- `watch-stream.contract.test.ts` — single test suite parameterized over `[remote WatchClient + fake server, LocalWatchClient + WatchHub]`. Same assertions on both: list→watch handshake, RELIST atomicity, abort behavior, late-event-after-RELIST_END is delivered as a delta. Catches drift between backends.
+
+### Migration regression tests
+
+For each migrated view in PR2/3/4: a smoke test that mounts the view with a seeded informer/event-bus, asserts initial render matches seed, publishes an event, asserts re-rendered output. Per-batch coverage without standing up E2E.
+
+### Acceptance verification
+
+- `grep -r setInterval src/tui` returns zero — added as a one-line CI check in PR5.
+- Existing Nexus E2E suite stays green across all PRs.
+- New targeted E2E: Nexus-backed run, kill+restart server mid-stream, assert TUI views recover without missed events or stale state past reconnect.
+
+## Migration plan (5 PRs)
+
+1. **PR1 — infra.** `WatchStream` interface, `LocalWatchClient`, `InformerFactory` discriminated-union options, `factory.relist`, `<InformerProvider>`, `useEntities` / `useEntity` / `useDerived`. New `RefreshProvider` over factory. Tests including the contract fixture. Local-store `WatchHub.publish` calls added where missing. Zero call-site changes — infra ships dark.
+
+2. **PR2 — Entity-backed reads.** Migrate the `usePolledData` *call sites* that read directly from the 3 kinds. Includes the claim portion of `claims.tsx`, `agent-list.tsx`, `pipeline-view.tsx`, `agent-graph.tsx`; the contribution portion of `activity.tsx`, `activity-panel.tsx`, `search-panel.tsx` (in-cache scope only), `detail.tsx`; the session portion of `agent-list.tsx`, `pipeline-view.tsx`, `agent-graph.tsx`. Mixed-source views keep their non-Entity polling paths until PR4. `usePolledData` itself stays in tree.
+
+3. **PR3 — aggregates.** Migrate views that compose across kinds: dag, dashboard cross-cuts, panel-manager detail (single-record + cross-kind context). Use `useDerived`.
+
+4. **PR4 — non-Entity sources.** Migrate GitHub PR, gossip, threads, bounties, outcomes, decisions, vfs, terminal output, artifact preview, search to `useEventDrivenData`. Add producer-side events for vfs (file watcher) and terminal output (ACP listener) so re-fetch is event-driven, not timer-driven.
+
+5. **PR5 — cleanup.** Move 3 `setInterval`s out of `src/tui/main.ts` into `src/local/cleanup-scheduler.ts`. Delete `usePolledData`, `usePanelState`, old `useRefreshContext`. Add CI grep check. Final acceptance grep == 0.
+
+## Risks and mitigations
+
+- **Two `WatchStream` implementations drift.** → Contract test fixture, parameterized over both, in PR1.
+- **Eager 3-kind subscription wastes resources on screens that need one.** → 3 SSE streams per TUI process is negligible; server multiplexes. Confirmed acceptable in design discussion.
+- **`useEntities` predicate-on-list churn under high event rate.** → Shallow-equal memo on the output array. If still hot, add a coarse opt-in indexed view in a follow-up; not required for A8.
+- **Local-mode hub doesn't publish for some kinds.** → PR1 adds publish calls where missing. Caught by the contract fixture if any kind regresses.
+- **Dual-path window between PR2 and PR5.** → Acceptable: each PR is small enough to revert. Final PR is mostly deletions.
+
+## Open items deferred to follow-ups
+
+- Server-side polling at the *producer* layer for non-Entity sources (e.g. GitHub webhook ingest). Out of A8 — acceptance is `src/tui` only.
+- Indexed views over the informer cache for predicates that scan large lists. Add only if profiling shows it matters.
+- Suspense-style loading boundaries instead of per-hook `hasSynced`. Larger React refactor; not blocking.

--- a/src/core/informer.test.ts
+++ b/src/core/informer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Informer, InformerFactory } from "./informer.js";
+import { WatchClient } from "./watch-client.js";
 import type { WatchEntity } from "./watch-events.js";
 
 // Minimal entity shapes (WatchClient passes them through as-is)
@@ -69,13 +70,15 @@ describe("Informer hasSynced", () => {
     const ac = new AbortController();
     let syncedDuringBegin = true; // assume true, set false when we see it
     const fetchImpl = makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac);
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: fetchImpl,
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: fetchImpl,
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler((_op, _entity) => {
       // Only called after RELIST_END; check synced at first delta
       syncedDuringBegin = informer.hasSynced();
@@ -90,13 +93,15 @@ describe("Informer hasSynced", () => {
 
   test("hasSynced false until first RELIST_END even on empty list", async () => {
     const ac = new AbortController();
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [], listResourceVersion: "5" }, "", ac),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [], listResourceVersion: "5" }, "", ac),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     expect(informer.hasSynced()).toBe(false);
     await informer.run(ac.signal);
     expect(informer.hasSynced()).toBe(true);
@@ -108,13 +113,15 @@ describe("Informer hasSynced", () => {
 describe("Informer cache after initial sync", () => {
   test("list() returns all items from snapshot", async () => {
     const ac = new AbortController();
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [E_A, E_B], listResourceVersion: "5" }, "", ac),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [E_A, E_B], listResourceVersion: "5" }, "", ac),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     await informer.run(ac.signal);
     const items = informer.list();
     expect(items).toHaveLength(2);
@@ -124,13 +131,15 @@ describe("Informer cache after initial sync", () => {
 
   test("getById returns entity by id (O(1) lookup)", async () => {
     const ac = new AbortController();
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [E_A, E_B], listResourceVersion: "5" }, "", ac),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [E_A, E_B], listResourceVersion: "5" }, "", ac),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     await informer.run(ac.signal);
     expect((informer.getById("cid-a") as { id: string } | undefined)?.id).toBe("cid-a");
     expect(informer.getById("nonexistent")).toBeUndefined();
@@ -143,17 +152,19 @@ describe("Informer delta events", () => {
   test("ADDED delta: adds to cache, fires handler", async () => {
     const ac = new AbortController();
     const events: Array<{ op: string; id: string }> = [];
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch(
-        { items: [], listResourceVersion: "5" },
-        sse("ADDED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
-        ac,
-      ),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch(
+          { items: [], listResourceVersion: "5" },
+          sse("ADDED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
+          ac,
+        ),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler((op, entity) => {
       events.push({ op, id: (entity as { id: string }).id });
       if (op === "ADDED") ac.abort();
@@ -166,17 +177,19 @@ describe("Informer delta events", () => {
   test("MODIFIED delta: updates cache, fires handler", async () => {
     const ac = new AbortController();
     const events: Array<{ op: string; id: string; rv: string }> = [];
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch(
-        { items: [E_A], listResourceVersion: "5" },
-        sse("MODIFIED", { rv: "6", kind: "Contribution", entity: E_A_v2 }, "6"),
-        ac,
-      ),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch(
+          { items: [E_A], listResourceVersion: "5" },
+          sse("MODIFIED", { rv: "6", kind: "Contribution", entity: E_A_v2 }, "6"),
+          ac,
+        ),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler((op, entity) => {
       events.push({
         op,
@@ -195,17 +208,19 @@ describe("Informer delta events", () => {
   test("DELETED delta: removes from cache, fires handler", async () => {
     const ac = new AbortController();
     const events: Array<{ op: string; id: string }> = [];
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch(
-        { items: [E_A], listResourceVersion: "5" },
-        sse("DELETED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
-        ac,
-      ),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch(
+          { items: [E_A], listResourceVersion: "5" },
+          sse("DELETED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
+          ac,
+        ),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler((op, entity) => {
       events.push({ op, id: (entity as { id: string }).id });
       if (op === "DELETED") ac.abort();
@@ -248,13 +263,15 @@ describe("Informer Replace reconciliation on relist", () => {
       throw new Error(`unexpected fetch ${url}`);
     }) as typeof fetch;
 
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: fetchImpl,
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: fetchImpl,
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler((op, entity) => {
       events.push({ op, id: (entity as { id: string }).id });
     });
@@ -289,13 +306,15 @@ describe("Informer Replace reconciliation on relist", () => {
       return new Response("", { headers: { "Content-Type": "text/event-stream" } });
     }) as typeof fetch;
 
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: fetchImpl,
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: fetchImpl,
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler((op, entity) => {
       events.push({ op, id: (entity as { id: string }).id });
     });
@@ -330,13 +349,15 @@ describe("Informer Replace reconciliation on relist", () => {
       return new Response("", { headers: { "Content-Type": "text/event-stream" } });
     }) as typeof fetch;
 
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: fetchImpl,
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: fetchImpl,
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler((op, entity) => {
       events.push({
         op,
@@ -376,13 +397,15 @@ describe("Informer Replace reconciliation on relist", () => {
       return new Response("", { headers: { "Content-Type": "text/event-stream" } });
     }) as typeof fetch;
 
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: fetchImpl,
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: fetchImpl,
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler((op, entity) => {
       events.push({ op, id: (entity as { id: string }).id });
     });
@@ -426,13 +449,15 @@ describe("Informer RELIST_ABORTED", () => {
       return new Response("", { headers: { "Content-Type": "text/event-stream" } });
     }) as typeof fetch;
 
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: fetchImpl,
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: fetchImpl,
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     await informer.run(ac.signal);
 
     // After abort mid-relist, cache still holds first synced state (E_A only)
@@ -451,17 +476,19 @@ describe("Informer multiple handlers", () => {
     const ac = new AbortController();
     const h1Events: string[] = [];
     const h2Events: string[] = [];
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch(
-        { items: [E_A], listResourceVersion: "5" },
-        sse("ADDED", { rv: "6", kind: "Contribution", entity: E_B }, "6"),
-        ac,
-      ),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch(
+          { items: [E_A], listResourceVersion: "5" },
+          sse("ADDED", { rv: "6", kind: "Contribution", entity: E_B }, "6"),
+          ac,
+        ),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler((op, entity) => {
       h1Events.push(`${op}:${(entity as { id: string }).id}`);
       if (op === "ADDED" && (entity as { id: string }).id === "cid-b") ac.abort();
@@ -485,17 +512,19 @@ describe("Informer handler sees post-update cache", () => {
   test("handler called after cache update (getById returns new state)", async () => {
     const ac = new AbortController();
     let seenInHandler: { id: string; rv: string } | undefined;
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch(
-        { items: [], listResourceVersion: "5" },
-        sse("ADDED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
-        ac,
-      ),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch(
+          { items: [], listResourceVersion: "5" },
+          sse("ADDED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
+          ac,
+        ),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler((op, entity) => {
       if (op === "ADDED") {
         const fromCache = informer.getById((entity as { id: string }).id);
@@ -520,6 +549,7 @@ describe("Informer handler sees post-update cache", () => {
 describe("InformerFactory memoization", () => {
   test("same instance returned for same kind", () => {
     const factory = new InformerFactory({
+      mode: "remote",
       baseUrl: "http://t",
       authHeader: "Bearer x",
     });
@@ -530,6 +560,7 @@ describe("InformerFactory memoization", () => {
 
   test("different instances for different kinds", () => {
     const factory = new InformerFactory({
+      mode: "remote",
       baseUrl: "http://t",
       authHeader: "Bearer x",
     });
@@ -542,8 +573,16 @@ describe("InformerFactory memoization", () => {
     // Each namespace gets its own factory (and its own authHeader that encodes
     // the namespace server-side). Two factories for different namespaces must
     // produce independent informers with no shared state.
-    const factoryNs1 = new InformerFactory({ baseUrl: "http://t", authHeader: "Bearer ns1-token" });
-    const factoryNs2 = new InformerFactory({ baseUrl: "http://t", authHeader: "Bearer ns2-token" });
+    const factoryNs1 = new InformerFactory({
+      mode: "remote",
+      baseUrl: "http://t",
+      authHeader: "Bearer ns1-token",
+    });
+    const factoryNs2 = new InformerFactory({
+      mode: "remote",
+      baseUrl: "http://t",
+      authHeader: "Bearer ns2-token",
+    });
     expect(factoryNs1.informerFor("Contribution")).not.toBe(factoryNs2.informerFor("Contribution"));
   });
 });
@@ -562,13 +601,15 @@ describe("Informer run() safety", () => {
       });
       throw new Error("unreachable");
     }) as unknown as typeof fetch;
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: fetchImpl,
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: fetchImpl,
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     // Start first run (will block waiting for list response)
     const firstRun = informer.run(ac.signal);
     // Second concurrent run must reject immediately
@@ -582,17 +623,19 @@ describe("Informer run() safety", () => {
     const ac = new AbortController();
     // Fetch: delivers one ADDED so the non-settling handler starts
     const fetchAc = new AbortController();
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch(
-        { items: [], listResourceVersion: "5" },
-        sse("ADDED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
-        fetchAc,
-      ),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch(
+          { items: [], listResourceVersion: "5" },
+          sse("ADDED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
+          fetchAc,
+        ),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler(async () => {
       // Never resolves on its own
       await new Promise<void>(() => {
@@ -613,23 +656,27 @@ describe("Informer run() safety", () => {
 
   test("run() is reusable after completion", async () => {
     const ac1 = new AbortController();
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [], listResourceVersion: "5" }, "", ac1),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [], listResourceVersion: "5" }, "", ac1),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     await informer.run(ac1.signal);
     // First run completed — second run must be accepted (not throw)
     const ac2 = new AbortController();
-    const informer2 = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [], listResourceVersion: "5" }, "", ac2),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer2 = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [], listResourceVersion: "5" }, "", ac2),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     // Different instance, but proves the _running flag resets after completion
     await expect(informer2.run(ac2.signal)).resolves.toBeUndefined();
   });
@@ -641,13 +688,15 @@ describe("Informer handler isolation", () => {
   test("throwing handler does not prevent other handlers from receiving events", async () => {
     const ac = new AbortController();
     const received: string[] = [];
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler(() => {
       throw new Error("handler boom");
     });
@@ -661,13 +710,15 @@ describe("Informer handler isolation", () => {
 
   test("throwing handler does not kill the watch loop (informer stays synced)", async () => {
     const ac = new AbortController();
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler(() => {
       throw new Error("noisy handler");
     });
@@ -679,17 +730,19 @@ describe("Informer handler isolation", () => {
   test("unsubscribed handler no longer receives events", async () => {
     const ac = new AbortController();
     const received: string[] = [];
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch(
-        { items: [], listResourceVersion: "5" },
-        sse("ADDED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
-        ac,
-      ),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch(
+          { items: [], listResourceVersion: "5" },
+          sse("ADDED", { rv: "6", kind: "Contribution", entity: E_A }, "6"),
+          ac,
+        ),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     const unsubscribe = informer.addEventHandler((op, entity) => {
       received.push(`${op}:${(entity as { id: string }).id}`);
     });
@@ -703,17 +756,19 @@ describe("Informer handler isolation", () => {
     const ac = new AbortController();
     const afterUnsub: string[] = [];
     let unsub: (() => void) | undefined;
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch(
-        { items: [E_A], listResourceVersion: "5" },
-        sse("ADDED", { rv: "6", kind: "Contribution", entity: E_B }, "6"),
-        ac,
-      ),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch(
+          { items: [E_A], listResourceVersion: "5" },
+          sse("ADDED", { rv: "6", kind: "Contribution", entity: E_B }, "6"),
+          ac,
+        ),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     unsub = informer.addEventHandler((op, entity) => {
       const id = (entity as { id: string }).id;
       if (id === "cid-a") {
@@ -735,13 +790,15 @@ describe("Informer handler isolation", () => {
     const ac = new AbortController();
     const h2Events: string[] = [];
     let unsub: (() => void) | undefined;
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     unsub = informer.addEventHandler(() => {
       unsub?.(); // self-unsubscribe during first dispatch
     });
@@ -756,13 +813,15 @@ describe("Informer handler isolation", () => {
   test("async handler rejection does not become unhandled and does not skip next handler", async () => {
     const ac = new AbortController();
     const h2Events: string[] = [];
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     // Async handler that rejects — must not propagate as unhandled rejection
     informer.addEventHandler(async () => {
       throw new Error("async handler boom");
@@ -782,17 +841,19 @@ describe("Informer handler isolation", () => {
     const order: string[] = [];
     let resolveFirst: (() => void) | undefined;
 
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch(
-        { items: [], listResourceVersion: "5" },
-        `${sse("ADDED", { rv: "6", kind: "Contribution", entity: E_A }, "6")}${sse("ADDED", { rv: "7", kind: "Contribution", entity: E_B }, "7")}`,
-        ac,
-      ),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch(
+          { items: [], listResourceVersion: "5" },
+          `${sse("ADDED", { rv: "6", kind: "Contribution", entity: E_A }, "6")}${sse("ADDED", { rv: "7", kind: "Contribution", entity: E_B }, "7")}`,
+          ac,
+        ),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     informer.addEventHandler(async (op, entity) => {
       order.push(`enter:${(entity as { id: string }).id}`);
       if ((entity as { id: string }).id === "cid-a") {
@@ -820,13 +881,15 @@ describe("Informer handler isolation", () => {
 describe("Informer cache immutability", () => {
   test("mutating a returned entity does not corrupt cache (resourceVersion frozen)", async () => {
     const ac = new AbortController();
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     await informer.run(ac.signal);
     const entity = informer.getById("cid-a");
     expect(entity).toBeDefined();
@@ -843,13 +906,15 @@ describe("Informer cache immutability", () => {
 
   test("entities returned by list() are frozen", async () => {
     const ac = new AbortController();
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [E_A, E_B], listResourceVersion: "5" }, "", ac),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [E_A, E_B], listResourceVersion: "5" }, "", ac),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     await informer.run(ac.signal);
     for (const e of informer.list()) {
       expect(Object.isFrozen(e)).toBe(true);
@@ -858,13 +923,15 @@ describe("Informer cache immutability", () => {
 
   test("mutating nested spec field does not corrupt cache (deep freeze)", async () => {
     const ac = new AbortController();
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     await informer.run(ac.signal);
     const entity = informer.getById("cid-a");
     const origSummary = (entity as unknown as { spec: { summary: string } })?.spec?.summary;
@@ -881,13 +948,15 @@ describe("Informer cache immutability", () => {
 
   test("nested objects within entities are frozen (deep freeze)", async () => {
     const ac = new AbortController();
-    const informer = new Informer({
-      baseUrl: "http://t",
-      kind: "Contribution",
-      authHeader: "Bearer x",
-      fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
-      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
-    });
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "Contribution",
+        authHeader: "Bearer x",
+        fetch: makeFetch({ items: [E_A], listResourceVersion: "5" }, "", ac),
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+    );
     await informer.run(ac.signal);
     const entity = informer.getById("cid-a") as unknown as { spec: object; metadata: object };
     expect(Object.isFrozen(entity)).toBe(true);

--- a/src/core/informer.test.ts
+++ b/src/core/informer.test.ts
@@ -876,6 +876,71 @@ describe("Informer handler isolation", () => {
   });
 });
 
+// ─── InformerFactory lifecycle ────────────────────────────────────────────────
+
+describe("InformerFactory lifecycle", () => {
+  test("startAll is idempotent — repeated calls do not double-run a kind", async () => {
+    const ac = new AbortController();
+    const fetchImpl = makeFetch({ items: [], listResourceVersion: "0" }, "", ac);
+    const factory = new InformerFactory({
+      mode: "remote",
+      baseUrl: "http://t",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    factory.startAll();
+    factory.startAll(); // second call must be a no-op (no second run() per kind)
+    await factory.stopAll();
+    // If startAll were not idempotent, the inner Informer.run() would have
+    // thrown "called while already running"; reaching here means it didn't.
+    expect(true).toBe(true);
+  });
+
+  test("stopAll aborts and awaits run promises", async () => {
+    const ac = new AbortController();
+    const fetchImpl = makeFetch({ items: [], listResourceVersion: "0" }, "", ac);
+    const factory = new InformerFactory({
+      mode: "remote",
+      baseUrl: "http://t",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    factory.startAll();
+    await factory.stopAll();
+    // After stopAll, factory is reusable.
+    const ac2 = new AbortController();
+    const fetchImpl2 = makeFetch({ items: [], listResourceVersion: "0" }, "", ac2);
+    const factory2 = new InformerFactory({
+      mode: "remote",
+      baseUrl: "http://t",
+      authHeader: "Bearer x",
+      fetch: fetchImpl2,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    factory2.startAll();
+    await factory2.stopAll();
+    expect(true).toBe(true);
+  });
+
+  test("relist(kind) restarts a single kind without throwing", async () => {
+    const ac = new AbortController();
+    const fetchImpl = makeFetch({ items: [], listResourceVersion: "0" }, "", ac);
+    const factory = new InformerFactory({
+      mode: "remote",
+      baseUrl: "http://t",
+      authHeader: "Bearer x",
+      fetch: fetchImpl,
+      backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+    });
+    factory.startAll();
+    await factory.relist("Contribution");
+    await factory.stopAll();
+    expect(true).toBe(true);
+  });
+});
+
 // ─── Cache immutability ───────────────────────────────────────────────────────
 
 describe("Informer cache immutability", () => {

--- a/src/core/informer.ts
+++ b/src/core/informer.ts
@@ -66,12 +66,18 @@ export class Informer<K extends WatchKind = WatchKind> {
    * Register a sync handler that fires on every RELIST_END, including empty
    * snapshots and snapshots that produce no per-entity deltas. Required so
    * hooks can flip hasSynced and recompute filtered views even when the
-   * snapshot is identical to the prior cache state. Fires immediately if
-   * the informer is already synced when the handler is registered.
+   * snapshot is identical to the prior cache state.
+   *
+   * @param fireIfSynced when true (default) and the informer is already
+   *   synced at registration time, fire `fn` immediately so newly-mounted
+   *   consumers don't have to wait for the next RELIST_END to learn the
+   *   cache is populated. Pass false to subscribe only to FUTURE RELIST_END
+   *   events — used by the factory's recovery handler so a stale `_synced
+   *   === true` from a prior run can't clear an error owned by the new run.
    */
-  addSyncHandler(fn: SyncHandlerFn): () => void {
+  addSyncHandler(fn: SyncHandlerFn, fireIfSynced = true): () => void {
     this.syncHandlers.push(fn);
-    if (this._synced) {
+    if (fireIfSynced && this._synced) {
       try {
         fn();
       } catch (err) {
@@ -450,18 +456,41 @@ export class InformerFactory {
       r.controller = new AbortController();
     }
     const generation = (r.generation = r.generation + 1);
-    const hadError = r.lastError !== null;
-    r.lastError = null;
-    if (hadError) this.fireError(kind, null);
+    // Do NOT clear lastError on start — clearing here would fire `null` to
+    // listeners while the new run is still pending or backing off, making
+    // hooks drop their visible error even though sync has not been re-proven.
+    // Wait for a concrete recovery signal: first successful RELIST_END after
+    // this start. The sync handler below clears + fires null exactly once.
+    // Subscribe with fireIfSynced=false so a stale `_synced === true` from
+    // the prior run doesn't trigger us synchronously and clear the error
+    // before the new run has actually re-proven sync.
+    const recovery = r.informer.addSyncHandler(() => {
+      // Stale-generation handlers must not clear errors owned by a newer run.
+      if (r.generation !== generation) {
+        recovery();
+        return;
+      }
+      if (r.lastError !== null) {
+        r.lastError = null;
+        this.fireError(kind, null);
+      }
+      // One-shot: detach after firing once. Subsequent syncs are healthy
+      // by definition and don't need to fire null again.
+      recovery();
+    }, false);
     const signal = r.controller.signal;
     const informer = r.informer;
     r.runPromise = informer.run(signal).then(
       () => {
-        if (r.generation === generation) r.runPromise = null;
+        if (r.generation === generation) {
+          r.runPromise = null;
+          recovery();
+        }
       },
       (err: unknown) => {
         if (r.generation === generation) {
           r.runPromise = null;
+          recovery();
           const errorObj = err instanceof Error ? err : new Error(String(err));
           r.lastError = errorObj;
           // Log so terminal failures (auth/config/permanent server errors)

--- a/src/core/informer.ts
+++ b/src/core/informer.ts
@@ -284,6 +284,8 @@ export type InformerFactoryOptions =
       readonly listFn: (kind: WatchKind) => readonly WatchEntity[];
     };
 
+export type FactoryErrorListener = (kind: WatchKind, err: Error | null) => void;
+
 interface RunningInformer {
   readonly informer: Informer;
   controller: AbortController;
@@ -311,9 +313,35 @@ const ALL_KINDS: readonly WatchKind[] = ["Contribution", "Claim", "AgentSession"
 export class InformerFactory {
   private readonly opts: InformerFactoryOptions;
   private readonly running = new Map<string, RunningInformer>();
+  private readonly errorListeners: Array<FactoryErrorListener> = [];
 
   constructor(opts: InformerFactoryOptions) {
     this.opts = opts;
+  }
+
+  /**
+   * Subscribe to terminal `informer.run()` rejections. Fires with the
+   * captured Error after a kind's run loop rejects, and again with `null`
+   * when a subsequent restart succeeds (i.e. clears the error). Hooks use
+   * this to surface auth/config/server failures instead of leaving
+   * consumers stuck at `hasSynced=false` with no error.
+   */
+  addErrorListener(fn: FactoryErrorListener): () => void {
+    this.errorListeners.push(fn);
+    return () => {
+      const idx = this.errorListeners.indexOf(fn);
+      if (idx >= 0) this.errorListeners.splice(idx, 1);
+    };
+  }
+
+  private fireError(kind: WatchKind, err: Error | null): void {
+    for (const fn of [...this.errorListeners]) {
+      try {
+        fn(kind, err);
+      } catch (e) {
+        console.error("InformerFactory: error listener threw, continuing fanout:", e);
+      }
+    }
   }
 
   /**
@@ -371,14 +399,19 @@ export class InformerFactory {
       .filter((r): r is RunningInformer => r !== undefined);
 
     await Promise.all(
-      targets.map((r) =>
-        this.withLock(r, async () => {
+      kinds.map((k) => {
+        const r = this.running.get(k);
+        if (!r) return Promise.resolve();
+        return this.withLock(r, async () => {
           await this.stopOne(r);
           r.controller = new AbortController();
-          this.startOne(r);
-        }),
-      ),
+          this.startOne(k, r);
+        });
+      }),
     );
+    // Reference targets so unused-var lints don't trip — this is the
+    // pre-filtered list used to avoid creating informers for unknown kinds.
+    void targets;
   }
 
   /** Last terminal error captured from a kind's `run()`, if any. */
@@ -393,25 +426,33 @@ export class InformerFactory {
       r = this.running.get(kind);
       if (!r) throw new Error(`unreachable: informerFor(${kind}) did not register a running entry`);
     }
-    void this.withLock(r, async () => {
-      this.startOne(r);
+    const entry = r;
+    void this.withLock(entry, async () => {
+      this.startOne(kind, entry);
     });
   }
 
   /**
+   * Relist a single kind via internal lock — used by the in-process
+   * `RefreshContext` button (and PR2 hook bindings).
+   */
+
+  /**
    * Start a fresh `run()` if not already running. Wraps the run promise so
    * terminal errors clear `runPromise` (allowing future restart), record
-   * `lastError`, and never bubble as unhandled rejections. The generation
-   * token guards against a settling run from a prior generation clearing
-   * state owned by the current one.
+   * `lastError`, fire the factory's error listeners, and never bubble as
+   * unhandled rejections. The generation token guards against a settling
+   * run from a prior generation clearing state owned by the current one.
    */
-  private startOne(r: RunningInformer): void {
+  private startOne(kind: WatchKind, r: RunningInformer): void {
     if (r.runPromise) return;
     if (r.controller.signal.aborted) {
       r.controller = new AbortController();
     }
     const generation = (r.generation = r.generation + 1);
+    const hadError = r.lastError !== null;
     r.lastError = null;
+    if (hadError) this.fireError(kind, null);
     const signal = r.controller.signal;
     const informer = r.informer;
     r.runPromise = informer.run(signal).then(
@@ -421,7 +462,12 @@ export class InformerFactory {
       (err: unknown) => {
         if (r.generation === generation) {
           r.runPromise = null;
-          r.lastError = err instanceof Error ? err : new Error(String(err));
+          const errorObj = err instanceof Error ? err : new Error(String(err));
+          r.lastError = errorObj;
+          // Log so terminal failures (auth/config/permanent server errors)
+          // aren't silently swallowed when no error listener is registered.
+          console.warn(`Informer[${kind}]: run() failed: ${errorObj.message}`);
+          this.fireError(kind, errorObj);
         }
       },
     );

--- a/src/core/informer.ts
+++ b/src/core/informer.ts
@@ -287,7 +287,15 @@ export type InformerFactoryOptions =
       readonly mode: "local";
       readonly hub: WatchHub;
       readonly namespace: string;
-      readonly listFn: (kind: WatchKind) => readonly WatchEntity[];
+      /**
+       * Snapshot source per kind. Sync and async shapes both supported so
+       * Promise-returning local stores (`ContributionStore.listEntities`,
+       * `ClaimStore.listEntities`) can be wired without forcing callers to
+       * pre-await. LocalWatchClient awaits the result before iteration.
+       */
+      readonly listFn: (
+        kind: WatchKind,
+      ) => readonly WatchEntity[] | Promise<readonly WatchEntity[]>;
     };
 
 export type FactoryErrorListener = (kind: WatchKind, err: Error | null) => void;
@@ -309,18 +317,18 @@ interface RunningInformer {
 }
 
 /**
- * Kinds the factory will start eagerly via `startAll()`.
+ * Kinds the factory will start eagerly via `startAll()` AND the only kinds
+ * `informerFor` will accept. AgentSession is intentionally excluded because
+ * the grove-server `/api/list` route currently returns 501 NOT_CONFIGURED
+ * for it (handler exists, list source not wired). Re-add once server
+ * support lands.
  *
- * AgentSession is intentionally excluded: the grove-server `/api/list` route
- * currently returns 501 NOT_CONFIGURED for AgentSession (handler exists, list
- * source not wired). Including it would terminate AgentSession's WatchClient
- * permanently on first list. Re-add once server-side support lands.
- *
- * Per-kind hooks may still call `informerFor("AgentSession")` to construct
- * the informer, but it stays idle until startAll/startKind is invoked
- * explicitly with server support in place.
+ * Asking for an unsupported kind throws — louder than handing back an
+ * informer that would silently never sync.
  */
 const ALL_KINDS: readonly WatchKind[] = ["Contribution", "Claim"];
+
+const SUPPORTED_KINDS = new Set<WatchKind>(ALL_KINDS);
 
 /**
  * InformerFactory memoizes one Informer per kind for a single namespace
@@ -365,8 +373,17 @@ export class InformerFactory {
   /**
    * Returns the Informer for a kind. Lazily constructs it on first call,
    * but does NOT start `run()` — call `startAll()` to start watching.
+   * Throws for kinds the server does not yet support — see SUPPORTED_KINDS
+   * comment for the AgentSession rationale.
    */
   informerFor<K extends WatchKind>(kind: K): Informer<K> {
+    if (!SUPPORTED_KINDS.has(kind)) {
+      throw new Error(
+        `InformerFactory.informerFor(${kind}): kind not yet supported by grove-server watch routes. Supported: ${[
+          ...SUPPORTED_KINDS,
+        ].join(", ")}.`,
+      );
+    }
     const existing = this.running.get(kind);
     if (existing) return existing.informer as Informer<K>;
     const stream = this.makeStream(kind);

--- a/src/core/informer.ts
+++ b/src/core/informer.ts
@@ -1,7 +1,7 @@
 /**
  * Informer<K> — K8s-informer-style local cache with event fanout (#294).
  *
- * Wraps WatchClient to maintain a Map<id, Entity> that tracks server state
+ * Consumes a WatchStream to maintain a Map<id, Entity> that tracks server state
  * via the list→watch handshake. One Informer per kind is shared across all
  * subscribers via InformerFactory.
  *
@@ -11,10 +11,10 @@
 
 import type { AgentSessionEntity, ClaimEntity, ContributionEntity } from "./entity.js";
 import { LocalWatchClient } from "./local-watch-client.js";
-import { WatchClient, type WatchClientEvent, type WatchClientOptions } from "./watch-client.js";
+import { WatchClient, type WatchClientOptions } from "./watch-client.js";
 import type { WatchEntity, WatchKind } from "./watch-events.js";
 import type { WatchHub } from "./watch-hub.js";
-import type { WatchStream } from "./watch-stream.js";
+import type { WatchClientEvent, WatchStream } from "./watch-stream.js";
 
 type EntityForKind<K extends WatchKind> = K extends "Contribution"
   ? ContributionEntity
@@ -244,7 +244,6 @@ export type InformerFactoryOptions =
       readonly hub: WatchHub;
       readonly namespace: string;
       readonly listFn: (kind: WatchKind) => readonly WatchEntity[];
-      readonly backoff?: Backoff;
     };
 
 interface RunningInformer {
@@ -317,14 +316,24 @@ export class InformerFactory {
    */
   async relist(kind?: WatchKind): Promise<void> {
     const kinds: WatchKind[] = kind ? [kind] : [...ALL_KINDS];
-    for (const k of kinds) {
-      const r = this.running.get(k);
-      if (!r) continue;
-      r.controller.abort();
-      if (r.runPromise) await r.runPromise.catch(() => undefined);
+    const targets = kinds
+      .map((k) => this.running.get(k))
+      .filter((r): r is RunningInformer => r !== undefined);
+
+    // Phase 1: abort all in parallel.
+    for (const r of targets) r.controller.abort();
+    // Phase 2: await all settlements in parallel.
+    await Promise.all(
+      targets.map((r) => (r.runPromise ? r.runPromise.catch(() => undefined) : Promise.resolve())),
+    );
+    // Phase 3: reset each controller.
+    for (const r of targets) {
       r.controller = new AbortController();
       r.runPromise = null;
-      this.startKind(k);
+    }
+    // Phase 4: restart each kind.
+    for (const k of kinds) {
+      if (this.running.has(k)) this.startKind(k);
     }
   }
 

--- a/src/core/informer.ts
+++ b/src/core/informer.ts
@@ -308,7 +308,19 @@ interface RunningInformer {
   lifecycleLock: Promise<void>;
 }
 
-const ALL_KINDS: readonly WatchKind[] = ["Contribution", "Claim", "AgentSession"];
+/**
+ * Kinds the factory will start eagerly via `startAll()`.
+ *
+ * AgentSession is intentionally excluded: the grove-server `/api/list` route
+ * currently returns 501 NOT_CONFIGURED for AgentSession (handler exists, list
+ * source not wired). Including it would terminate AgentSession's WatchClient
+ * permanently on first list. Re-add once server-side support lands.
+ *
+ * Per-kind hooks may still call `informerFor("AgentSession")` to construct
+ * the informer, but it stays idle until startAll/startKind is invoked
+ * explicitly with server support in place.
+ */
+const ALL_KINDS: readonly WatchKind[] = ["Contribution", "Claim"];
 
 /**
  * InformerFactory memoizes one Informer per kind for a single namespace

--- a/src/core/informer.ts
+++ b/src/core/informer.ts
@@ -484,7 +484,8 @@ export class InformerFactory {
     if (r.controller.signal.aborted) {
       r.controller = new AbortController();
     }
-    const generation = (r.generation = r.generation + 1);
+    r.generation += 1;
+    const generation = r.generation;
     // Do NOT clear lastError on start — clearing here would fire `null` to
     // listeners while the new run is still pending or backing off, making
     // hooks drop their visible error even though sync has not been re-proven.

--- a/src/core/informer.ts
+++ b/src/core/informer.ts
@@ -31,10 +31,13 @@ export type EventHandlerFn<K extends WatchKind = WatchKind> = (
   entity: EntityForKind<K>,
 ) => void | Promise<void>;
 
+export type SyncHandlerFn = () => void;
+
 export class Informer<K extends WatchKind = WatchKind> {
   private readonly stream: WatchStream;
   private readonly store = new Map<string, EntityForKind<K>>();
   private readonly handlers: Array<EventHandlerFn<K>> = [];
+  private readonly syncHandlers: Array<SyncHandlerFn> = [];
   private _synced = false;
   private staging: Map<string, EntityForKind<K>> | null = null;
   private _running = false;
@@ -56,6 +59,28 @@ export class Informer<K extends WatchKind = WatchKind> {
     return () => {
       const idx = this.handlers.indexOf(fn);
       if (idx >= 0) this.handlers.splice(idx, 1);
+    };
+  }
+
+  /**
+   * Register a sync handler that fires on every RELIST_END, including empty
+   * snapshots and snapshots that produce no per-entity deltas. Required so
+   * hooks can flip hasSynced and recompute filtered views even when the
+   * snapshot is identical to the prior cache state. Fires immediately if
+   * the informer is already synced when the handler is registered.
+   */
+  addSyncHandler(fn: SyncHandlerFn): () => void {
+    this.syncHandlers.push(fn);
+    if (this._synced) {
+      try {
+        fn();
+      } catch (err) {
+        console.error("Informer: sync handler threw, continuing fanout:", err);
+      }
+    }
+    return () => {
+      const idx = this.syncHandlers.indexOf(fn);
+      if (idx >= 0) this.syncHandlers.splice(idx, 1);
     };
   }
 
@@ -104,6 +129,7 @@ export class Informer<K extends WatchKind = WatchKind> {
         this._synced = true;
         await this.commitReplace(this.staging);
         this.staging = null;
+        this.fireSync();
         break;
 
       case "RELIST_ABORTED":
@@ -162,6 +188,18 @@ export class Informer<K extends WatchKind = WatchKind> {
     for (const e of deleted) await this.dispatch("DELETED", e);
     for (const e of added) await this.dispatch("ADDED", e);
     for (const e of modified) await this.dispatch("MODIFIED", e);
+  }
+
+  private fireSync(): void {
+    // Snapshot before iterating so a handler that calls its own unsubscribe
+    // mid-iteration does not skip the next handler.
+    for (const handler of [...this.syncHandlers]) {
+      try {
+        handler();
+      } catch (err) {
+        console.error("Informer: sync handler threw, continuing fanout:", err);
+      }
+    }
   }
 
   private async dispatch(op: InformerOp, entity: EntityForKind<K>): Promise<void> {
@@ -250,6 +288,16 @@ interface RunningInformer {
   readonly informer: Informer;
   controller: AbortController;
   runPromise: Promise<void> | null;
+  /** Generation token: incremented every (re)start. Lets a settling run
+   * identify whether the runPromise it owns is still the live one before
+   * clearing factory state, so a concurrent restart can't be undone by a
+   * late `runPromise = null` from a previous generation. */
+  generation: number;
+  /** Last terminal error from `informer.run()`, if any. Cleared on next start. */
+  lastError: Error | null;
+  /** Serialization lock: relist/startKind operations chain on this so two
+   * overlapping calls don't race on controller/runPromise state. */
+  lifecycleLock: Promise<void>;
 }
 
 const ALL_KINDS: readonly WatchKind[] = ["Contribution", "Claim", "AgentSession"];
@@ -281,6 +329,9 @@ export class InformerFactory {
       informer: informer as Informer,
       controller: new AbortController(),
       runPromise: null,
+      generation: 0,
+      lastError: null,
+      lifecycleLock: Promise.resolve(),
     });
     return informer;
   }
@@ -301,18 +352,17 @@ export class InformerFactory {
    * have settled and the factory is reusable.
    */
   async stopAll(): Promise<void> {
-    const promises: Promise<void>[] = [];
-    for (const r of this.running.values()) {
-      r.controller.abort();
-      if (r.runPromise) promises.push(r.runPromise.catch(() => undefined));
-    }
-    await Promise.all(promises);
+    // Serialize against in-flight relist/startKind so a concurrent restart
+    // can't replace the controller after we've aborted but before we await.
+    const stops = [...this.running.values()].map((r) => this.withLock(r, () => this.stopOne(r)));
+    await Promise.all(stops);
   }
 
   /**
    * Force a relist on a single kind (or all kinds when undefined). Aborts
    * the current run, awaits its settlement, then starts a new run with a
-   * fresh AbortController.
+   * fresh AbortController. Per-kind serialized so two overlapping callers
+   * don't lose track of the live controller or runPromise.
    */
   async relist(kind?: WatchKind): Promise<void> {
     const kinds: WatchKind[] = kind ? [kind] : [...ALL_KINDS];
@@ -320,21 +370,20 @@ export class InformerFactory {
       .map((k) => this.running.get(k))
       .filter((r): r is RunningInformer => r !== undefined);
 
-    // Phase 1: abort all in parallel.
-    for (const r of targets) r.controller.abort();
-    // Phase 2: await all settlements in parallel.
     await Promise.all(
-      targets.map((r) => (r.runPromise ? r.runPromise.catch(() => undefined) : Promise.resolve())),
+      targets.map((r) =>
+        this.withLock(r, async () => {
+          await this.stopOne(r);
+          r.controller = new AbortController();
+          this.startOne(r);
+        }),
+      ),
     );
-    // Phase 3: reset each controller.
-    for (const r of targets) {
-      r.controller = new AbortController();
-      r.runPromise = null;
-    }
-    // Phase 4: restart each kind.
-    for (const k of kinds) {
-      if (this.running.has(k)) this.startKind(k);
-    }
+  }
+
+  /** Last terminal error captured from a kind's `run()`, if any. */
+  getLastError(kind: WatchKind): Error | null {
+    return this.running.get(kind)?.lastError ?? null;
   }
 
   private startKind(kind: WatchKind): void {
@@ -344,8 +393,62 @@ export class InformerFactory {
       r = this.running.get(kind);
       if (!r) throw new Error(`unreachable: informerFor(${kind}) did not register a running entry`);
     }
+    void this.withLock(r, async () => {
+      this.startOne(r);
+    });
+  }
+
+  /**
+   * Start a fresh `run()` if not already running. Wraps the run promise so
+   * terminal errors clear `runPromise` (allowing future restart), record
+   * `lastError`, and never bubble as unhandled rejections. The generation
+   * token guards against a settling run from a prior generation clearing
+   * state owned by the current one.
+   */
+  private startOne(r: RunningInformer): void {
     if (r.runPromise) return;
-    r.runPromise = r.informer.run(r.controller.signal);
+    if (r.controller.signal.aborted) {
+      r.controller = new AbortController();
+    }
+    const generation = (r.generation = r.generation + 1);
+    r.lastError = null;
+    const signal = r.controller.signal;
+    const informer = r.informer;
+    r.runPromise = informer.run(signal).then(
+      () => {
+        if (r.generation === generation) r.runPromise = null;
+      },
+      (err: unknown) => {
+        if (r.generation === generation) {
+          r.runPromise = null;
+          r.lastError = err instanceof Error ? err : new Error(String(err));
+        }
+      },
+    );
+  }
+
+  /**
+   * Abort the current run (if any) and await settlement. Safe to call when
+   * no run is active — resolves immediately. Caller must hold lifecycleLock.
+   */
+  private async stopOne(r: RunningInformer): Promise<void> {
+    r.controller.abort();
+    if (r.runPromise) await r.runPromise;
+  }
+
+  /**
+   * Chain `op` onto the running entry's lifecycle lock so concurrent
+   * relist/start/stop calls execute one-at-a-time per kind. Errors in `op`
+   * are preserved on the lock chain — but never block subsequent operations
+   * since the lock is reset to a resolved state regardless of outcome.
+   */
+  private withLock<T>(r: RunningInformer, op: () => Promise<T>): Promise<T> {
+    const next = r.lifecycleLock.then(op, op);
+    r.lifecycleLock = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
   }
 
   private makeStream(kind: WatchKind): WatchStream {

--- a/src/core/informer.ts
+++ b/src/core/informer.ts
@@ -10,8 +10,11 @@
  */
 
 import type { AgentSessionEntity, ClaimEntity, ContributionEntity } from "./entity.js";
+import { LocalWatchClient } from "./local-watch-client.js";
 import { WatchClient, type WatchClientEvent, type WatchClientOptions } from "./watch-client.js";
-import type { WatchKind } from "./watch-events.js";
+import type { WatchEntity, WatchKind } from "./watch-events.js";
+import type { WatchHub } from "./watch-hub.js";
+import type { WatchStream } from "./watch-stream.js";
 
 type EntityForKind<K extends WatchKind> = K extends "Contribution"
   ? ContributionEntity
@@ -29,7 +32,7 @@ export type EventHandlerFn<K extends WatchKind = WatchKind> = (
 ) => void | Promise<void>;
 
 export class Informer<K extends WatchKind = WatchKind> {
-  private readonly clientOpts: WatchClientOptions;
+  private readonly stream: WatchStream;
   private readonly store = new Map<string, EntityForKind<K>>();
   private readonly handlers: Array<EventHandlerFn<K>> = [];
   private _synced = false;
@@ -38,8 +41,8 @@ export class Informer<K extends WatchKind = WatchKind> {
   // Set during run() so dispatch can race handlers against the abort signal.
   private _signal: AbortSignal | null = null;
 
-  constructor(opts: WatchClientOptions) {
-    this.clientOpts = opts;
+  constructor(stream: WatchStream) {
+    this.stream = stream;
   }
 
   /**
@@ -77,8 +80,7 @@ export class Informer<K extends WatchKind = WatchKind> {
     this._running = true;
     this._signal = signal;
     try {
-      const client = new WatchClient(this.clientOpts);
-      await client.run({ onEvent: (e) => this.onEvent(e), signal });
+      await this.stream.run({ onEvent: (e) => this.onEvent(e), signal });
     } finally {
       this._signal = null;
       this._running = false;
@@ -227,12 +229,31 @@ function isAbortError(err: unknown): boolean {
   return err instanceof DOMException && err.name === "AbortError";
 }
 
-export interface InformerFactoryOptions {
-  readonly baseUrl: string;
-  readonly authHeader: string;
-  readonly fetch?: typeof fetch;
-  readonly backoff?: WatchClientOptions["backoff"];
+export type Backoff = NonNullable<WatchClientOptions["backoff"]>;
+
+export type InformerFactoryOptions =
+  | {
+      readonly mode: "remote";
+      readonly baseUrl: string;
+      readonly authHeader: string;
+      readonly fetch?: typeof fetch;
+      readonly backoff?: Backoff;
+    }
+  | {
+      readonly mode: "local";
+      readonly hub: WatchHub;
+      readonly namespace: string;
+      readonly listFn: (kind: WatchKind) => readonly WatchEntity[];
+      readonly backoff?: Backoff;
+    };
+
+interface RunningInformer {
+  readonly informer: Informer;
+  controller: AbortController;
+  runPromise: Promise<void> | null;
 }
+
+const ALL_KINDS: readonly WatchKind[] = ["Contribution", "Claim", "AgentSession"];
 
 /**
  * InformerFactory memoizes one Informer per kind for a single namespace
@@ -242,29 +263,99 @@ export interface InformerFactoryOptions {
  */
 export class InformerFactory {
   private readonly opts: InformerFactoryOptions;
-  // key: kind string
-  private readonly informers = new Map<string, Informer>();
+  private readonly running = new Map<string, RunningInformer>();
 
   constructor(opts: InformerFactoryOptions) {
     this.opts = opts;
   }
 
+  /**
+   * Returns the Informer for a kind. Lazily constructs it on first call,
+   * but does NOT start `run()` — call `startAll()` to start watching.
+   */
   informerFor<K extends WatchKind>(kind: K): Informer<K> {
-    let informer = this.informers.get(kind) as Informer<K> | undefined;
-    if (!informer) {
-      // Build clientOpts conditionally so exactOptionalPropertyTypes doesn't
-      // treat undefined fetch/backoff as explicit-undefined (which violates
-      // WatchClientOptions where the props are optional, not optional|undefined).
-      const clientOpts: WatchClientOptions = {
-        baseUrl: this.opts.baseUrl,
-        kind,
-        authHeader: this.opts.authHeader,
-        ...(this.opts.fetch !== undefined ? { fetch: this.opts.fetch } : {}),
-        ...(this.opts.backoff !== undefined ? { backoff: this.opts.backoff } : {}),
-      };
-      informer = new Informer<K>(clientOpts);
-      this.informers.set(kind, informer as Informer);
-    }
+    const existing = this.running.get(kind);
+    if (existing) return existing.informer as Informer<K>;
+    const stream = this.makeStream(kind);
+    const informer = new Informer<K>(stream);
+    this.running.set(kind, {
+      informer: informer as Informer,
+      controller: new AbortController(),
+      runPromise: null,
+    });
     return informer;
+  }
+
+  /**
+   * Start `run()` on all known kinds. Idempotent — already-started kinds
+   * are skipped. Caller is responsible for `stopAll()` (or aborting the
+   * parent signal) on shutdown.
+   */
+  startAll(): void {
+    for (const kind of ALL_KINDS) {
+      this.startKind(kind);
+    }
+  }
+
+  /**
+   * Abort all running informers. After this returns, the run() promises
+   * have settled and the factory is reusable.
+   */
+  async stopAll(): Promise<void> {
+    const promises: Promise<void>[] = [];
+    for (const r of this.running.values()) {
+      r.controller.abort();
+      if (r.runPromise) promises.push(r.runPromise.catch(() => undefined));
+    }
+    await Promise.all(promises);
+  }
+
+  /**
+   * Force a relist on a single kind (or all kinds when undefined). Aborts
+   * the current run, awaits its settlement, then starts a new run with a
+   * fresh AbortController.
+   */
+  async relist(kind?: WatchKind): Promise<void> {
+    const kinds: WatchKind[] = kind ? [kind] : [...ALL_KINDS];
+    for (const k of kinds) {
+      const r = this.running.get(k);
+      if (!r) continue;
+      r.controller.abort();
+      if (r.runPromise) await r.runPromise.catch(() => undefined);
+      r.controller = new AbortController();
+      r.runPromise = null;
+      this.startKind(k);
+    }
+  }
+
+  private startKind(kind: WatchKind): void {
+    let r = this.running.get(kind);
+    if (!r) {
+      this.informerFor(kind);
+      r = this.running.get(kind);
+      if (!r) throw new Error(`unreachable: informerFor(${kind}) did not register a running entry`);
+    }
+    if (r.runPromise) return;
+    r.runPromise = r.informer.run(r.controller.signal);
+  }
+
+  private makeStream(kind: WatchKind): WatchStream {
+    const opts = this.opts;
+    if (opts.mode === "remote") {
+      const clientOpts: WatchClientOptions = {
+        baseUrl: opts.baseUrl,
+        kind,
+        authHeader: opts.authHeader,
+        ...(opts.fetch !== undefined ? { fetch: opts.fetch } : {}),
+        ...(opts.backoff !== undefined ? { backoff: opts.backoff } : {}),
+      };
+      return new WatchClient(clientOpts);
+    }
+    return new LocalWatchClient({
+      hub: opts.hub,
+      kind,
+      namespace: opts.namespace,
+      listFn: () => opts.listFn(kind),
+    });
   }
 }

--- a/src/core/local-watch-client.test.ts
+++ b/src/core/local-watch-client.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { LocalWatchClient } from "./local-watch-client.js";
+import type { WatchClientEvent } from "./watch-client.js";
+import type { WatchEntity } from "./watch-events.js";
+import { WatchHub } from "./watch-hub.js";
+
+const NS = "default";
+
+function mkContribution(id: string, rv: string): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: id,
+      artifacts: {},
+      relations: [],
+      tags: [],
+    },
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: rv,
+    metadata: { generation: 1 },
+  } as unknown as WatchEntity;
+}
+
+describe("LocalWatchClient", () => {
+  test("emits RELIST_BEGIN, one RELIST per snapshot entity, then RELIST_END", async () => {
+    const hub = new WatchHub();
+    const e1 = mkContribution("a", "1");
+    const e2 = mkContribution("b", "1");
+    const events: WatchClientEvent[] = [];
+    const ac = new AbortController();
+
+    const client = new LocalWatchClient({
+      hub,
+      kind: "Contribution",
+      namespace: NS,
+      listFn: () => [e1, e2],
+    });
+
+    const runPromise = client.run({
+      onEvent: (e) => {
+        events.push(e);
+        if (e.op === "RELIST_END") ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await runPromise;
+
+    expect(events.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST", "RELIST", "RELIST_END"]);
+    expect(events[1]?.entity?.id).toBe("a");
+    expect(events[2]?.entity?.id).toBe("b");
+    expect(events[0]?.entity).toBeNull();
+    expect(events[3]?.entity).toBeNull();
+  });
+
+  test("emits live deltas after RELIST_END", async () => {
+    const hub = new WatchHub();
+    const events: WatchClientEvent[] = [];
+    const ac = new AbortController();
+
+    const client = new LocalWatchClient({
+      hub,
+      kind: "Contribution",
+      namespace: NS,
+      listFn: () => [],
+    });
+
+    const runPromise = client.run({
+      onEvent: (e) => {
+        events.push(e);
+        if (e.op === "ADDED") ac.abort();
+      },
+      signal: ac.signal,
+    });
+
+    // Wait one microtask so the client has emitted RELIST_BEGIN/END before we publish.
+    await Promise.resolve();
+    await Promise.resolve();
+    hub.recordWrite({
+      op: "ADDED",
+      kind: "Contribution",
+      namespace: NS,
+      entity: mkContribution("a", "1"),
+    });
+    await runPromise;
+
+    const ops = events.map((e) => e.op);
+    expect(ops).toEqual(["RELIST_BEGIN", "RELIST_END", "ADDED"]);
+    expect(events[2]?.entity?.id).toBe("a");
+  });
+
+  test("respects pre-aborted signal — no events emitted", async () => {
+    const hub = new WatchHub();
+    const events: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    ac.abort();
+
+    const client = new LocalWatchClient({
+      hub,
+      kind: "Contribution",
+      namespace: NS,
+      listFn: () => [mkContribution("a", "1")],
+    });
+
+    await client.run({
+      onEvent: (e) => {
+        events.push(e);
+      },
+      signal: ac.signal,
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  test("captures currentRv before listing — events written between capture and subscribe replay correctly", async () => {
+    const hub = new WatchHub();
+    // Pre-existing event in hub before run() starts.
+    hub.recordWrite({
+      op: "ADDED",
+      kind: "Contribution",
+      namespace: NS,
+      entity: mkContribution("pre", "1"),
+    });
+
+    const events: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    const client = new LocalWatchClient({
+      hub,
+      kind: "Contribution",
+      namespace: NS,
+      listFn: () => [mkContribution("a", "1")],
+    });
+
+    const runPromise = client.run({
+      onEvent: (e) => {
+        events.push(e);
+        if (e.op === "RELIST_END") ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await runPromise;
+
+    // No replay of the pre-snapshot event — listFn is the source of truth at snapshot time.
+    expect(events.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST", "RELIST_END"]);
+  });
+});

--- a/src/core/local-watch-client.ts
+++ b/src/core/local-watch-client.ts
@@ -84,6 +84,7 @@ export class LocalWatchClient implements WatchStream {
     try {
       for await (const event of stream) {
         if (signal.aborted) return;
+        // Re-emit as WatchClientEvent — namespace is dropped (implicit in the subscription).
         await onEvent({
           op: event.op,
           rv: event.rv,
@@ -92,9 +93,9 @@ export class LocalWatchClient implements WatchStream {
         });
       }
     } catch (err) {
-      // Hub buffer overflow (unlikely in-process) — surface as RELIST_ABORTED so
-      // the Informer can drop the snapshot in flight; not relevant here since
-      // we're already past RELIST_END, so just rethrow for the caller's run loop.
+      // Buffer overflow or other hub errors during live-delta iteration. Boundary
+      // events are already emitted by this point, so the Informer won't see a
+      // RELIST_ABORTED — just rethrow so the caller's run loop handles it.
       if (!signal.aborted) throw err;
     }
   }

--- a/src/core/local-watch-client.ts
+++ b/src/core/local-watch-client.ts
@@ -1,0 +1,101 @@
+/**
+ * LocalWatchClient — in-process WatchStream backend (#295).
+ *
+ * Reads a snapshot from `listFn` and subscribes to a process-local
+ * WatchHub for deltas. Emits the same RELIST_BEGIN → RELIST* → RELIST_END
+ * → live-delta sequence as the remote WatchClient so consumers (Informer)
+ * can be backend-agnostic.
+ *
+ * Local mode (no Nexus) wires this against per-store snapshots; the stores
+ * themselves call `hub.recordWrite` on each write. Remote mode keeps using
+ * the HTTP-based WatchClient.
+ */
+
+import type { WatchClientEvent } from "./watch-client.js";
+import type { WatchEntity, WatchKind } from "./watch-events.js";
+import type { WatchHub } from "./watch-hub.js";
+import type { WatchStream } from "./watch-stream.js";
+
+export interface LocalWatchClientOptions {
+  readonly hub: WatchHub;
+  readonly kind: WatchKind;
+  readonly namespace: string;
+  readonly listFn: () => readonly WatchEntity[];
+}
+
+export class LocalWatchClient implements WatchStream {
+  private readonly hub: WatchHub;
+  private readonly kind: WatchKind;
+  private readonly namespace: string;
+  private readonly listFn: () => readonly WatchEntity[];
+
+  constructor(opts: LocalWatchClientOptions) {
+    this.hub = opts.hub;
+    this.kind = opts.kind;
+    this.namespace = opts.namespace;
+    this.listFn = opts.listFn;
+  }
+
+  async run(opts: {
+    onEvent: (e: WatchClientEvent) => void | Promise<void>;
+    signal: AbortSignal;
+  }): Promise<void> {
+    const { onEvent, signal } = opts;
+    if (signal.aborted) return;
+
+    // Capture the watch RV at the snapshot boundary, BEFORE listFn executes.
+    // The hub's subscribe() will replay everything strictly after this RV,
+    // so any write that happens after capture is delivered as a live delta.
+    const snapshotRv = this.hub.currentRv(this.namespace, this.kind);
+
+    // Subscribe BEFORE emitting RELIST events so we don't miss writes that
+    // race the snapshot. The hub buffers events into the subscriber's queue
+    // until the consumer iterates.
+    const stream = this.hub.subscribe(this.namespace, this.kind, snapshotRv, signal);
+
+    // Emit the snapshot.
+    await onEvent({
+      op: "RELIST_BEGIN",
+      rv: snapshotRv,
+      kind: this.kind,
+      entity: null,
+    });
+    if (signal.aborted) return;
+
+    for (const entity of this.listFn()) {
+      await onEvent({
+        op: "RELIST",
+        rv: snapshotRv,
+        kind: this.kind,
+        entity,
+      });
+      if (signal.aborted) return;
+    }
+
+    await onEvent({
+      op: "RELIST_END",
+      rv: snapshotRv,
+      kind: this.kind,
+      entity: null,
+    });
+    if (signal.aborted) return;
+
+    // Drain live deltas. The async iterator returns when the abort signal fires.
+    try {
+      for await (const event of stream) {
+        if (signal.aborted) return;
+        await onEvent({
+          op: event.op,
+          rv: event.rv,
+          kind: event.kind,
+          entity: event.entity,
+        });
+      }
+    } catch (err) {
+      // Hub buffer overflow (unlikely in-process) — surface as RELIST_ABORTED so
+      // the Informer can drop the snapshot in flight; not relevant here since
+      // we're already past RELIST_END, so just rethrow for the caller's run loop.
+      if (!signal.aborted) throw err;
+    }
+  }
+}

--- a/src/core/local-watch-client.ts
+++ b/src/core/local-watch-client.ts
@@ -52,6 +52,18 @@ export class LocalWatchClient implements WatchStream {
     // race the snapshot. The hub buffers events into the subscriber's queue
     // until the consumer iterates.
     const stream = this.hub.subscribe(this.namespace, this.kind, snapshotRv, signal);
+    // Cache the iterator so we can call return() on it during cleanup. Without
+    // this, an exception thrown between RELIST_BEGIN and the for-await loop
+    // would leave the hub subscriber alive (no abort, no iterator return),
+    // accumulating fanout until buffer overflow.
+    const iterator = stream[Symbol.asyncIterator]();
+    const closeStream = async (): Promise<void> => {
+      try {
+        await iterator.return?.();
+      } catch {
+        /* iterator already closed */
+      }
+    };
 
     // Snapshot dedup window. A write committed after currentRv() but before
     // listFn() reads the store is included in BOTH the snapshot and the
@@ -61,37 +73,68 @@ export class LocalWatchClient implements WatchStream {
     // mirroring WatchClient.snapshotWindow.
     const snapshotWindow = new Map<string, string>();
 
-    // Emit the snapshot.
-    await onEvent({
-      op: "RELIST_BEGIN",
-      rv: snapshotRv,
-      kind: this.kind,
-      entity: null,
-    });
-    if (signal.aborted) return;
-
-    for (const entity of this.listFn()) {
-      snapshotWindow.set(entity.id, entity.resourceVersion);
+    // Boundary invariant: once RELIST_BEGIN fires, exactly one of RELIST_END
+    // or RELIST_ABORTED follows. Track delivery so a snapshot-phase failure
+    // (listFn throw, onEvent throw) emits RELIST_ABORTED before rethrowing
+    // and the consumer can roll back staged state.
+    let relistOpen = false;
+    let primaryError: unknown;
+    try {
       await onEvent({
-        op: "RELIST",
+        op: "RELIST_BEGIN",
         rv: snapshotRv,
         kind: this.kind,
-        entity,
+        entity: null,
       });
-      if (signal.aborted) return;
+      relistOpen = true;
+      if (!signal.aborted) {
+        for (const entity of this.listFn()) {
+          if (signal.aborted) break;
+          snapshotWindow.set(entity.id, entity.resourceVersion);
+          await onEvent({
+            op: "RELIST",
+            rv: snapshotRv,
+            kind: this.kind,
+            entity,
+          });
+        }
+      }
+    } catch (err) {
+      primaryError = err;
     }
 
-    await onEvent({
-      op: "RELIST_END",
-      rv: snapshotRv,
-      kind: this.kind,
-      entity: null,
-    });
-    if (signal.aborted) return;
+    if (relistOpen) {
+      const interrupted = primaryError !== undefined || signal.aborted;
+      const closeOp = interrupted ? "RELIST_ABORTED" : "RELIST_END";
+      try {
+        await onEvent({
+          op: closeOp,
+          rv: snapshotRv,
+          kind: this.kind,
+          entity: null,
+        });
+      } catch (err) {
+        if (closeOp === "RELIST_END" && primaryError === undefined && !signal.aborted) {
+          primaryError = err;
+        }
+      }
+    }
+
+    if (primaryError !== undefined) {
+      await closeStream();
+      throw primaryError;
+    }
+    if (signal.aborted) {
+      await closeStream();
+      return;
+    }
 
     // Drain live deltas. The async iterator returns when the abort signal fires.
     try {
-      for await (const event of stream) {
+      while (!signal.aborted) {
+        const next = await iterator.next();
+        if (next.done) break;
+        const event = next.value;
         if (signal.aborted) return;
         // Snapshot-dedup with high-water mark. Drop replay frames whose
         // entity version is ≤ the snapshot's version for that id; forward
@@ -117,9 +160,11 @@ export class LocalWatchClient implements WatchStream {
       }
     } catch (err) {
       // Buffer overflow or other hub errors during live-delta iteration. Boundary
-      // events are already emitted by this point, so the Informer won't see a
-      // RELIST_ABORTED — just rethrow so the caller's run loop handles it.
+      // events were already emitted, so the Informer won't see a RELIST_ABORTED —
+      // just rethrow so the caller's run loop handles it.
       if (!signal.aborted) throw err;
+    } finally {
+      await closeStream();
     }
   }
 }

--- a/src/core/local-watch-client.ts
+++ b/src/core/local-watch-client.ts
@@ -11,7 +11,7 @@
  * the HTTP-based WatchClient.
  */
 
-import type { WatchClientEvent } from "./watch-client.js";
+import { isStaleVersion, type WatchClientEvent } from "./watch-client.js";
 import type { WatchEntity, WatchKind } from "./watch-events.js";
 import type { WatchHub } from "./watch-hub.js";
 import type { WatchStream } from "./watch-stream.js";
@@ -53,6 +53,14 @@ export class LocalWatchClient implements WatchStream {
     // until the consumer iterates.
     const stream = this.hub.subscribe(this.namespace, this.kind, snapshotRv, signal);
 
+    // Snapshot dedup window. A write committed after currentRv() but before
+    // listFn() reads the store is included in BOTH the snapshot and the
+    // subscription replay (rv > snapshotRv). Track {entity.id →
+    // resourceVersion} during RELIST so an immediately-following live event
+    // with the same (id, rv) tuple is suppressed instead of double-delivered,
+    // mirroring WatchClient.snapshotWindow.
+    const snapshotWindow = new Map<string, string>();
+
     // Emit the snapshot.
     await onEvent({
       op: "RELIST_BEGIN",
@@ -63,6 +71,7 @@ export class LocalWatchClient implements WatchStream {
     if (signal.aborted) return;
 
     for (const entity of this.listFn()) {
+      snapshotWindow.set(entity.id, entity.resourceVersion);
       await onEvent({
         op: "RELIST",
         rv: snapshotRv,
@@ -84,6 +93,20 @@ export class LocalWatchClient implements WatchStream {
     try {
       for await (const event of stream) {
         if (signal.aborted) return;
+        // Snapshot-dedup with high-water mark. Drop replay frames whose
+        // entity version is ≤ the snapshot's version for that id; forward
+        // strictly newer versions and DELETED. Treat the window as a
+        // high-water mark — never delete on a stale match, since further
+        // stale frames could still arrive in the same race window.
+        const seenRv = snapshotWindow.get(event.entity.id);
+        if (seenRv !== undefined) {
+          if (event.op !== "DELETED" && isStaleVersion(event.entity.resourceVersion, seenRv)) {
+            continue;
+          }
+          // Strictly newer real update or DELETED tombstone — clear the
+          // entry so subsequent events for this entity bypass dedup.
+          snapshotWindow.delete(event.entity.id);
+        }
         // Re-emit as WatchClientEvent — namespace is dropped (implicit in the subscription).
         await onEvent({
           op: event.op,

--- a/src/core/local-watch-client.ts
+++ b/src/core/local-watch-client.ts
@@ -20,14 +20,22 @@ export interface LocalWatchClientOptions {
   readonly hub: WatchHub;
   readonly kind: WatchKind;
   readonly namespace: string;
-  readonly listFn: () => readonly WatchEntity[];
+  /**
+   * Snapshot source for the local store. Returns either a synchronous array
+   * or a Promise resolving to one — the repo's real `ContributionStore` and
+   * `ClaimStore` `listEntities()` methods are async, so the contract supports
+   * both shapes. The promise (if any) is awaited inside `run()` before the
+   * RELIST iteration so an async snapshot can't sneak a Promise into the
+   * synchronous iteration loop.
+   */
+  readonly listFn: () => readonly WatchEntity[] | Promise<readonly WatchEntity[]>;
 }
 
 export class LocalWatchClient implements WatchStream {
   private readonly hub: WatchHub;
   private readonly kind: WatchKind;
   private readonly namespace: string;
-  private readonly listFn: () => readonly WatchEntity[];
+  private readonly listFn: () => readonly WatchEntity[] | Promise<readonly WatchEntity[]>;
 
   constructor(opts: LocalWatchClientOptions) {
     this.hub = opts.hub;
@@ -88,7 +96,11 @@ export class LocalWatchClient implements WatchStream {
       });
       relistOpen = true;
       if (!signal.aborted) {
-        for (const entity of this.listFn()) {
+        // Resolve sync or async list — real stores expose Promise-based
+        // listEntities(). Awaiting before iteration prevents Promise objects
+        // leaking into the snapshot loop and short-circuiting RELIST_END.
+        const list = await this.listFn();
+        for (const entity of list) {
           if (signal.aborted) break;
           snapshotWindow.set(entity.id, entity.resourceVersion);
           await onEvent({

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -381,7 +381,7 @@ function isDataOp(event: string): boolean {
  * extract the leading numeric prefix on both sides for a robust ordering.
  * Falls back to exact string equality when no numeric prefix is present.
  */
-function isStaleVersion(eventRv: string, snapshotRv: string): boolean {
+export function isStaleVersion(eventRv: string, snapshotRv: string): boolean {
   const a = parseRvPrefix(snapshotRv);
   const b = parseRvPrefix(eventRv);
   if (a !== null && b !== null) return b <= a;

--- a/src/core/watch-client.ts
+++ b/src/core/watch-client.ts
@@ -7,6 +7,7 @@
  */
 
 import type { WatchEntity, WatchKind } from "./watch-events.js";
+import type { WatchStream } from "./watch-stream.js";
 
 export type WatchClientOp =
   | "ADDED"
@@ -69,7 +70,7 @@ type StreamExit =
   | { kind: "ended"; lastRv: bigint; observedData: boolean }
   | { kind: "relist" };
 
-export class WatchClient {
+export class WatchClient implements WatchStream {
   private readonly baseUrl: string;
   private readonly kind: WatchKind;
   private readonly authHeader: string;

--- a/src/core/watch-stream.contract.test.ts
+++ b/src/core/watch-stream.contract.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import { LocalWatchClient } from "./local-watch-client.js";
+import type { WatchClientEvent } from "./watch-client.js";
+import { WatchClient } from "./watch-client.js";
+import type { WatchEntity, WatchKind } from "./watch-events.js";
+import { WatchHub } from "./watch-hub.js";
+import type { WatchStream } from "./watch-stream.js";
+
+const NS = "default";
+const KIND: WatchKind = "Contribution";
+
+function mkEntity(id: string, rv: string): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: id,
+      artifacts: {},
+      relations: [],
+      tags: [],
+    },
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: rv,
+    metadata: { generation: 1 },
+  } as unknown as WatchEntity;
+}
+
+interface Backend {
+  readonly name: string;
+  readonly stream: WatchStream;
+  readonly publishLive: (entity: WatchEntity) => void;
+}
+
+function localBackend(snapshot: readonly WatchEntity[]): Backend {
+  const hub = new WatchHub();
+  const stream = new LocalWatchClient({
+    hub,
+    kind: KIND,
+    namespace: NS,
+    listFn: () => snapshot,
+  });
+  return {
+    name: "LocalWatchClient",
+    stream,
+    publishLive: (entity) => {
+      hub.recordWrite({ op: "ADDED", kind: KIND, namespace: NS, entity });
+    },
+  };
+}
+
+function sse(event: string, data: unknown, id?: string): string {
+  const idLine = id ? `id: ${id}\n` : "";
+  return `${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function remoteBackend(snapshot: readonly WatchEntity[], live: readonly WatchEntity[]): Backend {
+  const list = { items: [...snapshot], listResourceVersion: "0" };
+  let body = "";
+  let rv = 1n;
+  for (const e of live) {
+    body += sse("ADDED", { rv: String(rv), op: "ADDED", kind: KIND, entity: e }, String(rv));
+    rv += 1n;
+  }
+  const ac = new AbortController();
+  let watchCalls = 0;
+  const fetchImpl = (async (input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.includes("/api/list")) {
+      return new Response(JSON.stringify(list), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url.includes("/api/watch")) {
+      watchCalls += 1;
+      if (watchCalls === 1) {
+        return new Response(body, { headers: { "Content-Type": "text/event-stream" } });
+      }
+      ac.abort();
+      return new Response("", { headers: { "Content-Type": "text/event-stream" } });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }) as typeof fetch;
+  const stream = new WatchClient({
+    baseUrl: "http://t",
+    kind: KIND,
+    authHeader: "Bearer x",
+    fetch: fetchImpl,
+    backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+  });
+  return {
+    name: "WatchClient (remote, fake fetch)",
+    stream,
+    publishLive: () => {
+      throw new Error("remote backend's live events are pre-baked into the SSE body");
+    },
+  };
+}
+
+describe("WatchStream contract", () => {
+  for (const make of [
+    () => localBackend([mkEntity("a", "1"), mkEntity("b", "1")]),
+    () => remoteBackend([mkEntity("a", "1"), mkEntity("b", "1")], []),
+  ]) {
+    const backend = make();
+
+    test(`${backend.name}: snapshot order = BEGIN, RELIST*, END`, async () => {
+      const events: WatchClientEvent[] = [];
+      const ac = new AbortController();
+      const runPromise = backend.stream.run({
+        onEvent: (e) => {
+          events.push(e);
+          if (e.op === "RELIST_END") ac.abort();
+        },
+        signal: ac.signal,
+      });
+      await runPromise.catch(() => undefined);
+
+      expect(events.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST", "RELIST", "RELIST_END"]);
+      expect(events[0]?.entity).toBeNull();
+      expect(events[3]?.entity).toBeNull();
+    });
+  }
+
+  test("LocalWatchClient: live ADDED arrives after RELIST_END", async () => {
+    const backend = localBackend([]);
+    const events: WatchClientEvent[] = [];
+    const ac = new AbortController();
+    const run = backend.stream.run({
+      onEvent: (e) => {
+        events.push(e);
+        if (e.op === "ADDED") ac.abort();
+      },
+      signal: ac.signal,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    backend.publishLive(mkEntity("live-a", "1"));
+    await run;
+    expect(events.map((e) => e.op)).toEqual(["RELIST_BEGIN", "RELIST_END", "ADDED"]);
+  });
+});

--- a/src/core/watch-stream.ts
+++ b/src/core/watch-stream.ts
@@ -1,0 +1,16 @@
+/**
+ * WatchStream — common contract implemented by remote (HTTP/SSE) and
+ * in-process watch clients. Consumed by Informer (#294) so the cache
+ * layer can be backend-agnostic.
+ */
+
+import type { WatchClientEvent } from "./watch-client.js";
+
+export interface WatchStream {
+  run(opts: {
+    onEvent: (e: WatchClientEvent) => void | Promise<void>;
+    signal: AbortSignal;
+  }): Promise<void>;
+}
+
+export type { WatchClientEvent };

--- a/src/shared/provider-factory.ts
+++ b/src/shared/provider-factory.ts
@@ -52,7 +52,13 @@ export function createStubContributionStore(identity?: string): ContributionStor
 export function isLoopbackUrl(url: string): boolean {
   try {
     const { hostname } = new URL(url);
-    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+    // Strip brackets from IPv6 forms: Bun's URL parser returns "[::1]" for
+    // `http://[::1]:4515` but Node's whatwg-URL returns "::1". Normalize
+    // both so trusted IPv6 loopback URLs aren't treated as remote.
+    const normalized = hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname;
+    return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
   } catch {
     return false;
   }

--- a/src/shared/provider-factory.ts
+++ b/src/shared/provider-factory.ts
@@ -49,7 +49,7 @@ export function createStubContributionStore(identity?: string): ContributionStor
   };
 }
 
-function isLoopbackUrl(url: string): boolean {
+export function isLoopbackUrl(url: string): boolean {
   try {
     const { hostname } = new URL(url);
     return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";

--- a/src/shared/provider-factory.ts
+++ b/src/shared/provider-factory.ts
@@ -55,9 +55,8 @@ export function isLoopbackUrl(url: string): boolean {
     // Strip brackets from IPv6 forms: Bun's URL parser returns "[::1]" for
     // `http://[::1]:4515` but Node's whatwg-URL returns "::1". Normalize
     // both so trusted IPv6 loopback URLs aren't treated as remote.
-    const normalized = hostname.startsWith("[") && hostname.endsWith("]")
-      ? hostname.slice(1, -1)
-      : hostname;
+    const normalized =
+      hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
     return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
   } catch {
     return false;

--- a/src/tui/hooks/informer-context.tsx
+++ b/src/tui/hooks/informer-context.tsx
@@ -1,9 +1,14 @@
 /**
  * InformerProvider — supplies an InformerFactory to React subscribers.
  *
- * Eager startAll() at provider mount, stopAll() on unmount. All hooks
- * (useEntities, useEntity, useDerived) consume the factory through this
- * context. Throws when used outside the provider.
+ * PR1 (#387) ships dark: the provider mounts but does NOT call startAll().
+ * Eager-start runs the watch loop (HTTP/SSE for remote, hub subscribe for
+ * local) which would surface backoff/error noise into the OpenTUI Console
+ * panel without any consumer reading the cache. PR2 (#388) flips eager-start
+ * on once the first view migrates to a hook — at that point the watch loop
+ * is justified by a real subscriber. All hooks (useEntities, useEntity,
+ * useDerived) still consume the factory through this context. Throws when
+ * used outside the provider.
  */
 
 import { createContext, type ReactNode, useContext, useEffect } from "react";
@@ -15,17 +20,24 @@ InformerContext.displayName = "InformerContext";
 
 export interface InformerProviderProps {
   readonly value: InformerFactory;
+  /**
+   * When true, the provider eagerly starts all informers on mount and stops
+   * them on unmount. Defaults to false in PR1 (dark ship). Set true once
+   * any hook actually subscribes — PR2 will gate this on env or per-call.
+   */
+  readonly eager?: boolean | undefined;
   readonly children: ReactNode;
 }
 
 export function InformerProvider(props: InformerProviderProps): ReactNode {
-  const { value, children } = props;
+  const { value, eager = false, children } = props;
   useEffect(() => {
+    if (!eager) return;
     value.startAll();
     return () => {
       void value.stopAll();
     };
-  }, [value]);
+  }, [value, eager]);
   return <InformerContext.Provider value={value}>{children}</InformerContext.Provider>;
 }
 

--- a/src/tui/hooks/informer-context.tsx
+++ b/src/tui/hooks/informer-context.tsx
@@ -1,0 +1,42 @@
+/**
+ * InformerProvider — supplies an InformerFactory to React subscribers.
+ *
+ * Eager startAll() at provider mount, stopAll() on unmount. All hooks
+ * (useEntities, useEntity, useDerived) consume the factory through this
+ * context. Throws when used outside the provider.
+ */
+
+import { createContext, type ReactNode, useContext, useEffect } from "react";
+import type { Informer, InformerFactory } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+
+const InformerContext = createContext<InformerFactory | null>(null);
+InformerContext.displayName = "InformerContext";
+
+export interface InformerProviderProps {
+  readonly value: InformerFactory;
+  readonly children: ReactNode;
+}
+
+export function InformerProvider(props: InformerProviderProps): ReactNode {
+  const { value, children } = props;
+  useEffect(() => {
+    value.startAll();
+    return () => {
+      void value.stopAll();
+    };
+  }, [value]);
+  return <InformerContext.Provider value={value}>{children}</InformerContext.Provider>;
+}
+
+export function useInformerFactory(): InformerFactory {
+  const factory = useContext(InformerContext);
+  if (!factory) {
+    throw new Error("useInformer*: must be called inside <InformerProvider>");
+  }
+  return factory;
+}
+
+export function useInformer<K extends WatchKind>(kind: K): Informer<K> {
+  return useInformerFactory().informerFor(kind);
+}

--- a/src/tui/hooks/informer-context.tsx
+++ b/src/tui/hooks/informer-context.tsx
@@ -11,7 +11,15 @@
  * used outside the provider.
  */
 
-import { createContext, type ReactNode, useContext, useEffect } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import type { Informer, InformerFactory } from "../../core/informer.js";
 import type { WatchKind } from "../../core/watch-events.js";
 
@@ -51,4 +59,93 @@ export function useInformerFactory(): InformerFactory {
 
 export function useInformer<K extends WatchKind>(kind: K): Informer<K> {
   return useInformerFactory().informerFor(kind);
+}
+
+/**
+ * Holder for a factory that's not yet known at provider mount time —
+ * needed by the interactive TUI flow (TuiApp) where the factory is
+ * created inside async onInit/onStart/onConnect callbacks AFTER the
+ * setup screen has already rendered. The TUI obtains the holder's
+ * `set()` once and calls it from each callback; the wrapping
+ * `<InformerProviderHolder>` re-renders on change so subsequent screens
+ * have the provider in scope.
+ *
+ * Children rendered before `set()` is called see the context value as
+ * null; calling any hook (`useInformer*`) in that window throws — so do
+ * not migrate any screen to hooks until PR2's view migrations have a
+ * code path guaranteed to render after `set()`.
+ */
+export interface InformerHolder {
+  readonly set: (factory: InformerFactory | null) => void;
+  readonly attach: (listener: () => void) => () => void;
+  readonly current: () => InformerFactory | null;
+}
+
+export function createInformerHolder(): InformerHolder {
+  let factory: InformerFactory | null = null;
+  const listeners = new Set<() => void>();
+  return {
+    set(f) {
+      if (factory === f) return;
+      factory = f;
+      for (const fn of [...listeners]) {
+        try {
+          fn();
+        } catch {
+          // listener thrown — already isolated; nothing to recover.
+        }
+      }
+    },
+    attach(fn) {
+      listeners.add(fn);
+      return () => {
+        listeners.delete(fn);
+      };
+    },
+    current() {
+      return factory;
+    },
+  };
+}
+
+export interface InformerProviderHolderProps {
+  readonly holder: InformerHolder;
+  readonly eager?: boolean | undefined;
+  readonly children: ReactNode;
+}
+
+/**
+ * Provider variant that listens to an `InformerHolder` for a factory that
+ * arrives asynchronously. While `holder.current() === null`, this renders
+ * children without an `<InformerContext>` — same semantics as not wrapping
+ * at all, so dark-ship views are unaffected. Once the factory is set, the
+ * `<InformerProvider>` mounts and any subsequent hook consumer works.
+ */
+export function InformerProviderHolder(props: InformerProviderHolderProps): ReactNode {
+  const { holder, eager, children } = props;
+  const [factory, setFactory] = useState<InformerFactory | null>(() => holder.current());
+  const lastSeen = useRef(factory);
+  lastSeen.current = factory;
+
+  // Coalesce rapid-fire updates from multiple onInit/onStart callbacks
+  // into a single re-render via React's setState semantics.
+  const sync = useCallback(() => {
+    const next = holder.current();
+    if (next !== lastSeen.current) {
+      setFactory(next);
+    }
+  }, [holder]);
+
+  useEffect(() => {
+    const detach = holder.attach(sync);
+    sync();
+    return detach;
+  }, [holder, sync]);
+
+  if (!factory) return <>{children}</>;
+  return (
+    <InformerProvider value={factory} eager={eager}>
+      {children}
+    </InformerProvider>
+  );
 }

--- a/src/tui/hooks/refresh-context.tsx
+++ b/src/tui/hooks/refresh-context.tsx
@@ -5,9 +5,10 @@
  * during the migration; PR5 deletes it.
  */
 
-import { createContext, type ReactNode, useCallback, useContext } from "react";
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useRef, useState } from "react";
 import type { InformerFactory } from "../../core/informer.js";
 import type { WatchKind } from "../../core/watch-events.js";
+import type { InformerHolder } from "./informer-context.js";
 
 type RefreshFn = (kind?: WatchKind) => void;
 
@@ -34,4 +35,32 @@ export function useRelistTrigger(): RefreshFn {
   const fn = useContext(RefreshContext);
   if (!fn) throw new Error("useRelistTrigger: must be inside <RefreshProvider>");
   return fn;
+}
+
+export interface RefreshProviderHolderProps {
+  readonly holder: InformerHolder;
+  readonly children: ReactNode;
+}
+
+/**
+ * Holder variant for the interactive TUI flow — same async-arrival
+ * semantics as `<InformerProviderHolder>` (children render bare until the
+ * factory is set; once set, `<RefreshProvider>` mounts).
+ */
+export function RefreshProviderHolder(props: RefreshProviderHolderProps): ReactNode {
+  const { holder, children } = props;
+  const [factory, setFactory] = useState<InformerFactory | null>(() => holder.current());
+  const lastSeen = useRef(factory);
+  lastSeen.current = factory;
+  const sync = useCallback(() => {
+    const next = holder.current();
+    if (next !== lastSeen.current) setFactory(next);
+  }, [holder]);
+  useEffect(() => {
+    const detach = holder.attach(sync);
+    sync();
+    return detach;
+  }, [holder, sync]);
+  if (!factory) return <>{children}</>;
+  return <RefreshProvider factory={factory}>{children}</RefreshProvider>;
 }

--- a/src/tui/hooks/refresh-context.tsx
+++ b/src/tui/hooks/refresh-context.tsx
@@ -1,0 +1,37 @@
+/**
+ * RefreshProvider — wires the global refresh trigger (r-key) to
+ * factory.relist(). Replaces use-refresh-context.ts's numeric-signal
+ * approach for informer-backed hooks. The old context stays in tree
+ * during the migration; PR5 deletes it.
+ */
+
+import { createContext, type ReactNode, useCallback, useContext } from "react";
+import type { InformerFactory } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+
+type RefreshFn = (kind?: WatchKind) => void;
+
+const RefreshContext = createContext<RefreshFn | null>(null);
+RefreshContext.displayName = "RefreshContext";
+
+export interface RefreshProviderProps {
+  readonly factory: InformerFactory;
+  readonly children: ReactNode;
+}
+
+export function RefreshProvider(props: RefreshProviderProps): ReactNode {
+  const { factory, children } = props;
+  const refresh = useCallback<RefreshFn>(
+    (kind) => {
+      void factory.relist(kind);
+    },
+    [factory],
+  );
+  return <RefreshContext.Provider value={refresh}>{children}</RefreshContext.Provider>;
+}
+
+export function useRelistTrigger(): RefreshFn {
+  const fn = useContext(RefreshContext);
+  if (!fn) throw new Error("useRelistTrigger: must be inside <RefreshProvider>");
+  return fn;
+}

--- a/src/tui/hooks/refresh-context.tsx
+++ b/src/tui/hooks/refresh-context.tsx
@@ -5,7 +5,15 @@
  * during the migration; PR5 deletes it.
  */
 
-import { createContext, type ReactNode, useCallback, useContext, useEffect, useRef, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import type { InformerFactory } from "../../core/informer.js";
 import type { WatchKind } from "../../core/watch-events.js";
 import type { InformerHolder } from "./informer-context.js";

--- a/src/tui/hooks/use-derived.test.ts
+++ b/src/tui/hooks/use-derived.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for useDerived pure reducer.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { stepDerived } from "./use-derived.js";
+
+describe("stepDerived", () => {
+  test("first compute success → data set, error null", () => {
+    const next = stepDerived<number>({ data: undefined, error: null }, () => 42);
+    expect(next.data).toBe(42);
+    expect(next.error).toBeNull();
+    expect(next.committed).toBe(true);
+  });
+
+  test("compute returns same value (Object.is) → no commit", () => {
+    const obj = { a: 1 };
+    const next = stepDerived({ data: obj, error: null }, () => obj);
+    expect(next.committed).toBe(false);
+  });
+
+  test("custom equals comparator → no commit when equal", () => {
+    const next = stepDerived<{ a: number }>(
+      { data: { a: 1 }, error: null },
+      () => ({ a: 1 }),
+      (a, b) => a.a === b.a,
+    );
+    expect(next.committed).toBe(false);
+  });
+
+  test("compute throws → error set, last data preserved", () => {
+    const next = stepDerived<number>({ data: 7, error: null }, () => {
+      throw new Error("boom");
+    });
+    expect(next.data).toBe(7);
+    expect(next.error?.message).toBe("boom");
+    expect(next.committed).toBe(true);
+  });
+
+  test("recovery: previous error cleared on success", () => {
+    const next = stepDerived<number>({ data: 7, error: new Error("old") }, () => 8);
+    expect(next.data).toBe(8);
+    expect(next.error).toBeNull();
+    expect(next.committed).toBe(true);
+  });
+});

--- a/src/tui/hooks/use-derived.ts
+++ b/src/tui/hooks/use-derived.ts
@@ -117,6 +117,18 @@ export function useDerived<T>(
         setStreamError(null);
       }),
     );
+    // Re-read after subscribing to close the gap between render-time
+    // initialization and effect-time subscription: an error fired in that
+    // window would otherwise be lost since addErrorListener only delivers
+    // future events. This reconciliation is safe — getLastError reflects
+    // the durable state, and setStreamError dedups identical values.
+    for (const k of kinds) {
+      const e = factory.getLastError(k);
+      if (e) {
+        setStreamError(e);
+        break;
+      }
+    }
     return () => {
       for (const u of unsubs) u();
     };

--- a/src/tui/hooks/use-derived.ts
+++ b/src/tui/hooks/use-derived.ts
@@ -1,0 +1,88 @@
+/**
+ * useDerived — reactive projection over one or more informers.
+ *
+ * Subscribes to every listed kind; recomputes `compute()` on any event
+ * from any of them; commits a new state only when the output changed
+ * (Object.is by default, caller-provided `equals` for non-trivial
+ * shapes). Exceptions in `compute` set `error`; last-good `data`
+ * is preserved.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import type { WatchKind } from "../../core/watch-events.js";
+import { useInformerFactory } from "./informer-context.js";
+
+export interface DerivedState<T> {
+  readonly data: T | undefined;
+  readonly error: Error | null;
+}
+
+export interface DerivedStep<T> extends DerivedState<T> {
+  readonly committed: boolean;
+}
+
+export function stepDerived<T>(
+  prev: DerivedState<T>,
+  compute: () => T,
+  equals: (a: T, b: T) => boolean = Object.is,
+): DerivedStep<T> {
+  try {
+    const next = compute();
+    if (prev.data !== undefined && equals(prev.data, next)) {
+      if (prev.error === null) {
+        return { data: prev.data, error: null, committed: false };
+      }
+      return { data: prev.data, error: null, committed: true };
+    }
+    return { data: next, error: null, committed: true };
+  } catch (err) {
+    return {
+      data: prev.data,
+      error: err instanceof Error ? err : new Error(String(err)),
+      committed: true,
+    };
+  }
+}
+
+export interface UseDerivedResult<T> {
+  readonly data: T | undefined;
+  readonly hasSynced: boolean;
+  readonly error: Error | null;
+}
+
+export function useDerived<T>(
+  compute: () => T,
+  kinds: readonly WatchKind[],
+  equals: (a: T, b: T) => boolean = Object.is,
+): UseDerivedResult<T> {
+  const factory = useInformerFactory();
+  const computeRef = useRef(compute);
+  computeRef.current = compute;
+  const equalsRef = useRef(equals);
+  equalsRef.current = equals;
+
+  const [state, setState] = useState<DerivedState<T>>(() =>
+    stepDerived<T>({ data: undefined, error: null }, () => computeRef.current()),
+  );
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const informers = kinds.map((k) => factory.informerFor(k));
+  const [hasSynced, setHasSynced] = useState<boolean>(() => informers.every((i) => i.hasSynced()));
+
+  const kindsKey = kinds.join(",");
+  // biome-ignore lint/correctness/useExhaustiveDependencies: kinds compared by joined string identity
+  useEffect(() => {
+    const tick = (): void => {
+      const next = stepDerived<T>(stateRef.current, () => computeRef.current(), equalsRef.current);
+      if (next.committed) setState({ data: next.data, error: next.error });
+      if (!hasSynced && informers.every((i) => i.hasSynced())) setHasSynced(true);
+    };
+    const unsubs = informers.map((i) => i.addEventHandler(tick));
+    return () => {
+      for (const u of unsubs) u();
+    };
+  }, [factory, kindsKey, hasSynced]);
+
+  return { data: state.data, hasSynced, error: state.error };
+}

--- a/src/tui/hooks/use-derived.ts
+++ b/src/tui/hooks/use-derived.ts
@@ -78,7 +78,13 @@ export function useDerived<T>(
       if (next.committed) setState({ data: next.data, error: next.error });
       if (!hasSynced && informers.every((i) => i.hasSynced())) setHasSynced(true);
     };
-    const unsubs = informers.map((i) => i.addEventHandler(tick));
+    // Subscribe to per-entity events AND RELIST_END so empty/unchanged
+    // snapshots still flip hasSynced when every kind has synced.
+    const unsubs: Array<() => void> = [];
+    for (const i of informers) {
+      unsubs.push(i.addEventHandler(tick));
+      unsubs.push(i.addSyncHandler(tick));
+    }
     return () => {
       for (const u of unsubs) u();
     };

--- a/src/tui/hooks/use-derived.ts
+++ b/src/tui/hooks/use-derived.ts
@@ -117,18 +117,21 @@ export function useDerived<T>(
         setStreamError(null);
       }),
     );
-    // Re-read after subscribing to close the gap between render-time
-    // initialization and effect-time subscription: an error fired in that
-    // window would otherwise be lost since addErrorListener only delivers
-    // future events. This reconciliation is safe — getLastError reflects
-    // the durable state, and setStreamError dedups identical values.
+    // Re-read after subscribing to close BOTH directions of the gap between
+    // render-time initialization and effect-time subscription: an error
+    // appearing OR being cleared in that window would otherwise be lost,
+    // since addErrorListener only delivers future events. Walk every
+    // watched kind and set unconditionally — null when all kinds are
+    // healthy, otherwise the first non-null error.
+    let firstErr: Error | null = null;
     for (const k of kinds) {
       const e = factory.getLastError(k);
       if (e) {
-        setStreamError(e);
+        firstErr = e;
         break;
       }
     }
+    setStreamError(firstErr);
     return () => {
       for (const u of unsubs) u();
     };

--- a/src/tui/hooks/use-derived.ts
+++ b/src/tui/hooks/use-derived.ts
@@ -69,6 +69,15 @@ export function useDerived<T>(
 
   const informers = kinds.map((k) => factory.informerFor(k));
   const [hasSynced, setHasSynced] = useState<boolean>(() => informers.every((i) => i.hasSynced()));
+  // First non-null factory error across all watched kinds; mirrors useEntities'
+  // separation so a recompute can't mask a terminal stream failure.
+  const [streamError, setStreamError] = useState<Error | null>(() => {
+    for (const k of kinds) {
+      const e = factory.getLastError(k);
+      if (e) return e;
+    }
+    return null;
+  });
 
   const kindsKey = kinds.join(",");
   // biome-ignore lint/correctness/useExhaustiveDependencies: kinds compared by joined string identity
@@ -85,10 +94,35 @@ export function useDerived<T>(
       unsubs.push(i.addEventHandler(tick));
       unsubs.push(i.addSyncHandler(tick));
     }
+    // Stream error subscription: surface terminal informer.run() failures
+    // for any of the watched kinds. Resolved (null) when the kind hits its
+    // first RELIST_END after restart — see InformerFactory.startOne.
+    const watched = new Set<WatchKind>(kinds);
+    unsubs.push(
+      factory.addErrorListener((kind, err) => {
+        if (!watched.has(kind)) return;
+        if (err) {
+          setStreamError(err);
+          return;
+        }
+        // Recovery for one kind — only clear if no other watched kind is
+        // still in error; otherwise show whichever one is still failing.
+        for (const k of kinds) {
+          const remaining = factory.getLastError(k);
+          if (remaining) {
+            setStreamError(remaining);
+            return;
+          }
+        }
+        setStreamError(null);
+      }),
+    );
     return () => {
       for (const u of unsubs) u();
     };
   }, [factory, kindsKey, hasSynced]);
 
-  return { data: state.data, hasSynced, error: state.error };
+  // Stream errors take precedence over compute errors — the watch lifecycle
+  // is the more actionable signal.
+  return { data: state.data, hasSynced, error: streamError ?? state.error };
 }

--- a/src/tui/hooks/use-entities.test.ts
+++ b/src/tui/hooks/use-entities.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for useEntities pure helpers.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { computeFilteredEntities, shallowArraysEqual } from "./use-entities.js";
+
+describe("shallowArraysEqual", () => {
+  test("identical references → true", () => {
+    const a = [1, 2, 3];
+    expect(shallowArraysEqual(a, a)).toBe(true);
+  });
+
+  test("different lengths → false", () => {
+    expect(shallowArraysEqual([1, 2], [1, 2, 3])).toBe(false);
+  });
+
+  test("same elements in same order → true", () => {
+    const a = { id: "a" };
+    const b = { id: "b" };
+    expect(shallowArraysEqual([a, b], [a, b])).toBe(true);
+  });
+
+  test("same length, different element identity → false", () => {
+    expect(shallowArraysEqual([{ id: "a" }], [{ id: "a" }])).toBe(false);
+  });
+
+  test("NaN handled by Object.is", () => {
+    expect(shallowArraysEqual([Number.NaN], [Number.NaN])).toBe(true);
+  });
+});
+
+describe("computeFilteredEntities", () => {
+  const e1 = { id: "a" } as unknown as { id: string };
+  const e2 = { id: "b" } as unknown as { id: string };
+
+  test("undefined predicate returns the input array reference", () => {
+    const list = [e1, e2];
+    expect(computeFilteredEntities(list, undefined)).toBe(list);
+  });
+
+  test("predicate filters", () => {
+    const out = computeFilteredEntities([e1, e2], (e) => e.id === "a");
+    expect(out).toEqual([e1]);
+  });
+
+  test("predicate that throws is propagated to caller", () => {
+    const boom = (): boolean => {
+      throw new Error("boom");
+    };
+    expect(() => computeFilteredEntities([e1], boom)).toThrow("boom");
+  });
+});

--- a/src/tui/hooks/use-entities.ts
+++ b/src/tui/hooks/use-entities.ts
@@ -12,7 +12,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Informer } from "../../core/informer.js";
 import type { WatchKind } from "../../core/watch-events.js";
-import { useInformer } from "./informer-context.js";
+import { useInformer, useInformerFactory } from "./informer-context.js";
 
 export function shallowArraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
   if (a === b) return true;
@@ -44,6 +44,7 @@ export function useEntities<K extends WatchKind>(
   predicate?: (e: EntityFor<K>) => boolean,
 ): UseEntitiesResult<EntityFor<K>> {
   const informer = useInformer(kind);
+  const factory = useInformerFactory();
   const predicateRef = useRef(predicate);
 
   const initial = useMemo<readonly EntityFor<K>[]>(() => {
@@ -59,7 +60,7 @@ export function useEntities<K extends WatchKind>(
 
   const [data, setData] = useState<readonly EntityFor<K>[]>(initial);
   const [hasSynced, setHasSynced] = useState<boolean>(informer.hasSynced());
-  const [error, setError] = useState<Error | null>(null);
+  const [error, setError] = useState<Error | null>(() => factory.getLastError(kind));
   const dataRef = useRef<readonly EntityFor<K>[]>(initial);
   dataRef.current = data;
 
@@ -106,15 +107,22 @@ export function useEntities<K extends WatchKind>(
     // hasSynced and trigger a recompute. Without this, a consumer mounted
     // before the first sync of an empty store stays hasSynced=false.
     const unsubSync = informer.addSyncHandler(recompute);
+    // Surface terminal informer.run() failures (remote 4xx, listFn throw)
+    // so consumers don't sit at hasSynced=false with no diagnostic.
+    const unsubError = factory.addErrorListener((errKind, err) => {
+      if (errKind !== kind) return;
+      setError(err);
+    });
     return () => {
       unsubEvent();
       unsubSync();
+      unsubError();
     };
     // recompute closes over informer, hasSynced, error — re-subscribe when
     // any change. Predicate captured via ref so identity changes don't
     // remount the subscription.
     // biome-ignore lint/correctness/useExhaustiveDependencies: recompute is the effect body itself
-  }, [informer, hasSynced, error]);
+  }, [informer, factory, kind, hasSynced, error]);
 
   return { data, hasSynced, error };
 }

--- a/src/tui/hooks/use-entities.ts
+++ b/src/tui/hooks/use-entities.ts
@@ -9,7 +9,7 @@
  * thin wrapper around them.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Informer } from "../../core/informer.js";
 import type { WatchKind } from "../../core/watch-events.js";
 import { useInformer, useInformerFactory } from "./informer-context.js";
@@ -63,9 +63,7 @@ export function useEntities<K extends WatchKind>(
   // Stream errors come from the factory's error listener — owned by the
   // watch lifecycle (4xx, listFn throw, etc). Cleared only when the factory
   // fires `null` (proven recovery: first RELIST_END after restart).
-  const [streamError, setStreamError] = useState<Error | null>(() =>
-    factory.getLastError(kind),
-  );
+  const [streamError, setStreamError] = useState<Error | null>(() => factory.getLastError(kind));
   // Compute errors come from the predicate function throwing during a
   // recompute. Cleared on the next successful recompute. Kept separate so
   // recompute-after-stale-sync can't erase a stream error owned by the
@@ -74,7 +72,11 @@ export function useEntities<K extends WatchKind>(
   const dataRef = useRef<readonly EntityFor<K>[]>(initial);
   dataRef.current = data;
 
-  const recompute = (): void => {
+  // Stable recompute via ref so the effect's dependency list stays tight —
+  // closure captures latest informer + predicate via ref, so the effect
+  // doesn't need to re-subscribe on every render to see fresh values.
+  const recomputeRef = useRef<() => void>(() => {});
+  recomputeRef.current = (): void => {
     try {
       const next = computeFilteredEntities(
         informer.list() as readonly EntityFor<K>[],
@@ -89,6 +91,7 @@ export function useEntities<K extends WatchKind>(
       setComputeError(err instanceof Error ? err : new Error(String(err)));
     }
   };
+  const recompute = useCallback((): void => recomputeRef.current(), []);
 
   // Recompute synchronously when the predicate identity changes — without
   // this, callers who pass a fresh closure every render would see stale
@@ -96,10 +99,7 @@ export function useEntities<K extends WatchKind>(
   if (predicateRef.current !== predicate) {
     predicateRef.current = predicate;
     try {
-      const next = computeFilteredEntities(
-        informer.list() as readonly EntityFor<K>[],
-        predicate,
-      );
+      const next = computeFilteredEntities(informer.list() as readonly EntityFor<K>[], predicate);
       if (!shallowArraysEqual(dataRef.current, next)) {
         // Defer to a microtask so the setState happens after this render
         // completes — React forbids setState during render of the same
@@ -107,9 +107,7 @@ export function useEntities<K extends WatchKind>(
         queueMicrotask(() => setData(next));
       }
     } catch (err) {
-      queueMicrotask(() =>
-        setComputeError(err instanceof Error ? err : new Error(String(err))),
-      );
+      queueMicrotask(() => setComputeError(err instanceof Error ? err : new Error(String(err))));
     }
   }
 
@@ -136,8 +134,7 @@ export function useEntities<K extends WatchKind>(
       unsubSync();
       unsubError();
     };
-    // biome-ignore lint/correctness/useExhaustiveDependencies: recompute closes over hasSynced via setState callback semantics
-  }, [informer, factory, kind, hasSynced]);
+  }, [informer, factory, kind, recompute]);
 
   // Stream errors take precedence — they signal the watch lifecycle is
   // unhealthy, which is more actionable than a transient predicate failure.

--- a/src/tui/hooks/use-entities.ts
+++ b/src/tui/hooks/use-entities.ts
@@ -45,7 +45,6 @@ export function useEntities<K extends WatchKind>(
 ): UseEntitiesResult<EntityFor<K>> {
   const informer = useInformer(kind);
   const predicateRef = useRef(predicate);
-  predicateRef.current = predicate;
 
   const initial = useMemo<readonly EntityFor<K>[]>(() => {
     try {
@@ -64,23 +63,57 @@ export function useEntities<K extends WatchKind>(
   const dataRef = useRef<readonly EntityFor<K>[]>(initial);
   dataRef.current = data;
 
-  useEffect(() => {
-    const unsub = informer.addEventHandler(() => {
-      try {
-        const next = computeFilteredEntities(
-          informer.list() as readonly EntityFor<K>[],
-          predicateRef.current,
-        );
-        if (!shallowArraysEqual(dataRef.current, next)) {
-          setData(next);
-        }
-        if (!hasSynced && informer.hasSynced()) setHasSynced(true);
-        if (error) setError(null);
-      } catch (err) {
-        setError(err instanceof Error ? err : new Error(String(err)));
+  const recompute = (): void => {
+    try {
+      const next = computeFilteredEntities(
+        informer.list() as readonly EntityFor<K>[],
+        predicateRef.current,
+      );
+      if (!shallowArraysEqual(dataRef.current, next)) {
+        setData(next);
       }
-    });
-    return unsub;
+      if (!hasSynced && informer.hasSynced()) setHasSynced(true);
+      if (error) setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    }
+  };
+
+  // Recompute synchronously when the predicate identity changes — without
+  // this, callers who pass a fresh closure every render would see stale
+  // filtered output until the next watch event arrived.
+  if (predicateRef.current !== predicate) {
+    predicateRef.current = predicate;
+    try {
+      const next = computeFilteredEntities(
+        informer.list() as readonly EntityFor<K>[],
+        predicate,
+      );
+      if (!shallowArraysEqual(dataRef.current, next)) {
+        // Defer to a microtask so the setState happens after this render
+        // completes — React forbids setState during render of the same
+        // component but allows it before commit.
+        queueMicrotask(() => setData(next));
+      }
+    } catch (err) {
+      queueMicrotask(() => setError(err instanceof Error ? err : new Error(String(err))));
+    }
+  }
+
+  useEffect(() => {
+    const unsubEvent = informer.addEventHandler(recompute);
+    // Subscribe to RELIST_END so empty/unchanged snapshots still flip
+    // hasSynced and trigger a recompute. Without this, a consumer mounted
+    // before the first sync of an empty store stays hasSynced=false.
+    const unsubSync = informer.addSyncHandler(recompute);
+    return () => {
+      unsubEvent();
+      unsubSync();
+    };
+    // recompute closes over informer, hasSynced, error — re-subscribe when
+    // any change. Predicate captured via ref so identity changes don't
+    // remount the subscription.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: recompute is the effect body itself
   }, [informer, hasSynced, error]);
 
   return { data, hasSynced, error };

--- a/src/tui/hooks/use-entities.ts
+++ b/src/tui/hooks/use-entities.ts
@@ -1,0 +1,87 @@
+/**
+ * useEntities — reactive filtered list view over the informer cache.
+ *
+ * Subscribes to the named kind's informer once per consumer; recomputes
+ * the filtered list on every event; commits a new array reference only
+ * when the filtered slice actually changed (shallow equality).
+ *
+ * Pure helpers below are exported for unit tests; the React hook is a
+ * thin wrapper around them.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Informer } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+import { useInformer } from "./informer-context.js";
+
+export function shallowArraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (!Object.is(a[i], b[i])) return false;
+  }
+  return true;
+}
+
+export function computeFilteredEntities<E>(
+  list: readonly E[],
+  predicate: ((e: E) => boolean) | undefined,
+): readonly E[] {
+  if (!predicate) return list;
+  return list.filter(predicate);
+}
+
+export interface UseEntitiesResult<E> {
+  readonly data: readonly E[];
+  readonly hasSynced: boolean;
+  readonly error: Error | null;
+}
+
+type EntityFor<K extends WatchKind> = ReturnType<Informer<K>["list"]>[number];
+
+export function useEntities<K extends WatchKind>(
+  kind: K,
+  predicate?: (e: EntityFor<K>) => boolean,
+): UseEntitiesResult<EntityFor<K>> {
+  const informer = useInformer(kind);
+  const predicateRef = useRef(predicate);
+  predicateRef.current = predicate;
+
+  const initial = useMemo<readonly EntityFor<K>[]>(() => {
+    try {
+      return computeFilteredEntities(
+        informer.list() as readonly EntityFor<K>[],
+        predicateRef.current,
+      );
+    } catch {
+      return [];
+    }
+  }, [informer]);
+
+  const [data, setData] = useState<readonly EntityFor<K>[]>(initial);
+  const [hasSynced, setHasSynced] = useState<boolean>(informer.hasSynced());
+  const [error, setError] = useState<Error | null>(null);
+  const dataRef = useRef<readonly EntityFor<K>[]>(initial);
+  dataRef.current = data;
+
+  useEffect(() => {
+    const unsub = informer.addEventHandler(() => {
+      try {
+        const next = computeFilteredEntities(
+          informer.list() as readonly EntityFor<K>[],
+          predicateRef.current,
+        );
+        if (!shallowArraysEqual(dataRef.current, next)) {
+          setData(next);
+        }
+        if (!hasSynced && informer.hasSynced()) setHasSynced(true);
+        if (error) setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+    return unsub;
+  }, [informer, hasSynced, error]);
+
+  return { data, hasSynced, error };
+}

--- a/src/tui/hooks/use-entities.ts
+++ b/src/tui/hooks/use-entities.ts
@@ -125,12 +125,12 @@ export function useEntities<K extends WatchKind>(
       if (errKind !== kind) return;
       setStreamError(err);
     });
-    // Re-read after subscribing to close the gap between render-time
-    // initialization and effect-time subscription: an error fired in that
-    // window would otherwise be lost since addErrorListener only delivers
-    // future events. setStreamError dedups identical values.
-    const currentErr = factory.getLastError(kind);
-    if (currentErr) setStreamError(currentErr);
+    // Re-read after subscribing to close BOTH directions of the gap between
+    // render-time initialization and effect-time subscription: an error
+    // appearing OR being cleared in that window would otherwise be lost,
+    // since addErrorListener only delivers future events. Set
+    // unconditionally to reconcile both error-appears and error-clears.
+    setStreamError(factory.getLastError(kind));
     return () => {
       unsubEvent();
       unsubSync();

--- a/src/tui/hooks/use-entities.ts
+++ b/src/tui/hooks/use-entities.ts
@@ -125,6 +125,12 @@ export function useEntities<K extends WatchKind>(
       if (errKind !== kind) return;
       setStreamError(err);
     });
+    // Re-read after subscribing to close the gap between render-time
+    // initialization and effect-time subscription: an error fired in that
+    // window would otherwise be lost since addErrorListener only delivers
+    // future events. setStreamError dedups identical values.
+    const currentErr = factory.getLastError(kind);
+    if (currentErr) setStreamError(currentErr);
     return () => {
       unsubEvent();
       unsubSync();

--- a/src/tui/hooks/use-entities.ts
+++ b/src/tui/hooks/use-entities.ts
@@ -60,7 +60,17 @@ export function useEntities<K extends WatchKind>(
 
   const [data, setData] = useState<readonly EntityFor<K>[]>(initial);
   const [hasSynced, setHasSynced] = useState<boolean>(informer.hasSynced());
-  const [error, setError] = useState<Error | null>(() => factory.getLastError(kind));
+  // Stream errors come from the factory's error listener — owned by the
+  // watch lifecycle (4xx, listFn throw, etc). Cleared only when the factory
+  // fires `null` (proven recovery: first RELIST_END after restart).
+  const [streamError, setStreamError] = useState<Error | null>(() =>
+    factory.getLastError(kind),
+  );
+  // Compute errors come from the predicate function throwing during a
+  // recompute. Cleared on the next successful recompute. Kept separate so
+  // recompute-after-stale-sync can't erase a stream error owned by the
+  // watch lifecycle.
+  const [computeError, setComputeError] = useState<Error | null>(null);
   const dataRef = useRef<readonly EntityFor<K>[]>(initial);
   dataRef.current = data;
 
@@ -74,9 +84,9 @@ export function useEntities<K extends WatchKind>(
         setData(next);
       }
       if (!hasSynced && informer.hasSynced()) setHasSynced(true);
-      if (error) setError(null);
+      setComputeError((prev) => (prev === null ? prev : null));
     } catch (err) {
-      setError(err instanceof Error ? err : new Error(String(err)));
+      setComputeError(err instanceof Error ? err : new Error(String(err)));
     }
   };
 
@@ -97,7 +107,9 @@ export function useEntities<K extends WatchKind>(
         queueMicrotask(() => setData(next));
       }
     } catch (err) {
-      queueMicrotask(() => setError(err instanceof Error ? err : new Error(String(err))));
+      queueMicrotask(() =>
+        setComputeError(err instanceof Error ? err : new Error(String(err))),
+      );
     }
   }
 
@@ -111,18 +123,17 @@ export function useEntities<K extends WatchKind>(
     // so consumers don't sit at hasSynced=false with no diagnostic.
     const unsubError = factory.addErrorListener((errKind, err) => {
       if (errKind !== kind) return;
-      setError(err);
+      setStreamError(err);
     });
     return () => {
       unsubEvent();
       unsubSync();
       unsubError();
     };
-    // recompute closes over informer, hasSynced, error — re-subscribe when
-    // any change. Predicate captured via ref so identity changes don't
-    // remount the subscription.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: recompute is the effect body itself
-  }, [informer, factory, kind, hasSynced, error]);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: recompute closes over hasSynced via setState callback semantics
+  }, [informer, factory, kind, hasSynced]);
 
-  return { data, hasSynced, error };
+  // Stream errors take precedence — they signal the watch lifecycle is
+  // unhealthy, which is more actionable than a transient predicate failure.
+  return { data, hasSynced, error: streamError ?? computeError };
 }

--- a/src/tui/hooks/use-entity.test.ts
+++ b/src/tui/hooks/use-entity.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for useEntity pure selector.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Informer } from "../../core/informer.js";
+import { selectEntityById } from "./use-entity.js";
+
+function fakeInformer<E extends { id: string }>(items: readonly E[]): Informer {
+  return {
+    list: () => items,
+    getById: (id: string) => items.find((i) => i.id === id),
+    hasSynced: () => true,
+    addEventHandler: () => () => undefined,
+  } as unknown as Informer;
+}
+
+describe("selectEntityById", () => {
+  test("undefined id returns undefined and never calls getById", () => {
+    let calls = 0;
+    const inf = {
+      ...fakeInformer([{ id: "a" }]),
+      getById: (_id: string) => {
+        calls += 1;
+        return undefined;
+      },
+    } as unknown as Informer;
+    expect(selectEntityById(inf, undefined)).toBeUndefined();
+    expect(calls).toBe(0);
+  });
+
+  test("id present in cache returns the entity", () => {
+    const a = { id: "a" };
+    const inf = fakeInformer([a]);
+    expect(selectEntityById(inf, "a")).toBe(a as never);
+  });
+
+  test("id absent returns undefined", () => {
+    const inf = fakeInformer<{ id: string }>([{ id: "a" }]);
+    expect(selectEntityById(inf, "missing")).toBeUndefined();
+  });
+});

--- a/src/tui/hooks/use-entity.ts
+++ b/src/tui/hooks/use-entity.ts
@@ -1,0 +1,53 @@
+/**
+ * useEntity — reactive single-record subscription over the informer cache.
+ *
+ * Subscribes to the named kind, but the handler ignores events whose
+ * entity id ≠ id, avoiding re-render churn for unrelated changes.
+ */
+
+import { useEffect, useState } from "react";
+import type { Informer } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+import { useInformer } from "./informer-context.js";
+
+export function selectEntityById<I extends Informer>(
+  informer: I,
+  id: string | undefined,
+): ReturnType<I["getById"]> | undefined {
+  if (id === undefined) return undefined;
+  return informer.getById(id) as ReturnType<I["getById"]>;
+}
+
+export interface UseEntityResult<E> {
+  readonly data: E | undefined;
+  readonly hasSynced: boolean;
+}
+
+type EntityFor<K extends WatchKind> = NonNullable<ReturnType<Informer<K>["getById"]>>;
+
+export function useEntity<K extends WatchKind>(
+  kind: K,
+  id: string | undefined,
+): UseEntityResult<EntityFor<K>> {
+  const informer = useInformer(kind);
+  const [data, setData] = useState<EntityFor<K> | undefined>(
+    () => selectEntityById(informer, id) as EntityFor<K> | undefined,
+  );
+  const [hasSynced, setHasSynced] = useState<boolean>(informer.hasSynced());
+
+  useEffect(() => {
+    if (id === undefined) {
+      setData(undefined);
+      return;
+    }
+    setData(selectEntityById(informer, id) as EntityFor<K> | undefined);
+    const unsub = informer.addEventHandler((_op, entity) => {
+      if (entity.id !== id) return;
+      setData(selectEntityById(informer, id) as EntityFor<K> | undefined);
+      if (!hasSynced && informer.hasSynced()) setHasSynced(true);
+    });
+    return unsub;
+  }, [informer, id, hasSynced]);
+
+  return { data, hasSynced };
+}

--- a/src/tui/hooks/use-entity.ts
+++ b/src/tui/hooks/use-entity.ts
@@ -41,12 +41,21 @@ export function useEntity<K extends WatchKind>(
       return;
     }
     setData(selectEntityById(informer, id) as EntityFor<K> | undefined);
-    const unsub = informer.addEventHandler((_op, entity) => {
+    const unsubEvent = informer.addEventHandler((_op, entity) => {
       if (entity.id !== id) return;
       setData(selectEntityById(informer, id) as EntityFor<K> | undefined);
       if (!hasSynced && informer.hasSynced()) setHasSynced(true);
     });
-    return unsub;
+    // Subscribe to RELIST_END so empty/unchanged snapshots still flip
+    // hasSynced and refresh data, even when no per-entity event fires.
+    const unsubSync = informer.addSyncHandler(() => {
+      setData(selectEntityById(informer, id) as EntityFor<K> | undefined);
+      if (!hasSynced && informer.hasSynced()) setHasSynced(true);
+    });
+    return () => {
+      unsubEvent();
+      unsubSync();
+    };
   }, [informer, id, hasSynced]);
 
   return { data, hasSynced };

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -474,18 +474,18 @@ async function buildAppProps(
           authHeader,
         });
       }
-    } else if (backend.mode === "local" && groveDir) {
-      const { WatchHub } = await import("../core/watch-hub.js");
-      informerFactory = new InformerFactory({
-        mode: "local",
-        hub: new WatchHub(),
-        namespace: "default",
-        listFn: () => [],
-      });
     }
-    // backend.mode === "nexus" intentionally NOT wired in PR1: WatchClient
-    // targets grove-server endpoints, not Nexus. Hooks called against a
-    // missing factory throw — a louder signal than a silent watch failure.
+    // backend.mode === "local" / "nexus" intentionally NOT wired in PR1:
+    // - "local": LocalWatchClient with listFn=() => [] would synthesize a
+    //   "synced empty cache" since RELIST_END would fire on the empty
+    //   snapshot, and the unconnected WatchHub would never receive
+    //   recordWrite from the existing local stores. PR2 wires real
+    //   listEntities() + recordWrite producers before exposing this.
+    // - "nexus": WatchClient targets grove-server `/api/list` + `/api/watch`,
+    //   which Nexus does not host. PR2 either adds a Nexus-backed WatchStream
+    //   or routes through grove-server.
+    // In both cases, hook consumers throw on a missing provider — a louder
+    // signal than a silent watch failure.
     //
     // No stopAll() callback in PR1 — InformerProvider doesn't auto-start
     // the informers (ships dark). PR2 turns eager-start on; at that point the

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -244,18 +244,24 @@ async function buildAppProps(
   const label = backendLabel(backend);
 
   // For remote backends, attach the local API key for topology/contract probes
-  // only when the user explicitly provided --grove (opting into credential scope).
-  // Without --grove, omit credentials to avoid leaking tokens to arbitrary --url targets.
+  // when the user explicitly provided --grove (opting into credential scope)
+  // OR the URL targets a trusted loopback (mirrors createProvider — common
+  // dev pattern: `grove tui --url http://localhost:4515`). Without either,
+  // omit credentials to avoid leaking tokens to arbitrary --url targets.
   let remoteAuthHeaders: Record<string, string> | undefined;
-  if (backend.mode === "remote" && backend.groveOverride) {
-    const { resolveGroveDir } = await import("../cli/utils/grove-dir.js");
-    const { readClientKey } = await import("../core/project-key.js");
-    try {
-      const { groveDir } = resolveGroveDir(backend.groveOverride);
-      const apiKey = readClientKey(groveDir);
-      if (apiKey) remoteAuthHeaders = { Authorization: `Bearer ${apiKey}` };
-    } catch {
-      /* no key available */
+  if (backend.mode === "remote") {
+    const { isLoopbackUrl } = await import("../shared/provider-factory.js");
+    const isLoopback = isLoopbackUrl(backend.url);
+    if (backend.groveOverride || isLoopback) {
+      const { resolveGroveDir } = await import("../cli/utils/grove-dir.js");
+      const { readClientKey } = await import("../core/project-key.js");
+      try {
+        const { groveDir } = resolveGroveDir(backend.groveOverride);
+        const apiKey = readClientKey(groveDir);
+        if (apiKey) remoteAuthHeaders = { Authorization: `Bearer ${apiKey}` };
+      } catch {
+        /* no key available */
+      }
     }
   }
 
@@ -445,23 +451,22 @@ async function buildAppProps(
   }
 
   // Construct InformerFactory for the new SSE-driven cache (#295). Ships dark
-  // in PR1 — no view consumes the factory yet. The factory is built from the
-  // resolved backend (post-health-fallback) so the watch source matches what
-  // the rest of the TUI is reading from. PR2 wires real local hub publishers
-  // and listFns when the first view migrates.
+  // in PR1 — no view consumes the factory yet. The factory targets the
+  // grove-server watch routes (`/api/list`, `/api/watch`), which means it's
+  // only usable in `mode: "remote"` (grove-server). `mode: "nexus"` talks to
+  // Nexus VFS endpoints which do not host these routes; PR2 either adds a
+  // Nexus-backed WatchStream or routes through grove-server. Local mode uses
+  // an in-process WatchHub; PR2 wires real local store snapshots and
+  // recordWrite publishers.
   let informerFactory: import("../core/informer.js").InformerFactory | undefined;
   {
     const { InformerFactory } = await import("../core/informer.js");
-    if (backend.mode === "nexus" || backend.mode === "remote") {
-      // For remote backends, prefer the credential resolved earlier in this
-      // function (remoteAuthHeaders) — it follows the same provider scope
-      // gate so we don't leak project keys into arbitrary --url targets.
-      // Falls back to env vars used by the legacy SSE bridge.
-      let authHeader = remoteAuthHeaders?.Authorization;
-      if (!authHeader) {
-        const apiKey = process.env.NEXUS_API_KEY;
-        if (apiKey) authHeader = `Bearer ${apiKey}`;
-      }
+    if (backend.mode === "remote") {
+      const authHeader = remoteAuthHeaders?.Authorization;
+      // Grove-server watch routes require auth; without a credential we can't
+      // construct a usable factory. Better to omit it than to start watching
+      // anonymously and surface 401 noise — hooks throw on factory absence
+      // when called outside a provider, which makes the gap obvious.
       if (authHeader) {
         informerFactory = new InformerFactory({
           mode: "remote",
@@ -469,10 +474,7 @@ async function buildAppProps(
           authHeader,
         });
       }
-      // No credential → no factory. Better to throw on hook use later than
-      // to silently watch with anonymous credentials and collide with
-      // permission rules.
-    } else if (groveDir) {
+    } else if (backend.mode === "local" && groveDir) {
       const { WatchHub } = await import("../core/watch-hub.js");
       informerFactory = new InformerFactory({
         mode: "local",
@@ -481,6 +483,10 @@ async function buildAppProps(
         listFn: () => [],
       });
     }
+    // backend.mode === "nexus" intentionally NOT wired in PR1: WatchClient
+    // targets grove-server endpoints, not Nexus. Hooks called against a
+    // missing factory throw — a louder signal than a silent watch failure.
+    //
     // No stopAll() callback in PR1 — InformerProvider doesn't auto-start
     // the informers (ships dark). PR2 turns eager-start on; at that point the
     // provider's own unmount cleanup handles stopAll. Adding a stopCallback

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -468,12 +468,11 @@ async function buildAppProps(
         listFn: () => [],
       });
     }
-    if (informerFactory) {
-      const f = informerFactory;
-      stopCallbacks.push(() => {
-        void f.stopAll();
-      });
-    }
+    // No stopAll() callback in PR1 — InformerProvider doesn't auto-start
+    // the informers (ships dark). PR2 turns eager-start on; at that point the
+    // provider's own unmount cleanup handles stopAll. Adding a stopCallback
+    // here would call stopAll() on a never-started factory, which is a no-op
+    // but adds noise.
   }
 
   return {

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -804,6 +804,14 @@ export async function handleTui(
 
     const presets = await loadPresetList();
 
+    // PR1 (#295): factory holder threaded into both lifecycle callbacks AND
+    // the React tree. Callbacks call `set()` after `buildAppProps` resolves;
+    // <InformerProviderHolder> re-renders the tree with the live factory in
+    // scope. Until the first set, useInformer*() throws — guard hooks with
+    // a runtime-presence check until PR2 has migrated views.
+    const { createInformerHolder } = await import("./hooks/informer-context.js");
+    const informerHolder = createInformerHolder();
+
     // onInit: handles "New session" in an existing grove, or full init for a new grove.
     // When GROVE_DIR/groveExists — skip executeInit entirely (don't touch Nexus or GROVE.md).
     // Only run executeInit when truly creating a new grove from scratch.
@@ -874,6 +882,11 @@ export async function handleTui(
       const result = await buildAppProps(newGroveDir, opts, presetName);
       activeProvider = result.provider;
       activeStopGc = result.stopGc;
+      // PR1 (#295): expose the factory to <InformerProviderHolder> so any
+      // hook consumer mounted after this callback resolves sees the live
+      // factory. Ships dark — no current view consumes hooks; this primes
+      // the runtime so PR2 migrations don't have to re-thread plumbing.
+      if (result.informerFactory) informerHolder.set(result.informerFactory);
 
       // Post-startup: update agent skill SKILL.md (non-blocking)
       updateSkillAfterStartup();
@@ -903,6 +916,7 @@ export async function handleTui(
       const result = await buildAppProps(effectiveGrove, opts, groveInfo?.preset);
       activeProvider = result.provider;
       activeStopGc = result.stopGc;
+      if (result.informerFactory) informerHolder.set(result.informerFactory);
 
       // Post-startup: update agent skill SKILL.md (non-blocking)
       updateSkillAfterStartup();
@@ -926,26 +940,38 @@ export async function handleTui(
       const result = await buildAppProps(effectiveGrove, { ...opts, nexus: nexusUrl });
       activeProvider = result.provider;
       activeStopGc = result.stopGc;
+      if (result.informerFactory) informerHolder.set(result.informerFactory);
       return result.appProps;
     };
 
     const { TuiApp } = await import("./tui-app.js");
+    const { InformerProviderHolder } = await import("./hooks/informer-context.js");
+    const { RefreshProviderHolder } = await import("./hooks/refresh-context.js");
 
+    const tuiAppEl = React.createElement(TuiApp, {
+      groveExists,
+      groveInfo,
+      presets,
+      sessions,
+      onInit,
+      onStart,
+      onConnect,
+      onNewSession,
+      autoConnectNexus: opts.nexus,
+    });
+    const refreshHolderEl = React.createElement(RefreshProviderHolder, {
+      holder: informerHolder,
+      children: tuiAppEl,
+    });
+    const informerHolderEl = React.createElement(InformerProviderHolder, {
+      holder: informerHolder,
+      children: refreshHolderEl,
+    });
     root.render(
       React.createElement(
         DialogProvider,
         null,
-        React.createElement(TuiApp, {
-          groveExists,
-          groveInfo,
-          presets,
-          sessions,
-          onInit,
-          onStart,
-          onConnect,
-          onNewSession,
-          autoConnectNexus: opts.nexus,
-        }),
+        informerHolderEl,
         React.createElement(Toaster, { position: "bottom-right" }),
       ),
     );

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -445,20 +445,33 @@ async function buildAppProps(
   }
 
   // Construct InformerFactory for the new SSE-driven cache (#295). Ships dark
-  // in PR1 — no view consumes the factory yet, so empty listFn / unwired
-  // local hub is intentional. PR2 wires real store snapshots and hub
-  // publishers; PR2-PR4 migrate views from usePolledData to useEntities/etc.
+  // in PR1 — no view consumes the factory yet. The factory is built from the
+  // resolved backend (post-health-fallback) so the watch source matches what
+  // the rest of the TUI is reading from. PR2 wires real local hub publishers
+  // and listFns when the first view migrates.
   let informerFactory: import("../core/informer.js").InformerFactory | undefined;
   {
-    const nexusUrl = process.env.GROVE_NEXUS_URL;
-    const apiKey = process.env.NEXUS_API_KEY;
     const { InformerFactory } = await import("../core/informer.js");
-    if (nexusUrl && apiKey) {
-      informerFactory = new InformerFactory({
-        mode: "remote",
-        baseUrl: nexusUrl,
-        authHeader: `Bearer ${apiKey}`,
-      });
+    if (backend.mode === "nexus" || backend.mode === "remote") {
+      // For remote backends, prefer the credential resolved earlier in this
+      // function (remoteAuthHeaders) — it follows the same provider scope
+      // gate so we don't leak project keys into arbitrary --url targets.
+      // Falls back to env vars used by the legacy SSE bridge.
+      let authHeader = remoteAuthHeaders?.Authorization;
+      if (!authHeader) {
+        const apiKey = process.env.NEXUS_API_KEY;
+        if (apiKey) authHeader = `Bearer ${apiKey}`;
+      }
+      if (authHeader) {
+        informerFactory = new InformerFactory({
+          mode: "remote",
+          baseUrl: backend.url,
+          authHeader,
+        });
+      }
+      // No credential → no factory. Better to throw on hook use later than
+      // to silently watch with anonymous credentials and collide with
+      // permission rules.
     } else if (groveDir) {
       const { WatchHub } = await import("../core/watch-hub.js");
       informerFactory = new InformerFactory({

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -210,6 +210,7 @@ async function buildAppProps(
   appProps: import("./app.js").AppProps;
   provider: TuiDataProvider;
   stopGc?: (() => void) | undefined;
+  informerFactory?: import("../core/informer.js").InformerFactory | undefined;
 }> {
   let backend = await resolveBackend({
     url: opts.url,
@@ -443,6 +444,38 @@ async function buildAppProps(
     }
   }
 
+  // Construct InformerFactory for the new SSE-driven cache (#295). Ships dark
+  // in PR1 — no view consumes the factory yet, so empty listFn / unwired
+  // local hub is intentional. PR2 wires real store snapshots and hub
+  // publishers; PR2-PR4 migrate views from usePolledData to useEntities/etc.
+  let informerFactory: import("../core/informer.js").InformerFactory | undefined;
+  {
+    const nexusUrl = process.env.GROVE_NEXUS_URL;
+    const apiKey = process.env.NEXUS_API_KEY;
+    const { InformerFactory } = await import("../core/informer.js");
+    if (nexusUrl && apiKey) {
+      informerFactory = new InformerFactory({
+        mode: "remote",
+        baseUrl: nexusUrl,
+        authHeader: `Bearer ${apiKey}`,
+      });
+    } else if (groveDir) {
+      const { WatchHub } = await import("../core/watch-hub.js");
+      informerFactory = new InformerFactory({
+        mode: "local",
+        hub: new WatchHub(),
+        namespace: "default",
+        listFn: () => [],
+      });
+    }
+    if (informerFactory) {
+      const f = informerFactory;
+      stopCallbacks.push(() => {
+        void f.stopAll();
+      });
+    }
+  }
+
   return {
     appProps: {
       provider,
@@ -459,6 +492,7 @@ async function buildAppProps(
     },
     provider,
     stopGc,
+    informerFactory,
   };
 }
 
@@ -724,15 +758,31 @@ export async function handleTui(
           );
         }
       }
+      // PR1 (#295): wrap App in InformerProvider/RefreshProvider when the
+      // informer factory was constructed. Ships dark — no view consumes the
+      // hooks yet; this primes the runtime so PR2 migrations don't have to
+      // re-thread plumbing through main.ts.
+      const { InformerProvider } = await import("./hooks/informer-context.js");
+      const { RefreshProvider } = await import("./hooks/refresh-context.js");
+      const appElement = React.createElement(
+        SpawnManagerContext,
+        { value: spawnManager },
+        React.createElement(App, result.appProps),
+      );
+      const wrappedApp = result.informerFactory
+        ? React.createElement(InformerProvider, {
+            value: result.informerFactory,
+            children: React.createElement(RefreshProvider, {
+              factory: result.informerFactory,
+              children: appElement,
+            }),
+          })
+        : appElement;
       root.render(
         React.createElement(
           DialogProvider,
           null,
-          React.createElement(
-            SpawnManagerContext,
-            { value: spawnManager },
-            React.createElement(App, result.appProps),
-          ),
+          wrappedApp,
           React.createElement(Toaster, { position: "bottom-right" }),
         ),
       );


### PR DESCRIPTION
## Summary

PR1 of 5 for epic #295 (A8 — Retire all polling reactive paths). Closes #387.

- Extracts a `WatchStream` interface implemented by both the existing remote `WatchClient` (HTTP/SSE) and a new in-process `LocalWatchClient` over `WatchHub`. Contract test fixture proves both backends produce identical event sequences.
- Refactors `Informer` to take a `WatchStream`. `InformerFactory` becomes a discriminated union of `{ mode: "remote" }` / `{ mode: "local" }` and gains `startAll() / stopAll() / relist(kind?)` for the global r-key.
- Adds `<InformerProvider>`, `<RefreshProvider>`, and the new view hooks `useEntities`, `useEntity`, `useDerived` (each with pure helpers covered by unit tests).
- `main.ts` constructs the factory at boot and wraps the `--url` render path with the providers.

**Ships dark.** No `usePolledData` call site is changed. No `setInterval` removed. No view migrated. The factory is constructed and the providers are mounted, but no consumer reads the cache yet.

Spec: `docs/superpowers/specs/2026-04-30-retire-polling-a8-design.md`
Plan: `docs/superpowers/plans/2026-04-30-retire-polling-a8-pr1-infra.md`

## Known gap (deferred to A8.2)

The interactive `tui-app.tsx` render path is **not** wrapped with the providers in this PR — that path renders `<TuiApp>` before `buildAppProps` resolves the factory. A8.2 (#388) wires this when its first migrated view needs the cache.

## Test plan

- [x] `bun test src/core src/tui/hooks` passes (2087 pass / 0 fail)
- [x] `bunx tsc --noEmit` clean
- [x] `usePolledData` call sites unchanged from main (32, dark ship)
- [x] New hooks only present in their own source/test files + main.ts factory wiring
- [x] Contract test fixture covers both `WatchClient` and `LocalWatchClient`
- [ ] Manual smoke: TUI launches in remote mode (`GROVE_NEXUS_URL` + `NEXUS_API_KEY`), all existing screens render
- [ ] Manual smoke: TUI launches in local mode (no env), all existing screens render

## Acceptance grep status (full epic)

- `grep -r setInterval src/tui` — 26 matches across 14 files (unchanged; A8.5 cleanup target)
- `grep -r usePolledData src/tui` — 32 matches (unchanged from main; A8.2-A8.4 migration targets)

## Sub-issues under epic #295

- A8.1 (this PR) — #387
- A8.2 — #388
- A8.3 — #389
- A8.4 — #390
- A8.5 — #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)