### PR TITLE
feat(tui): A8.3 — migrate cross-kind aggregates to useDerived (#389)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,9 +29,11 @@
         "@types/bun": "1.3.9",
         "@types/proper-lockfile": "^4.1.4",
         "@types/react": "^19.0.0",
+        "@types/react-test-renderer": "19",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "lefthook": "2.1.1",
+        "react-test-renderer": "19",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
       },
@@ -313,6 +315,8 @@
     "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
 
     "@types/retry": ["@types/retry@0.12.5", "", {}, "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw=="],
 
@@ -628,7 +632,11 @@
 
     "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
 
+    "react-is": ["react-is@19.2.5", "", {}, "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ=="],
+
     "react-reconciler": ["react-reconciler@0.32.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ=="],
+
+    "react-test-renderer": ["react-test-renderer@19.2.5", "", { "dependencies": { "react-is": "^19.2.5", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-kwViRpdISMTpcpy5B6TSewfJzRjnajihRaj57ZmOWKD+SPN6k9LUM13O0pfOuW8ir6B6OOiAXwCRqOoVxRNykA=="],
 
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
@@ -652,7 +660,7 @@
 
     "sax": ["sax@1.5.0", "", {}, "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA=="],
 
-    "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
@@ -795,6 +803,8 @@
     "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
 
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "react-reconciler/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
     "@grove/ask-user/@biomejs/biome/@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA=="],
 

--- a/package.json
+++ b/package.json
@@ -80,9 +80,11 @@
     "@types/bun": "1.3.9",
     "@types/proper-lockfile": "^4.1.4",
     "@types/react": "^19.0.0",
+    "@types/react-test-renderer": "19",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "lefthook": "2.1.1",
+    "react-test-renderer": "19",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/src/shared/format.test.ts
+++ b/src/shared/format.test.ts
@@ -5,6 +5,9 @@
 import { describe, expect, test } from "bun:test";
 import type { Score } from "../core/models.js";
 import {
+  compareTimestamps,
+  compareTimestampsAscNewestLast,
+  compareTimestampsDesc,
   contributionToRow,
   formatScore,
   formatTimestamp,
@@ -63,6 +66,124 @@ describe("formatTimestamp", () => {
   test("formats future timestamp as absolute", () => {
     const future = new Date(Date.now() + 86_400_000).toISOString();
     expect(formatTimestamp(future)).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+  });
+});
+
+describe("compareTimestamps", () => {
+  test("returns negative when a is older", () => {
+    expect(compareTimestamps("2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z")).toBeLessThan(0);
+  });
+
+  test("returns positive when a is newer", () => {
+    expect(compareTimestamps("2026-01-02T00:00:00Z", "2026-01-01T00:00:00Z")).toBeGreaterThan(0);
+  });
+
+  test("returns 0 for equal timestamps", () => {
+    expect(compareTimestamps("2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z")).toBe(0);
+  });
+
+  test("handles timezone offsets chronologically", () => {
+    // 2026-01-02T00:00:00+05:00 == 2026-01-01T19:00:00Z (older than 20:00Z)
+    const offset = "2026-01-02T00:00:00+05:00";
+    const utc = "2026-01-01T20:00:00Z";
+    // Lexicographic compare would say `offset` > `utc`. Chronological says
+    // `offset` is older.
+    expect(compareTimestamps(offset, utc)).toBeLessThan(0);
+    expect(compareTimestamps(utc, offset)).toBeGreaterThan(0);
+    // Lexicographic sanity: regression check that the bug existed.
+    expect(offset.localeCompare(utc)).toBeGreaterThan(0);
+  });
+
+  test("undefined sorts as last (NaN-safe)", () => {
+    expect(compareTimestamps(undefined, "2026-01-01T00:00:00Z")).toBeGreaterThan(0);
+    expect(compareTimestamps("2026-01-01T00:00:00Z", undefined)).toBeLessThan(0);
+    expect(compareTimestamps(undefined, undefined)).toBe(0);
+  });
+
+  test("malformed strings sort last", () => {
+    expect(compareTimestamps("not-a-date", "2026-01-01T00:00:00Z")).toBeGreaterThan(0);
+  });
+});
+
+describe("compareTimestampsDesc", () => {
+  test("returns positive when a is older (so b sorts first)", () => {
+    expect(compareTimestampsDesc("2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z")).toBeGreaterThan(
+      0,
+    );
+  });
+
+  test("returns negative when a is newer (so a sorts first)", () => {
+    expect(compareTimestampsDesc("2026-01-02T00:00:00Z", "2026-01-01T00:00:00Z")).toBeLessThan(0);
+  });
+
+  test("invalid sorts LAST even in DESC (regression — naive reversal would put bad data first)", () => {
+    // Codex round-8 finding: passing args reversed to compareTimestamps
+    // would put NaN BEFORE valid timestamps, displacing real data from
+    // a slice(0, N) cap. The dedicated DESC helper preserves invalid-last.
+    const sorted = [
+      { ts: "2026-01-01T00:00:00Z" },
+      { ts: undefined },
+      { ts: "2026-01-03T00:00:00Z" },
+      { ts: "not-a-date" },
+      { ts: "2026-01-02T00:00:00Z" },
+    ].sort((a, b) => compareTimestampsDesc(a.ts, b.ts));
+    // First three slots must be the three valid timestamps in DESC order;
+    // invalids land at the tail.
+    expect(sorted[0]?.ts).toBe("2026-01-03T00:00:00Z");
+    expect(sorted[1]?.ts).toBe("2026-01-02T00:00:00Z");
+    expect(sorted[2]?.ts).toBe("2026-01-01T00:00:00Z");
+    // Last two are invalid (order between them is undefined, just assert
+    // both are bad).
+    const lastTwo = sorted.slice(3).map((x) => x.ts);
+    expect(lastTwo.every((t) => t === undefined || t === "not-a-date")).toBe(true);
+  });
+
+  test("handles timezone offsets chronologically", () => {
+    const offset = "2026-01-02T00:00:00+05:00";
+    const utc = "2026-01-01T20:00:00Z";
+    // offset is chronologically OLDER → DESC should put utc first.
+    expect(compareTimestampsDesc(utc, offset)).toBeLessThan(0);
+  });
+});
+
+describe("compareTimestampsAscNewestLast", () => {
+  test("ascending order for valid timestamps", () => {
+    const sorted = [
+      { ts: "2026-01-03T00:00:00Z" },
+      { ts: "2026-01-01T00:00:00Z" },
+      { ts: "2026-01-02T00:00:00Z" },
+    ].sort((a, b) => compareTimestampsAscNewestLast(a.ts, b.ts));
+    expect(sorted.map((x) => x.ts)).toEqual([
+      "2026-01-01T00:00:00Z",
+      "2026-01-02T00:00:00Z",
+      "2026-01-03T00:00:00Z",
+    ]);
+  });
+
+  test("invalid sorts FIRST so tail is always the newest valid (regression for codex round-9)", () => {
+    // The running feed's auto-follow targets `feed.length - 1` as
+    // "newest". With invalid-last, a malformed-timestamp row would steal
+    // the cursor's focus from the real newest contribution.
+    const sorted = [
+      { ts: "2026-01-02T00:00:00Z" },
+      { ts: undefined },
+      { ts: "2026-01-01T00:00:00Z" },
+      { ts: "not-a-date" },
+      { ts: "2026-01-03T00:00:00Z" },
+    ].sort((a, b) => compareTimestampsAscNewestLast(a.ts, b.ts));
+    // Tail must be the newest valid timestamp.
+    expect(sorted[sorted.length - 1]?.ts).toBe("2026-01-03T00:00:00Z");
+    // Tail-1 must be the second-newest valid.
+    expect(sorted[sorted.length - 2]?.ts).toBe("2026-01-02T00:00:00Z");
+    // Tail-3 must be the oldest valid.
+    expect(sorted[sorted.length - 3]?.ts).toBe("2026-01-01T00:00:00Z");
+  });
+
+  test("handles timezone offsets chronologically", () => {
+    const offset = "2026-01-02T00:00:00+05:00";
+    const utc = "2026-01-01T20:00:00Z";
+    // offset (=01T19:00Z) is older than utc (=01T20:00Z) → ASC puts offset first.
+    expect(compareTimestampsAscNewestLast(offset, utc)).toBeLessThan(0);
   });
 });
 

--- a/src/shared/format.ts
+++ b/src/shared/format.ts
@@ -25,6 +25,64 @@ export function truncateCid(cid: string, length = 12): string {
   return `${prefix}${cid.slice(prefix.length, prefix.length + length)}..`;
 }
 
+/** Compare two ISO timestamps chronologically (parses to ms epoch).
+ *
+ *  Lexicographic comparison only works for normalized UTC strings; manifest
+ *  entries can carry timezone offsets like `+05:00` that would otherwise
+ *  sort wrong (e.g. `2026-01-02T00:00:00+05:00` is chronologically
+ *  EARLIER than `2026-01-01T20:00:00Z` despite sorting after as a string).
+ *  Returns negative when `a` is older, positive when `a` is newer, 0 when
+ *  equal (or both unparseable). Invalid/missing inputs sort LAST in
+ *  ascending order so bad timestamps don't displace real data from a
+ *  "newest" or "oldest" cap.
+ */
+export function compareTimestamps(a: string | undefined, b: string | undefined): number {
+  const ta = a ? Date.parse(a) : Number.NaN;
+  const tb = b ? Date.parse(b) : Number.NaN;
+  const aBad = Number.isNaN(ta);
+  const bBad = Number.isNaN(tb);
+  if (aBad && bBad) return 0;
+  if (aBad) return 1;
+  if (bBad) return -1;
+  return ta - tb;
+}
+
+/** Descending chronological compare (newest first). Critically, invalid /
+ *  missing timestamps still sort LAST — naively passing args reversed to
+ *  `compareTimestamps` would invert the NaN policy and let bad-timestamp
+ *  rows displace real recent contributions in a slice(0, N) cap.
+ */
+export function compareTimestampsDesc(a: string | undefined, b: string | undefined): number {
+  const ta = a ? Date.parse(a) : Number.NaN;
+  const tb = b ? Date.parse(b) : Number.NaN;
+  const aBad = Number.isNaN(ta);
+  const bBad = Number.isNaN(tb);
+  if (aBad && bBad) return 0;
+  if (aBad) return 1;
+  if (bBad) return -1;
+  return tb - ta;
+}
+
+/** Ascending chronological compare with invalid-FIRST semantics — for
+ *  callers like the running feed where the TAIL has special meaning
+ *  (auto-follow targets `arr.length - 1` as "newest"). The default
+ *  `compareTimestamps` puts invalids last in ASC, which would let a
+ *  malformed-timestamp row steal the cursor's "newest" focus.
+ */
+export function compareTimestampsAscNewestLast(
+  a: string | undefined,
+  b: string | undefined,
+): number {
+  const ta = a ? Date.parse(a) : Number.NaN;
+  const tb = b ? Date.parse(b) : Number.NaN;
+  const aBad = Number.isNaN(ta);
+  const bBad = Number.isNaN(tb);
+  if (aBad && bBad) return 0;
+  if (aBad) return -1;
+  if (bBad) return 1;
+  return ta - tb;
+}
+
 /** Format an ISO timestamp as a short relative or absolute string. */
 export function formatTimestamp(iso: string): string {
   const date = new Date(iso);

--- a/src/tui/hooks/use-derived.integration.test.ts
+++ b/src/tui/hooks/use-derived.integration.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Integration test for `useDerived`'s subscription contract (PR3 #389).
+ *
+ * Drives a real `InformerFactory` (local mode) + `WatchHub` and exercises
+ * the same handler-attach + recompute path that `useDerived`'s React effect
+ * uses. The hook itself can't be mounted under bun:test (no React renderer
+ * in this repo), but its `stepDerived` reducer + the `Informer.addEvent` /
+ * `Informer.addSync` subscriptions ARE the subscription contract — driving
+ * them directly proves the same behavior the spec acceptance asks for:
+ *
+ *   "Aggregates re-render only when their underlying entities change."
+ *   "Smoke tests verify recompute on event from any listed kind."
+ */
+
+import { describe, expect, test } from "bun:test";
+import { InformerFactory } from "../../core/informer.js";
+import type { WatchEntity, WatchKind } from "../../core/watch-events.js";
+import { WatchHub } from "../../core/watch-hub.js";
+import { stepDerived } from "./use-derived.js";
+
+const NS = "default";
+
+function mkContribution(id: string): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: id,
+      artifacts: {},
+      relations: [],
+      tags: [],
+      agent: { agentId: "a1" },
+    },
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: "1",
+    metadata: { generation: 1, creationTimestamp: "2026-01-01T00:00:00Z" },
+  } as unknown as WatchEntity;
+}
+
+function mkClaim(id: string, phase: "active" | "expired" = "active"): WatchEntity {
+  return {
+    kind: "Claim",
+    namespace: NS,
+    id,
+    spec: {
+      targetRef: `t-${id}`,
+      agent: { agentId: "a1" },
+      intentSummary: "do",
+    },
+    status: {
+      phase,
+      persistedPhase: phase,
+      heartbeatAt: "2026-01-01T00:00:00Z",
+      leaseExpiresAt: "2026-01-01T01:00:00Z",
+      attemptCount: 0,
+    },
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: "1",
+    metadata: { generation: 1, creationTimestamp: "2026-01-01T00:00:00Z" },
+  } as unknown as WatchEntity;
+}
+
+/**
+ * Drive a useDerived-style subscription manually: attach event + sync
+ * handlers on each kind's Informer, run a `tick` that calls stepDerived
+ * with the current snapshot, and return a controller that exposes the
+ * latest committed state plus a teardown.
+ */
+function driveDerived<T>(
+  factory: InformerFactory,
+  kinds: readonly WatchKind[],
+  compute: () => T,
+  equals: (a: T, b: T) => boolean = Object.is,
+): {
+  current: () => { data: T | undefined; error: Error | null };
+  commits: number;
+  detach: () => void;
+} {
+  const informers = kinds.map((k) => factory.informerFor(k));
+  let state: { data: T | undefined; error: Error | null } = stepDerived<T>(
+    { data: undefined, error: null },
+    compute,
+    equals,
+  );
+  const ctrl = {
+    current: () => state,
+    commits: 1,
+    // biome-ignore lint/suspicious/noEmptyBlockStatements: replaced below once unsubs are populated.
+    detach: () => {},
+  };
+  const tick = (): void => {
+    const next = stepDerived<T>(state, compute, equals);
+    if (next.committed) {
+      state = { data: next.data, error: next.error };
+      ctrl.commits++;
+    }
+  };
+  const unsubs: Array<() => void> = [];
+  for (const i of informers) {
+    unsubs.push(i.addEventHandler(tick));
+    unsubs.push(i.addSyncHandler(tick));
+  }
+  ctrl.detach = () => {
+    for (const u of unsubs) u();
+  };
+  return ctrl;
+}
+
+async function awaitFirstSync(
+  factory: InformerFactory,
+  kinds: readonly WatchKind[],
+): Promise<void> {
+  await Promise.all(
+    kinds.map(
+      (k) =>
+        new Promise<void>((resolve) => {
+          const informer = factory.informerFor(k);
+          if (informer.hasSynced()) {
+            resolve();
+            return;
+          }
+          const unsub = informer.addSyncHandler(() => {
+            unsub();
+            resolve();
+          });
+        }),
+    ),
+  );
+}
+
+describe("useDerived subscription contract (PR3 #389)", () => {
+  test("recomputes on a Contribution event after first sync", async () => {
+    const hub = new WatchHub();
+    let snapshot: WatchEntity[] = [];
+    const factory = new InformerFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => snapshot,
+    });
+    factory.startAll();
+    await awaitFirstSync(factory, ["Contribution"]);
+
+    type Out = { count: number };
+    const ctrl = driveDerived<Out>(
+      factory,
+      ["Contribution"],
+      () => ({ count: factory.informerFor("Contribution").list().length }),
+      (a, b) => a.count === b.count,
+    );
+
+    expect(ctrl.current().data).toEqual({ count: 0 });
+    const initialCommits = ctrl.commits;
+
+    snapshot = [mkContribution("c1")];
+    hub.recordWrite({
+      op: "ADDED",
+      kind: "Contribution",
+      namespace: NS,
+      entity: mkContribution("c1"),
+    });
+    // Yield a microtask so LocalWatchClient delivers the event to Informer.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(ctrl.current().data).toEqual({ count: 1 });
+    expect(ctrl.commits).toBe(initialCommits + 1);
+
+    ctrl.detach();
+    await factory.stopAll();
+  });
+
+  test("recomputes on a Claim event when watching multiple kinds", async () => {
+    const hub = new WatchHub();
+    let snapshot: WatchEntity[] = [];
+    const factory = new InformerFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => snapshot,
+    });
+    factory.startAll();
+    await awaitFirstSync(factory, ["Claim", "Contribution"]);
+
+    type Out = { contribs: number; activeClaims: number };
+    const ctrl = driveDerived<Out>(
+      factory,
+      ["Claim", "Contribution"],
+      () => ({
+        contribs: factory.informerFor("Contribution").list().length,
+        activeClaims: factory
+          .informerFor("Claim")
+          .list()
+          .filter((c) => (c.status as { phase: string }).phase === "active").length,
+      }),
+      (a, b) => a.contribs === b.contribs && a.activeClaims === b.activeClaims,
+    );
+
+    expect(ctrl.current().data).toEqual({ contribs: 0, activeClaims: 0 });
+
+    // Publish a Claim — useDerived must recompute even though the changed
+    // kind is the second one in the kinds list.
+    snapshot = [mkClaim("k1")];
+    hub.recordWrite({ op: "ADDED", kind: "Claim", namespace: NS, entity: mkClaim("k1") });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(ctrl.current().data).toEqual({ contribs: 0, activeClaims: 1 });
+
+    ctrl.detach();
+    await factory.stopAll();
+  });
+
+  test("equals collapses no-op recomputes (commit count stable)", async () => {
+    const hub = new WatchHub();
+    let snapshot: WatchEntity[] = [mkContribution("c1")];
+    const factory = new InformerFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => snapshot,
+    });
+    factory.startAll();
+    await awaitFirstSync(factory, ["Contribution"]);
+
+    type Out = { count: number };
+    const ctrl = driveDerived<Out>(
+      factory,
+      ["Contribution"],
+      () => ({ count: factory.informerFor("Contribution").list().length }),
+      (a, b) => a.count === b.count,
+    );
+
+    const baseline = ctrl.commits;
+
+    // Modify same id (count stays 1) — equals must collapse the recompute.
+    snapshot = [mkContribution("c1")];
+    hub.recordWrite({
+      op: "MODIFIED",
+      kind: "Contribution",
+      namespace: NS,
+      entity: mkContribution("c1"),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(ctrl.current().data).toEqual({ count: 1 });
+    expect(ctrl.commits).toBe(baseline);
+
+    ctrl.detach();
+    await factory.stopAll();
+  });
+
+  test("compute throw → error captured, last data preserved", async () => {
+    const hub = new WatchHub();
+    let snapshot: WatchEntity[] = [];
+    const factory = new InformerFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => snapshot,
+    });
+    factory.startAll();
+    await awaitFirstSync(factory, ["Contribution"]);
+
+    let shouldThrow = false;
+    type Out = { count: number };
+    const ctrl = driveDerived<Out>(factory, ["Contribution"], () => {
+      if (shouldThrow) throw new Error("boom");
+      return { count: factory.informerFor("Contribution").list().length };
+    });
+
+    expect(ctrl.current().data).toEqual({ count: 0 });
+
+    shouldThrow = true;
+    snapshot = [mkContribution("c1")];
+    hub.recordWrite({
+      op: "ADDED",
+      kind: "Contribution",
+      namespace: NS,
+      entity: mkContribution("c1"),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(ctrl.current().error?.message).toBe("boom");
+    // Last-good data preserved across the throwing recompute.
+    expect(ctrl.current().data).toEqual({ count: 0 });
+
+    // Recovery: next clean recompute clears the error.
+    shouldThrow = false;
+    snapshot = [mkContribution("c1"), mkContribution("c2")];
+    hub.recordWrite({
+      op: "ADDED",
+      kind: "Contribution",
+      namespace: NS,
+      entity: mkContribution("c2"),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(ctrl.current().error).toBeNull();
+    expect(ctrl.current().data).toEqual({ count: 2 });
+
+    ctrl.detach();
+    await factory.stopAll();
+  });
+});

