### PR TITLE
[codex] Add trajectory checker

### DIFF
--- a/docs/parity-matrix.md
+++ b/docs/parity-matrix.md
@@ -32,6 +32,7 @@ and their classification. All `shared` capabilities use the operations layer in
 | tree | Y | Y | Y | Y | shared |
 | thread | Y | Y | Y | Y | shared |
 | threads | Y | Y | Y | Y | shared |
+| check trajectory | Y | Y | - | - | shared |
 | check stop | - | Y | - | - | transport-only |
 | bounty create | Y | Y | - | - | shared |
 | bounty list | Y | Y | Y | Y | shared |

--- a/docs/superpowers/plans/2026-05-05-trajectory-check.md
+++ b/docs/superpowers/plans/2026-05-05-trajectory-check.md
@@ -1,0 +1,2641 @@
+# Trajectory Check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `grove check-trajectory` and `grove_check_trajectory` for local transcript files, with runtime normalization, deterministic YAML rule checks, and sequence cross-reference reports.
+
+**Architecture:** Add a focused `src/trajectory/` package for transcript indexing, runtime parsers, YAML specs, rule evaluation, and reports. Expose it through a shared operation in `src/core/operations/check-trajectory.ts`, then wire CLI and MCP surfaces around that operation.
+
+**Tech Stack:** Bun 1.3.x, TypeScript strict mode, `bun:test`, existing `yaml` dependency, existing MCP SDK, existing operation-result and CLI patterns.
+
+**Spec:** `docs/superpowers/specs/2026-05-05-trajectory-check-design.md`
+
+**Issue:** [#339](https://github.com/windoliver/grove/issues/339)
+
+---
+
+## File Map
+
+**Create:**
+- `src/trajectory/types.ts` - normalized event, parser, spec, rule, and report contracts.
+- `src/trajectory/types.test.ts` - event constants and sequence marker tests.
+- `src/trajectory/match.ts` - dotted-field lookup, glob alternation, event matching.
+- `src/trajectory/match.test.ts` - matcher behavior tests.
+- `src/trajectory/indexer.ts` - JSONL loading, runtime selection, sequence assignment, indexes.
+- `src/trajectory/indexer.test.ts` - sequence, lookup, malformed-line, and auto-detect tests.
+- `src/trajectory/parsers/acpx.ts` - ACP JSON-RPC NDJSON parser.
+- `src/trajectory/parsers/codex.ts` - Codex ACP and native transcript parser.
+- `src/trajectory/parsers/claude-stream-json.ts` - Claude Code stream-json parser with parent span mapping.
+- `src/trajectory/parsers/subprocess.ts` - line-oriented subprocess parser.
+- `src/trajectory/parsers/*.test.ts` - parser fixture tests.
+- `src/trajectory/spec-loader.ts` - YAML spec loading and validation.
+- `src/trajectory/spec-loader.test.ts` - valid spec, invalid spec, duplicate rule tests.
+- `src/trajectory/rules.ts` - deterministic rule engine.
+- `src/trajectory/rules.test.ts` - tests for all five rule kinds.
+- `src/trajectory/report.ts` - markdown, JSON, and annotated-log formatting.
+- `src/trajectory/report.test.ts` - formatter tests.
+- `src/core/operations/check-trajectory.ts` - operation wrapper shared by CLI and MCP.
+- `src/core/operations/check-trajectory.test.ts` - operation file I/O and validation tests.
+- `src/cli/commands/check-trajectory.ts` - CLI parser and runner.
+- `src/cli/commands/check-trajectory.test.ts` - CLI parser and temp-file command tests.
+- `src/mcp/tools/trajectory.ts` - MCP tool registration.
+- `src/mcp/tools/trajectory.test.ts` - MCP registration and result tests.
+- `tests/fixtures/trajectory/claude-stream-json.jsonl` - Claude delegation fixture.
+- `tests/fixtures/trajectory/codex-transcript.jsonl` - Codex native fixture.
+- `tests/fixtures/trajectory/subprocess.log` - subprocess fixture.
+- `spec/trajectory/common.yaml` - default deterministic check spec.
+
+**Modify:**
+- `src/core/operations/index.ts` - export check-trajectory operation and types.
+- `src/core/operations/parity-matrix.test.ts` - add shared operation coverage.
+- `src/cli/main.ts` - register `check-trajectory` command and help text.
+- `src/mcp/server.ts` - register trajectory MCP tools.
+- `docs/parity-matrix.md` - add check-trajectory row.
+
+---
+
+## Task 1: Core Types And Sequence Markers
+
+**Files:**
+- Create: `src/trajectory/types.ts`
+- Test: `src/trajectory/types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/trajectory/types.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { formatSeq, isTrajectoryEventType, TrajectoryEventType } from "./types.js";
+
+describe("TrajectoryEventType", () => {
+  test("includes deterministic issue #339 event types and timeline-compatible event families", () => {
+    expect(TrajectoryEventType.ToolCall).toBe("TOOL_CALL");
+    expect(TrajectoryEventType.PermissionDenied).toBe("PERMISSION_DENIED");
+    expect(TrajectoryEventType.WorkBlockStarted).toBe("WORK_BLOCK_STARTED");
+    expect(TrajectoryEventType.TaskScheduled).toBe("TASK_SCHEDULED");
+    expect(TrajectoryEventType.HealthRecovered).toBe("HEALTH_RECOVERED");
+    expect(TrajectoryEventType.Raw).toBe("RAW");
+  });
+
+  test("validates event type values", () => {
+    expect(isTrajectoryEventType("TOOL_CALL")).toBe(true);
+    expect(isTrajectoryEventType("tool_call")).toBe(false);
+    expect(isTrajectoryEventType("NOT_REAL")).toBe(false);
+  });
+});
+
+describe("formatSeq", () => {
+  test("formats sequence markers with four digits until values exceed four digits", () => {
+    expect(formatSeq(1)).toBe("[seq:0001]");
+    expect(formatSeq(42)).toBe("[seq:0042]");
+    expect(formatSeq(12_345)).toBe("[seq:12345]");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bun test src/trajectory/types.test.ts
+```
+
+Expected: FAIL with `Cannot find module './types.js'`.
+
+- [ ] **Step 3: Create the core contracts**
+
+Create `src/trajectory/types.ts` with these exports:
+
+```typescript
+export const TrajectoryEventType = {
+  AgentStart: "AGENT_START",
+  ToolCall: "TOOL_CALL",
+  ToolResult: "TOOL_RESULT",
+  Delegation: "DELEGATION",
+  DelegationReturn: "DELEGATION_RETURN",
+  AssistantMessage: "ASSISTANT_MESSAGE",
+  Compaction: "COMPACTION",
+  PermissionDenied: "PERMISSION_DENIED",
+  WorkBlockStarted: "WORK_BLOCK_STARTED",
+  WorkBlockUpdated: "WORK_BLOCK_UPDATED",
+  WorkBlockFinished: "WORK_BLOCK_FINISHED",
+  TaskTriggered: "TASK_TRIGGERED",
+  TaskAdmitted: "TASK_ADMITTED",
+  TaskScheduled: "TASK_SCHEDULED",
+  PermissionWait: "PERMISSION_WAIT",
+  PermissionDecision: "PERMISSION_DECISION",
+  HealthDegraded: "HEALTH_DEGRADED",
+  HealthRecovered: "HEALTH_RECOVERED",
+  ContributionChanged: "CONTRIBUTION_CHANGED",
+  ArtifactChanged: "ARTIFACT_CHANGED",
+  ReviewChanged: "REVIEW_CHANGED",
+  AdoptionChanged: "ADOPTION_CHANGED",
+  Raw: "RAW",
+} as const;
+
+export type TrajectoryEventType =
+  (typeof TrajectoryEventType)[keyof typeof TrajectoryEventType];
+
+export const TrajectoryRuntime = {
+  Acpx: "acpx",
+  Codex: "codex",
+  ClaudeStreamJson: "claude-stream-json",
+  Subprocess: "subprocess",
+  Unknown: "unknown",
+} as const;
+
+export type TrajectoryRuntime = (typeof TrajectoryRuntime)[keyof typeof TrajectoryRuntime];
+export type TrajectoryRuntimeInput = TrajectoryRuntime | "auto";
+export type ReportFormat = "markdown" | "json";
+
+export interface TrajectorySource {
+  readonly path: string;
+  readonly line: number;
+}
+
+export interface TrajectoryEvent {
+  readonly seq: number;
+  readonly type: TrajectoryEventType;
+  readonly runtime: TrajectoryRuntime;
+  readonly timestamp?: string | undefined;
+  readonly sessionId?: string | undefined;
+  readonly turnId?: string | undefined;
+  readonly agentId?: string | undefined;
+  readonly role?: string | undefined;
+  readonly spanId?: string | undefined;
+  readonly parentSpanId?: string | undefined;
+  readonly tool?: string | undefined;
+  readonly status?: string | undefined;
+  readonly input?: unknown;
+  readonly output?: unknown;
+  readonly message?: string | undefined;
+  readonly error?: string | undefined;
+  readonly raw?: unknown;
+  readonly source: TrajectorySource;
+}
+
+export type ParsedTrajectoryEvent = Omit<TrajectoryEvent, "seq">;
+
+export interface TranscriptIndex {
+  readonly runtime: TrajectoryRuntime;
+  readonly transcriptPath: string;
+  readonly events: readonly TrajectoryEvent[];
+  readonly warnings: readonly string[];
+  readonly bySeq: ReadonlyMap<number, TrajectoryEvent>;
+  readonly bySpanId: ReadonlyMap<string, readonly TrajectoryEvent[]>;
+  readonly childrenByParentSpanId: ReadonlyMap<string, readonly TrajectoryEvent[]>;
+}
+
+export interface EventMatcher {
+  readonly event?: string | undefined;
+  readonly tool?: string | undefined;
+  readonly field_match?: Readonly<Record<string, string>> | undefined;
+  readonly field_not_match?: Readonly<Record<string, string>> | undefined;
+}
+
+export interface RequiredMatcher extends EventMatcher {
+  readonly match_field?: string | undefined;
+}
+
+export type RuleKind =
+  | "precedes"
+  | "allowed_tools"
+  | "must_exist"
+  | "must_not_exist"
+  | "field_constraint";
+
+export interface RuleSpec {
+  readonly id: string;
+  readonly kind: RuleKind;
+  readonly match?: EventMatcher | undefined;
+  readonly trigger?: EventMatcher | undefined;
+  readonly required?: RequiredMatcher | undefined;
+  readonly allowed?: readonly string[] | undefined;
+  readonly field?: string | undefined;
+  readonly equals?: unknown;
+  readonly not_equals?: unknown;
+  readonly match_value?: string | undefined;
+  readonly not_match?: string | undefined;
+  readonly exists?: boolean | undefined;
+  readonly not_exists?: boolean | undefined;
+}
+
+export interface GoalSpec {
+  readonly id: string;
+  readonly criteria: string;
+  readonly evidence: readonly string[];
+}
+
+export interface TrajectorySpec {
+  readonly name: string;
+  readonly sourcePaths: readonly string[];
+  readonly rules: readonly RuleSpec[];
+  readonly goals: readonly GoalSpec[];
+}
+
+export type CheckStatus = "pass" | "fail" | "deferred";
+
+export interface RuleViolation {
+  readonly ruleId: string;
+  readonly message: string;
+  readonly seq?: number | undefined;
+  readonly seqRef?: string | undefined;
+  readonly source?: TrajectorySource | undefined;
+  readonly eventType?: TrajectoryEventType | undefined;
+  readonly tool?: string | undefined;
+  readonly status?: string | undefined;
+  readonly spanId?: string | undefined;
+  readonly messageSnippet?: string | undefined;
+}
+
+export interface RuleResult {
+  readonly ruleId: string;
+  readonly status: CheckStatus;
+  readonly violations: readonly RuleViolation[];
+}
+
+export interface GoalResult {
+  readonly goalId: string;
+  readonly status: "deferred";
+  readonly message: string;
+}
+
+export interface TrajectoryCheckReport {
+  readonly name: string;
+  readonly transcriptPath: string;
+  readonly runtime: TrajectoryRuntime;
+  readonly eventCount: number;
+  readonly specPaths: readonly string[];
+  readonly ruleResults: readonly RuleResult[];
+  readonly goalResults: readonly GoalResult[];
+  readonly parserWarnings: readonly string[];
+  readonly summary: {
+    readonly passed: number;
+    readonly failed: number;
+    readonly deferred: number;
+  };
+}
+
+const EVENT_TYPES = new Set<string>(Object.values(TrajectoryEventType));
+
+export function isTrajectoryEventType(value: string): value is TrajectoryEventType {
+  return EVENT_TYPES.has(value);
+}
+
+export function formatSeq(seq: number): string {
+  return `[seq:${seq.toString().padStart(4, "0")}]`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bun test src/trajectory/types.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/trajectory/types.ts src/trajectory/types.test.ts
+git commit -m "feat: add trajectory core types"
+```
+
+---
+
+## Task 2: Event Matching Utilities
+
+**Files:**
+- Create: `src/trajectory/match.ts`
+- Test: `src/trajectory/match.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/trajectory/match.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { fieldValue, matchesEvent, normalizeEventTypeName, patternMatches } from "./match.js";
+import { TrajectoryEventType, type TrajectoryEvent } from "./types.js";
+
+const baseEvent: TrajectoryEvent = {
+  seq: 7,
+  type: TrajectoryEventType.ToolCall,
+  runtime: "codex",
+  tool: "apply_patch",
+  input: { file_path: "src/app.ts", patch: "--- a/src/app.ts" },
+  raw: { nested: { value: "alpha" } },
+  source: { path: "transcript.jsonl", line: 3 },
+};
+
+describe("normalizeEventTypeName", () => {
+  test("accepts canonical and lowercase event aliases", () => {
+    expect(normalizeEventTypeName("TOOL_CALL")).toBe("TOOL_CALL");
+    expect(normalizeEventTypeName("tool_call")).toBe("TOOL_CALL");
+    expect(normalizeEventTypeName("permission_denied")).toBe("PERMISSION_DENIED");
+    expect(normalizeEventTypeName("not_real")).toBeUndefined();
+  });
+});
+
+describe("fieldValue", () => {
+  test("reads normalized fields and raw payload fields", () => {
+    expect(fieldValue(baseEvent, "input.file_path")).toBe("src/app.ts");
+    expect(fieldValue(baseEvent, "raw.nested.value")).toBe("alpha");
+    expect(fieldValue(baseEvent, "missing.value")).toBeUndefined();
+  });
+});
+
+describe("patternMatches", () => {
+  test("supports glob wildcards and pipe alternation", () => {
+    expect(patternMatches("apply_patch", "apply_patch|edit_file")).toBe(true);
+    expect(patternMatches("--- a/src/app.ts", "--- a/*")).toBe(true);
+    expect(patternMatches("read_file", "apply_patch|edit_file")).toBe(false);
+  });
+});
+
+describe("matchesEvent", () => {
+  test("matches by event, tool, field_match, and field_not_match", () => {
+    expect(
+      matchesEvent(baseEvent, {
+        event: "tool_call",
+        tool: "apply_patch|edit_file",
+        field_match: { "input.file_path": "src/*" },
+        field_not_match: { "input.patch": "--- /dev/null*" },
+      }),
+    ).toBe(true);
+
+    expect(
+      matchesEvent(baseEvent, {
+        event: "permission_denied",
+      }),
+    ).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bun test src/trajectory/match.test.ts
+```
+
+Expected: FAIL with `Cannot find module './match.js'`.
+
+- [ ] **Step 3: Implement match helpers**
+
+Create `src/trajectory/match.ts`:
+
+```typescript
+import { isDeepStrictEqual } from "node:util";
+import type { EventMatcher, TrajectoryEvent, TrajectoryEventType } from "./types.js";
+import { isTrajectoryEventType } from "./types.js";
+
+export function normalizeEventTypeName(value: string): TrajectoryEventType | undefined {
+  const upper = value.trim().toUpperCase();
+  return isTrajectoryEventType(upper) ? upper : undefined;
+}
+
+export function fieldValue(source: unknown, path: string): unknown {
+  if (path.length === 0) return undefined;
+  const parts = path.split(".");
+  let current = source;
+  for (const part of parts) {
+    if (typeof current !== "object" || current === null) return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+export function patternMatches(value: unknown, pattern: string): boolean {
+  if (value === undefined || value === null) return false;
+  const text = String(value);
+  return pattern.split("|").some((part) => globPartMatches(text, part));
+}
+
+export function valuesEqual(left: unknown, right: unknown): boolean {
+  return isDeepStrictEqual(left, right);
+}
+
+export function matchesEvent(event: TrajectoryEvent, matcher: EventMatcher): boolean {
+  if (matcher.event !== undefined) {
+    const normalized = normalizeEventTypeName(matcher.event);
+    if (normalized === undefined || event.type !== normalized) return false;
+  }
+
+  if (matcher.tool !== undefined && !patternMatches(event.tool, matcher.tool)) {
+    return false;
+  }
+
+  for (const [path, pattern] of Object.entries(matcher.field_match ?? {})) {
+    if (!patternMatches(fieldValue(event, path), pattern)) return false;
+  }
+
+  for (const [path, pattern] of Object.entries(matcher.field_not_match ?? {})) {
+    if (patternMatches(fieldValue(event, path), pattern)) return false;
+  }
+
+  return true;
+}
+
+function globPartMatches(value: string, pattern: string): boolean {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replaceAll("*", ".*")
+    .replaceAll("?", ".");
+  return new RegExp(`^${escaped}$`).test(value);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bun test src/trajectory/match.test.ts src/trajectory/types.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/trajectory/match.ts src/trajectory/match.test.ts
+git commit -m "feat: add trajectory event matching"
+```
+
+---
+
+## Task 3: Subprocess Parser
+
+**Files:**
+- Create: `src/trajectory/parsers/subprocess.ts`
+- Test: `src/trajectory/parsers/subprocess.test.ts`
+- Create: `tests/fixtures/trajectory/subprocess.log`
+
+- [ ] **Step 1: Write fixture and failing test**
+
+Create `tests/fixtures/trajectory/subprocess.log`:
+
+```text
+{"event":"AGENT_START","spanId":"proc-1","message":"started","timestamp":"2026-05-05T00:00:00Z"}
+plain stdout line
+{"stream":"stderr","message":"warning: denied","event":"PERMISSION_DENIED"}
+```
+
+Create `src/trajectory/parsers/subprocess.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { parseSubprocessLine } from "./subprocess.js";
+
+describe("parseSubprocessLine", () => {
+  test("maps structured events and keeps plain text as RAW", async () => {
+    const text = await readFile("tests/fixtures/trajectory/subprocess.log", "utf8");
+    const lines = text.trimEnd().split("\n");
+
+    const first = parseSubprocessLine(lines[0] ?? "", "subprocess.log", 1);
+    const second = parseSubprocessLine(lines[1] ?? "", "subprocess.log", 2);
+    const third = parseSubprocessLine(lines[2] ?? "", "subprocess.log", 3);
+
+    expect(first.events[0]?.type).toBe("AGENT_START");
+    expect(first.events[0]?.spanId).toBe("proc-1");
+    expect(second.events[0]?.type).toBe("RAW");
+    expect(second.events[0]?.message).toBe("plain stdout line");
+    expect(second.warnings[0]).toContain("line 2");
+    expect(third.events[0]?.type).toBe("PERMISSION_DENIED");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bun test src/trajectory/parsers/subprocess.test.ts
+```
+
+Expected: FAIL with `Cannot find module './subprocess.js'`.
+
+- [ ] **Step 3: Implement subprocess parser**
+
+Create `src/trajectory/parsers/subprocess.ts`:
+
+```typescript
+import { normalizeEventTypeName } from "../match.js";
+import type { ParsedTrajectoryEvent } from "../types.js";
+import { TrajectoryEventType, TrajectoryRuntime } from "../types.js";
+
+export function parseSubprocessLine(
+  line: string,
+  path: string,
+  lineNumber: number,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (typeof parsed !== "object" || parsed === null) {
+      return raw(line, path, lineNumber, "non-object JSONL record");
+    }
+    const record = parsed as Record<string, unknown>;
+    const type = inferType(record);
+    return {
+      events: [
+        {
+          type,
+          runtime: TrajectoryRuntime.Subprocess,
+          timestamp: stringField(record, "timestamp"),
+          spanId: stringField(record, "spanId") ?? stringField(record, "span_id"),
+          parentSpanId: stringField(record, "parentSpanId") ?? stringField(record, "parent_span_id"),
+          tool: stringField(record, "tool") ?? stringField(record, "tool_name"),
+          status: stringField(record, "status"),
+          input: record.input,
+          output: record.output,
+          message: stringField(record, "message") ?? stringField(record, "text"),
+          error: stringField(record, "error"),
+          raw: record,
+          source: { path, line: lineNumber },
+        },
+      ],
+      warnings: [],
+    };
+  } catch {
+    return raw(line, path, lineNumber, `line ${lineNumber}: non-JSON subprocess output kept as RAW`);
+  }
+}
+
+function inferType(record: Record<string, unknown>): TrajectoryEventType {
+  const eventName = stringField(record, "event") ?? stringField(record, "type") ?? stringField(record, "kind");
+  if (eventName !== undefined) {
+    const normalized = normalizeEventTypeName(eventName);
+    if (normalized !== undefined) return normalized;
+  }
+  if (record.stream === "stdout" || record.stream === "stderr") return TrajectoryEventType.AssistantMessage;
+  if (record.command !== undefined || record.pid !== undefined) return TrajectoryEventType.AgentStart;
+  return TrajectoryEventType.Raw;
+}
+
+function raw(
+  line: string,
+  path: string,
+  lineNumber: number,
+  warning: string,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  return {
+    events: [
+      {
+        type: TrajectoryEventType.Raw,
+        runtime: TrajectoryRuntime.Subprocess,
+        message: line,
+        error: warning,
+        raw: line,
+        source: { path, line: lineNumber },
+      },
+    ],
+    warnings: [warning],
+  };
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+bun test src/trajectory/parsers/subprocess.test.ts src/trajectory/match.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/trajectory/parsers/subprocess.ts src/trajectory/parsers/subprocess.test.ts tests/fixtures/trajectory/subprocess.log
+git commit -m "feat: parse subprocess trajectory logs"
+```
+
+---
+
+## Task 4: Transcript Indexer And Runtime Detection
+
+**Files:**
+- Create: `src/trajectory/indexer.ts`
+- Test: `src/trajectory/indexer.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/trajectory/indexer.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildTranscriptIndex, detectRuntimeFromLines } from "./indexer.js";
+import { TrajectoryEventType } from "./types.js";
+
+async function tempFile(name: string, content: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "trajectory-index-"));
+  const path = join(dir, name);
+  await writeFile(path, content, "utf8");
+  return path;
+}
+
+describe("detectRuntimeFromLines", () => {
+  test("detects codex ACP metadata before generic acpx", () => {
+    const lines = [
+      '{"jsonrpc":"2.0","id":0,"result":{"agentInfo":{"name":"codex-acp"}}}',
+      '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk"}}}',
+    ];
+    expect(detectRuntimeFromLines(lines)).toBe("codex");
+  });
+
+  test("detects claude stream-json parent tool use shape", () => {
+    const lines = ['{"type":"tool_result","tool_use_id":"child","parent_tool_use_id":"parent"}'];
+    expect(detectRuntimeFromLines(lines)).toBe("claude-stream-json");
+  });
+
+  test("falls back to subprocess", () => {
+    expect(detectRuntimeFromLines(["plain output"])).toBe("subprocess");
+  });
+});
+
+describe("buildTranscriptIndex", () => {
+  test("assigns sequence numbers, source lines, and span indexes", async () => {
+    const transcript = await tempFile(
+      "events.jsonl",
+      [
+        '{"event":"AGENT_START","spanId":"session-1"}',
+        '{"event":"TOOL_CALL","tool":"apply_patch","spanId":"tool-1","parentSpanId":"session-1"}',
+      ].join("\n"),
+    );
+
+    const index = await buildTranscriptIndex({
+      transcriptPath: transcript,
+      runtime: "subprocess",
+    });
+
+    expect(index.events.map((event) => event.seq)).toEqual([1, 2]);
+    expect(index.events[1]?.source.line).toBe(2);
+    expect(index.bySeq.get(2)?.tool).toBe("apply_patch");
+    expect(index.bySpanId.get("tool-1")?.[0]?.type).toBe(TrajectoryEventType.ToolCall);
+    expect(index.childrenByParentSpanId.get("session-1")?.[0]?.spanId).toBe("tool-1");
+  });
+
+  test("keeps malformed JSONL as RAW with a parser warning", async () => {
+    const transcript = await tempFile("bad.log", "not-json\n");
+    const index = await buildTranscriptIndex({ transcriptPath: transcript, runtime: "subprocess" });
+
+    expect(index.events).toHaveLength(1);
+    expect(index.events[0]?.type).toBe(TrajectoryEventType.Raw);
+    expect(index.warnings[0]).toContain("line 1");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bun test src/trajectory/indexer.test.ts
+```
+
+Expected: FAIL with `Cannot find module './indexer.js'`.
+
+- [ ] **Step 3: Implement the indexer with subprocess routing**
+
+Create `src/trajectory/indexer.ts`:
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { parseSubprocessLine } from "./parsers/subprocess.js";
+import type {
+  ParsedTrajectoryEvent,
+  TrajectoryEvent,
+  TrajectoryRuntime,
+  TrajectoryRuntimeInput,
+  TranscriptIndex,
+} from "./types.js";
+import { TrajectoryRuntime } from "./types.js";
+
+export interface BuildTranscriptIndexOptions {
+  readonly transcriptPath: string;
+  readonly runtime: TrajectoryRuntimeInput;
+}
+
+export function detectRuntimeFromLines(lines: readonly string[]): TrajectoryRuntime {
+  for (const line of lines) {
+    const parsed = parseJson(line);
+    if (parsed === undefined) continue;
+    const record = parsed as Record<string, unknown>;
+    if (JSON.stringify(record).includes("codex-acp")) return TrajectoryRuntime.Codex;
+    if (
+      "parent_tool_use_id" in record ||
+      "tool_use_id" in record ||
+      (record.type === "assistant" && Array.isArray(record.message))
+    ) {
+      return TrajectoryRuntime.ClaudeStreamJson;
+    }
+    if (record.method === "session/update" || record.method === "session/new") {
+      return TrajectoryRuntime.Acpx;
+    }
+    if (record.type === "codex_event" || record.source === "codex") return TrajectoryRuntime.Codex;
+  }
+  return TrajectoryRuntime.Subprocess;
+}
+
+export async function buildTranscriptIndex(
+  options: BuildTranscriptIndexOptions,
+): Promise<TranscriptIndex> {
+  const text = await readFile(options.transcriptPath, "utf8");
+  const lines = text.split(/\r?\n/).filter((line) => line.length > 0);
+  const runtime =
+    options.runtime === "auto" ? detectRuntimeFromLines(lines.slice(0, 20)) : options.runtime;
+  const warnings: string[] = [];
+  const parsedEvents: ParsedTrajectoryEvent[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const lineNumber = i + 1;
+    const line = lines[i] ?? "";
+    const parsed = parseLine(runtime, line, options.transcriptPath, lineNumber);
+    parsedEvents.push(...parsed.events);
+    warnings.push(...parsed.warnings);
+  }
+
+  const events = parsedEvents.map((event, index) => ({ ...event, seq: index + 1 }));
+  return createTranscriptIndex(runtime, options.transcriptPath, events, warnings);
+}
+
+function parseLine(
+  runtime: TrajectoryRuntime,
+  line: string,
+  path: string,
+  lineNumber: number,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  switch (runtime) {
+    case TrajectoryRuntime.Acpx:
+    case TrajectoryRuntime.Codex:
+    case TrajectoryRuntime.ClaudeStreamJson:
+    case TrajectoryRuntime.Subprocess:
+    case TrajectoryRuntime.Unknown:
+      return parseSubprocessLine(line, path, lineNumber);
+  }
+}
+
+function createTranscriptIndex(
+  runtime: TrajectoryRuntime,
+  transcriptPath: string,
+  events: readonly TrajectoryEvent[],
+  warnings: readonly string[],
+): TranscriptIndex {
+  const bySeq = new Map<number, TrajectoryEvent>();
+  const bySpanId = new Map<string, TrajectoryEvent[]>();
+  const childrenByParentSpanId = new Map<string, TrajectoryEvent[]>();
+
+  for (const event of events) {
+    bySeq.set(event.seq, event);
+    if (event.spanId !== undefined) {
+      const bucket = bySpanId.get(event.spanId) ?? [];
+      bucket.push(event);
+      bySpanId.set(event.spanId, bucket);
+    }
+    if (event.parentSpanId !== undefined) {
+      const bucket = childrenByParentSpanId.get(event.parentSpanId) ?? [];
+      bucket.push(event);
+      childrenByParentSpanId.set(event.parentSpanId, bucket);
+    }
+  }
+
+  return {
+    runtime,
+    transcriptPath,
+    events,
+    warnings,
+    bySeq,
+    bySpanId,
+    childrenByParentSpanId,
+  };
+}
+
+function parseJson(line: string): unknown | undefined {
+  try {
+    return JSON.parse(line) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bun test src/trajectory/indexer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/trajectory/indexer.ts src/trajectory/indexer.test.ts
+git commit -m "feat: build trajectory transcript index"
+```
+
+---
+
+## Task 5: ACP, Codex, And Claude Parsers
+
+**Files:**
+- Create: `src/trajectory/parsers/acpx.ts`
+- Create: `src/trajectory/parsers/codex.ts`
+- Create: `src/trajectory/parsers/claude-stream-json.ts`
+- Test: `src/trajectory/parsers/acpx.test.ts`
+- Test: `src/trajectory/parsers/codex.test.ts`
+- Test: `src/trajectory/parsers/claude-stream-json.test.ts`
+- Create: `tests/fixtures/trajectory/claude-stream-json.jsonl`
+- Create: `tests/fixtures/trajectory/codex-transcript.jsonl`
+
+- [ ] **Step 1: Write fixtures**
+
+Create `tests/fixtures/trajectory/claude-stream-json.jsonl`:
+
+```jsonl
+{"type":"assistant","message":[{"type":"text","text":"I will inspect the repo."}],"timestamp":"2026-05-05T00:00:00Z"}
+{"type":"tool_use","id":"tool-parent","name":"Task","input":{"description":"review"}}
+{"type":"tool_use","id":"tool-child","parent_tool_use_id":"tool-parent","name":"Read","input":{"file_path":"src/index.ts"}}
+{"type":"tool_result","tool_use_id":"tool-child","parent_tool_use_id":"tool-parent","content":"done"}
+{"type":"tool_result","tool_use_id":"tool-parent","content":"subagent returned"}
+```
+
+Create `tests/fixtures/trajectory/codex-transcript.jsonl`:
+
+```jsonl
+{"type":"agent_start","session_id":"sess-1","agent_id":"codex-1","timestamp":"2026-05-05T00:00:00Z"}
+{"type":"tool_call","call_id":"call-1","tool_name":"apply_patch","input":{"file_path":"src/app.ts"}}
+{"type":"tool_result","call_id":"call-1","output":"ok","status":"completed"}
+{"type":"assistant_message","message":"patched"}
+```
+
+- [ ] **Step 2: Write failing parser tests**
+
+Create `src/trajectory/parsers/acpx.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { parseAcpxLine } from "./acpx.js";
+
+describe("parseAcpxLine", () => {
+  test("maps ACP fixture session updates to trajectory events", async () => {
+    const text = await readFile("tests/fixtures/acp/claude-tool-call.ndjson", "utf8");
+    const all = text
+      .trimEnd()
+      .split("\n")
+      .flatMap((line, index) => parseAcpxLine(line, "claude-tool-call.ndjson", index + 1, "acpx").events);
+
+    expect(all.some((event) => event.type === "AGENT_START")).toBe(true);
+    expect(all.some((event) => event.type === "ASSISTANT_MESSAGE")).toBe(true);
+    expect(all.some((event) => event.type === "TOOL_CALL")).toBe(true);
+  });
+});
+```
+
+Create `src/trajectory/parsers/codex.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { parseCodexLine } from "./codex.js";
+
+describe("parseCodexLine", () => {
+  test("maps native codex transcript records", async () => {
+    const text = await readFile("tests/fixtures/trajectory/codex-transcript.jsonl", "utf8");
+    const all = text
+      .trimEnd()
+      .split("\n")
+      .flatMap((line, index) => parseCodexLine(line, "codex-transcript.jsonl", index + 1).events);
+
+    expect(all.map((event) => event.type)).toEqual([
+      "AGENT_START",
+      "TOOL_CALL",
+      "TOOL_RESULT",
+      "ASSISTANT_MESSAGE",
+    ]);
+    expect(all[1]?.tool).toBe("apply_patch");
+    expect(all[2]?.spanId).toBe("call-1");
+  });
+});
+```
+
+Create `src/trajectory/parsers/claude-stream-json.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { parseClaudeStreamJsonLine } from "./claude-stream-json.js";
+
+describe("parseClaudeStreamJsonLine", () => {
+  test("maps parent_tool_use_id into delegation spans", async () => {
+    const text = await readFile("tests/fixtures/trajectory/claude-stream-json.jsonl", "utf8");
+    const all = text
+      .trimEnd()
+      .split("\n")
+      .flatMap((line, index) =>
+        parseClaudeStreamJsonLine(line, "claude-stream-json.jsonl", index + 1).events,
+      );
+
+    expect(all[0]?.type).toBe("ASSISTANT_MESSAGE");
+    expect(all[1]?.type).toBe("DELEGATION");
+    expect(all[2]?.type).toBe("TOOL_CALL");
+    expect(all[2]?.parentSpanId).toBe("tool-parent");
+    expect(all[3]?.type).toBe("TOOL_RESULT");
+    expect(all[4]?.type).toBe("DELEGATION_RETURN");
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+bun test src/trajectory/parsers/acpx.test.ts src/trajectory/parsers/codex.test.ts src/trajectory/parsers/claude-stream-json.test.ts
+```
+
+Expected: FAIL with missing parser modules.
+
+- [ ] **Step 4: Implement parser helpers**
+
+Implement `src/trajectory/parsers/acpx.ts`:
+
+```typescript
+import type { ParsedTrajectoryEvent, TrajectoryRuntime } from "../types.js";
+import { TrajectoryEventType } from "../types.js";
+
+export function parseAcpxLine(
+  line: string,
+  path: string,
+  lineNumber: number,
+  runtime: TrajectoryRuntime,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  const parsed = parseJsonObject(line);
+  if (parsed === undefined) return raw(line, path, lineNumber, runtime, "invalid JSON");
+
+  if (parsed.method === "session/new") {
+    return { events: [], warnings: [] };
+  }
+
+  if (isObject(parsed.result) && typeof parsed.result.sessionId === "string") {
+    return {
+      events: [
+        {
+          type: TrajectoryEventType.AgentStart,
+          runtime,
+          sessionId: parsed.result.sessionId,
+          raw: parsed,
+          source: { path, line: lineNumber },
+        },
+      ],
+      warnings: [],
+    };
+  }
+
+  if (parsed.method === "session/update" && isObject(parsed.params)) {
+    const sessionId = stringField(parsed.params, "sessionId");
+    const update = parsed.params.update;
+    if (!isObject(update)) return raw(parsed, path, lineNumber, runtime, "session/update missing update");
+    const sessionUpdate = stringField(update, "sessionUpdate");
+    if (sessionUpdate === "agent_message_chunk" || sessionUpdate === "user_message_chunk") {
+      return event(TrajectoryEventType.AssistantMessage, runtime, path, lineNumber, parsed, {
+        sessionId,
+        message: readContentText(update.content),
+      });
+    }
+    if (sessionUpdate === "tool_call") {
+      return event(TrajectoryEventType.ToolCall, runtime, path, lineNumber, parsed, {
+        sessionId,
+        spanId: stringField(update, "toolCallId"),
+        tool: readCanonicalTool(update) ?? stringField(update, "title"),
+        status: stringField(update, "status"),
+        input: update.rawInput,
+      });
+    }
+    if (sessionUpdate === "tool_call_update") {
+      return event(TrajectoryEventType.ToolResult, runtime, path, lineNumber, parsed, {
+        sessionId,
+        spanId: stringField(update, "toolCallId"),
+        tool: readCanonicalTool(update) ?? stringField(update, "title"),
+        status: stringField(update, "status"),
+        input: update.rawInput,
+        output: update.rawOutput,
+      });
+    }
+    if (sessionUpdate === "permission_request") {
+      return event(TrajectoryEventType.PermissionWait, runtime, path, lineNumber, parsed, {
+        sessionId,
+        spanId: stringField(update, "id") ?? stringField(update, "toolCallId"),
+        tool: stringField(update, "tool"),
+        input: update.input,
+      });
+    }
+    return raw(parsed, path, lineNumber, runtime, `unmapped ACP update ${sessionUpdate ?? "unknown"}`);
+  }
+
+  if (isObject(parsed.error)) {
+    return event(TrajectoryEventType.PermissionDenied, runtime, path, lineNumber, parsed, {
+      error: stringField(parsed.error, "message"),
+    });
+  }
+
+  return { events: [], warnings: [] };
+}
+
+function event(
+  type: TrajectoryEventType,
+  runtime: TrajectoryRuntime,
+  path: string,
+  lineNumber: number,
+  raw: unknown,
+  fields: Partial<ParsedTrajectoryEvent>,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  return {
+    events: [{ type, runtime, raw, source: { path, line: lineNumber }, ...fields }],
+    warnings: [],
+  };
+}
+
+function raw(
+  rawValue: unknown,
+  path: string,
+  lineNumber: number,
+  runtime: TrajectoryRuntime,
+  warning: string,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  return {
+    events: [
+      {
+        type: TrajectoryEventType.Raw,
+        runtime,
+        raw: rawValue,
+        message: typeof rawValue === "string" ? rawValue : undefined,
+        error: warning,
+        source: { path, line: lineNumber },
+      },
+    ],
+    warnings: [`line ${lineNumber}: ${warning}`],
+  };
+}
+
+function parseJsonObject(line: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    return isObject(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readContentText(value: unknown): string | undefined {
+  if (!isObject(value)) return undefined;
+  const text = value.text;
+  return typeof text === "string" ? text : undefined;
+}
+
+function readCanonicalTool(update: Record<string, unknown>): string | undefined {
+  const meta = update._meta;
+  if (!isObject(meta)) return undefined;
+  const claudeCode = meta.claudeCode;
+  if (!isObject(claudeCode)) return undefined;
+  return stringField(claudeCode, "toolName");
+}
+```
+
+Implement `src/trajectory/parsers/codex.ts`:
+
+```typescript
+import { parseAcpxLine } from "./acpx.js";
+import { normalizeEventTypeName } from "../match.js";
+import type { ParsedTrajectoryEvent } from "../types.js";
+import { TrajectoryEventType, TrajectoryRuntime } from "../types.js";
+
+export function parseCodexLine(
+  line: string,
+  path: string,
+  lineNumber: number,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  if (line.includes('"jsonrpc"') || line.includes('"session/update"')) {
+    return parseAcpxLine(line, path, lineNumber, TrajectoryRuntime.Codex);
+  }
+
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (!isObject(parsed)) return raw(line, path, lineNumber, "non-object Codex record");
+    const type = inferCodexType(parsed);
+    return {
+      events: [
+        {
+          type,
+          runtime: TrajectoryRuntime.Codex,
+          timestamp: stringField(parsed, "timestamp"),
+          sessionId: stringField(parsed, "session_id") ?? stringField(parsed, "sessionId"),
+          agentId: stringField(parsed, "agent_id") ?? stringField(parsed, "agentId"),
+          spanId: stringField(parsed, "call_id") ?? stringField(parsed, "id"),
+          parentSpanId: stringField(parsed, "parent_call_id") ?? stringField(parsed, "parentSpanId"),
+          tool: stringField(parsed, "tool_name") ?? stringField(parsed, "tool"),
+          status: stringField(parsed, "status"),
+          input: parsed.input,
+          output: parsed.output,
+          message: stringField(parsed, "message") ?? stringField(parsed, "text"),
+          error: stringField(parsed, "error"),
+          raw: parsed,
+          source: { path, line: lineNumber },
+        },
+      ],
+      warnings: [],
+    };
+  } catch {
+    return raw(line, path, lineNumber, "invalid Codex JSONL record");
+  }
+}
+
+function inferCodexType(record: Record<string, unknown>): TrajectoryEventType {
+  const rawType = stringField(record, "type") ?? stringField(record, "event") ?? stringField(record, "kind");
+  if (rawType !== undefined) {
+    const normalized = normalizeEventTypeName(rawType);
+    if (normalized !== undefined) return normalized;
+    if (rawType === "agent_start") return TrajectoryEventType.AgentStart;
+    if (rawType === "assistant_message") return TrajectoryEventType.AssistantMessage;
+    if (rawType === "tool_call") return TrajectoryEventType.ToolCall;
+    if (rawType === "tool_result") return TrajectoryEventType.ToolResult;
+  }
+  if (record.tool_name !== undefined || record.tool !== undefined) return TrajectoryEventType.ToolCall;
+  return TrajectoryEventType.Raw;
+}
+
+function raw(
+  line: string,
+  path: string,
+  lineNumber: number,
+  warning: string,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  return {
+    events: [
+      {
+        type: TrajectoryEventType.Raw,
+        runtime: TrajectoryRuntime.Codex,
+        message: line,
+        error: warning,
+        raw: line,
+        source: { path, line: lineNumber },
+      },
+    ],
+    warnings: [`line ${lineNumber}: ${warning}`],
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+```
+
+Implement `src/trajectory/parsers/claude-stream-json.ts`:
+
+```typescript
+import type { ParsedTrajectoryEvent } from "../types.js";
+import { TrajectoryEventType, TrajectoryRuntime } from "../types.js";
+
+export function parseClaudeStreamJsonLine(
+  line: string,
+  path: string,
+  lineNumber: number,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (!isObject(parsed)) return raw(line, path, lineNumber, "non-object Claude stream-json record");
+    const type = inferClaudeType(parsed);
+    return {
+      events: [
+        {
+          type,
+          runtime: TrajectoryRuntime.ClaudeStreamJson,
+          timestamp: stringField(parsed, "timestamp"),
+          spanId:
+            stringField(parsed, "tool_use_id") ??
+            stringField(parsed, "tool_call_id") ??
+            stringField(parsed, "id"),
+          parentSpanId: stringField(parsed, "parent_tool_use_id"),
+          tool: stringField(parsed, "name") ?? stringField(parsed, "tool_name"),
+          status: stringField(parsed, "status"),
+          input: parsed.input,
+          output: parsed.output ?? parsed.content,
+          message: readMessage(parsed),
+          error: stringField(parsed, "error"),
+          raw: parsed,
+          source: { path, line: lineNumber },
+        },
+      ],
+      warnings: [],
+    };
+  } catch {
+    return raw(line, path, lineNumber, "invalid Claude stream-json record");
+  }
+}
+
+function inferClaudeType(record: Record<string, unknown>): TrajectoryEventType {
+  const type = stringField(record, "type");
+  const name = stringField(record, "name");
+  if (type === "assistant") return TrajectoryEventType.AssistantMessage;
+  if ((type === "tool_use" || type === "tool_call") && isDelegationTool(name)) {
+    return TrajectoryEventType.Delegation;
+  }
+  if (type === "tool_use" || type === "tool_call") return TrajectoryEventType.ToolCall;
+  if (type === "tool_result" && record.parent_tool_use_id === undefined) {
+    return TrajectoryEventType.DelegationReturn;
+  }
+  if (type === "tool_result") return TrajectoryEventType.ToolResult;
+  if (type === "permission_denied") return TrajectoryEventType.PermissionDenied;
+  return TrajectoryEventType.Raw;
+}
+
+function readMessage(record: Record<string, unknown>): string | undefined {
+  const direct = stringField(record, "message");
+  if (direct !== undefined) return direct;
+  const message = record.message;
+  if (!Array.isArray(message)) return undefined;
+  return message
+    .map((part) => {
+      if (!isObject(part)) return "";
+      const text = part.text;
+      return typeof text === "string" ? text : "";
+    })
+    .join("");
+}
+
+function isDelegationTool(name: string | undefined): boolean {
+  if (name === undefined) return false;
+  return name === "Task" || name.toLowerCase().includes("subagent");
+}
+
+function raw(
+  line: string,
+  path: string,
+  lineNumber: number,
+  warning: string,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  return {
+    events: [
+      {
+        type: TrajectoryEventType.Raw,
+        runtime: TrajectoryRuntime.ClaudeStreamJson,
+        message: line,
+        error: warning,
+        raw: line,
+        source: { path, line: lineNumber },
+      },
+    ],
+    warnings: [`line ${lineNumber}: ${warning}`],
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+```
+
+- [ ] **Step 5: Extend indexer routing for all runtime parsers**
+
+Modify `src/trajectory/indexer.ts` imports:
+
+```typescript
+import { parseAcpxLine } from "./parsers/acpx.js";
+import { parseClaudeStreamJsonLine } from "./parsers/claude-stream-json.js";
+import { parseCodexLine } from "./parsers/codex.js";
+```
+
+Then replace the runtime switch in `parseLine`:
+
+```typescript
+  switch (runtime) {
+    case TrajectoryRuntime.Acpx:
+      return parseAcpxLine(line, path, lineNumber, runtime);
+    case TrajectoryRuntime.Codex:
+      return parseCodexLine(line, path, lineNumber);
+    case TrajectoryRuntime.ClaudeStreamJson:
+      return parseClaudeStreamJsonLine(line, path, lineNumber);
+    case TrajectoryRuntime.Subprocess:
+    case TrajectoryRuntime.Unknown:
+      return parseSubprocessLine(line, path, lineNumber);
+  }
+```
+
+- [ ] **Step 6: Run parser and indexer tests**
+
+Run:
+
+```bash
+bun test src/trajectory/parsers/acpx.test.ts src/trajectory/parsers/codex.test.ts src/trajectory/parsers/claude-stream-json.test.ts src/trajectory/indexer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/trajectory/parsers tests/fixtures/trajectory src/trajectory/indexer.ts src/trajectory/indexer.test.ts
+git commit -m "feat: parse trajectory runtime transcripts"
+```
+
+---
+
+## Task 6: YAML Spec Loader
+
+**Files:**
+- Create: `src/trajectory/spec-loader.ts`
+- Test: `src/trajectory/spec-loader.test.ts`
+- Create: `spec/trajectory/common.yaml`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/trajectory/spec-loader.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadTrajectorySpecs } from "./spec-loader.js";
+
+async function writeSpec(name: string, text: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "trajectory-spec-"));
+  const path = join(dir, name);
+  await writeFile(path, text, "utf8");
+  return path;
+}
+
+describe("loadTrajectorySpecs", () => {
+  test("loads and merges rules and deferred goals", async () => {
+    const specPath = await writeSpec(
+      "common.yaml",
+      [
+        "name: common",
+        "rules:",
+        "  - id: no-denials",
+        "    kind: must_not_exist",
+        "    match:",
+        "      event: PERMISSION_DENIED",
+        "goals:",
+        "  - id: user-goal",
+        "    criteria: User goal was met.",
+        "    evidence: [assistant_message]",
+      ].join("\n"),
+    );
+
+    const spec = await loadTrajectorySpecs([specPath]);
+    expect(spec.name).toBe("common");
+    expect(spec.rules[0]?.id).toBe("no-denials");
+    expect(spec.goals[0]?.id).toBe("user-goal");
+    expect(spec.sourcePaths).toEqual([specPath]);
+  });
+
+  test("rejects duplicate rule ids across files", async () => {
+    const one = await writeSpec("one.yaml", "name: one\nrules:\n  - id: same\n    kind: must_exist\n");
+    const two = await writeSpec("two.yaml", "name: two\nrules:\n  - id: same\n    kind: must_not_exist\n");
+
+    await expect(loadTrajectorySpecs([one, two])).rejects.toThrow(/duplicate rule id: same/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bun test src/trajectory/spec-loader.test.ts
+```
+
+Expected: FAIL with `Cannot find module './spec-loader.js'`.
+
+- [ ] **Step 3: Implement loader**
+
+Create `src/trajectory/spec-loader.ts`:
+
+```typescript
+import { readFile } from "node:fs/promises";
+import YAML from "yaml";
+import type { GoalSpec, RuleKind, RuleSpec, TrajectorySpec } from "./types.js";
+
+const RULE_KINDS = new Set<RuleKind>([
+  "precedes",
+  "allowed_tools",
+  "must_exist",
+  "must_not_exist",
+  "field_constraint",
+]);
+
+export async function loadTrajectorySpecs(paths: readonly string[]): Promise<TrajectorySpec> {
+  const rules: RuleSpec[] = [];
+  const goals: GoalSpec[] = [];
+  const seenRuleIds = new Set<string>();
+  const names: string[] = [];
+
+  for (const path of paths) {
+    const text = await readFile(path, "utf8");
+    const parsed = YAML.parse(text) as unknown;
+    if (!isObject(parsed)) throw new Error(`Invalid trajectory spec ${path}: root must be an object`);
+    const name = stringField(parsed, "name") ?? path;
+    names.push(name);
+
+    for (const rule of arrayField(parsed, "rules")) {
+      const normalized = normalizeRule(rule, path);
+      if (seenRuleIds.has(normalized.id)) {
+        throw new Error(`duplicate rule id: ${normalized.id}`);
+      }
+      seenRuleIds.add(normalized.id);
+      rules.push(normalized);
+    }
+
+    for (const goal of arrayField(parsed, "goals")) {
+      goals.push(normalizeGoal(goal, path));
+    }
+  }
+
+  return {
+    name: names.join("+"),
+    sourcePaths: [...paths],
+    rules,
+    goals,
+  };
+}
+
+function normalizeRule(value: unknown, path: string): RuleSpec {
+  if (!isObject(value)) throw new Error(`Invalid rule in ${path}: rule must be an object`);
+  const id = stringField(value, "id");
+  const kind = stringField(value, "kind");
+  if (id === undefined) throw new Error(`Invalid rule in ${path}: id is required`);
+  if (kind === undefined || !RULE_KINDS.has(kind as RuleKind)) {
+    throw new Error(`Invalid rule ${id} in ${path}: unknown rule kind ${kind ?? ""}`);
+  }
+  return {
+    id,
+    kind: kind as RuleKind,
+    ...(isObject(value.match) ? { match: value.match as RuleSpec["match"] } : {}),
+    ...(isObject(value.trigger) ? { trigger: value.trigger as RuleSpec["trigger"] } : {}),
+    ...(isObject(value.required) ? { required: value.required as RuleSpec["required"] } : {}),
+    ...(Array.isArray(value.allowed) ? { allowed: value.allowed.map(String) } : {}),
+    ...(typeof value.field === "string" ? { field: value.field } : {}),
+    ...(Object.hasOwn(value, "equals") ? { equals: value.equals } : {}),
+    ...(Object.hasOwn(value, "not_equals") ? { not_equals: value.not_equals } : {}),
+    ...(typeof value.match_value === "string" ? { match_value: value.match_value } : {}),
+    ...(typeof value.not_match === "string" ? { not_match: value.not_match } : {}),
+    ...(typeof value.exists === "boolean" ? { exists: value.exists } : {}),
+    ...(typeof value.not_exists === "boolean" ? { not_exists: value.not_exists } : {}),
+  };
+}
+
+function normalizeGoal(value: unknown, path: string): GoalSpec {
+  if (!isObject(value)) throw new Error(`Invalid goal in ${path}: goal must be an object`);
+  const id = stringField(value, "id");
+  const criteria = stringField(value, "criteria");
+  if (id === undefined) throw new Error(`Invalid goal in ${path}: id is required`);
+  if (criteria === undefined) throw new Error(`Invalid goal ${id} in ${path}: criteria is required`);
+  return {
+    id,
+    criteria,
+    evidence: arrayField(value, "evidence").map(String),
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function arrayField(record: Record<string, unknown>, key: string): readonly unknown[] {
+  const value = record[key];
+  return Array.isArray(value) ? value : [];
+}
+```
+
+- [ ] **Step 4: Add default spec**
+
+Create `spec/trajectory/common.yaml`:
+
+```yaml
+name: common
+rules:
+  - id: no-permission-denials
+    kind: must_not_exist
+    match:
+      event: PERMISSION_DENIED
+
+  - id: has-agent-or-message
+    kind: must_exist
+    match:
+      event: ASSISTANT_MESSAGE|AGENT_START
+
+  - id: tool-calls-have-tool
+    kind: field_constraint
+    match:
+      event: TOOL_CALL
+    field: tool
+    exists: true
+
+  - id: tool-results-have-span
+    kind: field_constraint
+    match:
+      event: TOOL_RESULT
+    field: spanId
+    exists: true
+
+goals: []
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+bun test src/trajectory/spec-loader.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/trajectory/spec-loader.ts src/trajectory/spec-loader.test.ts spec/trajectory/common.yaml
+git commit -m "feat: load trajectory YAML specs"
+```
+
+---
+
+## Task 7: Deterministic Rule Engine
+
+**Files:**
+- Create: `src/trajectory/rules.ts`
+- Test: `src/trajectory/rules.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/trajectory/rules.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { evaluateRules } from "./rules.js";
+import type { RuleSpec, TrajectoryEvent, TranscriptIndex } from "./types.js";
+
+function event(seq: number, overrides: Partial<TrajectoryEvent>): TrajectoryEvent {
+  return {
+    seq,
+    type: "TOOL_CALL",
+    runtime: "codex",
+    source: { path: "t.jsonl", line: seq },
+    ...overrides,
+  };
+}
+
+function index(events: readonly TrajectoryEvent[]): TranscriptIndex {
+  return {
+    runtime: "codex",
+    transcriptPath: "t.jsonl",
+    events,
+    warnings: [],
+    bySeq: new Map(events.map((item) => [item.seq, item])),
+    bySpanId: new Map(),
+    childrenByParentSpanId: new Map(),
+  };
+}
+
+describe("evaluateRules", () => {
+  test("must_not_exist reports matching event sequence refs", () => {
+    const result = evaluateRules(index([event(1, { type: "PERMISSION_DENIED" })]), [
+      { id: "no-denials", kind: "must_not_exist", match: { event: "PERMISSION_DENIED" } },
+    ]);
+
+    expect(result[0]?.status).toBe("fail");
+    expect(result[0]?.violations[0]?.seqRef).toBe("[seq:0001]");
+  });
+
+  test("allowed_tools fails disallowed tool calls", () => {
+    const result = evaluateRules(index([event(2, { tool: "rm" })]), [
+      { id: "tools", kind: "allowed_tools", allowed: ["Read", "apply_patch"] },
+    ]);
+
+    expect(result[0]?.status).toBe("fail");
+    expect(result[0]?.violations[0]?.message).toContain("rm");
+  });
+
+  test("field_constraint validates existence and glob matches", () => {
+    const rules: RuleSpec[] = [
+      { id: "has-tool", kind: "field_constraint", match: { event: "TOOL_CALL" }, field: "tool", exists: true },
+      { id: "src-file", kind: "field_constraint", match: { event: "TOOL_CALL" }, field: "input.file_path", match_value: "src/*" },
+    ];
+    const result = evaluateRules(index([event(3, { tool: "Read", input: { file_path: "src/app.ts" } })]), rules);
+
+    expect(result.every((item) => item.status === "pass")).toBe(true);
+  });
+
+  test("precedes requires prior matching evidence with same field", () => {
+    const result = evaluateRules(
+      index([
+        event(1, { tool: "backup_file", input: { file_path: "src/app.ts" } }),
+        event(2, { tool: "apply_patch", input: { file_path: "src/app.ts" } }),
+        event(3, { tool: "apply_patch", input: { file_path: "src/other.ts" } }),
+      ]),
+      [
+        {
+          id: "backup-before-edit",
+          kind: "precedes",
+          trigger: { event: "TOOL_CALL", tool: "apply_patch" },
+          required: { event: "TOOL_CALL", tool: "backup_file", match_field: "input.file_path" },
+        },
+      ],
+    );
+
+    expect(result[0]?.status).toBe("fail");
+    expect(result[0]?.violations).toHaveLength(1);
+    expect(result[0]?.violations[0]?.seq).toBe(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bun test src/trajectory/rules.test.ts
+```
+
+Expected: FAIL with `Cannot find module './rules.js'`.
+
+- [ ] **Step 3: Implement rule engine**
+
+Create `src/trajectory/rules.ts`:
+
+```typescript
+import { fieldValue, matchesEvent, patternMatches, valuesEqual } from "./match.js";
+import type { RuleResult, RuleSpec, RuleViolation, TrajectoryEvent, TranscriptIndex } from "./types.js";
+import { formatSeq, TrajectoryEventType } from "./types.js";
+
+export function evaluateRules(index: TranscriptIndex, rules: readonly RuleSpec[]): readonly RuleResult[] {
+  return rules.map((rule) => evaluateRule(index, rule));
+}
+
+function evaluateRule(index: TranscriptIndex, rule: RuleSpec): RuleResult {
+  switch (rule.kind) {
+    case "must_exist":
+      return mustExist(index, rule);
+    case "must_not_exist":
+      return mustNotExist(index, rule);
+    case "allowed_tools":
+      return allowedTools(index, rule);
+    case "field_constraint":
+      return fieldConstraint(index, rule);
+    case "precedes":
+      return precedes(index, rule);
+  }
+}
+
+function mustExist(index: TranscriptIndex, rule: RuleSpec): RuleResult {
+  const matches = index.events.filter((event) => (rule.match ? matchesEvent(event, rule.match) : true));
+  return matches.length > 0
+    ? pass(rule.id)
+    : fail(rule.id, [{ ruleId: rule.id, message: "No matching event exists" }]);
+}
+
+function mustNotExist(index: TranscriptIndex, rule: RuleSpec): RuleResult {
+  const matches = index.events.filter((event) => (rule.match ? matchesEvent(event, rule.match) : true));
+  return matches.length === 0
+    ? pass(rule.id)
+    : fail(rule.id, matches.map((event) => violation(rule.id, event, "Forbidden event exists")));
+}
+
+function allowedTools(index: TranscriptIndex, rule: RuleSpec): RuleResult {
+  const allowed = rule.allowed ?? [];
+  const violations = index.events
+    .filter((event) => event.type === TrajectoryEventType.ToolCall)
+    .filter((event) => (rule.match ? matchesEvent(event, rule.match) : true))
+    .filter((event) => !allowed.some((pattern) => patternMatches(event.tool, pattern)))
+    .map((event) => violation(rule.id, event, `Disallowed tool call: ${event.tool ?? "<missing>"}`));
+  return violations.length === 0 ? pass(rule.id) : fail(rule.id, violations);
+}
+
+function fieldConstraint(index: TranscriptIndex, rule: RuleSpec): RuleResult {
+  if (rule.field === undefined) {
+    return fail(rule.id, [{ ruleId: rule.id, message: "field_constraint requires field" }]);
+  }
+  const violations = index.events
+    .filter((event) => (rule.match ? matchesEvent(event, rule.match) : true))
+    .filter((event) => !fieldCheck(event, rule))
+    .map((event) => violation(rule.id, event, `Field constraint failed for ${rule.field ?? ""}`));
+  return violations.length === 0 ? pass(rule.id) : fail(rule.id, violations);
+}
+
+function precedes(index: TranscriptIndex, rule: RuleSpec): RuleResult {
+  const trigger = rule.trigger;
+  const required = rule.required;
+  if (trigger === undefined || required === undefined) {
+    return fail(rule.id, [{ ruleId: rule.id, message: "precedes requires trigger and required" }]);
+  }
+  const violations: RuleViolation[] = [];
+  for (const event of index.events) {
+    if (!matchesEvent(event, trigger)) continue;
+    const prior = index.events.filter((candidate) => candidate.seq < event.seq && matchesEvent(candidate, required));
+    const match = prior.find((candidate) => {
+      if (required.match_field === undefined) return true;
+      const triggerValue = fieldValue(event, required.match_field);
+      const requiredValue = fieldValue(candidate, required.match_field);
+      return triggerValue !== undefined && requiredValue !== undefined && valuesEqual(triggerValue, requiredValue);
+    });
+    if (match === undefined) {
+      violations.push(violation(rule.id, event, "No prior required event matched"));
+    }
+  }
+  return violations.length === 0 ? pass(rule.id) : fail(rule.id, violations);
+}
+
+function fieldCheck(event: TrajectoryEvent, rule: RuleSpec): boolean {
+  const value = fieldValue(event, rule.field ?? "");
+  if (rule.exists === true && value === undefined) return false;
+  if (rule.not_exists === true && value !== undefined) return false;
+  if (Object.hasOwn(rule, "equals") && !valuesEqual(value, rule.equals)) return false;
+  if (Object.hasOwn(rule, "not_equals") && valuesEqual(value, rule.not_equals)) return false;
+  if (rule.match_value !== undefined && !patternMatches(value, rule.match_value)) return false;
+  if (rule.not_match !== undefined && patternMatches(value, rule.not_match)) return false;
+  return true;
+}
+
+function pass(ruleId: string): RuleResult {
+  return { ruleId, status: "pass", violations: [] };
+}
+
+function fail(ruleId: string, violations: readonly RuleViolation[]): RuleResult {
+  return { ruleId, status: "fail", violations };
+}
+
+function violation(ruleId: string, event: TrajectoryEvent, message: string): RuleViolation {
+  return {
+    ruleId,
+    message,
+    seq: event.seq,
+    seqRef: formatSeq(event.seq),
+    source: event.source,
+    eventType: event.type,
+    tool: event.tool,
+    status: event.status,
+    spanId: event.spanId,
+    messageSnippet: event.message?.slice(0, 120),
+  };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+bun test src/trajectory/rules.test.ts src/trajectory/match.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/trajectory/rules.ts src/trajectory/rules.test.ts
+git commit -m "feat: evaluate deterministic trajectory rules"
+```
+
+---
+
+## Task 8: Reports And Shared Operation
+
+**Files:**
+- Create: `src/trajectory/report.ts`
+- Test: `src/trajectory/report.test.ts`
+- Create: `src/core/operations/check-trajectory.ts`
+- Test: `src/core/operations/check-trajectory.test.ts`
+- Modify: `src/core/operations/index.ts`
+
+- [ ] **Step 1: Write failing report test**
+
+Create `src/trajectory/report.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { formatAnnotatedEvents, formatMarkdownReport, summarizeReport } from "./report.js";
+import type { TrajectoryCheckReport, TrajectoryEvent } from "./types.js";
+
+const report: TrajectoryCheckReport = {
+  name: "common",
+  transcriptPath: "transcript.jsonl",
+  runtime: "codex",
+  eventCount: 2,
+  specPaths: ["spec/trajectory/common.yaml"],
+  ruleResults: [
+    { ruleId: "ok", status: "pass", violations: [] },
+    {
+      ruleId: "bad",
+      status: "fail",
+      violations: [{ ruleId: "bad", message: "Denied", seq: 2, seqRef: "[seq:0002]" }],
+    },
+  ],
+  goalResults: [{ goalId: "goal", status: "deferred", message: "LLM goal grading is deferred" }],
+  parserWarnings: ["line 5: invalid"],
+  summary: { passed: 1, failed: 1, deferred: 1 },
+};
+
+describe("report formatting", () => {
+  test("summarizes rule and goal statuses", () => {
+    expect(summarizeReport(report.ruleResults, report.goalResults)).toEqual({
+      passed: 1,
+      failed: 1,
+      deferred: 1,
+    });
+  });
+
+  test("formats markdown with sequence references", () => {
+    const markdown = formatMarkdownReport(report);
+    expect(markdown).toContain("# Trajectory Check Report");
+    expect(markdown).toContain("[seq:0002]");
+    expect(markdown).toContain("Parser Warnings");
+  });
+
+  test("formats annotated event JSONL", () => {
+    const events: TrajectoryEvent[] = [
+      { seq: 1, type: "ASSISTANT_MESSAGE", runtime: "codex", message: "hi", source: { path: "t", line: 1 } },
+    ];
+    expect(formatAnnotatedEvents(events)).toContain('[seq:0001] {"seq":1');
+  });
+});
+```
+
+- [ ] **Step 2: Write failing operation test**
+
+Create `src/core/operations/check-trajectory.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkTrajectoryOperation } from "./check-trajectory.js";
+
+async function tempDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "trajectory-op-"));
+}
+
+describe("checkTrajectoryOperation", () => {
+  test("returns a JSON report for local transcript and spec files", async () => {
+    const dir = await tempDir();
+    const transcriptPath = join(dir, "transcript.jsonl");
+    const specPath = join(dir, "spec.yaml");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+    await writeFile(specPath, "name: local\nrules:\n  - id: has-message\n    kind: must_exist\n    match:\n      event: ASSISTANT_MESSAGE\n", "utf8");
+
+    const result = await checkTrajectoryOperation({
+      transcriptPath,
+      specPaths: [specPath],
+      runtime: "subprocess",
+      format: "json",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unexpected error");
+    expect(result.value.report.summary.failed).toBe(0);
+    expect(result.value.output).toContain('"eventCount"');
+  });
+
+  test("writes annotated log when requested", async () => {
+    const dir = await tempDir();
+    const transcriptPath = join(dir, "transcript.jsonl");
+    const specPath = join(dir, "spec.yaml");
+    const annotatedLogPath = join(dir, "annotated.jsonl");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+    await writeFile(specPath, "name: local\nrules: []\n", "utf8");
+
+    const result = await checkTrajectoryOperation({
+      transcriptPath,
+      specPaths: [specPath],
+      runtime: "subprocess",
+      format: "markdown",
+      annotatedLogPath,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(await readFile(annotatedLogPath, "utf8")).toContain("[seq:0001]");
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+bun test src/trajectory/report.test.ts src/core/operations/check-trajectory.test.ts
+```
+
+Expected: FAIL with missing modules.
+
+- [ ] **Step 4: Implement report formatter**
+
+Create `src/trajectory/report.ts`:
+
+```typescript
+import type { GoalResult, RuleResult, TrajectoryCheckReport, TrajectoryEvent } from "./types.js";
+import { formatSeq } from "./types.js";
+
+export function summarizeReport(
+  ruleResults: readonly RuleResult[],
+  goalResults: readonly GoalResult[],
+): TrajectoryCheckReport["summary"] {
+  return {
+    passed: ruleResults.filter((result) => result.status === "pass").length,
+    failed: ruleResults.filter((result) => result.status === "fail").length,
+    deferred: goalResults.length,
+  };
+}
+
+export function formatMarkdownReport(report: TrajectoryCheckReport): string {
+  const lines: string[] = [
+    "# Trajectory Check Report",
+    "",
+    `- Transcript: ${report.transcriptPath}`,
+    `- Runtime: ${report.runtime}`,
+    `- Specs: ${report.specPaths.join(", ")}`,
+    `- Events: ${report.eventCount.toString()}`,
+    "",
+    "## Summary",
+    "",
+    `- Passed: ${report.summary.passed.toString()}`,
+    `- Failed: ${report.summary.failed.toString()}`,
+    `- Deferred: ${report.summary.deferred.toString()}`,
+    "",
+  ];
+
+  lines.push("## Failed Rules", "");
+  const failed = report.ruleResults.filter((result) => result.status === "fail");
+  if (failed.length === 0) lines.push("None.", "");
+  for (const result of failed) {
+    lines.push(`### ${result.ruleId}`, "");
+    for (const violation of result.violations) {
+      lines.push(`- ${violation.seqRef ?? ""} ${violation.message}`.trim());
+    }
+    lines.push("");
+  }
+
+  lines.push("## Passed Rules", "");
+  for (const result of report.ruleResults.filter((item) => item.status === "pass")) {
+    lines.push(`- ${result.ruleId}`);
+  }
+  lines.push("");
+
+  lines.push("## Deferred Goals", "");
+  if (report.goalResults.length === 0) lines.push("None.", "");
+  for (const goal of report.goalResults) lines.push(`- ${goal.goalId}: ${goal.message}`);
+  lines.push("");
+
+  if (report.parserWarnings.length > 0) {
+    lines.push("## Parser Warnings", "");
+    for (const warning of report.parserWarnings) lines.push(`- ${warning}`);
+    lines.push("");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function formatJsonReport(report: TrajectoryCheckReport): string {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+export function formatAnnotatedEvents(events: readonly TrajectoryEvent[]): string {
+  return events.map((event) => `${formatSeq(event.seq)} ${JSON.stringify(compactEvent(event))}`).join("\n") + "\n";
+}
+
+function compactEvent(event: TrajectoryEvent): Record<string, unknown> {
+  return {
+    seq: event.seq,
+    type: event.type,
+    runtime: event.runtime,
+    source: event.source,
+    ...(event.tool !== undefined ? { tool: event.tool } : {}),
+    ...(event.status !== undefined ? { status: event.status } : {}),
+    ...(event.spanId !== undefined ? { spanId: event.spanId } : {}),
+    ...(event.parentSpanId !== undefined ? { parentSpanId: event.parentSpanId } : {}),
+    ...(event.message !== undefined ? { message: event.message } : {}),
+  };
+}
+```
+
+- [ ] **Step 5: Implement operation**
+
+Create `src/core/operations/check-trajectory.ts`:
+
+```typescript
+import { writeFile } from "node:fs/promises";
+import { buildTranscriptIndex } from "../../trajectory/indexer.js";
+import { evaluateRules } from "../../trajectory/rules.js";
+import { loadTrajectorySpecs } from "../../trajectory/spec-loader.js";
+import {
+  formatAnnotatedEvents,
+  formatJsonReport,
+  formatMarkdownReport,
+  summarizeReport,
+} from "../../trajectory/report.js";
+import type { ReportFormat, TrajectoryCheckReport, TrajectoryRuntimeInput } from "../../trajectory/types.js";
+import type { OperationResult } from "./result.js";
+import { err, ok, OperationErrorCode, validationErr } from "./result.js";
+
+export interface CheckTrajectoryInput {
+  readonly transcriptPath: string;
+  readonly specPaths: readonly string[];
+  readonly runtime: TrajectoryRuntimeInput;
+  readonly format: ReportFormat;
+  readonly annotatedLogPath?: string | undefined;
+}
+
+export interface CheckTrajectoryResult {
+  readonly report: TrajectoryCheckReport;
+  readonly output: string;
+}
+
+export async function checkTrajectoryOperation(
+  input: CheckTrajectoryInput,
+): Promise<OperationResult<CheckTrajectoryResult>> {
+  if (input.transcriptPath.trim().length === 0) return validationErr("transcriptPath is required");
+  if (input.specPaths.length === 0) return validationErr("at least one spec path is required");
+
+  try {
+    const index = await buildTranscriptIndex({
+      transcriptPath: input.transcriptPath,
+      runtime: input.runtime,
+    });
+    const spec = await loadTrajectorySpecs(input.specPaths);
+    const ruleResults = evaluateRules(index, spec.rules);
+    const goalResults = spec.goals.map((goal) => ({
+      goalId: goal.id,
+      status: "deferred" as const,
+      message: "LLM goal grading is deferred in this implementation slice",
+    }));
+    const summary = summarizeReport(ruleResults, goalResults);
+    const report: TrajectoryCheckReport = {
+      name: spec.name,
+      transcriptPath: input.transcriptPath,
+      runtime: index.runtime,
+      eventCount: index.events.length,
+      specPaths: spec.sourcePaths,
+      ruleResults,
+      goalResults,
+      parserWarnings: index.warnings,
+      summary,
+    };
+    if (input.annotatedLogPath !== undefined) {
+      await writeFile(input.annotatedLogPath, formatAnnotatedEvents(index.events), "utf8");
+    }
+    const output =
+      input.format === "json" ? formatJsonReport(report) : formatMarkdownReport(report);
+    return ok({ report, output });
+  } catch (error) {
+    return err({
+      code: OperationErrorCode.ValidationError,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+```
+
+Modify `src/core/operations/index.ts`:
+
+```typescript
+export type { CheckTrajectoryInput, CheckTrajectoryResult } from "./check-trajectory.js";
+export { checkTrajectoryOperation } from "./check-trajectory.js";
+```
+
+Place those exports in the operations barrel near the eval operation exports.
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+bun test src/trajectory/report.test.ts src/core/operations/check-trajectory.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/trajectory/report.ts src/trajectory/report.test.ts src/core/operations/check-trajectory.ts src/core/operations/check-trajectory.test.ts src/core/operations/index.ts
+git commit -m "feat: add trajectory check operation"
+```
+
+---
+
+## Task 9: CLI Surface
+
+**Files:**
+- Create: `src/cli/commands/check-trajectory.ts`
+- Test: `src/cli/commands/check-trajectory.test.ts`
+- Modify: `src/cli/main.ts`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Create `src/cli/commands/check-trajectory.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseCheckTrajectoryArgs, runCheckTrajectory } from "./check-trajectory.js";
+
+describe("parseCheckTrajectoryArgs", () => {
+  test("parses transcript, repeated specs, runtime, format, and annotated log", () => {
+    expect(
+      parseCheckTrajectoryArgs([
+        "--transcript",
+        "t.jsonl",
+        "--spec",
+        "a.yaml",
+        "--spec",
+        "b.yaml",
+        "--runtime",
+        "codex",
+        "--format",
+        "json",
+        "--annotated-log",
+        "annotated.jsonl",
+      ]),
+    ).toEqual({
+      transcriptPath: "t.jsonl",
+      specPaths: ["a.yaml", "b.yaml"],
+      runtime: "codex",
+      format: "json",
+      annotatedLogPath: "annotated.jsonl",
+    });
+  });
+});
+
+describe("runCheckTrajectory", () => {
+  test("writes markdown output through the injected writer", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trajectory-cli-"));
+    const transcriptPath = join(dir, "transcript.jsonl");
+    const specPath = join(dir, "spec.yaml");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+    await writeFile(specPath, "name: local\nrules: []\n", "utf8");
+    const lines: string[] = [];
+
+    await runCheckTrajectory(
+      {
+        transcriptPath,
+        specPaths: [specPath],
+        runtime: "subprocess",
+        format: "markdown",
+      },
+      (line) => lines.push(line),
+    );
+
+    expect(lines.join("\n")).toContain("# Trajectory Check Report");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bun test src/cli/commands/check-trajectory.test.ts
+```
+
+Expected: FAIL with missing command module.
+
+- [ ] **Step 3: Implement CLI command**
+
+Create `src/cli/commands/check-trajectory.ts`:
+
+```typescript
+import { parseArgs } from "node:util";
+import { checkTrajectoryOperation, type CheckTrajectoryInput } from "../../core/operations/index.js";
+import type { ReportFormat, TrajectoryRuntimeInput } from "../../trajectory/types.js";
+
+const RUNTIMES = new Set<TrajectoryRuntimeInput>([
+  "auto",
+  "acpx",
+  "codex",
+  "claude-stream-json",
+  "subprocess",
+  "unknown",
+]);
+const FORMATS = new Set<ReportFormat>(["markdown", "json"]);
+
+export function parseCheckTrajectoryArgs(argv: readonly string[]): CheckTrajectoryInput {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      transcript: { type: "string" },
+      spec: { type: "string", multiple: true },
+      runtime: { type: "string", default: "auto" },
+      format: { type: "string", default: "markdown" },
+      "annotated-log": { type: "string" },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+
+  if (values.transcript === undefined) throw new Error("--transcript is required");
+  const runtime = values.runtime ?? "auto";
+  if (!RUNTIMES.has(runtime as TrajectoryRuntimeInput)) {
+    throw new Error(`Invalid runtime: ${runtime}`);
+  }
+  const format = values.format ?? "markdown";
+  if (!FORMATS.has(format as ReportFormat)) {
+    throw new Error(`Invalid format: ${format}`);
+  }
+
+  return {
+    transcriptPath: values.transcript,
+    specPaths: values.spec ?? ["spec/trajectory/common.yaml"],
+    runtime: runtime as TrajectoryRuntimeInput,
+    format: format as ReportFormat,
+    ...(values["annotated-log"] !== undefined ? { annotatedLogPath: values["annotated-log"] } : {}),
+  };
+}
+
+export async function runCheckTrajectory(
+  input: CheckTrajectoryInput,
+  writer: (line: string) => void = console.log,
+): Promise<void> {
+  const result = await checkTrajectoryOperation(input);
+  if (!result.ok) throw new Error(result.error.message);
+  writer(result.value.output.trimEnd());
+}
+```
+
+Modify `src/cli/main.ts` command registry:
+
+```typescript
+{
+  name: "check-trajectory",
+  description: "Check a local agent transcript against trajectory rules",
+  needsStore: false,
+  helpText: `grove check-trajectory — check a local agent transcript
+
+Usage:
+  grove check-trajectory --transcript <path> [--spec <path>] [--runtime auto|acpx|codex|claude-stream-json|subprocess] [--format markdown|json] [--annotated-log <path>]`,
+  handler: async (args) => {
+    const { parseCheckTrajectoryArgs, runCheckTrajectory } = await import("./commands/check-trajectory.js");
+    await runCheckTrajectory(parseCheckTrajectoryArgs(args));
+  },
+},
+```
+
+Add it under `Advanced` in `printUsage()`:
+
+```text
+  grove check-trajectory --transcript <path> Check local transcript rules
+```
+
+- [ ] **Step 4: Run CLI tests**
+
+Run:
+
+```bash
+bun test src/cli/commands/check-trajectory.test.ts src/cli/main.integration.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/commands/check-trajectory.ts src/cli/commands/check-trajectory.test.ts src/cli/main.ts
+git commit -m "feat: add check-trajectory CLI"
+```
+
+---
+
+## Task 10: MCP Surface And Parity
+
+**Files:**
+- Create: `src/mcp/tools/trajectory.ts`
+- Test: `src/mcp/tools/trajectory.test.ts`
+- Modify: `src/mcp/server.ts`
+- Modify: `src/core/operations/parity-matrix.test.ts`
+- Modify: `docs/parity-matrix.md`
+
+- [ ] **Step 1: Write failing MCP test**
+
+Create `src/mcp/tools/trajectory.test.ts`:
+
+```typescript
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpDeps } from "../deps.js";
+import type { TestMcpDeps } from "../test-helpers.js";
+import { createTestMcpDeps } from "../test-helpers.js";
+import { registerTrajectoryTools } from "./trajectory.js";
+
+async function callTool(
+  server: McpServer,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ isError: boolean | undefined; text: string }> {
+  const registeredTools = (
+    server as unknown as {
+      _registeredTools: Record<string, { handler: (args: unknown) => Promise<unknown> }>;
+    }
+  )._registeredTools;
+  const tool = registeredTools[name];
+  if (!tool) throw new Error(`Tool ${name} not registered`);
+  const result = (await tool.handler(args)) as {
+    isError?: boolean;
+    content: Array<{ type: string; text: string }>;
+  };
+  return { isError: result.isError, text: result.content[0]?.text ?? "" };
+}
+
+describe("grove_check_trajectory", () => {
+  let testDeps: TestMcpDeps;
+  let deps: McpDeps;
+  let server: McpServer;
+
+  beforeEach(async () => {
+    testDeps = await createTestMcpDeps();
+    deps = testDeps.deps;
+    server = new McpServer({ name: "test", version: "0.0.1" }, { capabilities: { tools: {} } });
+    registerTrajectoryTools(server, deps);
+  });
+
+  afterEach(async () => {
+    await testDeps.cleanup();
+  });
+
+  test("returns trajectory report JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trajectory-mcp-"));
+    const transcriptPath = join(dir, "transcript.jsonl");
+    const specPath = join(dir, "spec.yaml");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+    await writeFile(specPath, "name: local\nrules: []\n", "utf8");
+
+    const result = await callTool(server, "grove_check_trajectory", {
+      transcriptPath,
+      specPaths: [specPath],
+      runtime: "subprocess",
+      format: "json",
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.text);
+    expect(data.report.eventCount).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bun test src/mcp/tools/trajectory.test.ts
+```
+
+Expected: FAIL with missing MCP tool module.
+
+- [ ] **Step 3: Implement MCP tool**
+
+Create `src/mcp/tools/trajectory.ts`:
+
+```typescript
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { checkTrajectoryOperation } from "../../core/operations/index.js";
+import type { ReportFormat, TrajectoryRuntimeInput } from "../../trajectory/types.js";
+import type { McpDeps } from "../deps.js";
+import { toMcpResult } from "../operation-adapter.js";
+
+const runtimeSchema = z.enum(["auto", "acpx", "codex", "claude-stream-json", "subprocess"]);
+const formatSchema = z.enum(["markdown", "json"]);
+
+export function registerTrajectoryTools(server: McpServer, _deps: McpDeps): void {
+  server.registerTool(
+    "grove_check_trajectory",
+    {
+      description:
+        "Check a local agent transcript JSONL file against deterministic Grove trajectory YAML rules.",
+      inputSchema: {
+        transcriptPath: z.string().min(1),
+        specPaths: z.array(z.string().min(1)).min(1).default(["spec/trajectory/common.yaml"]),
+        runtime: runtimeSchema.default("auto"),
+        format: formatSchema.default("json"),
+        annotatedLogPath: z.string().min(1).optional(),
+      },
+    },
+    async (args) => {
+      return toMcpResult(
+        await checkTrajectoryOperation({
+          transcriptPath: args.transcriptPath,
+          specPaths: args.specPaths,
+          runtime: args.runtime as TrajectoryRuntimeInput,
+          format: args.format as ReportFormat,
+          ...(args.annotatedLogPath !== undefined ? { annotatedLogPath: args.annotatedLogPath } : {}),
+        }),
+      );
+    },
+  );
+}
+```
+
+Modify `src/mcp/server.ts`:
+
+```typescript
+import { registerTrajectoryTools } from "./tools/trajectory.js";
+```
+
+Add registration near query tools:
+
+```typescript
+if (preset?.queries !== false) {
+  registerQueryTools(server, deps);
+  registerTrajectoryTools(server, deps);
+}
+```
+
+Modify `src/core/operations/parity-matrix.test.ts`:
+
+```typescript
+{ operation: "checkTrajectoryOperation", mcpTool: "grove_check_trajectory" },
+```
+
+Add the same operation to the CLI shared list:
+
+```typescript
+{ operation: "checkTrajectoryOperation", cliCommand: "check-trajectory" },
+```
+
+Add `"checkTrajectoryOperation"` to `expectedExports`.
+
+Modify `docs/parity-matrix.md` capability table:
+
+```markdown
+| check trajectory | Y | Y | - | - | shared |
+```
+
+- [ ] **Step 4: Run MCP and parity tests**
+
+Run:
+
+```bash
+bun test src/mcp/tools/trajectory.test.ts src/core/operations/parity-matrix.test.ts src/mcp/server.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/tools/trajectory.ts src/mcp/tools/trajectory.test.ts src/mcp/server.ts src/core/operations/parity-matrix.test.ts docs/parity-matrix.md
+git commit -m "feat: add trajectory MCP tool"
+```
+
+---
+
+## Task 11: End-To-End Verification
+
+**Files:**
+- Modify as needed from prior tasks only.
+
+- [ ] **Step 1: Run focused trajectory tests**
+
+Run:
+
+```bash
+bun test src/trajectory src/core/operations/check-trajectory.test.ts src/cli/commands/check-trajectory.test.ts src/mcp/tools/trajectory.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Biome check**
+
+Run:
+
+```bash
+bun run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full test suite if focused checks are clean**
+
+Run:
+
+```bash
+bun test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Manual CLI smoke test**
+
+Run:
+
+```bash
+bun run src/cli/main.ts check-trajectory \
+  --transcript tests/fixtures/trajectory/codex-transcript.jsonl \
+  --spec spec/trajectory/common.yaml \
+  --runtime codex \
+  --format markdown
+```
+
+Expected: output starts with `# Trajectory Check Report` and includes `Runtime: codex`.
+
+- [ ] **Step 6: Final commit for verification-only fixes**
+
+If verification required small fixes, commit them:
+
+```bash
+git add src docs spec tests
+git commit -m "test: verify trajectory checker"
+```
+
+If there were no verification-only changes, skip this commit and record the clean command output in the final handoff.
+
+---
+
+## Self-Review Notes
+
+Spec coverage:
+
+- Runtime parser support for `acpx`, Codex, Claude Code `stream-json`, and subprocess is covered by Tasks 4 and 5.
+- `TranscriptIndex`, sequence markers, and span indexes are covered by Tasks 1 and 3.
+- YAML spec loading and duplicate-rule validation are covered by Task 6.
+- Five deterministic rule kinds are covered by Task 7.
+- Markdown, JSON, and annotated sidecar reports are covered by Task 8.
+- CLI and MCP surfaces are covered by Tasks 9 and 10.
+- Default `common.yaml` and parity docs are covered by Tasks 6 and 10.
+- LLM goal grading remains intentionally deferred in Task 8 goal result handling.
+
+Type consistency:
+
+- Operation name is `checkTrajectoryOperation`.
+- CLI command is `check-trajectory`.
+- MCP tool name is `grove_check_trajectory`.
+- Runtime input type is `TrajectoryRuntimeInput`.
+- Report object type is `TrajectoryCheckReport`.
+
+No out-of-scope server route, SQLite persistence, or live log middleware is included in this implementation plan.

--- a/docs/superpowers/specs/2026-05-05-trajectory-check-design.md
+++ b/docs/superpowers/specs/2026-05-05-trajectory-check-design.md
@@ -1,0 +1,444 @@
+# Trajectory Check - Design
+
+- **Issue**: [#339](https://github.com/windoliver/grove/issues/339)
+- **Date**: 2026-05-05
+- **Status**: Approved
+- **Related**: [#211](https://github.com/windoliver/grove/issues/211), [#375](https://github.com/windoliver/grove/issues/375), [#376](https://github.com/windoliver/grove/issues/376), [#378](https://github.com/windoliver/grove/issues/378), [#379](https://github.com/windoliver/grove/issues/379)
+
+## Goal
+
+Add a local trajectory checker that normalizes agent transcript JSONL into a
+single event index, runs deterministic YAML rules, and exposes the same report
+through a CLI command and MCP tool.
+
+The first implementation slice supports local transcript files for all runtime
+families named in issue #339: `acpx`, Codex, Claude Code `stream-json`, and
+plain subprocess. It does not run LLM goal grading.
+
+## Non-goals
+
+- LLM-graded goals. Goal blocks are parsed and reported as deferred so #211 can
+  attach grading later.
+- Live transcript middleware that writes `[seq:NNNN]` into every runtime's
+  `info.log` and `debug.log`. This slice emits sequence cross-references in the
+  report and optional annotated sidecar files.
+- Persisting trajectory events into Grove's SQLite stores. The checker is a
+  local post-hoc analysis command over files.
+- Replacing WorkBlock, AgentTask, AutonomyProfile, or RunHealth models. The
+  event schema reserves compatible event families, but the canonical models are
+  owned by #375, #376, #378, and #379.
+- Remote transcript fetching, server routes, or hosted evaluation runs.
+
+## Command Shape
+
+CLI:
+
+```bash
+grove check-trajectory \
+  --transcript transcript.jsonl \
+  --spec spec/trajectory/common.yaml \
+  --runtime auto \
+  --format markdown
+```
+
+Flags:
+
+| Flag | Default | Behavior |
+| --- | --- | --- |
+| `--transcript <path>` | required | Local JSONL transcript file to evaluate |
+| `--spec <path>` | `spec/trajectory/common.yaml` | YAML check spec; may be passed multiple times |
+| `--runtime auto|acpx|codex|claude-stream-json|subprocess` | `auto` | Parser selection |
+| `--format markdown|json` | `markdown` | Report output format |
+| `--annotated-log <path>` | unset | Optional sidecar file that writes one normalized event per line with `[seq:NNNN]` |
+
+MCP:
+
+- Tool name: `grove_check_trajectory`
+- Input fields mirror the CLI: `transcriptPath`, `specPaths`, `runtime`,
+  `format`, and optional `annotatedLogPath`.
+- The tool reads local files only. It returns the same structured result the
+  CLI uses, formatted through the existing MCP operation adapter.
+
+The CLI command is registered in `src/cli/main.ts`. The MCP tool is registered
+through `src/mcp/server.ts` and lives in `src/mcp/tools/trajectory.ts`.
+
+## Architecture
+
+```
+transcript.jsonl
+  -> runtime parser
+  -> TranscriptIndex
+  -> YAML spec loader
+  -> deterministic rule engine
+  -> report formatter
+  -> CLI / MCP
+```
+
+Files:
+
+- `src/trajectory/types.ts`: event, parser, spec, rule, and report contracts.
+- `src/trajectory/indexer.ts`: JSONL loading, parser selection, sequence
+  assignment, span indexing, and event lookup helpers.
+- `src/trajectory/parsers/acpx.ts`: ACP JSON-RPC NDJSON parser using existing
+  ACP message semantics where practical.
+- `src/trajectory/parsers/codex.ts`: tolerant parser for Codex transcript JSONL
+  shapes and Codex ACP-compatible output.
+- `src/trajectory/parsers/claude-stream-json.ts`: parser for Claude Code
+  `stream-json`, including `parent_tool_use_id` span mapping.
+- `src/trajectory/parsers/subprocess.ts`: parser for plain stdout/stderr JSONL
+  and line-oriented subprocess logs.
+- `src/trajectory/spec-loader.ts`: YAML parsing and validation.
+- `src/trajectory/match.ts`: event and dotted-field matching helpers.
+- `src/trajectory/rules.ts`: five deterministic rule kinds.
+- `src/trajectory/report.ts`: markdown, JSON, and annotated-log formatting.
+- `src/core/operations/check-trajectory.ts`: operation wrapper shared by CLI
+  and MCP.
+- `src/cli/commands/check-trajectory.ts`: CLI parser and runner.
+- `src/mcp/tools/trajectory.ts`: MCP registration.
+- `spec/trajectory/common.yaml`: default deterministic rules.
+
+## Transcript Index
+
+Every normalized event has a monotonic sequence number assigned after parsing,
+starting at `1`. Human-facing references use zero-padded markers:
+`[seq:0001]`, `[seq:0002]`, and so on.
+
+```typescript
+export const TrajectoryEventType = {
+  AgentStart: "AGENT_START",
+  ToolCall: "TOOL_CALL",
+  ToolResult: "TOOL_RESULT",
+  Delegation: "DELEGATION",
+  DelegationReturn: "DELEGATION_RETURN",
+  AssistantMessage: "ASSISTANT_MESSAGE",
+  Compaction: "COMPACTION",
+  PermissionDenied: "PERMISSION_DENIED",
+  WorkBlockStarted: "WORK_BLOCK_STARTED",
+  WorkBlockUpdated: "WORK_BLOCK_UPDATED",
+  WorkBlockFinished: "WORK_BLOCK_FINISHED",
+  TaskTriggered: "TASK_TRIGGERED",
+  TaskAdmitted: "TASK_ADMITTED",
+  TaskScheduled: "TASK_SCHEDULED",
+  PermissionWait: "PERMISSION_WAIT",
+  PermissionDecision: "PERMISSION_DECISION",
+  HealthDegraded: "HEALTH_DEGRADED",
+  HealthRecovered: "HEALTH_RECOVERED",
+  ContributionChanged: "CONTRIBUTION_CHANGED",
+  ArtifactChanged: "ARTIFACT_CHANGED",
+  ReviewChanged: "REVIEW_CHANGED",
+  AdoptionChanged: "ADOPTION_CHANGED",
+  Raw: "RAW",
+} as const;
+```
+
+The extra event families from the issue comment are part of the schema now, but
+runtime parsers only emit them when transcript payloads carry enough
+information. This keeps the shape compatible with future timeline and health
+views without inventing their stores.
+
+`TrajectoryEvent` fields:
+
+- `seq`: assigned by `TranscriptIndex`.
+- `type`: one of `TrajectoryEventType`.
+- `runtime`: `acpx`, `codex`, `claude-stream-json`, `subprocess`, or
+  `unknown`.
+- `timestamp`: ISO string when present in the transcript.
+- `sessionId`, `turnId`, `agentId`, `role`: optional identity fields.
+- `spanId`: stable event span, usually a tool call id or generated parser id.
+- `parentSpanId`: delegation parent span, populated from
+  `parent_tool_use_id` or equivalent fields.
+- `tool`: canonical tool name when known.
+- `status`: lifecycle status when known.
+- `input`, `output`, `message`, `error`: normalized payload fields.
+- `raw`: original parsed JSON value or raw text for auditability.
+- `source`: `{ path, line }` for exact file provenance.
+
+The index keeps:
+
+- `events`: events in sequence order.
+- `bySeq`: direct lookup.
+- `bySpanId`: span lookup for delegation and tool result joins.
+- `childrenByParentSpanId`: delegation tree lookup.
+
+Malformed JSONL lines produce `RAW` events with `error` describing the parse
+failure. Parser exceptions are captured per line so one bad line does not hide
+later evidence.
+
+## Runtime Parsers
+
+### `acpx`
+
+The ACP parser accepts JSON-RPC NDJSON like the fixtures under
+`tests/fixtures/acp/`. It maps:
+
+- `session/new` result to `AGENT_START`.
+- `session/update` `agent_message_chunk` and `user_message_chunk` to
+  `ASSISTANT_MESSAGE` when emitted by the agent side, preserving raw payload.
+- `session/update` `tool_call` to `TOOL_CALL`.
+- `session/update` `tool_call_update` with terminal status or output to
+  `TOOL_RESULT`.
+- permission request signals to `PERMISSION_WAIT`.
+- denied or cancelled permission responses, when present, to
+  `PERMISSION_DENIED` and `PERMISSION_DECISION`.
+- final result frames with context compaction signals to `COMPACTION` only
+  when the raw payload explicitly names compaction.
+
+Unknown `session/update` kinds become `RAW` events.
+
+### `codex`
+
+The Codex parser handles two shapes:
+
+- Codex ACP-compatible NDJSON, using the same event mappings as `acpx` with
+  `runtime: "codex"`.
+- Codex transcript records that contain common fields such as `type`, `role`,
+  `message`, `tool`, `tool_name`, `call_id`, `id`, `input`, `output`,
+  `error`, `status`, and `timestamp`.
+
+It is intentionally tolerant because Codex transcript formats have changed
+over time. Records that cannot be confidently classified become `RAW`, but
+dotted-field rule matching can still inspect their `raw` payload.
+
+### `claude-stream-json`
+
+The Claude parser handles Claude Code `stream-json` records. It maps:
+
+- assistant text deltas to `ASSISTANT_MESSAGE`.
+- `tool_use` / `tool_call` records to `TOOL_CALL`.
+- `tool_result` records to `TOOL_RESULT`.
+- `subagent` or task-style tool calls to `DELEGATION`.
+- completion or result records for a delegated span to `DELEGATION_RETURN`.
+- permission denial records and blocked tool results to `PERMISSION_DENIED`.
+
+When a record carries `parent_tool_use_id`, the parser sets
+`parentSpanId = parent_tool_use_id` and `spanId` to the current `tool_use_id`,
+`tool_call_id`, or generated id. This makes subagent delegation structurally
+visible in the same index used by native Grove delegation.
+
+### `subprocess`
+
+The subprocess parser supports plain local command transcripts with weaker
+semantics:
+
+- JSONL records with `event`, `type`, or `kind` are mapped when they match a
+  known event name.
+- JSONL records with `stream: "stdout"` or `stream: "stderr"` become
+  `ASSISTANT_MESSAGE` unless they carry a tool or permission signal.
+- Non-JSON lines become `RAW` events with `message` set to the line text.
+- Process start records become `AGENT_START` when they include command or pid
+  fields.
+
+Subprocess output cannot reliably reconstruct tool calls unless the producer
+wrote structured events. The parser keeps raw evidence visible rather than
+pretending a stronger structure exists.
+
+### Auto Detection
+
+`auto` samples the first parseable records:
+
+1. JSON-RPC `session/update` or `session/new` means `acpx`, unless provider
+   metadata identifies Codex, then `codex`.
+2. Claude `stream-json` fields such as `parent_tool_use_id`, `tool_use_id`, or
+   `type: "assistant"` plus Claude-style content blocks mean
+   `claude-stream-json`.
+3. Codex-specific metadata or common Codex transcript event names mean `codex`.
+4. Everything else falls back to `subprocess`.
+
+The selected runtime is recorded in the report. Users can override it when auto
+detection is wrong.
+
+## YAML Spec
+
+Specs are YAML files with `name`, `rules`, and optional `goals`.
+
+```yaml
+name: review-loop-default
+rules:
+  - id: no-permission-denials
+    kind: must_not_exist
+    match:
+      event: PERMISSION_DENIED
+
+  - id: edits-require-backup
+    kind: precedes
+    trigger:
+      event: TOOL_CALL
+      tool: "apply_patch|edit_file"
+      field_not_match:
+        input.patch: "--- /dev/null*"
+    required:
+      event: TOOL_CALL
+      tool: backup_file
+      match_field: input.file_path
+
+goals:
+  - id: user-goal-achieved
+    criteria: The agent completed the requested task and reported results clearly.
+    evidence: [delegation, agent_start, assistant_message]
+```
+
+Event names in YAML accept either canonical uppercase names or lowercase aliases
+such as `tool_call`. Tool patterns use simple glob alternation, so
+`"apply_patch|edit_file"` matches either tool name exactly. Dotted field paths
+can read normalized event fields and `raw` payload fields.
+
+Multiple `--spec` files are merged in order. Duplicate rule ids are rejected
+with a validation error so operators do not accidentally shadow rules.
+
+## Rule Engine
+
+The engine returns `pass`, `fail`, or `deferred` checks. Deterministic rules
+never call an LLM.
+
+### `must_exist`
+
+Passes when at least one event matches `match`.
+
+Violation: one report entry with the rule id and a message stating that no
+matching event exists.
+
+### `must_not_exist`
+
+Passes when no events match `match`.
+
+Violation: one report entry per matching event, each with that event's
+`[seq:NNNN]`.
+
+### `allowed_tools`
+
+Validates every `TOOL_CALL` against an allowlist. Optional `match` can scope the
+allowlist to a subset of events.
+
+Violation: one report entry per disallowed tool call.
+
+### `field_constraint`
+
+Validates a dotted field path against `equals`, `not_equals`, `match`,
+`not_match`, `exists`, or `not_exists`.
+
+Violation: one report entry per matching event whose field check fails.
+
+### `precedes`
+
+For every event matching `trigger`, finds a prior event matching `required`.
+If `required.match_field` is set, the required event must have the same field
+value as the trigger event at that dotted path. If the required field is absent
+from either side, the trigger fails with an explicit missing-field reason.
+
+Violation: one report entry per trigger with no matching prior evidence.
+
+This rule supports the issue's backup-before-modify example without needing a
+custom rule.
+
+## Reporting
+
+JSON report shape:
+
+```typescript
+interface TrajectoryCheckReport {
+  readonly name: string;
+  readonly transcriptPath: string;
+  readonly runtime: string;
+  readonly eventCount: number;
+  readonly ruleResults: readonly RuleResult[];
+  readonly goalResults: readonly GoalResult[];
+  readonly summary: {
+    readonly passed: number;
+    readonly failed: number;
+    readonly deferred: number;
+  };
+}
+```
+
+Markdown report sections:
+
+- header with transcript, runtime, spec names, and event count
+- summary counts
+- failed deterministic rules first
+- passed deterministic rules
+- deferred goals
+- parser warnings
+
+Violation entries include:
+
+- `ruleId`
+- `message`
+- `seq` and `[seq:NNNN]` when tied to a specific event
+- `source.path` and `source.line`
+- compact event context: type, tool, status, span, and message snippet
+
+Annotated sidecar output writes JSONL where every line starts with
+`[seq:NNNN] ` followed by a compact normalized event JSON object. This gives
+operators a grep target immediately while leaving live log middleware for a
+later integration slice.
+
+## Default Spec
+
+`spec/trajectory/common.yaml` ships conservative rules:
+
+- no permission denials
+- every transcript has at least one agent start or assistant message
+- tool calls must have a tool name
+- tool results must reference a span id when one is present in the runtime
+- delegated returns must reference a known parent span when parent metadata is
+  present
+
+The default spec avoids Grove-specific workflow rules such as
+backup-before-modify because those can be too opinionated for research,
+support, incident, and subprocess sessions. Workflow presets can add local
+`mr-*.yaml` specs later.
+
+## Error Handling
+
+- Missing transcript: validation error.
+- Missing spec: validation error.
+- Invalid YAML: validation error with file path and parser message.
+- Unknown rule kind: validation error with rule id.
+- Invalid dotted field path syntax: validation error with rule id.
+- Bad JSONL line: parser warning plus `RAW` event; checking continues.
+- No parseable events: report is produced with failed default evidence rules.
+- Annotated-log write failure: operation returns an error after rule evaluation
+  because the user explicitly requested that file.
+
+## Testing
+
+All tests use `bun:test`.
+
+Parser fixtures:
+
+- ACP/Codex fixtures reuse `tests/fixtures/acp/codex-simple.ndjson`,
+  `claude-simple.ndjson`, and `claude-tool-call.ndjson`.
+- New `tests/fixtures/trajectory/claude-stream-json.jsonl` covers
+  `parent_tool_use_id` delegation.
+- New `tests/fixtures/trajectory/codex-transcript.jsonl` covers Codex native
+  transcript records.
+- New `tests/fixtures/trajectory/subprocess.log` covers mixed JSON and text
+  subprocess output.
+
+Unit tests:
+
+- index sequence assignment and lookup.
+- runtime auto detection.
+- parser mapping for each runtime.
+- dotted field lookup, glob matching, and negative guards.
+- each rule kind, including `precedes` with `match_field`.
+- YAML spec validation and duplicate rule rejection.
+- markdown, JSON, and annotated-log formatting.
+
+Surface tests:
+
+- CLI argument parsing and a temp-file end-to-end check.
+- MCP tool registration and result shape.
+- parity matrix update for the new shared capability.
+
+## Integration Path
+
+This slice creates the deterministic post-hoc layer that #211 can call later.
+Future work can add:
+
+- LLM goal grading over `goalResults`.
+- transcript middleware that emits `[seq:NNNN]` into live `info.log` and
+  `debug.log`.
+- persistence of trajectory events for timeline, health, diagnostics, and daily
+  digest surfaces.
+- session-local spec discovery such as `common.yaml` plus `mr-*.yaml`.

--- a/spec/trajectory/common.yaml
+++ b/spec/trajectory/common.yaml
@@ -1,0 +1,27 @@
+name: common
+rules:
+  - id: no-permission-denials
+    kind: must_not_exist
+    match:
+      event: PERMISSION_DENIED
+
+  - id: has-agent-or-message
+    kind: must_exist
+    match:
+      event: ASSISTANT_MESSAGE|AGENT_START
+
+  - id: tool-calls-have-tool
+    kind: field_constraint
+    match:
+      event: TOOL_CALL
+    field: tool
+    exists: true
+
+  - id: tool-results-have-span
+    kind: field_constraint
+    match:
+      event: TOOL_RESULT
+    field: spanId
+    exists: true
+
+goals: []

--- a/src/cli/commands/check-trajectory.test.ts
+++ b/src/cli/commands/check-trajectory.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
+import { UsageError } from "../errors.js";
 import { parseCheckTrajectoryArgs, runCheckTrajectory } from "./check-trajectory.js";
 
 describe("parseCheckTrajectoryArgs", () => {
@@ -28,6 +29,29 @@ describe("parseCheckTrajectoryArgs", () => {
       format: "json",
       annotatedLogPath: "annotated.jsonl",
     });
+  });
+
+  test("throws UsageError when transcript is missing", () => {
+    expect(() => parseCheckTrajectoryArgs([])).toThrow(UsageError);
+  });
+
+  test("throws UsageError when runtime is invalid", () => {
+    expect(() =>
+      parseCheckTrajectoryArgs(["--transcript", "t.jsonl", "--runtime", "invalid"]),
+    ).toThrow(UsageError);
+  });
+
+  test("wraps unknown flag parser errors as UsageError", () => {
+    expect(() => parseCheckTrajectoryArgs(["--transcript", "t.jsonl", "--wat"])).toThrow(
+      UsageError,
+    );
+  });
+
+  test("uses an absolute bundled default spec path", () => {
+    const parsed = parseCheckTrajectoryArgs(["--transcript", "t.jsonl"]);
+
+    expect(parsed.specPaths[0]).toEndWith(join("spec", "trajectory", "common.yaml"));
+    expect(isAbsolute(parsed.specPaths[0] ?? "")).toBe(true);
   });
 });
 

--- a/src/cli/commands/check-trajectory.test.ts
+++ b/src/cli/commands/check-trajectory.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseCheckTrajectoryArgs, runCheckTrajectory } from "./check-trajectory.js";
+
+describe("parseCheckTrajectoryArgs", () => {
+  test("parses transcript, repeated specs, runtime, format, and annotated log", () => {
+    expect(
+      parseCheckTrajectoryArgs([
+        "--transcript",
+        "t.jsonl",
+        "--spec",
+        "a.yaml",
+        "--spec",
+        "b.yaml",
+        "--runtime",
+        "codex",
+        "--format",
+        "json",
+        "--annotated-log",
+        "annotated.jsonl",
+      ]),
+    ).toEqual({
+      transcriptPath: "t.jsonl",
+      specPaths: ["a.yaml", "b.yaml"],
+      runtime: "codex",
+      format: "json",
+      annotatedLogPath: "annotated.jsonl",
+    });
+  });
+});
+
+describe("runCheckTrajectory", () => {
+  test("writes markdown output through the injected writer", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trajectory-cli-"));
+    const transcriptPath = join(dir, "transcript.jsonl");
+    const specPath = join(dir, "spec.yaml");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+    await writeFile(specPath, "name: local\nrules: []\n", "utf8");
+    const lines: string[] = [];
+
+    await runCheckTrajectory(
+      {
+        transcriptPath,
+        specPaths: [specPath],
+        runtime: "subprocess",
+        format: "markdown",
+      },
+      (line) => lines.push(line),
+    );
+
+    expect(lines.join("\n")).toContain("# Trajectory Check Report");
+  });
+});

--- a/src/cli/commands/check-trajectory.ts
+++ b/src/cli/commands/check-trajectory.ts
@@ -1,9 +1,15 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import type { CheckTrajectoryInput } from "../../core/operations/index.js";
 import { checkTrajectoryOperation } from "../../core/operations/index.js";
 import type { ReportFormat, TrajectoryRuntimeInput } from "../../trajectory/types.js";
+import { UsageError } from "../errors.js";
 
-const DEFAULT_SPEC_PATH = "spec/trajectory/common.yaml";
+const DEFAULT_SPEC_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../spec/trajectory/common.yaml",
+);
 const VALID_RUNTIMES = [
   "auto",
   "acpx",
@@ -17,27 +23,16 @@ const VALID_FORMATS = ["markdown", "json"] as const;
 type Writer = (line: string) => void;
 
 export function parseCheckTrajectoryArgs(argv: readonly string[]): CheckTrajectoryInput {
-  const { values } = parseArgs({
-    args: [...argv],
-    options: {
-      transcript: { type: "string" },
-      spec: { type: "string", multiple: true },
-      runtime: { type: "string", default: "auto" },
-      format: { type: "string", default: "markdown" },
-      "annotated-log": { type: "string" },
-    },
-    strict: true,
-    allowPositionals: false,
-  });
+  const { values } = parseCheckTrajectoryRawArgs(argv);
 
   if (values.transcript === undefined) {
-    throw new Error("--transcript is required");
+    throw new UsageError("--transcript is required");
   }
   if (!isTrajectoryRuntimeInput(values.runtime)) {
-    throw new Error(`Invalid --runtime: ${values.runtime}`);
+    throw new UsageError(`Invalid --runtime: ${values.runtime}`);
   }
   if (!isReportFormat(values.format)) {
-    throw new Error(`Invalid --format: ${values.format}`);
+    throw new UsageError(`Invalid --format: ${values.format}`);
   }
 
   return {
@@ -68,4 +63,27 @@ function isTrajectoryRuntimeInput(value: string | undefined): value is Trajector
 
 function isReportFormat(value: string | undefined): value is ReportFormat {
   return value !== undefined && VALID_FORMATS.includes(value as ReportFormat);
+}
+
+function parseCheckTrajectoryRawArgs(argv: readonly string[]): ReturnType<typeof parseArgs> {
+  try {
+    return parseArgs({
+      args: [...argv],
+      options: {
+        transcript: { type: "string" },
+        spec: { type: "string", multiple: true },
+        runtime: { type: "string", default: "auto" },
+        format: { type: "string", default: "markdown" },
+        "annotated-log": { type: "string" },
+      },
+      strict: true,
+      allowPositionals: false,
+    });
+  } catch (error) {
+    throw new UsageError(errorMessage(error));
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/cli/commands/check-trajectory.ts
+++ b/src/cli/commands/check-trajectory.ts
@@ -1,0 +1,71 @@
+import { parseArgs } from "node:util";
+import type { CheckTrajectoryInput } from "../../core/operations/index.js";
+import { checkTrajectoryOperation } from "../../core/operations/index.js";
+import type { ReportFormat, TrajectoryRuntimeInput } from "../../trajectory/types.js";
+
+const DEFAULT_SPEC_PATH = "spec/trajectory/common.yaml";
+const VALID_RUNTIMES = [
+  "auto",
+  "acpx",
+  "codex",
+  "claude-stream-json",
+  "subprocess",
+  "unknown",
+] as const;
+const VALID_FORMATS = ["markdown", "json"] as const;
+
+type Writer = (line: string) => void;
+
+export function parseCheckTrajectoryArgs(argv: readonly string[]): CheckTrajectoryInput {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      transcript: { type: "string" },
+      spec: { type: "string", multiple: true },
+      runtime: { type: "string", default: "auto" },
+      format: { type: "string", default: "markdown" },
+      "annotated-log": { type: "string" },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+
+  if (values.transcript === undefined) {
+    throw new Error("--transcript is required");
+  }
+  if (!isTrajectoryRuntimeInput(values.runtime)) {
+    throw new Error(`Invalid --runtime: ${values.runtime}`);
+  }
+  if (!isReportFormat(values.format)) {
+    throw new Error(`Invalid --format: ${values.format}`);
+  }
+
+  return {
+    transcriptPath: values.transcript,
+    specPaths: values.spec ?? [DEFAULT_SPEC_PATH],
+    runtime: values.runtime,
+    format: values.format,
+    annotatedLogPath: values["annotated-log"],
+  };
+}
+
+export async function runCheckTrajectory(
+  input: CheckTrajectoryInput,
+  writer: Writer = console.log,
+): Promise<void> {
+  const result = await checkTrajectoryOperation(input);
+
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+
+  writer(result.value.output.trimEnd());
+}
+
+function isTrajectoryRuntimeInput(value: string | undefined): value is TrajectoryRuntimeInput {
+  return value !== undefined && VALID_RUNTIMES.includes(value as (typeof VALID_RUNTIMES)[number]);
+}
+
+function isReportFormat(value: string | undefined): value is ReportFormat {
+  return value !== undefined && VALID_FORMATS.includes(value as ReportFormat);
+}

--- a/src/cli/commands/check-trajectory.ts
+++ b/src/cli/commands/check-trajectory.ts
@@ -22,6 +22,16 @@ const VALID_FORMATS = ["markdown", "json"] as const;
 
 type Writer = (line: string) => void;
 
+interface CheckTrajectoryRawArgs {
+  readonly values: {
+    readonly transcript?: string | undefined;
+    readonly spec?: readonly string[] | undefined;
+    readonly runtime: string;
+    readonly format: string;
+    readonly "annotated-log"?: string | undefined;
+  };
+}
+
 export function parseCheckTrajectoryArgs(argv: readonly string[]): CheckTrajectoryInput {
   const { values } = parseCheckTrajectoryRawArgs(argv);
 
@@ -65,9 +75,10 @@ function isReportFormat(value: string | undefined): value is ReportFormat {
   return value !== undefined && VALID_FORMATS.includes(value as ReportFormat);
 }
 
-function parseCheckTrajectoryRawArgs(argv: readonly string[]): ReturnType<typeof parseArgs> {
+function parseCheckTrajectoryRawArgs(argv: readonly string[]): CheckTrajectoryRawArgs {
+  let parsed: ReturnType<typeof parseArgs>;
   try {
-    return parseArgs({
+    parsed = parseArgs({
       args: [...argv],
       options: {
         transcript: { type: "string" },
@@ -82,8 +93,31 @@ function parseCheckTrajectoryRawArgs(argv: readonly string[]): ReturnType<typeof
   } catch (error) {
     throw new UsageError(errorMessage(error));
   }
+
+  return {
+    values: {
+      transcript: optionalString(parsed.values.transcript, "--transcript"),
+      spec: optionalStringArray(parsed.values.spec, "--spec"),
+      runtime: optionalString(parsed.values.runtime, "--runtime") ?? "auto",
+      format: optionalString(parsed.values.format, "--format") ?? "markdown",
+      "annotated-log": optionalString(parsed.values["annotated-log"], "--annotated-log"),
+    },
+  };
 }
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function optionalString(value: unknown, option: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return value;
+  throw new UsageError(`${option} must be a string`);
+}
+
+function optionalStringArray(value: unknown, option: string): readonly string[] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) return value;
+  throw new UsageError(`${option} must be a string`);
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -453,7 +453,7 @@ Usage:
       helpText: `grove check-trajectory — check a local agent transcript
 
 Usage:
-  grove check-trajectory --transcript <path> [--spec <path>] [--runtime auto|acpx|codex|claude-stream-json|subprocess] [--format markdown|json] [--annotated-log <path>]`,
+  grove check-trajectory --transcript <path> [--spec <path>] [--runtime auto|acpx|codex|claude-stream-json|subprocess|unknown] [--format markdown|json] [--annotated-log <path>]`,
       handler: async (args) => {
         const { parseCheckTrajectoryArgs, runCheckTrajectory } = await import(
           "./commands/check-trajectory.js"

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -447,6 +447,21 @@ Usage:
       },
     },
     {
+      name: "check-trajectory",
+      description: "Check a local agent transcript against trajectory rules",
+      needsStore: false,
+      helpText: `grove check-trajectory — check a local agent transcript
+
+Usage:
+  grove check-trajectory --transcript <path> [--spec <path>] [--runtime auto|acpx|codex|claude-stream-json|subprocess] [--format markdown|json] [--annotated-log <path>]`,
+      handler: async (args) => {
+        const { parseCheckTrajectoryArgs, runCheckTrajectory } = await import(
+          "./commands/check-trajectory.js"
+        );
+        await runCheckTrajectory(parseCheckTrajectoryArgs(args));
+      },
+    },
+    {
       name: "completions",
       description: "Generate shell completion scripts",
       needsStore: false,
@@ -602,6 +617,7 @@ Advanced:
   grove gossip <subcommand>            P2P federation (peers, sync, daemon, ...)
   grove skill install                  Install AI assistant skill files
   grove diagnostics [--out <path>]    Create a diagnostics ZIP for bug reports
+  grove check-trajectory --transcript <path> Check local transcript rules
   grove completions bash|zsh|fish      Generate shell completion scripts
   grove tui [--nexus <url>]            Operator TUI dashboard
 

--- a/src/cli/registry.test.ts
+++ b/src/cli/registry.test.ts
@@ -109,6 +109,7 @@ describe("COMMANDS registry", () => {
       ],
       release: ["completed", "json"],
       checkout: ["to", "frontier", "agent", "json"],
+      "check-trajectory": ["transcript", "spec", "runtime", "format", "annotated-log"],
       thread: ["depth", "n", "json"],
       ask: ["options", "context", "strategy", "config"],
       export: ["to-discussion", "to-pr", "category"],

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -135,6 +135,11 @@ export const COMMANDS: readonly CommandMeta[] = [
     flags: ["from", "depth", "json"],
   },
   {
+    name: "check-trajectory",
+    description: "Check an agent transcript against trajectory rules",
+    flags: ["transcript", "spec", "runtime", "format", "annotated-log"],
+  },
+  {
     name: "thread",
     description: "View a discussion thread",
     flags: ["depth", "n", "json"],

--- a/src/core/operations/check-trajectory.test.ts
+++ b/src/core/operations/check-trajectory.test.ts
@@ -9,6 +9,32 @@ async function tempDir(): Promise<string> {
 }
 
 describe("checkTrajectoryOperation", () => {
+  test("returns validation error when transcriptPath is blank", async () => {
+    const result = await checkTrajectoryOperation({
+      transcriptPath: "   ",
+      specPaths: ["/unused/spec.yaml"],
+      runtime: "subprocess",
+      format: "markdown",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unexpected success");
+    expect(result.error.message).toBe("transcriptPath is required");
+  });
+
+  test("returns validation error when specPaths is empty", async () => {
+    const result = await checkTrajectoryOperation({
+      transcriptPath: "/unused/transcript.jsonl",
+      specPaths: [],
+      runtime: "subprocess",
+      format: "markdown",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unexpected success");
+    expect(result.error.message).toBe("at least one specPath is required");
+  });
+
   test("returns a JSON report for local transcript and spec files", async () => {
     const dir = await tempDir();
     const transcriptPath = join(dir, "transcript.jsonl");
@@ -33,6 +59,37 @@ describe("checkTrajectoryOperation", () => {
     expect(result.value.output).toContain('"eventCount"');
   });
 
+  test("includes deferred goal results in report summary", async () => {
+    const dir = await tempDir();
+    const transcriptPath = join(dir, "transcript.jsonl");
+    const specPath = join(dir, "spec.yaml");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+    await writeFile(
+      specPath,
+      "name: local\ngoals:\n  - id: answer-quality\n    criteria: answer addresses the request\n",
+      "utf8",
+    );
+
+    const result = await checkTrajectoryOperation({
+      transcriptPath,
+      specPaths: [specPath],
+      runtime: "subprocess",
+      format: "markdown",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unexpected error");
+    expect(result.value.report.goalResults).toEqual([
+      {
+        goalId: "answer-quality",
+        status: "deferred",
+        message: "LLM goal grading is deferred in this implementation slice",
+      },
+    ]);
+    expect(result.value.report.summary.deferred).toBe(1);
+    expect(result.value.output).toContain("Runtime: subprocess");
+  });
+
   test("writes annotated log when requested", async () => {
     const dir = await tempDir();
     const transcriptPath = join(dir, "transcript.jsonl");
@@ -51,5 +108,24 @@ describe("checkTrajectoryOperation", () => {
 
     expect(result.ok).toBe(true);
     expect(await readFile(annotatedLogPath, "utf8")).toContain("[seq:0001]");
+  });
+
+  test("returns validation error when spec loading fails", async () => {
+    const dir = await tempDir();
+    const transcriptPath = join(dir, "transcript.jsonl");
+    const specPath = join(dir, "spec.yaml");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+    await writeFile(specPath, "[]\n", "utf8");
+
+    const result = await checkTrajectoryOperation({
+      transcriptPath,
+      specPaths: [specPath],
+      runtime: "subprocess",
+      format: "markdown",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unexpected success");
+    expect(result.error.message).toContain("root must be an object");
   });
 });

--- a/src/core/operations/check-trajectory.test.ts
+++ b/src/core/operations/check-trajectory.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkTrajectoryOperation } from "./check-trajectory.js";
+
+async function tempDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "trajectory-op-"));
+}
+
+describe("checkTrajectoryOperation", () => {
+  test("returns a JSON report for local transcript and spec files", async () => {
+    const dir = await tempDir();
+    const transcriptPath = join(dir, "transcript.jsonl");
+    const specPath = join(dir, "spec.yaml");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+    await writeFile(
+      specPath,
+      "name: local\nrules:\n  - id: has-message\n    kind: must_exist\n    match:\n      event: ASSISTANT_MESSAGE\n",
+      "utf8",
+    );
+
+    const result = await checkTrajectoryOperation({
+      transcriptPath,
+      specPaths: [specPath],
+      runtime: "subprocess",
+      format: "json",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unexpected error");
+    expect(result.value.report.summary.failed).toBe(0);
+    expect(result.value.output).toContain('"eventCount"');
+  });
+
+  test("writes annotated log when requested", async () => {
+    const dir = await tempDir();
+    const transcriptPath = join(dir, "transcript.jsonl");
+    const specPath = join(dir, "spec.yaml");
+    const annotatedLogPath = join(dir, "annotated.jsonl");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+    await writeFile(specPath, "name: local\nrules: []\n", "utf8");
+
+    const result = await checkTrajectoryOperation({
+      transcriptPath,
+      specPaths: [specPath],
+      runtime: "subprocess",
+      format: "markdown",
+      annotatedLogPath,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(await readFile(annotatedLogPath, "utf8")).toContain("[seq:0001]");
+  });
+});

--- a/src/core/operations/check-trajectory.ts
+++ b/src/core/operations/check-trajectory.ts
@@ -1,0 +1,86 @@
+import { writeFile } from "node:fs/promises";
+import { buildTranscriptIndex } from "../../trajectory/indexer.js";
+import {
+  formatAnnotatedEvents,
+  formatJsonReport,
+  formatMarkdownReport,
+  summarizeReport,
+} from "../../trajectory/report.js";
+import { evaluateRules } from "../../trajectory/rules.js";
+import { loadTrajectorySpecs } from "../../trajectory/spec-loader.js";
+import type {
+  GoalResult,
+  ReportFormat,
+  TrajectoryCheckReport,
+  TrajectoryRuntimeInput,
+} from "../../trajectory/types.js";
+import type { OperationResult } from "./result.js";
+import { err, OperationErrorCode, ok, validationErr } from "./result.js";
+
+export interface CheckTrajectoryInput {
+  readonly transcriptPath: string;
+  readonly specPaths: readonly string[];
+  readonly runtime: TrajectoryRuntimeInput;
+  readonly format: ReportFormat;
+  readonly annotatedLogPath?: string | undefined;
+}
+
+export interface CheckTrajectoryResult {
+  readonly report: TrajectoryCheckReport;
+  readonly output: string;
+}
+
+export async function checkTrajectoryOperation(
+  input: CheckTrajectoryInput,
+): Promise<OperationResult<CheckTrajectoryResult>> {
+  if (input.transcriptPath.trim().length === 0) {
+    return validationErr("transcriptPath is required");
+  }
+  if (input.specPaths.length === 0) {
+    return validationErr("at least one specPath is required");
+  }
+
+  try {
+    const index = await buildTranscriptIndex({
+      transcriptPath: input.transcriptPath,
+      runtime: input.runtime,
+    });
+    const spec = await loadTrajectorySpecs(input.specPaths);
+    const ruleResults = evaluateRules(index, spec.rules);
+    const goalResults: GoalResult[] = spec.goals.map((goal) => ({
+      goalId: goal.id,
+      status: "deferred",
+      message: "LLM goal grading is deferred in this implementation slice",
+    }));
+    const summary = summarizeReport(ruleResults, goalResults);
+    const report: TrajectoryCheckReport = {
+      name: spec.name,
+      transcriptPath: index.transcriptPath,
+      runtime: index.runtime,
+      eventCount: index.events.length,
+      specPaths: spec.sourcePaths,
+      ruleResults,
+      goalResults,
+      parserWarnings: index.warnings,
+      summary,
+    };
+
+    if (input.annotatedLogPath !== undefined) {
+      await writeFile(input.annotatedLogPath, formatAnnotatedEvents(index.events), "utf8");
+    }
+
+    return ok({
+      report,
+      output: input.format === "json" ? formatJsonReport(report) : formatMarkdownReport(report),
+    });
+  } catch (error) {
+    return err({
+      code: OperationErrorCode.ValidationError,
+      message: errorMessage(error),
+    });
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/core/operations/index.ts
+++ b/src/core/operations/index.ts
@@ -25,6 +25,8 @@ export {
   listBountiesOperation,
   settleBountyOperation,
 } from "./bounty.js";
+export type { CheckTrajectoryInput, CheckTrajectoryResult } from "./check-trajectory.js";
+export { checkTrajectoryOperation } from "./check-trajectory.js";
 // Checkout operation
 export type { CheckoutInput, CheckoutResult } from "./checkout.js";
 export { checkoutOperation } from "./checkout.js";

--- a/src/core/operations/parity-matrix.test.ts
+++ b/src/core/operations/parity-matrix.test.ts
@@ -38,6 +38,7 @@ const SHARED_OPERATIONS_MCP: ReadonlyArray<{
   { operation: "getOutcomeOperation", mcpTool: "grove_get_outcome" },
   { operation: "listOutcomesOperation", mcpTool: "grove_list_outcomes" },
   { operation: "outcomeStatsOperation", mcpTool: "grove_outcome_stats" },
+  { operation: "checkTrajectoryOperation", mcpTool: "grove_check_trajectory" },
 ];
 
 /**
@@ -62,6 +63,7 @@ const SHARED_OPERATIONS_CLI: ReadonlyArray<{
   { operation: "threadsOperation", cliCommand: "threads" },
   { operation: "checkoutOperation", cliCommand: "checkout" },
   { operation: "listClaimsOperation", cliCommand: "claims" },
+  { operation: "checkTrajectoryOperation", cliCommand: "check-trajectory" },
 ];
 
 describe("parity matrix: operations layer exports", () => {
@@ -93,6 +95,7 @@ describe("parity matrix: operations layer exports", () => {
       "getOutcomeOperation",
       "listOutcomesOperation",
       "outcomeStatsOperation",
+      "checkTrajectoryOperation",
     ];
 
     for (const name of expectedExports) {

--- a/src/mcp/server.integration.test.ts
+++ b/src/mcp/server.integration.test.ts
@@ -53,7 +53,7 @@ describe("MCP server integration", () => {
     await testDeps.cleanup();
   });
 
-  test("lists all 38 tools", async () => {
+  test("lists all 39 tools", async () => {
     const tools = await client.listTools();
     const toolNames = tools.tools.map((t) => t.name).sort();
     expect(toolNames).toEqual([
@@ -64,6 +64,7 @@ describe("MCP server integration", () => {
       "grove_bounty_settle",
       "grove_cas_put",
       "grove_check_stop",
+      "grove_check_trajectory",
       "grove_checkout",
       "grove_claim",
       "grove_create_plan",

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -65,6 +65,7 @@ describe("createMcpServer preset scoping", () => {
     "grove_bounty_settle",
     "grove_cas_put",
     "grove_check_stop",
+    "grove_check_trajectory",
     "grove_checkout",
     "grove_claim",
     "grove_create_plan",
@@ -187,6 +188,7 @@ describe("createMcpServer preset scoping", () => {
       "grove_tree",
       "grove_thread",
       "grove_threads",
+      "grove_check_trajectory",
     ];
     for (const t of queryTools) {
       expect(names).not.toContain(t);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -27,6 +27,7 @@ import { registerPlanTools } from "./tools/plans.js";
 import { registerQueryTools } from "./tools/queries.js";
 import { registerSessionTools } from "./tools/session.js";
 import { registerStopTools } from "./tools/stop.js";
+import { registerTrajectoryTools } from "./tools/trajectory.js";
 import { registerWorkspaceTools } from "./tools/workspace.js";
 
 // ---------------------------------------------------------------------------
@@ -103,7 +104,10 @@ export async function createMcpServer(deps: McpDeps, preset?: McpPresetConfig): 
   }
 
   if (preset?.claims !== false) registerClaimTools(server, deps);
-  if (preset?.queries !== false) registerQueryTools(server, deps);
+  if (preset?.queries !== false) {
+    registerQueryTools(server, deps);
+    registerTrajectoryTools(server, deps);
+  }
   if (preset?.workspace !== false) registerWorkspaceTools(server, deps);
   if (preset?.stop !== false) registerStopTools(server, deps);
   if (preset?.bounties !== false) registerBountyTools(server, deps);

--- a/src/mcp/tools/trajectory.test.ts
+++ b/src/mcp/tools/trajectory.test.ts
@@ -44,7 +44,7 @@ describe("grove_check_trajectory", () => {
   });
 
   test("returns trajectory report JSON", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "trajectory-mcp-"));
+    const dir = await mkdtemp(join(testDeps.tempDir, "trajectory-mcp-"));
     const transcriptPath = join(dir, "transcript.jsonl");
     const specPath = join(dir, "spec.yaml");
     await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
@@ -60,5 +60,65 @@ describe("grove_check_trajectory", () => {
     expect(result.isError).toBeUndefined();
     const data = JSON.parse(result.text);
     expect(data.report.eventCount).toBe(1);
+  });
+
+  test("uses bundled default spec when specPaths is omitted", async () => {
+    const transcriptPath = join(testDeps.tempDir, "transcript.jsonl");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+
+    const result = await callTool(server, "grove_check_trajectory", {
+      transcriptPath,
+      runtime: "subprocess",
+      format: "json",
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.text);
+    expect(data.report.name).toBe("common");
+    expect(data.report.specPaths[0]).toEndWith(join("spec", "trajectory", "common.yaml"));
+  });
+
+  test("rejects transcript paths outside the workspace boundary", async () => {
+    const result = await callTool(server, "grove_check_trajectory", {
+      transcriptPath: join(tmpdir(), "trajectory-outside-transcript.jsonl"),
+      runtime: "subprocess",
+      format: "json",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("Path containment violation");
+  });
+
+  test("rejects spec paths outside the workspace boundary", async () => {
+    const transcriptPath = join(testDeps.tempDir, "transcript.jsonl");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+
+    const result = await callTool(server, "grove_check_trajectory", {
+      transcriptPath,
+      specPaths: [join(tmpdir(), "trajectory-outside-spec.yaml")],
+      runtime: "subprocess",
+      format: "json",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("Path containment violation");
+  });
+
+  test("rejects annotated log paths outside the workspace boundary", async () => {
+    const transcriptPath = join(testDeps.tempDir, "transcript.jsonl");
+    const specPath = join(testDeps.tempDir, "spec.yaml");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+    await writeFile(specPath, "name: local\nrules: []\n", "utf8");
+
+    const result = await callTool(server, "grove_check_trajectory", {
+      transcriptPath,
+      specPaths: [specPath],
+      runtime: "subprocess",
+      format: "json",
+      annotatedLogPath: join(tmpdir(), "trajectory-outside.log"),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("Path containment violation");
   });
 });

--- a/src/mcp/tools/trajectory.test.ts
+++ b/src/mcp/tools/trajectory.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpDeps } from "../deps.js";
+import type { TestMcpDeps } from "../test-helpers.js";
+import { createTestMcpDeps } from "../test-helpers.js";
+import { registerTrajectoryTools } from "./trajectory.js";
+
+async function callTool(
+  server: McpServer,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ isError: boolean | undefined; text: string }> {
+  const registeredTools = (
+    server as unknown as {
+      _registeredTools: Record<string, { handler: (args: unknown) => Promise<unknown> }>;
+    }
+  )._registeredTools;
+  const tool = registeredTools[name];
+  if (!tool) throw new Error(`Tool ${name} not registered`);
+  const result = (await tool.handler(args)) as {
+    isError?: boolean;
+    content: Array<{ type: string; text: string }>;
+  };
+  return { isError: result.isError, text: result.content[0]?.text ?? "" };
+}
+
+describe("grove_check_trajectory", () => {
+  let testDeps: TestMcpDeps;
+  let deps: McpDeps;
+  let server: McpServer;
+
+  beforeEach(async () => {
+    testDeps = await createTestMcpDeps();
+    deps = testDeps.deps;
+    server = new McpServer({ name: "test", version: "0.0.1" }, { capabilities: { tools: {} } });
+    registerTrajectoryTools(server, deps);
+  });
+
+  afterEach(async () => {
+    await testDeps.cleanup();
+  });
+
+  test("returns trajectory report JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trajectory-mcp-"));
+    const transcriptPath = join(dir, "transcript.jsonl");
+    const specPath = join(dir, "spec.yaml");
+    await writeFile(transcriptPath, '{"event":"ASSISTANT_MESSAGE","message":"done"}\n', "utf8");
+    await writeFile(specPath, "name: local\nrules: []\n", "utf8");
+
+    const result = await callTool(server, "grove_check_trajectory", {
+      transcriptPath,
+      specPaths: [specPath],
+      runtime: "subprocess",
+      format: "json",
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.text);
+    expect(data.report.eventCount).toBe(1);
+  });
+});

--- a/src/mcp/tools/trajectory.ts
+++ b/src/mcp/tools/trajectory.ts
@@ -1,0 +1,58 @@
+/**
+ * MCP tool for local trajectory checking.
+ *
+ * grove_check_trajectory — Check local transcript JSONL against trajectory rules
+ *
+ * All business logic is delegated to the shared operations layer.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { checkTrajectoryOperation } from "../../core/operations/index.js";
+import type { McpDeps } from "../deps.js";
+import { toMcpResult } from "../operation-adapter.js";
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const trajectoryInputSchema = {
+  transcriptPath: z.string().min(1).describe("Path to the local transcript JSONL file"),
+  specPaths: z
+    .array(z.string().min(1))
+    .min(1)
+    .default(["spec/trajectory/common.yaml"])
+    .describe("Trajectory YAML spec paths to evaluate"),
+  runtime: z
+    .enum(["auto", "acpx", "codex", "claude-stream-json", "subprocess", "unknown"])
+    .default("auto")
+    .describe("Transcript runtime/parser to use"),
+  format: z.enum(["markdown", "json"]).default("json").describe("Report output format"),
+  annotatedLogPath: z.string().min(1).optional().describe("Optional path for annotated log output"),
+};
+
+// ---------------------------------------------------------------------------
+// Tool registration
+// ---------------------------------------------------------------------------
+
+export function registerTrajectoryTools(server: McpServer, _deps: McpDeps): void {
+  server.registerTool(
+    "grove_check_trajectory",
+    {
+      description:
+        "Check local agent transcript JSONL against deterministic Grove trajectory YAML rules.",
+      inputSchema: trajectoryInputSchema,
+    },
+    async (args) => {
+      const result = await checkTrajectoryOperation({
+        transcriptPath: args.transcriptPath,
+        specPaths: args.specPaths,
+        runtime: args.runtime,
+        format: args.format,
+        ...(args.annotatedLogPath !== undefined ? { annotatedLogPath: args.annotatedLogPath } : {}),
+      });
+      return toMcpResult(result);
+    },
+  );
+}

--- a/src/mcp/tools/trajectory.ts
+++ b/src/mcp/tools/trajectory.ts
@@ -6,23 +6,33 @@
  * All business logic is delegated to the shared operations layer.
  */
 
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import type { CheckTrajectoryInput } from "../../core/operations/index.js";
 import { checkTrajectoryOperation } from "../../core/operations/index.js";
+import { assertWithinBoundary } from "../../core/path-safety.js";
 import type { McpDeps } from "../deps.js";
+import { handleToolError } from "../error-handler.js";
 import { toMcpResult } from "../operation-adapter.js";
 
 // ---------------------------------------------------------------------------
 // Schemas
 // ---------------------------------------------------------------------------
 
+const DEFAULT_SPEC_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../spec/trajectory/common.yaml",
+);
+
 const trajectoryInputSchema = {
   transcriptPath: z.string().min(1).describe("Path to the local transcript JSONL file"),
   specPaths: z
     .array(z.string().min(1))
     .min(1)
-    .default(["spec/trajectory/common.yaml"])
+    .default([DEFAULT_SPEC_PATH])
     .describe("Trajectory YAML spec paths to evaluate"),
   runtime: z
     .enum(["auto", "acpx", "codex", "claude-stream-json", "subprocess", "unknown"])
@@ -36,7 +46,7 @@ const trajectoryInputSchema = {
 // Tool registration
 // ---------------------------------------------------------------------------
 
-export function registerTrajectoryTools(server: McpServer, _deps: McpDeps): void {
+export function registerTrajectoryTools(server: McpServer, deps: McpDeps): void {
   server.registerTool(
     "grove_check_trajectory",
     {
@@ -45,14 +55,45 @@ export function registerTrajectoryTools(server: McpServer, _deps: McpDeps): void
       inputSchema: trajectoryInputSchema,
     },
     async (args) => {
-      const result = await checkTrajectoryOperation({
-        transcriptPath: args.transcriptPath,
-        specPaths: args.specPaths,
-        runtime: args.runtime,
-        format: args.format,
-        ...(args.annotatedLogPath !== undefined ? { annotatedLogPath: args.annotatedLogPath } : {}),
-      });
-      return toMcpResult(result);
+      try {
+        const input = await resolveTrajectoryInput(args, deps);
+        const result = await checkTrajectoryOperation(input);
+        return toMcpResult(result);
+      } catch (error) {
+        return handleToolError(error);
+      }
     },
   );
+}
+
+async function resolveTrajectoryInput(
+  args: {
+    transcriptPath: string;
+    specPaths?: readonly string[] | undefined;
+    runtime: CheckTrajectoryInput["runtime"];
+    format: CheckTrajectoryInput["format"];
+    annotatedLogPath?: string | undefined;
+  },
+  deps: McpDeps,
+): Promise<CheckTrajectoryInput> {
+  const specPaths = args.specPaths ?? [DEFAULT_SPEC_PATH];
+  const resolvedSpecPaths = await Promise.all(
+    specPaths.map((specPath) =>
+      specPath === DEFAULT_SPEC_PATH
+        ? Promise.resolve(DEFAULT_SPEC_PATH)
+        : assertWithinBoundary(specPath, deps.workspaceBoundary),
+    ),
+  );
+  const annotatedLogPath =
+    args.annotatedLogPath !== undefined
+      ? await assertWithinBoundary(args.annotatedLogPath, deps.workspaceBoundary)
+      : undefined;
+
+  return {
+    transcriptPath: await assertWithinBoundary(args.transcriptPath, deps.workspaceBoundary),
+    specPaths: resolvedSpecPaths,
+    runtime: args.runtime,
+    format: args.format,
+    ...(annotatedLogPath !== undefined ? { annotatedLogPath } : {}),
+  };
 }

--- a/src/trajectory/indexer.test.ts
+++ b/src/trajectory/indexer.test.ts
@@ -63,25 +63,45 @@ describe("buildTranscriptIndex", () => {
     expect(index.childrenByParentSpanId.get("session-1")?.[0]?.spanId).toBe("tool-1");
   });
 
-  test("auto-detects runtime and routes known runtimes through subprocess parsing", async () => {
+  test("auto-detects runtime and routes known runtimes through dedicated parsers", async () => {
     const acpTranscript = await tempFile(
       "acp.jsonl",
-      ['{"jsonrpc":"2.0","method":"session/new"}', '{"event":"AGENT_START"}'].join("\n"),
+      [
+        '{"jsonrpc":"2.0","method":"session/new"}',
+        '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"sess-1"}}',
+      ].join("\n"),
     );
-    const codexTranscript = await tempFile("codex.jsonl", '{"source":"codex"}\n');
+    const codexTranscript = await tempFile(
+      "codex.jsonl",
+      '{"source":"codex","type":"tool_call","call_id":"call-1","tool_name":"apply_patch"}\n',
+    );
+    const claudeTranscript = await tempFile(
+      "claude.jsonl",
+      [
+        '{"type":"assistant","message":[]}',
+        '{"type":"tool_use","id":"tool-parent","name":"Task"}',
+      ].join("\n"),
+    );
     const unknownTranscript = await tempFile("unknown.jsonl", '{"event":"AGENT_START"}\n');
 
     const acp = await buildTranscriptIndex({ transcriptPath: acpTranscript, runtime: "auto" });
     const codex = await buildTranscriptIndex({ transcriptPath: codexTranscript, runtime: "auto" });
+    const claude = await buildTranscriptIndex({
+      transcriptPath: claudeTranscript,
+      runtime: "auto",
+    });
     const unknown = await buildTranscriptIndex({
       transcriptPath: unknownTranscript,
       runtime: "unknown",
     });
 
     expect(acp.runtime).toBe("acpx");
-    expect(acp.events[1]?.type).toBe(TrajectoryEventType.AgentStart);
+    expect(acp.events[0]?.type).toBe(TrajectoryEventType.AgentStart);
     expect(codex.runtime).toBe("codex");
-    expect(codex.events[0]?.type).toBe(TrajectoryEventType.Raw);
+    expect(codex.events[0]?.type).toBe(TrajectoryEventType.ToolCall);
+    expect(codex.events[0]?.tool).toBe("apply_patch");
+    expect(claude.runtime).toBe("claude-stream-json");
+    expect(claude.events[1]?.type).toBe(TrajectoryEventType.Delegation);
     expect(unknown.runtime).toBe("unknown");
     expect(unknown.events[0]?.type).toBe(TrajectoryEventType.AgentStart);
   });

--- a/src/trajectory/indexer.test.ts
+++ b/src/trajectory/indexer.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildTranscriptIndex, detectRuntimeFromLines } from "./indexer.js";
+import { TrajectoryEventType } from "./types.js";
+
+async function tempFile(name: string, content: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "trajectory-index-"));
+  const path = join(dir, name);
+  await writeFile(path, content, "utf8");
+  return path;
+}
+
+describe("detectRuntimeFromLines", () => {
+  test("detects codex ACP metadata before generic acpx", () => {
+    const lines = [
+      '{"jsonrpc":"2.0","id":0,"result":{"agentInfo":{"name":"codex-acp"}}}',
+      '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk"}}}',
+    ];
+    expect(detectRuntimeFromLines(lines)).toBe("codex");
+  });
+
+  test("detects claude stream-json parent tool use shape", () => {
+    const lines = ['{"type":"tool_result","tool_use_id":"child","parent_tool_use_id":"parent"}'];
+    expect(detectRuntimeFromLines(lines)).toBe("claude-stream-json");
+  });
+
+  test("detects claude stream-json assistant message arrays", () => {
+    const lines = ['{"type":"assistant","message":[]}'];
+    expect(detectRuntimeFromLines(lines)).toBe("claude-stream-json");
+  });
+
+  test("detects generic ACP and codex records", () => {
+    expect(detectRuntimeFromLines(['{"jsonrpc":"2.0","method":"session/new"}'])).toBe("acpx");
+    expect(detectRuntimeFromLines(['{"source":"codex"}'])).toBe("codex");
+  });
+
+  test("falls back to subprocess", () => {
+    expect(detectRuntimeFromLines(["plain output"])).toBe("subprocess");
+  });
+});
+
+describe("buildTranscriptIndex", () => {
+  test("assigns sequence numbers, source lines, and span indexes", async () => {
+    const transcript = await tempFile(
+      "events.jsonl",
+      [
+        '{"event":"AGENT_START","spanId":"session-1"}',
+        '{"event":"TOOL_CALL","tool":"apply_patch","spanId":"tool-1","parentSpanId":"session-1"}',
+      ].join("\n"),
+    );
+
+    const index = await buildTranscriptIndex({
+      transcriptPath: transcript,
+      runtime: "subprocess",
+    });
+
+    expect(index.events.map((event) => event.seq)).toEqual([1, 2]);
+    expect(index.events[1]?.source.line).toBe(2);
+    expect(index.bySeq.get(2)?.tool).toBe("apply_patch");
+    expect(index.bySpanId.get("tool-1")?.[0]?.type).toBe(TrajectoryEventType.ToolCall);
+    expect(index.childrenByParentSpanId.get("session-1")?.[0]?.spanId).toBe("tool-1");
+  });
+
+  test("auto-detects runtime and routes known runtimes through subprocess parsing", async () => {
+    const acpTranscript = await tempFile(
+      "acp.jsonl",
+      ['{"jsonrpc":"2.0","method":"session/new"}', '{"event":"AGENT_START"}'].join("\n"),
+    );
+    const codexTranscript = await tempFile("codex.jsonl", '{"source":"codex"}\n');
+    const unknownTranscript = await tempFile("unknown.jsonl", '{"event":"AGENT_START"}\n');
+
+    const acp = await buildTranscriptIndex({ transcriptPath: acpTranscript, runtime: "auto" });
+    const codex = await buildTranscriptIndex({ transcriptPath: codexTranscript, runtime: "auto" });
+    const unknown = await buildTranscriptIndex({
+      transcriptPath: unknownTranscript,
+      runtime: "unknown",
+    });
+
+    expect(acp.runtime).toBe("acpx");
+    expect(acp.events[1]?.type).toBe(TrajectoryEventType.AgentStart);
+    expect(codex.runtime).toBe("codex");
+    expect(codex.events[0]?.type).toBe(TrajectoryEventType.Raw);
+    expect(unknown.runtime).toBe("unknown");
+    expect(unknown.events[0]?.type).toBe(TrajectoryEventType.AgentStart);
+  });
+
+  test("keeps malformed JSONL as RAW with a parser warning", async () => {
+    const transcript = await tempFile("bad.log", "not-json\n");
+    const index = await buildTranscriptIndex({ transcriptPath: transcript, runtime: "subprocess" });
+
+    expect(index.events).toHaveLength(1);
+    expect(index.events[0]?.type).toBe(TrajectoryEventType.Raw);
+    expect(index.warnings[0]).toContain("line 1");
+  });
+});

--- a/src/trajectory/indexer.ts
+++ b/src/trajectory/indexer.ts
@@ -1,4 +1,7 @@
 import { readFile } from "node:fs/promises";
+import { parseAcpxLine } from "./parsers/acpx.js";
+import { parseClaudeStreamJsonLine } from "./parsers/claude-stream-json.js";
+import { parseCodexLine } from "./parsers/codex.js";
 import { parseSubprocessLine } from "./parsers/subprocess.js";
 import type {
   ParsedTrajectoryEvent,
@@ -78,8 +81,11 @@ function parseLine(
 ): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
   switch (runtime) {
     case TrajectoryRuntime.Acpx:
+      return parseAcpxLine(line, path, lineNumber, runtime);
     case TrajectoryRuntime.Codex:
+      return parseCodexLine(line, path, lineNumber);
     case TrajectoryRuntime.ClaudeStreamJson:
+      return parseClaudeStreamJsonLine(line, path, lineNumber);
     case TrajectoryRuntime.Subprocess:
     case TrajectoryRuntime.Unknown:
       return parseSubprocessLine(line, path, lineNumber);

--- a/src/trajectory/indexer.ts
+++ b/src/trajectory/indexer.ts
@@ -1,0 +1,175 @@
+import { readFile } from "node:fs/promises";
+import { parseSubprocessLine } from "./parsers/subprocess.js";
+import type {
+  ParsedTrajectoryEvent,
+  TrajectoryEvent,
+  TrajectoryRuntimeInput,
+  TranscriptIndex,
+} from "./types.js";
+import { TrajectoryRuntime } from "./types.js";
+
+export interface BuildTranscriptIndexOptions {
+  readonly transcriptPath: string;
+  readonly runtime: TrajectoryRuntimeInput;
+}
+
+export function detectRuntimeFromLines(lines: readonly string[]): TrajectoryRuntime {
+  const records = parsedRecords(lines);
+
+  if (records.some(hasCodexAcpMetadata)) {
+    return TrajectoryRuntime.Codex;
+  }
+
+  if (records.some(isClaudeStreamJsonRecord)) {
+    return TrajectoryRuntime.ClaudeStreamJson;
+  }
+
+  if (records.some(isGenericAcpRecord)) {
+    return TrajectoryRuntime.Acpx;
+  }
+
+  if (records.some(isCodexRecord)) {
+    return TrajectoryRuntime.Codex;
+  }
+
+  return TrajectoryRuntime.Subprocess;
+}
+
+export async function buildTranscriptIndex(
+  options: BuildTranscriptIndexOptions,
+): Promise<TranscriptIndex> {
+  const content = await readFile(options.transcriptPath, "utf8");
+  const lines = transcriptLines(content);
+  const runtime =
+    options.runtime === "auto"
+      ? detectRuntimeFromLines(lines.filter((line) => line.length > 0).slice(0, 20))
+      : options.runtime;
+
+  const events: TrajectoryEvent[] = [];
+  const warnings: string[] = [];
+  let seq = 1;
+
+  lines.forEach((line, index) => {
+    const result = parseLine(line, options.transcriptPath, index + 1, runtime);
+    warnings.push(...result.warnings);
+
+    for (const event of result.events) {
+      events.push({ ...event, seq });
+      seq += 1;
+    }
+  });
+
+  return {
+    runtime,
+    transcriptPath: options.transcriptPath,
+    events,
+    warnings,
+    bySeq: indexBySeq(events),
+    bySpanId: indexByStringField(events, "spanId"),
+    childrenByParentSpanId: indexByStringField(events, "parentSpanId"),
+  };
+}
+
+function parseLine(
+  line: string,
+  path: string,
+  lineNumber: number,
+  runtime: TrajectoryRuntime,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  switch (runtime) {
+    case TrajectoryRuntime.Acpx:
+    case TrajectoryRuntime.Codex:
+    case TrajectoryRuntime.ClaudeStreamJson:
+    case TrajectoryRuntime.Subprocess:
+    case TrajectoryRuntime.Unknown:
+      return parseSubprocessLine(line, path, lineNumber);
+  }
+}
+
+function transcriptLines(content: string): string[] {
+  const lines = content.split(/\r?\n/);
+  while (lines.at(-1) === "") {
+    lines.pop();
+  }
+  return lines;
+}
+
+function parsedRecords(lines: readonly string[]): readonly Record<string, unknown>[] {
+  const records: Record<string, unknown>[] = [];
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        records.push(parsed as Record<string, unknown>);
+      }
+    } catch {
+      // Runtime detection skips plain subprocess output and malformed JSONL.
+    }
+  }
+
+  return records;
+}
+
+function hasCodexAcpMetadata(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value.includes("codex-acp");
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(hasCodexAcpMetadata);
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return Object.values(value).some(hasCodexAcpMetadata);
+  }
+
+  return false;
+}
+
+function isClaudeStreamJsonRecord(record: Readonly<Record<string, unknown>>): boolean {
+  if (record.parent_tool_use_id !== undefined || record.tool_use_id !== undefined) {
+    return true;
+  }
+
+  return record.type === "assistant" && Array.isArray(record.message);
+}
+
+function isGenericAcpRecord(record: Readonly<Record<string, unknown>>): boolean {
+  return record.method === "session/update" || record.method === "session/new";
+}
+
+function isCodexRecord(record: Readonly<Record<string, unknown>>): boolean {
+  return record.type === "codex_event" || record.source === "codex";
+}
+
+function indexBySeq(events: readonly TrajectoryEvent[]): ReadonlyMap<number, TrajectoryEvent> {
+  const bySeq = new Map<number, TrajectoryEvent>();
+  for (const event of events) {
+    bySeq.set(event.seq, event);
+  }
+  return bySeq;
+}
+
+function indexByStringField(
+  events: readonly TrajectoryEvent[],
+  field: "spanId" | "parentSpanId",
+): ReadonlyMap<string, readonly TrajectoryEvent[]> {
+  const index = new Map<string, TrajectoryEvent[]>();
+
+  for (const event of events) {
+    const key = event[field];
+    if (key === undefined) {
+      continue;
+    }
+
+    const existing = index.get(key);
+    if (existing === undefined) {
+      index.set(key, [event]);
+    } else {
+      existing.push(event);
+    }
+  }
+
+  return index;
+}

--- a/src/trajectory/match.test.ts
+++ b/src/trajectory/match.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { fieldValue, matchesEvent, normalizeEventTypeName, patternMatches } from "./match.js";
-import { type TrajectoryEvent, TrajectoryEventType } from "./types.js";
+import {
+  fieldValue,
+  matchesEvent,
+  normalizeEventTypeName,
+  patternMatches,
+  valuesEqual,
+} from "./match.js";
+import { formatSeq, type TrajectoryEvent, TrajectoryEventType } from "./types.js";
 
 const baseEvent: TrajectoryEvent = {
   seq: 7,
@@ -21,6 +27,12 @@ describe("normalizeEventTypeName", () => {
   });
 });
 
+describe("formatSeq", () => {
+  test("pads sequence numbers for reports", () => {
+    expect(formatSeq(7)).toBe("[seq:0007]");
+  });
+});
+
 describe("fieldValue", () => {
   test("reads normalized fields and raw payload fields", () => {
     expect(fieldValue(baseEvent, "input.file_path")).toBe("src/app.ts");
@@ -37,7 +49,38 @@ describe("patternMatches", () => {
   });
 });
 
+describe("valuesEqual", () => {
+  test("compares structured values deeply", () => {
+    expect(valuesEqual({ status: "ok" }, { status: "ok" })).toBe(true);
+    expect(valuesEqual({ status: "ok" }, { status: "failed" })).toBe(false);
+  });
+});
+
 describe("matchesEvent", () => {
+  test("supports event alternation for canonical and lowercase event names", () => {
+    const matcher = { event: "ASSISTANT_MESSAGE|agent_start" };
+    const assistantMessage: TrajectoryEvent = {
+      ...baseEvent,
+      type: TrajectoryEventType.AssistantMessage,
+    };
+    const agentStart: TrajectoryEvent = {
+      ...baseEvent,
+      type: TrajectoryEventType.AgentStart,
+    };
+    const toolCall: TrajectoryEvent = {
+      ...baseEvent,
+      type: TrajectoryEventType.ToolCall,
+    };
+
+    expect(matchesEvent(assistantMessage, matcher)).toBe(true);
+    expect(matchesEvent(agentStart, matcher)).toBe(true);
+    expect(matchesEvent(toolCall, matcher)).toBe(false);
+  });
+
+  test("rejects event alternation containing unknown event names", () => {
+    expect(matchesEvent(baseEvent, { event: "TOOL_CALL|not_real" })).toBe(false);
+  });
+
   test("matches by event, tool, field_match, and field_not_match", () => {
     expect(
       matchesEvent(baseEvent, {

--- a/src/trajectory/match.test.ts
+++ b/src/trajectory/match.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { fieldValue, matchesEvent, normalizeEventTypeName, patternMatches } from "./match.js";
+import { type TrajectoryEvent, TrajectoryEventType } from "./types.js";
+
+const baseEvent: TrajectoryEvent = {
+  seq: 7,
+  type: TrajectoryEventType.ToolCall,
+  runtime: "codex",
+  tool: "apply_patch",
+  input: { file_path: "src/app.ts", patch: "--- a/src/app.ts" },
+  raw: { nested: { value: "alpha" } },
+  source: { path: "transcript.jsonl", line: 3 },
+};
+
+describe("normalizeEventTypeName", () => {
+  test("accepts canonical and lowercase event aliases", () => {
+    expect(normalizeEventTypeName("TOOL_CALL")).toBe("TOOL_CALL");
+    expect(normalizeEventTypeName("tool_call")).toBe("TOOL_CALL");
+    expect(normalizeEventTypeName("permission_denied")).toBe("PERMISSION_DENIED");
+    expect(normalizeEventTypeName("not_real")).toBeUndefined();
+  });
+});
+
+describe("fieldValue", () => {
+  test("reads normalized fields and raw payload fields", () => {
+    expect(fieldValue(baseEvent, "input.file_path")).toBe("src/app.ts");
+    expect(fieldValue(baseEvent, "raw.nested.value")).toBe("alpha");
+    expect(fieldValue(baseEvent, "missing.value")).toBeUndefined();
+  });
+});
+
+describe("patternMatches", () => {
+  test("supports glob wildcards and pipe alternation", () => {
+    expect(patternMatches("apply_patch", "apply_patch|edit_file")).toBe(true);
+    expect(patternMatches("--- a/src/app.ts", "--- a/*")).toBe(true);
+    expect(patternMatches("read_file", "apply_patch|edit_file")).toBe(false);
+  });
+});
+
+describe("matchesEvent", () => {
+  test("matches by event, tool, field_match, and field_not_match", () => {
+    expect(
+      matchesEvent(baseEvent, {
+        event: "tool_call",
+        tool: "apply_patch|edit_file",
+        field_match: { "input.file_path": "src/*" },
+        field_not_match: { "input.patch": "--- /dev/null*" },
+      }),
+    ).toBe(true);
+
+    expect(
+      matchesEvent(baseEvent, {
+        event: "permission_denied",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/trajectory/match.ts
+++ b/src/trajectory/match.ts
@@ -1,0 +1,62 @@
+import { isDeepStrictEqual } from "node:util";
+import type { EventMatcher, TrajectoryEvent, TrajectoryEventType } from "./types.js";
+import { isTrajectoryEventType } from "./types.js";
+
+export function normalizeEventTypeName(value: string): TrajectoryEventType | undefined {
+  const upper = value.trim().toUpperCase();
+  return isTrajectoryEventType(upper) ? upper : undefined;
+}
+
+export function fieldValue(source: unknown, path: string): unknown {
+  if (path.length === 0) return undefined;
+  const parts = path.split(".");
+  let current = source;
+  for (const part of parts) {
+    if (typeof current !== "object" || current === null) return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+export function patternMatches(value: unknown, pattern: string): boolean {
+  if (value === undefined || value === null) return false;
+  const text = String(value);
+  return pattern.split("|").some((part) => globPartMatches(text, part));
+}
+
+export function valuesEqual(left: unknown, right: unknown): boolean {
+  return isDeepStrictEqual(left, right);
+}
+
+export function matchesEvent(event: TrajectoryEvent, matcher: EventMatcher): boolean {
+  if (matcher.event !== undefined) {
+    const normalized = normalizeEventTypeName(matcher.event);
+    if (normalized === undefined || event.type !== normalized) return false;
+  }
+
+  if (matcher.tool !== undefined && !patternMatches(event.tool, matcher.tool)) {
+    return false;
+  }
+
+  for (const [path, pattern] of Object.entries(matcher.field_match ?? {})) {
+    if (!patternMatches(fieldValue(event, path), pattern)) return false;
+  }
+
+  for (const [path, pattern] of Object.entries(matcher.field_not_match ?? {})) {
+    if (patternMatches(fieldValue(event, path), pattern)) return false;
+  }
+
+  return true;
+}
+
+function globPartMatches(value: string, pattern: string): boolean {
+  const wildcardStar = "\u0000";
+  const wildcardQuestion = "\u0001";
+  const escaped = pattern
+    .replaceAll("*", wildcardStar)
+    .replaceAll("?", wildcardQuestion)
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replaceAll(wildcardStar, ".*")
+    .replaceAll(wildcardQuestion, ".");
+  return new RegExp(`^${escaped}$`).test(value);
+}

--- a/src/trajectory/match.ts
+++ b/src/trajectory/match.ts
@@ -7,6 +7,11 @@ export function normalizeEventTypeName(value: string): TrajectoryEventType | und
   return isTrajectoryEventType(upper) ? upper : undefined;
 }
 
+function matchesEventType(value: TrajectoryEventType, pattern: string): boolean {
+  const normalized = pattern.split("|").map((part) => normalizeEventTypeName(part));
+  return normalized.every((part) => part !== undefined) && normalized.includes(value);
+}
+
 export function fieldValue(source: unknown, path: string): unknown {
   if (path.length === 0) return undefined;
   const parts = path.split(".");
@@ -29,9 +34,8 @@ export function valuesEqual(left: unknown, right: unknown): boolean {
 }
 
 export function matchesEvent(event: TrajectoryEvent, matcher: EventMatcher): boolean {
-  if (matcher.event !== undefined) {
-    const normalized = normalizeEventTypeName(matcher.event);
-    if (normalized === undefined || event.type !== normalized) return false;
+  if (matcher.event !== undefined && !matchesEventType(event.type, matcher.event)) {
+    return false;
   }
 
   if (matcher.tool !== undefined && !patternMatches(event.tool, matcher.tool)) {

--- a/src/trajectory/parsers/acpx.test.ts
+++ b/src/trajectory/parsers/acpx.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { TrajectoryRuntime } from "../types.js";
+import { parseAcpxLine } from "./acpx.js";
+
+describe("parseAcpxLine", () => {
+  test("maps ACP session and update records to trajectory events", async () => {
+    const text = await readFile("tests/fixtures/acp/claude-tool-call.ndjson", "utf8");
+    const lines = text.trimEnd().split("\n");
+    const events = lines.flatMap(
+      (line, index) =>
+        parseAcpxLine(line, "claude-tool-call.ndjson", index + 1, TrajectoryRuntime.Acpx).events,
+    );
+
+    expect(events.some((event) => event.type === "AGENT_START")).toBe(true);
+    expect(events.some((event) => event.type === "ASSISTANT_MESSAGE")).toBe(true);
+    expect(events.some((event) => event.type === "TOOL_CALL")).toBe(true);
+    expect(events.every((event) => event.runtime === "acpx")).toBe(true);
+  });
+
+  test("maps ACP errors, permissions, and unknown updates", () => {
+    const denied = parseAcpxLine(
+      '{"jsonrpc":"2.0","error":{"message":"denied"}}',
+      "acp.ndjson",
+      1,
+      TrajectoryRuntime.Acpx,
+    );
+    const permission = parseAcpxLine(
+      '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess","update":{"sessionUpdate":"permission_request","permissionRequestId":"perm-1","title":"Bash"}}}',
+      "acp.ndjson",
+      2,
+      TrajectoryRuntime.Acpx,
+    );
+    const unknown = parseAcpxLine(
+      '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"usage_update"}}}',
+      "acp.ndjson",
+      3,
+      TrajectoryRuntime.Acpx,
+    );
+
+    expect(denied.events[0]?.type).toBe("PERMISSION_DENIED");
+    expect(denied.events[0]?.error).toBe("denied");
+    expect(permission.events[0]?.type).toBe("PERMISSION_WAIT");
+    expect(permission.events[0]?.spanId).toBe("perm-1");
+    expect(unknown.events[0]?.type).toBe("RAW");
+    expect(unknown.events[0]?.error).toBe(unknown.warnings[0]);
+  });
+
+  test("keeps invalid and non-object ACP records as RAW warnings", () => {
+    const invalid = parseAcpxLine("not-json", "acp.ndjson", 4, TrajectoryRuntime.Acpx);
+    const nonObject = parseAcpxLine("true", "acp.ndjson", 5, TrajectoryRuntime.Acpx);
+
+    expect(invalid.events[0]?.type).toBe("RAW");
+    expect(invalid.events[0]?.error).toBe(invalid.warnings[0]);
+    expect(nonObject.events[0]?.type).toBe("RAW");
+    expect(nonObject.warnings[0]).toContain("non-object");
+  });
+});

--- a/src/trajectory/parsers/acpx.test.ts
+++ b/src/trajectory/parsers/acpx.test.ts
@@ -68,6 +68,17 @@ describe("parseAcpxLine", () => {
     expect(permission.events[0]?.input).toEqual({ cmd: "ls" });
   });
 
+  test("does not emit tool results for progress-only ACP tool updates", () => {
+    const progress = parseAcpxLine(
+      '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess","update":{"sessionUpdate":"tool_call_update","toolCallId":"tool-1","rawInput":{"file_path":"src/index.ts"}}}}',
+      "acp.ndjson",
+      8,
+      TrajectoryRuntime.Acpx,
+    );
+
+    expect(progress.events.some((event) => event.type === "TOOL_RESULT")).toBe(false);
+  });
+
   test("keeps invalid and non-object ACP records as RAW warnings", () => {
     const invalid = parseAcpxLine("not-json", "acp.ndjson", 4, TrajectoryRuntime.Acpx);
     const nonObject = parseAcpxLine("true", "acp.ndjson", 5, TrajectoryRuntime.Acpx);

--- a/src/trajectory/parsers/acpx.test.ts
+++ b/src/trajectory/parsers/acpx.test.ts
@@ -54,6 +54,20 @@ describe("parseAcpxLine", () => {
     expect(denied.events[0]?.error).toBe("denied");
   });
 
+  test("maps canonical ACP permission requests", () => {
+    const permission = parseAcpxLine(
+      '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess","update":{"sessionUpdate":"permission_request","id":"p1","tool":"Bash","input":{"cmd":"ls"}}}}',
+      "acp.ndjson",
+      7,
+      TrajectoryRuntime.Acpx,
+    );
+
+    expect(permission.events[0]?.type).toBe("PERMISSION_WAIT");
+    expect(permission.events[0]?.spanId).toBe("p1");
+    expect(permission.events[0]?.tool).toBe("Bash");
+    expect(permission.events[0]?.input).toEqual({ cmd: "ls" });
+  });
+
   test("keeps invalid and non-object ACP records as RAW warnings", () => {
     const invalid = parseAcpxLine("not-json", "acp.ndjson", 4, TrajectoryRuntime.Acpx);
     const nonObject = parseAcpxLine("true", "acp.ndjson", 5, TrajectoryRuntime.Acpx);

--- a/src/trajectory/parsers/acpx.test.ts
+++ b/src/trajectory/parsers/acpx.test.ts
@@ -46,6 +46,14 @@ describe("parseAcpxLine", () => {
     expect(unknown.events[0]?.error).toBe(unknown.warnings[0]);
   });
 
+  test("maps string-valued ACP errors to permission denial events", () => {
+    const denied = parseAcpxLine('{"error":"denied"}', "acp.ndjson", 6, TrajectoryRuntime.Acpx);
+
+    expect(denied.events).toHaveLength(1);
+    expect(denied.events[0]?.type).toBe("PERMISSION_DENIED");
+    expect(denied.events[0]?.error).toBe("denied");
+  });
+
   test("keeps invalid and non-object ACP records as RAW warnings", () => {
     const invalid = parseAcpxLine("not-json", "acp.ndjson", 4, TrajectoryRuntime.Acpx);
     const nonObject = parseAcpxLine("true", "acp.ndjson", 5, TrajectoryRuntime.Acpx);

--- a/src/trajectory/parsers/acpx.ts
+++ b/src/trajectory/parsers/acpx.ts
@@ -1,0 +1,226 @@
+import type { ParsedTrajectoryEvent, TrajectoryRuntime } from "../types.js";
+import { TrajectoryEventType } from "../types.js";
+
+export function parseAcpxLine(
+  line: string,
+  path: string,
+  lineNumber: number,
+  runtime: TrajectoryRuntime,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return raw(
+        line,
+        path,
+        lineNumber,
+        runtime,
+        `line ${lineNumber}: non-object ACP record kept as RAW`,
+      );
+    }
+
+    const record = parsed as Record<string, unknown>;
+    if (typeof record.error === "object" && record.error !== null) {
+      return {
+        events: [
+          baseEvent(TrajectoryEventType.PermissionDenied, runtime, path, lineNumber, {
+            error: errorMessage(record.error),
+            raw: record,
+          }),
+        ],
+        warnings: [],
+      };
+    }
+
+    const result = objectField(record, "result");
+    const sessionId = stringField(result, "sessionId");
+    if (sessionId !== undefined) {
+      return {
+        events: [
+          baseEvent(TrajectoryEventType.AgentStart, runtime, path, lineNumber, {
+            sessionId,
+            raw: record,
+          }),
+        ],
+        warnings: [],
+      };
+    }
+
+    if (record.method === "session/update") {
+      return parseSessionUpdate(record, path, lineNumber, runtime);
+    }
+
+    return { events: [], warnings: [] };
+  } catch {
+    return raw(
+      line,
+      path,
+      lineNumber,
+      runtime,
+      `line ${lineNumber}: non-JSON ACP output kept as RAW`,
+    );
+  }
+}
+
+function parseSessionUpdate(
+  record: Readonly<Record<string, unknown>>,
+  path: string,
+  lineNumber: number,
+  runtime: TrajectoryRuntime,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  const params = objectField(record, "params");
+  const update = objectField(params, "update");
+  const sessionUpdate = stringField(update, "sessionUpdate");
+  const sessionId = stringField(params, "sessionId");
+
+  if (sessionUpdate === "agent_message_chunk" || sessionUpdate === "user_message_chunk") {
+    return {
+      events: [
+        baseEvent(TrajectoryEventType.AssistantMessage, runtime, path, lineNumber, {
+          sessionId,
+          message: contentText(update.content),
+          raw: record,
+        }),
+      ],
+      warnings: [],
+    };
+  }
+
+  if (sessionUpdate === "tool_call") {
+    return {
+      events: [
+        baseEvent(TrajectoryEventType.ToolCall, runtime, path, lineNumber, {
+          sessionId,
+          spanId: stringField(update, "toolCallId"),
+          tool: toolName(update),
+          status: stringField(update, "status"),
+          input: update.rawInput,
+          raw: record,
+        }),
+      ],
+      warnings: [],
+    };
+  }
+
+  if (sessionUpdate === "tool_call_update") {
+    return {
+      events: [
+        baseEvent(TrajectoryEventType.ToolResult, runtime, path, lineNumber, {
+          sessionId,
+          spanId: stringField(update, "toolCallId"),
+          tool: toolName(update),
+          status: stringField(update, "status"),
+          input: update.rawInput,
+          output: update.rawOutput ?? claudeToolOutput(update),
+          raw: record,
+        }),
+      ],
+      warnings: [],
+    };
+  }
+
+  if (sessionUpdate === "permission_request") {
+    return {
+      events: [
+        baseEvent(TrajectoryEventType.PermissionWait, runtime, path, lineNumber, {
+          sessionId,
+          spanId: stringField(update, "toolCallId") ?? stringField(update, "permissionRequestId"),
+          tool: toolName(update),
+          input: update,
+          raw: record,
+        }),
+      ],
+      warnings: [],
+    };
+  }
+
+  const warning = `line ${lineNumber}: unmapped ACP session update kept as RAW`;
+  return {
+    events: [
+      baseEvent(TrajectoryEventType.Raw, runtime, path, lineNumber, {
+        error: warning,
+        raw: record,
+      }),
+    ],
+    warnings: [warning],
+  };
+}
+
+function baseEvent(
+  type: ParsedTrajectoryEvent["type"],
+  runtime: TrajectoryRuntime,
+  path: string,
+  lineNumber: number,
+  fields: Omit<Partial<ParsedTrajectoryEvent>, "type" | "runtime" | "source">,
+): ParsedTrajectoryEvent {
+  return {
+    type,
+    runtime,
+    ...fields,
+    source: { path, line: lineNumber },
+  };
+}
+
+function raw(
+  line: string,
+  path: string,
+  lineNumber: number,
+  runtime: TrajectoryRuntime,
+  warning: string,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  return {
+    events: [
+      baseEvent(TrajectoryEventType.Raw, runtime, path, lineNumber, {
+        message: line,
+        error: warning,
+        raw: line,
+      }),
+    ],
+    warnings: [warning],
+  };
+}
+
+function objectField(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+): Record<string, unknown> {
+  const value = record[key];
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringField(record: Readonly<Record<string, unknown>>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function toolName(update: Readonly<Record<string, unknown>>): string | undefined {
+  const meta = objectField(update, "_meta");
+  const claudeCode = objectField(meta, "claudeCode");
+  return stringField(claudeCode, "toolName") ?? stringField(update, "title");
+}
+
+function contentText(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  return stringField(record, "text");
+}
+
+function claudeToolOutput(update: Readonly<Record<string, unknown>>): unknown {
+  const meta = objectField(update, "_meta");
+  const claudeCode = objectField(meta, "claudeCode");
+  const response = objectField(claudeCode, "toolResponse");
+  if (Object.keys(response).length > 0) {
+    return response;
+  }
+  return undefined;
+}
+
+function errorMessage(error: unknown): string | undefined {
+  if (typeof error === "string") return error;
+  if (typeof error !== "object" || error === null || Array.isArray(error)) return undefined;
+  const record = error as Record<string, unknown>;
+  return stringField(record, "message") ?? stringField(record, "code");
+}

--- a/src/trajectory/parsers/acpx.ts
+++ b/src/trajectory/parsers/acpx.ts
@@ -103,6 +103,11 @@ function parseSessionUpdate(
   }
 
   if (sessionUpdate === "tool_call_update") {
+    const output = update.rawOutput ?? claudeToolOutput(update);
+    if (!isTerminalStatus(stringField(update, "status")) && output === undefined) {
+      return { events: [], warnings: [] };
+    }
+
     return {
       events: [
         baseEvent(TrajectoryEventType.ToolResult, runtime, path, lineNumber, {
@@ -111,7 +116,7 @@ function parseSessionUpdate(
           tool: toolName(update),
           status: stringField(update, "status"),
           input: update.rawInput,
-          output: update.rawOutput ?? claudeToolOutput(update),
+          output,
           raw: record,
         }),
       ],
@@ -219,6 +224,16 @@ function claudeToolOutput(update: Readonly<Record<string, unknown>>): unknown {
     return response;
   }
   return undefined;
+}
+
+function isTerminalStatus(status: string | undefined): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "canceled" ||
+    status === "error"
+  );
 }
 
 function errorMessage(error: unknown): string | undefined {

--- a/src/trajectory/parsers/acpx.ts
+++ b/src/trajectory/parsers/acpx.ts
@@ -20,7 +20,7 @@ export function parseAcpxLine(
     }
 
     const record = parsed as Record<string, unknown>;
-    if (typeof record.error === "object" && record.error !== null) {
+    if (record.error !== undefined) {
       return {
         events: [
           baseEvent(TrajectoryEventType.PermissionDenied, runtime, path, lineNumber, {

--- a/src/trajectory/parsers/acpx.ts
+++ b/src/trajectory/parsers/acpx.ts
@@ -124,9 +124,12 @@ function parseSessionUpdate(
       events: [
         baseEvent(TrajectoryEventType.PermissionWait, runtime, path, lineNumber, {
           sessionId,
-          spanId: stringField(update, "toolCallId") ?? stringField(update, "permissionRequestId"),
-          tool: toolName(update),
-          input: update,
+          spanId:
+            stringField(update, "toolCallId") ??
+            stringField(update, "permissionRequestId") ??
+            stringField(update, "id"),
+          tool: toolName(update) ?? stringField(update, "tool"),
+          input: update.input ?? update,
           raw: record,
         }),
       ],

--- a/src/trajectory/parsers/claude-stream-json.test.ts
+++ b/src/trajectory/parsers/claude-stream-json.test.ts
@@ -19,6 +19,7 @@ describe("parseClaudeStreamJsonLine", () => {
       "DELEGATION_RETURN",
     ]);
     expect(events[2]?.parentSpanId).toBe("tool-parent");
+    expect(events[4]?.type).toBe("DELEGATION_RETURN");
   });
 
   test("maps permission denial and non-array assistant text", () => {
@@ -61,6 +62,28 @@ describe("parseClaudeStreamJsonLine", () => {
 
     expect(result.events[0]?.type).toBe("TOOL_RESULT");
     expect(result.events[0]?.spanId).toBe("read-1");
+  });
+
+  test("generates deterministic span ids for parented records without child ids", () => {
+    const result = parseClaudeStreamJsonLine(
+      '{"type":"tool_result","parent_tool_use_id":"tool-parent","content":"done"}',
+      "claude.jsonl",
+      8,
+    );
+
+    expect(result.events[0]?.type).toBe("TOOL_RESULT");
+    expect(result.events[0]?.parentSpanId).toBe("tool-parent");
+    expect(result.events[0]?.spanId).toBe("generated:8");
+  });
+
+  test("does not treat arbitrary task prose as delegation return evidence", () => {
+    const result = parseClaudeStreamJsonLine(
+      '{"type":"tool_result","tool_use_id":"read-1","content":"task completed"}',
+      "claude.jsonl",
+      9,
+    );
+
+    expect(result.events[0]?.type).toBe("TOOL_RESULT");
   });
 
   test("keeps invalid and non-object stream-json records as RAW warnings", () => {

--- a/src/trajectory/parsers/claude-stream-json.test.ts
+++ b/src/trajectory/parsers/claude-stream-json.test.ts
@@ -41,6 +41,17 @@ describe("parseClaudeStreamJsonLine", () => {
     expect(unknown.events[0]?.type).toBe("RAW");
   });
 
+  test("maps tool_call_id to Claude stream-json span ids", () => {
+    const call = parseClaudeStreamJsonLine(
+      '{"type":"tool_call","tool_call_id":"call-1","name":"Read"}',
+      "claude.jsonl",
+      6,
+    );
+
+    expect(call.events[0]?.type).toBe("TOOL_CALL");
+    expect(call.events[0]?.spanId).toBe("call-1");
+  });
+
   test("keeps invalid and non-object stream-json records as RAW warnings", () => {
     const invalid = parseClaudeStreamJsonLine("not-json", "claude.jsonl", 4);
     const nonObject = parseClaudeStreamJsonLine("false", "claude.jsonl", 5);

--- a/src/trajectory/parsers/claude-stream-json.test.ts
+++ b/src/trajectory/parsers/claude-stream-json.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { parseClaudeStreamJsonLine } from "./claude-stream-json.js";
+
+describe("parseClaudeStreamJsonLine", () => {
+  test("maps Claude stream-json tool nesting to delegation events", async () => {
+    const text = await readFile("tests/fixtures/trajectory/claude-stream-json.jsonl", "utf8");
+    const lines = text.trimEnd().split("\n");
+    const events = lines.flatMap(
+      (line, index) =>
+        parseClaudeStreamJsonLine(line, "claude-stream-json.jsonl", index + 1).events,
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "ASSISTANT_MESSAGE",
+      "DELEGATION",
+      "TOOL_CALL",
+      "TOOL_RESULT",
+      "DELEGATION_RETURN",
+    ]);
+    expect(events[2]?.parentSpanId).toBe("tool-parent");
+  });
+
+  test("maps permission denial and non-array assistant text", () => {
+    const assistant = parseClaudeStreamJsonLine(
+      '{"type":"assistant","message":"hello"}',
+      "claude.jsonl",
+      1,
+    );
+    const denied = parseClaudeStreamJsonLine(
+      '{"type":"permission_denied","error":"no"}',
+      "claude.jsonl",
+      2,
+    );
+    const unknown = parseClaudeStreamJsonLine('{"type":"unknown"}', "claude.jsonl", 3);
+
+    expect(assistant.events[0]?.type).toBe("ASSISTANT_MESSAGE");
+    expect(assistant.events[0]?.message).toBe("hello");
+    expect(denied.events[0]?.type).toBe("PERMISSION_DENIED");
+    expect(denied.events[0]?.error).toBe("no");
+    expect(unknown.events[0]?.type).toBe("RAW");
+  });
+
+  test("keeps invalid and non-object stream-json records as RAW warnings", () => {
+    const invalid = parseClaudeStreamJsonLine("not-json", "claude.jsonl", 4);
+    const nonObject = parseClaudeStreamJsonLine("false", "claude.jsonl", 5);
+
+    expect(invalid.events[0]?.type).toBe("RAW");
+    expect(invalid.events[0]?.error).toBe(invalid.warnings[0]);
+    expect(nonObject.events[0]?.type).toBe("RAW");
+    expect(nonObject.warnings[0]).toContain("non-object");
+  });
+});

--- a/src/trajectory/parsers/claude-stream-json.test.ts
+++ b/src/trajectory/parsers/claude-stream-json.test.ts
@@ -52,6 +52,17 @@ describe("parseClaudeStreamJsonLine", () => {
     expect(call.events[0]?.spanId).toBe("call-1");
   });
 
+  test("maps plain Claude tool results without parents to tool results", () => {
+    const result = parseClaudeStreamJsonLine(
+      '{"type":"tool_result","tool_use_id":"read-1","content":"done"}',
+      "claude.jsonl",
+      7,
+    );
+
+    expect(result.events[0]?.type).toBe("TOOL_RESULT");
+    expect(result.events[0]?.spanId).toBe("read-1");
+  });
+
   test("keeps invalid and non-object stream-json records as RAW warnings", () => {
     const invalid = parseClaudeStreamJsonLine("not-json", "claude.jsonl", 4);
     const nonObject = parseClaudeStreamJsonLine("false", "claude.jsonl", 5);

--- a/src/trajectory/parsers/claude-stream-json.ts
+++ b/src/trajectory/parsers/claude-stream-json.ts
@@ -41,6 +41,7 @@ function eventFromRecord(
   const spanId =
     stringField(record, "id") ??
     stringField(record, "tool_use_id") ??
+    stringField(record, "tool_call_id") ??
     stringField(record, "spanId") ??
     stringField(record, "span_id");
   const parentSpanId =

--- a/src/trajectory/parsers/claude-stream-json.ts
+++ b/src/trajectory/parsers/claude-stream-json.ts
@@ -1,0 +1,152 @@
+import type { ParsedTrajectoryEvent } from "../types.js";
+import { TrajectoryEventType, TrajectoryRuntime } from "../types.js";
+
+export function parseClaudeStreamJsonLine(
+  line: string,
+  path: string,
+  lineNumber: number,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return raw(
+        line,
+        path,
+        lineNumber,
+        `line ${lineNumber}: non-object Claude stream-json record kept as RAW`,
+      );
+    }
+
+    const record = parsed as Record<string, unknown>;
+    return {
+      events: [eventFromRecord(record, path, lineNumber)],
+      warnings: [],
+    };
+  } catch {
+    return raw(
+      line,
+      path,
+      lineNumber,
+      `line ${lineNumber}: non-JSON Claude stream-json output kept as RAW`,
+    );
+  }
+}
+
+function eventFromRecord(
+  record: Readonly<Record<string, unknown>>,
+  path: string,
+  lineNumber: number,
+): ParsedTrajectoryEvent {
+  const type = stringField(record, "type");
+  const spanId =
+    stringField(record, "id") ??
+    stringField(record, "tool_use_id") ??
+    stringField(record, "spanId") ??
+    stringField(record, "span_id");
+  const parentSpanId =
+    stringField(record, "parent_tool_use_id") ??
+    stringField(record, "parentSpanId") ??
+    stringField(record, "parent_span_id");
+  const tool =
+    stringField(record, "name") ?? stringField(record, "tool") ?? stringField(record, "tool_name");
+
+  return {
+    type: inferType(type, tool, parentSpanId),
+    runtime: TrajectoryRuntime.ClaudeStreamJson,
+    timestamp: stringField(record, "timestamp"),
+    spanId,
+    parentSpanId,
+    tool,
+    status: stringField(record, "status"),
+    input: record.input,
+    output: record.output ?? record.content,
+    message: assistantMessage(record),
+    error: stringField(record, "error"),
+    raw: record,
+    source: { path, line: lineNumber },
+  };
+}
+
+function inferType(
+  type: string | undefined,
+  tool: string | undefined,
+  parentSpanId: string | undefined,
+): ParsedTrajectoryEvent["type"] {
+  if (type === "assistant") {
+    return TrajectoryEventType.AssistantMessage;
+  }
+
+  if (type === "tool_use" || type === "tool_call") {
+    return isDelegationTool(tool) ? TrajectoryEventType.Delegation : TrajectoryEventType.ToolCall;
+  }
+
+  if (type === "tool_result") {
+    return parentSpanId === undefined
+      ? TrajectoryEventType.DelegationReturn
+      : TrajectoryEventType.ToolResult;
+  }
+
+  if (type === "permission_denied") {
+    return TrajectoryEventType.PermissionDenied;
+  }
+
+  return TrajectoryEventType.Raw;
+}
+
+function raw(
+  line: string,
+  path: string,
+  lineNumber: number,
+  warning: string,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  return {
+    events: [
+      {
+        type: TrajectoryEventType.Raw,
+        runtime: TrajectoryRuntime.ClaudeStreamJson,
+        message: line,
+        error: warning,
+        raw: line,
+        source: { path, line: lineNumber },
+      },
+    ],
+    warnings: [warning],
+  };
+}
+
+function assistantMessage(record: Readonly<Record<string, unknown>>): string | undefined {
+  const message = record.message;
+  if (typeof message === "string") {
+    return message;
+  }
+
+  if (!Array.isArray(message)) {
+    return stringField(record, "text");
+  }
+
+  const parts: string[] = [];
+  for (const part of message) {
+    if (typeof part !== "object" || part === null || Array.isArray(part)) {
+      continue;
+    }
+    const text = stringField(part as Record<string, unknown>, "text");
+    if (text !== undefined) {
+      parts.push(text);
+    }
+  }
+
+  return parts.length > 0 ? parts.join("") : undefined;
+}
+
+function isDelegationTool(tool: string | undefined): boolean {
+  if (tool === undefined) {
+    return false;
+  }
+  const normalized = tool.toLowerCase();
+  return normalized === "task" || normalized.includes("subagent");
+}
+
+function stringField(record: Readonly<Record<string, unknown>>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/trajectory/parsers/claude-stream-json.ts
+++ b/src/trajectory/parsers/claude-stream-json.ts
@@ -52,7 +52,7 @@ function eventFromRecord(
     stringField(record, "name") ?? stringField(record, "tool") ?? stringField(record, "tool_name");
 
   return {
-    type: inferType(type, tool, parentSpanId),
+    type: inferType(record, type, tool, parentSpanId),
     runtime: TrajectoryRuntime.ClaudeStreamJson,
     timestamp: stringField(record, "timestamp"),
     spanId,
@@ -69,6 +69,7 @@ function eventFromRecord(
 }
 
 function inferType(
+  record: Readonly<Record<string, unknown>>,
   type: string | undefined,
   tool: string | undefined,
   parentSpanId: string | undefined,
@@ -82,7 +83,7 @@ function inferType(
   }
 
   if (type === "tool_result") {
-    return parentSpanId === undefined
+    return parentSpanId === undefined && hasDelegationReturnEvidence(record)
       ? TrajectoryEventType.DelegationReturn
       : TrajectoryEventType.ToolResult;
   }
@@ -145,6 +146,37 @@ function isDelegationTool(tool: string | undefined): boolean {
   }
   const normalized = tool.toLowerCase();
   return normalized === "task" || normalized.includes("subagent");
+}
+
+function hasDelegationReturnEvidence(record: Readonly<Record<string, unknown>>): boolean {
+  return (
+    hasDelegationText(record.content) ||
+    hasDelegationText(record.message) ||
+    hasDelegationText(record.tool) ||
+    hasDelegationText(record.name) ||
+    hasDelegationText(record.id)
+  );
+}
+
+function hasDelegationText(value: unknown): boolean {
+  if (typeof value === "string") {
+    const normalized = value.toLowerCase();
+    return (
+      normalized.includes("delegation") ||
+      normalized.includes("subagent") ||
+      normalized.includes("task")
+    );
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(hasDelegationText);
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return Object.values(value).some(hasDelegationText);
+  }
+
+  return false;
 }
 
 function stringField(record: Readonly<Record<string, unknown>>, key: string): string | undefined {

--- a/src/trajectory/parsers/claude-stream-json.ts
+++ b/src/trajectory/parsers/claude-stream-json.ts
@@ -48,6 +48,8 @@ function eventFromRecord(
     stringField(record, "parent_tool_use_id") ??
     stringField(record, "parentSpanId") ??
     stringField(record, "parent_span_id");
+  const resolvedSpanId =
+    spanId ?? (parentSpanId === undefined ? undefined : `generated:${lineNumber}`);
   const tool =
     stringField(record, "name") ?? stringField(record, "tool") ?? stringField(record, "tool_name");
 
@@ -55,7 +57,7 @@ function eventFromRecord(
     type: inferType(record, type, tool, parentSpanId),
     runtime: TrajectoryRuntime.ClaudeStreamJson,
     timestamp: stringField(record, "timestamp"),
-    spanId,
+    spanId: resolvedSpanId,
     parentSpanId,
     tool,
     status: stringField(record, "status"),
@@ -152,20 +154,16 @@ function hasDelegationReturnEvidence(record: Readonly<Record<string, unknown>>):
   return (
     hasDelegationText(record.content) ||
     hasDelegationText(record.message) ||
-    hasDelegationText(record.tool) ||
-    hasDelegationText(record.name) ||
-    hasDelegationText(record.id)
+    hasDelegationIdentifier(record.tool) ||
+    hasDelegationIdentifier(record.name) ||
+    hasDelegationIdentifier(record.id)
   );
 }
 
 function hasDelegationText(value: unknown): boolean {
   if (typeof value === "string") {
     const normalized = value.toLowerCase();
-    return (
-      normalized.includes("delegation") ||
-      normalized.includes("subagent") ||
-      normalized.includes("task")
-    );
+    return normalized.includes("delegation") || normalized.includes("subagent");
   }
 
   if (Array.isArray(value)) {
@@ -177,6 +175,20 @@ function hasDelegationText(value: unknown): boolean {
   }
 
   return false;
+}
+
+function hasDelegationIdentifier(value: unknown): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const normalized = value.toLowerCase();
+  return (
+    normalized === "task" ||
+    normalized.includes("task") ||
+    normalized.includes("delegation") ||
+    normalized.includes("subagent")
+  );
 }
 
 function stringField(record: Readonly<Record<string, unknown>>, key: string): string | undefined {

--- a/src/trajectory/parsers/codex.test.ts
+++ b/src/trajectory/parsers/codex.test.ts
@@ -40,6 +40,17 @@ describe("parseCodexLine", () => {
     expect(unknown.events[0]?.type).toBe("RAW");
   });
 
+  test("maps native Codex id and parent_call_id span fields", () => {
+    const result = parseCodexLine(
+      '{"type":"tool_call","id":"child","parent_call_id":"parent","tool_name":"Read"}',
+      "codex.jsonl",
+      5,
+    );
+
+    expect(result.events[0]?.spanId).toBe("child");
+    expect(result.events[0]?.parentSpanId).toBe("parent");
+  });
+
   test("covers matcher helpers loaded by trajectory parsers", () => {
     const event = {
       seq: 1,

--- a/src/trajectory/parsers/codex.test.ts
+++ b/src/trajectory/parsers/codex.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { matchesEvent, patternMatches, valuesEqual } from "../match.js";
+import { formatSeq, isTrajectoryEventType } from "../types.js";
+import { parseCodexLine } from "./codex.js";
+
+describe("parseCodexLine", () => {
+  test("maps Codex transcript records to trajectory events", async () => {
+    const text = await readFile("tests/fixtures/trajectory/codex-transcript.jsonl", "utf8");
+    const lines = text.trimEnd().split("\n");
+    const events = lines.flatMap(
+      (line, index) => parseCodexLine(line, "codex-transcript.jsonl", index + 1).events,
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "AGENT_START",
+      "TOOL_CALL",
+      "TOOL_RESULT",
+      "ASSISTANT_MESSAGE",
+    ]);
+    expect(events[1]?.tool).toBe("apply_patch");
+    expect(events[2]?.spanId).toBe("call-1");
+  });
+
+  test("delegates Codex ACP records and keeps invalid records as RAW", () => {
+    const delegated = parseCodexLine(
+      '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"sess-2"}}',
+      "codex.jsonl",
+      1,
+    );
+    const uppercase = parseCodexLine('{"event":"TOOL_CALL","spanId":"span-1"}', "codex.jsonl", 2);
+    const invalid = parseCodexLine("[1]", "codex.jsonl", 3);
+    const unknown = parseCodexLine('{"source":"codex"}', "codex.jsonl", 4);
+
+    expect(delegated.events[0]?.runtime).toBe("codex");
+    expect(delegated.events[0]?.type).toBe("AGENT_START");
+    expect(uppercase.events[0]?.type).toBe("TOOL_CALL");
+    expect(invalid.events[0]?.type).toBe("RAW");
+    expect(invalid.events[0]?.error).toBe(invalid.warnings[0]);
+    expect(unknown.events[0]?.type).toBe("RAW");
+  });
+
+  test("covers matcher helpers loaded by trajectory parsers", () => {
+    const event = {
+      seq: 1,
+      type: "TOOL_CALL" as const,
+      runtime: "codex" as const,
+      tool: "apply_patch",
+      spanId: "span-1",
+      input: { file_path: "src/app.ts" },
+      source: { path: "codex.jsonl", line: 1 },
+    };
+
+    expect(patternMatches("apply_patch", "apply_*")).toBe(true);
+    expect(patternMatches(undefined, "*")).toBe(false);
+    expect(valuesEqual({ a: 1 }, { a: 1 })).toBe(true);
+    expect(matchesEvent(event, { event: "TOOL_CALL", tool: "apply_*" })).toBe(true);
+    expect(matchesEvent(event, { event: "missing" })).toBe(false);
+    expect(matchesEvent(event, { field_match: { "input.file_path": "src/*" } })).toBe(true);
+    expect(matchesEvent(event, { field_not_match: { tool: "Read" } })).toBe(true);
+    expect(isTrajectoryEventType("TOOL_CALL")).toBe(true);
+    expect(formatSeq(3)).toBe("[seq:0003]");
+  });
+});

--- a/src/trajectory/parsers/codex.ts
+++ b/src/trajectory/parsers/codex.ts
@@ -1,0 +1,108 @@
+import { normalizeEventTypeName } from "../match.js";
+import type { ParsedTrajectoryEvent } from "../types.js";
+import { TrajectoryEventType, TrajectoryRuntime } from "../types.js";
+import { parseAcpxLine } from "./acpx.js";
+
+export function parseCodexLine(
+  line: string,
+  path: string,
+  lineNumber: number,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return raw(line, path, lineNumber, `line ${lineNumber}: non-object Codex record kept as RAW`);
+    }
+
+    const record = parsed as Record<string, unknown>;
+    if (record.jsonrpc !== undefined || record.method === "session/update") {
+      return parseAcpxLine(line, path, lineNumber, TrajectoryRuntime.Codex);
+    }
+
+    return {
+      events: [
+        {
+          type: inferType(record),
+          runtime: TrajectoryRuntime.Codex,
+          timestamp: stringField(record, "timestamp"),
+          sessionId: stringField(record, "sessionId") ?? stringField(record, "session_id"),
+          agentId: stringField(record, "agentId") ?? stringField(record, "agent_id"),
+          spanId:
+            stringField(record, "spanId") ??
+            stringField(record, "span_id") ??
+            stringField(record, "call_id") ??
+            stringField(record, "callId"),
+          parentSpanId:
+            stringField(record, "parentSpanId") ?? stringField(record, "parent_span_id"),
+          tool: stringField(record, "tool") ?? stringField(record, "tool_name"),
+          status: stringField(record, "status"),
+          input: record.input,
+          output: record.output,
+          message: stringField(record, "message") ?? stringField(record, "text"),
+          error: stringField(record, "error"),
+          raw: record,
+          source: { path, line: lineNumber },
+        },
+      ],
+      warnings: [],
+    };
+  } catch {
+    return raw(line, path, lineNumber, `line ${lineNumber}: non-JSON Codex output kept as RAW`);
+  }
+}
+
+function raw(
+  line: string,
+  path: string,
+  lineNumber: number,
+  warning: string,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  return {
+    events: [
+      {
+        type: TrajectoryEventType.Raw,
+        runtime: TrajectoryRuntime.Codex,
+        message: line,
+        error: warning,
+        raw: line,
+        source: { path, line: lineNumber },
+      },
+    ],
+    warnings: [warning],
+  };
+}
+
+function inferType(record: Readonly<Record<string, unknown>>): ParsedTrajectoryEvent["type"] {
+  const explicit =
+    stringField(record, "event") ?? stringField(record, "type") ?? stringField(record, "kind");
+  if (explicit === undefined) {
+    return TrajectoryEventType.Raw;
+  }
+
+  const alias = codexAlias(explicit);
+  if (alias !== undefined) {
+    return alias;
+  }
+
+  return normalizeEventTypeName(explicit) ?? TrajectoryEventType.Raw;
+}
+
+function codexAlias(value: string): ParsedTrajectoryEvent["type"] | undefined {
+  switch (value.trim().toLowerCase()) {
+    case "agent_start":
+      return TrajectoryEventType.AgentStart;
+    case "assistant_message":
+      return TrajectoryEventType.AssistantMessage;
+    case "tool_call":
+      return TrajectoryEventType.ToolCall;
+    case "tool_result":
+      return TrajectoryEventType.ToolResult;
+    default:
+      return undefined;
+  }
+}
+
+function stringField(record: Readonly<Record<string, unknown>>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/trajectory/parsers/codex.ts
+++ b/src/trajectory/parsers/codex.ts
@@ -31,9 +31,12 @@ export function parseCodexLine(
             stringField(record, "spanId") ??
             stringField(record, "span_id") ??
             stringField(record, "call_id") ??
-            stringField(record, "callId"),
+            stringField(record, "callId") ??
+            stringField(record, "id"),
           parentSpanId:
-            stringField(record, "parentSpanId") ?? stringField(record, "parent_span_id"),
+            stringField(record, "parent_call_id") ??
+            stringField(record, "parentSpanId") ??
+            stringField(record, "parent_span_id"),
           tool: stringField(record, "tool") ?? stringField(record, "tool_name"),
           status: stringField(record, "status"),
           input: record.input,

--- a/src/trajectory/parsers/subprocess.test.ts
+++ b/src/trajectory/parsers/subprocess.test.ts
@@ -29,6 +29,16 @@ describe("parseSubprocessLine", () => {
     expect(result.warnings[0]).toContain("non-object JSONL record");
   });
 
+  test("keeps array JSON as RAW with a warning", () => {
+    const result = parseSubprocessLine("[1]", "subprocess.log", 12);
+
+    expect(result.events[0]?.type).toBe("RAW");
+    expect(result.events[0]?.message).toBe("[1]");
+    expect(result.events[0]?.raw).toBe("[1]");
+    expect(result.warnings[0]).toContain("line 12");
+    expect(result.warnings[0]).toContain("non-object JSONL record");
+  });
+
   test("infers assistant messages from stdout and stderr streams", () => {
     const stdout = parseSubprocessLine('{"stream":"stdout","text":"hello"}', "subprocess.log", 5);
     const stderr = parseSubprocessLine('{"stream":"stderr","text":"warning"}', "subprocess.log", 6);

--- a/src/trajectory/parsers/subprocess.test.ts
+++ b/src/trajectory/parsers/subprocess.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { formatSeq } from "../types.js";
+import { parseSubprocessLine } from "./subprocess.js";
+
+describe("parseSubprocessLine", () => {
+  test("maps structured events and keeps plain text as RAW", async () => {
+    const text = await readFile("tests/fixtures/trajectory/subprocess.log", "utf8");
+    const lines = text.trimEnd().split("\n");
+
+    const first = parseSubprocessLine(lines[0] ?? "", "subprocess.log", 1);
+    const second = parseSubprocessLine(lines[1] ?? "", "subprocess.log", 2);
+    const third = parseSubprocessLine(lines[2] ?? "", "subprocess.log", 3);
+
+    expect(first.events[0]?.type).toBe("AGENT_START");
+    expect(first.events[0]?.spanId).toBe("proc-1");
+    expect(second.events[0]?.type).toBe("RAW");
+    expect(second.events[0]?.message).toBe("plain stdout line");
+    expect(second.warnings[0]).toContain("line 2");
+    expect(third.events[0]?.type).toBe("PERMISSION_DENIED");
+  });
+
+  test("keeps non-object JSON as RAW with a warning", () => {
+    const result = parseSubprocessLine("true", "subprocess.log", 4);
+
+    expect(result.events[0]?.type).toBe("RAW");
+    expect(result.events[0]?.runtime).toBe("subprocess");
+    expect(result.events[0]?.raw).toBe("true");
+    expect(result.warnings[0]).toContain("non-object JSONL record");
+  });
+
+  test("infers assistant messages from stdout and stderr streams", () => {
+    const stdout = parseSubprocessLine('{"stream":"stdout","text":"hello"}', "subprocess.log", 5);
+    const stderr = parseSubprocessLine('{"stream":"stderr","text":"warning"}', "subprocess.log", 6);
+
+    expect(stdout.events[0]?.type).toBe("ASSISTANT_MESSAGE");
+    expect(stdout.events[0]?.message).toBe("hello");
+    expect(stderr.events[0]?.type).toBe("ASSISTANT_MESSAGE");
+  });
+
+  test("infers agent start from subprocess command or pid fields", () => {
+    const command = parseSubprocessLine('{"command":"bun test"}', "subprocess.log", 7);
+    const pid = parseSubprocessLine('{"pid":123}', "subprocess.log", 8);
+
+    expect(command.events[0]?.type).toBe("AGENT_START");
+    expect(pid.events[0]?.type).toBe("AGENT_START");
+  });
+
+  test("uses aliases and falls back to RAW for unknown structured records", () => {
+    const aliased = parseSubprocessLine(
+      '{"kind":"TOOL_CALL","span_id":"child","parent_span_id":"parent","tool_name":"shell","status":"ok","input":{"cmd":"ls"},"output":"done","error":"none"}',
+      "subprocess.log",
+      9,
+    );
+    const unknownEvent = parseSubprocessLine('{"event":"missing"}', "subprocess.log", 10);
+    const unknownRecord = parseSubprocessLine('{"value":1}', "subprocess.log", 11);
+
+    expect(aliased.events[0]?.type).toBe("TOOL_CALL");
+    expect(aliased.events[0]?.spanId).toBe("child");
+    expect(aliased.events[0]?.parentSpanId).toBe("parent");
+    expect(aliased.events[0]?.tool).toBe("shell");
+    expect(aliased.events[0]?.status).toBe("ok");
+    expect(aliased.events[0]?.input).toEqual({ cmd: "ls" });
+    expect(aliased.events[0]?.output).toBe("done");
+    expect(aliased.events[0]?.error).toBe("none");
+    expect(unknownEvent.events[0]?.type).toBe("RAW");
+    expect(unknownRecord.events[0]?.type).toBe("RAW");
+  });
+
+  test("covers shared sequence formatting used by trajectory reports", () => {
+    expect(formatSeq(12)).toBe("[seq:0012]");
+  });
+});

--- a/src/trajectory/parsers/subprocess.test.ts
+++ b/src/trajectory/parsers/subprocess.test.ts
@@ -17,6 +17,7 @@ describe("parseSubprocessLine", () => {
     expect(second.events[0]?.type).toBe("RAW");
     expect(second.events[0]?.message).toBe("plain stdout line");
     expect(second.warnings[0]).toContain("line 2");
+    expect(second.events[0]?.error).toBe(second.warnings[0]);
     expect(third.events[0]?.type).toBe("PERMISSION_DENIED");
   });
 

--- a/src/trajectory/parsers/subprocess.ts
+++ b/src/trajectory/parsers/subprocess.ts
@@ -1,0 +1,91 @@
+import { normalizeEventTypeName } from "../match.js";
+import type { ParsedTrajectoryEvent } from "../types.js";
+import { TrajectoryEventType, TrajectoryRuntime } from "../types.js";
+
+export function parseSubprocessLine(
+  line: string,
+  path: string,
+  lineNumber: number,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (typeof parsed !== "object" || parsed === null) {
+      return raw(line, path, lineNumber, `line ${lineNumber}: non-object JSONL record kept as RAW`);
+    }
+
+    const record = parsed as Record<string, unknown>;
+    const type = inferType(record);
+    return {
+      events: [
+        {
+          type,
+          runtime: TrajectoryRuntime.Subprocess,
+          timestamp: stringField(record, "timestamp"),
+          spanId: stringField(record, "spanId") ?? stringField(record, "span_id"),
+          parentSpanId:
+            stringField(record, "parentSpanId") ?? stringField(record, "parent_span_id"),
+          tool: stringField(record, "tool") ?? stringField(record, "tool_name"),
+          status: stringField(record, "status"),
+          input: record.input,
+          output: record.output,
+          message: stringField(record, "message") ?? stringField(record, "text"),
+          error: stringField(record, "error"),
+          raw: record,
+          source: { path, line: lineNumber },
+        },
+      ],
+      warnings: [],
+    };
+  } catch {
+    return raw(
+      line,
+      path,
+      lineNumber,
+      `line ${lineNumber}: non-JSON subprocess output kept as RAW`,
+    );
+  }
+}
+
+function raw(
+  line: string,
+  path: string,
+  lineNumber: number,
+  warning: string,
+): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
+  return {
+    events: [
+      {
+        type: TrajectoryEventType.Raw,
+        runtime: TrajectoryRuntime.Subprocess,
+        message: line,
+        raw: line,
+        source: { path, line: lineNumber },
+      },
+    ],
+    warnings: [warning],
+  };
+}
+
+function inferType(record: Readonly<Record<string, unknown>>): ParsedTrajectoryEvent["type"] {
+  const explicit =
+    stringField(record, "event") ?? stringField(record, "type") ?? stringField(record, "kind");
+  if (explicit !== undefined) {
+    return normalizeEventTypeName(explicit) ?? TrajectoryEventType.Raw;
+  }
+
+  const stream = stringField(record, "stream");
+  if (stream === "stdout" || stream === "stderr") {
+    return TrajectoryEventType.AssistantMessage;
+  }
+
+  if (record.command !== undefined || record.pid !== undefined) {
+    return TrajectoryEventType.AgentStart;
+  }
+
+  return TrajectoryEventType.Raw;
+}
+
+function stringField(record: Readonly<Record<string, unknown>>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/trajectory/parsers/subprocess.ts
+++ b/src/trajectory/parsers/subprocess.ts
@@ -9,7 +9,7 @@ export function parseSubprocessLine(
 ): { readonly events: readonly ParsedTrajectoryEvent[]; readonly warnings: readonly string[] } {
   try {
     const parsed = JSON.parse(line) as unknown;
-    if (typeof parsed !== "object" || parsed === null) {
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
       return raw(line, path, lineNumber, `line ${lineNumber}: non-object JSONL record kept as RAW`);
     }
 

--- a/src/trajectory/parsers/subprocess.ts
+++ b/src/trajectory/parsers/subprocess.ts
@@ -58,6 +58,7 @@ function raw(
         type: TrajectoryEventType.Raw,
         runtime: TrajectoryRuntime.Subprocess,
         message: line,
+        error: warning,
         raw: line,
         source: { path, line: lineNumber },
       },

--- a/src/trajectory/report.test.ts
+++ b/src/trajectory/report.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { formatAnnotatedEvents, formatMarkdownReport, summarizeReport } from "./report.js";
+import type { TrajectoryCheckReport, TrajectoryEvent } from "./types.js";
+
+const report: TrajectoryCheckReport = {
+  name: "common",
+  transcriptPath: "transcript.jsonl",
+  runtime: "codex",
+  eventCount: 2,
+  specPaths: ["spec/trajectory/common.yaml"],
+  ruleResults: [
+    { ruleId: "ok", status: "pass", violations: [] },
+    {
+      ruleId: "bad",
+      status: "fail",
+      violations: [{ ruleId: "bad", message: "Denied", seq: 2, seqRef: "[seq:0002]" }],
+    },
+  ],
+  goalResults: [{ goalId: "goal", status: "deferred", message: "LLM goal grading is deferred" }],
+  parserWarnings: ["line 5: invalid"],
+  summary: { passed: 1, failed: 1, deferred: 1 },
+};
+
+describe("report formatting", () => {
+  test("summarizes rule and goal statuses", () => {
+    expect(summarizeReport(report.ruleResults, report.goalResults)).toEqual({
+      passed: 1,
+      failed: 1,
+      deferred: 1,
+    });
+  });
+
+  test("formats markdown with sequence references", () => {
+    const markdown = formatMarkdownReport(report);
+    expect(markdown).toContain("# Trajectory Check Report");
+    expect(markdown).toContain("[seq:0002]");
+    expect(markdown).toContain("Parser Warnings");
+  });
+
+  test("formats annotated event JSONL", () => {
+    const events: TrajectoryEvent[] = [
+      {
+        seq: 1,
+        type: "ASSISTANT_MESSAGE",
+        runtime: "codex",
+        message: "hi",
+        source: { path: "t", line: 1 },
+      },
+    ];
+    expect(formatAnnotatedEvents(events)).toContain('[seq:0001] {"seq":1');
+  });
+});

--- a/src/trajectory/report.ts
+++ b/src/trajectory/report.ts
@@ -1,0 +1,101 @@
+import type { GoalResult, RuleResult, TrajectoryCheckReport, TrajectoryEvent } from "./types.js";
+import { formatSeq } from "./types.js";
+
+export function summarizeReport(
+  ruleResults: readonly RuleResult[],
+  goalResults: readonly GoalResult[],
+): TrajectoryCheckReport["summary"] {
+  return {
+    passed: ruleResults.filter((result) => result.status === "pass").length,
+    failed: ruleResults.filter((result) => result.status === "fail").length,
+    deferred: goalResults.length,
+  };
+}
+
+export function formatMarkdownReport(report: TrajectoryCheckReport): string {
+  const lines: string[] = [
+    "# Trajectory Check Report",
+    "",
+    `- Name: ${report.name}`,
+    `- Transcript: ${report.transcriptPath}`,
+    `- Runtime: ${report.runtime}`,
+    `- Specs: ${report.specPaths.join(", ")}`,
+    `- Events: ${report.eventCount}`,
+    "",
+    "## Summary",
+    "",
+    `- Passed: ${report.summary.passed}`,
+    `- Failed: ${report.summary.failed}`,
+    `- Deferred: ${report.summary.deferred}`,
+    "",
+  ];
+
+  const failedRules = report.ruleResults.filter((result) => result.status === "fail");
+  lines.push("## Failed Rules", "");
+  if (failedRules.length === 0) {
+    lines.push("- None", "");
+  } else {
+    for (const result of failedRules) {
+      lines.push(`- ${result.ruleId}`);
+      for (const violation of result.violations) {
+        const seqRef =
+          violation.seqRef ?? (violation.seq === undefined ? undefined : formatSeq(violation.seq));
+        const prefix = seqRef === undefined ? "" : `${seqRef} `;
+        lines.push(`  - ${prefix}${violation.message}`);
+      }
+    }
+    lines.push("");
+  }
+
+  const passedRules = report.ruleResults.filter((result) => result.status === "pass");
+  lines.push("## Passed Rules", "");
+  if (passedRules.length === 0) {
+    lines.push("- None", "");
+  } else {
+    lines.push(...passedRules.map((result) => `- ${result.ruleId}`), "");
+  }
+
+  lines.push("## Deferred Goals", "");
+  if (report.goalResults.length === 0) {
+    lines.push("- None", "");
+  } else {
+    for (const result of report.goalResults) {
+      lines.push(`- ${result.goalId}: ${result.message}`);
+    }
+    lines.push("");
+  }
+
+  if (report.parserWarnings.length > 0) {
+    lines.push("## Parser Warnings", "");
+    lines.push(...report.parserWarnings.map((warning) => `- ${warning}`), "");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function formatJsonReport(report: TrajectoryCheckReport): string {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+export function formatAnnotatedEvents(events: readonly TrajectoryEvent[]): string {
+  if (events.length === 0) return "";
+  return `${events.map((event) => `${formatSeq(event.seq)} ${JSON.stringify(compactEvent(event))}`).join("\n")}\n`;
+}
+
+function compactEvent(event: TrajectoryEvent): Readonly<Record<string, unknown>> {
+  return {
+    seq: event.seq,
+    type: event.type,
+    runtime: event.runtime,
+    source: event.source,
+    ...optionalField("tool", event.tool),
+    ...optionalField("status", event.status),
+    ...optionalField("spanId", event.spanId),
+    ...optionalField("parentSpanId", event.parentSpanId),
+    ...optionalField("message", event.message),
+  };
+}
+
+function optionalField(key: string, value: string | undefined): Record<string, string> {
+  return value === undefined ? {} : { [key]: value };
+}

--- a/src/trajectory/rules.test.ts
+++ b/src/trajectory/rules.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import { evaluateRules } from "./rules.js";
+import type { RuleSpec, TrajectoryEvent, TranscriptIndex } from "./types.js";
+
+function event(seq: number, overrides: Partial<TrajectoryEvent>): TrajectoryEvent {
+  return {
+    seq,
+    type: "TOOL_CALL",
+    runtime: "codex",
+    source: { path: "t.jsonl", line: seq },
+    ...overrides,
+  };
+}
+
+function index(events: readonly TrajectoryEvent[]): TranscriptIndex {
+  return {
+    runtime: "codex",
+    transcriptPath: "t.jsonl",
+    events,
+    warnings: [],
+    bySeq: new Map(events.map((item) => [item.seq, item])),
+    bySpanId: new Map(),
+    childrenByParentSpanId: new Map(),
+  };
+}
+
+describe("evaluateRules", () => {
+  test("must_exist fails when no event matches", () => {
+    const result = evaluateRules(index([event(1, { type: "TOOL_CALL" })]), [
+      { id: "requires-denial", kind: "must_exist", match: { event: "PERMISSION_DENIED" } },
+    ]);
+
+    expect(result[0]?.status).toBe("fail");
+    expect(result[0]?.violations[0]?.message).toContain("requires-denial");
+  });
+
+  test("must_not_exist reports matching event sequence refs", () => {
+    const result = evaluateRules(index([event(1, { type: "PERMISSION_DENIED" })]), [
+      { id: "no-denials", kind: "must_not_exist", match: { event: "PERMISSION_DENIED" } },
+    ]);
+
+    expect(result[0]?.status).toBe("fail");
+    expect(result[0]?.violations[0]?.seqRef).toBe("[seq:0001]");
+  });
+
+  test("allowed_tools fails disallowed tool calls", () => {
+    const result = evaluateRules(index([event(2, { tool: "rm" })]), [
+      { id: "tools", kind: "allowed_tools", allowed: ["Read", "apply_patch"] },
+    ]);
+
+    expect(result[0]?.status).toBe("fail");
+    expect(result[0]?.violations[0]?.message).toContain("rm");
+  });
+
+  test("allowed_tools fails missing tool names", () => {
+    const result = evaluateRules(index([event(2, {})]), [
+      { id: "tools", kind: "allowed_tools", allowed: ["Read", "apply_patch"] },
+    ]);
+
+    expect(result[0]?.status).toBe("fail");
+    expect(result[0]?.violations[0]?.message).toContain("<missing>");
+  });
+
+  test("field_constraint validates existence and glob matches", () => {
+    const rules: RuleSpec[] = [
+      {
+        id: "has-tool",
+        kind: "field_constraint",
+        match: { event: "TOOL_CALL" },
+        field: "tool",
+        exists: true,
+      },
+      {
+        id: "src-file",
+        kind: "field_constraint",
+        match: { event: "TOOL_CALL" },
+        field: "input.file_path",
+        match_value: "src/*",
+      },
+    ];
+    const result = evaluateRules(
+      index([event(3, { tool: "Read", input: { file_path: "src/app.ts" } })]),
+      rules,
+    );
+
+    expect(result.every((item) => item.status === "pass")).toBe(true);
+  });
+
+  test("field_constraint reports failed constraint variants", () => {
+    const result = evaluateRules(
+      index([event(4, { tool: "Read", input: { file_path: "src/app.ts" } })]),
+      [
+        { id: "missing", kind: "field_constraint", field: "input.missing", exists: true },
+        { id: "exists-false", kind: "field_constraint", field: "tool", exists: false },
+        { id: "not-exists", kind: "field_constraint", field: "tool", not_exists: true },
+        { id: "equals", kind: "field_constraint", field: "tool", equals: "Write" },
+        { id: "not-equals", kind: "field_constraint", field: "tool", not_equals: "Read" },
+        { id: "match", kind: "field_constraint", field: "input.file_path", match_value: "lib/*" },
+        { id: "not-match", kind: "field_constraint", field: "input.file_path", not_match: "src/*" },
+      ],
+    );
+
+    expect(result.every((item) => item.status === "fail")).toBe(true);
+    expect(result.every((item) => item.violations.length === 1)).toBe(true);
+  });
+
+  test("invalid rule configuration returns failures", () => {
+    const result = evaluateRules(index([]), [
+      { id: "allowed-config", kind: "allowed_tools" },
+      { id: "field-config", kind: "field_constraint" },
+      { id: "precedes-trigger-config", kind: "precedes", required: { event: "TOOL_CALL" } },
+      { id: "precedes-required-config", kind: "precedes", trigger: { event: "TOOL_CALL" } },
+    ]);
+
+    expect(result.every((item) => item.status === "fail")).toBe(true);
+    expect(result.map((item) => item.violations[0]?.message)).toEqual([
+      "allowed_tools rule requires an allowed list.",
+      "field_constraint rule requires a field.",
+      "precedes rule requires a trigger matcher.",
+      "precedes rule requires a required matcher.",
+    ]);
+  });
+
+  test("precedes requires prior matching evidence with same field", () => {
+    const result = evaluateRules(
+      index([
+        event(1, { tool: "backup_file", input: { file_path: "src/app.ts" } }),
+        event(2, { tool: "apply_patch", input: { file_path: "src/app.ts" } }),
+        event(3, { tool: "apply_patch", input: { file_path: "src/other.ts" } }),
+      ]),
+      [
+        {
+          id: "backup-before-edit",
+          kind: "precedes",
+          trigger: { event: "TOOL_CALL", tool: "apply_patch" },
+          required: { event: "TOOL_CALL", tool: "backup_file", match_field: "input.file_path" },
+        },
+      ],
+    );
+
+    expect(result[0]?.status).toBe("fail");
+    expect(result[0]?.violations).toHaveLength(1);
+    expect(result[0]?.violations[0]?.seq).toBe(3);
+  });
+
+  test("precedes accepts any prior required event without match_field", () => {
+    const result = evaluateRules(
+      index([event(1, { tool: "backup_file" }), event(2, { tool: "apply_patch" })]),
+      [
+        {
+          id: "backup-before-edit",
+          kind: "precedes",
+          trigger: { event: "TOOL_CALL", tool: "apply_patch" },
+          required: { event: "TOOL_CALL", tool: "backup_file" },
+        },
+      ],
+    );
+
+    expect(result[0]?.status).toBe("pass");
+  });
+
+  test("precedes includes truncated message snippets on violations", () => {
+    const longMessage = "x".repeat(140);
+    const result = evaluateRules(
+      index([event(1, { tool: "Read" }), event(2, { tool: "apply_patch", message: longMessage })]),
+      [
+        {
+          id: "backup-before-edit",
+          kind: "precedes",
+          trigger: { event: "TOOL_CALL", tool: "apply_patch" },
+          required: { event: "TOOL_CALL", tool: "backup_file" },
+        },
+      ],
+    );
+
+    expect(result[0]?.status).toBe("fail");
+    expect(result[0]?.violations[0]?.messageSnippet).toHaveLength(120);
+  });
+});

--- a/src/trajectory/rules.ts
+++ b/src/trajectory/rules.ts
@@ -1,0 +1,245 @@
+import { fieldValue, matchesEvent, patternMatches, valuesEqual } from "./match.js";
+import type {
+  EventMatcher,
+  RequiredMatcher,
+  RuleResult,
+  RuleSpec,
+  RuleViolation,
+  TrajectoryEvent,
+  TranscriptIndex,
+} from "./types.js";
+import { formatSeq, TrajectoryEventType } from "./types.js";
+
+export function evaluateRules(
+  index: TranscriptIndex,
+  rules: readonly RuleSpec[],
+): readonly RuleResult[] {
+  return rules.map((rule) => evaluateRule(index.events, rule));
+}
+
+function evaluateRule(events: readonly TrajectoryEvent[], rule: RuleSpec): RuleResult {
+  switch (rule.kind) {
+    case "must_exist":
+      return evaluateMustExist(events, rule);
+    case "must_not_exist":
+      return evaluateMustNotExist(events, rule);
+    case "allowed_tools":
+      return evaluateAllowedTools(events, rule);
+    case "field_constraint":
+      return evaluateFieldConstraint(events, rule);
+    case "precedes":
+      return evaluatePrecedes(events, rule);
+  }
+}
+
+function evaluateMustExist(events: readonly TrajectoryEvent[], rule: RuleSpec): RuleResult {
+  const found = events.some((item) => matchesOptionalRule(item, rule.match));
+  if (found) return pass(rule);
+
+  return fail(rule, [
+    {
+      ruleId: rule.id,
+      message: `Rule ${rule.id} requires at least one matching event.`,
+    },
+  ]);
+}
+
+function evaluateMustNotExist(events: readonly TrajectoryEvent[], rule: RuleSpec): RuleResult {
+  const violations = events
+    .filter((item) => matchesOptionalRule(item, rule.match))
+    .map((item) =>
+      eventViolation(rule, item, `Rule ${rule.id} forbids matching event ${formatSeq(item.seq)}.`),
+    );
+
+  return result(rule, violations);
+}
+
+function evaluateAllowedTools(events: readonly TrajectoryEvent[], rule: RuleSpec): RuleResult {
+  const allowed = rule.allowed;
+  if (allowed === undefined) {
+    return configError(rule, "allowed_tools rule requires an allowed list.");
+  }
+
+  const violations = events
+    .filter((item) => item.type === TrajectoryEventType.ToolCall)
+    .filter((item) => matchesOptionalRule(item, rule.match))
+    .filter((item) => !allowed.some((pattern) => patternMatches(item.tool, pattern)))
+    .map((item) => {
+      const tool = item.tool ?? "<missing>";
+      return eventViolation(rule, item, `Tool ${tool} is not allowed by rule ${rule.id}.`);
+    });
+
+  return result(rule, violations);
+}
+
+function evaluateFieldConstraint(events: readonly TrajectoryEvent[], rule: RuleSpec): RuleResult {
+  if (rule.field === undefined) {
+    return configError(rule, "field_constraint rule requires a field.");
+  }
+
+  const violations: RuleViolation[] = [];
+  for (const item of events) {
+    if (!matchesOptionalRule(item, rule.match)) continue;
+
+    const value = fieldValue(item, rule.field);
+    if (rule.exists === true && value === undefined) {
+      violations.push(
+        eventViolation(rule, item, `Field ${rule.field} must exist for rule ${rule.id}.`),
+      );
+    }
+    if (rule.exists === false && value !== undefined) {
+      violations.push(
+        eventViolation(rule, item, `Field ${rule.field} must not exist for rule ${rule.id}.`),
+      );
+    }
+    if (rule.not_exists === true && value !== undefined) {
+      violations.push(
+        eventViolation(rule, item, `Field ${rule.field} must not exist for rule ${rule.id}.`),
+      );
+    }
+    if (hasOwn(rule, "equals") && !valuesEqual(value, rule.equals)) {
+      violations.push(
+        eventViolation(
+          rule,
+          item,
+          `Field ${rule.field} must equal expected value for rule ${rule.id}.`,
+        ),
+      );
+    }
+    if (hasOwn(rule, "not_equals") && valuesEqual(value, rule.not_equals)) {
+      violations.push(
+        eventViolation(
+          rule,
+          item,
+          `Field ${rule.field} must not equal forbidden value for rule ${rule.id}.`,
+        ),
+      );
+    }
+    if (rule.match_value !== undefined && !patternMatches(value, rule.match_value)) {
+      violations.push(
+        eventViolation(
+          rule,
+          item,
+          `Field ${rule.field} must match ${rule.match_value} for rule ${rule.id}.`,
+        ),
+      );
+    }
+    if (rule.not_match !== undefined && patternMatches(value, rule.not_match)) {
+      violations.push(
+        eventViolation(
+          rule,
+          item,
+          `Field ${rule.field} must not match ${rule.not_match} for rule ${rule.id}.`,
+        ),
+      );
+    }
+  }
+
+  return result(rule, violations);
+}
+
+function evaluatePrecedes(events: readonly TrajectoryEvent[], rule: RuleSpec): RuleResult {
+  if (rule.trigger === undefined) {
+    return configError(rule, "precedes rule requires a trigger matcher.");
+  }
+  if (rule.required === undefined) {
+    return configError(rule, "precedes rule requires a required matcher.");
+  }
+
+  const trigger = rule.trigger;
+  const required = rule.required;
+  const violations: RuleViolation[] = [];
+  for (const item of events) {
+    if (!matchesEvent(item, trigger)) continue;
+
+    const hasPrior = events.some((candidate) => {
+      return candidate.seq < item.seq && requiredMatchesTrigger(candidate, item, required);
+    });
+
+    if (!hasPrior) {
+      violations.push(
+        eventViolation(
+          rule,
+          item,
+          `Rule ${rule.id} requires prior matching evidence before ${formatSeq(item.seq)}.`,
+        ),
+      );
+    }
+  }
+
+  return result(rule, violations);
+}
+
+function requiredMatchesTrigger(
+  candidate: TrajectoryEvent,
+  trigger: TrajectoryEvent,
+  required: RequiredMatcher,
+): boolean {
+  if (!matchesEvent(candidate, required)) return false;
+  if (required.match_field === undefined) return true;
+
+  const candidateValue = fieldValue(candidate, required.match_field);
+  const triggerValue = fieldValue(trigger, required.match_field);
+  return (
+    candidateValue !== undefined &&
+    triggerValue !== undefined &&
+    valuesEqual(candidateValue, triggerValue)
+  );
+}
+
+function matchesOptionalRule(event: TrajectoryEvent, matcher: EventMatcher | undefined): boolean {
+  return matcher === undefined || matchesEvent(event, matcher);
+}
+
+function result(rule: RuleSpec, violations: readonly RuleViolation[]): RuleResult {
+  return violations.length === 0 ? pass(rule) : fail(rule, violations);
+}
+
+function pass(rule: RuleSpec): RuleResult {
+  return {
+    ruleId: rule.id,
+    status: "pass",
+    violations: [],
+  };
+}
+
+function fail(rule: RuleSpec, violations: readonly RuleViolation[]): RuleResult {
+  return {
+    ruleId: rule.id,
+    status: "fail",
+    violations,
+  };
+}
+
+function configError(rule: RuleSpec, message: string): RuleResult {
+  return fail(rule, [
+    {
+      ruleId: rule.id,
+      message,
+    },
+  ]);
+}
+
+function eventViolation(rule: RuleSpec, event: TrajectoryEvent, message: string): RuleViolation {
+  return {
+    ruleId: rule.id,
+    message,
+    seq: event.seq,
+    seqRef: formatSeq(event.seq),
+    source: event.source,
+    eventType: event.type,
+    tool: event.tool,
+    status: event.status,
+    spanId: event.spanId,
+    messageSnippet: snippet(event.message ?? event.error),
+  };
+}
+
+function snippet(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return value.length <= 120 ? value : `${value.slice(0, 117)}...`;
+}
+
+function hasOwn<Key extends keyof RuleSpec>(rule: RuleSpec, key: Key): boolean {
+  return Object.hasOwn(rule, key);
+}

--- a/src/trajectory/spec-loader.test.ts
+++ b/src/trajectory/spec-loader.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadTrajectorySpecs } from "./spec-loader.js";
+
+async function writeSpec(name: string, text: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "trajectory-spec-"));
+  const path = join(dir, name);
+  await writeFile(path, text, "utf8");
+  return path;
+}
+
+describe("loadTrajectorySpecs", () => {
+  test("loads and merges rules and deferred goals", async () => {
+    const specPath = await writeSpec(
+      "common.yaml",
+      [
+        "name: common",
+        "rules:",
+        "  - id: no-denials",
+        "    kind: must_not_exist",
+        "    match:",
+        "      event: PERMISSION_DENIED",
+        "goals:",
+        "  - id: user-goal",
+        "    criteria: User goal was met.",
+        "    evidence: [assistant_message]",
+      ].join("\n"),
+    );
+
+    const spec = await loadTrajectorySpecs([specPath]);
+    expect(spec.name).toBe("common");
+    expect(spec.rules[0]?.id).toBe("no-denials");
+    expect(spec.goals[0]?.id).toBe("user-goal");
+    expect(spec.sourcePaths).toEqual([specPath]);
+  });
+
+  test("rejects duplicate rule ids across files", async () => {
+    const one = await writeSpec(
+      "one.yaml",
+      "name: one\nrules:\n  - id: same\n    kind: must_exist\n",
+    );
+    const two = await writeSpec(
+      "two.yaml",
+      "name: two\nrules:\n  - id: same\n    kind: must_not_exist\n",
+    );
+
+    await expect(loadTrajectorySpecs([one, two])).rejects.toThrow(/duplicate rule id: same/);
+  });
+});

--- a/src/trajectory/spec-loader.ts
+++ b/src/trajectory/spec-loader.ts
@@ -1,0 +1,214 @@
+import { readFile } from "node:fs/promises";
+import YAML from "yaml";
+import type {
+  EventMatcher,
+  GoalSpec,
+  RequiredMatcher,
+  RuleKind,
+  RuleSpec,
+  TrajectorySpec,
+} from "./types.js";
+
+const RULE_KINDS = new Set<string>([
+  "precedes",
+  "allowed_tools",
+  "must_exist",
+  "must_not_exist",
+  "field_constraint",
+]);
+
+type UnknownRecord = Record<string, unknown>;
+
+export async function loadTrajectorySpecs(paths: readonly string[]): Promise<TrajectorySpec> {
+  const names: string[] = [];
+  const rules: RuleSpec[] = [];
+  const goals: GoalSpec[] = [];
+  const ruleIds = new Set<string>();
+
+  for (const path of paths) {
+    const text = await readFile(path, "utf8");
+    const root = expectRecord(YAML.parse(text), `${path}: root must be an object`);
+    const name = getOptionalString(root, "name") ?? path;
+    names.push(name);
+
+    for (const rule of normalizeRules(root, path)) {
+      if (ruleIds.has(rule.id)) {
+        throw new Error(`duplicate rule id: ${rule.id}`);
+      }
+      ruleIds.add(rule.id);
+      rules.push(rule);
+    }
+
+    goals.push(...normalizeGoals(root, path));
+  }
+
+  return {
+    name: names.join("+"),
+    sourcePaths: [...paths],
+    rules,
+    goals,
+  };
+}
+
+function normalizeRules(root: UnknownRecord, path: string): RuleSpec[] {
+  const value = root.rules;
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error(`${path}: rules must be an array`);
+  return value.map((rule, index) => normalizeRule(rule, `${path}: rules[${index}]`));
+}
+
+function normalizeRule(value: unknown, context: string): RuleSpec {
+  const record = expectRecord(value, `${context} must be an object`);
+  const id = expectString(record.id, `${context}.id must be a string`);
+  const kind = expectRuleKind(record.kind, `${context}.kind must be a valid rule kind`);
+
+  return {
+    id,
+    kind,
+    ...optionalObjectField(record, "match", normalizeEventMatcher, context),
+    ...optionalObjectField(record, "trigger", normalizeEventMatcher, context),
+    ...optionalObjectField(record, "required", normalizeRequiredMatcher, context),
+    ...optionalStringArrayField(record, "allowed", context),
+    ...optionalStringField(record, "field", context),
+    ...optionalPassthroughField(record, "equals"),
+    ...optionalPassthroughField(record, "not_equals"),
+    ...optionalStringField(record, "match_value", context),
+    ...optionalStringField(record, "not_match", context),
+    ...optionalBooleanField(record, "exists", context),
+    ...optionalBooleanField(record, "not_exists", context),
+  };
+}
+
+function normalizeGoals(root: UnknownRecord, path: string): GoalSpec[] {
+  const value = root.goals;
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error(`${path}: goals must be an array`);
+  return value.map((goal, index) => normalizeGoal(goal, `${path}: goals[${index}]`));
+}
+
+function normalizeGoal(value: unknown, context: string): GoalSpec {
+  const record = expectRecord(value, `${context} must be an object`);
+  const id = expectString(record.id, `${context}.id must be a string`);
+  const criteria = expectString(record.criteria, `${context}.criteria must be a string`);
+  const evidence =
+    record.evidence === undefined
+      ? []
+      : expectArray(record.evidence, `${context}.evidence must be an array`).map(String);
+  return { id, criteria, evidence };
+}
+
+function normalizeEventMatcher(value: unknown, context: string): EventMatcher {
+  const record = expectRecord(value, `${context} must be an object`);
+  return {
+    ...optionalStringField(record, "event", context),
+    ...optionalStringField(record, "tool", context),
+    ...optionalStringRecordField(record, "field_match", context),
+    ...optionalStringRecordField(record, "field_not_match", context),
+  };
+}
+
+function normalizeRequiredMatcher(value: unknown, context: string): RequiredMatcher {
+  const matcher = normalizeEventMatcher(value, context);
+  const record = expectRecord(value, `${context} must be an object`);
+  return {
+    ...matcher,
+    ...optionalStringField(record, "match_field", context),
+  };
+}
+
+function optionalObjectField<T>(
+  record: UnknownRecord,
+  field: string,
+  normalize: (value: unknown, context: string) => T,
+  context: string,
+): Record<string, T> {
+  if (record[field] === undefined) return {};
+  return { [field]: normalize(record[field], `${context}.${field}`) };
+}
+
+function optionalStringField(
+  record: UnknownRecord,
+  field: string,
+  context: string,
+): Record<string, string> {
+  if (record[field] === undefined) return {};
+  return { [field]: expectString(record[field], `${context}.${field} must be a string`) };
+}
+
+function optionalBooleanField(
+  record: UnknownRecord,
+  field: string,
+  context: string,
+): Record<string, boolean> {
+  if (record[field] === undefined) return {};
+  return { [field]: expectBoolean(record[field], `${context}.${field} must be a boolean`) };
+}
+
+function optionalStringArrayField(
+  record: UnknownRecord,
+  field: string,
+  context: string,
+): Record<string, readonly string[]> {
+  if (record[field] === undefined) return {};
+  const values = expectArray(record[field], `${context}.${field} must be an array`);
+  return {
+    [field]: values.map((item) =>
+      expectString(item, `${context}.${field} entries must be strings`),
+    ),
+  };
+}
+
+function optionalStringRecordField(
+  record: UnknownRecord,
+  field: string,
+  context: string,
+): Record<string, Readonly<Record<string, string>>> {
+  if (record[field] === undefined) return {};
+  const value = expectRecord(record[field], `${context}.${field} must be an object`);
+  return {
+    [field]: Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        expectString(item, `${context}.${field}.${key} must be a string`),
+      ]),
+    ),
+  };
+}
+
+function optionalPassthroughField(record: UnknownRecord, field: string): Record<string, unknown> {
+  if (!Object.hasOwn(record, field)) return {};
+  return { [field]: record[field] };
+}
+
+function expectRecord(value: unknown, message: string): UnknownRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(message);
+  }
+  return value as UnknownRecord;
+}
+
+function expectArray(value: unknown, message: string): readonly unknown[] {
+  if (!Array.isArray(value)) throw new Error(message);
+  return value;
+}
+
+function expectString(value: unknown, message: string): string {
+  if (typeof value !== "string") throw new Error(message);
+  return value;
+}
+
+function getOptionalString(record: UnknownRecord, field: string): string | undefined {
+  const value = record[field];
+  if (value === undefined) return undefined;
+  return typeof value === "string" ? value : undefined;
+}
+
+function expectBoolean(value: unknown, message: string): boolean {
+  if (typeof value !== "boolean") throw new Error(message);
+  return value;
+}
+
+function expectRuleKind(value: unknown, message: string): RuleKind {
+  if (typeof value !== "string" || !RULE_KINDS.has(value)) throw new Error(message);
+  return value as RuleKind;
+}

--- a/src/trajectory/types.test.ts
+++ b/src/trajectory/types.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { formatSeq, isTrajectoryEventType, TrajectoryEventType } from "./types.js";
+
+describe("TrajectoryEventType", () => {
+  test("includes deterministic issue #339 event types and timeline-compatible event families", () => {
+    expect(TrajectoryEventType.ToolCall).toBe("TOOL_CALL");
+    expect(TrajectoryEventType.PermissionDenied).toBe("PERMISSION_DENIED");
+    expect(TrajectoryEventType.WorkBlockStarted).toBe("WORK_BLOCK_STARTED");
+    expect(TrajectoryEventType.TaskScheduled).toBe("TASK_SCHEDULED");
+    expect(TrajectoryEventType.HealthRecovered).toBe("HEALTH_RECOVERED");
+    expect(TrajectoryEventType.Raw).toBe("RAW");
+  });
+
+  test("validates event type values", () => {
+    expect(isTrajectoryEventType("TOOL_CALL")).toBe(true);
+    expect(isTrajectoryEventType("tool_call")).toBe(false);
+    expect(isTrajectoryEventType("NOT_REAL")).toBe(false);
+  });
+});
+
+describe("formatSeq", () => {
+  test("formats sequence markers with four digits until values exceed four digits", () => {
+    expect(formatSeq(1)).toBe("[seq:0001]");
+    expect(formatSeq(42)).toBe("[seq:0042]");
+    expect(formatSeq(12_345)).toBe("[seq:12345]");
+  });
+});

--- a/src/trajectory/types.ts
+++ b/src/trajectory/types.ts
@@ -1,0 +1,177 @@
+export const TrajectoryEventType = {
+  AgentStart: "AGENT_START",
+  ToolCall: "TOOL_CALL",
+  ToolResult: "TOOL_RESULT",
+  Delegation: "DELEGATION",
+  DelegationReturn: "DELEGATION_RETURN",
+  AssistantMessage: "ASSISTANT_MESSAGE",
+  Compaction: "COMPACTION",
+  PermissionDenied: "PERMISSION_DENIED",
+  WorkBlockStarted: "WORK_BLOCK_STARTED",
+  WorkBlockUpdated: "WORK_BLOCK_UPDATED",
+  WorkBlockFinished: "WORK_BLOCK_FINISHED",
+  TaskTriggered: "TASK_TRIGGERED",
+  TaskAdmitted: "TASK_ADMITTED",
+  TaskScheduled: "TASK_SCHEDULED",
+  PermissionWait: "PERMISSION_WAIT",
+  PermissionDecision: "PERMISSION_DECISION",
+  HealthDegraded: "HEALTH_DEGRADED",
+  HealthRecovered: "HEALTH_RECOVERED",
+  ContributionChanged: "CONTRIBUTION_CHANGED",
+  ArtifactChanged: "ARTIFACT_CHANGED",
+  ReviewChanged: "REVIEW_CHANGED",
+  AdoptionChanged: "ADOPTION_CHANGED",
+  Raw: "RAW",
+} as const;
+
+export type TrajectoryEventType = (typeof TrajectoryEventType)[keyof typeof TrajectoryEventType];
+
+export const TrajectoryRuntime = {
+  Acpx: "acpx",
+  Codex: "codex",
+  ClaudeStreamJson: "claude-stream-json",
+  Subprocess: "subprocess",
+  Unknown: "unknown",
+} as const;
+
+export type TrajectoryRuntime = (typeof TrajectoryRuntime)[keyof typeof TrajectoryRuntime];
+export type TrajectoryRuntimeInput = TrajectoryRuntime | "auto";
+export type ReportFormat = "markdown" | "json";
+
+export interface TrajectorySource {
+  readonly path: string;
+  readonly line: number;
+}
+
+export interface TrajectoryEvent {
+  readonly seq: number;
+  readonly type: TrajectoryEventType;
+  readonly runtime: TrajectoryRuntime;
+  readonly timestamp?: string | undefined;
+  readonly sessionId?: string | undefined;
+  readonly turnId?: string | undefined;
+  readonly agentId?: string | undefined;
+  readonly role?: string | undefined;
+  readonly spanId?: string | undefined;
+  readonly parentSpanId?: string | undefined;
+  readonly tool?: string | undefined;
+  readonly status?: string | undefined;
+  readonly input?: unknown;
+  readonly output?: unknown;
+  readonly message?: string | undefined;
+  readonly error?: string | undefined;
+  readonly raw?: unknown;
+  readonly source: TrajectorySource;
+}
+
+export type ParsedTrajectoryEvent = Omit<TrajectoryEvent, "seq">;
+
+export interface TranscriptIndex {
+  readonly runtime: TrajectoryRuntime;
+  readonly transcriptPath: string;
+  readonly events: readonly TrajectoryEvent[];
+  readonly warnings: readonly string[];
+  readonly bySeq: ReadonlyMap<number, TrajectoryEvent>;
+  readonly bySpanId: ReadonlyMap<string, readonly TrajectoryEvent[]>;
+  readonly childrenByParentSpanId: ReadonlyMap<string, readonly TrajectoryEvent[]>;
+}
+
+export interface EventMatcher {
+  readonly event?: string | undefined;
+  readonly tool?: string | undefined;
+  readonly field_match?: Readonly<Record<string, string>> | undefined;
+  readonly field_not_match?: Readonly<Record<string, string>> | undefined;
+}
+
+export interface RequiredMatcher extends EventMatcher {
+  readonly match_field?: string | undefined;
+}
+
+export type RuleKind =
+  | "precedes"
+  | "allowed_tools"
+  | "must_exist"
+  | "must_not_exist"
+  | "field_constraint";
+
+export interface RuleSpec {
+  readonly id: string;
+  readonly kind: RuleKind;
+  readonly match?: EventMatcher | undefined;
+  readonly trigger?: EventMatcher | undefined;
+  readonly required?: RequiredMatcher | undefined;
+  readonly allowed?: readonly string[] | undefined;
+  readonly field?: string | undefined;
+  readonly equals?: unknown;
+  readonly not_equals?: unknown;
+  readonly match_value?: string | undefined;
+  readonly not_match?: string | undefined;
+  readonly exists?: boolean | undefined;
+  readonly not_exists?: boolean | undefined;
+}
+
+export interface GoalSpec {
+  readonly id: string;
+  readonly criteria: string;
+  readonly evidence: readonly string[];
+}
+
+export interface TrajectorySpec {
+  readonly name: string;
+  readonly sourcePaths: readonly string[];
+  readonly rules: readonly RuleSpec[];
+  readonly goals: readonly GoalSpec[];
+}
+
+export type CheckStatus = "pass" | "fail" | "deferred";
+
+export interface RuleViolation {
+  readonly ruleId: string;
+  readonly message: string;
+  readonly seq?: number | undefined;
+  readonly seqRef?: string | undefined;
+  readonly source?: TrajectorySource | undefined;
+  readonly eventType?: TrajectoryEventType | undefined;
+  readonly tool?: string | undefined;
+  readonly status?: string | undefined;
+  readonly spanId?: string | undefined;
+  readonly messageSnippet?: string | undefined;
+}
+
+export interface RuleResult {
+  readonly ruleId: string;
+  readonly status: CheckStatus;
+  readonly violations: readonly RuleViolation[];
+}
+
+export interface GoalResult {
+  readonly goalId: string;
+  readonly status: "deferred";
+  readonly message: string;
+}
+
+export interface TrajectoryCheckReport {
+  readonly name: string;
+  readonly transcriptPath: string;
+  readonly runtime: TrajectoryRuntime;
+  readonly eventCount: number;
+  readonly specPaths: readonly string[];
+  readonly ruleResults: readonly RuleResult[];
+  readonly goalResults: readonly GoalResult[];
+  readonly parserWarnings: readonly string[];
+  readonly summary: {
+    readonly passed: number;
+    readonly failed: number;
+    readonly deferred: number;
+  };
+}
+
+const EVENT_TYPES = new Set<string>(Object.values(TrajectoryEventType));
+
+export function isTrajectoryEventType(value: string): value is TrajectoryEventType {
+  return EVENT_TYPES.has(value);
+}
+
+export function formatSeq(seq: number): string {
+  return `[seq:${seq.toString().padStart(4, "0")}]`;
+}

--- a/tests/fixtures/trajectory/claude-stream-json.jsonl
+++ b/tests/fixtures/trajectory/claude-stream-json.jsonl
@@ -1,0 +1,5 @@
+{"type":"assistant","message":[{"type":"text","text":"I will inspect the repo."}],"timestamp":"2026-05-05T00:00:00Z"}
+{"type":"tool_use","id":"tool-parent","name":"Task","input":{"description":"review"}}
+{"type":"tool_use","id":"tool-child","parent_tool_use_id":"tool-parent","name":"Read","input":{"file_path":"src/index.ts"}}
+{"type":"tool_result","tool_use_id":"tool-child","parent_tool_use_id":"tool-parent","content":"done"}
+{"type":"tool_result","tool_use_id":"tool-parent","content":"subagent returned"}

--- a/tests/fixtures/trajectory/codex-transcript.jsonl
+++ b/tests/fixtures/trajectory/codex-transcript.jsonl
@@ -1,0 +1,4 @@
+{"type":"agent_start","session_id":"sess-1","agent_id":"codex-1","timestamp":"2026-05-05T00:00:00Z"}
+{"type":"tool_call","call_id":"call-1","tool_name":"apply_patch","input":{"file_path":"src/app.ts"}}
+{"type":"tool_result","call_id":"call-1","output":"ok","status":"completed"}
+{"type":"assistant_message","message":"patched"}

--- a/tests/fixtures/trajectory/subprocess.log
+++ b/tests/fixtures/trajectory/subprocess.log
@@ -1,0 +1,3 @@
+{"event":"AGENT_START","spanId":"proc-1","message":"started","timestamp":"2026-05-05T00:00:00Z"}
+plain stdout line
+{"stream":"stderr","message":"warning: denied","event":"PERMISSION_DENIED"}


### PR DESCRIPTION
## Summary

Adds a deterministic trajectory checking surface for issue #339.

- Adds trajectory event models, transcript parsers, matchers, spec loading, rule evaluation, and Markdown/JSON reporting.
- Adds `grove check-trajectory` CLI support plus MCP tool parity through `grove_check_trajectory`.
- Ships a common trajectory spec and fixtures for Codex, ACPx, Claude stream JSON, and subprocess-style logs.
- Updates parity docs and adds focused tests for CLI, operation, parser, MCP, and registry behavior.

## Validation

- `BUN_OPTIONS=--bun bun run build` passed.
- Pre-push hook passed with `BUN_OPTIONS=--bun`, including build and typecheck.
- Earlier focused trajectory/MCP suites passed, and full `bun test` had no test failures but still exited nonzero on the repository's existing coverage gate outside the new trajectory files.

Closes #339
