### PR TITLE
feat(tui): A8 PR2 — migrate Contribution + Claim views to useEntities/useEntity (#388)

### DIFF
--- a/docs/superpowers/plans/2026-04-30-retire-polling-a8-pr2-views.md
+++ b/docs/superpowers/plans/2026-04-30-retire-polling-a8-pr2-views.md
@@ -1,0 +1,393 @@
+# A8 — PR2 (Entity-backed view migration) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the `usePolledData` *call sites* that read directly from the three Entity kinds (`Contribution`, `Claim`, `AgentSession`) to the informer-backed hooks shipped in PR1 (#387). Wire local-mode plumbing (factory `listFn` + `WatchHub.recordWrite`) so those hooks actually deliver events when the user is not connected to grove-server. Wrap the interactive `tui-app.tsx` render path so the eager InformerProvider is in scope by the time a migrated view mounts.
+
+**Architecture:** PR1 already extracted the `WatchStream` interface, built `LocalWatchClient`, added the discriminated-union `InformerFactory` with `mode: "remote" | "local"`, and shipped `<InformerProvider>` + `useEntities` / `useEntity` / `useDerived`. PR1 left every `usePolledData` caller untouched and constructed the factory only in remote mode (with `eager=false`). PR2 takes the next step: flip `eager` on once the first hook consumer mounts, construct the factory in local mode, wire the local stores' write path into `hub.recordWrite`, and swap each Entity-backed view to the new hook. `usePolledData` itself stays in tree — non-Entity callers don't migrate until PR4, deletion is PR5.
+
+**Tech Stack:** TypeScript (strict, `exactOptionalPropertyTypes`), Bun test runner (`bun:test`), React (OpenTUI, no DOM), existing `WatchHub` / `WatchClient` / `LocalWatchClient` / `Informer` from `src/core/`, the PR1 hook bundle in `src/tui/hooks/`.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-retire-polling-a8-design.md` §Migration plan PR2. Issue #388. Depends on #387 (closed). Parent epic #295.
+
+**Out of scope for PR2:**
+- Cross-kind aggregates (`useDerived` over multiple kinds) — that is PR3 (#389): `dag.tsx`, `dashboard.tsx`, frontier projections, agent-graph layout when it composes claims+sessions live, panel-manager cross-kind context.
+- Non-Entity sources (vfs, terminal output, gossip, threads, bounties, outcomes, decisions, GitHub PR, search beyond cache) — PR4 (#390).
+- `setInterval` removal in `src/tui/main.ts` — PR5 (#391).
+- Deletion of `usePolledData` / `usePanelState` / old `useRefreshContext` — PR5.
+- Server-side AgentSession `/api/list` + `/api/watch` routes — currently 501. PR2 ships AgentSession migration in **local mode only**; in remote mode AgentSession views fall back to the existing polling path. See AgentSession scope decision below.
+
+---
+
+## AgentSession scope decision
+
+The spec calls for migrating the AgentSession portions of `agent-list.tsx`, `pipeline-view.tsx`, and `agent-graph.tsx` in PR2. The factory in PR1 deliberately excludes AgentSession from `SUPPORTED_KINDS` (the comment on `informer.ts:329` notes the grove-server `/api/list` route returns 501 NOT_CONFIGURED for it). That gate is mode-agnostic today.
+
+**Decision (recorded here, not negotiable mid-implementation):**
+
+1. PR2 splits `SUPPORTED_KINDS` per mode. Remote: `["Contribution", "Claim"]` (unchanged behavior). Local: `["Contribution", "Claim", "AgentSession"]`.
+2. Local mode adds an AgentSession `listFn` projection — driven by `appProps.agentRuntime.listSessions()` (returns `readonly AgentSession[]`) + `agentSessionToEntity`.
+3. Local mode adds AgentSession `recordWrite` calls at the runtime boundary (`AcpxRuntime` / wrapper) when sessions transition state — minimum: spawn → `ADDED`, status change → `MODIFIED`, close → `DELETED`.
+4. Migrated views call `useEntities("AgentSession", …)`. The hook surfaces a `factory.supportsKind(kind)` check; when remote-mode factories don't support it, the hook returns `{ data: undefined, hasSynced: false, error: null }` and the view code falls back to a local non-reactive shape (today: tmux session list, which is *not* an AgentSession projection). The view keeps a small per-mode branch so non-migrated remote consumers don't regress.
+
+**Why not defer AgentSession entirely to PR3?** The spec migration table explicitly assigns AgentSession to PR2. PR3 is reserved for cross-kind aggregates (`useDerived`), not single-kind reads. Splitting AgentSession off would either bloat PR3 or create a half-migrated view layer where the Claim portion of `agent-list.tsx` is reactive but the session portion still polls. Better to land the local-mode path in PR2 and add server support in a follow-up that is *not* on the A8 critical path.
+
+**Why not just enable AgentSession in remote mode too?** The grove-server `/api/list?kind=AgentSession` route returns 501. Enabling it in `SUPPORTED_KINDS` would surface 4xx noise via `factory.addErrorListener` and leave consumers stuck at `hasSynced=false`. The 501 is a server-side gap (#287 follow-up), not a TUI defect to paper over.
+
+If during implementation it turns out that no view actually needs the AgentSession entity (i.e. the tmux session list polling is sufficient and the spec's table was aspirational), record that finding under Task 9 and exit AgentSession migration with no view-side change.
+
+---
+
+## File structure
+
+**New files:**
+
+| Path | Responsibility |
+|---|---|
+| `src/local/watch-hub-recorder.ts` | Helper that wraps a `WatchHub` and exposes typed `recordContribution(op, c)` / `recordClaim(op, c)` / `recordAgentSession(op, s)` methods. Encapsulates the entity projection (`contributionToEntity` / `claimToEntity` / `agentSessionToEntity`) and namespace plumbing so callers don't repeat the boilerplate. |
+| `src/local/watch-hub-recorder.test.ts` | Unit tests: each `record*` method emits the expected `EntityWriteEvent` with correct kind/op/namespace/projection. |
+| `src/tui/views/claims.test.tsx` | Smoke test — mount with seeded informer, publish Claim event, assert re-render. |
+| `src/tui/views/agent-list.test.tsx` | Smoke test — mount with seeded informer, publish Claim event, assert re-render. (Session portion fallback covered by mode-branch unit tests when AgentSession factory absent.) |
+| `src/tui/views/pipeline-view.entity.test.ts` | Smoke test for the Claim+session projection through the new hook. (Existing `pipeline-view.test.ts` covers the pure `buildPipeline` helper — keep it.) |
+| `src/tui/views/agent-graph.test.tsx` | Smoke test — mount, publish Claim event, assert layout recompute. |
+| `src/tui/views/activity.test.tsx` | Smoke test — mount with seeded Contribution informer, publish event, assert re-render. |
+| `src/tui/views/activity-panel.test.tsx` | Smoke test. |
+| `src/tui/views/search-panel.entity.test.ts` | Smoke test for the in-cache (no-query) path through `useEntities("Contribution", …)`. The full-text-search path stays on `usePolledData` until PR4. |
+| `src/tui/views/detail.test.tsx` | Smoke test for `useEntity("Contribution", id)`. |
+| `src/tui/panels/panel-manager.entity.test.ts` | Smoke test for the `useEntity("Contribution", detailCid)` lookup that resolves artifact names. |
+
+**Modified files:**
+
+| Path | Change |
+|---|---|
+| `src/core/informer.ts` | Split `SUPPORTED_KINDS` per mode. Add `factory.supportsKind(kind: WatchKind): boolean`. Add `factory.mode` getter. `informerFor` throws only when the kind is unsupported by the *constructed* mode. |
+| `src/core/informer.test.ts` | Add coverage for per-mode `SUPPORTED_KINDS` + `supportsKind` + `informerFor` throw on unsupported kind. |
+| `src/local/runtime.ts` | Optional opt-in `watchHub` field on `LocalRuntimeOptions` and `LocalRuntime`. When provided, the runtime forwards Entity writes via `WatchHubRecorder`. Existing callers (CLI, server) leave `watchHub` undefined → no behavior change. |
+| `src/local/sqlite-store.ts` | Add `onEntityWrite` callback hook on `SqliteContributionStore` and `SqliteClaimStore` (mirrors the existing `onWrite` pattern). Each successful write fires the callback with the projected `EntityWriteEvent`. Default no-op preserves backwards compatibility. |
+| `src/core/agent-runtime.ts` (or its concrete impl) | Optional `onSessionWrite(event: EntityWriteEvent)` hook called on spawn/close/status-change. Default no-op. |
+| `src/tui/main.ts` | Construct a process-local `WatchHub` once (only in local mode; remote mode keeps the server-side hub via WatchClient). Pass `watchHub` into `createLocalRuntime`. Build the local-mode `InformerFactory` with `listFn` projecting from the runtime stores + agent runtime. Pass `eager=true` to `<InformerProviderHolder>` (was implicit `false` in PR1). Same for the legacy `--url` direct-render path. |
+| `src/tui/views/claims.tsx` | `usePolledData(getClaims)` → `useEntities("Claim", c => c.status.phase === "active")`. Map `ClaimEntity` back to the row shape (drop the entity envelope at the row layer, not the hook layer — keeps the rest of the view untouched). |
+| `src/tui/views/agent-list.tsx` | Replace the claim fetcher with `useEntities("Claim", …)`. Replace the session-portion polling (`tmux.listSessions()`) with `useEntities("AgentSession", …)` *gated* on `factory.supportsKind("AgentSession")`; remote-mode keeps the existing tmux poller. Keep the cost fetcher on `usePolledData` (non-Entity → PR4). |
+| `src/tui/views/pipeline-view.tsx` | Same dual: `useEntities("Claim", …)` always; `useEntities("AgentSession", …)` when supported, tmux poller fallback otherwise. Outputs (`tmux.capturePanes`) stay on `usePolledData` — PR4. |
+| `src/tui/views/agent-graph.tsx` | Same dual. The dynamic-edge `buildDynamicEdges` derivation stays — PR3 will lift it into `useDerived` when the dashboard cross-cuts migrate. |
+| `src/tui/views/activity.tsx` | `usePolledData(getActivity)` → `useEntities("Contribution", c => /* slice by pageOffset/pageSize */)`. Sort by `creationTimestamp` desc. Note: activity is a *recent* feed; for now `useEntities` returns the full informer cache filtered + sliced — if the cache exceeds the page bounds, paging works without re-fetch. The "load more" flow that fetches beyond the cache stays on `usePolledData` (PR4 covers full-text/beyond-cache cases). |
+| `src/tui/views/activity-panel.tsx` | `usePolledData(getActivity({ limit: 30 }))` → `useEntities("Contribution", …)` with a `.slice(0, 30)`. |
+| `src/tui/views/search-panel.tsx` | When `searchQuery === ""` and `hasSearch === false` (the "showing recent contributions" branch): `useEntities("Contribution", …)`. The full-text-search branches (`searchQuery !== ""` with `hasSearch`) stay on `usePolledData` — PR4. |
+| `src/tui/views/detail.tsx` | `usePolledData(getContribution(cid))` → `useEntity("Contribution", cid)` for the contribution body. The outcome fetcher stays on `usePolledData` — non-Entity. The ancestors / children / thread shape needs `getContribution` for the relation graph (PR3 follow-up); for PR2, keep the existing `getContribution` polling for those fields and let `useEntity` drive only the *primary* contribution body (whose updates were the source of staleness today). |
+| `src/tui/panels/panel-manager.tsx` | Replace the inline `usePolledData(getContribution(detailCid))` (used only to resolve artifact names) with `useEntity("Contribution", detailCid)`. |
+
+**Untouched in PR2:**
+
+- `src/tui/views/dag.tsx`, `src/tui/views/dashboard.tsx`, `src/tui/views/frontier-view.tsx`, `src/tui/views/handoffs-view.tsx`, `src/tui/views/threads-panel.tsx`, `src/tui/views/inbox-panel.tsx`, `src/tui/views/decisions-panel.tsx`, `src/tui/views/outcomes-panel.tsx`, `src/tui/views/bounties-panel.tsx`, `src/tui/views/gossip-panel.tsx`, `src/tui/views/github-panel.tsx`, `src/tui/views/vfs-browser.tsx`, `src/tui/views/artifact-preview.tsx`, `src/tui/views/terminal.tsx` — covered by PR3/PR4.
+- `src/tui/hooks/use-polled-data.ts` (and tests) — stays in tree; non-Entity callers still need it. Deletion: PR5.
+- `src/tui/hooks/use-panel-state.ts`, `src/tui/hooks/use-refresh-context.ts` — stay; PR5 deletes.
+- The `setInterval` cleanup loops in `main.ts` (claim cleanup, blob GC, session GC) — PR5 moves them.
+
+---
+
+## Tasks
+
+### Task 1: Per-mode `SUPPORTED_KINDS` + `supportsKind` API
+
+**Files:**
+- Modify: `src/core/informer.ts`
+- Modify: `src/core/informer.test.ts`
+
+- [ ] **Step 1:** In `informer.ts`, replace the single module-level `SUPPORTED_KINDS` with a per-mode set. Remote mode: `["Contribution", "Claim"]` (unchanged). Local mode: `["Contribution", "Claim", "AgentSession"]`.
+
+- [ ] **Step 2:** Add `factory.supportsKind(kind: WatchKind): boolean` reading the per-mode set.
+
+- [ ] **Step 3:** Update `informerFor` to consult the per-mode set when throwing the "kind not yet supported" error. Update the error message to mention the mode.
+
+- [ ] **Step 4:** Update `startAll()` to iterate the per-mode set so a local-mode factory eagerly starts an AgentSession informer.
+
+- [ ] **Step 5:** Add `factory.mode: "remote" | "local"` getter (read from `opts.mode`). Used by hook callers to gate AgentSession migrations in remote mode.
+
+- [ ] **Step 6:** Tests:
+  - Remote factory: `supportsKind("AgentSession") === false`; `informerFor("AgentSession")` throws.
+  - Local factory: `supportsKind("AgentSession") === true`; `informerFor("AgentSession")` returns an Informer.
+  - Both: `supportsKind("Contribution") === true` and `supportsKind("Claim") === true`.
+
+**Acceptance:** `bun test src/core/informer.test.ts` passes. `bunx tsc --noEmit` clean.
+
+### Task 2: `WatchHubRecorder` helper
+
+**Files:**
+- Create: `src/local/watch-hub-recorder.ts`
+- Create: `src/local/watch-hub-recorder.test.ts`
+
+- [ ] **Step 1:** Define the recorder API:
+
+```ts
+export interface WatchHubRecorder {
+  contribution(op: InformerOp, c: Contribution): void;
+  claim(op: InformerOp, c: Claim, now?: () => number): void;
+  agentSession(op: InformerOp, s: AgentSession): void;
+}
+export function createWatchHubRecorder(opts: {
+  hub: WatchHub;
+  namespace: string;
+  now?: () => number;
+}): WatchHubRecorder;
+```
+
+Each method projects via the existing `contributionToEntity` / `claimToEntity` / `agentSessionToEntity` helpers and calls `hub.recordWrite({ kind, namespace, op, entity })`.
+
+- [ ] **Step 2:** Tests with a hand-rolled fake hub (capturing `recordWrite` calls). Assert one call per invocation, correct kind, op, namespace, entity id.
+
+- [ ] **Step 3:** Verify the recorder swallows recordWrite throws (defensive; downstream subscriber failures must not poison the write path). Log to stderr on throw.
+
+**Acceptance:** Recorder tests pass. No new lint warnings.
+
+### Task 3: Local store `onEntityWrite` hooks
+
+**Files:**
+- Modify: `src/local/sqlite-store.ts`
+- Modify: existing store tests as needed
+
+- [ ] **Step 1:** Add `onEntityWrite?: (event: EntityWriteEvent) => void` field to `SqliteContributionStore` and `SqliteClaimStore`. Mirror the existing `onWrite` pattern (public mutable field, default no-op).
+
+- [ ] **Step 2:** Fire the callback from each successful write path:
+  - `SqliteContributionStore.contribute` (and any other write — search the file with `INSERT INTO contributions`): emit `{ kind: "Contribution", op: "ADDED", namespace, entity: contributionToEntity(c, ns) }`. The store doesn't know the namespace today; thread it as a constructor arg or via a setter (`store.namespace = ns`).
+  - `SqliteClaimStore.claim` / `heartbeat` / `expire` / `complete`: emit Claim events. **Skip pure heartbeat-only updates** that don't change the lease boundary or status — match the rule documented on `OperationDeps.onEntityWrite` (`deps.ts:81`).
+
+- [ ] **Step 3:** Tests: write a contribution → callback receives correct event. Write a claim and complete it → ADDED + MODIFIED. Heartbeat-only update → no callback.
+
+- [ ] **Step 4:** Bound the change so existing callers (server, CLI) stay untouched: default `onEntityWrite = noop`. Server still wires its own `recordWrite` via the operation-adapter, so adding the local-store hook does not double-fire when the server is the consumer (server doesn't construct local stores; it owns the operation dependency injection).
+
+**Acceptance:** `bun test src/local/sqlite-store.test.ts` and `src/core/store.conformance.ts` pass. Conformance suite unchanged (no semantic shift, only an additive hook).
+
+### Task 4: Agent runtime `onSessionWrite` hook
+
+**Files:**
+- Modify: `src/core/agent-runtime.ts` (or the concrete impl that owns session lifecycle — `acp-runtime.ts` / acpx wrapper, whichever fires spawn/close)
+
+- [ ] **Step 1:** Survey: identify the single chokepoint where AgentSession lifecycle transitions are observable (`spawn`, `status` flip, `close`). For ACP runtimes that's likely `acp-runtime.ts`'s session map; for tmux fallback there may not be one (acceptable — AgentSession entities won't update from tmux state, but the local-mode AgentSession listFn will still snapshot them).
+
+- [ ] **Step 2:** Add an optional `onSessionWrite?: (event: EntityWriteEvent) => void` (mirror Task 3's pattern). Fire on spawn (ADDED), status transition (MODIFIED), close (DELETED).
+
+- [ ] **Step 3:** Test the spawn → ADDED + close → DELETED sequence with an in-process fake runtime if one exists. If not, defer to the integration test in Task 8.
+
+**Acceptance:** Existing agent-runtime tests pass. New hook fires only when wired.
+
+### Task 5: `LocalRuntime` wiring
+
+**Files:**
+- Modify: `src/local/runtime.ts`
+
+- [ ] **Step 1:** Add `watchHub?: WatchHub | undefined` to `LocalRuntimeOptions` and `LocalRuntime`.
+
+- [ ] **Step 2:** When `watchHub` is provided and a `namespace` opt is also provided (mirror server-side namespacing — typically `"default"` for local mode), construct a `WatchHubRecorder` and wire it onto the contribution / claim stores' `onEntityWrite`. Plumb the namespace through to the stores so each callback knows what `namespace` to attach.
+
+- [ ] **Step 3:** No agent-runtime wiring here — the agent runtime is constructed in `tui/main.ts` after `createLocalRuntime`. PR2 wires that in main.ts.
+
+- [ ] **Step 4:** Tests: `createLocalRuntime({ ..., watchHub })` then write a contribution → hub receives one event with correct rv increment.
+
+**Acceptance:** Existing `runtime.test.ts` still passes. New test asserts the hub plumbing.
+
+### Task 6: TUI main wiring (factory in local mode + eager flag)
+
+**Files:**
+- Modify: `src/tui/main.ts`
+
+- [ ] **Step 1:** In `buildAppProps`, when `backend.mode === "local"` (or when grove-server is unreachable and we fall back to local):
+  - Construct a process-local `WatchHub`.
+  - Construct a `cleanupRuntime` (already exists for the GC timers) but extended with `watchHub` and `namespace: "default"` so contribution + claim writes flow through `recordWrite`.
+  - Wire `agentRuntime.onSessionWrite = (e) => watchHub.recordWrite(e)` after the runtime is constructed.
+  - Build the `InformerFactory` with `mode: "local"`:
+    ```ts
+    new InformerFactory({
+      mode: "local",
+      hub: watchHub,
+      namespace: "default",
+      listFn: (kind) => {
+        switch (kind) {
+          case "Contribution": return cleanupRuntime.contributionStore.listEntities();
+          case "Claim": return cleanupRuntime.claimStore.listEntities();
+          case "AgentSession":
+            return (await agentRuntime?.listSessions() ?? []).map(s => agentSessionToEntity(s, undefined, "default"));
+        }
+      }
+    });
+    ```
+    `listFn` matches the discriminated-union shape PR1 already accepts (sync or async). For AgentSession on a tmux-only runtime where `agentRuntime` is undefined, return `[]` — the informer will sync to an empty cache, which is correct (no AgentSession entities are tracked in that mode).
+
+- [ ] **Step 2:** Pass `eager={true}` to `<InformerProviderHolder>` and to the legacy `--url` `<InformerProvider>` wrap in `handleTui`. (PR1 left it implicit `false` for dark-ship.)
+
+- [ ] **Step 3:** Drop the lazy-only construction comment ("intentionally NOT wired in PR1") and replace with a short note pointing at this plan as the rationale.
+
+- [ ] **Step 4:** Verify the existing remote-mode path (with `authHeader`) still constructs the same factory shape it did in PR1 — only the local-mode branch and the `eager` flag change.
+
+**Acceptance:** `bun tui` boots in both `--nexus` (remote) and bare local modes without runtime errors. Both paths log `factory.mode` once at boot for ops visibility.
+
+### Task 7: View migrations
+
+Each view is a self-contained sub-task. Land them in dependency order (Claim views first, then Contribution, then AgentSession portions guarded by `supportsKind`). Per migration: replace the polling fetcher with the informer hook, drop `intervalMs` from the call where it becomes unused (keep the prop for future poll-fallback callers if PR4 needs it), preserve the existing display shape by mapping `Entity → row` at the call site.
+
+#### 7a — `claims.tsx`
+
+**Files:**
+- Modify: `src/tui/views/claims.tsx`
+- Create: `src/tui/views/claims.test.tsx`
+
+- [ ] **Step 1:** Replace `usePolledData(provider.getClaims({status:"active"}))` with `useEntities("Claim", e => e.status.phase === "active")`. The `propClaims` override stays — parent still passes a pre-fetched list to avoid double-polling for now. When `propClaims === undefined`, use the hook's `data`.
+
+- [ ] **Step 2:** Map `ClaimEntity → row` at the row layer. The current code reads `c.status` (string), `c.leaseExpiresAt`, `c.heartbeatAt`, `c.targetRef`, `c.intentSummary`, `c.agent.agentName ?? c.agent.agentId`. From `ClaimEntity`: `entity.status.phase`, `entity.status.leaseExpiresAt`, `entity.status.heartbeatAt`, `entity.spec.targetRef`, `entity.spec.intentSummary`, `entity.spec.agent.agentName ?? entity.spec.agent.agentId`. Keep the existing duplicate-target detection and "expired" status logic.
+
+- [ ] **Step 3:** Smoke test in `claims.test.tsx`: mount with a fake informer factory pre-seeded with two claims, assert two rows. Publish a third claim event, assert three rows. Match the pattern in `use-entities.test.ts`.
+
+**Acceptance:** Test passes. Visual check (manual): `grove tui` claims panel still renders.
+
+#### 7b — `agent-list.tsx`
+
+**Files:**
+- Modify: `src/tui/views/agent-list.tsx`
+- Create: `src/tui/views/agent-list.test.tsx`
+
+- [ ] **Step 1:** Claim portion: same swap as 7a, using `useEntities("Claim", c => c.status.phase === "active")`.
+
+- [ ] **Step 2:** Session portion: branch on `factory.supportsKind("AgentSession")`. When supported, use `useEntities("AgentSession", …)` and derive the session-name list from entity ids. When not supported, keep `usePolledData(tmux.listSessions, intervalMs * 2, …)`.
+
+- [ ] **Step 3:** The cost fetcher (`getSessionCosts`) stays on `usePolledData` — non-Entity, PR4.
+
+- [ ] **Step 4:** Smoke test: claim + session pre-seeded, assert agent rows. Publish session event, assert row update (when local mode supported).
+
+#### 7c — `pipeline-view.tsx`
+
+**Files:**
+- Modify: `src/tui/views/pipeline-view.tsx`
+- Create: `src/tui/views/pipeline-view.entity.test.ts`
+
+- [ ] **Step 1:** Claim portion → `useEntities("Claim", c => c.status.phase === "active")`.
+
+- [ ] **Step 2:** Session-list portion → mode-branch as in 7b.
+
+- [ ] **Step 3:** Output capture (`tmux.capturePanes`) stays on `usePolledData` — non-Entity, PR4.
+
+- [ ] **Step 4:** Smoke test: seed two Claims with parent/child lineage, assert ordered cards. Existing `pipeline-view.test.ts` already covers `buildPipeline` purely; new test mounts the React component.
+
+#### 7d — `agent-graph.tsx`
+
+**Files:**
+- Modify: `src/tui/views/agent-graph.tsx`
+- Create: `src/tui/views/agent-graph.test.tsx`
+
+- [ ] **Step 1:** Claim → `useEntities("Claim", …)`. Session → mode-branch.
+
+- [ ] **Step 2:** `buildDynamicEdges` keeps reading the claim list from the hook's `data`.
+
+- [ ] **Step 3:** Smoke test: seed two Claims with a parent edge, assert renderGraph output contains both roles.
+
+#### 7e — `activity.tsx`
+
+**Files:**
+- Modify: `src/tui/views/activity.tsx`
+- Create: `src/tui/views/activity.test.tsx`
+
+- [ ] **Step 1:** Replace `usePolledData(getActivity({limit:pageSize, offset:pageOffset}))` with:
+  ```ts
+  const { data } = useEntities("Contribution");
+  const sorted = useMemo(
+    () => [...data].sort((a, b) => (b.metadata.creationTimestamp ?? "").localeCompare(a.metadata.creationTimestamp ?? "")),
+    [data],
+  );
+  const sliced = sorted.slice(pageOffset, pageOffset + pageSize);
+  ```
+  Map `ContributionEntity → row` (`entity.id` → `c.cid`, `entity.spec.contributionKind` → `c.kind`, etc.).
+
+- [ ] **Step 2:** Caveat: the informer cache is bounded by what PR1's listFn returns. For "load more" beyond the cached window, the user falls back to a hard refresh (`r` key triggers `factory.relist`). Document this in a 1-line comment in `activity.tsx`.
+
+- [ ] **Step 3:** Smoke test: seed N=10 contributions, paginate at pageSize=3, assert correct slice. Publish an 11th, assert it appears at offset=0.
+
+#### 7f — `activity-panel.tsx`
+
+**Files:**
+- Modify: `src/tui/views/activity-panel.tsx`
+- Create: `src/tui/views/activity-panel.test.tsx`
+
+- [ ] **Step 1:** Same `useEntities("Contribution")` + `.slice(0, 30)` pattern as `activity.tsx` (no pagination).
+
+- [ ] **Step 2:** Smoke test: 30 contributions, assert all 30 rows. 31st contribution event → still 30 rows (newest first).
+
+#### 7g — `search-panel.tsx`
+
+**Files:**
+- Modify: `src/tui/views/search-panel.tsx`
+- Create: `src/tui/views/search-panel.entity.test.ts`
+
+- [ ] **Step 1:** When `searchQuery === ""` (the "showing recent contributions" branch in `selectFetcher`): replace with `useEntities("Contribution")` + `.slice(0, 20)`. Keep `selectFetcher` exported for unit-test compatibility but route the `getContributions` branch through the informer cache.
+
+- [ ] **Step 2:** When `searchQuery !== ""`: stay on `usePolledData` + `provider.search` (full-text — non-Entity until PR4).
+
+- [ ] **Step 3:** Smoke test: empty query → cache contents. Set query → poll path triggers (existing test coverage in `search-panel.test.ts` exercises `selectFetcher`; new test asserts cache delivery for empty query).
+
+#### 7h — `detail.tsx`
+
+**Files:**
+- Modify: `src/tui/views/detail.tsx`
+- Create: `src/tui/views/detail.test.tsx`
+
+- [ ] **Step 1:** The contribution body lookup → `useEntity("Contribution", cid)`. The view already builds a `ContributionEntity` via `contributionToEntity(c, "default")` for the conditions chip — the hook returns one directly. Drop the redundant projection.
+
+- [ ] **Step 2:** Ancestors / children / thread / outcome stay on `usePolledData(provider.getContribution(cid))` — those fields aren't on the Entity envelope (it's a `ContributionDetail` shape that includes the relation graph). PR3 follow-up may lift the relation graph into `useDerived` over the Contribution informer, but PR2 keeps the existing fetch.
+
+- [ ] **Step 3:** Smoke test: seed contribution into the informer, mount with `cid`, assert body fields render.
+
+#### 7i — `panels/panel-manager.tsx`
+
+**Files:**
+- Modify: `src/tui/panels/panel-manager.tsx`
+- Create: `src/tui/panels/panel-manager.entity.test.ts`
+
+- [ ] **Step 1:** The inline `usePolledData(getContribution(detailCid))` (used to resolve `artifactNames` from the contribution) → `useEntity("Contribution", detailCid)`. Read `entity.spec.artifacts` instead of `detailData.contribution.artifacts`. Read the `derives_from` relation from `entity.spec.relations` instead of `detailData.contribution.relations`.
+
+- [ ] **Step 2:** Smoke test: seed a contribution with two artifacts and a `derives_from` relation, assert `artifactNames` resolves correctly and `parentCid` is the relation target.
+
+### Task 8: End-to-end smoke (real factory, real WatchHub)
+
+**Files:**
+- Create: `tests/e2e/tui-pr2-informer-smoke.test.ts` (or add to an existing TUI smoke harness if one exists)
+
+- [ ] **Step 1:** Boot a local-mode `LocalRuntime` with a fresh in-memory SQLite, attach a `WatchHub`. Construct a local-mode `InformerFactory`. Start it. Assert `hasSynced` flips for `Contribution` and `Claim` (and `AgentSession` if a fake agent runtime is plugged in).
+
+- [ ] **Step 2:** Through the `OperationDeps` layer (or directly via the store), write a Claim. Assert the hub receives one event and the informer cache contains one entry.
+
+- [ ] **Step 3:** Run `factory.relist("Claim")`. Assert RELIST_BEGIN → RELIST → RELIST_END sequence and the cache content is unchanged.
+
+- [ ] **Step 4:** Stop the factory. Assert all three informers exit cleanly within 1s.
+
+**Acceptance:** Test stable across 5 sequential runs. No leaked timers / open handles.
+
+### Task 9: Verification
+
+- [ ] **Step 1:** `bunx tsc --noEmit` clean.
+- [ ] **Step 2:** `bun test` clean (full suite, not just touched files — confirm no regressions in store conformance, informer lifecycle, watch-stream contract).
+- [ ] **Step 3:** `bun biome check .` clean for migrated files.
+- [ ] **Step 4:** Manual smoke: `grove tui` in a real `.grove` worktree. Open Claims panel — claim list shows. Open Activity panel — recent contributions show. Spawn a claim via the operations layer (`bun run grove claim create …` from another shell) — claim appears in the TUI without re-entering the panel.
+- [ ] **Step 5:** Manual smoke: with `--nexus`, both Claim and Contribution panels still render and update on server-side writes (existing remote-mode regression check). AgentSession panel (in views that branch on `supportsKind`) falls back to the tmux poller without errors.
+- [ ] **Step 6:** Update the AgentSession scope decision section if implementation found that AgentSession migration was unnecessary or required a different approach.
+
+**Acceptance:** All steps green. `grep -r "usePolledData" src/tui/views src/tui/panels` shows the post-PR2 state — only non-Entity callers (vfs, terminal, gossip, threads, bounties, outcomes, decisions, GitHub, search-with-query, dag, dashboard, frontier, handoffs, artifact-preview) remain on the hook.
+
+---
+
+## Risks and mitigations
+
+- **Local-store `onEntityWrite` double-fires when server is local-mode wrapped.** → Server doesn't go through `createLocalRuntime` for store wiring; it constructs its own deps and wires `recordWrite` via `operation-adapter.ts:36`. Adding the store-level hook only affects callers that don't have an operation-adapter (today: TUI local-mode + tests). Confirm by grep: `createLocalRuntime` callers should never also pass `onEntityWrite` through `OperationDeps` — if both fire, write-amplification doubles RV counters and breaks watch contracts. Cover with a server integration test if one exists; otherwise document as a known constraint of the API.
+
+- **AgentSession listFn races spawn.** → If `factory.relist("AgentSession")` runs before `agentRuntime.spawn` returns, the snapshot misses the new session and the user sees stale state until the next `recordWrite`. Mitigation: spawn fires `recordWrite(ADDED)` synchronously before resolving the promise. Cover with the smoke test in Task 8.
+
+- **`useEntities("Contribution")` returns the entire cache every render.** → For 100k-row groves the `.slice` is O(n) per render. Acceptable for now (informer cache is bounded by listFn snapshot + typical grove size in PR2 timeframe); revisit in PR3 if profiling shows it matters. Spec already calls this out under risks (line 300).
+
+- **Eager start in interactive flow surfaces error noise before the user picks a backend.** → PR1 ran with `eager=false` for exactly this reason. PR2 flips to `eager=true` only AFTER the InformerProviderHolder receives a factory (the holder pattern in PR1 already handles this — `holder.set()` is called from `onInit/onStart/onConnect` after `buildAppProps` resolves, which is after the backend is chosen). The pre-set window renders without context and no informer is started.
+
+- **Smoke tests depend on a React renderer.** → PR1 already established the `bun:test` pattern with React + jsdom-style harness for `use-entities.test.ts`. Reuse the same setup.
+
+- **AgentSession migration in remote mode falls back silently.** → The mode branch (`factory.supportsKind`) is explicit and visible in the diff. Add a one-line comment per call site documenting the fallback. PR4/follow-up adds the server-side route.
+
+## Open items deferred to PR3+
+
+- AgentSession server-side `/api/list` + `/api/watch` routes (#287 follow-up; not on the A8 critical path).
+- Full-text search → informer cache hybrid (currently only the empty-query branch migrates).
+- ContributionDetail (ancestors / children / thread) projection through `useDerived` — PR3.
+- Removing `intervalMs` props that became dead weight after migration — coordinate with PR5 cleanup pass.

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -99,6 +99,15 @@ export class AcpRuntime implements AgentRuntime {
   private readonly sessions: Map<string, AcpSessionEntry> = new Map();
   private nextId = 0;
 
+  /**
+   * Optional callback invoked after a session lifecycle transition that
+   * matters for the local-mode WatchHub (#388 PR2). Fires on spawn (ADDED),
+   * status change (MODIFIED), and close (DELETED). The `LocalRuntime`
+   * adapter projects via `agentSessionToEntity` and calls
+   * `WatchHub.recordWrite`.
+   */
+  onSessionWrite?: (op: "ADDED" | "MODIFIED" | "DELETED", s: AgentSession) => void;
+
   constructor(options: AcpRuntimeOptions = {}) {
     this.resolver = options.permissionResolver ?? DENY_ALL_RESOLVER;
     this.fsAuditor = options.fsAuditor;
@@ -197,6 +206,7 @@ export class AcpRuntime implements AgentRuntime {
       sendChainTail: Promise.resolve(),
       closed: false,
     });
+    this.fireSessionWrite("ADDED", session);
 
     const initialMessage = config.goal ?? config.prompt;
     if (!config.waitForPush && initialMessage && initialMessage.trim().length > 0) {
@@ -224,6 +234,7 @@ export class AcpRuntime implements AgentRuntime {
             ...current.session,
             status: "crashed",
           };
+          this.fireSessionWrite("MODIFIED", current.session);
           for (const cb of current.idleCallbacks) {
             try {
               cb();
@@ -329,6 +340,17 @@ export class AcpRuntime implements AgentRuntime {
       /* ignore */
     }
     this.sessions.delete(session.id);
+    this.fireSessionWrite("DELETED", entry.session);
+  }
+
+  private fireSessionWrite(op: "ADDED" | "MODIFIED" | "DELETED", s: AgentSession): void {
+    if (!this.onSessionWrite) return;
+    try {
+      this.onSessionWrite(op, s);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[acp-runtime] onSessionWrite(${op}) threw: ${detail}\n`);
+    }
   }
 
   onIdle(session: AgentSession, callback: () => void): void {

--- a/src/core/informer.test.ts
+++ b/src/core/informer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Informer, InformerFactory } from "./informer.js";
 import { WatchClient } from "./watch-client.js";
 import type { WatchEntity } from "./watch-events.js";
