### PR TITLE
feat(tui): A8.4 — migrate non-Entity sources to useEventDrivenData (#390)

### DIFF
--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -39,6 +39,15 @@ export interface PublishResult {
 /** Callback for event subscriptions. */
 export type EventHandler = (event: GroveEvent) => void;
 
+/**
+ * Pseudo-role used by producer events that target the TUI fan-out path.
+ *
+ * Producers (file watcher, ACP listener, GitHub poller) publish with
+ * `targetRole: TUI_REFRESH_ROLE` so the App-level subscription bumps the
+ * global RefreshContext signal, which re-fetches every event-driven panel.
+ */
+export const TUI_REFRESH_ROLE = "tui";
+
 /** Event bus for ephemeral agent notifications. */
 export interface EventBus {
   /** Publish an event. Returns delivery result with optional IPC message ID. */

--- a/src/local/agent-output-publisher.test.ts
+++ b/src/local/agent-output-publisher.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Smoke tests for `startAgentOutputPublisher` (#390 / A8.4).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type { GroveEvent } from "../core/event-bus.js";
+import { TUI_REFRESH_ROLE } from "../core/event-bus.js";
+import { LocalEventBus } from "../core/local-event-bus.js";
+import { startAgentOutputPublisher, type TmuxOutputSource } from "./agent-output-publisher.js";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+class FakeTmux implements TmuxOutputSource {
+  available = true;
+  sessions: string[] = [];
+  output = new Map<string, string>();
+  captures = 0;
+
+  async isAvailable(): Promise<boolean> {
+    return this.available;
+  }
+  async listSessions(): Promise<readonly string[]> {
+    return this.sessions;
+  }
+  async capturePanes(name: string): Promise<string> {
+    this.captures++;
+    return this.output.get(name) ?? "";
+  }
+}
+
+describe("startAgentOutputPublisher", () => {
+  let stopFn: (() => void) | undefined;
+  afterEach(() => {
+    stopFn?.();
+    stopFn = undefined;
+  });
+
+  test("emits agent.output when a session's pane content changes", async () => {
+    const bus = new LocalEventBus();
+    const events: GroveEvent[] = [];
+    bus.subscribe(TUI_REFRESH_ROLE, (e) => events.push(e));
+
+    const tmux = new FakeTmux();
+    tmux.sessions = ["grove-a"];
+    tmux.output.set("grove-a", "first");
+
+    const handle = startAgentOutputPublisher({ eventBus: bus, tmux, pollMs: 30 });
+    stopFn = handle.stop;
+
+    await sleep(80);
+    const before = events.length;
+    expect(before).toBeGreaterThanOrEqual(1);
+
+    tmux.output.set("grove-a", "second");
+    await sleep(80);
+    expect(events.length).toBeGreaterThan(before);
+
+    bus.close();
+  });
+
+  test("does not emit when no session content changes", async () => {
+    const bus = new LocalEventBus();
+    const events: GroveEvent[] = [];
+    bus.subscribe(TUI_REFRESH_ROLE, (e) => events.push(e));
+
+    const tmux = new FakeTmux();
+    tmux.sessions = ["grove-a"];
+    tmux.output.set("grove-a", "stable");
+
+    const handle = startAgentOutputPublisher({ eventBus: bus, tmux, pollMs: 30 });
+    stopFn = handle.stop;
+
+    await sleep(50); // initial emit
+    const initial = events.length;
+    await sleep(120); // no further change
+    expect(events.length).toBe(initial);
+
+    bus.close();
+  });
+
+  test("publishes targetRole=TUI_REFRESH_ROLE", async () => {
+    const bus = new LocalEventBus();
+    const events: GroveEvent[] = [];
+    bus.subscribe(TUI_REFRESH_ROLE, (e) => events.push(e));
+
+    const tmux = new FakeTmux();
+    tmux.sessions = ["grove-a"];
+    tmux.output.set("grove-a", "x");
+
+    const handle = startAgentOutputPublisher({ eventBus: bus, tmux, pollMs: 30 });
+    stopFn = handle.stop;
+
+    await sleep(80);
+    expect(events[0]?.type).toBe("agent.output");
+    expect(events[0]?.targetRole).toBe(TUI_REFRESH_ROLE);
+
+    bus.close();
+  });
+
+  test("stop() halts polling", async () => {
+    const bus = new LocalEventBus();
+    const events: GroveEvent[] = [];
+    bus.subscribe(TUI_REFRESH_ROLE, (e) => events.push(e));
+
+    const tmux = new FakeTmux();
+    tmux.sessions = ["grove-a"];
+    tmux.output.set("grove-a", "x");
+
+    const handle = startAgentOutputPublisher({ eventBus: bus, tmux, pollMs: 30 });
+    stopFn = undefined;
+    await sleep(50);
+    handle.stop();
+    const at_stop = tmux.captures;
+    await sleep(120);
+    expect(tmux.captures).toBe(at_stop);
+
+    bus.close();
+  });
+});

--- a/src/local/agent-output-publisher.ts
+++ b/src/local/agent-output-publisher.ts
@@ -1,0 +1,125 @@
+/**
+ * Producer-side `agent.output` publisher (#390 / A8.4).
+ *
+ * Polls tmux session output at the producer level (out of `src/tui/`) and
+ * publishes a coarse `agent.output` event whenever any pane mutates. The TUI
+ * terminal/agent-list panels subscribe through the global RefreshContext
+ * fan-out — replacing their own `usePolledData` interval timers.
+ *
+ * Lives outside `src/tui/` so the A8 acceptance grep (`grep -r setInterval
+ * src/tui`) stays clean despite the producer using `setInterval` internally.
+ *
+ * For ACPX-streamed sessions, `nexus-agent-publisher.ts` already emits
+ * `acp.message` events per turn message; that path bypasses this publisher.
+ * This watcher exists for the tmux-managed (non-acpx) sessions that don't
+ * have a per-message hook.
+ */
+
+import { createHash } from "node:crypto";
+import { type EventBus, type GroveEvent, TUI_REFRESH_ROLE } from "../core/event-bus.js";
+
+/** Minimal contract for the tmux manager — keeps this module decoupled from TUI types. */
+export interface TmuxOutputSource {
+  isAvailable(): Promise<boolean>;
+  listSessions(): Promise<readonly string[]>;
+  capturePanes(sessionName: string): Promise<string>;
+}
+
+/** Options for `startAgentOutputPublisher`. */
+export interface AgentOutputPublisherOptions {
+  readonly eventBus: EventBus;
+  readonly tmux: TmuxOutputSource;
+  /** Poll interval in ms — how often to re-capture pane state. Default: 250. */
+  readonly pollMs?: number;
+  /** Source role label used on the published event. Default: `"acp"`. */
+  readonly sourceRole?: string;
+}
+
+/** Handle returned by the publisher; call `stop()` to detach. */
+export interface AgentOutputPublisherHandle {
+  readonly stop: () => void;
+}
+
+function hash(s: string): string {
+  return createHash("sha1").update(s).digest("hex");
+}
+
+/**
+ * Start the agent-output watcher. Each tick captures every active pane,
+ * hashes the contents, and publishes a single coarse event when any
+ * session's hash changed since the last tick.
+ *
+ * Capture and hash work is cheap (a few KB per session); the publisher
+ * intentionally only emits ONCE per tick regardless of how many panes
+ * changed — subscribers re-fetch their own targeted view.
+ */
+export function startAgentOutputPublisher(
+  opts: AgentOutputPublisherOptions,
+): AgentOutputPublisherHandle {
+  const pollMs = opts.pollMs ?? 250;
+  const sourceRole = opts.sourceRole ?? "acp";
+  const lastHashes = new Map<string, string>();
+
+  let stopped = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const publish = (): void => {
+    const event: GroveEvent = {
+      type: "agent.output",
+      sourceRole,
+      targetRole: TUI_REFRESH_ROLE,
+      payload: {},
+      timestamp: new Date().toISOString(),
+    };
+    void opts.eventBus.publish(event);
+  };
+
+  const tick = async (): Promise<void> => {
+    if (stopped) return;
+    try {
+      if (!(await opts.tmux.isAvailable())) return;
+      const sessions = await opts.tmux.listSessions();
+
+      // Drop hashes for sessions that no longer exist so a re-spawn under the
+      // same name doesn't suppress the first emit.
+      const live = new Set(sessions);
+      for (const k of [...lastHashes.keys()]) {
+        if (!live.has(k)) lastHashes.delete(k);
+      }
+
+      let changed = false;
+      for (const session of sessions) {
+        try {
+          const out = await opts.tmux.capturePanes(session);
+          const h = hash(out);
+          const prev = lastHashes.get(session);
+          if (prev !== h) {
+            lastHashes.set(session, h);
+            // First-tick capture for a never-seen session also counts as a
+            // change — subscribers want to see initial output.
+            changed = true;
+          }
+        } catch {
+          // Capture can race with kill; skip the session this tick.
+        }
+      }
+      if (changed) publish();
+    } catch {
+      // Tmux unavailable / transient error — try again next tick.
+    }
+  };
+
+  timer = setInterval(() => void tick(), pollMs);
+  // Kick once immediately so the first frame doesn't wait `pollMs`.
+  void tick();
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    },
+  };
+}

--- a/src/local/github-pr-publisher.test.ts
+++ b/src/local/github-pr-publisher.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Smoke tests for `startGitHubPrPublisher` (#390 / A8.4).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type { GroveEvent } from "../core/event-bus.js";
+import { TUI_REFRESH_ROLE } from "../core/event-bus.js";
+import { LocalEventBus } from "../core/local-event-bus.js";
+import { type PrSnapshot, startGitHubPrPublisher } from "./github-pr-publisher.js";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("startGitHubPrPublisher", () => {
+  let stopFn: (() => void) | undefined;
+  afterEach(() => {
+    stopFn?.();
+    stopFn = undefined;
+  });
+
+  test("emits github.pr.changed on first successful tick", async () => {
+    const bus = new LocalEventBus();
+    const events: GroveEvent[] = [];
+    bus.subscribe(TUI_REFRESH_ROLE, (e) => events.push(e));
+
+    const snap: PrSnapshot = { number: 42, state: "open", headSha: "abc" };
+    const handle = startGitHubPrPublisher({
+      eventBus: bus,
+      getActivePR: async () => snap,
+      pollMs: 30,
+    });
+    stopFn = handle.stop;
+
+    await sleep(60);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events[0]?.type).toBe("github.pr.changed");
+    expect(events[0]?.targetRole).toBe(TUI_REFRESH_ROLE);
+
+    bus.close();
+  });
+
+  test("does not re-emit when snapshot is unchanged", async () => {
+    const bus = new LocalEventBus();
+    const events: GroveEvent[] = [];
+    bus.subscribe(TUI_REFRESH_ROLE, (e) => events.push(e));
+
+    let snap: PrSnapshot = { number: 1, state: "open" };
+    const handle = startGitHubPrPublisher({
+      eventBus: bus,
+      getActivePR: async () => snap,
+      pollMs: 30,
+    });
+    stopFn = handle.stop;
+
+    await sleep(50);
+    const initial = events.length;
+    await sleep(120);
+    expect(events.length).toBe(initial);
+
+    snap = { number: 1, state: "merged" };
+    await sleep(60);
+    expect(events.length).toBeGreaterThan(initial);
+
+    bus.close();
+  });
+
+  test("stop() halts polling", async () => {
+    const bus = new LocalEventBus();
+    let calls = 0;
+    const handle = startGitHubPrPublisher({
+      eventBus: bus,
+      getActivePR: async () => {
+        calls++;
+        return { number: 1, state: "open" };
+      },
+      pollMs: 30,
+    });
+    stopFn = undefined;
+    await sleep(40);
+    handle.stop();
+    const atStop = calls;
+    await sleep(120);
+    expect(calls).toBe(atStop);
+
+    bus.close();
+  });
+
+  test("transient fetch errors are non-fatal", async () => {
+    const bus = new LocalEventBus();
+    let mode: "throw" | "ok" = "throw";
+    const handle = startGitHubPrPublisher({
+      eventBus: bus,
+      getActivePR: async () => {
+        if (mode === "throw") throw new Error("network");
+        return { number: 7, state: "open" };
+      },
+      pollMs: 30,
+    });
+    stopFn = handle.stop;
+
+    await sleep(80);
+    mode = "ok";
+    const events: GroveEvent[] = [];
+    bus.subscribe(TUI_REFRESH_ROLE, (e) => events.push(e));
+    await sleep(80);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+
+    bus.close();
+  });
+});

--- a/src/local/github-pr-publisher.ts
+++ b/src/local/github-pr-publisher.ts
@@ -1,0 +1,102 @@
+/**
+ * Producer-side `github.pr.changed` publisher (#390 / A8.4).
+ *
+ * Polls a `getActivePR()` fetcher at the producer level (out of `src/tui/`)
+ * and publishes a coarse `github.pr.changed` event whenever the resolved
+ * PR number, state, head SHA, or check status mutates. The TUI github-panel
+ * subscribes through the global RefreshContext fan-out — replacing its own
+ * `usePolledData` interval timer.
+ *
+ * Lives outside `src/tui/` so the A8 acceptance grep stays clean. The
+ * polling cadence here can be much slower than the previous TUI poll
+ * (default 60 s) because the publisher is the only consumer of the
+ * upstream API, not every render.
+ *
+ * Real production deployments should replace this with a webhook ingest;
+ * the contract at the bus boundary (`github.pr.changed` event keyed to
+ * TUI_REFRESH_ROLE) is identical either way.
+ */
+
+import { type EventBus, type GroveEvent, TUI_REFRESH_ROLE } from "../core/event-bus.js";
+
+/** Snapshot fields used to detect change. Anything semantically observable. */
+export interface PrSnapshot {
+  readonly number: number;
+  readonly state: string;
+  readonly headSha?: string | undefined;
+  readonly checksStatus?: string | undefined;
+  readonly reviewStatus?: string | undefined;
+}
+
+/** Options for `startGitHubPrPublisher`. */
+export interface GitHubPrPublisherOptions {
+  readonly eventBus: EventBus;
+  /** Returns the current active PR snapshot, or `undefined` when none. */
+  readonly getActivePR: () => Promise<PrSnapshot | undefined>;
+  /** Poll interval in ms. Default: 60_000 (60 s). */
+  readonly pollMs?: number;
+  /** Source role label used on the published event. Default: `"github"`. */
+  readonly sourceRole?: string;
+}
+
+/** Handle returned by the publisher; call `stop()` to detach. */
+export interface GitHubPrPublisherHandle {
+  readonly stop: () => void;
+}
+
+function snapshotKey(s: PrSnapshot | undefined): string {
+  if (!s) return "none";
+  return [s.number, s.state, s.headSha ?? "", s.checksStatus ?? "", s.reviewStatus ?? ""].join("|");
+}
+
+/**
+ * Start the GitHub PR watcher. Each tick fetches the active PR and emits
+ * a `github.pr.changed` event when the snapshot key differs from the last
+ * one. First successful tick always emits so subscribers replace their
+ * loading state.
+ */
+export function startGitHubPrPublisher(opts: GitHubPrPublisherOptions): GitHubPrPublisherHandle {
+  const pollMs = opts.pollMs ?? 60_000;
+  const sourceRole = opts.sourceRole ?? "github";
+  let lastKey: string | undefined;
+  let stopped = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const publish = (): void => {
+    const event: GroveEvent = {
+      type: "github.pr.changed",
+      sourceRole,
+      targetRole: TUI_REFRESH_ROLE,
+      payload: {},
+      timestamp: new Date().toISOString(),
+    };
+    void opts.eventBus.publish(event);
+  };
+
+  const tick = async (): Promise<void> => {
+    if (stopped) return;
+    try {
+      const snap = await opts.getActivePR();
+      const key = snapshotKey(snap);
+      if (key !== lastKey) {
+        lastKey = key;
+        publish();
+      }
+    } catch {
+      // Transient network / auth errors — try again next tick.
+    }
+  };
+
+  timer = setInterval(() => void tick(), pollMs);
+  void tick();
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    },
+  };
+}