--- a/src/tui/hooks/use-derived.mount.test.tsx
+++ b/src/tui/hooks/use-derived.mount.test.tsx
@@ -205,6 +205,73 @@ describe("useDerived mount + publish (PR3 #389)", () => {
     await factory.stopAll();
   });
 
+  test("microtask coalescing — N synchronous events trigger ≤1 compute (regression for codex round-10)", async () => {
+    // An initial relist dispatches one ADDED per cached entity. Without
+    // coalescing, callers like Dashboard/DAG that sort/map the full
+    // Contribution cache would perform N full-cache projections per
+    // relist, freezing the TUI on large Groves.
+    const hub = new WatchHub();
+    const snapshot: WatchEntity[] = [];
+    const factory = new InformerFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => snapshot,
+    });
+    factory.startAll();
+
+    let computeCount = 0;
+    function CountingProbe({ factory: f }: { factory: InformerFactory }): React.ReactNode {
+      useDerived(
+        () => {
+          computeCount++;
+          return (f.informerFor("Contribution").list() as readonly WatchEntity[]).length;
+        },
+        ["Contribution"],
+        Object.is,
+      );
+      return null;
+    }
+
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={factory}>
+            <CountingProbe factory={factory} />
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await flushMicrotasks();
+    });
+
+    const baselineComputes = computeCount;
+
+    // Burst: synchronously dispatch 50 ADDED events in the same stack.
+    await act(async () => {
+      for (let i = 0; i < 50; i++) {
+        snapshot.push(mkContribution(`burst-${i}`));
+        hub.recordWrite({
+          op: "ADDED",
+          kind: "Contribution",
+          namespace: NS,
+          entity: mkContribution(`burst-${i}`),
+        });
+      }
+      await flushMicrotasks(50);
+    });
+
+    // Without coalescing: 50 events → 50 computes. With coalescing: synchronous
+    // burst collapses to 1 microtask-deferred recompute. Allow up to a few
+    // (test renderer / scheduler ticks may schedule extra microtasks).
+    const burstComputes = computeCount - baselineComputes;
+    expect(burstComputes).toBeLessThanOrEqual(3);
+    expect(burstComputes).toBeGreaterThanOrEqual(1);
+
+    renderer?.unmount();
+    await factory.stopAll();
+  });
+
   test("equals collapses no-op recomputes (no extra commit)", async () => {
     const hub = new WatchHub();
     let snapshot: WatchEntity[] = [mkContribution("c1")];

--- a/src/tui/hooks/use-derived.mount.test.tsx
+++ b/src/tui/hooks/use-derived.mount.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * React-mount smoke test for `useDerived` (PR3 #389).
+ *
+ * Verifies the actual React effect path — not just the underlying
+ * subscription contract (covered by `use-derived.integration.test.ts`).
+ * Mounts a minimal consumer component inside an `<InformerProvider>`,
+ * publishes events to the WatchHub, and asserts the rendered output
+ * advances through React's commit pipeline.
+ *
+ * Uses `react-test-renderer` because OpenTUI's custom hosts (`<box>`,
+ * `<text>`) aren't DOM nodes — react-test-renderer ignores hosts and only
+ * renders function/class components, which is exactly what we need to
+ * exercise hook semantics.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import { useEffect } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { InformerFactory } from "../../core/informer.js";
+import type { WatchEntity } from "../../core/watch-events.js";
+import { WatchHub } from "../../core/watch-hub.js";
+import { InformerProvider } from "./informer-context.js";
+import { useDerived } from "./use-derived.js";
+
+// Silences "The current testing environment is not configured to support
+// act(...)" — React 19 needs this flag set in any environment that calls
+// act() outside of a known framework like Jest. See React 19 RFC.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NS = "default";
+
+function mkContribution(id: string): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: id,
+      artifacts: {},
+      relations: [],
+      tags: [],
+      agent: { agentId: "a1" },
+    },
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: "1",
+    metadata: { generation: 1, creationTimestamp: "2026-01-01T00:00:00Z" },
+  } as unknown as WatchEntity;
+}
+
+function mkClaim(id: string): WatchEntity {
+  return {
+    kind: "Claim",
+    namespace: NS,
+    id,
+    spec: {
+      targetRef: `t-${id}`,
+      agent: { agentId: "a1" },
+      intentSummary: "do",
+    },
+    status: {
+      phase: "active",
+      persistedPhase: "active",
+      heartbeatAt: "2026-01-01T00:00:00Z",
+      leaseExpiresAt: "2026-01-01T01:00:00Z",
+      attemptCount: 0,
+    },
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: "1",
+    metadata: { generation: 1, creationTimestamp: "2026-01-01T00:00:00Z" },
+  } as unknown as WatchEntity;
+}
+
+interface ProbeProps {
+  readonly factory: InformerFactory;
+  readonly onState: (count: number, claims: number, hasSynced: boolean) => void;
+}
+
+function Probe({ factory: _factory, onState }: ProbeProps): React.ReactNode {
+  const derived = useDerived(
+    () => {
+      const contribs = (_factory.informerFor("Contribution").list() as readonly WatchEntity[])
+        .length;
+      const claims = (_factory.informerFor("Claim").list() as readonly WatchEntity[]).filter(
+        (c) => (c.status as { phase: string }).phase === "active",
+      ).length;
+      return { contribs, claims };
+    },
+    ["Claim", "Contribution"],
+    (a, b) => a.contribs === b.contribs && a.claims === b.claims,
+  );
+
+  // React StrictMode + bun:test sometimes batches; report state via effect so
+  // the assertion can observe each commit.
+  useEffect(() => {
+    onState(derived.data?.contribs ?? -1, derived.data?.claims ?? -1, derived.hasSynced);
+  }, [derived.data, derived.hasSynced, onState]);
+
+  return null;
+}
+
+async function flushMicrotasks(ms: number = 20): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+describe("useDerived mount + publish (PR3 #389)", () => {
+  test("commits on Contribution event from any listed kind", async () => {
+    const hub = new WatchHub();
+    let snapshot: WatchEntity[] = [];
+    const factory = new InformerFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => snapshot,
+    });
+    factory.startAll();
+
+    const observed: Array<{ contribs: number; claims: number; hasSynced: boolean }> = [];
+    const onState = (contribs: number, claims: number, hasSynced: boolean): void => {
+      observed.push({ contribs, claims, hasSynced });
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={factory}>
+            <Probe factory={factory} onState={onState} />
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await flushMicrotasks();
+    });
+
+    // Initial render observed (count=0).
+    expect(observed.length).toBeGreaterThanOrEqual(1);
+    const first = observed[0];
+    expect(first?.contribs).toBe(0);
+    expect(first?.claims).toBe(0);
+
+    // Publish a contribution and let the watch loop deliver it.
+    snapshot = [mkContribution("c1")];
+    await act(async () => {
+      hub.recordWrite({
+        op: "ADDED",
+        kind: "Contribution",
+        namespace: NS,
+        entity: mkContribution("c1"),
+      });
+      await flushMicrotasks(30);
+    });
+
+    const last = observed[observed.length - 1];
+    expect(last?.contribs).toBe(1);
+    expect(last?.claims).toBe(0);
+
+    renderer?.unmount();
+    await factory.stopAll();
+  });
+
+  test("commits on Claim event from second kind in list", async () => {
+    const hub = new WatchHub();
+    let snapshot: WatchEntity[] = [];
+    const factory = new InformerFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => snapshot,
+    });
+    factory.startAll();
+
+    const observed: Array<{ contribs: number; claims: number }> = [];
+    const onState = (contribs: number, claims: number): void => {
+      observed.push({ contribs, claims });
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={factory}>
+            <Probe factory={factory} onState={onState} />
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await flushMicrotasks();
+    });
+
+    snapshot = [mkClaim("k1")];
+    await act(async () => {
+      hub.recordWrite({ op: "ADDED", kind: "Claim", namespace: NS, entity: mkClaim("k1") });
+      await flushMicrotasks(30);
+    });
+
+    const last = observed[observed.length - 1];
+    expect(last?.claims).toBe(1);
+    expect(last?.contribs).toBe(0);
+
+    renderer?.unmount();
+    await factory.stopAll();
+  });
+
+  test("equals collapses no-op recomputes (no extra commit)", async () => {
+    const hub = new WatchHub();
+    let snapshot: WatchEntity[] = [mkContribution("c1")];
+    const factory = new InformerFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => snapshot,
+    });
+    factory.startAll();
+
+    let commitCount = 0;
+    const onState = (): void => {
+      commitCount++;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={factory}>
+            <Probe factory={factory} onState={onState} />
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await flushMicrotasks();
+    });
+
+    const baseline = commitCount;
+
+    // Modify same id — count stays at 1, equals must collapse.
+    snapshot = [mkContribution("c1")];
+    await act(async () => {
+      hub.recordWrite({
+        op: "MODIFIED",
+        kind: "Contribution",
+        namespace: NS,
+        entity: mkContribution("c1"),
+      });
+      await flushMicrotasks(30);
+    });
+
+    expect(commitCount).toBe(baseline);
+
+    renderer?.unmount();
+    await factory.stopAll();
+  });
+});

