### PR TITLE
[codex] Fix review findings

### DIFF
--- a/src/core/operations/contribute.test.ts
+++ b/src/core/operations/contribute.test.ts
@@ -805,6 +805,38 @@ describe("contributeOperation: idempotencyKey", () => {
     expect(second.error.message).toMatch(/ephemeral.*only valid on kind=discussion/i);
   });
 
+  test("post-reserve validation errors release the durable idempotency key", async () => {
+    const key = `invalid-ephemeral-${crypto.randomUUID()}`;
+    const invalid = await contributeOperation(
+      {
+        kind: "work",
+        summary: "invalid ephemeral retry",
+        context: { ephemeral: true },
+        agent: { agentId: "a1" },
+        idempotencyKey: key,
+      },
+      deps,
+    );
+
+    expect(invalid.ok).toBe(false);
+    if (invalid.ok) return;
+    expect(invalid.error.code).toBe("VALIDATION_ERROR");
+
+    const retry = await contributeOperation(
+      {
+        kind: "work",
+        summary: "invalid ephemeral retry",
+        agent: { agentId: "a1" },
+        idempotencyKey: key,
+      },
+      deps,
+    );
+
+    expect(retry.ok).toBe(true);
+    if (!retry.ok) return;
+    expect(retry.value.summary).toBe("invalid ephemeral retry");
+  });
+
   test("ephemeral flag on discussion is allowed (normal path)", async () => {
     const result = await contributeOperation(
       {

--- a/src/core/operations/contribute.ts
+++ b/src/core/operations/contribute.ts
@@ -1000,6 +1000,23 @@ export async function contributeOperation(
       }
     }
 
+    // --- Ephemeral flag is reserved for discussions ---
+    // context.ephemeral=true is a routing/frontier skip signal intended for
+    // chat messages and grove_done session terminators, both of which are
+    // kind=discussion. Reject this before durable idempotency reservation so
+    // corrected retries can reuse the key after this permanent validation error.
+    if (input.kind !== CK.Discussion && input.context?.ephemeral === true) {
+      const errResult = validationErr(
+        `context.ephemeral=true is only valid on kind=discussion contributions ` +
+          `(chat messages and session terminators). Got kind='${input.kind}'. ` +
+          `The ephemeral flag suppresses topology routing, handoff creation, and ` +
+          `frontier inclusion — setting it on progress contributions would make them invisible.`,
+      );
+      idempotencySlot?.resolve(errResult);
+      idempotencySlot = undefined;
+      return errResult;
+    }
+
     // Cross-process durable reserve — losing the race means another
     // process already started the write; return retryable conflict.
     if (
@@ -1043,28 +1060,6 @@ export async function contributeOperation(
     const contributionInput = withRuntimeRoutingSignature(unsignedContributionInput);
 
     const contribution = createContribution(contributionInput);
-
-    // --- Ephemeral flag is reserved for discussions ---
-    // context.ephemeral=true is a routing/frontier skip signal intended for
-    // chat messages and grove_done session terminators, both of which are
-    // kind=discussion. Allowing it on work/review/reproduction/adoption would
-    // make real progress invisible to the topology router, handoff store,
-    // stop-condition evaluator, AND the frontier calculator (which filters
-    // out ephemeral contributions). Reject the combination explicitly so
-    // caller bugs surface instead of silently dropping work.
-    if (contribution.kind !== CK.Discussion && contribution.context?.ephemeral === true) {
-      const errResult = validationErr(
-        `context.ephemeral=true is only valid on kind=discussion contributions ` +
-          `(chat messages and session terminators). Got kind='${contribution.kind}'. ` +
-          `The ephemeral flag suppresses topology routing, handoff creation, and ` +
-          `frontier inclusion — setting it on progress contributions would make them invisible.`,
-      );
-      // Resolve the idempotency slot with this permanent error so any
-      // concurrent retry with the same key gets the same response.
-      rollbackOwnedDurableReservation();
-      idempotencySlot?.resolve(errResult);
-      return errResult;
-    }
 
     const returnDuplicate = (
       storedContribution: Contribution,

--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -108,6 +108,23 @@ runClaimStoreTests(async () => {
   };
 });
 
+describe("SqliteIdempotencyStore", () => {
+  test("reserve returns false when a peer already owns the same pending key", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-idempotency-reserve-"));
+    const dbPath = join(dir, "test.db");
+    const first = createSqliteStores(dbPath);
+    const second = createSqliteStores(dbPath);
+    try {
+      expect(first.idempotencyStore.reserve("agent:key", "fingerprint-1")).toBe(true);
+      expect(second.idempotencyStore.reserve("agent:key", "fingerprint-1")).toBe(false);
+    } finally {
+      first.close();
+      second.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("SqliteContributionStore ordering", () => {
   test("list supports newest-first ordering for bounded pollers", async () => {
     const dir = await mkdtemp(join(tmpdir(), "sqlite-order-"));

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -639,7 +639,7 @@ export class SqliteIdempotencyStore {
       [cacheKey, Date.now() - 5 * 60 * 1000],
     );
     const result = this.reserveStmt.run(cacheKey, fingerprint, Date.now());
-    return result.changes > 0;
+    return result.changes === 1;
   }
 
   /** Remove a pending reservation on failure (pre-commit rollback). */

--- a/src/nexus/nexus-http-client.ts
+++ b/src/nexus/nexus-http-client.ts
@@ -32,6 +32,7 @@ import type {
 } from "./client.js";
 import {
   NexusAuthError,
+  NexusConflictError,
   NexusConnectionError,
   NexusNotFoundError,
   NexusTimeoutError,
@@ -213,7 +214,9 @@ export class NexusHttpClient implements NexusClient {
       // Optimistic-concurrency mismatch (if_match / if_none_match). Surface
       // as a structured error so callers (claim store CAS path) can retry.
       const detail = await response.text().catch(() => "");
-      throw new NexusConnectionError(`Precondition failed: ${detail || response.status}`);
+      throw new NexusConflictError({
+        message: `Precondition failed: ${detail || response.status}`,
+      });
     }
     if (response.status === 429) {
       const retryAfter = response.headers.get("retry-after");

--- a/src/server/routes/contributions.ts
+++ b/src/server/routes/contributions.ts
@@ -13,6 +13,7 @@ import type { Hono as HonoType } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import type {
+  Contribution,
   ContributionKind,
   ContributionMode,
   JsonValue,
@@ -21,7 +22,7 @@ import type {
 } from "../../core/models.js";
 import type { ContributeInput } from "../../core/operations/index.js";
 import { contributeOperation } from "../../core/operations/index.js";
-import type { OutcomeStatus } from "../../core/outcome.js";
+import type { OutcomeStats, OutcomeStatus } from "../../core/outcome.js";
 import type { ContributionQuery } from "../../core/store.js";
 import type { ServerEnv } from "../deps.js";
 import { toHttpResult, toOperationDeps } from "../operation-adapter.js";
@@ -137,6 +138,59 @@ function toContributionQuery(raw: {
     offset: raw.offset,
     ...(raw.sessionId !== undefined ? { sessionId: raw.sessionId } : {}),
   };
+}
+
+function hasContributionFilters(raw: {
+  kind?: string | undefined;
+  mode?: string | undefined;
+  tags?: string | undefined;
+  agentId?: string | undefined;
+  agentName?: string | undefined;
+  sessionId?: string | undefined;
+}): boolean {
+  return (
+    raw.kind !== undefined ||
+    raw.mode !== undefined ||
+    raw.tags !== undefined ||
+    raw.agentId !== undefined ||
+    raw.agentName !== undefined ||
+    raw.sessionId !== undefined
+  );
+}
+
+function matchesContributionFilters(contribution: Contribution, query: ContributionQuery): boolean {
+  if (query.kind !== undefined && contribution.kind !== query.kind) return false;
+  if (query.mode !== undefined && contribution.mode !== query.mode) return false;
+  if (query.agentId !== undefined && contribution.agent.agentId !== query.agentId) return false;
+  if (query.agentName !== undefined && contribution.agent.agentName !== query.agentName) {
+    return false;
+  }
+  if (
+    query.tags !== undefined &&
+    query.tags.length > 0 &&
+    !query.tags.every((tag) => contribution.tags.includes(tag))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function compareByRecencyDesc(a: Contribution, b: Contribution): number {
+  const byDate = Date.parse(b.createdAt) - Date.parse(a.createdAt);
+  return byDate !== 0 ? byDate : b.cid.localeCompare(a.cid);
+}
+
+function totalForOutcomeStatus(stats: OutcomeStats, status: OutcomeStatus): number {
+  switch (status) {
+    case "accepted":
+      return stats.accepted;
+    case "rejected":
+      return stats.rejected;
+    case "crashed":
+      return stats.crashed;
+    case "invalidated":
+      return stats.invalidated;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -352,9 +406,6 @@ contributions.get("/", zValidator("query", listQuerySchema), async (c) => {
   // process-global store when no factory is wired (tests, local-only mode).
   const listStore = contributionStoreForSession(deps, raw.sessionId);
 
-  // When outcome filter is specified, we must fetch ALL matching contributions
-  // (without limit/offset), filter by outcome status, then paginate manually.
-  // Otherwise the page may be underfilled and X-Total-Count would be wrong.
   if (raw.outcome !== undefined) {
     if (outcomeStore === undefined) {
       return c.json(
@@ -363,19 +414,37 @@ contributions.get("/", zValidator("query", listQuerySchema), async (c) => {
       );
     }
 
-    const baseQuery = toContributionQuery({ ...raw, limit: undefined, offset: undefined });
-    const allResults = await listStore.list(baseQuery);
-
-    const cids = allResults.map((r) => r.cid);
-    const outcomes = await outcomeStore.getBatch(cids);
     const targetStatus = raw.outcome as OutcomeStatus;
-    const filtered = allResults.filter((r) => {
-      const record = outcomes.get(r.cid);
-      return record !== undefined && record.status === targetStatus;
-    });
-
     const limit = raw.limit ?? 20;
     const offset = raw.offset ?? 0;
+
+    if (!hasContributionFilters(raw)) {
+      const outcomes = await outcomeStore.list({ status: targetStatus, limit, offset });
+      const contributions = await listStore.getMany(outcomes.map((outcome) => outcome.cid));
+      const page: Contribution[] = [];
+      for (const outcome of outcomes) {
+        const contribution = contributions.get(outcome.cid);
+        if (contribution !== undefined) page.push(contribution);
+      }
+      const stats = await outcomeStore.getStats();
+      c.header("X-Total-Count", String(totalForOutcomeStatus(stats, targetStatus)));
+      return c.json(page);
+    }
+
+    const filterQuery = toContributionQuery({ ...raw, limit: undefined, offset: undefined });
+    const outcomes = await outcomeStore.list({ status: targetStatus });
+    const contributions = await listStore.getMany(outcomes.map((outcome) => outcome.cid));
+    const filtered: Contribution[] = [];
+    const seen = new Set<string>();
+    for (const outcome of outcomes) {
+      if (seen.has(outcome.cid)) continue;
+      seen.add(outcome.cid);
+      const contribution = contributions.get(outcome.cid);
+      if (contribution !== undefined && matchesContributionFilters(contribution, filterQuery)) {
+        filtered.push(contribution);
+      }
+    }
+    filtered.sort(compareByRecencyDesc);
     const page = filtered.slice(offset, offset + limit);
 
     c.header("X-Total-Count", String(filtered.length));
@@ -411,8 +480,48 @@ contributions.get("/:cid", zValidator("param", cidParamSchema), async (c) => {
   return c.json(contribution);
 });
 
+/** GET /api/contributions/:cid/artifacts/:name/meta — Artifact metadata (size + mediaType). */
+contributions.get("/:cid/artifacts/:name{.+}/meta", async (c) => {
+  const deps = c.get("deps");
+  const contributionStore = contributionStoreForSession(deps, c.req.query("sessionId"));
+  const { cas } = deps;
+  const cid = c.req.param("cid");
+  const name = c.req.param("name");
+
+  const contribution = await contributionStore.get(cid);
+  if (!contribution) {
+    return c.json({ error: { code: "NOT_FOUND", message: `Contribution ${cid} not found` } }, 404);
+  }
+
+  const contentHash = contribution.artifacts[name];
+  if (!contentHash) {
+    return c.json(
+      { error: { code: "NOT_FOUND", message: `Artifact '${name}' not found in ${cid}` } },
+      404,
+    );
+  }
+
+  const meta = await cas.stat(contentHash);
+  if (!meta) {
+    return c.json(
+      {
+        error: {
+          code: "NOT_FOUND",
+          message: `Artifact blob not found for hash ${contentHash}`,
+        },
+      },
+      404,
+    );
+  }
+
+  return c.json({
+    sizeBytes: meta.sizeBytes,
+    ...(meta.mediaType !== undefined ? { mediaType: meta.mediaType } : {}),
+  });
+});
+
 /** GET /api/contributions/:cid/artifacts/:name — Download artifact blob. */
-contributions.get("/:cid/artifacts/:name", async (c) => {
+contributions.get("/:cid/artifacts/:name{.+}", async (c) => {
   const deps = c.get("deps");
   const contributionStore = contributionStoreForSession(deps, c.req.query("sessionId"));
   const { cas } = deps;
@@ -452,46 +561,6 @@ contributions.get("/:cid/artifacts/:name", async (c) => {
       "Content-Type": meta?.mediaType ?? "application/octet-stream",
       "Content-Length": String(data.byteLength),
     },
-  });
-});
-
-/** GET /api/contributions/:cid/artifacts/:name/meta — Artifact metadata (size + mediaType). */
-contributions.get("/:cid/artifacts/:name/meta", async (c) => {
-  const deps = c.get("deps");
-  const contributionStore = contributionStoreForSession(deps, c.req.query("sessionId"));
-  const { cas } = deps;
-  const cid = c.req.param("cid");
-  const name = c.req.param("name");
-
-  const contribution = await contributionStore.get(cid);
-  if (!contribution) {
-    return c.json({ error: { code: "NOT_FOUND", message: `Contribution ${cid} not found` } }, 404);
-  }
-
-  const contentHash = contribution.artifacts[name];
-  if (!contentHash) {
-    return c.json(
-      { error: { code: "NOT_FOUND", message: `Artifact '${name}' not found in ${cid}` } },
-      404,
-    );
-  }
-
-  const meta = await cas.stat(contentHash);
-  if (!meta) {
-    return c.json(
-      {
-        error: {
-          code: "NOT_FOUND",
-          message: `Artifact blob not found for hash ${contentHash}`,
-        },
-      },
-      404,
-    );
-  }
-
-  return c.json({
-    sizeBytes: meta.sizeBytes,
-    ...(meta.mediaType !== undefined ? { mediaType: meta.mediaType } : {}),
   });
 });
 

--- a/tests/nexus/unit/coverage.test.ts
+++ b/tests/nexus/unit/coverage.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../src/nexus/errors.js";
 import { LruCache } from "../../../src/nexus/lru-cache.js";
 import { MockNexusClient } from "../../../src/nexus/mock-client.js";
+import { NexusHttpClient } from "../../../src/nexus/nexus-http-client.js";
 
 // ---------------------------------------------------------------------------
 // LruCache — delete and size
@@ -75,6 +76,24 @@ describe("mapJsonRpcError", () => {
   test("INVALID_PATH maps to GroveError", () => {
     const err = mapJsonRpcError({ code: NEXUS_ERROR_CODES.INVALID_PATH, message: "bad path" });
     expect(err).toBeInstanceOf(GroveError);
+  });
+});
+
+describe("NexusHttpClient", () => {
+  test("maps HTTP precondition failures to NexusConflictError", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response("precondition failed", { status: 412 })) as typeof fetch;
+    try {
+      const client = new NexusHttpClient({ url: "http://nexus.test" });
+      await expect(
+        client.write("/zones/z/contributions/c.json", new TextEncoder().encode("{}"), {
+          ifNoneMatch: "*",
+        }),
+      ).rejects.toBeInstanceOf(NexusConflictError);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/tests/server/contributions.test.ts
+++ b/tests/server/contributions.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ContributionQuery, ContributionStore } from "../../src/core/store.js";
+import { createApp } from "../../src/server/app.js";
 import type { TestContext } from "./helpers.js";
-import { createTestContext, TEST_AUTH_HEADERS, validManifestBody } from "./helpers.js";
+import {
+  createTestContext,
+  TEST_AUTH_HEADERS,
+  TEST_KEY,
+  TEST_NAMESPACE,
+  validManifestBody,
+} from "./helpers.js";
 
 describe("POST /api/contributions", () => {
   let ctx: TestContext;
@@ -419,6 +427,58 @@ describe("GET /api/contributions", () => {
     });
     expect(res.status).toBe(400);
   });
+
+  test("outcome filter does not issue an unbounded contribution list", async () => {
+    const created: { cid: string }[] = [];
+    for (let i = 0; i < 3; i++) {
+      const res = await ctx.app.request("/api/contributions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+        body: JSON.stringify(
+          validManifestBody({
+            summary: `Outcome-filtered ${i}`,
+            createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+          }),
+        ),
+      });
+      expect(res.status).toBe(201);
+      created.push((await res.json()) as { cid: string });
+    }
+
+    await ctx.outcomeStore.set(created[0].cid, { status: "accepted", evaluatedBy: "reviewer" });
+    await ctx.outcomeStore.set(created[1].cid, { status: "accepted", evaluatedBy: "reviewer" });
+    await ctx.outcomeStore.set(created[2].cid, { status: "rejected", evaluatedBy: "reviewer" });
+
+    let unboundedListCalls = 0;
+    const guardedStore = new Proxy(ctx.contributionStore, {
+      get(target, prop, receiver) {
+        if (prop === "list") {
+          return (query?: ContributionQuery) => {
+            if (query?.limit === undefined) unboundedListCalls++;
+            return target.list(query);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver) as unknown;
+        if (typeof value === "function") return value.bind(target);
+        return value;
+      },
+    }) as ContributionStore;
+
+    const app = createApp(
+      { ...ctx.deps, contributionStore: guardedStore },
+      new Map([[TEST_KEY, TEST_NAMESPACE]]),
+    );
+
+    const res = await app.request("/api/contributions?outcome=accepted&limit=1", {
+      headers: TEST_AUTH_HEADERS,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Total-Count")).toBe("2");
+    const data = (await res.json()) as readonly unknown[];
+    expect(data).toHaveLength(1);
+    expect(unboundedListCalls).toBe(0);
+  });
 });
 
 describe("GET /api/contributions/:cid", () => {
@@ -523,6 +583,36 @@ describe("GET /api/contributions/:cid/artifacts/:name", () => {
 
     const downloaded = new Uint8Array(await res.arrayBuffer());
     expect(new TextDecoder().decode(downloaded)).toBe("print('hello')");
+  });
+
+  test("downloads nested artifact paths and metadata", async () => {
+    const content = new TextEncoder().encode("export const answer = 42;\n");
+    const hash = await ctx.cas.put(content, { mediaType: "text/typescript" });
+
+    const createRes = await ctx.app.request("/api/contributions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(validManifestBody({ artifacts: { "src/main.ts": hash } })),
+    });
+    const created = (await createRes.json()) as { cid: string };
+
+    const downloadRes = await ctx.app.request(
+      `/api/contributions/${created.cid}/artifacts/src/main.ts`,
+      { headers: TEST_AUTH_HEADERS },
+    );
+    expect(downloadRes.status).toBe(200);
+    expect(new TextDecoder().decode(await downloadRes.arrayBuffer())).toBe(
+      "export const answer = 42;\n",
+    );
+
+    const metaRes = await ctx.app.request(
+      `/api/contributions/${created.cid}/artifacts/src/main.ts/meta`,
+      { headers: TEST_AUTH_HEADERS },
+    );
+    expect(metaRes.status).toBe(200);
+    const meta = (await metaRes.json()) as { sizeBytes: number; mediaType?: string };
+    expect(meta.sizeBytes).toBe(content.byteLength);
+    expect(meta.mediaType).toBe("text/typescript");
   });
 
   test("returns 404 for non-existent artifact name", async () => {


### PR DESCRIPTION
## Summary
- tighten durable idempotency reservation ownership and move invalid ephemeral validation before durable reserve
- map Nexus HTTP 409/412 conditional failures to `NexusConflictError`
- support slash-containing artifact names and avoid unbounded contribution listing for outcome-filtered pages

## Validation
- PASS: focused regressions after rebase: 7 pass, 0 fail
- PASS before rebase: `bun run check`, `bun run build`, `bun run typecheck`
- BLOCKED after rebase: `bun run typecheck` / local pre-push hook fail in `packages/ask-user` during `tsup` because Rollup cannot resolve the optional native package `@rollup/rollup-darwin-arm64`; no TypeScript diagnostics surfaced before that build-step failure