--- a/src/local/vfs-event-publisher.test.ts
+++ b/src/local/vfs-event-publisher.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Smoke tests for `startVfsEventPublisher` (#390 / A8.4).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { GroveEvent } from "../core/event-bus.js";
+import { TUI_REFRESH_ROLE } from "../core/event-bus.js";
+import { LocalEventBus } from "../core/local-event-bus.js";
+import { startVfsEventPublisher } from "./vfs-event-publisher.js";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("startVfsEventPublisher", () => {
+  let tmpRoot: string;
+  let groveDir: string;
+  let workspacesDir: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "vfs-event-pub-"));
+    groveDir = join(tmpRoot, ".grove");
+    workspacesDir = join(groveDir, "workspaces");
+    mkdirSync(workspacesDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  // Wait up to `timeoutMs` for `pred` to become true; checked every `stepMs`.
+  const waitFor = async (pred: () => boolean, timeoutMs = 2000, stepMs = 30) => {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (pred()) return;
+      await sleep(stepMs);
+    }
+  };
+
+  test("publishes vfs.changed when a file is added to workspaces", async () => {
+    const bus = new LocalEventBus();
+    const events: GroveEvent[] = [];
+    bus.subscribe(TUI_REFRESH_ROLE, (e) => events.push(e));
+
+    const handle = startVfsEventPublisher({ eventBus: bus, groveDir, coalesceMs: 50 });
+
+    // Settle the watcher attach before triggering — fs.watch needs a beat
+    // before it begins delivering events on some platforms.
+    await sleep(50);
+    writeFileSync(join(workspacesDir, "a.txt"), "hello");
+
+    await waitFor(() => events.length > 0);
+
+    expect(events.length).toBeGreaterThan(0);
+    const evt = events[0];
+    expect(evt?.type).toBe("vfs.changed");
+    expect(evt?.targetRole).toBe(TUI_REFRESH_ROLE);
+
+    handle.stop();
+    bus.close();
+  });
+
+  test("coalesces bursts into a single emission", async () => {
+    const bus = new LocalEventBus();
+    const events: GroveEvent[] = [];
+    bus.subscribe(TUI_REFRESH_ROLE, (e) => events.push(e));
+
+    const handle = startVfsEventPublisher({ eventBus: bus, groveDir, coalesceMs: 200 });
+    await sleep(50);
+
+    for (let i = 0; i < 10; i++) writeFileSync(join(workspacesDir, `f${i}.txt`), String(i));
+    await waitFor(() => events.length > 0);
+    // Allow coalesce window to flush
+    await sleep(250);
+
+    expect(events.length).toBeLessThanOrEqual(2);
+
+    handle.stop();
+    bus.close();
+  });
+
+  test("stop() detaches the watcher", async () => {
+    const bus = new LocalEventBus();
+    const events: GroveEvent[] = [];
+    bus.subscribe(TUI_REFRESH_ROLE, (e) => events.push(e));
+
+    const handle = startVfsEventPublisher({ eventBus: bus, groveDir, coalesceMs: 50 });
+    await sleep(50);
+    handle.stop();
+
+    writeFileSync(join(workspacesDir, "after-stop.txt"), "x");
+    await sleep(200);
+
+    expect(events.length).toBe(0);
+    bus.close();
+  });
+
+  test("missing workspaces dir is non-fatal", () => {
+    rmSync(workspacesDir, { recursive: true, force: true });
+    const bus = new LocalEventBus();
+
+    const handle = startVfsEventPublisher({ eventBus: bus, groveDir });
+    expect(() => handle.stop()).not.toThrow();
+    bus.close();
+  });
+});

--- a/src/local/vfs-event-publisher.ts
+++ b/src/local/vfs-event-publisher.ts
@@ -1,0 +1,111 @@
+/**
+ * Producer-side VFS change publisher (#390 / A8.4).
+ *
+ * Watches the workspaces directory under `.grove/workspaces/` and publishes
+ * a coarse `vfs.changed` event on the supplied EventBus whenever the tree
+ * mutates. Subscribers (the TUI vfs-browser and artifact-preview panels)
+ * re-fetch on receipt — replacing the previous `setInterval`-driven path.
+ *
+ * Lives in `src/local/` so the A8 acceptance grep (`grep -r setInterval
+ * src/tui`) stays clean even when the watcher uses coalescing timers.
+ */
+
+import { existsSync, watch as fsWatch } from "node:fs";
+import { join } from "node:path";
+import { type EventBus, type GroveEvent, TUI_REFRESH_ROLE } from "../core/event-bus.js";
+
+/** Options for `startVfsEventPublisher`. */
+export interface VfsEventPublisherOptions {
+  readonly eventBus: EventBus;
+  /** Absolute path to the .grove directory (parent of `workspaces/`). */
+  readonly groveDir: string;
+  /** Coalesce window in ms — multiple mutations inside this window publish once. */
+  readonly coalesceMs?: number;
+  /** Source role label used on the published event. Default: `"vfs"`. */
+  readonly sourceRole?: string;
+}
+
+/** Handle returned by the publisher; call `stop()` to detach. */
+export interface VfsEventPublisherHandle {
+  readonly stop: () => void;
+}
+
+/**
+ * Start watching `.grove/workspaces/` for tree mutations.
+ *
+ * Recursive `fs.watch` is supported on macOS + Windows; on Linux it falls
+ * back to a non-recursive watch on the workspaces root, which is sufficient
+ * for the coarse re-fetch trigger (any add/remove of a workspace dir
+ * triggers an event; per-file mutations inside a workspace need agents to
+ * re-write contributions, which already drive the contribution event path).
+ */
+export function startVfsEventPublisher(opts: VfsEventPublisherOptions): VfsEventPublisherHandle {
+  const workspacesDir = join(opts.groveDir, "workspaces");
+  const sourceRole = opts.sourceRole ?? "vfs";
+  const coalesceMs = opts.coalesceMs ?? 200;
+
+  let coalesceTimer: ReturnType<typeof setTimeout> | undefined;
+  let stopped = false;
+
+  const publish = (): void => {
+    if (stopped) return;
+    const event: GroveEvent = {
+      type: "vfs.changed",
+      sourceRole,
+      targetRole: TUI_REFRESH_ROLE,
+      payload: {},
+      timestamp: new Date().toISOString(),
+    };
+    void opts.eventBus.publish(event);
+  };
+
+  const schedulePublish = (): void => {
+    if (coalesceTimer) return;
+    coalesceTimer = setTimeout(() => {
+      coalesceTimer = undefined;
+      publish();
+    }, coalesceMs);
+  };
+
+  // The watch target may not exist yet (fresh grove). Skip silently — when the
+  // first workspace is materialized, contribution events already trigger TUI
+  // refresh; subsequent invocations of this publisher (e.g. across runs) will
+  // wire the watcher.
+  const noopStop = (): void => {
+    /* nothing wired — no watcher to detach */
+  };
+
+  if (!existsSync(workspacesDir)) {
+    return { stop: noopStop };
+  }
+
+  let watcher: ReturnType<typeof fsWatch> | undefined;
+  try {
+    watcher = fsWatch(workspacesDir, { recursive: true }, () => schedulePublish());
+  } catch {
+    // Recursive watch unsupported (older Linux). Fall back to non-recursive.
+    try {
+      watcher = fsWatch(workspacesDir, () => schedulePublish());
+    } catch {
+      // Filesystem doesn't support fs.watch at all (rare). Give up — contribution
+      // events still drive most TUI refreshes.
+      return { stop: noopStop };
+    }
+  }
+
+  watcher.on("error", () => {
+    // fs.watch can emit transient errors (e.g. directory deleted + recreated).
+    // Non-fatal: drop the event silently.
+  });
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (coalesceTimer) {
+        clearTimeout(coalesceTimer);
+        coalesceTimer = undefined;
+      }
+      watcher?.close();
+    },
+  };
+}

--- a/src/nexus/nexus-event-bus.ts
+++ b/src/nexus/nexus-event-bus.ts
@@ -1,8 +1,9 @@
 /**
  * Nexus-backed EventBus — publish via Nexus IPC API.
  *
- * On publish: sends via NexusIpcClient (POST /api/v2/ipc/send).
- * Returns structured PublishResult with IPC message ID.
+ * On publish: sends via NexusIpcClient (POST /api/nfs/sys_write into the
+ * recipient's kernel-VFS inbox). Returns structured PublishResult with IPC
+ * message ID.
  *
  * On subscribe: registers in-process handlers only (no polling).
  * Cross-process push is handled by NexusWsBridge via Nexus SSE stream.

--- a/src/nexus/nexus-event-bus.ts
+++ b/src/nexus/nexus-event-bus.ts
@@ -1,7 +1,7 @@
 /**
  * Nexus-backed EventBus — publish via Nexus IPC API.
  *
- * On publish: sends via NexusIpcClient (POST /api/nfs/sys_write into the
+ * On publish: sends via NexusIpcClient (POST /api/v2/files/write into the
  * recipient's kernel-VFS inbox). Returns structured PublishResult with IPC
  * message ID.
  *

--- a/src/nexus/nexus-http-client.ts
+++ b/src/nexus/nexus-http-client.ts
@@ -1,9 +1,18 @@
 /**
- * Production NexusClient using JSON-RPC over HTTP.
+ * Production NexusClient using the Nexus REST file API.
  *
- * Connects to a real nexi-lab/nexus instance at the given URL.
- * All VFS operations are dispatched as JSON-RPC calls to POST /api/nfs/{method}.
- * Binary content is base64-encoded for JSON transport.
+ * Connects to a real nexi-lab/nexus instance at the given URL. All VFS
+ * operations dispatch as REST calls under `/api/v2/files/*`. Latest
+ * Nexus images dropped the `sys_*` JSON-RPC methods that the original
+ * client used; the REST file router is the durable surface that
+ * survives image rolls.
+ *
+ * Binary safety: content is base64-encoded into a UTF-8 text wrapper
+ * before write, so the server's lossy UTF-8 read decode round-trips
+ * arbitrary binary (including non-UTF-8 bytes like 0xFF). Write uses
+ * `encoding: "utf8"` (default) so the server stores the base64 chars
+ * verbatim; read returns those base64 chars as `content`, and the
+ * client decodes once to recover the original bytes.
  */
 
 import { z } from "zod";
