### PR TITLE
[codex] Fix review feedback for session and CAS safety

### DIFF
--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -136,6 +136,21 @@ describe("SqliteContributionStore ordering", () => {
   });
 });
 
+describe("SqliteStore session filtering", () => {
+  test("fresh legacy store returns empty results for a session filter", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-session-filter-"));
+    const dbPath = join(dir, "test.db");
+    const store = new SqliteStore(dbPath);
+    try {
+      expect(await store.list({ sessionId: "missing-session" })).toEqual([]);
+      expect(await store.count({ sessionId: "missing-session" })).toBe(0);
+    } finally {
+      store.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // putMany with rich contributions (relations, tags, artifacts)
 // ---------------------------------------------------------------------------

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -38,7 +38,7 @@ import type {
 } from "../core/store.js";
 import { ExpiryReason } from "../core/store.js";
 import { BOUNTY_DDL, SqliteBountyStore } from "./sqlite-bounty-store.js";
-import { SqliteGoalSessionStore } from "./sqlite-goal-session-store.js";
+import { GOAL_SESSION_DDL, SqliteGoalSessionStore } from "./sqlite-goal-session-store.js";
 import { HANDOFF_DDL, SqliteHandoffStore } from "./sqlite-handoff-store.js";
 import { SqliteOutcomeStore } from "./sqlite-outcome-store.js";
 
@@ -234,6 +234,7 @@ export function initSqliteDb(dbPath: string): Database {
   const initSchema = db.transaction(() => {
     db.exec(SCHEMA_DDL);
     db.exec(FTS_DDL);
+    db.exec(GOAL_SESSION_DDL);
 
     // Pre-HANDOFF_DDL column-safe migration: legacy handoffs tables (pre-#164)
     // lack session_id/seen_at/acked_at/ipc_message_id. HANDOFF_DDL now includes

--- a/src/nexus/config.ts
+++ b/src/nexus/config.ts
@@ -40,6 +40,15 @@ export interface NexusConfig {
    */
   readonly existsThresholdBytes?: number | undefined;
 
+  /**
+   * Maximum file size accepted by NexusCas.putFile().
+   *
+   * Nexus currently uploads blobs through a JSON/base64 transport, so putFile()
+   * must reject very large files before reading them into memory. Defaults to
+   * 67,108,864 bytes (64 MiB).
+   */
+  readonly maxPutFileBytes?: number | undefined;
+
   /** Maximum entries in the LRU cache for immutable data. Defaults to 1000. */
   readonly cacheMaxEntries?: number | undefined;
 
@@ -60,6 +69,7 @@ export interface ResolvedNexusConfig {
   readonly sessionId: string | undefined;
   readonly maxConcurrency: number;
   readonly existsThresholdBytes: number;
+  readonly maxPutFileBytes: number;
   readonly cacheMaxEntries: number;
   readonly retryMaxAttempts: number;
   readonly retryBaseDelayMs: number;
@@ -75,6 +85,7 @@ export function resolveConfig(config: NexusConfig): ResolvedNexusConfig {
     sessionId: config.sessionId,
     maxConcurrency: config.maxConcurrency ?? 20,
     existsThresholdBytes: config.existsThresholdBytes ?? 65_536,
+    maxPutFileBytes: config.maxPutFileBytes ?? 67_108_864,
     cacheMaxEntries: config.cacheMaxEntries ?? 1_000,
     retryMaxAttempts: config.retryMaxAttempts ?? 3,
     retryBaseDelayMs: config.retryBaseDelayMs ?? 100,

--- a/src/nexus/nexus-cas.ts
+++ b/src/nexus/nexus-cas.ts
@@ -16,7 +16,7 @@
  * - Retry with exponential backoff for transient errors
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 
 import { hash } from "blake3";
@@ -227,6 +227,13 @@ export class NexusCas implements ContentStore {
   async putFile(filePath: string, options?: PutOptions): Promise<string> {
     const mediaType = options?.mediaType || undefined;
     if (mediaType) validateMediaType(mediaType);
+
+    const fileSizeBytes = statSync(filePath).size;
+    if (fileSizeBytes > this.config.maxPutFileBytes) {
+      throw new Error(
+        `File '${filePath}' is ${fileSizeBytes} bytes, exceeds Nexus CAS putFile limit of ${this.config.maxPutFileBytes} bytes`,
+      );
+    }
 
     // Read file and compute hash
     const fileData = new Uint8Array(readFileSync(filePath));

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -18,6 +18,7 @@ import type { AgentTopology } from "../../core/topology.js";
 import { AgentTopologySchema, wireToTopology } from "../../core/topology.js";
 import { resolveTopology } from "../../core/topology-resolver.js";
 import type { ServerEnv } from "../deps.js";
+import { CID_REGEX } from "../schemas.js";
 import { contributionStoreForSession, notConfigured, readJsonBody } from "./shared.js";
 
 // ---------------------------------------------------------------------------
@@ -35,7 +36,7 @@ const createSessionSchema = z.object({
 });
 
 const addContributionSchema = z.object({
-  cid: z.string().min(1),
+  cid: z.string().regex(CID_REGEX, "CID must be in format blake3:<64-hex-chars>"),
 });
 
 // ---------------------------------------------------------------------------
@@ -264,27 +265,37 @@ sessions.post("/:id/contributions", async (c) => {
     return c.json({ error: { code: "VALIDATION_ERROR", details: parsed.error.issues } }, 400);
   }
 
-  // Verify contribution exists and run policy enforcement when possible
   const contributionStore = contributionStoreForSession(deps, sessionId);
-  const contribution = await contributionStore.get(parsed.data.cid);
-  if (contribution) {
-    // Policy enforcement against session config (only when contribution is available)
-    const sessionConfig = await goalSessionStore.getSessionConfig(sessionId);
-    if (sessionConfig) {
-      const { PolicyEnforcer } = await import("../../core/policy-enforcer.js");
-      const enforcer = new PolicyEnforcer(sessionConfig, contributionStore);
-      const result = await enforcer.enforce(contribution, false);
-      if (result.violations && result.violations.length > 0) {
-        return c.json(
-          {
-            error: {
-              code: "VALIDATION_ERROR",
-              message: `Contribution violates session policy: ${result.violations.map((v: { message: string }) => v.message).join(", ")}`,
-            },
+  const authoritativeStore =
+    deps.contributionStoreForSession !== undefined ? contributionStore : deps.contributionStore;
+  const contribution = await authoritativeStore.get(parsed.data.cid);
+  if (contribution === undefined) {
+    return c.json(
+      {
+        error: {
+          code: "NOT_FOUND",
+          message: `Contribution not found: ${parsed.data.cid}`,
+        },
+      },
+      404,
+    );
+  }
+
+  const sessionConfig = await goalSessionStore.getSessionConfig(sessionId);
+  if (sessionConfig) {
+    const { PolicyEnforcer } = await import("../../core/policy-enforcer.js");
+    const enforcer = new PolicyEnforcer(sessionConfig, contributionStore);
+    const result = await enforcer.enforce(contribution, false);
+    if (result.violations && result.violations.length > 0) {
+      return c.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: `Contribution violates session policy: ${result.violations.map((v: { message: string }) => v.message).join(", ")}`,
           },
-          400,
-        );
-      }
+        },
+        400,
+      );
     }
   }
 

--- a/tests/nexus/unit/nexus-cas.test.ts
+++ b/tests/nexus/unit/nexus-cas.test.ts
@@ -6,6 +6,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { runContentStoreTests } from "../../../src/core/cas.conformance.js";
 import type {
@@ -179,6 +182,24 @@ describe("NexusCas adapter-specific", () => {
     expect(artifact?.sizeBytes).toBe(data.byteLength);
     store.close();
     await encodedClient.close();
+  });
+
+  test("putFile rejects files above configured maxPutFileBytes before upload", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "nexus-cas-putfile-limit-"));
+    const filePath = join(dir, "artifact.bin");
+    await writeFile(filePath, new Uint8Array([1, 2, 3, 4]));
+    const store = new NexusCas({
+      client,
+      zoneId: "test",
+      maxPutFileBytes: 3,
+      retryMaxAttempts: 1,
+    });
+    try {
+      await expect(store.putFile(filePath)).rejects.toThrow("exceeds Nexus CAS putFile limit");
+    } finally {
+      store.close();
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   describe("existsMany", () => {

--- a/tests/server/goals-sessions.test.ts
+++ b/tests/server/goals-sessions.test.ts
@@ -10,7 +10,9 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Hono } from "hono";
+import type { GroveContract } from "../../src/core/contract.js";
 import { DefaultFrontierCalculator } from "../../src/core/frontier.js";
+import { makeContribution } from "../../src/core/test-helpers.js";
 import { WatchHub } from "../../src/core/watch-hub.js";
 import { FsCas } from "../../src/local/fs-cas.js";
 import { createSqliteStores } from "../../src/local/sqlite-store.js";
@@ -33,11 +35,14 @@ const GS_TEST_REGISTRY: KeyRegistry = new Map([[GS_TEST_KEY, GS_TEST_NAMESPACE]]
 
 interface GoalSessionTestContext {
   readonly app: Hono<ServerEnv>;
+  readonly stores: ReturnType<typeof createSqliteStores>;
   readonly tempDir: string;
   readonly cleanup: () => Promise<void>;
 }
 
-async function createGoalSessionContext(): Promise<GoalSessionTestContext> {
+async function createGoalSessionContext(options?: {
+  readonly contract?: GroveContract | undefined;
+}): Promise<GoalSessionTestContext> {
   const tempDir = await mkdtemp(join(tmpdir(), "grove-goals-test-"));
   const dbPath = join(tempDir, "test.db");
   const casDir = join(tempDir, "cas");
@@ -53,7 +58,7 @@ async function createGoalSessionContext(): Promise<GoalSessionTestContext> {
     cas,
     frontier,
     goalSessionStore: stores.goalSessionStore,
-    contract: { contractVersion: 3, name: "test-contract" },
+    contract: options?.contract ?? { contractVersion: 3, name: "test-contract" },
     watchHub: new WatchHub(),
   };
 
@@ -61,6 +66,7 @@ async function createGoalSessionContext(): Promise<GoalSessionTestContext> {
 
   return {
     app,
+    stores,
     tempDir,
     cleanup: async () => {
       stores.close();
@@ -351,7 +357,32 @@ describe("PUT /api/sessions/:id/archive", () => {
 });
 
 describe("POST /api/sessions/:id/contributions", () => {
-  test("adds contribution to session", async () => {
+  test("adds an existing contribution to session", async () => {
+    const createRes = await ctx.app.request("/api/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...GS_TEST_AUTH_HEADERS },
+      body: JSON.stringify({}),
+    });
+    const created = await createRes.json();
+    const contribution = makeContribution({ summary: "stored contribution" });
+    await ctx.stores.contributionStore.put(contribution);
+
+    const res = await ctx.app.request(`/api/sessions/${created.sessionId}/contributions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...GS_TEST_AUTH_HEADERS },
+      body: JSON.stringify({ cid: contribution.cid }),
+    });
+    expect(res.status).toBe(204);
+
+    // Verify contribution count increased
+    const getRes = await ctx.app.request(`/api/sessions/${created.sessionId}`, {
+      headers: GS_TEST_AUTH_HEADERS,
+    });
+    const data = await getRes.json();
+    expect(data.contributionCount).toBe(1);
+  });
+
+  test("rejects malformed CIDs", async () => {
     const createRes = await ctx.app.request("/api/sessions", {
       method: "POST",
       headers: { "Content-Type": "application/json", ...GS_TEST_AUTH_HEADERS },
@@ -364,14 +395,71 @@ describe("POST /api/sessions/:id/contributions", () => {
       headers: { "Content-Type": "application/json", ...GS_TEST_AUTH_HEADERS },
       body: JSON.stringify({ cid: "blake3:abc123" }),
     });
-    expect(res.status).toBe(204);
+    expect(res.status).toBe(400);
 
-    // Verify contribution count increased
     const getRes = await ctx.app.request(`/api/sessions/${created.sessionId}`, {
       headers: GS_TEST_AUTH_HEADERS,
     });
     const data = await getRes.json();
-    expect(data.contributionCount).toBe(1);
+    expect(data.contributionCount).toBe(0);
+  });
+
+  test("rejects well-formed CIDs that are not stored contributions", async () => {
+    const createRes = await ctx.app.request("/api/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...GS_TEST_AUTH_HEADERS },
+      body: JSON.stringify({}),
+    });
+    const created = await createRes.json();
+    const missingCid = `blake3:${"0".repeat(64)}`;
+
+    const res = await ctx.app.request(`/api/sessions/${created.sessionId}/contributions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...GS_TEST_AUTH_HEADERS },
+      body: JSON.stringify({ cid: missingCid }),
+    });
+    expect(res.status).toBe(404);
+
+    const getRes = await ctx.app.request(`/api/sessions/${created.sessionId}`, {
+      headers: GS_TEST_AUTH_HEADERS,
+    });
+    const data = await getRes.json();
+    expect(data.contributionCount).toBe(0);
+  });
+
+  test("enforces session policy before attaching a stored contribution", async () => {
+    const policyCtx = await createGoalSessionContext({
+      contract: {
+        contractVersion: 3,
+        name: "policy-test",
+        gates: [{ type: "min_score", metric: "quality", threshold: 0.7 }],
+      },
+    });
+    try {
+      const createRes = await policyCtx.app.request("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...GS_TEST_AUTH_HEADERS },
+        body: JSON.stringify({}),
+      });
+      const created = await createRes.json();
+      const contribution = makeContribution({ summary: "missing quality score" });
+      await policyCtx.stores.contributionStore.put(contribution);
+
+      const res = await policyCtx.app.request(`/api/sessions/${created.sessionId}/contributions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...GS_TEST_AUTH_HEADERS },
+        body: JSON.stringify({ cid: contribution.cid }),
+      });
+      expect(res.status).toBe(400);
+
+      const getRes = await policyCtx.app.request(`/api/sessions/${created.sessionId}`, {
+        headers: GS_TEST_AUTH_HEADERS,
+      });
+      const data = await getRes.json();
+      expect(data.contributionCount).toBe(0);
+    } finally {
+      await policyCtx.cleanup();
+    }
   });
 
   test("returns 404 for missing session", async () => {


### PR DESCRIPTION
## Summary

- Validate session contribution CIDs before attach, read the authoritative contribution store, reject missing CIDs, and enforce session policy before recording the session contribution.
- Initialize goal/session tables as part of shared SQLite DB setup so session-filtered contribution queries work on a fresh `SqliteStore`.
- Add a configurable Nexus CAS `putFile` size cap before `readFileSync` to avoid unbounded memory use, with regression coverage.

## Validation

- `PATH="/Users/tafeng/.bun/bin:$PATH" /Users/tafeng/.bun/bin/bun --bun run typecheck` passed.
- `PATH="/Users/tafeng/.bun/bin:$PATH" /Users/tafeng/.bun/bin/bun --bun run check` passed with existing unrelated Biome warnings/infos.
- `PATH="/Users/tafeng/.bun/bin:$PATH" /Users/tafeng/.bun/bin/bun --bun test tests/server/goals-sessions.test.ts src/local/sqlite-store.test.ts tests/nexus/unit/nexus-cas.test.ts` reported `314 pass`, `0 fail`, then exited nonzero due repository coverage thresholds on a partial run.
- Full root `PATH="/Users/tafeng/.bun/bin:$PATH" /Users/tafeng/.bun/bin/bun --bun test` earlier reported `6478 pass`, `38 skip`, `0 fail`, then exited nonzero after coverage reporting.
- `PATH="/Users/tafeng/.bun/bin:$PATH" /Users/tafeng/.bun/bin/bun --bun test --cwd packages/ask-user` reported `78 pass`, `0 fail`.
- Pre-push hook reran typecheck and build successfully.

Note: I ran commands through Bun’s runtime (`bun --bun`) because the project is Bun-only and the local Node shebang path hits a Rollup native module code-signature issue.