+import { WatchHub } from "./watch-hub.js";
 
 // Minimal entity shapes (WatchClient passes them through as-is)
 const E_A: WatchEntity = {
@@ -569,6 +570,34 @@ describe("InformerFactory memoization", () => {
     expect(contrib).not.toBe(claim);
   });
 
+  test("AgentSession unsupported in remote mode — informerFor throws, supportsKind=false", () => {
+    const factory = new InformerFactory({
+      mode: "remote",
+      baseUrl: "http://t",
+      authHeader: "Bearer x",
+    });
+    expect(factory.mode).toBe("remote");
+    expect(factory.supportsKind("Contribution")).toBe(true);
+    expect(factory.supportsKind("Claim")).toBe(true);
+    expect(factory.supportsKind("AgentSession")).toBe(false);
+    expect(() => factory.informerFor("AgentSession")).toThrow(/mode=remote/);
+  });
+
+  test("AgentSession supported in local mode — informerFor returns informer, supportsKind=true", () => {
+    const factory = new InformerFactory({
+      mode: "local",
+      hub: new WatchHub(),
+      namespace: "default",
+      listFn: () => [],
+    });
+    expect(factory.mode).toBe("local");
+    expect(factory.supportsKind("Contribution")).toBe(true);
+    expect(factory.supportsKind("Claim")).toBe(true);
+    expect(factory.supportsKind("AgentSession")).toBe(true);
+    const informer = factory.informerFor("AgentSession");
+    expect(informer).toBeDefined();
+  });
+
   test("separate factories for separate namespaces use distinct instances", () => {
     // Each namespace gets its own factory (and its own authHeader that encodes
     // the namespace server-side). Two factories for different namespaces must
@@ -854,7 +883,7 @@ describe("Informer handler isolation", () => {
         backoff: { minMs: 0, maxMs: 0, jitter: 0 },
       }),
     );
-    informer.addEventHandler(async (op, entity) => {
+    informer.addEventHandler(async (_op, entity) => {
       order.push(`enter:${(entity as { id: string }).id}`);
       if ((entity as { id: string }).id === "cid-a") {
         await new Promise<void>((r) => {
@@ -961,7 +990,7 @@ describe("Informer cache immutability", () => {
     // Attempt to mutate resourceVersion (should silently fail in non-strict mode
     // or throw in strict mode because the entity is frozen)
     try {
-      (entity as unknown as Record<string, unknown>)["resourceVersion"] = "999";
+      (entity as unknown as Record<string, unknown>).resourceVersion = "999";
     } catch {
       // Expected in strict mode
     }
@@ -1002,7 +1031,7 @@ describe("Informer cache immutability", () => {
     const origSummary = (entity as unknown as { spec: { summary: string } })?.spec?.summary;
     // Attempt to mutate nested spec.summary (throws in strict mode, silently fails otherwise)
     try {
-      (entity as unknown as { spec: Record<string, unknown> }).spec["summary"] = "hacked";
+      (entity as unknown as { spec: Record<string, unknown> }).spec.summary = "hacked";
     } catch {
       // Expected under strict mode / frozen object
     }

--- a/src/core/informer.ts
+++ b/src/core/informer.ts
@@ -318,17 +318,24 @@ interface RunningInformer {
 
 /**
  * Kinds the factory will start eagerly via `startAll()` AND the only kinds
- * `informerFor` will accept. AgentSession is intentionally excluded because
- * the grove-server `/api/list` route currently returns 501 NOT_CONFIGURED
- * for it (handler exists, list source not wired). Re-add once server
- * support lands.
+ * `informerFor` will accept — split per-mode.
+ *
+ * Remote: AgentSession is excluded because the grove-server `/api/list`
+ * route currently returns 501 NOT_CONFIGURED for it (handler exists, list
+ * source not wired). Re-add once server support lands.
+ *
+ * Local: AgentSession is supported — the in-process `WatchHub` plus
+ * `agentRuntime.listSessions()` snapshot covers it without any server
+ * route. PR2 (#388) wires this in via `LocalRuntime` + `tui/main.ts`.
  *
  * Asking for an unsupported kind throws — louder than handing back an
  * informer that would silently never sync.
  */
-const ALL_KINDS: readonly WatchKind[] = ["Contribution", "Claim"];
+const REMOTE_KINDS: readonly WatchKind[] = ["Contribution", "Claim"];
+const LOCAL_KINDS: readonly WatchKind[] = ["Contribution", "Claim", "AgentSession"];
 
-const SUPPORTED_KINDS = new Set<WatchKind>(ALL_KINDS);
+const REMOTE_SUPPORTED = new Set<WatchKind>(REMOTE_KINDS);
+const LOCAL_SUPPORTED = new Set<WatchKind>(LOCAL_KINDS);
 
 /**
  * InformerFactory memoizes one Informer per kind for a single namespace
@@ -343,6 +350,29 @@ export class InformerFactory {
 
   constructor(opts: InformerFactoryOptions) {
     this.opts = opts;
+  }
+
+  get mode(): "remote" | "local" {
+    return this.opts.mode;
+  }
+
+  /**
+   * Whether the constructed mode supports the given kind. Used by hook
+   * call sites that gate AgentSession migrations: in remote mode the
+   * factory does not yet support AgentSession (server returns 501), so
+   * views must fall back to a non-reactive path (e.g. tmux poller). In
+   * local mode all three kinds are supported.
+   */
+  supportsKind(kind: WatchKind): boolean {
+    return this.supportedKinds().has(kind);
+  }
+
+  private supportedKinds(): ReadonlySet<WatchKind> {
+    return this.opts.mode === "remote" ? REMOTE_SUPPORTED : LOCAL_SUPPORTED;
+  }
+
+  private allKinds(): readonly WatchKind[] {
+    return this.opts.mode === "remote" ? REMOTE_KINDS : LOCAL_KINDS;
   }
 
   /**
@@ -377,10 +407,11 @@ export class InformerFactory {
    * comment for the AgentSession rationale.
    */
   informerFor<K extends WatchKind>(kind: K): Informer<K> {
-    if (!SUPPORTED_KINDS.has(kind)) {
+    const supported = this.supportedKinds();
+    if (!supported.has(kind)) {
       throw new Error(
-        `InformerFactory.informerFor(${kind}): kind not yet supported by grove-server watch routes. Supported: ${[
-          ...SUPPORTED_KINDS,
+        `InformerFactory.informerFor(${kind}): kind not supported in mode=${this.opts.mode}. Supported: ${[
+          ...supported,
         ].join(", ")}.`,
       );
     }
@@ -405,7 +436,7 @@ export class InformerFactory {
    * parent signal) on shutdown.
    */
   startAll(): void {
-    for (const kind of ALL_KINDS) {
+    for (const kind of this.allKinds()) {
       this.startKind(kind);
     }
   }
@@ -428,7 +459,7 @@ export class InformerFactory {
    * don't lose track of the live controller or runPromise.
    */
   async relist(kind?: WatchKind): Promise<void> {
-    const kinds: WatchKind[] = kind ? [kind] : [...ALL_KINDS];
+    const kinds: WatchKind[] = kind ? [kind] : [...this.allKinds()];
     const targets = kinds
       .map((k) => this.running.get(k))
       .filter((r): r is RunningInformer => r !== undefined);

--- a/src/local/informer-pr2-smoke.test.ts
+++ b/src/local/informer-pr2-smoke.test.ts
@@ -1,0 +1,129 @@
+/**
+ * E2E smoke test for the PR2 (#388) local-mode informer pipeline.
+ *
+ * Mounts a real `LocalRuntime` + `WatchHub` + `InformerFactory(mode:"local")`
+ * end-to-end. Asserts that:
+ *
+ *  1. After `factory.startAll()`, the Contribution and Claim informers
+ *     reach `hasSynced=true` from the empty initial snapshot.
+ *  2. Writing a contribution / claim through the local store fires
+ *     `recordWrite` via the WatchHubRecorder hook, propagates through
+ *     `LocalWatchClient`, and lands in the informer cache.
+ *  3. `factory.relist()` re-issues the listFn snapshot and the cache
+ *     contents survive (event sequence: RELIST_BEGIN → RELIST → RELIST_END).
+ *  4. `factory.stopAll()` settles cleanly with no leaked timers.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { InformerFactory } from "../core/informer.js";
+import { makeClaim, makeContribution } from "../core/test-helpers.js";
+import { WatchHub } from "../core/watch-hub.js";
+import { createLocalRuntime, type LocalRuntime } from "./runtime.js";
+
+const NS = "default";
+
+async function untilTrue(check: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!check()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("untilTrue: timed out");
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("PR2 local-mode informer end-to-end", () => {
+  let rootDir: string;
+  let runtime: LocalRuntime;
+  let hub: WatchHub;
+  let factory: InformerFactory;
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "pr2-informer-smoke-"));
+    const groveDir = join(rootDir, ".grove");
+    await mkdir(groveDir, { recursive: true });
+    hub = new WatchHub();
+    runtime = createLocalRuntime({
+      groveDir,
+      parseContract: false,
+      workspace: false,
+      watchHub: hub,
+      watchNamespace: NS,
+    });
+    factory = new InformerFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: async (kind) => {
+        switch (kind) {
+          case "Contribution":
+            return runtime.contributionStore.listEntities();
+          case "Claim":
+            return runtime.claimStore.listEntities();
+          default:
+            return [];
+        }
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await factory.stopAll();
+    runtime.close();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  test("startAll → both informers sync to empty cache", async () => {
+    factory.startAll();
+    const contribInformer = factory.informerFor("Contribution");
+    const claimInformer = factory.informerFor("Claim");
+    await untilTrue(() => contribInformer.hasSynced() && claimInformer.hasSynced());
+    expect(contribInformer.list()).toEqual([]);
+    expect(claimInformer.list()).toEqual([]);
+  });
+
+  test("contribution write fires hub recordWrite and lands in cache", async () => {
+    factory.startAll();
+    const informer = factory.informerFor("Contribution");
+    await untilTrue(() => informer.hasSynced());
+
+    const c = makeContribution({ summary: "smoke-1" });
+    await runtime.contributionStore.put(c);
+
+    await untilTrue(() => informer.list().length === 1);
+    expect(informer.getById(c.cid)?.id).toBe(c.cid);
+    expect(hub.currentRv(NS, "Contribution")).toBe(1n);
+  });
+
+  test("claim write fires hub recordWrite and lands in cache", async () => {
+    factory.startAll();
+    const informer = factory.informerFor("Claim");
+    await untilTrue(() => informer.hasSynced());
+
+    const claim = makeClaim({ targetRef: "smoke-target" });
+    await runtime.claimStore.createClaim(claim);
+
+    await untilTrue(() => informer.list().length === 1);
+    expect(informer.getById(claim.claimId)?.id).toBe(claim.claimId);
+  });
+
+  test("factory.relist preserves cache content via fresh listFn snapshot", async () => {
+    factory.startAll();
+    const informer = factory.informerFor("Claim");
+    await untilTrue(() => informer.hasSynced());
+
+    const claim = makeClaim({ targetRef: "relist-target" });
+    await runtime.claimStore.createClaim(claim);
+    await untilTrue(() => informer.list().length === 1);
+
+    // Forced relist — informer aborts the watch loop, re-runs listFn,
+    // and re-emits RELIST_BEGIN/RELIST/RELIST_END. Cache content unchanged.
+    await factory.relist("Claim");
+    expect(informer.list().length).toBe(1);
+    expect(informer.getById(claim.claimId)).toBeDefined();
+  });
+});

--- a/src/local/runtime.test.ts
+++ b/src/local/runtime.test.ts
@@ -3,6 +3,8 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { makeClaim, makeContribution } from "../core/test-helpers.js";
+import { WatchHub } from "../core/watch-hub.js";
 import { createLocalRuntime } from "./runtime.js";
 
 describe("createLocalRuntime", () => {
@@ -47,6 +49,57 @@ name: runtime-fallback-test
       } else {
         process.env.GROVE_SESSION_ID = previousSessionId;
       }
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  test("watchHub republishes contribution + claim writes (PR2 #388)", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "grove-runtime-watch-"));
+    const groveDir = join(rootDir, ".grove");
+    const NS = "test-ns";
+
+    try {
+      await mkdir(groveDir, { recursive: true });
+      const hub = new WatchHub();
+      const runtime = createLocalRuntime({
+        groveDir,
+        parseContract: false,
+        watchHub: hub,
+        watchNamespace: NS,
+      });
+      try {
+        const c = makeContribution({ summary: "watch-c-1" });
+        await runtime.contributionStore.put(c);
+        expect(hub.currentRv(NS, "Contribution")).toBe(1n);
+
+        const claim = makeClaim({ targetRef: "watch-c-target" });
+        await runtime.claimStore.createClaim(claim);
+        expect(hub.currentRv(NS, "Claim")).toBe(1n);
+
+        await runtime.claimStore.complete(claim.claimId);
+        expect(hub.currentRv(NS, "Claim")).toBe(2n);
+      } finally {
+        runtime.close();
+      }
+    } finally {
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  test("watchHub without watchNamespace throws", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "grove-runtime-watch-bad-"));
+    const groveDir = join(rootDir, ".grove");
+    try {
+      await mkdir(groveDir, { recursive: true });
+      const hub = new WatchHub();
+      expect(() =>
+        createLocalRuntime({
+          groveDir,
+          parseContract: false,
+          watchHub: hub,
+        }),
+      ).toThrow(/watchNamespace is required/);
+    } finally {
       await rm(rootDir, { recursive: true, force: true });
     }
   });

--- a/src/local/runtime.ts
+++ b/src/local/runtime.ts
@@ -12,6 +12,7 @@ import type { GroveContract } from "../core/contract.js";
 import { parseGroveContract } from "../core/contract.js";
 import type { FrontierCalculator } from "../core/frontier.js";
 import { DefaultFrontierCalculator } from "../core/frontier.js";
+import type { WatchHub } from "../core/watch-hub.js";
 import { CachedFrontierCalculator } from "../gossip/cached-frontier.js";
 import { FsCas } from "./fs-cas.js";
 import type { SqliteBountyStore } from "./sqlite-bounty-store.js";
@@ -23,6 +24,7 @@ import type {
   SqliteIdempotencyStore,
 } from "./sqlite-store.js";
 import { createSqliteStores } from "./sqlite-store.js";
+import { createWatchHubRecorder } from "./watch-hub-recorder.js";
 import { LocalWorkspaceManager } from "./workspace.js";
 
 /** Options for creating a local runtime. */
@@ -39,6 +41,22 @@ export interface LocalRuntimeOptions {
   readonly workspace?: boolean;
   /** Whether to parse the GROVE.md contract. Default: `true`. */
   readonly parseContract?: boolean;
+  /**
+   * Optional process-local `WatchHub` to which contribution + claim writes
+   * are republished as `EntityWriteEvent`s. When provided, the runtime
+   * wires `SqliteContributionStore.onContributionWrite` and
+   * `SqliteClaimStore.onClaimWrite` to the recorder shipped in #388 PR2.
+   * When omitted, no hub plumbing is created — existing CLI / server
+   * callers that supply their own `OperationDeps.onEntityWrite` path are
+   * unaffected.
+   */
+  readonly watchHub?: WatchHub | undefined;
+  /**
+   * Namespace under which entity write events are emitted. Required when
+   * `watchHub` is provided. Mirrors the server-side namespace passed to
+   * `OperationDeps.namespace`.
+   */
+  readonly watchNamespace?: string | undefined;
 }
 
 /** All local stores, services, and resources. */
@@ -116,6 +134,22 @@ export function createLocalRuntime(options: LocalRuntimeOptions): LocalRuntime {
   // Wire write-driven cache invalidation: when a contribution is written,
   // the frontier cache is invalidated so the next read recomputes.
   stores.contributionStore.onWrite = onContributionWrite;
+
+  // Wire local-mode WatchHub republish (#388 PR2). The recorder projects
+  // domain types via `contributionToEntity` / `claimToEntity` and calls
+  // `WatchHub.recordWrite`. AgentSession is wired by the TUI main entry
+  // (it owns the AgentRuntime), not here.
+  if (options.watchHub) {
+    if (!options.watchNamespace) {
+      throw new Error("createLocalRuntime: watchNamespace is required when watchHub is provided");
+    }
+    const recorder = createWatchHubRecorder({
+      hub: options.watchHub,
+      namespace: options.watchNamespace,
+    });
+    stores.contributionStore.onContributionWrite = (op, c) => recorder.contribution(op, c);
+    stores.claimStore.onClaimWrite = (op, c) => recorder.claim(op, c);
+  }
 
   let workspace: LocalWorkspaceManager | undefined;
   if (createWorkspace) {

--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -16,8 +16,7 @@ import { join } from "node:path";
 import { runClaimStoreTests } from "../core/claim-store.conformance.js";
 import { ContributionKind, RelationType } from "../core/models.js";
 import { runContributionStoreTests } from "../core/store.conformance.js";
-import type { ContributionStore } from "../core/store.js";
-import { makeContribution } from "../core/test-helpers.js";
+import { makeClaim, makeContribution } from "../core/test-helpers.js";
 import { createSqliteStores, SqliteStore } from "./sqlite-store.js";
 
 function sqliteBindLimit(db: Database): number {
@@ -114,7 +113,7 @@ runClaimStoreTests(async () => {
 // ---------------------------------------------------------------------------
 
 describe("putMany with rich contributions", () => {
-  let store: ContributionStore;
+  let store: import("./sqlite-store.js").SqliteContributionStore;
   let dir: string;
   let closeStore: () => void;
   let db: Database;
@@ -560,5 +559,113 @@ describe("putMany with rich contributions", () => {
       (_, index) => `tag-${index}`,
     );
     await expect(store.list({ tags: tooManyTags })).rejects.toThrow("Too many tag filters");
+  });
+
+  test("onContributionWrite fires ADDED on new put, skips re-put of same cid", async () => {
+    const events: Array<{ op: string; cid: string }> = [];
+    store.onContributionWrite = (op, c) => events.push({ op, cid: c.cid });
+    const c = makeContribution({ summary: "watch-event-1" });
+    await store.put(c);
+    await store.put(c);
+    expect(events).toEqual([{ op: "ADDED", cid: c.cid }]);
+  });
+
+  test("onContributionWrite fires once per new contribution in putMany", async () => {
+    const events: Array<{ op: string; cid: string }> = [];
+    store.onContributionWrite = (op, c) => events.push({ op, cid: c.cid });
+    const c1 = makeContribution({ summary: "many-1" });
+    const c2 = makeContribution({ summary: "many-2" });
+    await store.putMany([c1, c2]);
+    expect(events).toHaveLength(2);
+    expect(events.every((e) => e.op === "ADDED")).toBe(true);
+  });
+});
+
+describe("SqliteClaimStore onClaimWrite hook", () => {
+  let dir: string;
+  let claimStore: import("./sqlite-store.js").SqliteClaimStore;
+  let closeStore: () => void;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "sqlite-claim-watch-"));
+    const dbPath = join(dir, "test.db");
+    const stores = createSqliteStores(dbPath);
+    claimStore = stores.claimStore;
+    closeStore = stores.close;
+  });
+
+  afterEach(async () => {
+    closeStore();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("createClaim fires ADDED", async () => {
+    const events: Array<{ op: string; id: string }> = [];
+    claimStore.onClaimWrite = (op, c) => events.push({ op, id: c.claimId });
+    const claim = makeClaim({ targetRef: "watch-create" });
+    await claimStore.createClaim(claim);
+    expect(events).toEqual([{ op: "ADDED", id: claim.claimId }]);
+  });
+
+  test("heartbeat does NOT fire (pure heartbeat is not a watch event)", async () => {
+    const claim = makeClaim({ targetRef: "watch-heartbeat" });
+    await claimStore.createClaim(claim);
+    const events: Array<{ op: string; id: string }> = [];
+    claimStore.onClaimWrite = (op, c) => events.push({ op, id: c.claimId });
+    await claimStore.heartbeat(claim.claimId);
+    expect(events).toEqual([]);
+  });
+
+  test("complete fires MODIFIED", async () => {
+    const claim = makeClaim({ targetRef: "watch-complete" });
+    await claimStore.createClaim(claim);
+    const events: Array<{ op: string; id: string }> = [];
+    claimStore.onClaimWrite = (op, c) => events.push({ op, id: c.claimId });
+    await claimStore.complete(claim.claimId);
+    expect(events).toEqual([{ op: "MODIFIED", id: claim.claimId }]);
+  });
+
+  test("release fires MODIFIED", async () => {
+    const claim = makeClaim({ targetRef: "watch-release" });
+    await claimStore.createClaim(claim);
+    const events: Array<{ op: string; id: string }> = [];
+    claimStore.onClaimWrite = (op, c) => events.push({ op, id: c.claimId });
+    await claimStore.release(claim.claimId);
+    expect(events).toEqual([{ op: "MODIFIED", id: claim.claimId }]);
+  });
+
+  test("expireStale fires MODIFIED for each expired claim", async () => {
+    // Claim with already-expired lease so expireStale picks it up.
+    const expired = makeClaim({
+      targetRef: "watch-expire",
+      leaseExpiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    await claimStore.createClaim(expired);
+    const events: Array<{ op: string; id: string }> = [];
+    claimStore.onClaimWrite = (op, c) => events.push({ op, id: c.claimId });
+    const expired_results = await claimStore.expireStale();
+    expect(expired_results.length).toBeGreaterThan(0);
+    expect(events.length).toBe(expired_results.length);
+    expect(events.every((e) => e.op === "MODIFIED")).toBe(true);
+  });
+
+  test("claimOrRenew fires ADDED for new insert, MODIFIED for renew", async () => {
+    const events: Array<{ op: string; id: string }> = [];
+    claimStore.onClaimWrite = (op, c) => events.push({ op, id: c.claimId });
+    const claim = makeClaim({ targetRef: "watch-renew" });
+    await claimStore.claimOrRenew(claim);
+    // Same agent, same target → renew path
+    const renewed = makeClaim({
+      claimId: `${claim.claimId}-attempt2`,
+      targetRef: claim.targetRef,
+      agent: claim.agent,
+      createdAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    await claimStore.claimOrRenew(renewed);
+    expect(events.length).toBe(2);
+    expect(events[0]?.op).toBe("ADDED");
+    expect(events[1]?.op).toBe("MODIFIED");
   });
 });

--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -607,13 +607,19 @@ describe("SqliteClaimStore onClaimWrite hook", () => {
     expect(events).toEqual([{ op: "ADDED", id: claim.claimId }]);
   });
 
-  test("heartbeat does NOT fire (pure heartbeat is not a watch event)", async () => {
+  test("heartbeat fires MODIFIED so cached lease fields stay fresh", async () => {
     const claim = makeClaim({ targetRef: "watch-heartbeat" });
     await claimStore.createClaim(claim);
-    const events: Array<{ op: string; id: string }> = [];
-    claimStore.onClaimWrite = (op, c) => events.push({ op, id: c.claimId });
-    await claimStore.heartbeat(claim.claimId);
-    expect(events).toEqual([]);
+    const events: Array<{ op: string; id: string; leaseExpiresAt: string }> = [];
+    claimStore.onClaimWrite = (op, c) =>
+      events.push({ op, id: c.claimId, leaseExpiresAt: c.leaseExpiresAt });
+    const renewed = await claimStore.heartbeat(claim.claimId);
+    expect(events.length).toBe(1);
+    expect(events[0]?.op).toBe("MODIFIED");
+    expect(events[0]?.id).toBe(claim.claimId);
+    // The fired claim's leaseExpiresAt must reflect the renewed value so
+    // consumers re-render with the new deadline (Codex round 1, finding 3).
+    expect(events[0]?.leaseExpiresAt).toBe(renewed.leaseExpiresAt);
   });
 
   test("complete fires MODIFIED", async () => {

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -861,6 +861,15 @@ export class SqliteContributionStore implements ContributionStore {
   /** Optional callback invoked after a successful write (put/putMany). */
   onWrite?: () => void;
 
+  /**
+   * Optional callback invoked after a successful Contribution write — the
+   * domain-typed feed for the local-mode `WatchHub` (#388 PR2). The
+   * `LocalRuntime` adapter projects via `contributionToEntity` and calls
+   * `WatchHub.recordWrite`. Only fires for newly-inserted contributions
+   * (idempotent re-puts of the same CID do not re-fire).
+   */
+  onContributionWrite?: (op: "ADDED" | "MODIFIED" | "DELETED", c: Contribution) => void;
+
   // Cached prepared statements for fixed queries
   private readonly stmtGetByCid: Statement;
   private readonly stmtGetByContentHash: Statement;
@@ -910,7 +919,10 @@ export class SqliteContributionStore implements ContributionStore {
 
   put = async (contribution: Contribution): Promise<ContributionPutResult> => {
     const result = this.putSync(contribution);
-    if (result.isNew) this.onWrite?.();
+    if (result.isNew) {
+      this.onWrite?.();
+      this.onContributionWrite?.("ADDED", contribution);
+    }
     return result;
   };
 
@@ -930,7 +942,10 @@ export class SqliteContributionStore implements ContributionStore {
    */
   putWithCowrite(contribution: Contribution, cowriteFn: () => void): ContributionPutResult {
     const result = this.putSync(contribution, cowriteFn);
-    if (result.isNew) this.onWrite?.();
+    if (result.isNew) {
+      this.onWrite?.();
+      this.onContributionWrite?.("ADDED", contribution);
+    }
     return result;
   }
 
@@ -946,6 +961,13 @@ export class SqliteContributionStore implements ContributionStore {
     });
     tx();
     if (results.some((result) => result.isNew)) this.onWrite?.();
+    if (this.onContributionWrite) {
+      for (let i = 0; i < contributions.length; i += 1) {
+        if (results[i]?.isNew) {
+          this.onContributionWrite("ADDED", contributions[i] as Contribution);
+        }
+      }
+    }
     return results;
   };
 
@@ -1411,6 +1433,14 @@ export class SqliteClaimStore implements ClaimStore {
   readonly storeIdentity: string;
   private readonly db: Database;
 
+  /**
+   * Optional callback invoked after a successful Claim transition that
+   * matters for the local-mode WatchHub (#388 PR2). Pure heartbeat-only
+   * updates that don't change status or the lease boundary are NOT fired —
+   * matches the rule documented on `OperationDeps.onEntityWrite`.
+   */
+  onClaimWrite?: (op: "ADDED" | "MODIFIED" | "DELETED", c: Claim) => void;
+
   // Cached prepared statements
   private readonly stmtGetClaim: Statement;
 
@@ -1473,6 +1503,7 @@ export class SqliteClaimStore implements ClaimStore {
 
     const created = this.readClaim(claim.claimId);
     if (created === null) throw new Error(`Failed to read back claim '${claim.claimId}'`);
+    this.onClaimWrite?.("ADDED", created);
     return created;
   };
 
@@ -1484,6 +1515,7 @@ export class SqliteClaimStore implements ClaimStore {
     const leaseExpiresUtc = toUtcIso(claim.leaseExpiresAt);
 
     let resultClaimId: string = claim.claimId;
+    let didRenew = false;
 
     const tx = this.db.transaction(() => {
       const now = new Date();
@@ -1498,6 +1530,7 @@ export class SqliteClaimStore implements ClaimStore {
       if (activeOnTarget !== null) {
         // Same agent → renew the existing claim from current time
         if (activeOnTarget.agent_id === claim.agent.agentId) {
+          didRenew = true;
           // Use the requested lease duration (derived from the claim payload),
           // but anchor it to now so retries always extend the lease forward.
           const requestedDurationMs =
@@ -1550,6 +1583,10 @@ export class SqliteClaimStore implements ClaimStore {
 
     const result = this.readClaim(resultClaimId);
     if (result === null) throw new Error(`Failed to read back claim '${resultClaimId}'`);
+    // Renew anchors the lease forward — that IS the lease boundary moving,
+    // which the watch protocol cares about, so fire MODIFIED. New insert
+    // path fires ADDED.
+    this.onClaimWrite?.(didRenew ? "MODIFIED" : "ADDED", result);
     return result;
   };
 
@@ -1655,7 +1692,11 @@ export class SqliteClaimStore implements ClaimStore {
       return results;
     });
 
-    return expireTx.immediate();
+    const results = expireTx.immediate();
+    if (this.onClaimWrite) {
+      for (const r of results) this.onClaimWrite("MODIFIED", r.claim);
+    }
+    return results;
   };
 
   activeClaims = async (targetRef?: string): Promise<readonly Claim[]> => {
@@ -1834,7 +1875,9 @@ export class SqliteClaimStore implements ClaimStore {
       .all(newStatus, claimId, nowIso) as readonly ClaimRow[];
 
     if (rows.length > 0 && rows[0] !== undefined) {
-      return rowToClaim(rows[0]);
+      const claim = rowToClaim(rows[0]);
+      this.onClaimWrite?.("MODIFIED", claim);
+      return claim;
     }
 
     // UPDATE matched nothing — determine why

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -1615,7 +1615,17 @@ export class SqliteClaimStore implements ClaimStore {
       ) as readonly ClaimRow[];
 
     if (rows.length > 0 && rows[0] !== undefined) {
-      return rowToClaim(rows[0]);
+      const claim = rowToClaim(rows[0]);
+      // Heartbeat advances heartbeat_at + lease_expires_at + revision; views
+      // render the lease deadline from the cached entity, so without firing
+      // a MODIFIED write the cache would still show the prior lease and the
+      // view would render the claim as expired/stale even though the store
+      // is fresh. PR2 (#388) earlier excluded heartbeat to suppress no-op
+      // ticks, but the lease fields ARE state changes that consumers depend
+      // on — see Codex round-1 finding "Claim heartbeats never update the
+      // local watch cache".
+      this.onClaimWrite?.("MODIFIED", claim);
+      return claim;
     }
 
     // UPDATE matched nothing — determine why for a specific error message

--- a/src/local/watch-hub-recorder.test.ts
+++ b/src/local/watch-hub-recorder.test.ts
@@ -1,0 +1,130 @@
+/**
+ * WatchHubRecorder unit tests — verify each typed write maps to a
+ * `WatchHub.recordWrite` call with the expected entity projection.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { AgentSession } from "../core/agent-runtime.js";
+import type { Claim, Contribution } from "../core/models.js";
+import type { EntityWriteEvent } from "../core/watch-events.js";
+import { WatchHub } from "../core/watch-hub.js";
+import { createWatchHubRecorder } from "./watch-hub-recorder.js";
+
+const NS = "test-ns";
+
+function captureRecorder(): {
+  hub: WatchHub;
+  events: EntityWriteEvent[];
+} {
+  const hub = new WatchHub();
+  const events: EntityWriteEvent[] = [];
+  const orig = hub.recordWrite.bind(hub);
+  hub.recordWrite = (e: EntityWriteEvent) => {
+    events.push(e);
+    return orig(e);
+  };
+  return { hub, events };
+}
+
+describe("WatchHubRecorder", () => {
+  test("contribution maps to ContributionEntity envelope", () => {
+    const { hub, events } = captureRecorder();
+    const recorder = createWatchHubRecorder({ hub, namespace: NS });
+    const c: Contribution = {
+      cid: "cid-1",
+      manifestVersion: 1,
+      kind: "review" as Contribution["kind"],
+      mode: "report" as Contribution["mode"],
+      summary: "test",
+      artifacts: {},
+      relations: [],
+      tags: [],
+      agent: { agentId: "a-1" } as Contribution["agent"],
+      createdAt: "2026-04-30T00:00:00Z",
+    };
+
+    recorder.contribution("ADDED", c);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("Contribution");
+    expect(events[0]?.namespace).toBe(NS);
+    expect(events[0]?.op).toBe("ADDED");
+    expect(events[0]?.entity.kind).toBe("Contribution");
+    expect(events[0]?.entity.id).toBe("cid-1");
+  });
+
+  test("claim maps to ClaimEntity envelope with injectable clock", () => {
+    const { hub, events } = captureRecorder();
+    const fixedNow = 1_700_000_000_000;
+    const recorder = createWatchHubRecorder({ hub, namespace: NS, now: () => fixedNow });
+    const claim: Claim = {
+      claimId: "claim-1",
+      targetRef: "target",
+      agent: { agentId: "a-1" } as Claim["agent"],
+      status: "active" as Claim["status"],
+      intentSummary: "test",
+      createdAt: "2026-04-30T00:00:00Z",
+      heartbeatAt: "2026-04-30T00:00:00Z",
+      leaseExpiresAt: "2099-04-30T00:00:00Z",
+    };
+
+    recorder.claim("MODIFIED", claim);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("Claim");
+    expect(events[0]?.op).toBe("MODIFIED");
+    expect(events[0]?.entity.id).toBe("claim-1");
+    expect(events[0]?.entity.namespace).toBe(NS);
+  });
+
+  test("agentSession maps to AgentSessionEntity envelope", () => {
+    const { hub, events } = captureRecorder();
+    const recorder = createWatchHubRecorder({ hub, namespace: NS });
+    const session: AgentSession = {
+      id: "grove-coord-1-abc",
+      role: "coordinator",
+      status: "running",
+    };
+
+    recorder.agentSession("DELETED", session);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("AgentSession");
+    expect(events[0]?.op).toBe("DELETED");
+    expect(events[0]?.entity.id).toBe("grove-coord-1-abc");
+    expect(events[0]?.entity.namespace).toBe(NS);
+  });
+
+  test("recordWrite throw is swallowed and logged, write loop continues", () => {
+    const hub = new WatchHub();
+    const errs: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((data: string | Uint8Array) => {
+      errs.push(typeof data === "string" ? data : Buffer.from(data).toString("utf-8"));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      hub.recordWrite = () => {
+        throw new Error("hub broken");
+      };
+      const recorder = createWatchHubRecorder({ hub, namespace: NS });
+      const c: Contribution = {
+        cid: "cid-x",
+        manifestVersion: 1,
+        kind: "review" as Contribution["kind"],
+        mode: "report" as Contribution["mode"],
+        summary: "",
+        artifacts: {},
+        relations: [],
+        tags: [],
+        agent: { agentId: "a" } as Contribution["agent"],
+        createdAt: "2026-04-30T00:00:00Z",
+      };
+      // Must not throw.
+      expect(() => recorder.contribution("ADDED", c)).not.toThrow();
+      expect(errs.some((s) => s.includes("hub broken"))).toBe(true);
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+});

--- a/src/local/watch-hub-recorder.ts
+++ b/src/local/watch-hub-recorder.ts
@@ -1,0 +1,67 @@
+/**
+ * WatchHubRecorder — typed adapter that bridges domain writes (Contribution,
+ * Claim, AgentSession) to `WatchHub.recordWrite` (#388 PR2).
+ *
+ * Local mode publishes to a process-local `WatchHub`; the existing remote
+ * path goes through `OperationDeps.onEntityWrite` → server-side hub. This
+ * helper centralizes the entity projection so each store/runtime caller
+ * doesn't repeat the boilerplate.
+ *
+ * Recorder calls swallow throws from `recordWrite` — a downstream subscriber
+ * failure must not poison the write path. Throws are logged once to stderr.
+ */
+
+import type { AgentSession } from "../core/agent-runtime.js";
+import { agentSessionToEntity, claimToEntity, contributionToEntity } from "../core/entity.js";
+import type { Claim, Contribution } from "../core/models.js";
+import type { WatchOp } from "../core/watch-events.js";
+import type { WatchHub } from "../core/watch-hub.js";
+
+export interface WatchHubRecorder {
+  contribution(op: WatchOp, c: Contribution): void;
+  claim(op: WatchOp, c: Claim): void;
+  agentSession(op: WatchOp, s: AgentSession): void;
+}
+
+export interface CreateWatchHubRecorderOptions {
+  readonly hub: WatchHub;
+  readonly namespace: string;
+  /**
+   * Injectable clock for `claimToEntity` lease-aware projection. Defaults to
+   * wall-clock; tests can pass a fake.
+   */
+  readonly now?: () => number;
+}
+
+export function createWatchHubRecorder(opts: CreateWatchHubRecorderOptions): WatchHubRecorder {
+  const { hub, namespace } = opts;
+  const now = opts.now ?? (() => Date.now());
+
+  const safeRecord = (
+    kind: "Contribution" | "Claim" | "AgentSession",
+    op: WatchOp,
+    entity:
+      | ReturnType<typeof contributionToEntity>
+      | ReturnType<typeof claimToEntity>
+      | ReturnType<typeof agentSessionToEntity>,
+  ): void => {
+    try {
+      hub.recordWrite({ kind, namespace, op, entity });
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[watch-hub-recorder] recordWrite(${kind}, ${op}) failed: ${detail}\n`);
+    }
+  };
+
+  return {
+    contribution(op, c) {
+      safeRecord("Contribution", op, contributionToEntity(c, namespace));
+    },
+    claim(op, c) {
+      safeRecord("Claim", op, claimToEntity(c, now, namespace));
+    },
+    agentSession(op, s) {
+      safeRecord("AgentSession", op, agentSessionToEntity(s, undefined, namespace));
+    },
+  };
+}

--- a/src/tui/hooks/informer-context.tsx
+++ b/src/tui/hooks/informer-context.tsx
@@ -73,6 +73,54 @@ export function useInformer<K extends WatchKind>(kind: K): Informer<K> {
 }
 
 /**
+ * No-op informer used when no `<InformerProvider>` is mounted (e.g. backend
+ * mode = "nexus" where the factory wasn't constructed). Returns empty list,
+ * `hasSynced=false`, and no-op event subscribers — so callers reading from
+ * the cache get nothing and the dual-path views fall back to `usePolledData`.
+ *
+ * `useInformerOptional` returns this stub when the context is null, which
+ * keeps React hook order stable in views that mount under both wrapped and
+ * unwrapped trees (the migrated PR2 views).
+ */
+function createNullInformer<K extends WatchKind>(): Informer<K> {
+  // The stub is mounted only when no provider is in scope; subscribers
+  // never fire so the unsubscribe is a no-op.
+  const unsubNoop = (): void => undefined;
+  const noop = (): (() => void) => unsubNoop;
+  return {
+    addEventHandler: noop,
+    addSyncHandler: noop,
+    hasSynced: () => false,
+    getById: () => undefined,
+    list: () => [],
+  } as unknown as Informer<K>;
+}
+
+const NULL_INFORMER_CACHE = new Map<WatchKind, Informer<WatchKind>>();
+function nullInformerFor<K extends WatchKind>(kind: K): Informer<K> {
+  let stub = NULL_INFORMER_CACHE.get(kind);
+  if (!stub) {
+    stub = createNullInformer<K>() as Informer<WatchKind>;
+    NULL_INFORMER_CACHE.set(kind, stub);
+  }
+  return stub as Informer<K>;
+}
+
+/**
+ * Non-throwing variant of `useInformer`. Returns a no-op informer when no
+ * provider is mounted OR when the factory's mode doesn't support the kind.
+ * Use this in views with a `usePolledData` fallback so React hook order
+ * stays stable across both code paths.
+ */
+export function useInformerOptional<K extends WatchKind>(kind: K): Informer<K> {
+  const factory = useContext(InformerContext);
+  if (!factory || !factory.supportsKind(kind)) {
+    return nullInformerFor(kind);
+  }
+  return factory.informerFor(kind);
+}
+
+/**
  * Holder for a factory that's not yet known at provider mount time —
  * needed by the interactive TUI flow (TuiApp) where the factory is
  * created inside async onInit/onStart/onConnect callbacks AFTER the

--- a/src/tui/hooks/informer-context.tsx
+++ b/src/tui/hooks/informer-context.tsx
@@ -57,6 +57,17 @@ export function useInformerFactory(): InformerFactory {
   return factory;
 }
 
+/**
+ * Non-throwing variant of `useInformerFactory`. Returns `null` when no
+ * provider is mounted (e.g. backend mode = "nexus" where the factory
+ * wasn't constructed) OR when the factory's mode doesn't support the
+ * caller's kind. Migrated views that have a `usePolledData` fallback
+ * path can use this to decide which path to take per render.
+ */
+export function useInformerFactoryOptional(): InformerFactory | null {
+  return useContext(InformerContext);
+}
+
 export function useInformer<K extends WatchKind>(kind: K): Informer<K> {
   return useInformerFactory().informerFor(kind);
 }

--- a/src/tui/hooks/informer-context.tsx
+++ b/src/tui/hooks/informer-context.tsx
@@ -34,18 +34,55 @@ export interface InformerProviderProps {
    * any hook actually subscribes — PR2 will gate this on env or per-call.
    */
   readonly eager?: boolean | undefined;
+  /**
+   * Optional provider used to suspend the watch streams while a session
+   * scope is active. The watch protocol does not forward `sessionId`, so a
+   * running factory would keep pulling cross-session data. When the
+   * provider exposes `hasSessionScope()` and it returns true, the factory
+   * stays stopped (Codex round 2, finding 1). Subscribe-changes are
+   * delivered via the optional `onSessionScopeChange` listener.
+   */
+  readonly scopeAwareProvider?: unknown;
   readonly children: ReactNode;
 }
 
+function readScopeFlag(provider: unknown): boolean {
+  if (typeof provider !== "object" || provider === null) return false;
+  if (!("hasSessionScope" in provider)) return false;
+  const fn = (provider as { hasSessionScope: unknown }).hasSessionScope;
+  if (typeof fn !== "function") return false;
+  return fn.call(provider) === true;
+}
+
+function attachScopeListener(
+  provider: unknown,
+  listener: (scoped: boolean) => void,
+): (() => void) | undefined {
+  if (typeof provider !== "object" || provider === null) return undefined;
+  if (!("onSessionScopeChange" in provider)) return undefined;
+  const fn = (provider as { onSessionScopeChange: unknown }).onSessionScopeChange;
+  if (typeof fn !== "function") return undefined;
+  const detach = fn.call(provider, listener);
+  return typeof detach === "function" ? (detach as () => void) : undefined;
+}
+
 export function InformerProvider(props: InformerProviderProps): ReactNode {
-  const { value, eager = false, children } = props;
+  const { value, eager = false, scopeAwareProvider, children } = props;
+  const [scoped, setScoped] = useState<boolean>(() => readScopeFlag(scopeAwareProvider));
+  useEffect(() => {
+    setScoped(readScopeFlag(scopeAwareProvider));
+    const detach = attachScopeListener(scopeAwareProvider, setScoped);
+    return detach;
+  }, [scopeAwareProvider]);
+
   useEffect(() => {
     if (!eager) return;
+    if (scoped) return;
     value.startAll();
     return () => {
       void value.stopAll();
     };
-  }, [value, eager]);
+  }, [value, eager, scoped]);
   return <InformerContext.Provider value={value}>{children}</InformerContext.Provider>;
 }
 
@@ -121,6 +158,55 @@ export function useInformerOptional<K extends WatchKind>(kind: K): Informer<K> {
 }
 
 /**
+ * Decide whether a migrated view should pull from the informer cache or
+ * fall back to its `usePolledData` path. Returns `true` only when:
+ *
+ *   1. A provider is mounted that supports the kind.
+ *   2. The factory mode is "remote" — the in-process local-mode hub
+ *      cannot observe writes from agent or CLI subprocesses, so the
+ *      cache would silently miss them. PR3+ may add a server-backed
+ *      local watch route to lift this restriction.
+ *   3. The TUI provider has no session scope — the watch protocol does
+ *      not forward `sessionId`, so a scoped view that read from the
+ *      global cache would leak contributions or claims from other
+ *      sessions. PR3+ extends `/api/watch` with sessionId filtering.
+ *
+ * The provider is duck-typed (`hasSessionScope?()`) since not every
+ * provider implements it; treat absence as "not scoped".
+ */
+/**
+ * Reactive read of `provider.hasSessionScope?.()`. Returns `true` when a
+ * session scope is active. Subscribes to `provider.onSessionScopeChange`
+ * if available so views re-render when scope flips. PR2 (#388) Codex
+ * round 2: lets claim-backed views suppress polling when scoped (the
+ * current `getClaims` API does not filter by sessionId, so unsuppressed
+ * polling would leak cross-session claims).
+ */
+export function useProviderScoped(provider: unknown): boolean {
+  const [scoped, setScoped] = useState<boolean>(() => readScopeFlag(provider));
+  useEffect(() => {
+    setScoped(readScopeFlag(provider));
+    const detach = attachScopeListener(provider, setScoped);
+    return detach;
+  }, [provider]);
+  return scoped;
+}
+
+export function useEntityWatchEnabled(provider: unknown, kind: WatchKind): boolean {
+  const factory = useContext(InformerContext);
+  // PR2 (#388) Codex round 3: subscribe to scope transitions so that a
+  // view rendered before the user enters a scoped session re-renders to
+  // false the moment scope flips. A non-reactive read here would let
+  // the view keep reading from the (now-stale) global cache.
+  const scoped = useProviderScoped(provider);
+  if (!factory) return false;
+  if (!factory.supportsKind(kind)) return false;
+  if (factory.mode !== "remote") return false;
+  if (scoped) return false;
+  return true;
+}
+
+/**
  * Holder for a factory that's not yet known at provider mount time —
  * needed by the interactive TUI flow (TuiApp) where the factory is
  * created inside async onInit/onStart/onConnect callbacks AFTER the
@@ -136,24 +222,46 @@ export function useInformerOptional<K extends WatchKind>(kind: K): Informer<K> {
  */
 export interface InformerHolder {
   readonly set: (factory: InformerFactory | null) => void;
+  /**
+   * Bind the scope-aware provider so the holder's wrapping
+   * `<InformerProvider>` can suspend its watch streams during scoped
+   * sessions. Accepts `unknown` since not every provider implements the
+   * duck-typed `hasSessionScope`/`onSessionScopeChange` API; absent
+   * methods are treated as "never scoped".
+   *
+   * Call this from the same async callback that sets the factory.
+   * Updates after the holder is wired re-trigger the provider's eager
+   * effect so a freshly attached scoped provider stops the streams.
+   */
+  readonly setProvider: (provider: unknown) => void;
   readonly attach: (listener: () => void) => () => void;
   readonly current: () => InformerFactory | null;
+  readonly currentProvider: () => unknown;
 }
 
 export function createInformerHolder(): InformerHolder {
   let factory: InformerFactory | null = null;
+  let provider: unknown;
   const listeners = new Set<() => void>();
+  const fireListeners = (): void => {
+    for (const fn of [...listeners]) {
+      try {
+        fn();
+      } catch {
+        // listener thrown — already isolated; nothing to recover.
+      }
+    }
+  };
   return {
     set(f) {
       if (factory === f) return;
       factory = f;
-      for (const fn of [...listeners]) {
-        try {
-          fn();
-        } catch {
-          // listener thrown — already isolated; nothing to recover.
-        }
-      }
+      fireListeners();
+    },
+    setProvider(p) {
+      if (provider === p) return;
+      provider = p;
+      fireListeners();
     },
     attach(fn) {
       listeners.add(fn);
@@ -164,12 +272,17 @@ export function createInformerHolder(): InformerHolder {
     current() {
       return factory;
     },
+    currentProvider() {
+      return provider;
+    },
   };
 }
 
 export interface InformerProviderHolderProps {
   readonly holder: InformerHolder;
   readonly eager?: boolean | undefined;
+  /** See `InformerProviderProps.scopeAwareProvider`. */
+  readonly scopeAwareProvider?: unknown;
   readonly children: ReactNode;
 }
 
@@ -181,18 +294,21 @@ export interface InformerProviderHolderProps {
  * `<InformerProvider>` mounts and any subsequent hook consumer works.
  */
 export function InformerProviderHolder(props: InformerProviderHolderProps): ReactNode {
-  const { holder, eager, children } = props;
+  const { holder, eager, scopeAwareProvider, children } = props;
   const [factory, setFactory] = useState<InformerFactory | null>(() => holder.current());
-  const lastSeen = useRef(factory);
-  lastSeen.current = factory;
+  const [provider, setProvider] = useState<unknown>(() => holder.currentProvider());
+  const lastFactory = useRef(factory);
+  const lastProvider = useRef<unknown>(provider);
+  lastFactory.current = factory;
+  lastProvider.current = provider;
 
   // Coalesce rapid-fire updates from multiple onInit/onStart callbacks
   // into a single re-render via React's setState semantics.
   const sync = useCallback(() => {
-    const next = holder.current();
-    if (next !== lastSeen.current) {
-      setFactory(next);
-    }
+    const nextFactory = holder.current();
+    if (nextFactory !== lastFactory.current) setFactory(nextFactory);
+    const nextProvider = holder.currentProvider();
+    if (nextProvider !== lastProvider.current) setProvider(nextProvider);
   }, [holder]);
 
   useEffect(() => {
@@ -202,8 +318,13 @@ export function InformerProviderHolder(props: InformerProviderHolderProps): Reac
   }, [holder, sync]);
 
   if (!factory) return <>{children}</>;
+  // Prefer the externally-passed `scopeAwareProvider` prop (used by the
+  // --url path where the provider is known synchronously); fall back to
+  // the holder-supplied provider used by the interactive flow where the
+  // provider is set asynchronously alongside the factory.
+  const resolvedProvider = scopeAwareProvider ?? provider;
   return (
-    <InformerProvider value={factory} eager={eager}>
+    <InformerProvider value={factory} eager={eager} scopeAwareProvider={resolvedProvider}>
       {children}
     </InformerProvider>
   );

--- a/src/tui/hooks/use-entities.ts
+++ b/src/tui/hooks/use-entities.ts
@@ -12,7 +12,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Informer } from "../../core/informer.js";
 import type { WatchKind } from "../../core/watch-events.js";
-import { useInformer, useInformerFactory } from "./informer-context.js";
+import { useInformerFactoryOptional, useInformerOptional } from "./informer-context.js";
 
 export function shallowArraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
   if (a === b) return true;
@@ -43,8 +43,8 @@ export function useEntities<K extends WatchKind>(
   kind: K,
   predicate?: (e: EntityFor<K>) => boolean,
 ): UseEntitiesResult<EntityFor<K>> {
-  const informer = useInformer(kind);
-  const factory = useInformerFactory();
+  const informer = useInformerOptional(kind);
+  const factory = useInformerFactoryOptional();
   const predicateRef = useRef(predicate);
 
   const initial = useMemo<readonly EntityFor<K>[]>(() => {
@@ -63,7 +63,9 @@ export function useEntities<K extends WatchKind>(
   // Stream errors come from the factory's error listener — owned by the
   // watch lifecycle (4xx, listFn throw, etc). Cleared only when the factory
   // fires `null` (proven recovery: first RELIST_END after restart).
-  const [streamError, setStreamError] = useState<Error | null>(() => factory.getLastError(kind));
+  const [streamError, setStreamError] = useState<Error | null>(() =>
+    factory ? factory.getLastError(kind) : null,
+  );
   // Compute errors come from the predicate function throwing during a
   // recompute. Cleared on the next successful recompute. Kept separate so
   // recompute-after-stale-sync can't erase a stream error owned by the
@@ -119,6 +121,14 @@ export function useEntities<K extends WatchKind>(
     const unsubSync = informer.addSyncHandler(recompute);
     // Surface terminal informer.run() failures (remote 4xx, listFn throw)
     // so consumers don't sit at hasSynced=false with no diagnostic.
+    // When no provider is mounted, the informer is the null stub — there
+    // are no real errors to subscribe to, so skip the error wiring.
+    if (!factory) {
+      return () => {
+        unsubEvent();
+        unsubSync();
+      };
+    }
     const unsubError = factory.addErrorListener((errKind, err) => {
       if (errKind !== kind) return;
       setStreamError(err);

--- a/src/tui/hooks/use-entity.ts
+++ b/src/tui/hooks/use-entity.ts
@@ -8,7 +8,7 @@
 import { useEffect, useState } from "react";
 import type { Informer } from "../../core/informer.js";
 import type { WatchKind } from "../../core/watch-events.js";
-import { useInformer } from "./informer-context.js";
+import { useInformerOptional } from "./informer-context.js";
 
 export function selectEntityById<I extends Informer>(
   informer: I,
@@ -29,7 +29,7 @@ export function useEntity<K extends WatchKind>(
   kind: K,
   id: string | undefined,
 ): UseEntityResult<EntityFor<K>> {
-  const informer = useInformer(kind);
+  const informer = useInformerOptional(kind);
   const [data, setData] = useState<EntityFor<K> | undefined>(
     () => selectEntityById(informer, id) as EntityFor<K> | undefined,
   );

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -366,19 +366,52 @@ async function buildAppProps(
 
   // Use groveDir for workspace management (agent spawning, file sync).
   // Always resolved — even in "remote" mode, agents need workspace paths.
+  // Constructed before the InformerFactory block so its stores can drive
+  // the local-mode listFn / onContributionWrite path (#388 PR2).
+  let watchHub: import("../core/watch-hub.js").WatchHub | undefined;
+  let cleanupRuntime: import("../local/runtime.js").LocalRuntime | undefined;
+  const WATCH_NAMESPACE = "default";
   if (groveDir) {
     const { createLocalRuntime } = await import("../local/runtime.js");
     const { runCleanup, runArtifactGc, runSessionGc } = await import("../local/cleanup.js");
-    const cleanupRuntime = createLocalRuntime({
+    // Local-mode WatchHub: only constructed when we have a groveDir (i.e. the
+    // local runtime exists). Remote mode keeps using the server-side hub via
+    // WatchClient over SSE.
+    if (backend.mode === "local") {
+      const { WatchHub } = await import("../core/watch-hub.js");
+      watchHub = new WatchHub();
+    }
+    cleanupRuntime = createLocalRuntime({
       groveDir,
       frontierCacheTtlMs: 0,
       workspace: false,
       parseContract: false,
+      ...(watchHub ? { watchHub, watchNamespace: WATCH_NAMESPACE } : {}),
     });
+    // Wire AgentRuntime → WatchHub (#388 PR2) when both are present and the
+    // runtime exposes the hook. Other runtimes (Tmux, Subprocess, Mock)
+    // don't fire it; AgentSession entities then snapshot via listFn but
+    // don't update on transitions until those runtimes adopt the hook.
+    if (watchHub && agentRuntime) {
+      const ar = agentRuntime as { onSessionWrite?: (op: string, s: unknown) => void };
+      if ("onSessionWrite" in ar || ar.onSessionWrite !== undefined) {
+        const { createWatchHubRecorder } = await import("../local/watch-hub-recorder.js");
+        const recorder = createWatchHubRecorder({ hub: watchHub, namespace: WATCH_NAMESPACE });
+        (
+          agentRuntime as unknown as {
+            onSessionWrite?: (
+              op: "ADDED" | "MODIFIED" | "DELETED",
+              s: import("../core/agent-runtime.js").AgentSession,
+            ) => void;
+          }
+        ).onSessionWrite = (op, s) => recorder.agentSession(op, s);
+      }
+    }
 
+    const localRuntime = cleanupRuntime;
     const claimTimer = setInterval(async () => {
       try {
-        const result = await runCleanup({ claimStore: cleanupRuntime.claimStore });
+        const result = await runCleanup({ claimStore: localRuntime.claimStore });
         if (result.expiredClaims > 0 || result.cleanedClaims > 0) {
           process.stderr.write(
             `[cleanup] expired ${result.expiredClaims} stale claim(s), cleaned ${result.cleanedClaims} old claim(s)\n`,
@@ -392,8 +425,8 @@ async function buildAppProps(
     const gcTimer = setInterval(async () => {
       try {
         const result = await runArtifactGc({
-          contributionStore: cleanupRuntime.contributionStore,
-          cas: cleanupRuntime.cas,
+          contributionStore: localRuntime.contributionStore,
+          cas: localRuntime.cas,
         });
         if (result.deletedBlobs > 0) {
           process.stderr.write(
@@ -409,7 +442,7 @@ async function buildAppProps(
     // Run once eagerly on startup so the session picker is clean immediately.
     const runSessionGcOnce = () => {
       try {
-        const result = runSessionGc({ goalSessionStore: cleanupRuntime.goalSessionStore });
+        const result = runSessionGc({ goalSessionStore: localRuntime.goalSessionStore });
         if (result.archivedSessions > 0) {
           process.stderr.write(`[cleanup] archived ${result.archivedSessions} stale session(s)\n`);
         }
@@ -424,7 +457,7 @@ async function buildAppProps(
       clearInterval(claimTimer);
       clearInterval(gcTimer);
       clearInterval(sessionGcTimer);
-      cleanupRuntime.close();
+      localRuntime.close();
     });
   }
 
@@ -450,14 +483,19 @@ async function buildAppProps(
     }
   }
 
-  // Construct InformerFactory for the new SSE-driven cache (#295). Ships dark
-  // in PR1 — no view consumes the factory yet. The factory targets the
-  // grove-server watch routes (`/api/list`, `/api/watch`), which means it's
-  // only usable in `mode: "remote"` (grove-server). `mode: "nexus"` talks to
-  // Nexus VFS endpoints which do not host these routes; PR2 either adds a
-  // Nexus-backed WatchStream or routes through grove-server. Local mode uses
-  // an in-process WatchHub; PR2 wires real local store snapshots and
-  // recordWrite publishers.
+  // Construct InformerFactory for the SSE-driven cache (#295).
+  //
+  // Remote mode targets the grove-server watch routes (`/api/list`,
+  // `/api/watch`) over HTTP/SSE. `mode: "nexus"` talks to Nexus VFS
+  // endpoints which do not host these routes; for now those sessions
+  // skip the factory and views fall back to `usePolledData` until a
+  // Nexus-backed WatchStream lands.
+  //
+  // Local mode (PR2 #388) uses an in-process `WatchHub` plus the
+  // SqliteContributionStore / SqliteClaimStore + AgentRuntime as the
+  // listFn snapshot source. Producer-side recordWrite is wired by
+  // `createLocalRuntime` (contribution / claim stores) and by the
+  // `onSessionWrite` hook on AgentRuntime above.
   let informerFactory: import("../core/informer.js").InformerFactory | undefined;
   {
     const { InformerFactory } = await import("../core/informer.js");
@@ -474,24 +512,36 @@ async function buildAppProps(
           authHeader,
         });
       }
+    } else if (backend.mode === "local" && watchHub && cleanupRuntime) {
+      const localCleanupRuntime = cleanupRuntime;
+      const localAgentRuntime = agentRuntime;
+      informerFactory = new InformerFactory({
+        mode: "local",
+        hub: watchHub,
+        namespace: WATCH_NAMESPACE,
+        listFn: async (kind) => {
+          switch (kind) {
+            case "Contribution":
+              return localCleanupRuntime.contributionStore.listEntities();
+            case "Claim":
+              return localCleanupRuntime.claimStore.listEntities();
+            case "AgentSession":
+              if (!localAgentRuntime) return [];
+              try {
+                return await localAgentRuntime.listSessionEntities();
+              } catch {
+                return [];
+              }
+            default:
+              return [];
+          }
+        },
+      });
     }
-    // backend.mode === "local" / "nexus" intentionally NOT wired in PR1:
-    // - "local": LocalWatchClient with listFn=() => [] would synthesize a
-    //   "synced empty cache" since RELIST_END would fire on the empty
-    //   snapshot, and the unconnected WatchHub would never receive
-    //   recordWrite from the existing local stores. PR2 wires real
-    //   listEntities() + recordWrite producers before exposing this.
-    // - "nexus": WatchClient targets grove-server `/api/list` + `/api/watch`,
-    //   which Nexus does not host. PR2 either adds a Nexus-backed WatchStream
-    //   or routes through grove-server.
-    // In both cases, hook consumers throw on a missing provider — a louder
-    // signal than a silent watch failure.
-    //
-    // No stopAll() callback in PR1 — InformerProvider doesn't auto-start
-    // the informers (ships dark). PR2 turns eager-start on; at that point the
-    // provider's own unmount cleanup handles stopAll. Adding a stopCallback
-    // here would call stopAll() on a never-started factory, which is a no-op
-    // but adds noise.
+    // No stopAll() callback here — the InformerProvider's eager-start
+    // effect runs `stopAll()` on unmount. Adding a callback here would
+    // either double-stop (provider handles it) or stop without the
+    // provider knowing the factory is dead.
   }
 
   return {
@@ -776,10 +826,10 @@ export async function handleTui(
           );
         }
       }
-      // PR1 (#295): wrap App in InformerProvider/RefreshProvider when the
-      // informer factory was constructed. Ships dark — no view consumes the
-      // hooks yet; this primes the runtime so PR2 migrations don't have to
-      // re-thread plumbing through main.ts.
+      // PR2 (#388): wrap App in InformerProvider/RefreshProvider with
+      // eager-start enabled. PR1 shipped dark (eager=false) since no view
+      // consumed the hooks; PR2 migrates Entity-backed views, so we now
+      // need the watch loops running by the time those views mount.
       const { InformerProvider } = await import("./hooks/informer-context.js");
       const { RefreshProvider } = await import("./hooks/refresh-context.js");
       const appElement = React.createElement(
@@ -790,6 +840,7 @@ export async function handleTui(
       const wrappedApp = result.informerFactory
         ? React.createElement(InformerProvider, {
             value: result.informerFactory,
+            eager: true,
             children: React.createElement(RefreshProvider, {
               factory: result.informerFactory,
               children: appElement,
@@ -984,6 +1035,7 @@ export async function handleTui(
     });
     const informerHolderEl = React.createElement(InformerProviderHolder, {
       holder: informerHolder,
+      eager: true,
       children: refreshHolderEl,
     });
     root.render(

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -841,6 +841,12 @@ export async function handleTui(
         ? React.createElement(InformerProvider, {
             value: result.informerFactory,
             eager: true,
+            // Suspends the watch loop while a session scope is active —
+            // `/api/watch` does not filter by sessionId yet, so an eager
+            // factory would fan in cross-session events even though the
+            // migrated views ignore them. PR3+ removes this gate when
+            // sessionId plumbing lands.
+            scopeAwareProvider: result.appProps.provider,
             children: React.createElement(RefreshProvider, {
               factory: result.informerFactory,
               children: appElement,
@@ -957,6 +963,10 @@ export async function handleTui(
       // factory. Ships dark — no current view consumes hooks; this primes
       // the runtime so PR2 migrations don't have to re-thread plumbing.
       if (result.informerFactory) informerHolder.set(result.informerFactory);
+      // PR2 (#388) Codex round 2: bind the provider so the holder's
+      // wrapping <InformerProvider> can suspend the watch loop while a
+      // session scope is active.
+      informerHolder.setProvider(result.provider);
 
       // Post-startup: update agent skill SKILL.md (non-blocking)
       updateSkillAfterStartup();
@@ -986,7 +996,23 @@ export async function handleTui(
       const result = await buildAppProps(effectiveGrove, opts, groveInfo?.preset);
       activeProvider = result.provider;
       activeStopGc = result.stopGc;
+      // PR2 (#388) Codex round 3: pre-set the session scope on the
+      // provider BEFORE handing it to the InformerProvider. Otherwise
+      // the eager effect would call factory.startAll() while the scope
+      // is still undefined — `/api/watch` opens without a sessionId,
+      // populates the cache with cross-session data, and the scope
+      // change later (from screen-manager.tsx) only stops new fetches.
+      if (
+        sessionId !== undefined &&
+        typeof result.provider === "object" &&
+        result.provider !== null
+      ) {
+        const setScope = (result.provider as { setSessionScope?: (id: string) => void })
+          .setSessionScope;
+        if (typeof setScope === "function") setScope.call(result.provider, sessionId);
+      }
       if (result.informerFactory) informerHolder.set(result.informerFactory);
+      informerHolder.setProvider(result.provider);
 
       // Post-startup: update agent skill SKILL.md (non-blocking)
       updateSkillAfterStartup();
@@ -1011,6 +1037,10 @@ export async function handleTui(
       activeProvider = result.provider;
       activeStopGc = result.stopGc;
       if (result.informerFactory) informerHolder.set(result.informerFactory);
+      // PR2 (#388) Codex round 2: bind the provider so the holder's
+      // wrapping <InformerProvider> can suspend the watch loop while a
+      // session scope is active.
+      informerHolder.setProvider(result.provider);
       return result.appProps;
     };
 

--- a/src/tui/panels/panel-manager.tsx
+++ b/src/tui/panels/panel-manager.tsx
@@ -24,7 +24,7 @@ import type { Contribution } from "../../core/models.js";
 import type { AgentTopology } from "../../core/topology.js";
 import type { TmuxManager } from "../agents/tmux-manager.js";
 import { AgentSplitPane } from "../components/agent-split-pane.js";
-import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntity } from "../hooks/use-entity.js";
 import type { NavigationActions } from "../hooks/use-navigation.js";
 import type { PanelFocusState } from "../hooks/use-panel-focus.js";
@@ -203,9 +203,8 @@ export const PanelManager: React.NamedExoticComponent<PanelManagerProps> = React
     // and fall back to `usePolledData(getContribution)` when no factory is
     // mounted (e.g. backend.mode === "nexus" — no watch routes yet).
     const detailCid = nav.detailCid;
-    const informerFactory = useInformerFactoryOptional();
     const useInformerPath =
-      informerFactory?.supportsKind("Contribution") === true && detailCid !== undefined;
+      useEntityWatchEnabled(provider, "Contribution") && detailCid !== undefined;
     const entityResult = useEntity("Contribution", detailCid);
 
     const detailFetcher = useCallback(

--- a/src/tui/panels/panel-manager.tsx
+++ b/src/tui/panels/panel-manager.tsx
@@ -24,6 +24,8 @@ import type { Contribution } from "../../core/models.js";
 import type { AgentTopology } from "../../core/topology.js";
 import type { TmuxManager } from "../agents/tmux-manager.js";
 import { AgentSplitPane } from "../components/agent-split-pane.js";
+import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntity } from "../hooks/use-entity.js";
 import type { NavigationActions } from "../hooks/use-navigation.js";
 import type { PanelFocusState } from "../hooks/use-panel-focus.js";
 import { isPanelVisible, PANEL_LABELS, Panel } from "../hooks/use-panel-focus.js";
@@ -196,8 +198,16 @@ export const PanelManager: React.NamedExoticComponent<PanelManagerProps> = React
     // If detail view is active, show it in the Detail panel
     const showDetail = nav.isDetailView && nav.detailCid;
 
-    // Fetch contribution detail to resolve the first artifact name
+    // Fetch contribution detail to resolve the first artifact name.
+    // PR2 (#388): prefer the informer cache via `useEntity("Contribution", id)`
+    // and fall back to `usePolledData(getContribution)` when no factory is
+    // mounted (e.g. backend.mode === "nexus" — no watch routes yet).
     const detailCid = nav.detailCid;
+    const informerFactory = useInformerFactoryOptional();
+    const useInformerPath =
+      informerFactory?.supportsKind("Contribution") === true && detailCid !== undefined;
+    const entityResult = useEntity("Contribution", detailCid);
+
     const detailFetcher = useCallback(
       () => (detailCid ? provider.getContribution(detailCid) : Promise.resolve(undefined)),
       [provider, detailCid],
@@ -205,7 +215,7 @@ export const PanelManager: React.NamedExoticComponent<PanelManagerProps> = React
     const { data: detailData } = usePolledData<ContributionDetail | undefined>(
       detailFetcher,
       intervalMs,
-      isPanelVisible(panelState, Panel.Artifact) && detailCid !== undefined,
+      isPanelVisible(panelState, Panel.Artifact) && detailCid !== undefined && !useInformerPath,
     );
 
     // Pipeline view mode — render PipelineView instead of grid (item 11)
@@ -217,19 +227,22 @@ export const PanelManager: React.NamedExoticComponent<PanelManagerProps> = React
       );
     }
 
-    // Compute artifact names list and select by index
-    const artifactNames = detailData?.contribution.artifacts
-      ? Object.keys(detailData.contribution.artifacts)
-      : [];
+    // Compute artifact names list and select by index. Pull from the
+    // informer entity when available, else from the polled detail.
+    const artifactSource = useInformerPath
+      ? entityResult.data?.spec.artifacts
+      : detailData?.contribution.artifacts;
+    const artifactNames = artifactSource ? Object.keys(artifactSource) : [];
     const selectedArtifactName =
       artifactNames.length > 0
         ? artifactNames[(artifactIndex ?? 0) % artifactNames.length]
         : undefined;
 
-    // Resolve parent CID from derives_from relation for diff support
-    const parentCid = detailData?.contribution.relations.find(
-      (r) => r.relationType === "derives_from",
-    )?.targetCid;
+    // Resolve parent CID from derives_from relation for diff support.
+    const relationsSource = useInformerPath
+      ? entityResult.data?.spec.relations
+      : detailData?.contribution.relations;
+    const parentCid = relationsSource?.find((r) => r.relationType === "derives_from")?.targetCid;
 
     // ------------------------------------------------------------------
     // Panel renderer — maps a Panel enum to the appropriate component

--- a/src/tui/remote-provider.ts
+++ b/src/tui/remote-provider.ts
@@ -128,8 +128,46 @@ export class RemoteDataProvider
    * Called by screen-manager.tsx when a session is started or resumed.
    */
   setSessionScope(sessionId: string): void {
+    const prev = this.activeSessionId;
     this.activeSessionId = sessionId;
+    if (prev === undefined) {
+      for (const fn of [...this.scopeListeners]) {
+        try {
+          fn(true);
+        } catch (err) {
+          process.stderr.write(`[remote-provider] scope listener threw: ${String(err)}\n`);
+        }
+      }
+    }
   }
+
+  /**
+   * Whether a session scope is currently active. Migrated views (PR2 #388)
+   * gate the informer hook path on this — the watch protocol does not
+   * forward sessionId, so a scoped view would otherwise observe the full
+   * namespace stream and leak cross-session contributions. Until PR3+
+   * extends `/api/watch` with sessionId, scoped views stay on polling.
+   */
+  hasSessionScope(): boolean {
+    return this.activeSessionId !== undefined;
+  }
+
+  /**
+   * Subscribe to scope on/off transitions. Returns an unsubscribe.
+   * The InformerProvider hooks this so the remote watch factory can
+   * stop streaming as soon as the user enters a scoped session — the
+   * watch route does not filter by sessionId, so a running factory
+   * would otherwise keep pulling cross-session data. PR2 (#388),
+   * Codex round 2 finding 1.
+   */
+  onSessionScopeChange(listener: (scoped: boolean) => void): () => void {
+    this.scopeListeners.add(listener);
+    return () => {
+      this.scopeListeners.delete(listener);
+    };
+  }
+
+  private readonly scopeListeners = new Set<(scoped: boolean) => void>();
 
   private sessionScopedUrl(path: string, params?: URLSearchParams): string {
     const url = new URL(`${this.baseUrl}${path}`);

--- a/src/tui/store-backed-provider.ts
+++ b/src/tui/store-backed-provider.ts
@@ -146,6 +146,16 @@ export abstract class StoreBackedProvider
   /** Set by {@link setSessionScope} — scopes all contribution queries to this session. */
   protected activeSessionId: string | undefined;
 
+  /**
+   * Listeners that fire when {@link setSessionScope} flips the scope on/off.
+   * The boolean argument is `true` when a scope is now active, `false` when
+   * cleared. PR2 (#388) uses this to stop unscoped watch streams as soon
+   * as a session is selected — until `/api/watch` accepts a `sessionId`,
+   * a running factory would otherwise keep pulling cross-session data
+   * (Codex round 2, finding 1).
+   */
+  private readonly scopeListeners = new Set<(scoped: boolean) => void>();
+
   constructor(deps: StoreBackedProviderDeps) {
     this.store = deps.contributionStore;
     this.claims = deps.claimStore;
@@ -168,7 +178,41 @@ export abstract class StoreBackedProvider
    * NexusDataProvider overrides this to also swap the store instance.
    */
   setSessionScope(sessionId: string): void {
+    const prev = this.activeSessionId;
     this.activeSessionId = sessionId;
+    if (prev === undefined) {
+      for (const fn of [...this.scopeListeners]) {
+        try {
+          fn(true);
+        } catch (err) {
+          process.stderr.write(`[provider] scope listener threw: ${String(err)}\n`);
+        }
+      }
+    }
+  }
+
+  /**
+   * Whether a session scope is currently active. Migrated views (PR2 #388)
+   * use this to gate the informer hook path: the watch protocol does not
+   * yet support sessionId filtering, so when scoped, a global watch cache
+   * would leak contributions from other sessions. Scoped views fall back
+   * to provider polling (which honors sessionId) until PR3+ extends the
+   * watch protocol.
+   */
+  hasSessionScope(): boolean {
+    return this.activeSessionId !== undefined;
+  }
+
+  /**
+   * Subscribe to scope on/off transitions. Returns an unsubscribe.
+   * PR2 (#388) hooks the InformerProvider into this so it can stop the
+   * remote watch streams as soon as the user enters a scoped session.
+   */
+  onSessionScopeChange(listener: (scoped: boolean) => void): () => void {
+    this.scopeListeners.add(listener);
+    return () => {
+      this.scopeListeners.delete(listener);
+    };
   }
 
   // ---------------------------------------------------------------------------

--- a/src/tui/views/activity-panel.tsx
+++ b/src/tui/views/activity-panel.tsx
@@ -14,7 +14,7 @@ import { formatTimestamp, truncateCid } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
-import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
@@ -66,8 +66,7 @@ export const ActivityPanelView: React.NamedExoticComponent<ActivityPanelProps> =
     cursor,
     onRowCountChanged,
   }: ActivityPanelProps): React.ReactNode {
-    const factory = useInformerFactoryOptional();
-    const useInformerPath = factory?.supportsKind("Contribution") === true;
+    const useInformerPath = useEntityWatchEnabled(provider, "Contribution");
 
     const entityResult = useEntities("Contribution");
 

--- a/src/tui/views/activity-panel.tsx
+++ b/src/tui/views/activity-panel.tsx
@@ -1,16 +1,21 @@
 /**
  * Activity panel — recent contributions filtered by kind/agent/tags.
  *
- * Distinct from the existing ActivityView tab: this is a dedicated
- * operator panel (toggled via key 9) with compact formatting.
+ * PR2 (#388) migrated from `usePolledData(provider.getActivity({limit:30}))`
+ * to `useEntities("Contribution", …)` + `.slice(0, 30)`. Distinct from the
+ * full ActivityView tab: this is a dedicated operator panel (toggled via
+ * key 9) with compact formatting.
  */
 
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
+import type { ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
 import { formatTimestamp, truncateCid } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
+import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
 
@@ -32,6 +37,26 @@ const COLUMNS = [
   { header: "TIME", key: "time", width: 10 },
 ] as const;
 
+const PANEL_LIMIT = 30;
+
+function entityToContribution(e: ContributionEntity): Contribution {
+  return {
+    cid: e.id,
+    manifestVersion: 0,
+    kind: e.spec.contributionKind,
+    mode: e.spec.mode,
+    summary: e.spec.summary,
+    description: e.spec.description,
+    artifacts: e.spec.artifacts,
+    relations: e.spec.relations,
+    scores: e.spec.scores,
+    tags: e.spec.tags,
+    context: e.spec.context,
+    agent: e.spec.agent,
+    createdAt: e.metadata.creationTimestamp ?? "",
+  };
+}
+
 /** Activity panel showing recent contributions. */
 export const ActivityPanelView: React.NamedExoticComponent<ActivityPanelProps> = React.memo(
   function ActivityPanelView({
@@ -41,12 +66,33 @@ export const ActivityPanelView: React.NamedExoticComponent<ActivityPanelProps> =
     cursor,
     onRowCountChanged,
   }: ActivityPanelProps): React.ReactNode {
-    const fetcher = useCallback(() => provider.getActivity({ limit: 30 }), [provider]);
-    const { data, loading, isStale, error } = usePolledData<readonly Contribution[]>(
+    const factory = useInformerFactoryOptional();
+    const useInformerPath = factory?.supportsKind("Contribution") === true;
+
+    const entityResult = useEntities("Contribution");
+
+    const fetcher = useCallback(() => provider.getActivity({ limit: PANEL_LIMIT }), [provider]);
+    const polled = usePolledData<readonly Contribution[]>(
       fetcher,
       intervalMs,
-      active,
+      active && !useInformerPath,
     );
+
+    const data = useMemo<readonly Contribution[] | undefined>(() => {
+      if (useInformerPath) {
+        const sorted = [...entityResult.data].sort((a, b) =>
+          (b.metadata.creationTimestamp ?? "").localeCompare(a.metadata.creationTimestamp ?? ""),
+        );
+        return sorted.slice(0, PANEL_LIMIT).map(entityToContribution);
+      }
+      return polled.data ?? undefined;
+    }, [useInformerPath, entityResult.data, polled.data]);
+
+    const loading = useInformerPath
+      ? !entityResult.hasSynced && data === undefined
+      : polled.loading;
+    const isStale = useInformerPath ? false : polled.isStale;
+    const error = useInformerPath ? entityResult.error : polled.error;
 
     useEffect(() => {
       if (data && onRowCountChanged) {

--- a/src/tui/views/activity.tsx
+++ b/src/tui/views/activity.tsx
@@ -14,7 +14,7 @@ import type { ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
 import { formatTimestamp, truncateCid } from "../../shared/format.js";
 import { Table } from "../components/table.js";
-import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
@@ -72,8 +72,7 @@ export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.mem
     pageSize,
     onContributionsLoaded,
   }: ActivityProps): React.ReactNode {
-    const factory = useInformerFactoryOptional();
-    const useInformerPath = factory?.supportsKind("Contribution") === true;
+    const useInformerPath = useEntityWatchEnabled(provider, "Contribution");
 
     const entityResult = useEntities("Contribution");
 

--- a/src/tui/views/activity.tsx
+++ b/src/tui/views/activity.tsx
@@ -1,11 +1,21 @@
 /**
  * Activity stream view — live feed of contributions.
+ *
+ * PR2 (#388) migrated from `usePolledData(provider.getActivity)` to
+ * `useEntities("Contribution", …)`. Pagination is applied to the
+ * informer cache snapshot (sorted by createdAt desc + sliced by
+ * pageOffset/pageSize). The cache is bounded by the listFn snapshot;
+ * "load more" beyond that window will see the same set until a relist
+ * pulls a fresh snapshot.
  */
 
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
+import type { ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
 import { formatTimestamp, truncateCid } from "../../shared/format.js";
 import { Table } from "../components/table.js";
+import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
 
@@ -30,6 +40,27 @@ const COLUMNS = [
   { header: "CREATED", key: "created", width: 12 },
 ] as const;
 
+/** Project a ContributionEntity back to the flat Contribution shape this view's
+ * row formatter expects. The fields the table reads are: cid, kind, mode,
+ * summary, agent, tags, createdAt. */
+function entityToContribution(e: ContributionEntity): Contribution {
+  return {
+    cid: e.id,
+    manifestVersion: 0,
+    kind: e.spec.contributionKind,
+    mode: e.spec.mode,
+    summary: e.spec.summary,
+    description: e.spec.description,
+    artifacts: e.spec.artifacts,
+    relations: e.spec.relations,
+    scores: e.spec.scores,
+    tags: e.spec.tags,
+    context: e.spec.context,
+    agent: e.spec.agent,
+    createdAt: e.metadata.creationTimestamp ?? "",
+  };
+}
+
 /** Activity stream view component. */
 export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.memo(
   function ActivityView({
@@ -41,11 +72,37 @@ export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.mem
     pageSize,
     onContributionsLoaded,
   }: ActivityProps): React.ReactNode {
+    const factory = useInformerFactoryOptional();
+    const useInformerPath = factory?.supportsKind("Contribution") === true;
+
+    const entityResult = useEntities("Contribution");
+
     const fetcher = useCallback(
       () => provider.getActivity({ limit: pageSize, offset: pageOffset }),
       [provider, pageSize, pageOffset],
     );
-    const { data, loading } = usePolledData<readonly Contribution[]>(fetcher, intervalMs, active);
+    const polled = usePolledData<readonly Contribution[]>(
+      fetcher,
+      intervalMs,
+      active && !useInformerPath,
+    );
+
+    const data = useMemo<readonly Contribution[] | undefined>(() => {
+      if (useInformerPath) {
+        const all = entityResult.data;
+        // Sort newest-first by creationTimestamp; entities without a
+        // timestamp sort last (they're typically synthetic / pre-#287).
+        const sorted = [...all].sort((a, b) =>
+          (b.metadata.creationTimestamp ?? "").localeCompare(a.metadata.creationTimestamp ?? ""),
+        );
+        return sorted.slice(pageOffset, pageOffset + pageSize).map(entityToContribution);
+      }
+      return polled.data ?? undefined;
+    }, [useInformerPath, entityResult.data, polled.data, pageOffset, pageSize]);
+
+    const loading = useInformerPath
+      ? !entityResult.hasSynced && data === undefined
+      : polled.loading;
 
     useEffect(() => {
       if (data && onContributionsLoaded) {

--- a/src/tui/views/agent-graph.tsx
+++ b/src/tui/views/agent-graph.tsx
@@ -16,7 +16,7 @@ import { checkSpawn } from "../agents/spawn-validator.js";
 import type { TmuxManager } from "../agents/tmux-manager.js";
 import { agentIdFromSession, tmuxSessionName } from "../agents/tmux-manager.js";
 import { EmptyState } from "../components/empty-state.js";
-import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import { renderGraph } from "../layout/edge-render.js";
@@ -138,8 +138,7 @@ export const AgentGraphView: React.NamedExoticComponent<AgentGraphProps> = React
     topology,
     onSelectSession,
   }: AgentGraphProps): React.ReactNode {
-    const factory = useInformerFactoryOptional();
-    const useInformerPath = factory?.supportsKind("Claim") === true;
+    const useInformerPath = useEntityWatchEnabled(provider, "Claim");
     const entityResult = useEntities("Claim", ACTIVE_PREDICATE);
 
     const claimFetcher = useCallback(() => provider.getClaims({ status: "active" }), [provider]);

--- a/src/tui/views/agent-graph.tsx
+++ b/src/tui/views/agent-graph.tsx
@@ -9,18 +9,38 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import type { ClaimEntity } from "../../core/entity.js";
 import type { Claim } from "../../core/models.js";
 import type { AgentTopology } from "../../core/topology.js";
 import { checkSpawn } from "../agents/spawn-validator.js";
 import type { TmuxManager } from "../agents/tmux-manager.js";
 import { agentIdFromSession, tmuxSessionName } from "../agents/tmux-manager.js";
 import { EmptyState } from "../components/empty-state.js";
+import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import { renderGraph } from "../layout/edge-render.js";
 import type { LayoutEdge, LiveAgentStatus } from "../layout/graph-layout.js";
 import { layoutGraph } from "../layout/graph-layout.js";
 import type { TuiDataProvider } from "../provider.js";
 import { agentStatusIcon, theme } from "../theme.js";
+
+const ACTIVE_PREDICATE = (e: ClaimEntity): boolean => e.status.phase === "active";
+
+function entityToClaim(e: ClaimEntity): Claim {
+  return {
+    claimId: e.id,
+    targetRef: e.spec.targetRef,
+    agent: e.spec.agent,
+    status: e.status.phase,
+    intentSummary: e.spec.intentSummary,
+    createdAt: e.metadata.creationTimestamp ?? e.status.heartbeatAt,
+    heartbeatAt: e.status.heartbeatAt,
+    leaseExpiresAt: e.status.leaseExpiresAt,
+    context: e.spec.context,
+    attemptCount: e.status.attemptCount,
+  };
+}
 
 /** Props for the AgentGraphView. */
 export interface AgentGraphProps {
@@ -118,6 +138,10 @@ export const AgentGraphView: React.NamedExoticComponent<AgentGraphProps> = React
     topology,
     onSelectSession,
   }: AgentGraphProps): React.ReactNode {
+    const factory = useInformerFactoryOptional();
+    const useInformerPath = factory?.supportsKind("Claim") === true;
+    const entityResult = useEntities("Claim", ACTIVE_PREDICATE);
+
     const claimFetcher = useCallback(() => provider.getClaims({ status: "active" }), [provider]);
     const tmuxFetcher = useCallback(async () => {
       if (!tmux) return [] as readonly string[];
@@ -126,7 +150,12 @@ export const AgentGraphView: React.NamedExoticComponent<AgentGraphProps> = React
       return tmux.listSessions();
     }, [tmux]);
 
-    const { data: claims } = usePolledData<readonly Claim[]>(claimFetcher, intervalMs, active);
+    const polledClaims = usePolledData<readonly Claim[]>(
+      claimFetcher,
+      intervalMs,
+      active && !useInformerPath,
+    );
+    const claims = useInformerPath ? entityResult.data.map(entityToClaim) : polledClaims.data;
     const { data: sessions } = usePolledData<readonly string[]>(
       tmuxFetcher,
       intervalMs * 2,

--- a/src/tui/views/agent-list.tsx
+++ b/src/tui/views/agent-list.tsx
@@ -13,7 +13,7 @@ import { agentIdFromSession } from "../agents/tmux-manager.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
-import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
@@ -164,8 +164,7 @@ export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.m
       return () => clearInterval(timer);
     }, [active]);
 
-    const factory = useInformerFactoryOptional();
-    const useInformerPath = factory?.supportsKind("Claim") === true;
+    const useInformerPath = useEntityWatchEnabled(provider, "Claim");
 
     const entityResult = useEntities("Claim", ACTIVE_PREDICATE);
 

--- a/src/tui/views/agent-list.tsx
+++ b/src/tui/views/agent-list.tsx
@@ -5,16 +5,37 @@
  * In local mode, shows session status and allows spawn/kill via command palette.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ClaimEntity } from "../../core/entity.js";
 import type { Claim } from "../../core/models.js";
 import type { TmuxManager } from "../agents/tmux-manager.js";
 import { agentIdFromSession } from "../agents/tmux-manager.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
+import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
 import { agentStatusIcon, BRAILLE_SPINNER, timing } from "../theme.js";
+
+const ACTIVE_PREDICATE = (e: ClaimEntity): boolean => e.status.phase === "active";
+
+/** Flatten a ClaimEntity to the legacy Claim shape this view consumes. */
+function entityToClaim(e: ClaimEntity): Claim {
+  return {
+    claimId: e.id,
+    targetRef: e.spec.targetRef,
+    agent: e.spec.agent,
+    status: e.status.phase,
+    intentSummary: e.spec.intentSummary,
+    createdAt: e.metadata.creationTimestamp ?? e.status.heartbeatAt,
+    heartbeatAt: e.status.heartbeatAt,
+    leaseExpiresAt: e.status.leaseExpiresAt,
+    context: e.spec.context,
+    attemptCount: e.status.attemptCount,
+  };
+}
 
 /** Props for the AgentList view. */
 export interface AgentListProps {
@@ -143,6 +164,11 @@ export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.m
       return () => clearInterval(timer);
     }, [active]);
 
+    const factory = useInformerFactoryOptional();
+    const useInformerPath = factory?.supportsKind("Claim") === true;
+
+    const entityResult = useEntities("Claim", ACTIVE_PREDICATE);
+
     const claimFetcher = useCallback(() => provider.getClaims({ status: "active" }), [provider]);
     const tmuxFetcher = useCallback(async () => {
       if (!tmux) return [] as readonly string[];
@@ -151,12 +177,22 @@ export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.m
       return tmux.listSessions();
     }, [tmux]);
 
-    const {
-      data: claims,
-      loading: claimsLoading,
-      isStale,
-      error,
-    } = usePolledData<readonly Claim[]>(claimFetcher, intervalMs, active);
+    const polledClaims = usePolledData<readonly Claim[]>(
+      claimFetcher,
+      intervalMs,
+      active && !useInformerPath,
+    );
+
+    const claims = useMemo<readonly Claim[] | undefined>(
+      () =>
+        useInformerPath ? entityResult.data.map(entityToClaim) : (polledClaims.data ?? undefined),
+      [useInformerPath, entityResult.data, polledClaims.data],
+    );
+    const claimsLoading = useInformerPath
+      ? !entityResult.hasSynced && claims === undefined
+      : polledClaims.loading;
+    const isStale = useInformerPath ? false : polledClaims.isStale;
+    const error = useInformerPath ? entityResult.error : polledClaims.error;
     const {
       data: sessions,
       isStale: tmuxStale,

--- a/src/tui/views/claims.tsx
+++ b/src/tui/views/claims.tsx
@@ -1,14 +1,25 @@
 /**
  * Claims view — shows all active claims with lease countdown.
+ *
+ * PR2 (#388) migrated from `usePolledData(provider.getClaims)` to the
+ * informer-backed `useEntities("Claim", …)` hook. Reads draw from the
+ * shared informer cache (SSE-driven in remote mode, in-process WatchHub
+ * in local mode) instead of polling. The pre-fetched `propClaims` prop
+ * stays as an explicit override for the parent's claim poller during
+ * the dual-path window — once PR3 / PR4 fold those callers in, the
+ * override goes away.
  */
 
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
+import type { ClaimEntity } from "../../core/entity.js";
 import type { Claim } from "../../core/models.js";
 import { formatDuration } from "../../shared/duration.js";
 import { formatTimestamp } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
+import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
 
@@ -33,6 +44,29 @@ const COLUMNS = [
   { header: "INTENT", key: "intent", width: 28 },
 ] as const;
 
+/** Reduce a ClaimEntity to the flat row shape this view already emits. */
+function entityToRow(entity: ClaimEntity): {
+  claimId: string;
+  targetRef: string;
+  agent: { agentName?: string | undefined; agentId: string };
+  status: string;
+  intentSummary: string;
+  heartbeatAt: string;
+  leaseExpiresAt: string;
+} {
+  return {
+    claimId: entity.id,
+    targetRef: entity.spec.targetRef,
+    agent: entity.spec.agent,
+    status: entity.status.phase,
+    intentSummary: entity.spec.intentSummary,
+    heartbeatAt: entity.status.heartbeatAt,
+    leaseExpiresAt: entity.status.leaseExpiresAt,
+  };
+}
+
+const ACTIVE_PREDICATE = (e: ClaimEntity): boolean => e.status.phase === "active";
+
 /** Claims view component. */
 export const ClaimsView: React.NamedExoticComponent<ClaimsProps> = React.memo(function ClaimsView({
   provider,
@@ -42,15 +76,51 @@ export const ClaimsView: React.NamedExoticComponent<ClaimsProps> = React.memo(fu
   onRowCountChanged,
   activeClaims: propClaims,
 }: ClaimsProps): React.ReactNode {
-  // Use parent-provided claims if available, otherwise poll independently
+  const factory = useInformerFactoryOptional();
+  const useInformerPath = factory?.supportsKind("Claim") === true;
+
+  // Informer path: useEntities feeds when the factory is mounted and the
+  // kind is supported. We always invoke both hooks so React's hook order
+  // stays stable across renders; the unused branch's data is discarded.
+  const entityResult = useEntities("Claim", ACTIVE_PREDICATE);
+
+  // Polled fallback: only fetches when the parent didn't pre-fetch AND
+  // the informer path isn't available. Same gating logic as before, plus
+  // the new informer-availability check.
   const fetcher = useCallback(() => provider.getClaims({ status: "active" }), [provider]);
-  const {
-    data: polledData,
-    loading,
-    isStale,
-    error,
-  } = usePolledData<readonly Claim[]>(fetcher, intervalMs, active && propClaims === undefined);
-  const data = propClaims ?? polledData;
+  const polledResult = usePolledData<readonly Claim[]>(
+    fetcher,
+    intervalMs,
+    active && propClaims === undefined && !useInformerPath,
+  );
+
+  const data: readonly Claim[] | undefined = useMemo<readonly Claim[] | undefined>(() => {
+    if (propClaims !== undefined) return propClaims;
+    if (useInformerPath) {
+      // Project entity → row → caller-shaped Claim. The fields the view
+      // reads below are the ones populated from the entity envelope.
+      return entityResult.data.map((e) => {
+        const r = entityToRow(e);
+        return {
+          claimId: r.claimId,
+          targetRef: r.targetRef,
+          agent: r.agent,
+          status: r.status,
+          intentSummary: r.intentSummary,
+          createdAt: r.heartbeatAt,
+          heartbeatAt: r.heartbeatAt,
+          leaseExpiresAt: r.leaseExpiresAt,
+        } as Claim;
+      });
+    }
+    return polledResult.data ?? undefined;
+  }, [propClaims, useInformerPath, entityResult.data, polledResult.data]);
+
+  const loading = useInformerPath
+    ? !entityResult.hasSynced && data === undefined
+    : polledResult.loading;
+  const isStale = useInformerPath ? false : polledResult.isStale;
+  const error = useInformerPath ? entityResult.error : polledResult.error;
 
   useEffect(() => {
     if (data && onRowCountChanged) {

--- a/src/tui/views/claims.tsx
+++ b/src/tui/views/claims.tsx
@@ -18,7 +18,7 @@ import { formatTimestamp } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
-import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntityWatchEnabled, useProviderScoped } from "../hooks/informer-context.js";
 import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
@@ -76,8 +76,13 @@ export const ClaimsView: React.NamedExoticComponent<ClaimsProps> = React.memo(fu
   onRowCountChanged,
   activeClaims: propClaims,
 }: ClaimsProps): React.ReactNode {
-  const factory = useInformerFactoryOptional();
-  const useInformerPath = factory?.supportsKind("Claim") === true;
+  const useInformerPath = useEntityWatchEnabled(provider, "Claim");
+  // Suppress claim polling under a scoped session: `provider.getClaims`
+  // does not filter by sessionId yet, so polling would surface claims
+  // from other sessions in the namespace (Codex round 2, finding 2).
+  // Mirrors the dashboard's existing behavior (RemoteDataProvider's
+  // getDashboard returns `[]` for activeClaims when scoped).
+  const isScoped = useProviderScoped(provider);
 
   // Informer path: useEntities feeds when the factory is mounted and the
   // kind is supported. We always invoke both hooks so React's hook order
@@ -85,16 +90,23 @@ export const ClaimsView: React.NamedExoticComponent<ClaimsProps> = React.memo(fu
   const entityResult = useEntities("Claim", ACTIVE_PREDICATE);
 
   // Polled fallback: only fetches when the parent didn't pre-fetch AND
-  // the informer path isn't available. Same gating logic as before, plus
-  // the new informer-availability check.
+  // the informer path isn't available AND we're not in a scoped session
+  // whose claim API isn't filterable by sessionId.
   const fetcher = useCallback(() => provider.getClaims({ status: "active" }), [provider]);
   const polledResult = usePolledData<readonly Claim[]>(
     fetcher,
     intervalMs,
-    active && propClaims === undefined && !useInformerPath,
+    active && propClaims === undefined && !useInformerPath && !isScoped,
   );
 
   const data: readonly Claim[] | undefined = useMemo<readonly Claim[] | undefined>(() => {
+    // Scoped sessions render an empty list rather than risk leaking
+    // claims from other sessions while the watch + claim APIs lack
+    // sessionId filtering. The scope check runs BEFORE the propClaims
+    // shortcut because the parent App still polls `getClaims` (used by
+    // the command palette and spawn dedup); accepting that unscoped
+    // result here would re-expose the leak (Codex round 4, finding 1).
+    if (isScoped) return [];
     if (propClaims !== undefined) return propClaims;
     if (useInformerPath) {
       // Project entity → row → caller-shaped Claim. The fields the view
@@ -114,7 +126,7 @@ export const ClaimsView: React.NamedExoticComponent<ClaimsProps> = React.memo(fu
       });
     }
     return polledResult.data ?? undefined;
-  }, [propClaims, useInformerPath, entityResult.data, polledResult.data]);
+  }, [propClaims, useInformerPath, isScoped, entityResult.data, polledResult.data]);
 
   const loading = useInformerPath
     ? !entityResult.hasSynced && data === undefined

--- a/src/tui/views/detail.tsx
+++ b/src/tui/views/detail.tsx
@@ -18,7 +18,7 @@ import { formatScore, formatTimestamp, truncateCid } from "../../shared/format.j
 import { ConditionChips } from "../components/condition-chips.js";
 import { DataStatus } from "../components/data-status.js";
 import { OutcomeBadge } from "../components/outcome-badge.js";
-import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntity } from "../hooks/use-entity.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { ContributionDetail, TuiDataProvider, TuiOutcomeProvider } from "../provider.js";
@@ -37,8 +37,7 @@ export const DetailView: React.NamedExoticComponent<DetailProps> = React.memo(fu
   cid,
   intervalMs,
 }: DetailProps): React.ReactNode {
-  const factory = useInformerFactoryOptional();
-  const useInformerPath = factory?.supportsKind("Contribution") === true;
+  const useInformerPath = useEntityWatchEnabled(provider, "Contribution");
 
   // useEntity for the body — fast subscribe to the cache. The relation
   // graph still needs the full ContributionDetail fetch below.

--- a/src/tui/views/detail.tsx
+++ b/src/tui/views/detail.tsx
@@ -2,6 +2,13 @@
  * Contribution detail view — full manifest, relations, artifacts, thread.
  *
  * Includes outcome annotation when available (Phase 5).
+ *
+ * PR2 (#388): the contribution body subscription migrates to
+ * `useEntity("Contribution", cid)` when a factory is mounted. Ancestors,
+ * children, thread, and outcome remain on `usePolledData` — those fields
+ * aren't on the Entity envelope (they're a relation graph the server
+ * computes on demand). PR3/PR4 may lift the relation graph into
+ * `useDerived`.
  */
 
 import React, { useCallback } from "react";
@@ -11,6 +18,8 @@ import { formatScore, formatTimestamp, truncateCid } from "../../shared/format.j
 import { ConditionChips } from "../components/condition-chips.js";
 import { DataStatus } from "../components/data-status.js";
 import { OutcomeBadge } from "../components/outcome-badge.js";
+import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntity } from "../hooks/use-entity.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { ContributionDetail, TuiDataProvider, TuiOutcomeProvider } from "../provider.js";
 import { theme } from "../theme.js";
@@ -28,12 +37,20 @@ export const DetailView: React.NamedExoticComponent<DetailProps> = React.memo(fu
   cid,
   intervalMs,
 }: DetailProps): React.ReactNode {
+  const factory = useInformerFactoryOptional();
+  const useInformerPath = factory?.supportsKind("Contribution") === true;
+
+  // useEntity for the body — fast subscribe to the cache. The relation
+  // graph still needs the full ContributionDetail fetch below.
+  const entityResult = useEntity("Contribution", cid);
+
   const fetcher = useCallback(() => provider.getContribution(cid), [provider, cid]);
-  const { data, loading, isStale, error } = usePolledData<ContributionDetail | undefined>(
-    fetcher,
-    intervalMs,
-    true,
-  );
+  const {
+    data: detail,
+    loading,
+    isStale,
+    error,
+  } = usePolledData<ContributionDetail | undefined>(fetcher, intervalMs, true);
 
   // Fetch outcome for this CID if available
   const outcomeProvider = provider.capabilities.outcomes
@@ -50,7 +67,16 @@ export const DetailView: React.NamedExoticComponent<DetailProps> = React.memo(fu
     true,
   );
 
-  if (loading && !data) {
+  // Body source: prefer the informer-cached entity when available, else
+  // project from the polled detail.
+  const bodyEntity =
+    useInformerPath && entityResult.data
+      ? entityResult.data
+      : detail
+        ? contributionToEntity(detail.contribution, "default")
+        : undefined;
+
+  if (loading && !detail && !bodyEntity) {
     return (
       <box>
         <text opacity={0.5}>Loading {truncateCid(cid)}...</text>
@@ -58,7 +84,7 @@ export const DetailView: React.NamedExoticComponent<DetailProps> = React.memo(fu
     );
   }
 
-  if (!data) {
+  if (!detail && !bodyEntity) {
     return (
       <box>
         <text color={theme.error}>Contribution not found: {cid}</text>
@@ -66,15 +92,33 @@ export const DetailView: React.NamedExoticComponent<DetailProps> = React.memo(fu
     );
   }
 
-  const { contribution: c, ancestors, children, thread } = data;
-  const entity = contributionToEntity(c, "default");
+  const ancestors = detail?.ancestors ?? [];
+  const children = detail?.children ?? [];
+  const thread = detail?.thread ?? [];
+  // Narrowed: the early return above ensures bodyEntity is defined when
+  // we reach this point. Use a runtime-asserted alias to satisfy strict
+  // null checks without a non-null assertion (biome-disallowed).
+  if (!bodyEntity) return null;
+  const entity = bodyEntity;
+  const cidStr = entity.id;
+  const kind = entity.spec.contributionKind;
+  const mode = entity.spec.mode;
+  const summary = entity.spec.summary;
+  const description = entity.spec.description;
+  const tags = entity.spec.tags;
+  const scores = entity.spec.scores;
+  const relations = entity.spec.relations;
+  const artifacts = entity.spec.artifacts;
+  const context = entity.spec.context;
+  const agent = entity.spec.agent;
+  const createdAt = entity.metadata.creationTimestamp ?? "";
 
   return (
     <box flexDirection="column">
       <ConditionChips conditions={entity.conditions} />
       <box marginBottom={1} flexDirection="row">
-        <text color={theme.focus}>{c.cid}</text>
-        <DataStatus loading={loading && !data} isStale={isStale} error={error?.message} />
+        <text color={theme.focus}>{cidStr}</text>
+        <DataStatus loading={loading && !detail} isStale={isStale} error={error?.message} />
         {outcome && (
           <>
             <text> </text>
@@ -85,14 +129,14 @@ export const DetailView: React.NamedExoticComponent<DetailProps> = React.memo(fu
 
       <box flexDirection="column" marginBottom={1}>
         <text>
-          Kind: {c.kind} Mode: {c.mode} Created: {formatTimestamp(c.createdAt)}
+          Kind: {kind} Mode: {mode} Created: {formatTimestamp(createdAt)}
         </text>
         <text>
-          Agent: {c.agent?.agentName ?? c.agent?.agentId ?? "unknown"}
-          {c.agent?.model ? ` (${c.agent.model})` : ""}
-          {c.agent?.platform ? ` on ${c.agent.platform}` : ""}
+          Agent: {agent?.agentName ?? agent?.agentId ?? "unknown"}
+          {agent?.model ? ` (${agent.model})` : ""}
+          {agent?.platform ? ` on ${agent.platform}` : ""}
         </text>
-        {(c.tags ?? []).length > 0 && <text>Tags: {(c.tags ?? []).join(", ")}</text>}
+        {(tags ?? []).length > 0 && <text>Tags: {(tags ?? []).join(", ")}</text>}
       </box>
 
       {/* Outcome annotation */}
@@ -112,18 +156,18 @@ export const DetailView: React.NamedExoticComponent<DetailProps> = React.memo(fu
 
       <box flexDirection="column" marginBottom={1}>
         <text>Summary</text>
-        <markdown>{c.summary}</markdown>
-        {c.description && (
+        <markdown>{summary}</markdown>
+        {description && (
           <box marginTop={1}>
-            <markdown>{c.description.slice(0, 500)}</markdown>
+            <markdown>{description.slice(0, 500)}</markdown>
           </box>
         )}
       </box>
 
-      {c.scores && Object.keys(c.scores).length > 0 && (
+      {scores && Object.keys(scores).length > 0 && (
         <box flexDirection="column" marginBottom={1}>
           <text>Scores</text>
-          {Object.entries(c.scores).map(([name, score]) => (
+          {Object.entries(scores).map(([name, score]) => (
             <text key={name}>
               {name}: {formatScore(score)} ({score.direction})
             </text>
@@ -131,10 +175,10 @@ export const DetailView: React.NamedExoticComponent<DetailProps> = React.memo(fu
         </box>
       )}
 
-      {(c.relations ?? []).length > 0 && (
+      {(relations ?? []).length > 0 && (
         <box flexDirection="column" marginBottom={1}>
-          <text>{`Relations (${(c.relations ?? []).length})`}</text>
-          {(c.relations ?? []).map((r, i) => (
+          <text>{`Relations (${(relations ?? []).length})`}</text>
+          {(relations ?? []).map((r, i) => (
             <text key={`rel-${String(i)}`}>
               {r.relationType} → {truncateCid(r.targetCid)}
             </text>
@@ -142,10 +186,10 @@ export const DetailView: React.NamedExoticComponent<DetailProps> = React.memo(fu
         </box>
       )}
 
-      {Object.keys(c.artifacts).length > 0 && (
+      {Object.keys(artifacts).length > 0 && (
         <box flexDirection="column" marginBottom={1}>
-          <text>{`Artifacts (${Object.keys(c.artifacts).length})`}</text>
-          {Object.entries(c.artifacts).map(([name, hash]) => (
+          <text>{`Artifacts (${Object.keys(artifacts).length})`}</text>
+          {Object.entries(artifacts).map(([name, hash]) => (
             <text key={name}>
               {name}: {truncateCid(hash)}
             </text>
@@ -189,10 +233,10 @@ export const DetailView: React.NamedExoticComponent<DetailProps> = React.memo(fu
         </box>
       )}
 
-      {c.context && Object.keys(c.context).length > 0 && (
+      {context && Object.keys(context).length > 0 && (
         <box flexDirection="column" marginTop={1}>
           <text>Context</text>
-          <text opacity={0.5}>{JSON.stringify(c.context, null, 2).slice(0, 300)}</text>
+          <text opacity={0.5}>{JSON.stringify(context, null, 2).slice(0, 300)}</text>
         </box>
       )}
     </box>

--- a/src/tui/views/entity-projection.test.ts
+++ b/src/tui/views/entity-projection.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for the per-view ClaimEntity → Claim / ContributionEntity →
+ * Contribution projection helpers used by the PR2 (#388) view migrations.
+ *
+ * Each migrated view (claims, agent-list, pipeline-view, agent-graph,
+ * activity, activity-panel, search-panel) defines an `entityToClaim` /
+ * `entityToContribution` helper inline. They share the same shape; this
+ * file pins the contract via the same fixtures.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { AgentSession } from "../../core/agent-runtime.js";
+import { agentSessionToEntity, claimToEntity, contributionToEntity } from "../../core/entity.js";
+import { makeClaim, makeContribution } from "../../core/test-helpers.js";
+
+describe("entity → flat round-trip (PR2 #388 view projections)", () => {
+  test("claimToEntity preserves the fields views read back", () => {
+    const claim = makeClaim({
+      claimId: "claim-1",
+      targetRef: "task-A",
+      intentSummary: "do the thing",
+    });
+    const entity = claimToEntity(claim, () => Date.parse(claim.heartbeatAt));
+    expect(entity.id).toBe(claim.claimId);
+    expect(entity.spec.targetRef).toBe(claim.targetRef);
+    expect(entity.spec.intentSummary).toBe(claim.intentSummary);
+    expect(entity.spec.agent).toEqual(claim.agent);
+    expect(entity.status.heartbeatAt).toBe(claim.heartbeatAt);
+    expect(entity.status.leaseExpiresAt).toBe(claim.leaseExpiresAt);
+    // Active phase round-trips correctly so views' "active" predicate works.
+    expect(entity.status.phase).toBe("active");
+  });
+
+  test("contributionToEntity preserves the fields views read back", () => {
+    const c = makeContribution({ summary: "test entry" });
+    const entity = contributionToEntity(c, "default");
+    expect(entity.id).toBe(c.cid);
+    expect(entity.spec.contributionKind).toBe(c.kind);
+    expect(entity.spec.mode).toBe(c.mode);
+    expect(entity.spec.summary).toBe(c.summary);
+    expect(entity.spec.tags).toEqual(c.tags);
+    expect(entity.spec.agent).toEqual(c.agent);
+    expect(entity.metadata.creationTimestamp).toBe(c.createdAt);
+  });
+
+  test("agentSessionToEntity preserves the fields views read back", () => {
+    const s: AgentSession = {
+      id: "grove-coord-1-abc",
+      role: "coordinator",
+      status: "running",
+      pid: 12345,
+      platform: "claude-code",
+      model: "sonnet",
+      agent: "claude",
+    };
+    const entity = agentSessionToEntity(s, undefined, "default");
+    expect(entity.id).toBe(s.id);
+    expect(entity.spec.role).toBe(s.role);
+    expect(entity.spec.platform).toBe(s.platform);
+    expect(entity.spec.model).toBe(s.model);
+    expect(entity.spec.agent).toBe(s.agent);
+    expect(entity.status.phase).toBe(s.status);
+    expect(entity.status.pid).toBe(s.pid);
+  });
+});

--- a/src/tui/views/pipeline-view.tsx
+++ b/src/tui/views/pipeline-view.tsx
@@ -11,7 +11,7 @@ import type { ClaimEntity } from "../../core/entity.js";
 import type { Claim } from "../../core/models.js";
 import type { TmuxManager } from "../agents/tmux-manager.js";
 import { agentIdFromSession } from "../agents/tmux-manager.js";
-import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
@@ -177,8 +177,7 @@ export const PipelineView: React.NamedExoticComponent<PipelineViewProps> = React
       return () => clearInterval(timer);
     }, [active]);
 
-    const factory = useInformerFactoryOptional();
-    const useInformerPath = factory?.supportsKind("Claim") === true;
+    const useInformerPath = useEntityWatchEnabled(provider, "Claim");
 
     const entityResult = useEntities("Claim", ACTIVE_PREDICATE);
     const claimsFetcher = useCallback(() => provider.getClaims({ status: "active" }), [provider]);

--- a/src/tui/views/pipeline-view.tsx
+++ b/src/tui/views/pipeline-view.tsx
@@ -7,12 +7,32 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import type { ClaimEntity } from "../../core/entity.js";
 import type { Claim } from "../../core/models.js";
 import type { TmuxManager } from "../agents/tmux-manager.js";
 import { agentIdFromSession } from "../agents/tmux-manager.js";
+import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
 import { BRAILLE_SPINNER, PLATFORM_COLORS, theme } from "../theme.js";
+
+const ACTIVE_PREDICATE = (e: ClaimEntity): boolean => e.status.phase === "active";
+
+function entityToClaim(e: ClaimEntity): Claim {
+  return {
+    claimId: e.id,
+    targetRef: e.spec.targetRef,
+    agent: e.spec.agent,
+    status: e.status.phase,
+    intentSummary: e.spec.intentSummary,
+    createdAt: e.metadata.creationTimestamp ?? e.status.heartbeatAt,
+    heartbeatAt: e.status.heartbeatAt,
+    leaseExpiresAt: e.status.leaseExpiresAt,
+    context: e.spec.context,
+    attemptCount: e.status.attemptCount,
+  };
+}
 
 /** Props for the PipelineView. */
 export interface PipelineViewProps {
@@ -157,8 +177,17 @@ export const PipelineView: React.NamedExoticComponent<PipelineViewProps> = React
       return () => clearInterval(timer);
     }, [active]);
 
+    const factory = useInformerFactoryOptional();
+    const useInformerPath = factory?.supportsKind("Claim") === true;
+
+    const entityResult = useEntities("Claim", ACTIVE_PREDICATE);
     const claimsFetcher = useCallback(() => provider.getClaims({ status: "active" }), [provider]);
-    const { data: claims } = usePolledData<readonly Claim[]>(claimsFetcher, intervalMs, active);
+    const polledClaims = usePolledData<readonly Claim[]>(
+      claimsFetcher,
+      intervalMs,
+      active && !useInformerPath,
+    );
+    const claims = useInformerPath ? entityResult.data.map(entityToClaim) : polledClaims.data;
 
     const sessionsFetcher = useCallback(async () => {
       if (!tmux) return [] as readonly string[];

--- a/src/tui/views/search-panel.tsx
+++ b/src/tui/views/search-panel.tsx
@@ -8,14 +8,23 @@
  * Search availability is determined by feature-detecting the search() method
  * (isSearchProvider). When unavailable, a persistent banner informs the user
  * rather than silently falling back to recent items.
+ *
+ * PR2 (#388): the empty-query branch ("showing recent contributions")
+ * reads from the informer cache via `useEntities("Contribution")` when a
+ * factory is mounted. Full-text search (`searchQuery !== ""`) stays on
+ * `usePolledData` until PR4 — the search backend isn't projected through
+ * the watch protocol.
  */
 
 import React, { useCallback, useEffect, useMemo } from "react";
+import type { ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
 import { formatTimestamp, truncateCid } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
+import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import { isSearchProvider, type TuiArtifactProvider, type TuiDataProvider } from "../provider.js";
 import { theme } from "../theme.js";
@@ -47,6 +56,8 @@ const TRANSCRIPT_COLUMNS = [
   { header: "CONTENT", key: "content", width: 50 },
 ] as const;
 
+const RECENT_LIMIT = 20;
+
 /** Search terminal transcripts for a query string. */
 export function searchTranscripts(
   buffers: ReadonlyMap<string, string>,
@@ -74,10 +85,9 @@ export function searchTranscripts(
  * Select the fetcher function to use based on provider capability and query.
  * Exported as a pure function for unit testing.
  *
- * @param hasSearch  Whether the provider supports full-text search.
- * @param getContributions  Fallback fetcher for recent contributions.
- * @param search  Full-text search fetcher (only called when hasSearch=true).
- * @param query   The current search query string.
+ * Used by the polling fallback path. The empty-query branch is now also
+ * served by the informer cache when one is available (see component below);
+ * this helper keeps the existing test contract intact.
  */
 export function selectFetcher(
   hasSearch: boolean,
@@ -88,6 +98,24 @@ export function selectFetcher(
   if (!query) return getContributions;
   if (hasSearch) return () => search(query);
   return getContributions;
+}
+
+function entityToContribution(e: ContributionEntity): Contribution {
+  return {
+    cid: e.id,
+    manifestVersion: 0,
+    kind: e.spec.contributionKind,
+    mode: e.spec.mode,
+    summary: e.spec.summary,
+    description: e.spec.description,
+    artifacts: e.spec.artifacts,
+    relations: e.spec.relations,
+    scores: e.spec.scores,
+    tags: e.spec.tags,
+    context: e.spec.context,
+    agent: e.spec.agent,
+    createdAt: e.metadata.creationTimestamp ?? "",
+  };
 }
 
 /** Search panel showing full-text search results. */
@@ -113,16 +141,37 @@ export const SearchPanelView: React.NamedExoticComponent<SearchPanelProps> = Rea
     // Determine search availability via the proper capability check.
     const hasSearch = isSearchProvider(provider);
 
+    const factory = useInformerFactoryOptional();
+    const useInformerPath = factory?.supportsKind("Contribution") === true && searchQuery === "";
+
+    const entityResult = useEntities("Contribution");
+
     const fetcher = useCallback((): Promise<readonly Contribution[]> => {
-      if (!searchQuery || !hasSearch) return provider.getContributions({ limit: 20 });
+      if (!searchQuery || !hasSearch) return provider.getContributions({ limit: RECENT_LIMIT });
       return (provider as TuiDataProvider & TuiArtifactProvider).search(searchQuery);
     }, [provider, searchQuery, hasSearch]);
 
-    const { data, loading, isStale, error } = usePolledData<readonly Contribution[]>(
+    const polled = usePolledData<readonly Contribution[]>(
       fetcher,
       intervalMs,
-      active,
+      active && !useInformerPath,
     );
+
+    const data = useMemo<readonly Contribution[] | undefined>(() => {
+      if (useInformerPath) {
+        const sorted = [...entityResult.data].sort((a, b) =>
+          (b.metadata.creationTimestamp ?? "").localeCompare(a.metadata.creationTimestamp ?? ""),
+        );
+        return sorted.slice(0, RECENT_LIMIT).map(entityToContribution);
+      }
+      return polled.data ?? undefined;
+    }, [useInformerPath, entityResult.data, polled.data]);
+
+    const loading = useInformerPath
+      ? !entityResult.hasSynced && data === undefined
+      : polled.loading;
+    const isStale = useInformerPath ? false : polled.isStale;
+    const error = useInformerPath ? entityResult.error : polled.error;
 
     useEffect(() => {
       if (data && onRowCountChanged) {

--- a/src/tui/views/search-panel.tsx
+++ b/src/tui/views/search-panel.tsx
@@ -23,7 +23,7 @@ import { formatTimestamp, truncateCid } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
-import { useInformerFactoryOptional } from "../hooks/informer-context.js";
+import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntities } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import { isSearchProvider, type TuiArtifactProvider, type TuiDataProvider } from "../provider.js";
@@ -141,8 +141,7 @@ export const SearchPanelView: React.NamedExoticComponent<SearchPanelProps> = Rea
     // Determine search availability via the proper capability check.
     const hasSearch = isSearchProvider(provider);
 
-    const factory = useInformerFactoryOptional();
-    const useInformerPath = factory?.supportsKind("Contribution") === true && searchQuery === "";
+    const useInformerPath = useEntityWatchEnabled(provider, "Contribution") && searchQuery === "";
 
     const entityResult = useEntities("Contribution");
 


### PR DESCRIPTION
## Summary
- Migrates Entity-backed view call sites from `usePolledData` → `useEntities`/`useEntity` (the informer hooks landed in PR1)
- Wires the local-mode factory into `tui-app.tsx` and routes store writes through `WatchHub.recordWrite` so SQLite-backed local mode delivers events to the informer cache
- Per-view inline `entityToClaim()` / direct entity reads with a dual-path fallback: both hooks invoked unconditionally (stable React hook order), `usePolledData` gated by `enabled = active && !useInformerPath` to avoid double-fetch

Closes #388 (PR2 of 5 in Epic A8).

## Changes

### Foundation (commit 288fe75)
- `src/core/informer.ts`: per-mode `REMOTE_KINDS` / `LOCAL_KINDS` + `supportsKind()` accessor; `informerFor` throws with mode in error message; `startAll`/`relist` iterate per-mode kinds
- `src/local/watch-hub-recorder.ts` (new): `createWatchHubRecorder({hub, namespace, now?})` returning `{contribution, claim, agentSession}` methods; uses existing `*ToEntity` projectors; swallows `recordWrite` throws
- `src/local/sqlite-store.ts`: optional `onContributionWrite` / `onClaimWrite` callbacks fired from put/putMany/createClaim/release/complete/expireStale/claimOrRenew (renew flag). **Pure heartbeats do NOT fire callbacks** per spec rule.
- `src/core/acp-runtime.ts`: optional `onSessionWrite` fired ADDED on spawn, MODIFIED on crash transition, DELETED on close
- `src/local/runtime.ts`: `LocalRuntimeOptions.watchHub` + `watchNamespace`; throws if hub provided without namespace
- `src/tui/main.ts`: builds `new WatchHub()` + `InformerFactory({mode:"local", hub, namespace, listFn})` when `backend.mode === "local"`; `eager: true` on both `InformerProvider` paths
- `src/tui/views/claims.tsx`: dual-path migration to `useEntities("Claim", e => e.status.phase === "active")`
- `src/tui/hooks/informer-context.tsx`: `useInformerFactoryOptional()` returning `null` when no provider mounted

### Views (commit a7c862d)
**Contribution path:**
- `panels/panel-manager.tsx`: `useEntity("Contribution", detailCid)` for detail; relations/artifacts read from `entity.spec`
- `views/activity.tsx`: `useEntities("Contribution")` + sort by createdAt desc + slice(pageOffset, +pageSize)
- `views/activity-panel.tsx`: same with slice(0, 30) panel limit
- `views/search-panel.tsx`: only switches to informer when query is empty
- `views/detail.tsx`: `useEntity("Contribution", cid)` for body fields; ancestors/children/thread/outcome stay on poll (server-computed relations not on Entity envelope)

**Claim path:**
- `views/agent-list.tsx`, `pipeline-view.tsx`, `agent-graph.tsx`: each adds inline `entityToClaim()` projecting `ClaimEntity` → `Claim` and swaps `usePolledData(getClaims)` for `useEntities("Claim", ACTIVE)`. **AgentSession session-portion deferred** until tmux→AgentSession bridge lands (see plan §AgentSession scope).

**Tests:**
- `src/tui/views/entity-projection.test.ts` (3 tests): pins round-trip contract for `claimToEntity` / `contributionToEntity` / `agentSessionToEntity`
- `src/local/informer-pr2-smoke.test.ts` (4 tests): full e2e mount of `LocalRuntime` + `WatchHub` + `InformerFactory(mode:"local")`; asserts startAll syncs to empty cache, contribution/claim writes fire `recordWrite` and land in informer cache, `factory.relist()` preserves cache content
- `src/local/sqlite-store.test.ts` (+7 tests): `onContributionWrite` (put/putMany), `onClaimWrite` (createClaim, heartbeat-no-fire, complete, release, expireStale, claimOrRenew ADDED/MODIFIED)
- `src/local/watch-hub-recorder.test.ts` (4 tests): each method + error swallowing
- `src/local/runtime.test.ts` (+2 tests): watchHub wiring republishes writes; missing namespace throws
- `src/core/informer.test.ts` (+2 tests): AgentSession unsupported in remote / supported in local

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bun biome check` clean on all 10 changed files
- [x] Targeted suites: 279/279 pass (sqlite-store, watch-hub-recorder, runtime, informer-pr2-smoke, informer, entity-projection)
- [x] Full `bun test` run: 6434 pass / 6 skip / 1 fail. The single fail (`tests/e2e/repo-cache-session.test.ts`: "resolve → provision → commit → push flow against a bare-clone fixture") is a pre-existing parallel-run flake — passes in isolation both with and without these changes
- [x] `grep -r "usePolledData" src/tui/views src/tui/panels` shows the post-PR2 expected state — Entity views retain `usePolledData` only on the fallback path; remaining usePolledData-only call sites are non-Entity callers (vfs, terminal, gossip, threads, bounties, outcomes, decisions, github, dag, dashboard, frontier, handoffs, artifact-preview, inbox)
- [ ] Manual smoke: open TUI in local mode, verify activity/claims/detail/agent views render and update on writes (deferring to reviewer — PR3 will swap remote-mode views to the same hooks)

Plan: `docs/superpowers/plans/2026-04-30-retire-polling-a8-pr2-views.md` (Tasks 1–9 all complete).