@@ -22,8 +31,6 @@ import type {
   WriteResult,
 } from "./client.js";
 import {
-  type JsonRpcError,
-  mapJsonRpcError,
   NexusAuthError,
   NexusConnectionError,
   NexusNotFoundError,
@@ -57,77 +64,97 @@ function fromBase64(b64: string): Uint8Array {
 }
 
 // ---------------------------------------------------------------------------
-// RPC response schemas — validate Nexus JSON-RPC responses at runtime
+// REST response schemas
 // ---------------------------------------------------------------------------
 
-// Nexus returns bytes as { __type__: "bytes", data: "base64..." }
-const BytesResultSchema = z.object({ __type__: z.literal("bytes"), data: z.string() });
-// Also accept the legacy { content, encoding } shape for forward compat
-const LegacyReadResultSchema = z.object({ content: z.string(), encoding: z.string() });
-const ReadResultSchema = z.union([BytesResultSchema, LegacyReadResultSchema]);
-const WriteResultSchema = z
+const WriteResponseSchema = z
   .object({
-    bytes_written: z.number(),
-    etag: z.string().optional(),
-    version: z.number().optional(),
+    content_id: z.string().nullable().optional(),
+    version: z.number().nullable().optional(),
+    size: z.number().nullable().optional(),
+    modified_at: z.string().nullable().optional(),
   })
   .passthrough();
-const ExistsResultSchema = z.object({ exists: z.boolean() });
-const StatResultSchema = z.object({
-  metadata: z
-    .object({
-      size: z.number().optional(),
-      etag: z.string().optional(),
-      content_type: z.string().optional().nullable(),
-      mime_type: z.string().optional().nullable(),
-      created_at: z.string().optional().nullable(),
-      modified_at: z.string().optional().nullable(),
-    })
-    .passthrough()
-    .nullable(),
-});
-const DeleteResultSchema = z.object({ deleted: z.boolean() });
-// Nexus list returns either flat strings or objects depending on details flag.
-// - Without details: ["path/to/file", ...]
-// - With details: [{ path, size, etag, is_directory, ... }, ...]
-const ListEntrySchema = z.union([
-  z.string(),
-  z.object({
-    name: z.string().optional(),
+
+const ReadResponseSchema = z
+  .object({
+    content: z.string(),
+    content_id: z.string().nullable().optional(),
+    version: z.number().nullable().optional(),
+    size: z.number().nullable().optional(),
+    modified_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const ExistsResponseSchema = z.object({ exists: z.boolean() });
+
+const MetadataResponseSchema = z
+  .object({
+    path: z.string(),
+    size: z.number(),
+    content_id: z.string().nullable().optional(),
+    version: z.number(),
+    is_directory: z.boolean(),
+    created_at: z.string().nullable().optional(),
+    modified_at: z.string().nullable().optional(),
+    mime_type: z.string().nullable().optional(),
+    content_type: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const DeleteResponseSchema = z.object({ deleted: z.boolean(), path: z.string() });
+
+// Both serialized aliases (camelCase) and the underlying snake_case fields
+// can appear depending on the FastAPI response_model_by_alias toggle. Accept
+// either to insulate the client from server-side serialization changes.
+const FileItemSchema = z
+  .object({
+    name: z.string(),
     path: z.string(),
     size: z.number().optional(),
-    etag: z.string().optional(),
+    isDirectory: z.boolean().optional(),
     is_directory: z.boolean().optional(),
-  }),
-]);
-const ListResultSchema = z.object({
-  files: z.array(ListEntrySchema),
-  has_more: z.boolean(),
-  next_cursor: z.string().optional().nullable(),
+    contentId: z.string().nullable().optional(),
+    content_id: z.string().nullable().optional(),
+    modifiedAt: z.string().nullable().optional(),
+    modified_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const ListResponseSchema = z.object({
+  items: z.array(FileItemSchema),
+  has_more: z.boolean().optional(),
+  hasMore: z.boolean().optional(),
+  next_cursor: z.string().nullable().optional(),
+  nextCursor: z.string().nullable().optional(),
 });
-const MkdirResultSchema = z.object({ created: z.boolean() });
-const SearchResultSchema = z.object({
-  results: z.array(
-    z.object({
-      path: z.string(),
-      snippet: z.string().optional(),
-      score: z.number().optional(),
-    }),
-  ),
+
+const GrepMatchSchema = z.object({
+  file: z.string(),
+  line: z.number(),
+  content: z.string(),
+  match: z.string(),
+});
+
+const GrepResponseSchema = z.object({
+  matches: z.array(GrepMatchSchema),
+  total: z.number(),
+  truncated: z.boolean().optional(),
+  pattern: z.string().optional(),
+  base_path: z.string().optional(),
 });
 
 // ---------------------------------------------------------------------------
 // NexusHttpClient
 // ---------------------------------------------------------------------------
 
-/**
- * JSON-RPC HTTP client for nexi-lab/nexus.
- */
+type RestMethod = "GET" | "POST" | "DELETE";
+
+/** REST HTTP client for nexi-lab/nexus v2 file API. */
 export class NexusHttpClient implements NexusClient {
   private readonly baseUrl: string;
   private readonly apiKey: string | undefined;
   private readonly timeoutMs: number;
-  private requestId = 0;
   private closed = false;
 
   constructor(config: NexusHttpConfig) {
@@ -137,28 +164,33 @@ export class NexusHttpClient implements NexusClient {
   }
 
   // -----------------------------------------------------------------------
-  // JSON-RPC transport
+  // REST transport
   // -----------------------------------------------------------------------
 
-  private async rpc<T>(
-    method: string,
-    params: Record<string, unknown>,
+  private async request<T>(
+    method: RestMethod,
+    path: string,
     schema: z.ZodType<T>,
+    opts?: { query?: Record<string, string | number | boolean | undefined>; body?: unknown },
   ): Promise<T> {
     if (this.closed) throw new NexusConnectionError("Client is closed");
 
-    const id = ++this.requestId;
-    const body = JSON.stringify({ jsonrpc: "2.0", method, params, id });
+    const url = new URL(`${this.baseUrl}${path}`);
+    if (opts?.query) {
+      for (const [k, v] of Object.entries(opts.query)) {
+        if (v !== undefined) url.searchParams.set(k, String(v));
+      }
+    }
 
     let response: Response;
     try {
-      response = await fetch(`${this.baseUrl}/api/nfs/${method}`, {
-        method: "POST",
+      response = await fetch(url.toString(), {
+        method,
         headers: {
-          "Content-Type": "application/json",
+          ...(opts?.body !== undefined ? { "Content-Type": "application/json" } : {}),
           ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}),
         },
-        body,
+        ...(opts?.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
         signal: AbortSignal.timeout(this.timeoutMs),
       });
     } catch (err) {
@@ -174,6 +206,15 @@ export class NexusHttpClient implements NexusClient {
     if (response.status === 401 || response.status === 403) {
       throw new NexusAuthError(`Auth failed: HTTP ${response.status}`);
     }
+    if (response.status === 404) {
+      throw new NexusNotFoundError(path);
+    }
+    if (response.status === 412 || response.status === 409) {
+      // Optimistic-concurrency mismatch (if_match / if_none_match). Surface
+      // as a structured error so callers (claim store CAS path) can retry.
+      const detail = await response.text().catch(() => "");
+      throw new NexusConnectionError(`Precondition failed: ${detail || response.status}`);
+    }
     if (response.status === 429) {
       const retryAfter = response.headers.get("retry-after");
       throw new NexusConnectionError(
@@ -183,29 +224,13 @@ export class NexusHttpClient implements NexusClient {
     if (response.status >= 500) {
       throw new NexusConnectionError(`Nexus server error: HTTP ${response.status}`);
     }
-
-    const envelope = (await response.json()) as {
-      result?: unknown;
-      error?: JsonRpcError | string;
-      detail?: string;
-      retry_after?: number;
-    };
-
-    // Handle non-JSON-RPC error responses (e.g., rate limit responses
-    // returned as plain JSON instead of JSON-RPC envelope)
-    if (typeof envelope.error === "string") {
-      if (envelope.error.toLowerCase().includes("rate limit")) {
-        throw new NexusConnectionError(
-          `Nexus rate limit: ${envelope.error} (retry after ${envelope.retry_after ?? "?"}s)`,
-        );
-      }
-      throw new NexusConnectionError(`Nexus error: ${envelope.error}`);
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new NexusConnectionError(`Nexus HTTP ${response.status}: ${detail}`);
     }
 
-    if (envelope.error) {
-      throw mapJsonRpcError(envelope.error);
-    }
-    return schema.parse(envelope.result);
+    const json = (await response.json()) as unknown;
+    return schema.parse(json);
   }
 
   // -----------------------------------------------------------------------
@@ -214,12 +239,12 @@ export class NexusHttpClient implements NexusClient {
 
   async read(path: string): Promise<Uint8Array | undefined> {
     try {
-      const result = await this.rpc("sys_read", { path }, ReadResultSchema);
-      // Nexus returns stored bytes base64-encoded for JSON transport.
-      // We also base64-encode on write (for binary safety), so we need
-      // to decode twice: once for transport, once for our storage encoding.
-      const transportDecoded = this.decodeReadResult(result);
-      return fromBase64(new TextDecoder().decode(transportDecoded));
+      const result = await this.request("GET", "/api/v2/files/read", ReadResponseSchema, {
+        query: { path },
+      });
+      // Server returns the stored UTF-8 text directly. We base64-encoded
+      // on write for binary safety, so decode once to recover original bytes.
+      return fromBase64(result.content);
     } catch (err) {
       if (err instanceof NexusNotFoundError) return undefined;
       throw err;
@@ -228,20 +253,16 @@ export class NexusHttpClient implements NexusClient {
 
   async readWithMeta(path: string): Promise<ReadResult | undefined> {
     try {
-      // Nexus sys_read doesn't return etag inline. We stat FIRST to get
-      // the etag, then read. This ordering is safe for CAS: if a concurrent
-      // writer updates between stat and read, we get a stale etag with newer
-      // content. A subsequent ifMatch write will fail (etag mismatch),
-      // forcing a correct retry. The unsafe direction (read-then-stat) could
-      // pair old content with a new etag, allowing a write to succeed when
-      // it shouldn't.
-      const meta = await this.stat(path);
-      if (meta === undefined) return undefined;
-
-      const result = await this.rpc("sys_read", { path }, ReadResultSchema);
-      const transportDecoded = this.decodeReadResult(result);
-      const content = fromBase64(new TextDecoder().decode(transportDecoded));
-      return { content, etag: meta.etag };
+      // Combined read + metadata. The REST /read endpoint returns
+      // content_id (the etag) inline, so a single round-trip suffices —
+      // no need for the stat-then-read CAS dance the JSON-RPC client used.
+      const result = await this.request("GET", "/api/v2/files/read", ReadResponseSchema, {
+        query: { path, include_metadata: true },
+      });
+      return {
+        content: fromBase64(result.content),
+        etag: result.content_id ?? "",
+      };
     } catch (err) {
       if (err instanceof NexusNotFoundError) return undefined;
       throw err;
@@ -249,55 +270,46 @@ export class NexusHttpClient implements NexusClient {
   }
 
   async write(path: string, content: Uint8Array, opts?: WriteOptions): Promise<WriteResult> {
-    // Nexus sys_write treats `content` as a raw string stored verbatim.
-    // We base64-encode content so arbitrary binary (including non-UTF-8
-    // bytes like 0xFF) survives the JSON transport and storage round-trip.
-    // The corresponding read() double-decodes (transport base64 → our base64).
-    const params: Record<string, unknown> = {
+    // We base64-encode arbitrary bytes into a UTF-8 text wrapper so binary
+    // (e.g. CAS blobs) round-trips through the server's lossy UTF-8 read
+    // decode. Server stores the base64 chars verbatim; read decodes once
+    // to recover the original bytes.
+    const body: Record<string, unknown> = {
       path,
       content: toBase64(content),
+      encoding: "utf8",
     };
-    if (opts?.ifMatch !== undefined) params.if_match = opts.ifMatch;
-    if (opts?.ifNoneMatch !== undefined) params.if_none_match = opts.ifNoneMatch;
-    if (opts?.force !== undefined) params.force = opts.force;
+    if (opts?.ifMatch !== undefined) body.if_match = opts.ifMatch;
+    if (opts?.ifNoneMatch !== undefined) body.if_none_match = opts.ifNoneMatch;
 
-    const result = await this.rpc("sys_write", params, WriteResultSchema);
+    const result = await this.request("POST", "/api/v2/files/write", WriteResponseSchema, {
+      body,
+    });
     return {
-      bytesWritten: result.bytes_written,
-      etag: result.etag ?? "",
-      version: result.version,
+      bytesWritten: result.size ?? content.byteLength,
+      etag: result.content_id ?? "",
+      version: result.version ?? undefined,
     };
-  }
-
-  /** Decode a sys_read response into raw stored bytes (before our base64 layer). */
-  private decodeReadResult(
-    result: { __type__: "bytes"; data: string } | { content: string; encoding: string },
-  ): Uint8Array {
-    if ("__type__" in result && result.__type__ === "bytes") {
-      return fromBase64(result.data);
-    }
-    if ("encoding" in result && result.encoding === "base64") {
-      return fromBase64(result.content);
-    }
-    return new TextEncoder().encode("content" in result ? result.content : "");
   }
 
   async exists(path: string): Promise<boolean> {
-    const result = await this.rpc("exists", { path }, ExistsResultSchema);
+    const result = await this.request("GET", "/api/v2/files/exists", ExistsResponseSchema, {
+      query: { path },
+    });
     return result.exists;
   }
 
   async stat(path: string): Promise<FileMeta | undefined> {
     try {
-      const result = await this.rpc("sys_stat", { path }, StatResultSchema);
-      const m = result.metadata;
-      if (!m) return { size: 0, etag: "" };
+      const result = await this.request("GET", "/api/v2/files/metadata", MetadataResponseSchema, {
+        query: { path },
+      });
       return {
-        size: m.size ?? 0,
-        etag: m.etag ?? "",
-        contentType: m.content_type ?? m.mime_type ?? undefined,
-        createdAt: m.created_at ?? undefined,
-        modifiedAt: m.modified_at ?? undefined,
+        size: result.size,
+        etag: result.content_id ?? "",
+        contentType: result.content_type ?? result.mime_type ?? undefined,
+        createdAt: result.created_at ?? undefined,
+        modifiedAt: result.modified_at ?? undefined,
       };
     } catch (err) {
       if (err instanceof NexusNotFoundError) return undefined;
@@ -307,8 +319,10 @@ export class NexusHttpClient implements NexusClient {
 
   async delete(path: string): Promise<boolean> {
     try {
-      await this.rpc("delete", { path }, DeleteResultSchema);
-      return true;
+      const result = await this.request("DELETE", "/api/v2/files/delete", DeleteResponseSchema, {
+        query: { path },
+      });
+      return result.deleted;
     } catch (err) {
       if (err instanceof NexusNotFoundError) return false;
       throw err;
@@ -316,55 +330,56 @@ export class NexusHttpClient implements NexusClient {
   }
 
   async list(path: string, opts?: ListOptions): Promise<ListResult> {
-    const params: Record<string, unknown> = { path };
-    if (opts?.recursive !== undefined) params.recursive = opts.recursive;
-    if (opts?.details !== undefined) params.details = opts.details;
-    if (opts?.limit !== undefined) params.limit = opts.limit;
-    if (opts?.cursor !== undefined) params.cursor = opts.cursor;
-
-    const result = await this.rpc("list", params, ListResultSchema);
-
+    const result = await this.request("GET", "/api/v2/files/list", ListResponseSchema, {
+      query: {
+        path,
+        ...(opts?.limit !== undefined ? { limit: opts.limit } : {}),
+        ...(opts?.cursor !== undefined ? { cursor: opts.cursor } : {}),
+      },
+    });
     return {
-      files: result.files.map((f): ListEntry => {
-        if (typeof f === "string") {
-          // Flat string path — extract name and infer isDirectory from trailing /
-          const isDir = f.endsWith("/");
-          const cleanPath = isDir ? f.slice(0, -1) : f;
-          const name = cleanPath.split("/").pop() ?? cleanPath;
-          return { name, path: cleanPath, isDirectory: isDir };
-        }
-        // Object entry (details=true)
-        return {
-          name: f.name ?? f.path.split("/").pop() ?? f.path,
+      files: result.items.map(
+        (f): ListEntry => ({
+          name: f.name,
           path: f.path,
           size: f.size,
-          etag: f.etag,
-          isDirectory: f.is_directory,
-        };
-      }),
-      hasMore: result.has_more,
-      nextCursor: result.next_cursor ?? undefined,
+          isDirectory: f.isDirectory ?? f.is_directory,
+          etag: f.contentId ?? f.content_id ?? undefined,
+        }),
+      ),
+      hasMore: result.has_more ?? result.hasMore ?? false,
+      nextCursor: result.next_cursor ?? result.nextCursor ?? undefined,
     };
   }
 
   async mkdir(path: string, opts?: MkdirOptions): Promise<void> {
-    const params: Record<string, unknown> = { path };
-    if (opts?.parents !== undefined) params.parents = opts.parents;
-    await this.rpc("mkdir", params, MkdirResultSchema);
+    await this.request("POST", "/api/v2/files/mkdir", z.unknown(), {
+      body: {
+        path,
+        ...(opts?.parents !== undefined ? { parents: opts.parents } : {}),
+      },
+    });
   }
 
   async search(query: string, opts?: SearchOptions): Promise<readonly SearchResult[]> {
-    const params: Record<string, unknown> = { query };
-    if (opts?.path !== undefined) params.path = opts.path;
-    if (opts?.limit !== undefined) params.limit = opts.limit;
-
-    const result = await this.rpc("search", params, SearchResultSchema);
-
-    return result.results.map(
-      (r): SearchResult => ({
-        path: r.path,
-        snippet: r.snippet,
-        score: r.score,
+    // The legacy `search` JSON-RPC method was full-text/semantic. The REST
+    // file API exposes regex grep, which is a strict subset. Treat the
+    // user query as a literal pattern (escaped) so word-style searches
+    // still work; semantic ranking is no longer available, so we report
+    // a constant score.
+    const literal = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const result = await this.request("GET", "/api/v2/files/grep", GrepResponseSchema, {
+      query: {
+        pattern: literal,
+        path: opts?.path ?? "/",
+        ...(opts?.limit !== undefined ? { limit: opts.limit } : {}),
+      },
+    });
+    return result.matches.map(
+      (m): SearchResult => ({
+        path: m.file,
+        snippet: m.content,
+        score: 1,
       }),
     );
   }

--- a/src/nexus/nexus-ipc-client.ts
+++ b/src/nexus/nexus-ipc-client.ts
@@ -1,11 +1,12 @@
 /**
- * Shared Nexus IPC client for sending messages via the Nexus kernel-VFS RPC.
+ * Shared Nexus IPC client for sending messages via the Nexus kernel-VFS.
  *
- * Migrated from the removed `/api/v2/ipc/send` route to the post-PR-#3912
- * RPC surface: messages are written into the recipient's inbox at
- * `/ipc/{recipient}/inbox/{message_id}.json` via `POST /api/nfs/sys_write`.
- * Subscribers consume those writes through `/api/v2/events/stream` with a
- * matching path pattern (handled by NexusWsBridge).
+ * Migrated from the removed `/api/v2/ipc/send` route to the v2 REST file
+ * surface: messages are written into the recipient's inbox at
+ * `/ipc/{recipient}/inbox/{message_id}.json` via `POST /api/v2/files/write`
+ * with a base64-encoded JSON envelope. Subscribers consume those writes
+ * through `/api/v2/events/stream` with a matching path pattern (handled
+ * by NexusWsBridge).
  *
  * Returns structured results with IPC message IDs for handoff tracking.
  */
@@ -95,18 +96,17 @@ export class NexusIpcClient {
         payload,
         timestamp: new Date().toISOString(),
       });
-      const buf = Buffer.from(envelope, "utf8").toString("base64");
-      const resp = await fetch(`${this.nexusUrl}/api/nfs/sys_write`, {
+      const content = Buffer.from(envelope, "utf8").toString("base64");
+      const resp = await fetch(`${this.nexusUrl}/api/v2/files/write`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${this.apiKey}`,
         },
         body: JSON.stringify({
-          jsonrpc: "2.0",
-          method: "sys_write",
-          params: { path: `/ipc/${recipient}/inbox/${messageId}.json`, buf },
-          id: 1,
+          path: `/ipc/${recipient}/inbox/${messageId}.json`,
+          content,
+          encoding: "base64",
         }),
       });
 

--- a/src/nexus/nexus-ipc-client.ts
+++ b/src/nexus/nexus-ipc-client.ts
@@ -1,8 +1,11 @@
 /**
- * Shared Nexus IPC client for sending messages via the Nexus IPC API.
+ * Shared Nexus IPC client for sending messages via the Nexus kernel-VFS RPC.
  *
- * Consolidates the duplicate POST /api/v2/ipc/send calls that previously
- * existed in both NexusEventBus and NexusWsBridge (Issue #165 / 5A).
+ * Migrated from the removed `/api/v2/ipc/send` route to the post-PR-#3912
+ * RPC surface: messages are written into the recipient's inbox at
+ * `/ipc/{recipient}/inbox/{message_id}.json` via `POST /api/nfs/sys_write`.
+ * Subscribers consume those writes through `/api/v2/events/stream` with a
+ * matching path pattern (handled by NexusWsBridge).
  *
  * Returns structured results with IPC message IDs for handoff tracking.
  */
@@ -83,13 +86,28 @@ export class NexusIpcClient {
     }
 
     try {
-      const resp = await fetch(`${this.nexusUrl}/api/v2/ipc/send`, {
+      const messageId = globalThis.crypto?.randomUUID?.() ?? `msg-${Date.now()}`;
+      const envelope = JSON.stringify({
+        message_id: messageId,
+        sender,
+        recipient,
+        type: "event",
+        payload,
+        timestamp: new Date().toISOString(),
+      });
+      const buf = Buffer.from(envelope, "utf8").toString("base64");
+      const resp = await fetch(`${this.nexusUrl}/api/nfs/sys_write`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${this.apiKey}`,
         },
-        body: JSON.stringify({ sender, recipient, type: "event", payload }),
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "sys_write",
+          params: { path: `/ipc/${recipient}/inbox/${messageId}.json`, buf },
+          id: 1,
+        }),
       });
 
       if (!resp.ok) {
@@ -117,18 +135,9 @@ export class NexusIpcClient {
       this.endpointAvailable = true;
       this.transientFailureAt = undefined; // clear backoff on success
 
-      // Try to extract message_id from response
-      let messageId: string | undefined;
-      try {
-        const body = (await resp.json()) as { message_id?: string };
-        messageId = body.message_id;
-      } catch {
-        // Response may not be JSON — still a success
-      }
-
       debugLog(
         "nexus-ipc",
-        `SEND OK sender=${sender} recipient=${recipient} messageId=${messageId ?? "(none)"}`,
+        `SEND OK sender=${sender} recipient=${recipient} messageId=${messageId}`,
       );
       return { ok: true, messageId };
     } catch (err) {

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { useKeyboard, useRenderer } from "@opentui/react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { TUI_REFRESH_ROLE } from "../core/event-bus.js";
 import type { Claim, Contribution } from "../core/models.js";
 import { safeCleanup } from "../shared/safe-cleanup.js";
 import { checkSpawn, checkSpawnDepth } from "./agents/spawn-validator.js";
@@ -551,8 +552,11 @@ export function App({
   // depth and is not removed here.
   useEffect(() => {
     if (!eventBus) return;
-    const roles = topology?.roles.map((r) => r.name) ?? [];
-    if (roles.length === 0) return;
+    const topologyRoles = topology?.roles.map((r) => r.name) ?? [];
+    // TUI_REFRESH_ROLE catches producer events (vfs.changed, agent.output,
+    // github.pr.changed) that don't target an agent role. Always subscribe
+    // so the fan-out works even before topology resolves.
+    const roles = [...topologyRoles, TUI_REFRESH_ROLE];
     const handler = () => {
       // Invalidate provider TTL caches BEFORE bumping the refresh signal.
       // The store-backed provider hands back its last full scan inside

--- a/src/tui/components/agent-split-pane.tsx
+++ b/src/tui/components/agent-split-pane.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback } from "react";
 import type { TmuxManager } from "../agents/tmux-manager.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import { agentStatusIcon, theme } from "../theme.js";
 
 /** Maximum visible agent panes. Overflow agents are listed but not rendered. */
@@ -19,9 +19,9 @@ export interface AgentSplitPaneProps {
   readonly sessions: readonly string[];
   /** TmuxManager for pane capture. */
   readonly tmux: TmuxManager;
-  /** Polling interval in milliseconds. */
-  readonly intervalMs: number;
-  /** Whether this view is actively polling. */
+  /** Unused after A8.4 migration; producer-side `agent.output` events drive re-fetch. */
+  readonly intervalMs?: number;
+  /** Whether this view is actively rendering. */
   readonly active: boolean;
   /** Index of the focused pane (for highlight). */
   readonly focusedIndex?: number | undefined;
@@ -37,13 +37,11 @@ function agentSymbol(_sessionName: string, _sessions: readonly string[]): string
 const AgentPane = React.memo(function AgentPane({
   sessionName,
   tmux,
-  intervalMs,
   active,
   focused,
 }: {
   readonly sessionName: string;
   readonly tmux: TmuxManager;
-  readonly intervalMs: number;
   readonly active: boolean;
   readonly focused: boolean;
 }) {
@@ -51,8 +49,7 @@ const AgentPane = React.memo(function AgentPane({
     return tmux.capturePanes(sessionName);
   }, [tmux, sessionName]);
 
-  const captureMs = Math.max(intervalMs, 200);
-  const { data: output } = usePolledData<string>(fetcher, captureMs, active);
+  const { data: output } = useEventDrivenData<string>(fetcher, undefined, undefined, active);
 
   const rawOutput = output ?? "";
   const lines = rawOutput.trimEnd().split("\n").slice(-15);
@@ -90,7 +87,6 @@ export const AgentSplitPane: React.NamedExoticComponent<AgentSplitPaneProps> = R
   function AgentSplitPane({
     sessions,
     tmux,
-    intervalMs,
     active,
     focusedIndex,
   }: AgentSplitPaneProps): React.ReactNode {
@@ -113,7 +109,6 @@ export const AgentSplitPane: React.NamedExoticComponent<AgentSplitPaneProps> = R
               key={session}
               sessionName={session}
               tmux={tmux}
-              intervalMs={intervalMs}
               active={active}
               focused={focusedIndex === i}
             />

--- a/src/tui/hooks/use-agent-monitor.ts
+++ b/src/tui/hooks/use-agent-monitor.ts
@@ -160,8 +160,8 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
 
   // Subscribe to EventBus for IPC message log.
   // Deduplicate: MCP TopologyRouter AND TUI wsBridge.send BOTH write into
-  // the kernel-VFS inbox via /api/nfs/sys_write → SSE → same handler fires
-  // twice per routing.
+  // the kernel-VFS inbox via /api/v2/files/write → SSE → same handler
+  // fires twice per routing.
   // Use source→target with a time window to collapse duplicates.
   useEffect(() => {
     if (!eventBus || !topology) return;

--- a/src/tui/hooks/use-agent-monitor.ts
+++ b/src/tui/hooks/use-agent-monitor.ts
@@ -159,8 +159,9 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
   }, []);
 
   // Subscribe to EventBus for IPC message log.
-  // Deduplicate: MCP TopologyRouter AND TUI wsBridge.send BOTH fire events
-  // through Nexus /api/v2/ipc/send → SSE → same handler fires twice per routing.
+  // Deduplicate: MCP TopologyRouter AND TUI wsBridge.send BOTH write into
+  // the kernel-VFS inbox via /api/nfs/sys_write → SSE → same handler fires
+  // twice per routing.
   // Use source→target with a time window to collapse duplicates.
   useEffect(() => {
     if (!eventBus || !topology) return;

--- a/src/tui/hooks/use-event-driven-data.ts
+++ b/src/tui/hooks/use-event-driven-data.ts
@@ -1,15 +1,19 @@
 /**
- * Event-driven data hook for Nexus mode.
+ * Event-driven data hook — drop-in replacement for usePolledData.
  *
- * Replaces usePolledData when EventBus is available:
- * 1. Fetches once on mount
- * 2. Subscribes to EventBus — re-fetches when events arrive
+ * Re-fetches on three triggers:
+ *   1. Initial mount (one fetch)
+ *   2. Direct EventBus events (when `eventBus` + `role` provided)
+ *   3. Global RefreshContext signal (r-key + app-level event fan-out)
  *
- * NO polling. EventBus is the single source of truth.
+ * NO setInterval. App-level `useEffect` already subscribes to every topology
+ * role and bumps RefreshContext on event — so panels typically pass
+ * `undefined` for `eventBus`/`role` and ride the existing fan-out.
  */
 
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import type { EventBus, EventHandler, GroveEvent } from "../../core/event-bus.js";
+import { useRefreshSignal } from "./use-refresh-context.js";
 
 /** Result — same interface as usePolledData for drop-in replacement. */
 export interface EventDrivenResult<T> {
@@ -102,7 +106,11 @@ export function useEventDrivenData<T>(
     };
   }, [active, eventBus, role, doFetch]);
 
-  // No polling. EventBus is the single update path.
+  // App-level RefreshContext — covers r-key + app's topology-role event fan-out.
+  // Lets panels migrate without prop-drilling eventBus/role.
+  useRefreshSignal(doFetch);
+
+  // No polling. EventBus + RefreshContext are the only update paths.
 
   return {
     data: state.data,

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -483,6 +483,44 @@ async function buildAppProps(
     }
   }
 
+  // A8.4 (#390): when an EventBus exists and we have a local groveDir,
+  // start the producer-side VFS watcher. It publishes coarse `vfs.changed`
+  // events into the bus, which the App-level subscription forwards to the
+  // global RefreshContext — vfs-browser and artifact-preview re-fetch
+  // without their own setInterval.
+  if (eventBus && groveDir) {
+    const { startVfsEventPublisher } = await import("../local/vfs-event-publisher.js");
+    const handle = startVfsEventPublisher({ eventBus, groveDir });
+    stopCallbacks.push(handle.stop);
+  }
+
+  // A8.4 (#390): producer-side `agent.output` publisher for tmux-managed
+  // sessions. ACPX-streamed sessions already publish `acp.message` events
+  // via `nexus-agent-publisher`; this watcher covers the tmux fan-out so
+  // terminal/agent-list panels stop polling.
+  if (eventBus && tmux) {
+    const { startAgentOutputPublisher } = await import("../local/agent-output-publisher.js");
+    const handle = startAgentOutputPublisher({ eventBus, tmux });
+    stopCallbacks.push(handle.stop);
+  }
+
+  // A8.4 (#390): producer-side `github.pr.changed` publisher for the
+  // github-panel. Polls the GitHub API at the producer level so the panel
+  // doesn't need its own setInterval. Real deployments should swap this
+  // for webhook ingest; the bus contract stays identical.
+  if (eventBus) {
+    const { isGitHubProvider } = await import("./provider.js");
+    if (isGitHubProvider(provider)) {
+      const ghProvider = provider;
+      const { startGitHubPrPublisher } = await import("../local/github-pr-publisher.js");
+      const handle = startGitHubPrPublisher({
+        eventBus,
+        getActivePR: () => ghProvider.getActivePR(),
+      });
+      stopCallbacks.push(handle.stop);
+    }
+  }
+
   // Construct InformerFactory for the SSE-driven cache (#295).
   //
   // Remote mode targets the grove-server watch routes (`/api/list`,

--- a/src/tui/nexus-ws-bridge.test.ts
+++ b/src/tui/nexus-ws-bridge.test.ts
@@ -561,13 +561,25 @@ describe("NexusWsBridge", () => {
 
     expect(ok).toBe(true);
     expect(fetchCalls).toHaveLength(1);
-    expect(fetchCalls[0]!.url).toBe("http://localhost:9999/api/v2/ipc/send");
-    expect(fetchCalls[0]!.body).toEqual({
-      sender: "coder",
-      recipient: "reviewer",
-      type: "event",
-      payload: { summary: "test" },
-    });
+    expect(fetchCalls[0]!.url).toBe("http://localhost:9999/api/nfs/sys_write");
+    const body = fetchCalls[0]!.body as {
+      jsonrpc: string;
+      method: string;
+      params: { path: string; buf: string };
+    };
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.method).toBe("sys_write");
+    expect(body.params.path).toMatch(/^\/ipc\/reviewer\/inbox\/.+\.json$/);
+    const decoded = JSON.parse(Buffer.from(body.params.buf, "base64").toString("utf8")) as {
+      sender: string;
+      recipient: string;
+      type: string;
+      payload: Record<string, unknown>;
+    };
+    expect(decoded.sender).toBe("coder");
+    expect(decoded.recipient).toBe("reviewer");
+    expect(decoded.type).toBe("event");
+    expect(decoded.payload).toEqual({ summary: "test" });
 
     bridge.close();
   });
@@ -892,7 +904,7 @@ describe("NexusWsBridge", () => {
     // Registration accepts any 2xx; stream probe also requires real
     // text/event-stream content-type to count as ready.
     globalThis.fetch = ((url: string) => {
-      if (url.includes("/api/v2/ipc/stream/")) {
+      if (url.includes("/api/v2/events/stream")) {
         return Promise.resolve(
           new Response("", { status: 200, headers: { "content-type": "text/event-stream" } }),
         );
@@ -913,7 +925,7 @@ describe("NexusWsBridge", () => {
         regCalls += 1;
         return Promise.resolve(new Response("", { status: regCalls === 1 ? 200 : 409 }));
       }
-      if (url.includes("/api/v2/ipc/stream/")) {
+      if (url.includes("/api/v2/events/stream")) {
         return Promise.resolve(
           new Response("", { status: 200, headers: { "content-type": "text/event-stream" } }),
         );
@@ -928,7 +940,7 @@ describe("NexusWsBridge", () => {
 
   test("connect rejects when probe returns 2xx without event-stream content-type", async () => {
     globalThis.fetch = ((url: string) => {
-      if (url.includes("/api/v2/ipc/stream/")) {
+      if (url.includes("/api/v2/events/stream")) {
         // 2xx but plain text/html — a misconfigured proxy scenario.
         return Promise.resolve(
           new Response("not a stream", {
@@ -979,7 +991,7 @@ describe("NexusWsBridge", () => {
     // stream probe (GET /ipc/stream/<role>) returns 403 — simulating a
     // deployment where registration is permissive but stream auth is not.
     globalThis.fetch = ((url: string) => {
-      if (url.includes("/api/v2/ipc/stream/")) {
+      if (url.includes("/api/v2/events/stream")) {
         return Promise.resolve(new Response("", { status: 403 }));
       }
       return Promise.resolve(new Response("{}", { status: 200 }));

--- a/src/tui/nexus-ws-bridge.test.ts
+++ b/src/tui/nexus-ws-bridge.test.ts
@@ -561,16 +561,15 @@ describe("NexusWsBridge", () => {
 
     expect(ok).toBe(true);
     expect(fetchCalls).toHaveLength(1);
-    expect(fetchCalls[0]!.url).toBe("http://localhost:9999/api/nfs/sys_write");
+    expect(fetchCalls[0]!.url).toBe("http://localhost:9999/api/v2/files/write");
     const body = fetchCalls[0]!.body as {
-      jsonrpc: string;
-      method: string;
-      params: { path: string; buf: string };
+      path: string;
+      content: string;
+      encoding: string;
     };
-    expect(body.jsonrpc).toBe("2.0");
-    expect(body.method).toBe("sys_write");
-    expect(body.params.path).toMatch(/^\/ipc\/reviewer\/inbox\/.+\.json$/);
-    const decoded = JSON.parse(Buffer.from(body.params.buf, "base64").toString("utf8")) as {
+    expect(body.path).toMatch(/^\/ipc\/reviewer\/inbox\/.+\.json$/);
+    expect(body.encoding).toBe("base64");
+    const decoded = JSON.parse(Buffer.from(body.content, "base64").toString("utf8")) as {
       sender: string;
       recipient: string;
       type: string;

--- a/src/tui/nexus-ws-bridge.test.ts
+++ b/src/tui/nexus-ws-bridge.test.ts
@@ -152,9 +152,9 @@ describe("NexusWsBridge", () => {
       new Response(
         JSON.stringify({
           content: JSON.stringify({
-                sender: "coder",
-                payload: { cid: "blake3:abc", kind: "work", summary: "test contribution" },
-              }),
+            sender: "coder",
+            payload: { cid: "blake3:abc", kind: "work", summary: "test contribution" },
+          }),
         }),
         { status: 200 },
       )) as unknown as typeof fetch;
@@ -327,9 +327,9 @@ describe("NexusWsBridge", () => {
       new Response(
         JSON.stringify({
           content: JSON.stringify({
-                sender: "coder",
-                payload: { summary: "implement auth module" },
-              }),
+            sender: "coder",
+            payload: { summary: "implement auth module" },
+          }),
         }),
         { status: 200 },
       )) as unknown as typeof fetch;
@@ -370,14 +370,14 @@ describe("NexusWsBridge", () => {
       new Response(
         JSON.stringify({
           content: JSON.stringify({
-                sender: "coder",
-                payload: {
-                  cid: "blake3:abc123",
-                  kind: "work",
-                  summary: "implement auth module",
-                  agentId: "coder-1",
-                },
-              }),
+            sender: "coder",
+            payload: {
+              cid: "blake3:abc123",
+              kind: "work",
+              summary: "implement auth module",
+              agentId: "coder-1",
+            },
+          }),
         }),
         { status: 200 },
       )) as unknown as typeof fetch;
@@ -420,14 +420,14 @@ describe("NexusWsBridge", () => {
       new Response(
         JSON.stringify({
           content: JSON.stringify({
-                sender: "reviewer",
-                payload: {
-                  cid: "blake3:review1",
-                  kind: "review",
-                  summary: "fix the race condition in handler.ts",
-                  agentId: "reviewer-1",
-                },
-              }),
+            sender: "reviewer",
+            payload: {
+              cid: "blake3:review1",
+              kind: "review",
+              summary: "fix the race condition in handler.ts",
+              agentId: "reviewer-1",
+            },
+          }),
         }),
         { status: 200 },
       )) as unknown as typeof fetch;

--- a/src/tui/nexus-ws-bridge.test.ts
+++ b/src/tui/nexus-ws-bridge.test.ts
@@ -151,14 +151,10 @@ describe("NexusWsBridge", () => {
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
-          result: {
-            data: Buffer.from(
-              JSON.stringify({
+          content: JSON.stringify({
                 sender: "coder",
                 payload: { cid: "blake3:abc", kind: "work", summary: "test contribution" },
               }),
-            ).toString("base64"),
-          },
         }),
         { status: 200 },
       )) as unknown as typeof fetch;
@@ -210,11 +206,7 @@ describe("NexusWsBridge", () => {
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
-          result: {
-            data: Buffer.from(
-              JSON.stringify({ sender: "coder", payload: { summary: "plain notice" } }),
-            ).toString("base64"),
-          },
+          content: JSON.stringify({ sender: "coder", payload: { summary: "plain notice" } }),
         }),
         { status: 200 },
       )) as unknown as typeof fetch;
@@ -277,11 +269,7 @@ describe("NexusWsBridge", () => {
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
-          result: {
-            data: Buffer.from(
-              JSON.stringify({ sender: "coder", payload: { summary: "test" } }),
-            ).toString("base64"),
-          },
+          content: JSON.stringify({ sender: "coder", payload: { summary: "test" } }),
         }),
         { status: 200 },
       )) as unknown as typeof fetch;
@@ -338,14 +326,10 @@ describe("NexusWsBridge", () => {
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
-          result: {
-            data: Buffer.from(
-              JSON.stringify({
+          content: JSON.stringify({
                 sender: "coder",
                 payload: { summary: "implement auth module" },
               }),
-            ).toString("base64"),
-          },
         }),
         { status: 200 },
       )) as unknown as typeof fetch;
@@ -385,9 +369,7 @@ describe("NexusWsBridge", () => {
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
-          result: {
-            data: Buffer.from(
-              JSON.stringify({
+          content: JSON.stringify({
                 sender: "coder",
                 payload: {
                   cid: "blake3:abc123",
@@ -396,8 +378,6 @@ describe("NexusWsBridge", () => {
                   agentId: "coder-1",
                 },
               }),
-            ).toString("base64"),
-          },
         }),
         { status: 200 },
       )) as unknown as typeof fetch;
@@ -439,9 +419,7 @@ describe("NexusWsBridge", () => {
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
-          result: {
-            data: Buffer.from(
-              JSON.stringify({
+          content: JSON.stringify({
                 sender: "reviewer",
                 payload: {
                   cid: "blake3:review1",
@@ -450,8 +428,6 @@ describe("NexusWsBridge", () => {
                   agentId: "reviewer-1",
                 },
               }),
-            ).toString("base64"),
-          },
         }),
         { status: 200 },
       )) as unknown as typeof fetch;
@@ -515,11 +491,11 @@ describe("NexusWsBridge", () => {
     bridge.close();
   });
 
-  test("readAndPush handles missing data field gracefully", async () => {
+  test("readAndPush handles missing content field gracefully", async () => {
     const runtime = makeMockRuntime();
 
     globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ result: {} }), { status: 200 })) as unknown as typeof fetch;
+      new Response(JSON.stringify({}), { status: 200 })) as unknown as typeof fetch;
 
     const bridge = new TestableNexusWsBridge(makeBridgeOpts({ runtime }));
     const session = makeSession("reviewer");
@@ -861,19 +837,15 @@ describe("NexusWsBridge", () => {
     globalThis.fetch = (async () =>
       new Response(
         JSON.stringify({
-          result: {
-            data: Buffer.from(
-              JSON.stringify({
-                sender: "coder",
-                payload: {
-                  type: "acp.message",
-                  sessionId: "s1",
-                  turnId: "t1",
-                  message: { kind: "text", turnId: "t1", text: "hi", chunk: true },
-                },
-              }),
-            ).toString("base64"),
-          },
+          content: JSON.stringify({
+            sender: "coder",
+            payload: {
+              type: "acp.message",
+              sessionId: "s1",
+              turnId: "t1",
+              message: { kind: "text", turnId: "t1", text: "hi", chunk: true },
+            },
+          }),
         }),
         { status: 200 },
       )) as unknown as typeof fetch;

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -2,15 +2,13 @@
  * Nexus IPC bridge — real-time push via Nexus SSE + RPC.
  *
  * Endpoints used (post-2026-04-27 — Nexus PR #3912 deleted the legacy
- * `/api/v2/ipc/*` router; IPC is now kernel-VFS-as-IPC over the RPC
- * surface and the events_replay SSE stream):
+ * `/api/v2/ipc/*` router; IPC is now kernel-VFS-as-IPC over the events
+ * stream + REST file surface):
  *   GET  /api/v2/events/stream         — SSE stream of file-write events
  *                                        filtered by `path_pattern` to the
  *                                        per-role inbox prefix
- *   POST /api/nfs/sys_write            — RPC: write a message file into
+ *   POST /api/v2/files/write           — REST: write a message file into
  *                                        the recipient's inbox directory
- *   POST /api/nfs/sys_read             — RPC: read the message file when
- *                                        an SSE event references it
  *   POST /api/v2/agents/register       — register agent (auto-provisions
  *                                        the `/ipc/{agent_id}/inbox/` dir
  *                                        per agent_registration.py:236+)
@@ -18,8 +16,8 @@
  * Flow: SSE delivers `event` records (shape from `EventReplayService`) for
  * any `write` to a path matching the per-role inbox glob (any-zone-prefix +
  * `/ipc/{role}/inbox/`) → bridge translates to the legacy `SseEvent` shape
- * internally → reads message via sys_read → pushes to target agent via
- * runtime.send().
+ * internally → reads message via the REST file API → pushes to target
+ * agent via runtime.send().
  *
  * No process.stderr.write — all logging goes through the TUI's log system
  * to avoid corrupting the alternate screen.
@@ -72,6 +70,15 @@ export interface NexusWsBridgeOptions {
    * TUI kept accepting work.
    */
   onRoleUnhealthy?: ((role: string, consecutiveFailures: number) => void) | undefined;
+  /**
+   * Called when a role's SSE stream completes a healthy cycle after
+   * having previously fired `onRoleUnhealthy`. Lets the caller flip
+   * a degraded session back to live delivery without requiring a TUI
+   * restart. Without this, a transient Nexus restart that exceeds the
+   * unhealthy threshold leaves the session permanently degraded even
+   * after the channel recovers.
+   */
+  onRoleRecovered?: ((role: string) => void) | undefined;
   /** Default: 3. */
   unhealthyThreshold?: number | undefined;
 }
@@ -391,9 +398,11 @@ export class NexusWsBridge {
       const result = await this.opts.ipcClient.send(sender, recipient, payload);
       return result.ok;
     }
-    // Fallback: direct write to the recipient's inbox via Nexus RPC
-    // (`sys_write`). The legacy `/api/v2/ipc/send` route was removed when
-    // Nexus migrated IPC to the kernel-VFS surface.
+    // Fallback: direct write to the recipient's inbox via the v2 REST
+    // endpoint. The legacy `/api/v2/ipc/send` route and the JSON-RPC
+    // `sys_write` method were both removed in subsequent Nexus releases;
+    // `POST /api/v2/files/write` is the durable REST surface that
+    // materializes a kernel-VFS file the inbox SSE stream observes.
     try {
       const messageId = (globalThis.crypto?.randomUUID?.() ?? String(Date.now()));
       const envelope = JSON.stringify({
@@ -404,18 +413,17 @@ export class NexusWsBridge {
         payload,
         timestamp: new Date().toISOString(),
       });
-      const buf = Buffer.from(envelope, "utf8").toString("base64");
-      const resp = await fetch(`${this.opts.nexusUrl}/api/nfs/sys_write`, {
+      const content = Buffer.from(envelope, "utf8").toString("base64");
+      const resp = await fetch(`${this.opts.nexusUrl}/api/v2/files/write`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${this.opts.apiKey}`,
         },
         body: JSON.stringify({
-          jsonrpc: "2.0",
-          method: "sys_write",
-          params: { path: inboxFilePath(recipient, messageId), buf },
-          id: 1,
+          path: inboxFilePath(recipient, messageId),
+          content,
+          encoding: "base64",
         }),
       });
       return resp.ok;
@@ -482,6 +490,11 @@ export class NexusWsBridge {
     // recurrence) would never re-trigger onRoleUnhealthy because the
     // flag stayed latched from the first breach.
     let firedUnhealthy = false;
+    // Reconnect backoff schedule (ms). Exponential so a single Nexus
+    // restart cycle (typically 20–30s) does not burn through the full
+    // failure threshold before the channel comes back. Capped to 60s
+    // so a sustained outage still escalates within a couple of minutes.
+    const backoffSchedule = [5000, 10000, 20000, 40000, 60000];
     while (!this.closed && !signal.aborted) {
       let streamOk = false;
       try {
@@ -491,8 +504,19 @@ export class NexusWsBridge {
       }
       if (signal.aborted) return;
       if (streamOk) {
+        const wasUnhealthy = firedUnhealthy;
         consecutiveFailures = 0;
         firedUnhealthy = false;
+        // If the role had previously been declared unhealthy, surface the
+        // recovery so the SpawnManager can flip delivery back to ready
+        // instead of staying in the disabled trap state.
+        if (wasUnhealthy) {
+          try {
+            this.opts.onRoleRecovered?.(role);
+          } catch {
+            // callback errors shouldn't kill the reconnect loop
+          }
+        }
       } else {
         consecutiveFailures += 1;
         // Gate escalation on the role still being live. A stale loop that
@@ -510,6 +534,8 @@ export class NexusWsBridge {
         }
       }
       if (!this.closed && !signal.aborted) {
+        const idx = Math.min(consecutiveFailures, backoffSchedule.length - 1);
+        const delayMs = streamOk ? (backoffSchedule[0] ?? 5000) : (backoffSchedule[idx] ?? 5000);
         await new Promise<void>((resolve) => {
           // Wake early on abort so torn-down roles don't linger in the
           // reconnect backoff. When the timer fires the normal way, we
@@ -519,7 +545,7 @@ export class NexusWsBridge {
           const timer = setTimeout(() => {
             if (onAbort) signal.removeEventListener("abort", onAbort);
             resolve();
-          }, 5000);
+          }, delayMs);
           onAbort = () => {
             clearTimeout(timer);
             resolve();

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -1379,20 +1379,17 @@ export class NexusWsBridge {
       // failure is silently lost. Exit early.
       if (this.draining || this.closed) return;
       // Retry on 429 (rate limit) — the inbox read is critical for IPC delivery.
+      // Migrated from `POST /api/nfs/sys_read` (JSON-RPC, dropped in recent
+      // Nexus images) to `GET /api/v2/files/read` (REST). Send path writes
+      // the message envelope with `encoding: "base64"`, so the server stores
+      // the raw JSON bytes; REST read returns that JSON as `content` text.
       let resp: Response | undefined;
+      const readUrl = `${this.opts.nexusUrl}/api/v2/files/read?path=${encodeURIComponent(path)}`;
       for (let attempt = 0; attempt < 5; attempt++) {
-        resp = await fetch(`${this.opts.nexusUrl}/api/nfs/sys_read`, {
-          method: "POST",
+        resp = await fetch(readUrl, {
           headers: {
-            "Content-Type": "application/json",
             Authorization: `Bearer ${this.opts.apiKey}`,
           },
-          body: JSON.stringify({
-            jsonrpc: "2.0",
-            method: "sys_read",
-            params: { path },
-            id: 1,
-          }),
         });
         if (resp.status !== 429) break;
         // Backoff: 2s, 4s, 8s, 16s, 32s
@@ -1407,17 +1404,14 @@ export class NexusWsBridge {
         return;
       }
 
-      const result = (await resp.json()) as { result?: { data?: string }; error?: unknown };
-      if (!result.result?.data) {
-        debugLog(
-          "wsBridge.readAndPush",
-          `NO DATA path=${path} error=${JSON.stringify(result.error ?? "none").slice(0, 100)}`,
-        );
+      const result = (await resp.json()) as { content?: string };
+      if (!result.content) {
+        debugLog("wsBridge.readAndPush", `NO DATA path=${path}`);
         this.publishInvalidation(_targetRole, ipcMessageId);
         return;
       }
 
-      const raw = Buffer.from(result.result.data, "base64").toString();
+      const raw = result.content;
       const msg = JSON.parse(raw) as {
         from?: string;
         sender?: string;

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -404,7 +404,7 @@ export class NexusWsBridge {
     // `POST /api/v2/files/write` is the durable REST surface that
     // materializes a kernel-VFS file the inbox SSE stream observes.
     try {
-      const messageId = (globalThis.crypto?.randomUUID?.() ?? String(Date.now()));
+      const messageId = globalThis.crypto?.randomUUID?.() ?? String(Date.now());
       const envelope = JSON.stringify({
         message_id: messageId,
         sender,

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -1,13 +1,25 @@
 /**
- * Nexus IPC bridge — real-time push via Nexus SSE + IPC API (v0.9.14+).
+ * Nexus IPC bridge — real-time push via Nexus SSE + RPC.
  *
- * Endpoints used:
- *   POST /api/v2/ipc/send              — send message to agent inbox
- *   GET  /api/v2/ipc/stream/{agent_id} — SSE stream for inbox notifications
- *   POST /api/v2/agents/register       — provision agent (creates inbox)
+ * Endpoints used (post-2026-04-27 — Nexus PR #3912 deleted the legacy
+ * `/api/v2/ipc/*` router; IPC is now kernel-VFS-as-IPC over the RPC
+ * surface and the events_replay SSE stream):
+ *   GET  /api/v2/events/stream         — SSE stream of file-write events
+ *                                        filtered by `path_pattern` to the
+ *                                        per-role inbox prefix
+ *   POST /api/nfs/sys_write            — RPC: write a message file into
+ *                                        the recipient's inbox directory
+ *   POST /api/nfs/sys_read             — RPC: read the message file when
+ *                                        an SSE event references it
+ *   POST /api/v2/agents/register       — register agent (auto-provisions
+ *                                        the `/ipc/{agent_id}/inbox/` dir
+ *                                        per agent_registration.py:236+)
  *
- * Flow: SSE delivers message_delivered events → reads message via VFS →
- * pushes to target agent via runtime.send().
+ * Flow: SSE delivers `event` records (shape from `EventReplayService`) for
+ * any `write` to a path matching the per-role inbox glob (any-zone-prefix +
+ * `/ipc/{role}/inbox/`) → bridge translates to the legacy `SseEvent` shape
+ * internally → reads message via sys_read → pushes to target agent via
+ * runtime.send().
  *
  * No process.stderr.write — all logging goes through the TUI's log system
  * to avoid corrupting the alternate screen.
@@ -71,6 +83,52 @@ interface SseEvent {
   recipient: string;
   type: string;
   path: string;
+}
+
+/**
+ * Shape returned by Nexus' EventReplayService over `/api/v2/events/stream`
+ * (see `src/nexus/services/event_log/replay.py` `EventRecord.to_dict`).
+ * The bridge translates this into the legacy `SseEvent` shape its handler
+ * already expects.
+ */
+interface EventRecordPayload {
+  event_id: string;
+  type: string;
+  path: string;
+  agent_id?: string | undefined;
+  zone_id?: string | undefined;
+  timestamp?: string | undefined;
+  sequence_number?: number | undefined;
+}
+
+/** URL builder for the per-role inbox subscription on the new events SSE. */
+function inboxStreamUrl(nexusUrl: string, role: string): string {
+  // path_pattern is matched (SQL LIKE) against the stored zone-prefixed path.
+  // `*/ipc/{role}/inbox/*` → `%/ipc/{role}/inbox/%` covers any zone.
+  const pattern = `*/ipc/${role}/inbox/*`;
+  const params = new URLSearchParams({
+    path_pattern: pattern,
+    event_types: "write",
+  });
+  return `${nexusUrl}/api/v2/events/stream?${params.toString()}`;
+}
+
+/**
+ * Strip a leading `/zone/{zone_id}/` prefix from a stored event path so the
+ * remaining path can be passed to `sys_read` (which re-applies zone scoping
+ * via the RPC dispatcher). Returns the original path when no prefix matches.
+ */
+function stripZonePrefix(path: string): string {
+  // `/zone/<id>/<rest>` → `/<rest>`. The id is opaque (uuid/string), so we
+  // only strip when the path starts with `/zone/` and has at least one more
+  // segment before the rest of the path.
+  const match = path.match(/^\/zone\/[^/]+(\/.*)$/);
+  return match ? (match[1] ?? path) : path;
+}
+
+/** Build the inbox file path for a recipient role. */
+function inboxFilePath(recipient: string, messageId: string): string {
+  return `/ipc/${recipient}/inbox/${messageId}.json`;
 }
 
 export class NexusWsBridge {
@@ -243,16 +301,13 @@ export class NexusWsBridge {
         const onAbort = () => ac.abort();
         deadline.addEventListener("abort", onAbort, { once: true });
         try {
-          const resp = await fetch(
-            `${this.opts.nexusUrl}/api/v2/ipc/stream/${encodeURIComponent(role.name)}`,
-            {
-              headers: {
-                Authorization: `Bearer ${this.opts.apiKey}`,
-                Accept: "text/event-stream",
-              },
-              signal: ac.signal,
+          const resp = await fetch(inboxStreamUrl(this.opts.nexusUrl, role.name), {
+            headers: {
+              Authorization: `Bearer ${this.opts.apiKey}`,
+              Accept: "text/event-stream",
             },
-          );
+            signal: ac.signal,
+          });
           if (!resp.ok) return { role: role.name, reason: `HTTP ${resp.status}` };
           // 2xx is necessary but not sufficient — a misconfigured proxy can
           // serve a success status without an actual event stream. Verify
@@ -336,15 +391,32 @@ export class NexusWsBridge {
       const result = await this.opts.ipcClient.send(sender, recipient, payload);
       return result.ok;
     }
-    // Fallback: direct fetch (backward compat when ipcClient not injected)
+    // Fallback: direct write to the recipient's inbox via Nexus RPC
+    // (`sys_write`). The legacy `/api/v2/ipc/send` route was removed when
+    // Nexus migrated IPC to the kernel-VFS surface.
     try {
-      const resp = await fetch(`${this.opts.nexusUrl}/api/v2/ipc/send`, {
+      const messageId = (globalThis.crypto?.randomUUID?.() ?? String(Date.now()));
+      const envelope = JSON.stringify({
+        message_id: messageId,
+        sender,
+        recipient,
+        type: "event",
+        payload,
+        timestamp: new Date().toISOString(),
+      });
+      const buf = Buffer.from(envelope, "utf8").toString("base64");
+      const resp = await fetch(`${this.opts.nexusUrl}/api/nfs/sys_write`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${this.opts.apiKey}`,
         },
-        body: JSON.stringify({ sender, recipient, type: "event", payload }),
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "sys_write",
+          params: { path: inboxFilePath(recipient, messageId), buf },
+          id: 1,
+        }),
       });
       return resp.ok;
     } catch {
@@ -493,7 +565,7 @@ export class NexusWsBridge {
       // and prevent onRoleUnhealthy from ever firing.
       const openMs = 15000;
       const openTimer = setTimeout(() => ac.abort(), openMs);
-      const url = `${this.opts.nexusUrl}/api/v2/ipc/stream/${encodeURIComponent(role)}`;
+      const url = inboxStreamUrl(this.opts.nexusUrl, role);
 
       let resp: Response;
       try {
@@ -549,9 +621,9 @@ export class NexusWsBridge {
       // proxies stuck mid-stream that hold the TCP pipe open without
       // delivering data.
       //
-      // Set to 5 min because Nexus's `/api/v2/ipc/stream` does NOT emit
-      // keep-alive comments — it sends a single `connected` event then
-      // stays silent until an inbox message lands. A shorter watchdog
+      // Set to 5 min because Nexus's `/api/v2/events/stream` does NOT
+      // emit keep-alive comments — it sends a single `connected` event
+      // then stays silent until an inbox-matching write lands. A shorter watchdog
       // (60 s) would treat every quiet stretch as an outage, escalate
       // through 3 reconnect cycles, and fire onRoleUnhealthy → flip
       // delivery to disabled even though the channel is healthy. 5 min
@@ -601,7 +673,11 @@ export class NexusWsBridge {
           } else if (line.startsWith("data: ")) {
             eventData = line.slice(6);
           } else if (line === "" && eventData) {
-            if (eventType === "message_delivered") sawDelivery = true;
+            // Post-PR-#3912 events_replay emits `event: event` for every
+            // matched write. The legacy ipc-stream emitted
+            // `event: message_delivered`. Treat both as delivery signals
+            // so cycle-health accounting works against either backend.
+            if (eventType === "event" || eventType === "message_delivered") sawDelivery = true;
             this.handleEvent(role, eventType, eventData);
             eventType = null;
             eventData = null;
@@ -625,9 +701,33 @@ export class NexusWsBridge {
 
   private handleEvent(role: string, eventType: string | null, raw: string): void {
     try {
-      if (eventType !== "message_delivered") return;
+      // Accept both the legacy `message_delivered` envelope and the new
+      // events_replay `event` envelope (post-PR-#3912). The new payload is
+      // an EventRecord describing a file write — translate it to the
+      // SseEvent shape the rest of the pipeline already speaks.
+      let event: SseEvent;
+      if (eventType === "message_delivered") {
+        event = JSON.parse(raw) as SseEvent;
+      } else if (eventType === "event") {
+        const rec = JSON.parse(raw) as EventRecordPayload;
+        // Filter to file-write ops on inbox files. The path_pattern query
+        // param already constrains the SSE feed to writes against the
+        // role's inbox prefix; this is belt-and-suspenders against future
+        // pattern drift or shared streams.
+        if (rec.type !== "write") return;
+        const relPath = stripZonePrefix(rec.path);
+        event = {
+          event: "message_delivered",
+          message_id: rec.event_id,
+          sender: rec.agent_id ?? "",
+          recipient: role,
+          type: "event",
+          path: relPath,
+        };
+      } else {
+        return;
+      }
 
-      const event = JSON.parse(raw) as SseEvent;
       debugLog(
         "wsBridge.handleEvent",
         `role=${role} sender=${event.sender} path=${event.path} registeredSessions=[${[...this.sessions.keys()].join(",")}]`,

--- a/src/tui/resolve-backend.test.ts
+++ b/src/tui/resolve-backend.test.ts
@@ -275,17 +275,15 @@ describe("backendLabel", () => {
 // ---------------------------------------------------------------------------
 
 describe("checkNexusHealth", () => {
-  test("returns 'ok' on 200 JSON-RPC response", async () => {
+  test("returns 'ok' on 200 REST exists response", async () => {
     const server = Bun.serve({
       port: 0,
       fetch(req) {
-        // Verify it hits the correct Nexus JSON-RPC endpoint
         const url = new URL(req.url);
-        expect(url.pathname).toBe("/api/nfs/exists");
-        expect(req.method).toBe("POST");
-        return new Response(JSON.stringify({ jsonrpc: "2.0", result: { exists: true }, id: 1 }), {
-          status: 200,
-        });
+        expect(url.pathname).toBe("/api/v2/files/exists");
+        expect(url.searchParams.get("path")).toBe("/");
+        expect(req.method).toBe("GET");
+        return new Response(JSON.stringify({ exists: true }), { status: 200 });
       },
     });
     try {

--- a/src/tui/resolve-backend.ts
+++ b/src/tui/resolve-backend.ts
@@ -250,13 +250,16 @@ export async function checkNexusHealth(
 ): Promise<NexusHealthStatus> {
   try {
     const apiKey = process.env.NEXUS_API_KEY;
-    const resp = await fetch(`${url.replace(/\/+$/, "")}/api/nfs/exists`, {
-      method: "POST",
+    // Use the REST file-exists probe — the legacy `/api/nfs/exists` JSON-RPC
+    // method was dropped in recent Nexus images (see NexusHttpClient
+    // migration). The v2 file router is the durable surface; a 200 with
+    // `{exists: …}` proves the server is up and routing through to the
+    // metadata layer.
+    const base = url.replace(/\/+$/, "");
+    const resp = await fetch(`${base}/api/v2/files/exists?path=${encodeURIComponent("/")}`, {
       headers: {
-        "Content-Type": "application/json",
         ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
       },
-      body: JSON.stringify({ jsonrpc: "2.0", method: "exists", params: { path: "/" }, id: 1 }),
       signal: AbortSignal.timeout(timeoutMs ?? DEFAULT_HEALTH_TIMEOUT_MS),
     });
     if (resp.ok) return "ok";

--- a/src/tui/resolve-backend.ts
+++ b/src/tui/resolve-backend.ts
@@ -240,9 +240,9 @@ export type NexusHealthStatus =
 /**
  * Lightweight health check against a Nexus server.
  *
- * Sends a minimal JSON-RPC `exists` call to `POST /api/nfs/exists`,
- * which matches the Nexus wire protocol (all VFS ops go through
- * `POST /api/nfs/{method}` as JSON-RPC).
+ * Sends a `GET /api/v2/files/exists?path=/` probe — the v2 file router is
+ * the durable surface across recent Nexus images (PR #3912 dropped the
+ * legacy `/api/nfs/*` JSON-RPC methods).
  */
 export async function checkNexusHealth(
   url: string,

--- a/src/tui/spawn-manager.test.ts
+++ b/src/tui/spawn-manager.test.ts
@@ -977,3 +977,36 @@ describe("SpawnManager — reconciliation", () => {
     expect(registered[0]!.sessionId).toBe("grove-code-reviewer-0--mo3i3zh6");
   });
 });
+
+describe("SpawnManager — delivery state recovery", () => {
+  const makeManager = () => {
+    const provider = makeMockProvider();
+    const tmux = new MockTmuxManager();
+    return new SpawnManager(provider, tmux, () => {}, [{ kind: "local" as const, path: "/tmp" }]);
+  };
+
+  test("markDeliveryRecovered flips disabled → ready", () => {
+    const manager = makeManager();
+    manager.markDeliveryDisabled("transient outage");
+    expect(manager.getDeliveryState()).toBe("disabled");
+
+    manager.markDeliveryRecovered();
+    expect(manager.getDeliveryState()).toBe("ready");
+    expect(manager.getDeliveryDisabledReason()).toBeUndefined();
+  });
+
+  test("markDeliveryRecovered is a no-op when already ready", () => {
+    const manager = makeManager();
+    manager.markDeliveryReady();
+    expect(manager.getDeliveryState()).toBe("ready");
+    manager.markDeliveryRecovered();
+    expect(manager.getDeliveryState()).toBe("ready");
+  });
+
+  test("markDeliveryRecovered resolves pending waiters", async () => {
+    const manager = makeManager();
+    manager.markDeliveryDisabled("outage");
+    manager.markDeliveryRecovered();
+    await expect(manager.testWaitForDelivery(100)).resolves.toBeUndefined();
+  });
+});

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -193,6 +193,41 @@ export class SpawnManager {
   }
 
   /**
+   * Recover from a `disabled` delivery state once the bridge reports a
+   * role's SSE channel has resumed. Without this transition, a transient
+   * Nexus restart that briefly exceeded the unhealthy threshold leaves
+   * the session permanently fail-closed even after the channel is
+   * delivering events again.
+   *
+   * Distinct from `markDeliveryReady()` so callers must opt in: only the
+   * bridge's per-role `onRoleRecovered` should re-arm delivery, never the
+   * normal startup path.
+   */
+  markDeliveryRecovered(): void {
+    if (this.deliveryState !== "disabled") return;
+    this.deliveryState = "ready";
+    this.deliveryDisabledReason = undefined;
+    const waiters = this.deliveryReadyWaiters;
+    this.deliveryReadyWaiters = [];
+    for (const w of waiters) w.resolve();
+  }
+
+  /** @internal — test surface for delivery state assertions */
+  getDeliveryState(): "pending" | "ready" | "disabled" {
+    return this.deliveryState;
+  }
+
+  /** @internal — test surface for delivery state assertions */
+  getDeliveryDisabledReason(): string | undefined {
+    return this.deliveryDisabledReason;
+  }
+
+  /** @internal — test surface for waitForDelivery() (private). */
+  testWaitForDelivery(timeoutMs: number): Promise<void> {
+    return this.waitForDelivery(timeoutMs);
+  }
+
+  /**
    * Wait until the bridge transitions to "ready" or "disabled". Default
    * timeout (120s) covers the full bridge init retry budget plus margin.
    * One connect() attempt = provisionAgents(10s) + probeStreams(10s) =

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -706,17 +706,11 @@ export class SpawnManager {
       throw spawnErr;
     }
 
-    // Step 3b: Provision IPC inbox in Nexus for this role.
-    const nexusUrl = process.env.GROVE_NEXUS_URL;
-    const nexusKey = process.env.NEXUS_API_KEY;
-    if (nexusUrl && nexusKey) {
-      void fetch(`${nexusUrl}/api/v2/ipc/provision/${encodeURIComponent(roleId)}`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${nexusKey}` },
-      }).catch(() => {
-        /* best-effort */
-      });
-    }
+    // Step 3b: Inbox provisioning is handled by Nexus during agent
+    // registration (see nexus/system_services/agent_registration.py — the
+    // post-#3912 code path materializes `/ipc/{role}/inbox/` on first
+    // touch). The legacy `/api/v2/ipc/provision/{role}` route was removed,
+    // so no explicit call is needed here.
 
     // Step 4: Record spawn + register for IPC push + create log buffer.
     // No claims, no heartbeats — agents create claims themselves via grove_claim

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -435,6 +435,13 @@ export const TuiApp: React.NamedExoticComponent<TuiAppProps> = React.memo(functi
                 manager.markDeliveryDisabled(reason);
               }
             },
+            // Recovery: when the SSE channel comes back after a degraded
+            // window, flip delivery back to ready so the session resumes
+            // accepting work instead of staying fail-closed forever.
+            onRoleRecovered: (role) => {
+              process.stderr.write(`[grove] RECOVERED: SSE stream for role=${role}\n`);
+              manager.markDeliveryRecovered();
+            },
           });
           // Bridge readiness is a startup invariant: connect() resolves only
           // after every role passes registration + SSE stream handshake.

--- a/src/tui/views/agent-list.tsx
+++ b/src/tui/views/agent-list.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
 import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntities } from "../hooks/use-entities.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
 import { agentStatusIcon, BRAILLE_SPINNER, timing } from "../theme.js";
@@ -192,11 +193,13 @@ export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.m
       : polledClaims.loading;
     const isStale = useInformerPath ? false : polledClaims.isStale;
     const error = useInformerPath ? entityResult.error : polledClaims.error;
+    // A8.4 (#390): tmux session list re-fetches on producer-side `agent.output`
+    // events (and the global RefreshContext fan-out), no setInterval.
     const {
       data: sessions,
       isStale: tmuxStale,
       error: tmuxError,
-    } = usePolledData<readonly string[]>(tmuxFetcher, intervalMs * 2, active && !!tmux);
+    } = useEventDrivenData<readonly string[]>(tmuxFetcher, undefined, undefined, active && !!tmux);
 
     const costFetcher = useCallback(async () => {
       const cp = provider as unknown as {
@@ -223,7 +226,9 @@ export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.m
       }
       return map;
     }, [provider]);
-    const { data: agentCosts } = usePolledData(costFetcher, intervalMs * 2, active);
+    // A8.4 (#390): cost rollups re-fetch on EventBus events via the global
+    // RefreshContext fan-out (any agent.output / contribution event).
+    const { data: agentCosts } = useEventDrivenData(costFetcher, undefined, undefined, active);
 
     // Combine staleness from both data sources
     const combinedStale = isStale || tmuxStale;

--- a/src/tui/views/artifact-preview.tsx
+++ b/src/tui/views/artifact-preview.tsx
@@ -10,7 +10,7 @@
 
 import React, { createElement, useCallback, useMemo } from "react";
 import { DataStatus } from "../components/data-status.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { ArtifactMeta, TuiArtifactProvider, TuiDataProvider } from "../provider.js";
 import { theme } from "../theme.js";
 
@@ -246,7 +246,8 @@ export interface ArtifactPreviewProps {
   readonly parentCid?: string | undefined;
   /** Whether to show diff view instead of content view. */
   readonly showDiff?: boolean | undefined;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration to useEventDrivenData; kept for caller-stability. */
+  readonly intervalMs?: number;
   readonly active: boolean;
 }
 
@@ -264,7 +265,6 @@ export const ArtifactPreviewView: React.NamedExoticComponent<ArtifactPreviewProp
     artifactIndex,
     parentCid,
     showDiff,
-    intervalMs,
     active,
   }: ArtifactPreviewProps): React.ReactNode {
     const artifactProvider = provider.capabilities.artifacts
@@ -283,9 +283,10 @@ export const ArtifactPreviewView: React.NamedExoticComponent<ArtifactPreviewProp
       return { meta, content };
     }, [artifactProvider, cid, artifactName]);
 
-    const { data, loading, error, isStale } = usePolledData<ArtifactData | undefined>(
+    const { data, loading, error, isStale } = useEventDrivenData<ArtifactData | undefined>(
       fetcher,
-      intervalMs,
+      undefined,
+      undefined,
       active,
     );
 
@@ -300,10 +301,11 @@ export const ArtifactPreviewView: React.NamedExoticComponent<ArtifactPreviewProp
       data: diffData,
       loading: diffLoading,
       error: diffError,
-    } = usePolledData<DiffData | undefined>(
+    } = useEventDrivenData<DiffData | undefined>(
       diffFetcher,
-      intervalMs,
-      active && showDiff && parentCid !== undefined,
+      undefined,
+      undefined,
+      active && showDiff === true && parentCid !== undefined,
     );
 
     // Build artifact selector header

--- a/src/tui/views/bounties-panel.tsx
+++ b/src/tui/views/bounties-panel.tsx
@@ -13,13 +13,14 @@ import { formatTimestamp, truncateCid } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import { isBountyProvider, type TuiDataProvider } from "../provider.js";
 
 /** Props for the BountiesPanel view. */
 export interface BountiesPanelProps {
   readonly provider: TuiDataProvider;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration to useEventDrivenData; kept for caller-stability. */
+  readonly intervalMs?: number;
   readonly active: boolean;
   readonly cursor: number;
   readonly onRowCountChanged?: ((count: number) => void) | undefined;
@@ -47,7 +48,6 @@ const COLUMNS = [
 export const BountiesPanelView: React.NamedExoticComponent<BountiesPanelProps> = React.memo(
   function BountiesPanelView({
     provider,
-    intervalMs,
     active,
     cursor,
     onRowCountChanged,
@@ -69,9 +69,10 @@ export const BountiesPanelView: React.NamedExoticComponent<BountiesPanelProps> =
       }));
     }, [provider]);
 
-    const { data, loading, isStale, error } = usePolledData<readonly BountyRow[]>(
+    const { data, loading, isStale, error } = useEventDrivenData<readonly BountyRow[]>(
       fetcher,
-      intervalMs,
+      undefined,
+      undefined,
       active,
     );
 

--- a/src/tui/views/decisions-panel.tsx
+++ b/src/tui/views/decisions-panel.tsx
@@ -11,13 +11,14 @@ import { formatTimestamp } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { PendingQuestion, TuiAskUserProvider, TuiDataProvider } from "../provider.js";
 
 /** Props for the DecisionsPanel view. */
 export interface DecisionsPanelProps {
   readonly provider: TuiDataProvider;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration to useEventDrivenData; kept for caller-stability. */
+  readonly intervalMs?: number;
   readonly active: boolean;
   readonly cursor: number;
   readonly onRowCountChanged?: ((count: number) => void) | undefined;
@@ -50,7 +51,6 @@ function hasAskUser(provider: TuiDataProvider): provider is TuiDataProvider & Tu
 export const DecisionsPanelView: React.NamedExoticComponent<DecisionsPanelProps> = React.memo(
   function DecisionsPanelView({
     provider,
-    intervalMs,
     active,
     cursor,
     onRowCountChanged,
@@ -75,9 +75,10 @@ export const DecisionsPanelView: React.NamedExoticComponent<DecisionsPanelProps>
       }));
     }, [provider, supportsAskUser]);
 
-    const { data, loading, isStale, error } = usePolledData<readonly DecisionRow[]>(
+    const { data, loading, isStale, error } = useEventDrivenData<readonly DecisionRow[]>(
       fetcher,
-      intervalMs,
+      undefined,
+      undefined,
       active,
     );
 

--- a/src/tui/views/github-panel.tsx
+++ b/src/tui/views/github-panel.tsx
@@ -9,14 +9,15 @@
 import React, { useCallback } from "react";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { GitHubPRSummary, TuiDataProvider, TuiGitHubProvider } from "../provider.js";
 import { theme } from "../theme.js";
 
 /** Props for the GitHubPanel view. */
 export interface GitHubPanelProps {
   readonly provider: TuiDataProvider;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration; producer-side `github.pr.changed` drives re-fetch. */
+  readonly intervalMs?: number;
   readonly active: boolean;
   readonly cursor: number;
   readonly onRowCountChanged?: ((count: number) => void) | undefined;
@@ -34,7 +35,6 @@ function hasGitHub(provider: TuiDataProvider): provider is TuiDataProvider & Tui
 export const GitHubPanelView: React.NamedExoticComponent<GitHubPanelProps> = React.memo(
   function GitHubPanelView({
     provider,
-    intervalMs,
     active,
     cursor,
     onRowCountChanged,
@@ -51,9 +51,10 @@ export const GitHubPanelView: React.NamedExoticComponent<GitHubPanelProps> = Rea
       return (provider as unknown as TuiGitHubProvider).getActivePR();
     }, [provider, supportsGitHub]);
 
-    const { data, loading, isStale, error } = usePolledData<GitHubPRSummary | undefined>(
+    const { data, loading, isStale, error } = useEventDrivenData<GitHubPRSummary | undefined>(
       fetcher,
-      intervalMs,
+      undefined,
+      undefined,
       active,
     );
 

--- a/src/tui/views/gossip-panel.tsx
+++ b/src/tui/views/gossip-panel.tsx
@@ -12,13 +12,14 @@ import { formatTimestamp } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import { isGossipProvider, type TuiDataProvider } from "../provider.js";
 
 /** Props for the GossipPanel view. */
 export interface GossipPanelProps {
   readonly provider: TuiDataProvider;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration to useEventDrivenData; kept for caller-stability. */
+  readonly intervalMs?: number;
   readonly active: boolean;
   readonly cursor: number;
   readonly onRowCountChanged?: ((count: number) => void) | undefined;
@@ -44,7 +45,6 @@ const COLUMNS = [
 export const GossipPanelView: React.NamedExoticComponent<GossipPanelProps> = React.memo(
   function GossipPanelView({
     provider,
-    intervalMs,
     active,
     cursor,
     onRowCountChanged,
@@ -67,9 +67,10 @@ export const GossipPanelView: React.NamedExoticComponent<GossipPanelProps> = Rea
       }));
     }, [provider]);
 
-    const { data, loading, isStale, error } = usePolledData<readonly PeerRow[]>(
+    const { data, loading, isStale, error } = useEventDrivenData<readonly PeerRow[]>(
       fetcher,
-      intervalMs,
+      undefined,
+      undefined,
       active,
     );
 

--- a/src/tui/views/handoffs-view.tsx
+++ b/src/tui/views/handoffs-view.tsx
@@ -13,7 +13,7 @@ import type { HandoffQuery } from "../../core/handoff.js";
 import { type Handoff, HandoffStatus } from "../../core/handoff.js";
 import { truncateCid } from "../../shared/format.js";
 import { Table } from "../components/table.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { TuiDataProvider } from "../provider.js";
 import { isHandoffProvider } from "../provider.js";
 import { theme } from "../theme.js";
@@ -88,7 +88,8 @@ function isOverdue(h: Handoff): boolean {
 
 export interface HandoffsViewProps {
   readonly provider: TuiDataProvider;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration to useEventDrivenData; kept for caller-stability. */
+  readonly intervalMs?: number;
   readonly active: boolean;
   readonly cursor: number;
   /** Filter by status. Omit to show all. */
@@ -97,8 +98,7 @@ export interface HandoffsViewProps {
   readonly toRoleFilter?: string | undefined;
   /** ISO timestamp — only show handoffs created at or after this time (current session). */
   readonly sessionStartedAt?: string | undefined;
-  /** Pre-fetched handoffs from parent. When provided, skips internal usePolledData
-   *  (which doesn't work in OpenTUI due to component unmount/remount cycles). */
+  /** Pre-fetched handoffs from parent. When provided, skips the internal fetch. */
   readonly handoffs?: readonly Handoff[] | undefined;
 }
 
@@ -106,7 +106,6 @@ export interface HandoffsViewProps {
 export const HandoffsView: React.NamedExoticComponent<HandoffsViewProps> = React.memo(
   function HandoffsView({
     provider,
-    intervalMs,
     active,
     cursor,
     statusFilter,
@@ -114,7 +113,6 @@ export const HandoffsView: React.NamedExoticComponent<HandoffsViewProps> = React
     sessionStartedAt,
     handoffs: prefetched,
   }: HandoffsViewProps): React.ReactNode {
-    // usePolledData's setInterval doesn't survive OpenTUI's component unmount/remount.
     // When parent provides pre-fetched handoffs, use those directly.
     const fetcher = useCallback(async () => {
       if (!isHandoffProvider(provider)) return [] as readonly Handoff[];
@@ -128,9 +126,14 @@ export const HandoffsView: React.NamedExoticComponent<HandoffsViewProps> = React
       return all.filter((h) => h.createdAt >= cutoff);
     }, [provider, statusFilter, toRoleFilter, sessionStartedAt]);
 
-    const polled = usePolledData<readonly Handoff[]>(fetcher, intervalMs, active && !prefetched);
-    const data = prefetched ?? polled.data;
-    const loading = prefetched ? false : polled.loading;
+    const driven = useEventDrivenData<readonly Handoff[]>(
+      fetcher,
+      undefined,
+      undefined,
+      active && !prefetched,
+    );
+    const data = prefetched ?? driven.data;
+    const loading = prefetched ? false : driven.loading;
 
     if (!isHandoffProvider(provider)) {
       return (

--- a/src/tui/views/inbox-panel.tsx
+++ b/src/tui/views/inbox-panel.tsx
@@ -11,13 +11,14 @@ import { formatTimestamp } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { InboxMessage, TuiDataProvider, TuiMessagingProvider } from "../provider.js";
 
 /** Props for the InboxPanel view. */
 export interface InboxPanelProps {
   readonly provider: TuiDataProvider;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration to useEventDrivenData; kept for caller-stability. */
+  readonly intervalMs?: number;
   readonly active: boolean;
   readonly cursor: number;
   readonly onRowCountChanged?: ((count: number) => void) | undefined;
@@ -52,7 +53,6 @@ function hasMessaging(
 export const InboxPanelView: React.NamedExoticComponent<InboxPanelProps> = React.memo(
   function InboxPanelView({
     provider,
-    intervalMs,
     active,
     cursor,
     onRowCountChanged,
@@ -80,9 +80,10 @@ export const InboxPanelView: React.NamedExoticComponent<InboxPanelProps> = React
       }));
     }, [provider, supportsMessaging]);
 
-    const { data, loading, isStale, error } = usePolledData<readonly MessageRow[]>(
+    const { data, loading, isStale, error } = useEventDrivenData<readonly MessageRow[]>(
       fetcher,
-      intervalMs,
+      undefined,
+      undefined,
       active,
     );
 

--- a/src/tui/views/outcomes-panel.tsx
+++ b/src/tui/views/outcomes-panel.tsx
@@ -11,13 +11,14 @@ import { formatTimestamp, truncateCid } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { TuiDataProvider, TuiOutcomeProvider } from "../provider.js";
 
 /** Props for the OutcomesPanel view. */
 export interface OutcomesPanelProps {
   readonly provider: TuiDataProvider;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration to useEventDrivenData; kept for caller-stability. */
+  readonly intervalMs?: number;
   readonly active: boolean;
   readonly cursor: number;
   readonly onRowCountChanged?: ((count: number) => void) | undefined;
@@ -51,7 +52,6 @@ function hasOutcomes(provider: TuiDataProvider): provider is TuiDataProvider & T
 export const OutcomesPanelView: React.NamedExoticComponent<OutcomesPanelProps> = React.memo(
   function OutcomesPanelView({
     provider,
-    intervalMs,
     active,
     cursor,
     onRowCountChanged,
@@ -75,9 +75,10 @@ export const OutcomesPanelView: React.NamedExoticComponent<OutcomesPanelProps> =
       }));
     }, [provider, supportsOutcomes]);
 
-    const { data, loading, isStale, error } = usePolledData<readonly OutcomeRow[]>(
+    const { data, loading, isStale, error } = useEventDrivenData<readonly OutcomeRow[]>(
       fetcher,
-      intervalMs,
+      undefined,
+      undefined,
       active,
     );
 

--- a/src/tui/views/pipeline-view.tsx
+++ b/src/tui/views/pipeline-view.tsx
@@ -13,6 +13,7 @@ import type { TmuxManager } from "../agents/tmux-manager.js";
 import { agentIdFromSession } from "../agents/tmux-manager.js";
 import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntities } from "../hooks/use-entities.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import { usePolledData } from "../hooks/use-polled-data.js";
 import type { TuiDataProvider } from "../provider.js";
 import { BRAILLE_SPINNER, PLATFORM_COLORS, theme } from "../theme.js";
@@ -194,9 +195,12 @@ export const PipelineView: React.NamedExoticComponent<PipelineViewProps> = React
       if (!available) return [] as readonly string[];
       return tmux.listSessions();
     }, [tmux]);
-    const { data: sessions } = usePolledData<readonly string[]>(
+    // A8.4 (#390): tmux session list re-fetches on producer-side `agent.output`
+    // events via the global RefreshContext fan-out — no setInterval here.
+    const { data: sessions } = useEventDrivenData<readonly string[]>(
       sessionsFetcher,
-      intervalMs * 2,
+      undefined,
+      undefined,
       active && !!tmux,
     );
 
@@ -215,9 +219,11 @@ export const PipelineView: React.NamedExoticComponent<PipelineViewProps> = React
       );
       return new Map(entries);
     }, [tmux, sessions]);
-    const { data: outputs } = usePolledData<Map<string, string>>(
+    // A8.4 (#390): per-session pane capture is event-driven (agent.output).
+    const { data: outputs } = useEventDrivenData<Map<string, string>>(
       outputsFetcher,
-      intervalMs * 2,
+      undefined,
+      undefined,
       active && !!tmux && (sessions?.length ?? 0) > 0,
     );
 

--- a/src/tui/views/search-panel.tsx
+++ b/src/tui/views/search-panel.tsx
@@ -11,9 +11,11 @@
  *
  * PR2 (#388): the empty-query branch ("showing recent contributions")
  * reads from the informer cache via `useEntities("Contribution")` when a
- * factory is mounted. Full-text search (`searchQuery !== ""`) stays on
- * `usePolledData` until PR4 — the search backend isn't projected through
- * the watch protocol.
+ * factory is mounted.
+ * PR4 (#390): full-text search (`searchQuery !== ""`) migrates from
+ * `usePolledData` to `useEventDrivenData` — the search backend isn't
+ * projected through the watch protocol but re-runs on the global refresh
+ * fan-out (any contribution event invalidates the result set).
  */
 
 import React, { useCallback, useEffect, useMemo } from "react";
@@ -25,14 +27,15 @@ import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
 import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useEntities } from "../hooks/use-entities.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import { isSearchProvider, type TuiArtifactProvider, type TuiDataProvider } from "../provider.js";
 import { theme } from "../theme.js";
 
 /** Props for the SearchPanel view. */
 export interface SearchPanelProps {
   readonly provider: TuiDataProvider;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration to useEventDrivenData; kept for caller-stability. */
+  readonly intervalMs?: number;
   readonly active: boolean;
   readonly cursor: number;
   readonly searchQuery: string;
@@ -122,7 +125,6 @@ function entityToContribution(e: ContributionEntity): Contribution {
 export const SearchPanelView: React.NamedExoticComponent<SearchPanelProps> = React.memo(
   function SearchPanelView({
     provider,
-    intervalMs,
     active,
     cursor,
     searchQuery,
@@ -150,9 +152,10 @@ export const SearchPanelView: React.NamedExoticComponent<SearchPanelProps> = Rea
       return (provider as TuiDataProvider & TuiArtifactProvider).search(searchQuery);
     }, [provider, searchQuery, hasSearch]);
 
-    const polled = usePolledData<readonly Contribution[]>(
+    const driven = useEventDrivenData<readonly Contribution[]>(
       fetcher,
-      intervalMs,
+      undefined,
+      undefined,
       active && !useInformerPath,
     );
 
@@ -163,14 +166,14 @@ export const SearchPanelView: React.NamedExoticComponent<SearchPanelProps> = Rea
         );
         return sorted.slice(0, RECENT_LIMIT).map(entityToContribution);
       }
-      return polled.data ?? undefined;
-    }, [useInformerPath, entityResult.data, polled.data]);
+      return driven.data ?? undefined;
+    }, [useInformerPath, entityResult.data, driven.data]);
 
     const loading = useInformerPath
       ? !entityResult.hasSynced && data === undefined
-      : polled.loading;
-    const isStale = useInformerPath ? false : polled.isStale;
-    const error = useInformerPath ? entityResult.error : polled.error;
+      : driven.loading;
+    const isStale = useInformerPath ? false : driven.isStale;
+    const error = useInformerPath ? entityResult.error : driven.error;
 
     useEffect(() => {
       if (data && onRowCountChanged) {

--- a/src/tui/views/terminal.tsx
+++ b/src/tui/views/terminal.tsx
@@ -17,8 +17,8 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import type { TmuxManager } from "../agents/tmux-manager.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { InputMode } from "../hooks/use-panel-focus.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
 import { theme } from "../theme.js";
 
 // ---------------------------------------------------------------------------
@@ -306,7 +306,8 @@ const VIEWPORT_LINES = 30;
 export interface TerminalProps {
   readonly sessionName?: string | undefined;
   readonly tmux?: TmuxManager | undefined;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration; producer-side `agent.output` events drive re-fetch. */
+  readonly intervalMs?: number;
   readonly active: boolean;
   readonly mode: InputMode;
   /** Scroll offset from the bottom (0 = auto-scroll, >0 = pinned). */
@@ -319,14 +320,12 @@ export const TerminalView: React.NamedExoticComponent<TerminalProps> = React.mem
   function TerminalView({
     sessionName,
     tmux,
-    intervalMs,
     active,
     mode,
     scrollOffset,
     onScrollChange: _onScrollChange,
   }: TerminalProps): React.ReactNode {
     void _onScrollChange; // available for parent scroll tracking
-    const captureMs = Math.max(intervalMs, 200);
     const [xtermReady, setXtermReady] = useState(xtermModule !== null);
 
     useEffect(() => {
@@ -359,9 +358,10 @@ export const TerminalView: React.NamedExoticComponent<TerminalProps> = React.mem
       return tmux.capturePanes(sessionName);
     }, [tmux, sessionName]);
 
-    const { data: output } = usePolledData<string>(
+    const { data: output } = useEventDrivenData<string>(
       fetcher,
-      captureMs,
+      undefined,
+      undefined,
       active && !!sessionName && !!tmux,
     );
 

--- a/src/tui/views/threads-panel.tsx
+++ b/src/tui/views/threads-panel.tsx
@@ -11,13 +11,14 @@ import { formatTimestamp, truncateCid } from "../../shared/format.js";
 import { DataStatus } from "../components/data-status.js";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { TuiDataProvider } from "../provider.js";
 
 /** Props for the ThreadsPanel view. */
 export interface ThreadsPanelProps {
   readonly provider: TuiDataProvider;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration to useEventDrivenData; kept for caller-stability. */
+  readonly intervalMs?: number;
   readonly active: boolean;
   readonly cursor: number;
   readonly onRowCountChanged?: ((count: number) => void) | undefined;
@@ -35,15 +36,15 @@ const COLUMNS = [
 export const ThreadsPanelView: React.NamedExoticComponent<ThreadsPanelProps> = React.memo(
   function ThreadsPanelView({
     provider,
-    intervalMs,
     active,
     cursor,
     onRowCountChanged,
   }: ThreadsPanelProps): React.ReactNode {
     const fetcher = useCallback(() => provider.getHotThreads(20), [provider]);
-    const { data, loading, isStale, error } = usePolledData<readonly ThreadSummary[]>(
+    const { data, loading, isStale, error } = useEventDrivenData<readonly ThreadSummary[]>(
       fetcher,
-      intervalMs,
+      undefined,
+      undefined,
       active,
     );
 

--- a/src/tui/views/vfs-browser.tsx
+++ b/src/tui/views/vfs-browser.tsx
@@ -8,14 +8,15 @@
 import React, { createElement, useCallback, useEffect, useRef, useState } from "react";
 import { EmptyState } from "../components/empty-state.js";
 import { Table } from "../components/table.js";
-import { usePolledData } from "../hooks/use-polled-data.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { FsEntry, TuiDataProvider, TuiVfsProvider } from "../provider.js";
 import { theme } from "../theme.js";
 
 /** Props for the VFS browser view. */
 export interface VfsBrowserProps {
   readonly provider: TuiDataProvider;
-  readonly intervalMs: number;
+  /** Unused after A8.4 migration to useEventDrivenData; kept for caller-stability. */
+  readonly intervalMs?: number;
   readonly active: boolean;
   readonly cursor: number;
   /** Incremented by parent when Enter is pressed; triggers navigation into directories. */
@@ -216,7 +217,6 @@ function FilePreview({ name, content, loading, error }: FilePreviewProps): React
 export const VfsBrowserView: React.NamedExoticComponent<VfsBrowserProps> = React.memo(
   function VfsBrowserView({
     provider,
-    intervalMs,
     active,
     cursor,
     navigateTrigger,
@@ -232,9 +232,10 @@ export const VfsBrowserView: React.NamedExoticComponent<VfsBrowserProps> = React
       return vfsProvider.listPath(currentPath);
     }, [vfsProvider, currentPath]);
 
-    const { data: entries, loading } = usePolledData<readonly FsEntry[]>(
+    const { data: entries, loading } = useEventDrivenData<readonly FsEntry[]>(
       fetcher,
-      intervalMs,
+      undefined,
+      undefined,
       active && isVfsProvider(provider),
     );
 


### PR DESCRIPTION
## Summary

PR4 of 5 in the polling-retirement epic (#295). Migrates the non-Entity
TUI panels from `usePolledData` to `useEventDrivenData` and adds three
producer-side publishers for sources that previously had no event hook.

**Hook refactor** — `useEventDrivenData` now also subscribes to
`RefreshContext`, which `app.tsx` already bumps on every EventBus event
for every topology role. Panels migrate without prop-drilling
`eventBus`/`role`; they ride the existing fan-out.

**View migrations** (15 files):
- threads, bounties, outcomes, decisions, inbox, handoffs, gossip,
  search (full-text), github panels.
- vfs-browser, artifact-preview.
- terminal, agent-split-pane.
- agent-list tmux/session list + cost rollups (active claim stays
  lease-aware via `usePolledData`, per PR3 hardening).
- pipeline-view sessions + outputs (claim list also stays lease-aware).

**Producers** (out of `src/tui/`):
- `src/local/vfs-event-publisher.ts` — `fs.watch` on
  `.grove/workspaces/`, 200 ms coalesce window, emits `vfs.changed`.
- `src/local/agent-output-publisher.ts` — polls `tmux.capturePanes`
  per session, hashes content, emits `agent.output` only on change.
- `src/local/github-pr-publisher.ts` — polls `getActivePR()` (default
  60 s), emits `github.pr.changed` on snapshot mutation.

All three target the new `TUI_REFRESH_ROLE` pseudo-role so the existing
app-level subscription catches them.

## Test plan

- [x] `bun test src/local/vfs-event-publisher.test.ts src/local/agent-output-publisher.test.ts src/local/github-pr-publisher.test.ts` — 12/12 pass
- [x] `bun test src/tui/views src/tui/hooks` — green except 2 pre-existing `react-test-renderer` import errors
- [x] `bun tsc --noEmit -p tsconfig.json` clean
- [x] `bun run check` clean
- [ ] Live tmux TUI smoke (panel re-fetch on agent contribution + workspace edit)
- [ ] Soak test on a Grove with 10+ active agents (event volume)

## Acceptance (per #390)

- ✅ Every migrated view re-fetches on the relevant EventBus event.
- ✅ No `setInterval` remains in any migrated view's hook chain.
- ✅ Producer-side polling lives outside `src/tui/`.

The remaining `setInterval`s in `src/tui/` (claim-cleanup loops in
`main.ts`, spinner animations, lease-aware claim polling, pre-A8
hooks like `use-agent-monitor`) are out of PR4 scope; PR5 (#391)
finishes the cleanup and adds the CI grep gate.

Closes #390.