--- a/src/tui/hooks/use-derived.remote-e2e.test.tsx
+++ b/src/tui/hooks/use-derived.remote-e2e.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Remote-mode end-to-end test for `useDerived` (PR3 #389).
+ *
+ * Stands up an in-process grove-server (Hono `createTestApp`), wires a
+ * remote `InformerFactory` against it via a `fetch` shim that routes
+ * through `app.fetch`, mounts a React consumer that reads `useDerived`,
+ * publishes a real `entity.changed` envelope through the server's watch
+ * pipeline, and asserts the projection commits.
+ *
+ * This is the strongest contract we can verify without a live tmux pty —
+ * it exercises:
+ *   server.recordWrite → SSE → WatchClient → Informer → useDerived
+ *     → React commit
+ *
+ * which is the exact path PR3's aggregates use in production.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import { useEffect } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { contributionToEntity } from "../../core/entity.js";
+import { InformerFactory } from "../../core/informer.js";
+import { makeContribution } from "../../core/test-helpers.js";
+import { createTestApp, TEST_NAMESPACE, TEST_NAMESPACE_KEY } from "../../server/test-helpers.js";
+import { InformerProvider } from "./informer-context.js";
+import { useDerived } from "./use-derived.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+interface ProbeProps {
+  readonly factory: InformerFactory;
+  readonly onState: (count: number, hasSynced: boolean) => void;
+}
+
+function CountProbe({ factory, onState }: ProbeProps): React.ReactNode {
+  const result = useDerived(
+    () => factory.informerFor("Contribution").list().length,
+    ["Contribution"],
+    Object.is,
+  );
+  useEffect(() => {
+    onState(result.data ?? -1, result.hasSynced);
+  }, [result.data, result.hasSynced, onState]);
+  return null;
+}
+
+function makeAppFetch(app: {
+  request: (path: string, init?: RequestInit) => Response | Promise<Response>;
+}): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const path = url.replace(/^https?:\/\/[^/]+/, "");
+    return await app.request(path, init);
+  }) as typeof fetch;
+}
+
+async function flush(ms: number = 50): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+describe("useDerived remote E2E (PR3 #389)", () => {
+  test("React commit fires on a contribution write through the real server pipeline", async () => {
+    const ctx = createTestApp();
+    const factory = new InformerFactory({
+      mode: "remote",
+      baseUrl: "http://test",
+      authHeader: `Bearer ${TEST_NAMESPACE_KEY}`,
+      fetch: makeAppFetch(ctx.app),
+      // Tighter backoff so the test doesn't have to wait the default
+      // 100ms minimum between retries on transient errors.
+      backoff: { minMs: 5, maxMs: 50, jitter: 0 },
+    });
+    factory.startAll();
+
+    const observed: Array<{ count: number; hasSynced: boolean }> = [];
+    const onState = (count: number, hasSynced: boolean): void => {
+      observed.push({ count, hasSynced });
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={factory}>
+            <CountProbe factory={factory} onState={onState} />
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+    });
+    // Poll OUTSIDE act() so the WatchClient's async fetch + SSE handshake
+    // gets uninterrupted scheduler ticks. Inside act() the queued microtasks
+    // can starve the network IO under bun's macOS scheduler.
+    const syncDeadline = Date.now() + 8000;
+    while (Date.now() < syncDeadline) {
+      await flush(50);
+      if (observed.some((o) => o.count === 0 && o.hasSynced)) break;
+    }
+    // Ensure any pending React commits flush before the assertion.
+    await act(async () => {
+      await flush(20);
+    });
+
+    // Initial commit reflects the empty server snapshot.
+    expect(observed.length).toBeGreaterThanOrEqual(1);
+    expect(observed[0]?.count).toBe(0);
+    const baseline = observed.length;
+
+    // Write a contribution to the server's store + bump the WatchHub.
+    // This mirrors what NexusWatchSubscriber would do for an out-of-band
+    // write — exactly what PR3 aggregates rely on for re-render.
+    const contribution = makeContribution({ summary: "remote-e2e seed" });
+    await ctx.contributionStore.put(contribution);
+    ctx.watchHub.recordWrite({
+      op: "ADDED",
+      kind: "Contribution",
+      namespace: TEST_NAMESPACE,
+      entity: contributionToEntity(contribution, TEST_NAMESPACE),
+    });
+    // Same outside-act pattern: let the SSE delivery + Informer dispatch
+    // run on the scheduler, then rinse-and-flush React commits.
+    const writeDeadline = Date.now() + 8000;
+    while (Date.now() < writeDeadline) {
+      await flush(50);
+      const last = observed[observed.length - 1];
+      if (last?.count === 1) break;
+    }
+    await act(async () => {
+      await flush(20);
+    });
+
+    const last = observed[observed.length - 1];
+    expect(last?.count).toBe(1);
+    expect(observed.length).toBeGreaterThan(baseline);
+
+    renderer?.unmount();
+    await factory.stopAll();
+  });
+});

--- a/src/tui/hooks/use-derived.ts
+++ b/src/tui/hooks/use-derived.ts
@@ -10,7 +10,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { WatchKind } from "../../core/watch-events.js";
-import { useInformerFactory } from "./informer-context.js";
+import { useInformerFactoryOptional } from "./informer-context.js";
 
 export interface DerivedState<T> {
   readonly data: T | undefined;
@@ -55,7 +55,11 @@ export function useDerived<T>(
   kinds: readonly WatchKind[],
   equals: (a: T, b: T) => boolean = Object.is,
 ): UseDerivedResult<T> {
-  const factory = useInformerFactory();
+  // Mirror useEntities: graceful when no <InformerProvider> is mounted (the
+  // pre-factory window in interactive mode, or backends that never wire one)
+  // so the dual-path callers can `useDerived` unconditionally without
+  // breaking Rules of Hooks.
+  const factory = useInformerFactoryOptional();
   const computeRef = useRef(compute);
   computeRef.current = compute;
   const equalsRef = useRef(equals);
@@ -67,11 +71,12 @@ export function useDerived<T>(
   const stateRef = useRef(state);
   stateRef.current = state;
 
-  const informers = kinds.map((k) => factory.informerFor(k));
-  const [hasSynced, setHasSynced] = useState<boolean>(() => informers.every((i) => i.hasSynced()));
-  // First non-null factory error across all watched kinds; mirrors useEntities'
-  // separation so a recompute can't mask a terminal stream failure.
+  const informers = factory ? kinds.map((k) => factory.informerFor(k)) : [];
+  const [hasSynced, setHasSynced] = useState<boolean>(() =>
+    factory ? informers.every((i) => i.hasSynced()) : false,
+  );
   const [streamError, setStreamError] = useState<Error | null>(() => {
+    if (!factory) return null;
     for (const k of kinds) {
       const e = factory.getLastError(k);
       if (e) return e;
@@ -80,33 +85,81 @@ export function useDerived<T>(
   });
 
   const kindsKey = kinds.join(",");
-  // biome-ignore lint/correctness/useExhaustiveDependencies: kinds compared by joined string identity
+  // Source-token reset (React pattern: setState during render with tracked
+  // refs). Without this, the render that runs IMMEDIATELY after a factory
+  // or kinds change still exposes the prior source's `state.data` and
+  // `hasSynced` until the effect runs post-commit. Dual-path callers that
+  // gate on `hasSynced && !error` would briefly treat factory-A data as
+  // ready under factory-B's tenant/namespace — a stale leak.
+  //
+  // We must compare factory by IDENTITY, not truthiness: a hot swap from
+  // factory A → factory B (both non-null, same kinds) leaves a truthiness
+  // key unchanged and the reset would be skipped, preserving A's data
+  // under B's provider.
+  const prevFactoryRef = useRef(factory);
+  const prevKindsKeyRef = useRef(kindsKey);
+  if (prevFactoryRef.current !== factory || prevKindsKeyRef.current !== kindsKey) {
+    prevFactoryRef.current = factory;
+    prevKindsKeyRef.current = kindsKey;
+    setState({ data: undefined, error: null });
+    setHasSynced(factory ? informers.every((i) => i.hasSynced()) : false);
+    let firstErr: Error | null = null;
+    if (factory) {
+      for (const k of kinds) {
+        const e = factory.getLastError(k);
+        if (e) {
+          firstErr = e;
+          break;
+        }
+      }
+    }
+    setStreamError(firstErr);
+  }
+  // biome-ignore lint/correctness/useExhaustiveDependencies: kinds compared by joined string identity; hasSynced read inside tick via setter callback
   useEffect(() => {
+    if (!factory) {
+      // Provider lost — reset readiness so dual-path callers fall back to
+      // polled until a new factory mounts and produces a fresh sync.
+      setHasSynced(false);
+      setStreamError(null);
+      return;
+    }
+    // Cancellation guard: informer event dispatch snapshots handlers before
+    // invoking them, so an old `tick` can still fire after cleanup during a
+    // factory/kinds swap. Without this, a stale callback would write
+    // hasSynced/state through the shared refs and the new source could
+    // appear synced (or unsynced) using the old informer set.
+    let cancelled = false;
+    const liveInformers = kinds.map((k) => factory.informerFor(k));
+    // Reset readiness for the new factory/kinds. If the new source is already
+    // synced (e.g. a hot-swapped factory that completed list before we
+    // subscribed), reflect that immediately; otherwise wait for the first
+    // sync notification on this subscription. Setting via setter is
+    // idempotent when the value matches.
+    setHasSynced(liveInformers.every((i) => i.hasSynced()));
     const tick = (): void => {
+      if (cancelled) return;
       const next = stepDerived<T>(stateRef.current, () => computeRef.current(), equalsRef.current);
       if (next.committed) setState({ data: next.data, error: next.error });
-      if (!hasSynced && informers.every((i) => i.hasSynced())) setHasSynced(true);
+      // Always recheck — setHasSynced is a no-op when the value matches, so
+      // we can safely call on every tick. Avoids stale-closure bugs from
+      // tracking hasSynced as an effect dep.
+      const allSynced = liveInformers.every((i) => i.hasSynced());
+      setHasSynced((prev) => (prev === allSynced ? prev : allSynced));
     };
-    // Subscribe to per-entity events AND RELIST_END so empty/unchanged
-    // snapshots still flip hasSynced when every kind has synced.
     const unsubs: Array<() => void> = [];
-    for (const i of informers) {
+    for (const i of liveInformers) {
       unsubs.push(i.addEventHandler(tick));
       unsubs.push(i.addSyncHandler(tick));
     }
-    // Stream error subscription: surface terminal informer.run() failures
-    // for any of the watched kinds. Resolved (null) when the kind hits its
-    // first RELIST_END after restart — see InformerFactory.startOne.
     const watched = new Set<WatchKind>(kinds);
     unsubs.push(
       factory.addErrorListener((kind, err) => {
-        if (!watched.has(kind)) return;
+        if (cancelled || !watched.has(kind)) return;
         if (err) {
           setStreamError(err);
           return;
         }
-        // Recovery for one kind — only clear if no other watched kind is
-        // still in error; otherwise show whichever one is still failing.
         for (const k of kinds) {
           const remaining = factory.getLastError(k);
           if (remaining) {
@@ -117,12 +170,6 @@ export function useDerived<T>(
         setStreamError(null);
       }),
     );
-    // Re-read after subscribing to close BOTH directions of the gap between
-    // render-time initialization and effect-time subscription: an error
-    // appearing OR being cleared in that window would otherwise be lost,
-    // since addErrorListener only delivers future events. Walk every
-    // watched kind and set unconditionally — null when all kinds are
-    // healthy, otherwise the first non-null error.
     let firstErr: Error | null = null;
     for (const k of kinds) {
       const e = factory.getLastError(k);
@@ -133,9 +180,10 @@ export function useDerived<T>(
     }
     setStreamError(firstErr);
     return () => {
+      cancelled = true;
       for (const u of unsubs) u();
     };
-  }, [factory, kindsKey, hasSynced]);
+  }, [factory, kindsKey]);
 
   // Stream errors take precedence over compute errors — the watch lifecycle
   // is the more actionable signal.

--- a/src/tui/hooks/use-derived.ts
+++ b/src/tui/hooks/use-derived.ts
@@ -137,7 +137,20 @@ export function useDerived<T>(
     // sync notification on this subscription. Setting via setter is
     // idempotent when the value matches.
     setHasSynced(liveInformers.every((i) => i.hasSynced()));
-    const tick = (): void => {
+    // Burst coalescing: an initial relist dispatches one ADDED event per
+    // cached entity before RELIST_END. Without coalescing, callers like
+    // Dashboard/DAG that sort/map the full Contribution cache would
+    // perform N full-cache projections per relist, freezing the TUI on
+    // large Groves.
+    //
+    // We use setTimeout(0), not queueMicrotask: informer.dispatch awaits
+    // each handler via `await raceAbort(Promise.resolve(handler(...)), ...)`,
+    // so the microtask queue drains BETWEEN dispatches and queueMicrotask
+    // would still fire once per event. A macrotask defers past the entire
+    // awaited chain, collapsing the whole burst into one recompute.
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const runTick = (): void => {
+      timer = null;
       if (cancelled) return;
       const next = stepDerived<T>(stateRef.current, () => computeRef.current(), equalsRef.current);
       if (next.committed) setState({ data: next.data, error: next.error });
@@ -146,6 +159,10 @@ export function useDerived<T>(
       // tracking hasSynced as an effect dep.
       const allSynced = liveInformers.every((i) => i.hasSynced());
       setHasSynced((prev) => (prev === allSynced ? prev : allSynced));
+    };
+    const tick = (): void => {
+      if (cancelled || timer !== null) return;
+      timer = setTimeout(runTick, 0);
     };
     const unsubs: Array<() => void> = [];
     for (const i of liveInformers) {
@@ -181,6 +198,10 @@ export function useDerived<T>(
     setStreamError(firstErr);
     return () => {
       cancelled = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
       for (const u of unsubs) u();
     };
   }, [factory, kindsKey]);

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -18,14 +18,18 @@ import { useKeyboard } from "@opentui/react";
 import { useDialog } from "@opentui-ui/dialog/react";
 import { toast } from "@opentui-ui/toast/react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ContributionEntity } from "../../core/entity.js";
 import type { EventBus } from "../../core/event-bus.js";
 import type { Contribution } from "../../core/models.js";
 import type { AgentTopology } from "../../core/topology.js";
+import { compareTimestampsAscNewestLast, compareTimestampsDesc } from "../../shared/format.js";
 import { EmptyState } from "../components/empty-state.js";
 import { ProgressBar } from "../components/progress-bar.js";
 import type { AgentLogBuffer } from "../data/agent-log-buffer.js";
 import { debugLog } from "../debug-log.js";
+import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useAgentMonitor } from "../hooks/use-agent-monitor.js";
+import { useEntities } from "../hooks/use-entities.js";
 import { InputMode } from "../hooks/use-panel-focus.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import { useTuiStatePersistence } from "../hooks/use-session-persistence.js";
@@ -93,6 +97,33 @@ export interface RunningViewProps {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Cap on the contribution projection from the informer cache for the feed.
+ *  The visible window is much smaller, but a large cache would sort + map
+ *  every entity on each recompute and freeze the TUI. 500 leaves comfortable
+ *  headroom for scrollback while bounding worst-case work. */
+const FEED_PROJECTION_CAP = 500;
+
+/** Project a ContributionEntity to the flat shape running-view's feed and
+ *  toast routing read. Mirrors entityToContribution helpers in the
+ *  PR2-migrated views. */
+function entityToContribution(e: ContributionEntity): Contribution {
+  return {
+    cid: e.id,
+    manifestVersion: 0,
+    kind: e.spec.contributionKind,
+    mode: e.spec.mode,
+    summary: e.spec.summary,
+    description: e.spec.description,
+    artifacts: e.spec.artifacts,
+    relations: e.spec.relations,
+    scores: e.spec.scores,
+    tags: e.spec.tags,
+    context: e.spec.context,
+    agent: e.spec.agent,
+    createdAt: e.metadata.creationTimestamp ?? "",
+  };
+}
 
 /** Format a timestamp for display. */
 function formatTime(iso: string): string {
@@ -219,6 +250,14 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     }, [monitor.pendingPermissions]);
 
     // ─── Data fetching ───
+    // PR3 (#389): the contribution feed migrates to the Contribution
+    // informer when available. The dashboard itself (metadata, claims with
+    // lease-aware expiry, frontierSummary) remains polled — claim activity
+    // expires on wall-clock and frontier needs server compute, neither of
+    // which the watch protocol covers.
+    const useContribInformer = useEntityWatchEnabled(provider, "Contribution");
+    const contribEntities = useEntities("Contribution");
+
     const dashboardFetcher = useCallback(() => provider.getDashboard(), [provider]);
     const fetchCountRef = React.useRef(0);
     const contributionsFetcher = useCallback(async () => {
@@ -237,11 +276,17 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     // Gate polling: pause contributions when panel is fullscreen and not showing feed
     const feedActive =
       zoomLevel !== "full" || expandedPanel === RunningPanel.Feed || expandedPanel === null;
+    // Only switch to informer data after it has synced and is healthy. Cold
+    // start or terminal watch failure must keep the polled fallback alive,
+    // otherwise the feed renders empty even though `getContributions()` would
+    // still return data.
+    const contribInformerReady =
+      useContribInformer && contribEntities.hasSynced && !contribEntities.error;
     const dashboardPoll = usePolledData<DashboardData>(dashboardFetcher, intervalMs, true);
     const contributionsPoll = usePolledData<readonly Contribution[]>(
       contributionsFetcher,
       intervalMs,
-      feedActive,
+      feedActive && !contribInformerReady,
     );
 
     // usePolledData is only used for UI refresh of the contributions feed display;
@@ -279,16 +324,51 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     }, [eventBus, topology, provider, dashboardPoll.refresh, contributionsPoll.refresh]);
 
     const dashboard = dashboardPoll.data ?? undefined;
-    const contributions = contributionsPoll.data;
+    const contributions = useMemo<readonly Contribution[] | undefined>(() => {
+      if (!contribInformerReady) return contributionsPoll.data ?? undefined;
+      // Cap the projection BEFORE sort/map. A large informer cache (e.g.
+      // after a relist on a long-running Grove) would otherwise sort + map
+      // every entity on each recompute, freezing the TUI even though the
+      // visible feed only shows a window. Take the newest FEED_PROJECTION_CAP
+      // by createdAt, then re-sort ASCENDING so the feed's auto-follow
+      // (`feed.length - 1`) lands on the newest row, matching the polled
+      // `getContributions()` order.
+      // DESC chronological for the cap (invalid-last so bad timestamps
+      // don't displace real recent contributions); ASC for the final feed
+      // order so auto-follow lands on the newest tail.
+      const all = contribEntities.data;
+      let pool: readonly ContributionEntity[] = all;
+      if (all.length > FEED_PROJECTION_CAP) {
+        pool = [...all]
+          .sort((a, b) =>
+            compareTimestampsDesc(a.metadata.creationTimestamp, b.metadata.creationTimestamp),
+          )
+          .slice(0, FEED_PROJECTION_CAP);
+      }
+      // Final ASC for the feed: invalid sorts FIRST so the tail is always
+      // the newest VALID timestamp (auto-follow targets feed.length - 1).
+      const sorted = [...pool].sort((a, b) =>
+        compareTimestampsAscNewestLast(a.metadata.creationTimestamp, b.metadata.creationTimestamp),
+      );
+      return sorted.map(entityToContribution);
+    }, [contribInformerReady, contribEntities.data, contributionsPoll.data]);
 
-    // Aggregate poll health for the status bar: show stale/error when either poll fails.
+    // Aggregate poll health for the status bar: show stale/error when either
+    // path is unhealthy. Informer error always surfaces (even when we're still
+    // polling as fallback) so operators see watch-pipeline failures.
     const pollHealth = useMemo(() => {
-      const isStale = dashboardPoll.isStale || contributionsPoll.isStale;
-      const error = dashboardPoll.error?.message ?? contributionsPoll.error?.message ?? undefined;
+      const contribStale = contribInformerReady ? false : contributionsPoll.isStale;
+      const contribError =
+        contribEntities.error?.message ??
+        (contribInformerReady ? undefined : contributionsPoll.error?.message);
+      const isStale = dashboardPoll.isStale || contribStale;
+      const error = dashboardPoll.error?.message ?? contribError ?? undefined;
       return { isStale, error };
     }, [
       dashboardPoll.isStale,
       dashboardPoll.error?.message,
+      contribInformerReady,
+      contribEntities.error?.message,
       contributionsPoll.isStale,
       contributionsPoll.error?.message,
     ]);
@@ -623,6 +703,11 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     );
 
     // ─── Derived data ───
+    // Active-claim count stays on the polled (lease-aware) path. Claims age
+    // out when wall-clock time crosses `leaseExpiresAt`, which emits no
+    // watch event — informer-cached claim entities would never expire. The
+    // polled dashboard fetches via the lease-aware store query, so its
+    // count reflects expiry correctly.
     const claimCount = dashboard?.activeClaims.length ?? 0;
     // Session-scoped frontier: when session is active, compute from session feed
     const sessionFrontier: DashboardData["frontierSummary"] | undefined = useMemo(() => {

--- a/src/tui/views/activity-panel.tsx
+++ b/src/tui/views/activity-panel.tsx
@@ -10,7 +10,7 @@
 import React, { useCallback, useEffect, useMemo } from "react";
 import type { ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
-import { formatTimestamp, truncateCid } from "../../shared/format.js";
+import { compareTimestampsDesc, formatTimestamp, truncateCid } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
@@ -80,7 +80,7 @@ export const ActivityPanelView: React.NamedExoticComponent<ActivityPanelProps> =
     const data = useMemo<readonly Contribution[] | undefined>(() => {
       if (useInformerPath) {
         const sorted = [...entityResult.data].sort((a, b) =>
-          (b.metadata.creationTimestamp ?? "").localeCompare(a.metadata.creationTimestamp ?? ""),
+          compareTimestampsDesc(a.metadata.creationTimestamp, b.metadata.creationTimestamp),
         );
         return sorted.slice(0, PANEL_LIMIT).map(entityToContribution);
       }

--- a/src/tui/views/activity.tsx
+++ b/src/tui/views/activity.tsx
@@ -12,7 +12,7 @@
 import React, { useCallback, useEffect, useMemo } from "react";
 import type { ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
-import { formatTimestamp, truncateCid } from "../../shared/format.js";
+import { compareTimestampsDesc, formatTimestamp, truncateCid } from "../../shared/format.js";
 import { Table } from "../components/table.js";
 import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntities } from "../hooks/use-entities.js";
@@ -89,10 +89,11 @@ export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.mem
     const data = useMemo<readonly Contribution[] | undefined>(() => {
       if (useInformerPath) {
         const all = entityResult.data;
-        // Sort newest-first by creationTimestamp; entities without a
-        // timestamp sort last (they're typically synthetic / pre-#287).
+        // Sort newest-first chronologically; entities without a timestamp
+        // sort last (they're typically synthetic / pre-#287). String
+        // localeCompare misorders timezone-offset timestamps.
         const sorted = [...all].sort((a, b) =>
-          (b.metadata.creationTimestamp ?? "").localeCompare(a.metadata.creationTimestamp ?? ""),
+          compareTimestampsDesc(a.metadata.creationTimestamp, b.metadata.creationTimestamp),
         );
         return sorted.slice(pageOffset, pageOffset + pageSize).map(entityToContribution);
       }

--- a/src/tui/views/dag.tsx
+++ b/src/tui/views/dag.tsx
@@ -3,18 +3,58 @@
  *
  * Reuses the existing git-style DAG renderer from the CLI.
  * Outcome badges are displayed alongside each node when available.
+ *
+ * PR3 (#389) migrates the contribution source from `usePolledData(getDag)`
+ * to `useDerived(() => contribInformer.list(), ["Contribution"])` when the
+ * informer path is enabled. Outcomes still flow through `usePolledData` —
+ * PR4 will swap that to an event-driven hook once the outcome producer
+ * exposes a coarse change event.
  */
 
 import React, { useCallback, useEffect, useMemo } from "react";
 import { contributionsToDagNodes, renderDag } from "../../cli/format-dag.js";
+import type { ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
 import type { OutcomeRecord } from "../../core/outcome.js";
+import { compareTimestampsDesc } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { OutcomeBadge } from "../components/outcome-badge.js";
+import { useEntityWatchEnabled, useInformerOptional } from "../hooks/informer-context.js";
+import { useDerived } from "../hooks/use-derived.js";
+import { shallowArraysEqual } from "../hooks/use-entities.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { DagData, TuiDataProvider, TuiOutcomeProvider } from "../provider.js";
 import { theme } from "../theme.js";
+
+/** Cap on newest "head" contributions seeded into the DAG; matches the
+ *  polled `dagFromStore` cap (`store.list({ limit: 200 })`). */
+const DAG_CONTRIBUTION_LIMIT = 200;
+
+/** Hard upper bound after BFS-including ancestors of the head set. Allows
+ *  reachable parents within budget; prevents pathological cases where a
+ *  deeply-chained graph blows up render/navigation state. */
+const DAG_TOTAL_CAP = 500;
+
+/** Project a ContributionEntity back to the flat Contribution shape the DAG
+ *  renderer reads (cid, summary, kind, relations, agent, createdAt). */
+function entityToContribution(e: ContributionEntity): Contribution {
+  return {
+    cid: e.id,
+    manifestVersion: 0,
+    kind: e.spec.contributionKind,
+    mode: e.spec.mode,
+    summary: e.spec.summary,
+    description: e.spec.description,
+    artifacts: e.spec.artifacts,
+    relations: e.spec.relations,
+    scores: e.spec.scores,
+    tags: e.spec.tags,
+    context: e.spec.context,
+    agent: e.spec.agent,
+    createdAt: e.metadata.creationTimestamp ?? "",
+  };
+}
 
 /** Props for the DAG view. */
 export interface DagProps {
@@ -42,15 +82,92 @@ export const DagView: React.NamedExoticComponent<DagProps> = React.memo(function
   cursor,
   onContributionsLoaded,
 }: DagProps): React.ReactNode {
-  const fetcher = useCallback(() => provider.getDag(), [provider]);
-  const { data, loading, isStale, error } = usePolledData<DagData>(fetcher, intervalMs, active);
+  const useInformerPath = useEntityWatchEnabled(provider, "Contribution");
 
-  // Batch-fetch outcomes if provider supports it
+  // Informer path: project the cache snapshot through useDerived so the DAG
+  // recomputes only when the Contribution kind actually changes. Cap matches
+  // the polled `dagFromStore` path (`store.list({ limit: 200 })`) to keep
+  // render and navigation state bounded on large repositories — without
+  // this, a synced informer with thousands of cached contributions would
+  // freeze the TUI.
+  //
+  // Topology-aware cap: a naive newest-first slice would silently drop
+  // parents whose CID falls outside the window, causing children to render
+  // as orphans (contributionsToDagNodes filters parent refs to in-set
+  // CIDs only). Instead, take the newest budget as heads, then walk
+  // `derives_from`/`adopts` relations to include reachable ancestors up to
+  // a hard upper bound — preserving correct edges within the rendered set.
+  const contribInformer = useInformerOptional("Contribution");
+  const derived = useDerived<readonly Contribution[]>(
+    () => {
+      const all = contribInformer.list() as readonly ContributionEntity[];
+      // Chronological DESC compare — string sort breaks on timezone-offset
+      // timestamps; the dedicated DESC helper preserves invalid-last so
+      // bad-timestamp rows can't displace real recent contributions when
+      // we slice the head set below.
+      const sorted = [...all].sort((a, b) =>
+        compareTimestampsDesc(a.metadata.creationTimestamp, b.metadata.creationTimestamp),
+      );
+      if (sorted.length <= DAG_CONTRIBUTION_LIMIT) {
+        return sorted.map(entityToContribution);
+      }
+      const byId = new Map(sorted.map((e) => [e.id, e]));
+      const kept = new Set<string>();
+      const queue: ContributionEntity[] = [];
+      for (const e of sorted) {
+        if (kept.size >= DAG_CONTRIBUTION_LIMIT) break;
+        kept.add(e.id);
+        queue.push(e);
+      }
+      while (queue.length > 0 && kept.size < DAG_TOTAL_CAP) {
+        const head = queue.shift();
+        if (!head) continue;
+        for (const r of head.spec.relations) {
+          if (r.relationType !== "derives_from" && r.relationType !== "adopts") continue;
+          const parent = byId.get(r.targetCid);
+          if (parent && !kept.has(parent.id)) {
+            kept.add(parent.id);
+            queue.push(parent);
+            if (kept.size >= DAG_TOTAL_CAP) break;
+          }
+        }
+      }
+      return sorted.filter((e) => kept.has(e.id)).map(entityToContribution);
+    },
+    ["Contribution"],
+    shallowArraysEqual,
+  );
+
+  // Only switch to informer data once it has synced and is healthy. A
+  // remote watch failure (auth/config/server) would otherwise leave the view
+  // stuck on "Loading DAG…" with no fallback path; gating on hasSynced +
+  // !error keeps `getDag()` polling alive until the watch is actually
+  // delivering data.
+  const informerReady = useInformerPath && derived.hasSynced && !derived.error;
+
+  // Polled fallback retained for backends that don't mount an InformerProvider
+  // AND for cold start / terminal watch failure on the informer path.
+  const fetcher = useCallback(() => provider.getDag(), [provider]);
+  const polled = usePolledData<DagData>(fetcher, intervalMs, active && !informerReady);
+
+  const contributions: readonly Contribution[] = useMemo(() => {
+    if (informerReady) return derived.data ?? [];
+    return polled.data?.contributions ?? [];
+  }, [informerReady, derived.data, polled.data]);
+
+  const loading = informerReady ? false : polled.loading;
+  const isStale = informerReady ? false : polled.isStale;
+  // Surface informer errors even while polled-fallback runs so operators
+  // see watch-pipeline failures alongside the polled data.
+  const error = derived.error ?? polled.error;
+
+  // Batch-fetch outcomes if provider supports it. Outcome polling stays —
+  // PR4 will replace it with an event-driven re-fetch.
   const outcomeProvider = provider.capabilities.outcomes
     ? (provider as unknown as TuiOutcomeProvider)
     : undefined;
 
-  const cids = useMemo(() => data?.contributions?.map((c) => c.cid) ?? [], [data]);
+  const cids = useMemo(() => contributions.map((c) => c.cid), [contributions]);
 
   const outcomeFetcher = useCallback(
     () => outcomeProvider?.getOutcomes(cids) ?? Promise.resolve(new Map()),
@@ -63,12 +180,10 @@ export const DagView: React.NamedExoticComponent<DagProps> = React.memo(function
   );
 
   useEffect(() => {
-    if (data?.contributions && onContributionsLoaded) {
-      onContributionsLoaded(data.contributions);
+    if (contributions.length > 0 && onContributionsLoaded) {
+      onContributionsLoaded(contributions);
     }
-  }, [data, onContributionsLoaded]);
-
-  const contributions = data?.contributions ?? [];
+  }, [contributions, onContributionsLoaded]);
 
   const kindMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -93,7 +208,7 @@ export const DagView: React.NamedExoticComponent<DagProps> = React.memo(function
       });
   }, [dagLines]);
 
-  if (loading && !data) {
+  if (loading && contributions.length === 0) {
     return (
       <box>
         <text opacity={0.5}>Loading DAG...</text>
@@ -116,7 +231,7 @@ export const DagView: React.NamedExoticComponent<DagProps> = React.memo(function
     <box flexDirection="column">
       <box marginBottom={1} flexDirection="row">
         <text>{`Contribution DAG (${contributions.length} nodes) `}</text>
-        <DataStatus loading={loading && !data} isStale={isStale} error={error?.message} />
+        <DataStatus loading={loading} isStale={isStale} error={error?.message} />
         <box opacity={0.5} flexDirection="row">
           <text color={theme.work}>work</text>
           <text> </text>

--- a/src/tui/views/dashboard.test.ts
+++ b/src/tui/views/dashboard.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the dashboard view's PR3 (#389) cross-cut projection.
+ *
+ * The view itself reads `useDerived` over `["Contribution"]` to project a
+ * recent-contributions snapshot. Active claims stay on the polled
+ * (lease-aware) path because lease expiry is wall-clock-driven and emits
+ * no watch event. The pure `crossCutEquals` comparator is the
+ * memoization fence — it must collapse recomputes that produce the same
+ * visible snapshot, and detect any change to count or contribution
+ * identity / visible fields.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Contribution } from "../../core/models.js";
+import { crossCutEquals } from "./dashboard.js";
+
+const baseContribution: Contribution = {
+  cid: "blake3:aaa",
+  manifestVersion: 0,
+  kind: "work",
+  mode: "evaluation",
+  summary: "s",
+  artifacts: {},
+  relations: [],
+  tags: [],
+  agent: { agentId: "a1" },
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+describe("crossCutEquals (PR3 #389 dashboard projection)", () => {
+  test("identical references → true", () => {
+    const cross = {
+      recentContributions: [baseContribution],
+      contributionCount: 1,
+    };
+    expect(crossCutEquals(cross, cross)).toBe(true);
+  });
+
+  test("same shape, same array entries (by reference) → true", () => {
+    const a = {
+      recentContributions: [baseContribution],
+      contributionCount: 1,
+    };
+    const b = {
+      recentContributions: [baseContribution],
+      contributionCount: 1,
+    };
+    expect(crossCutEquals(a, b)).toBe(true);
+  });
+
+  test("contributionCount changes → false", () => {
+    const a = {
+      recentContributions: [baseContribution],
+      contributionCount: 1,
+    };
+    const b = { ...a, contributionCount: 2 };
+    expect(crossCutEquals(a, b)).toBe(false);
+  });
+
+  test("contribution identity changes → false (counts the same)", () => {
+    const contrib2: Contribution = { ...baseContribution, cid: "blake3:bbb" };
+    const a = {
+      recentContributions: [baseContribution],
+      contributionCount: 1,
+    };
+    const b = { ...a, recentContributions: [contrib2] };
+    expect(crossCutEquals(a, b)).toBe(false);
+  });
+
+  test("distinct object instances with identical projected fields → true (structural compare)", () => {
+    // Regression for codex round-1: each useDerived recompute calls
+    // entityToContribution producing fresh objects. Reference compare would
+    // always fail; structural compare must collapse no-ops.
+    const cloneA: Contribution = { ...baseContribution };
+    const cloneB: Contribution = { ...baseContribution };
+    const a = {
+      recentContributions: [cloneA],
+      contributionCount: 1,
+    };
+    const b = {
+      recentContributions: [cloneB],
+      contributionCount: 1,
+    };
+    expect(cloneA === cloneB).toBe(false);
+    expect(crossCutEquals(a, b)).toBe(true);
+  });
+
+  test("contribution kind change → false (visible column)", () => {
+    // Regression for codex round-3: agent/kind backfills on a stable cid
+    // must invalidate the memoization fence.
+    const updated: Contribution = { ...baseContribution, kind: "review" };
+    const a = {
+      recentContributions: [baseContribution],
+      contributionCount: 1,
+    };
+    const b = { ...a, recentContributions: [updated] };
+    expect(crossCutEquals(a, b)).toBe(false);
+  });
+
+  test("contribution agent display change → false (visible column)", () => {
+    const updated: Contribution = {
+      ...baseContribution,
+      agent: { agentId: "a1", agentName: "agent-one" },
+    };
+    const a = {
+      recentContributions: [baseContribution],
+      contributionCount: 1,
+    };
+    const b = { ...a, recentContributions: [updated] };
+    expect(crossCutEquals(a, b)).toBe(false);
+  });
+
+  test("contribution summary change → false", () => {
+    const updated: Contribution = { ...baseContribution, summary: "different" };
+    const a = {
+      recentContributions: [baseContribution],
+      contributionCount: 1,
+    };
+    const b = { ...a, recentContributions: [updated] };
+    expect(crossCutEquals(a, b)).toBe(false);
+  });
+
+  test("array length differs → false", () => {
+    const a = {
+      recentContributions: [baseContribution],
+      contributionCount: 1,
+    };
+    const b = {
+      recentContributions: [baseContribution, { ...baseContribution, cid: "blake3:bbb" }],
+      contributionCount: 2,
+    };
+    expect(crossCutEquals(a, b)).toBe(false);
+  });
+});

--- a/src/tui/views/dashboard.tsx
+++ b/src/tui/views/dashboard.tsx
@@ -2,17 +2,93 @@
  * Dashboard view — the default TUI view.
  *
  * Shows grove metadata, active claims, frontier summary, and recent contributions.
+ *
+ * PR3 (#389) migrates the cross-kind aggregates (activeClaims +
+ * recentContributions + counts) from `usePolledData(getDashboard)` to
+ * `useDerived(...)` over the `Claim` + `Contribution` informers. The
+ * remaining polled call still supplies `metadata` (name/backendLabel) and
+ * `frontierSummary` — both require server compute that does not flow
+ * through the watch protocol — at the same cadence as before.
  */
 
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
+import type { ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
 import { formatDuration } from "../../shared/duration.js";
-import { formatTimestamp, truncateCid } from "../../shared/format.js";
+import { compareTimestampsDesc, formatTimestamp, truncateCid } from "../../shared/format.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
+import { useEntityWatchEnabled, useInformerOptional } from "../hooks/informer-context.js";
+import { useDerived } from "../hooks/use-derived.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { DashboardData, TuiDataProvider } from "../provider.js";
 import { theme } from "../theme.js";
+
+/** Limit the recent-contribution slice projected from the informer cache. */
+const RECENT_CONTRIBUTIONS_LIMIT = 50;
+
+/** Cross-cut snapshot derived from the Contribution informer. Active claims
+ *  are NOT migrated here: their "active" status is lease-aware (a claim ages
+ *  out when wall-clock time crosses `leaseExpiresAt`) and the watch protocol
+ *  emits no event for that transition. The polled `getDashboard()` path
+ *  computes it correctly via the lease-aware store query, so we keep claim
+ *  list/count on that path and only swap contributions to the informer. */
+interface DashboardCrossCut {
+  readonly recentContributions: readonly Contribution[];
+  readonly contributionCount: number;
+}
+
+const EMPTY_CROSS_CUT: DashboardCrossCut = {
+  recentContributions: [],
+  contributionCount: 0,
+};
+
+function entityToContribution(e: ContributionEntity): Contribution {
+  return {
+    cid: e.id,
+    manifestVersion: 0,
+    kind: e.spec.contributionKind,
+    mode: e.spec.mode,
+    summary: e.spec.summary,
+    description: e.spec.description,
+    artifacts: e.spec.artifacts,
+    relations: e.spec.relations,
+    scores: e.spec.scores,
+    tags: e.spec.tags,
+    context: e.spec.context,
+    agent: e.spec.agent,
+    createdAt: e.metadata.creationTimestamp ?? "",
+  };
+}
+
+/** Compare every visible column the contribution table renders: cid, kind,
+ *  summary, agent display identity, createdAt. Even though contributions are
+ *  conceptually append-only, the watch protocol carries MODIFIED events and
+ *  late agent-name backfills can change the rendered row for a stable cid. */
+function contributionsEqual(a: Contribution, b: Contribution): boolean {
+  if (a === b) return true;
+  return (
+    a.cid === b.cid &&
+    a.kind === b.kind &&
+    a.summary === b.summary &&
+    a.createdAt === b.createdAt &&
+    a.agent.agentId === b.agent.agentId &&
+    a.agent.agentName === b.agent.agentName
+  );
+}
+
+/** Structural cross-cut compare — fields, then per-row projected compare. */
+export function crossCutEquals(a: DashboardCrossCut, b: DashboardCrossCut): boolean {
+  if (a === b) return true;
+  if (a.contributionCount !== b.contributionCount) return false;
+  if (a.recentContributions.length !== b.recentContributions.length) return false;
+  for (let i = 0; i < a.recentContributions.length; i++) {
+    const ai = a.recentContributions[i];
+    const bi = b.recentContributions[i];
+    if (!ai || !bi || !contributionsEqual(ai, bi)) return false;
+  }
+  return true;
+}
 
 /** Props for the Dashboard view. */
 export interface DashboardProps {
@@ -47,8 +123,62 @@ export const DashboardView: React.NamedExoticComponent<DashboardProps> = React.m
     cursor,
     onContributionsLoaded,
   }: DashboardProps): React.ReactNode {
+    const useInformerPath = useEntityWatchEnabled(provider, "Contribution");
+    const contribInformer = useInformerOptional("Contribution");
+
+    // Contribution-only derived snapshot. Claims stay on the polled
+    // (lease-aware) path because lease expiry is wall-clock-driven and
+    // emits no watch event — see DashboardCrossCut docstring.
+    const derived = useDerived<DashboardCrossCut>(
+      () => {
+        const allContribs = contribInformer.list() as readonly ContributionEntity[];
+        // DESC chronological compare — invalid-last so missing/malformed
+        // timestamps can't displace real recent contributions in the slice.
+        const recent = [...allContribs]
+          .sort((a, b) =>
+            compareTimestampsDesc(a.metadata.creationTimestamp, b.metadata.creationTimestamp),
+          )
+          .slice(0, RECENT_CONTRIBUTIONS_LIMIT)
+          .map(entityToContribution);
+        return {
+          recentContributions: recent,
+          contributionCount: allContribs.length,
+        };
+      },
+      ["Contribution"],
+      crossCutEquals,
+    );
+
     const fetcher = useCallback(() => provider.getDashboard(), [provider]);
-    const { data, loading, error } = usePolledData<DashboardData>(fetcher, intervalMs, active);
+    const {
+      data: polledData,
+      loading,
+      error,
+    } = usePolledData<DashboardData>(fetcher, intervalMs, active);
+
+    // Compose the rendered DashboardData: prefer informer-derived
+    // contributions when the path is active AND has synced without error;
+    // claims, metadata, and frontierSummary always come from the polled
+    // call (claims because they're lease-aware, the others because they
+    // require server compute outside the watch protocol).
+    //
+    // Why hasSynced gating: without it, cold start (informer up but no
+    // RELIST_END yet) or terminal watch failure would inject EMPTY_CROSS_CUT
+    // — fabricating a zeroed dashboard over real polled data.
+    const informerReady = useInformerPath && derived.hasSynced && !derived.error;
+    const data: DashboardData | undefined = useMemo(() => {
+      if (!polledData) return undefined;
+      if (!informerReady) return polledData;
+      const cross = derived.data ?? EMPTY_CROSS_CUT;
+      return {
+        ...polledData,
+        metadata: {
+          ...polledData.metadata,
+          contributionCount: cross.contributionCount,
+        },
+        recentContributions: cross.recentContributions,
+      };
+    }, [polledData, informerReady, derived.data]);
 
     useEffect(() => {
       if (data && onContributionsLoaded) {

--- a/src/tui/views/frontier-view.test.ts
+++ b/src/tui/views/frontier-view.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, expect, test } from "bun:test";
 import type { Frontier, FrontierEntry } from "../../core/frontier.js";
+import { flatRowsEqual } from "./frontier-view.js";
 
 // ---------------------------------------------------------------------------
 // Import the module-scoped functions.
@@ -201,6 +202,60 @@ describe("flattenFrontier", () => {
 // ---------------------------------------------------------------------------
 // formatValue
 // ---------------------------------------------------------------------------
+
+describe("flatRowsEqual (PR3 #389 useDerived equals)", () => {
+  type Row = {
+    rank: number;
+    cid: string;
+    metric: string;
+    dimensionKey: string;
+    value: number;
+    summary: string;
+  };
+
+  const r = (overrides: Partial<Row> = {}): Row => ({
+    rank: 1,
+    cid: "blake3:aaa",
+    metric: "accuracy",
+    dimensionKey: "score:accuracy",
+    value: 0.9,
+    summary: "best",
+    ...overrides,
+  });
+
+  test("same array reference → true", () => {
+    const rows = [r()];
+    expect(flatRowsEqual(rows, rows)).toBe(true);
+  });
+
+  test("same shape, different references → true", () => {
+    expect(flatRowsEqual([r()], [r()])).toBe(true);
+  });
+
+  test("different lengths → false", () => {
+    expect(flatRowsEqual([r()], [r(), r({ rank: 2, cid: "blake3:bbb" })])).toBe(false);
+  });
+
+  test("rank changes → false", () => {
+    expect(flatRowsEqual([r()], [r({ rank: 2 })])).toBe(false);
+  });
+
+  test("value changes → false", () => {
+    expect(flatRowsEqual([r()], [r({ value: 0.91 })])).toBe(false);
+  });
+
+  test("cid changes → false", () => {
+    expect(flatRowsEqual([r()], [r({ cid: "blake3:bbb" })])).toBe(false);
+  });
+
+  test("dimensionKey changes → false (collision detection)", () => {
+    expect(flatRowsEqual([r()], [r({ dimensionKey: "scalar:accuracy" })])).toBe(false);
+  });
+
+  test("summary changes → false", () => {
+    expect(flatRowsEqual([r()], [r({ summary: "second" })])).toBe(false);
+  });
+});
 
 describe("formatValue", () => {
   test("integer that is not a timestamp is returned as-is", () => {

--- a/src/tui/views/frontier-view.tsx
+++ b/src/tui/views/frontier-view.tsx
@@ -3,6 +3,14 @@
  *
  * Shows frontier entries from all dimensions (byMetric, byAdoption,
  * byRecency, byReviewScore, byReproduction) as a flat ranked table.
+ *
+ * PR3 (#389): Frontier itself is server-computed (scoring + ranking) and
+ * does not flow through the watch protocol, so the data source remains
+ * `usePolledData(getFrontier)`. We layer `useDerived` over the projection
+ * step so the flattened ranking memoizes against the Contribution informer
+ * — recomputes happen only on Contribution events and equality is
+ * structural. We also kick a polled refresh on Contribution events so the
+ * underlying Frontier doesn't lag the cache by an interval.
  */
 
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
@@ -11,6 +19,8 @@ import { truncateCid } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
+import { useEntityWatchEnabled, useInformerOptional } from "../hooks/informer-context.js";
+import { useDerived } from "../hooks/use-derived.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
 import { theme } from "../theme.js";
@@ -95,6 +105,29 @@ function flattenFrontier(frontier: Frontier): readonly FrontierRow[] {
   return rows;
 }
 
+/** Structural equality across the flattened-frontier projection. Used as the
+ *  `equals` for `useDerived` so a recompute that produces the same ranks +
+ *  values + summaries doesn't trigger a re-render. */
+export function flatRowsEqual(a: readonly FrontierRow[], b: readonly FrontierRow[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const ra = a[i] as FrontierRow;
+    const rb = b[i] as FrontierRow;
+    if (
+      ra.rank !== rb.rank ||
+      ra.cid !== rb.cid ||
+      ra.metric !== rb.metric ||
+      ra.dimensionKey !== rb.dimensionKey ||
+      ra.value !== rb.value ||
+      ra.summary !== rb.summary
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /** Format a numeric value for display (handles large timestamps, decimals, etc.). */
 function formatValue(value: number): string {
   if (Number.isInteger(value) && value > 1_000_000_000_000) {
@@ -130,11 +163,91 @@ export const FrontierView: React.NamedExoticComponent<FrontierViewProps> = React
     // Enter-key handling that calls it lives in app.tsx.
     void onCompareSelect;
 
-    const fetcher = useCallback(() => provider.getFrontier(), [provider]);
-    const { data, loading, isStale, error } = usePolledData<Frontier>(fetcher, intervalMs, active);
+    // Race guard for getFrontier(): on a relist or burst, multiple refresh()
+    // calls fan out concurrent fetches. Without sequencing, a slower-older
+    // response can land after a newer one and overwrite fresh data with
+    // stale. Track the latest in-flight promise; older fetches (success OR
+    // rejection) defer to the newer's eventual outcome so dispatch order
+    // doesn't matter.
+    const latestFetchRef = useRef<Promise<Frontier> | null>(null);
+    const fetcher = useCallback(async (): Promise<Frontier> => {
+      const p = provider.getFrontier();
+      latestFetchRef.current = p;
+      try {
+        const result = await p;
+        const newest = latestFetchRef.current;
+        if (newest !== p && newest !== null) {
+          // A newer fetch superseded ours — return its eventual value so we
+          // never dispatch stale data over fresh state.
+          return await newest;
+        }
+        return result;
+      } catch (err) {
+        const newest = latestFetchRef.current;
+        if (newest !== p && newest !== null) {
+          // Stale rejection; the newer request is authoritative. Returning
+          // the newer's value (or rethrowing its rejection) keeps the dispatch
+          // path consistent with the latest known result.
+          return await newest;
+        }
+        throw err;
+      }
+    }, [provider]);
+    const { data, loading, isStale, error, refresh } = usePolledData<Frontier>(
+      fetcher,
+      intervalMs,
+      active,
+    );
 
-    // Cap total rows to avoid O(dimensions × table-limit) explosion when many score metrics exist.
-    const flatRows = useMemo(() => (data ? flattenFrontier(data).slice(0, 200) : []), [data]);
+    // Coalesce Contribution-driven refreshes. During an initial relist the
+    // informer dispatches one ADDED per entity, which without debounce would
+    // produce N+1 frontier fetches and hammer the server-computed endpoint.
+    // We subscribe only to event (not sync): events already fire for every
+    // entity, and the polled cadence covers the rare empty-relist case.
+    const useInformerPath = useEntityWatchEnabled(provider, "Contribution");
+    const contribInformer = useInformerOptional("Contribution");
+    const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    useEffect(() => {
+      if (!useInformerPath) return;
+      const handler = (): void => {
+        if (refreshTimerRef.current !== null) return;
+        refreshTimerRef.current = setTimeout(() => {
+          refreshTimerRef.current = null;
+          const p = provider as { invalidateCaches?: () => void };
+          p.invalidateCaches?.();
+          refresh();
+        }, 100);
+      };
+      const unsubEvent = contribInformer.addEventHandler(handler);
+      return () => {
+        unsubEvent();
+        if (refreshTimerRef.current !== null) {
+          clearTimeout(refreshTimerRef.current);
+          refreshTimerRef.current = null;
+        }
+      };
+    }, [useInformerPath, contribInformer, provider, refresh]);
+
+    // Project the Frontier to flat rows via useDerived so the flattening
+    // memoizes against the Contribution kind. compute() reads `data` via
+    // closure; the kind subscription drives recompute on contribution
+    // events; flatRowsEqual() collapses no-op recomputes.
+    const dataRef = useRef<Frontier | null>(data);
+    dataRef.current = data;
+    const derivedRows = useDerived<readonly FrontierRow[]>(
+      () => (dataRef.current ? flattenFrontier(dataRef.current).slice(0, 200) : []),
+      ["Contribution"],
+      flatRowsEqual,
+    );
+    // The polled snapshot can change without a contribution event firing
+    // (interval tick), so we re-derive against `data` directly too — the
+    // memoized result is stable as long as the rows match.
+    const flatRows = useMemo<readonly FrontierRow[]>(() => {
+      if (!data) return derivedRows.data ?? [];
+      const fresh = flattenFrontier(data).slice(0, 200);
+      const cached = derivedRows.data;
+      return cached && flatRowsEqual(cached, fresh) ? cached : fresh;
+    }, [data, derivedRows.data]);
 
     // Track selected CIDs set for efficient lookup
     const selectedSet = useMemo(() => new Set(compareCids ?? []), [compareCids]);

--- a/src/tui/views/search-panel.tsx
+++ b/src/tui/views/search-panel.tsx
@@ -19,7 +19,7 @@
 import React, { useCallback, useEffect, useMemo } from "react";
 import type { ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
-import { formatTimestamp, truncateCid } from "../../shared/format.js";
+import { compareTimestampsDesc, formatTimestamp, truncateCid } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
@@ -159,7 +159,7 @@ export const SearchPanelView: React.NamedExoticComponent<SearchPanelProps> = Rea
     const data = useMemo<readonly Contribution[] | undefined>(() => {
       if (useInformerPath) {
         const sorted = [...entityResult.data].sort((a, b) =>
-          (b.metadata.creationTimestamp ?? "").localeCompare(a.metadata.creationTimestamp ?? ""),
+          compareTimestampsDesc(a.metadata.creationTimestamp, b.metadata.creationTimestamp),
         );
         return sorted.slice(0, RECENT_LIMIT).map(entityToContribution);
       }


### PR DESCRIPTION
## Summary

Migrates dag, dashboard, frontier-view, and running-view contribution
projections from `usePolledData` to informer-driven `useDerived`. PR3 of 5
in the polling-retirement epic (#389).

Polled fallback is preserved on every dual-path caller for cold start,
watch errors, and lease-aware claims (which expire on wall-clock with no
watch event — they stay polled).

## Hardening (9 rounds of `/review-loop` adversarial review)

- **`useDerived`**: factory-optional, render-time source-key reset on
  factory/kinds change (compares factory IDENTITY, not just truthiness),
  cancellation guard against stale callbacks after cleanup.
- **Dashboard / running-view**: gate informer use on `hasSynced && !error`
  so cold start or terminal watch failure doesn't fabricate empty state
  over real polled data. Active-claim count stays polled (lease-aware).
- **Structural equality** functions compare every visible row field
  (cid/kind/summary/agent/createdAt) — fresh projection objects on each
  recompute would otherwise defeat the memoization fence.
- **DAG view**: topology-aware cap (newest 200 + BFS parents up to 500
  total) so large repositories don't render orphan children with excluded
  parents.
- **Frontier view**: race-guarded fetcher (older requests defer to
  newest's outcome) + 100ms debounce on Contribution-driven refresh,
  dropping redundant `addSyncHandler` subscription that caused N+1
  stampede on relist.
- **Running feed**: capped projection (500 newest) before sort/map to
  prevent O(N²) work on large informer caches.
- **Chronological timestamp comparators** (`compareTimestamps`,
  `compareTimestampsDesc`, `compareTimestampsAscNewestLast`) with
  NaN-safe semantics — replaces lexicographic sorts that misorder
  timezone-offset timestamps. Also swept `activity.tsx`,
  `activity-panel.tsx`, `search-panel.tsx`.

## Test plan

- [x] `bun test src/shared/format.test.ts src/tui/views/dashboard.test.ts src/tui/hooks/use-derived.*test* src/tui/views/frontier-view.test.ts` — 78/78 PR3-scoped pass
- [x] `tsc --noEmit` clean
- [x] Biome check clean (pre-commit hook passed)
- [ ] Live tmux TUI smoke (capture-pane + agent spawn) — verified earlier in session
- [ ] Soak test on a large Grove (relist with N>500 contributions)

## Deferred follow-ups

- `useDerived` microtask coalescing for N-entity relist bursts
  (perf optimization; relist on a large Grove can recompute N times
  before RELIST_END — flagged round 10, separate PR).
- `activity.tsx`, `activity-panel.tsx`, `search-panel.tsx` `hasSynced`
  gate (PR2-migrated single-kind views; same class of bug, separate PR).

Closes #389.