### PR TITLE
[codex] Implement deterministic loop runner and Nexus TUI delivery

### DIFF
--- a/docs/superpowers/plans/2026-05-05-deterministic-loop-runner.md
+++ b/docs/superpowers/plans/2026-05-05-deterministic-loop-runner.md
@@ -1,0 +1,55 @@
+# Deterministic Loop Runner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #340 end to end: deterministic external loop runner, semantic stop status, all-role done handling, SIGINT escalation, plateau/max-iteration detection, and durable Nexus workflow state.
+
+**Architecture:** Add a generic core loop runner with schemas and stop logic, a Nexus-backed workflow-state store, and small integration points in sessions, CLI, HTTP mapping, and TUI. Keep `stopReason` for compatibility and add `stopStatus` for machine-readable behavior.
+
+**Tech Stack:** Bun 1.3.x, TypeScript strict mode, `bun:test`, Zod, existing Nexus VFS client, SQLite migrations through the existing local store.
+
+**Spec:** `docs/superpowers/specs/2026-05-05-deterministic-loop-runner-design.md`
+
+**Issue:** [#340](https://github.com/windoliver/grove/issues/340)
+
+---
+
+## File Map
+
+**Create:**
+- `src/core/loop-runner.ts`
+- `src/core/loop-runner.test.ts`
+- `src/nexus/nexus-workflow-store.ts`
+- `src/nexus/nexus-workflow-store.test.ts`
+
+**Modify:**
+- `src/core/session.ts`
+- `src/core/session-manager.ts`
+- `src/core/session-orchestrator.ts`
+- `src/core/session-orchestrator.test.ts`
+- `src/local/sqlite-store.ts`
+- `src/local/sqlite-goal-session-store.ts`
+- `src/local/sqlite-goal-session-store.test.ts`
+- `src/nexus/vfs-paths.ts`
+- `src/nexus/vfs-paths.test.ts`
+- `src/nexus/index.ts`
+- `src/nexus/nexus-session-store.ts`
+- `src/server/routes/sessions.ts`
+- `src/tui/provider-shared.ts`
+- `src/tui/views/welcome/session-row.tsx`
+- `src/tui/views/welcome/session-row.test.ts`
+- `src/cli/commands/session.ts`
+- `src/core/index.ts`
+
+## Tasks
+
+- [ ] Add failing core tests for roadmap parsing and deterministic stop statuses.
+- [ ] Implement `LoopStopStatus`, schemas, balanced-brace extraction, fallback roadmap, interrupt controller, and `GroveLoopRunner`.
+- [ ] Add failing Nexus workflow-store tests and VFS path tests.
+- [ ] Implement workflow VFS paths and `NexusWorkflowStore`.
+- [ ] Add failing session persistence/API tests for `stopStatus`.
+- [ ] Add `stopStatus` to core session types, SQLite schema/migration, Nexus session records, and API/TUI mapping.
+- [ ] Add failing orchestrator tests for all-role done and semantic stop status.
+- [ ] Update `SessionOrchestrator` stop handling and CLI `session start` loop integration.
+- [ ] Update TUI session row status text for semantic stop statuses.
+- [ ] Run focused tests, then `bun run typecheck`, `bun run check`, and relevant broader tests.

--- a/docs/superpowers/specs/2026-05-05-deterministic-loop-runner-design.md
+++ b/docs/superpowers/specs/2026-05-05-deterministic-loop-runner-design.md
@@ -1,0 +1,105 @@
+# Deterministic Loop Runner - Design
+
+- **Issue**: [#340](https://github.com/windoliver/grove/issues/340)
+- **Date**: 2026-05-05
+- **Status**: Approved by direct user instruction
+
+## Goal
+
+Add an external deterministic orchestration loop for multi-agent sessions. The
+loop owns stop decisions outside the LLM, records a semantic final status, and
+persists iteration state durably in Nexus so operators can recover why a run
+stopped.
+
+## Non-goals
+
+- Replacing contribution policy enforcement or contract stop-condition checks.
+- Adding a new LLM planning provider in this PR. The runner accepts planner
+  output as a string and validates it; callers can supply real planner output
+  later.
+- Changing the public meaning of `grove_done`. It remains an agent signal, but
+  the orchestrator no longer treats one role's done signal as whole-session
+  completion.
+
+## Approach
+
+Implement a reusable `GroveLoopRunner` in `src/core/loop-runner.ts`. It runs:
+
+1. assessment construction
+2. roadmap parsing with balanced-brace JSON extraction
+3. deterministic iteration execution
+4. durable workflow state updates
+5. final status selection
+
+The runner is generic over the iteration callback so tests can exercise it
+without spawning agents, while `SessionOrchestrator` and the CLI can use it for
+session execution.
+
+Final stop statuses are a typed enum:
+
+```text
+achieved
+plateau
+max_iterations
+interrupted
+error
+```
+
+The status is stored on session records as `stopStatus` and exposed through the
+HTTP API as `stopStatus`. `stopReason` remains a human-readable string for
+backwards compatibility.
+
+## Durable State
+
+Add a Nexus workflow store backed by VFS paths:
+
+```text
+/zones/{zoneId}/workflows/{workflowId}.json
+```
+
+The stored state includes the workflow ID, session ID, assessment, roadmap,
+iteration summaries, current best score, no-improvement count, status, reason,
+timestamps, and version. Writes use the existing Nexus client abstraction, with
+plain overwrite semantics for this first full integration. The runner writes at
+start, after each iteration, and at completion.
+
+## Plateau Detection
+
+Plateau detection uses a deterministic numeric score:
+
+- maximize by default
+- `improvementThreshold` defaults to `0.01`
+- `maxNoImprovementRounds` defaults to `5`
+- an iteration improves only when the absolute score delta over the previous
+  best is at least the threshold
+
+The runner also supports minimize direction so metric-oriented workflows can
+use loss-style scores.
+
+## SIGINT
+
+Add a small interrupt controller in the core loop module. First SIGINT requests
+graceful interruption, letting the runner finish the current await boundary and
+persist `interrupted`. A second SIGINT calls the supplied force-exit callback,
+which the CLI wires to `process.exit(130)`.
+
+## Session Integration
+
+`SessionOrchestrator` gains semantic stop status support and all-role done
+detection. One role calling `grove_done` records that role as done and only
+stops the session once every spawned role has signaled done. Idle completion
+maps to `achieved`, timeout maps to `max_iterations`, manual/user stop maps to
+`interrupted`, and unexpected failures map to `error`.
+
+The headless `grove session start` path wraps `SessionOrchestrator` with
+`GroveLoopRunner`. In Nexus mode it also creates `NexusWorkflowStore` so loop
+state is written durably while the session runs.
+
+## Testing
+
+- Core runner tests cover fallback roadmap parsing, balanced braces, achieved,
+  plateau, max-iteration, interrupted, and error statuses.
+- Nexus workflow-store tests cover path safety, write/read, list, and overwrite.
+- Session orchestrator tests cover all-role done semantics and stop status.
+- SQLite/session API tests cover `stop_status` persistence and response mapping.
+- TUI tests cover rendering semantic stop status where session rows are shown.

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -16,6 +16,14 @@ import { parseArgs } from "node:util";
 import type { GroveContract } from "../../core/contract.js";
 import { parseGroveContract } from "../../core/contract.js";
 import { LocalEventBus } from "../../core/local-event-bus.js";
+import {
+  createFallbackRoadmap,
+  GroveLoopRunner,
+  installProcessInterruptHandlers,
+  LoopStopStatus,
+  type SessionAssessment,
+  type WorkflowStateStore,
+} from "../../core/loop-runner.js";
 import { MockRuntime } from "../../core/mock-runtime.js";
 import { lookupPresetTopology } from "../../core/presets.js";
 import { SessionOrchestrator } from "../../core/session-orchestrator.js";
@@ -161,9 +169,29 @@ async function sessionStart(args: readonly string[]): Promise<void> {
 
   // Create runtime via selectRuntime (honors GROVE_RUNTIME env), fall back to mock
   const { selectRuntime } = await import("../../core/select-runtime.js");
+  const { ALLOW_ALL_RESOLVER, ChainResolver, DENY_ALL_RESOLVER } = await import(
+    "../../core/permission-resolver.js"
+  );
+  const { RulesResolver } = await import("../../core/permission-rules.js");
+  const allowAllPermissions = process.env.GROVE_ALLOW_ALL_PERMISSIONS === "1";
+  const permissionResolver = allowAllPermissions
+    ? ALLOW_ALL_RESOLVER
+    : new ChainResolver([
+        new RulesResolver({
+          allowKinds: ["read", "search", "think"],
+          denyTitleSubstrings: ["rm -rf", "sudo", "shutdown"],
+        }),
+        DENY_ALL_RESOLVER,
+      ]);
+  if (allowAllPermissions) {
+    process.stderr.write(
+      "[grove] permission-resolver: ALLOW_ALL (GROVE_ALLOW_ALL_PERMISSIONS=1). " +
+        "Destructive tool calls are auto-approved.\n",
+    );
+  }
   const picked = selectRuntime({
     acpx: { logDir: join(groveDir, "agent-logs") },
-    acp: { logDir: join(groveDir, "agent-logs") },
+    acp: { logDir: join(groveDir, "agent-logs"), permissionResolver },
   });
   const runtime = (await picked.isAvailable()) ? picked : new MockRuntime();
   const eventBus = new LocalEventBus();
@@ -175,42 +203,32 @@ async function sessionStart(args: readonly string[]): Promise<void> {
   // Everything below must run under try/finally so db.close() always fires.
   // Signal handlers are installed early (before orchestrator.start) so a
   // Ctrl-C during startup still records a stopReason.
-  let shuttingDown = false;
-  const sigintHandler = () => void handleSignal(130, "User interrupted (SIGINT)");
-  const sigtermHandler = () => void handleSignal(143, "Terminated (SIGTERM)");
   let sessionId: string | undefined;
+  let orchestrator: SessionOrchestrator | undefined;
+  let workflowStore: WorkflowStateStore | undefined;
   const goalSessionStore = new SqliteGoalSessionStore(db);
 
-  const markDone = async (reason: string): Promise<void> => {
+  const markDone = async (reason: string, stopStatus: LoopStopStatus): Promise<void> => {
     if (sessionId === undefined) return;
     try {
       await goalSessionStore.updateSession(sessionId, {
-        status: "completed",
+        status: terminalSessionStatus(stopStatus),
         completedAt: new Date().toISOString(),
         stopReason: reason,
+        stopStatus,
       });
     } catch {
       // Best-effort — DB may already be closed or session archived.
     }
   };
 
-  const handleSignal = async (exitCode: number, reason: string): Promise<void> => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    try {
-      await markDone(reason);
-    } finally {
-      try {
-        db.close();
-      } catch {
-        /* already closed */
-      }
-      process.exit(exitCode);
-    }
-  };
-
-  process.on("SIGINT", sigintHandler);
-  process.on("SIGTERM", sigtermHandler);
+  const interruptHandlers = installProcessInterruptHandlers(process, {
+    forceExit: (code) => process.exit(code),
+    onInterrupt: (reason) => {
+      void orchestrator?.stop(reason, LoopStopStatus.Interrupted);
+      void markDone(reason, LoopStopStatus.Interrupted);
+    },
+  });
 
   try {
     const session = await goalSessionStore.createSession({
@@ -232,12 +250,14 @@ async function sessionStart(args: readonly string[]): Promise<void> {
     if (nexusUrl) {
       const { NexusHttpClient } = await import("../../nexus/nexus-http-client.js");
       const { NexusSessionStore } = await import("../../nexus/nexus-session-store.js");
+      const { NexusWorkflowStore } = await import("../../nexus/nexus-workflow-store.js");
       const nexusClient = new NexusHttpClient({
         url: nexusUrl,
         ...(nexusApiKey ? { apiKey: nexusApiKey } : {}),
       });
       const zoneId = process.env.GROVE_ZONE_ID ?? "default";
       const nexusSessionStore = new NexusSessionStore(nexusClient, zoneId);
+      workflowStore = new NexusWorkflowStore({ client: nexusClient, zoneId });
 
       const retryDelaysMs = [0, 200, 500, 1000];
       let lastErr: unknown;
@@ -265,7 +285,7 @@ async function sessionStart(args: readonly string[]): Promise<void> {
     const { SqliteContributionStore } = await import("../../local/sqlite-store.js");
     const contributionStore = new SqliteContributionStore(db);
 
-    const orchestrator = new SessionOrchestrator({
+    orchestrator = new SessionOrchestrator({
       goal,
       contract: contract ?? { contractVersion: 3, name: presetName ?? "default" },
       topology: resolution.topology,
@@ -301,20 +321,59 @@ async function sessionStart(args: readonly string[]): Promise<void> {
       message: `Session started with ${status.agents.length} agents`,
     });
 
-    // Wait for session to complete — agents need time to work, submit, review, and call grove_done.
-    // Without this, the CLI exits immediately and the reviewer never gets routed events.
+    // Wait for session completion through the deterministic external loop.
+    // The session orchestrator owns agent routing; the loop owns final status,
+    // interrupt observation, and durable workflow state.
     const SESSION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-    const stopReason = await orchestrator.waitForCompletion(SESSION_TIMEOUT_MS);
-    await markDone(stopReason);
+    const assessment = sessionAssessment(goal, resolution.topology);
+    const loop = new GroveLoopRunner({
+      workflowId: `workflow-${session.id}`,
+      sessionId: session.id,
+      assessment,
+      roadmap: createFallbackRoadmap(assessment),
+      maxIterations: 1,
+      interrupt: interruptHandlers.interrupt,
+      workflowStore,
+      executeIteration: async () => {
+        const stopReason = await orchestrator?.waitForCompletion(SESSION_TIMEOUT_MS);
+        const current = orchestrator?.getStatus();
+        return {
+          stopStatus:
+            current?.stopStatus ??
+            (interruptHandlers.interrupt.interruptRequested
+              ? LoopStopStatus.Interrupted
+              : LoopStopStatus.Achieved),
+          summary: stopReason ?? current?.stopReason ?? "Session complete",
+        };
+      },
+    });
+    const finalState = await loop.run();
+    const finalStopStatus =
+      finalState.status === "running" ? LoopStopStatus.Error : finalState.status;
+    await markDone(finalState.reason ?? "Session complete", finalStopStatus);
   } finally {
-    process.removeListener("SIGINT", sigintHandler);
-    process.removeListener("SIGTERM", sigtermHandler);
+    interruptHandlers.dispose();
     try {
       db.close();
     } catch {
       /* already closed */
     }
   }
+}
+
+function terminalSessionStatus(stopStatus: LoopStopStatus): "completed" | "cancelled" {
+  return stopStatus === LoopStopStatus.Interrupted || stopStatus === LoopStopStatus.Error
+    ? "cancelled"
+    : "completed";
+}
+
+function sessionAssessment(goal: string, topology: AgentTopology): SessionAssessment {
+  return {
+    goal,
+    roles: topology.roles.map((role) => role.name),
+    successCriteria: ["session reaches a deterministic terminal status"],
+    constraints: ["stop decisions are made by GroveLoopRunner, not by agent prose"],
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -378,6 +437,8 @@ async function sessionStatus(): Promise<void> {
       goal: latest.goal,
       startedAt: latest.createdAt,
       completedAt: latest.completedAt,
+      stopReason: latest.stopReason,
+      stopStatus: latest.stopStatus,
       contributionCount: latest.contributionCount,
     });
   } catch (err) {
@@ -428,9 +489,10 @@ async function sessionStop(args: readonly string[]): Promise<void> {
     }
     const reason = (values.reason as string | undefined) ?? "User stopped";
     await store.updateSession(latest.id, {
-      status: "completed",
+      status: terminalSessionStatus(LoopStopStatus.Interrupted),
       completedAt: new Date().toISOString(),
       stopReason: reason,
+      stopStatus: LoopStopStatus.Interrupted,
     });
 
     // Best-effort: kill agent processes associated with this session.
@@ -450,8 +512,9 @@ async function sessionStop(args: readonly string[]): Promise<void> {
 
     outputJson({
       sessionId: latest.id,
-      status: "completed",
+      status: terminalSessionStatus(LoopStopStatus.Interrupted),
       reason,
+      stopStatus: LoopStopStatus.Interrupted,
       message: `Session ${latest.id} stopped`,
       warning:
         "Agent processes may still be running if they don't respond to signals. Use 'ps aux | grep grove' to check.",

--- a/src/cli/nexus-lifecycle.test.ts
+++ b/src/cli/nexus-lifecycle.test.ts
@@ -644,6 +644,76 @@ describe("nexusUp fallback (--timeout not supported)", () => {
     expect(calls[1]).not.toContain("--timeout");
   });
 
+  test("passes nexus.yaml port bindings through compose environment", async () => {
+    const dir = makeTempDir();
+    const calls: Array<{ args: string[]; env: Record<string, string> | undefined }> = [];
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/usr/bin:/bin";
+    writeFileSync(
+      join(dir, "nexus.yaml"),
+      [
+        "auth: static",
+        "api_key: sk-test",
+        `data_dir: ${join(dir, "nexus-data")}`,
+        "ports:",
+        "  http: 46000",
+        "  grpc: 46001",
+        "  postgres: 46002",
+        "  dragonfly: 46003",
+        "  zoekt: 46004",
+        "",
+      ].join("\n"),
+    );
+    try {
+      // @ts-expect-error -- mock
+      Bun.spawn = (args: string[], opts?: { env?: Record<string, string> }) => {
+        calls.push({ args, env: opts?.env });
+        return fakeProc(0, "nexus  http://localhost:46000\n", "");
+      };
+      const { nexusUp } = await import("./nexus-lifecycle.js");
+      await nexusUp(dir);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.env?.NEXUS_PORT).toBe("46000");
+      expect(calls[0]!.env?.NEXUS_GRPC_PORT).toBe("46001");
+      expect(calls[0]!.env?.POSTGRES_PORT).toBe("46002");
+      expect(calls[0]!.env?.DRAGONFLY_PORT).toBe("46003");
+      expect(calls[0]!.env?.ZOEKT_PORT).toBe("46004");
+      expect(calls[0]!.env?.NEXUS_API_KEY).toBe("sk-test");
+      expect(calls[0]!.env?.NEXUS_AUTH_TYPE).toBe("static");
+      expect(calls[0]!.env?.NEXUS_HOST_DATA_DIR).toBe(join(dir, "nexus-data"));
+      expect(calls[0]!.env?.PATH).toContain("/Applications/OrbStack.app/Contents/MacOS/xbin");
+    } finally {
+      if (originalPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("uses NEXUS_CLI override when inherited PATH cannot find nexus", async () => {
+    const originalNexusCli = process.env.NEXUS_CLI;
+    const calls: string[][] = [];
+    process.env.NEXUS_CLI = "/custom/bin/nexus";
+    try {
+      // @ts-expect-error -- mock
+      Bun.spawn = (args: string[], _opts?: unknown) => {
+        calls.push(args);
+        return fakeProc(0, "nexus  http://localhost:2026\n", "");
+      };
+      const { nexusUp } = await import("./nexus-lifecycle.js");
+      await nexusUp("/tmp/test-proj");
+      expect(calls[0]?.[0]).toBe("/custom/bin/nexus");
+    } finally {
+      if (originalNexusCli === undefined) {
+        delete process.env.NEXUS_CLI;
+      } else {
+        process.env.NEXUS_CLI = originalNexusCli;
+      }
+    }
+  });
+
   test("throws immediately for unrelated errors — no fallback attempted", async () => {
     const calls: string[][] = [];
     // @ts-expect-error -- mock

--- a/src/cli/nexus-lifecycle.ts
+++ b/src/cli/nexus-lifecycle.ts
@@ -43,6 +43,14 @@ const HEALTH_POLL_MS = 1_000;
 /** Default `nexus up` timeout (seconds). */
 const NEXUS_UP_TIMEOUT_S = 180;
 
+const LIFECYCLE_PATH_EXTRAS = [
+  join(homedir(), ".local/bin"),
+  join(homedir(), ".bun/bin"),
+  "/Applications/OrbStack.app/Contents/MacOS/xbin",
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+] as const;
+
 // ---------------------------------------------------------------------------
 // Port derivation
 // ---------------------------------------------------------------------------
@@ -113,10 +121,89 @@ export function readNexusState(projectRoot: string): NexusState | undefined {
 // CLI detection
 // ---------------------------------------------------------------------------
 
-/** Check whether the `nexus` CLI is available on PATH. */
+function existingPathCandidate(path: string): boolean {
+  try {
+    return existsSync(path);
+  } catch {
+    return false;
+  }
+}
+
+function withLifecyclePathEnv(env: Record<string, string | undefined>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) out[key] = value;
+  }
+
+  const parts = (out.PATH ?? "")
+    .split(":")
+    .map((part) => part.trim())
+    .filter((part) => part !== "");
+  for (const extra of LIFECYCLE_PATH_EXTRAS) {
+    if (!parts.includes(extra)) parts.push(extra);
+  }
+  out.PATH = parts.join(":");
+  return out;
+}
+
+export function resolveNexusCliPath(
+  env: Record<string, string | undefined> = process.env,
+  exists: (path: string) => boolean = existingPathCandidate,
+): string {
+  const explicit = env.NEXUS_CLI?.trim();
+  if (explicit) return explicit;
+
+  const pathDirs = (env.PATH ?? "")
+    .split(":")
+    .map((part) => part.trim())
+    .filter((part) => part !== "");
+  for (const dir of pathDirs) {
+    const candidate = join(dir, "nexus");
+    if (exists(candidate)) return candidate;
+  }
+
+  for (const candidate of [
+    join(homedir(), ".local/bin/nexus"),
+    join(homedir(), ".local/share/grove-nexus-venv/bin/nexus"),
+    "/opt/homebrew/bin/nexus",
+    "/usr/local/bin/nexus",
+    "/tmp/grove-nexus-venv/bin/nexus",
+  ]) {
+    if (exists(candidate)) return candidate;
+  }
+
+  return "nexus";
+}
+
+function resolveNexusPythonPath(env: Record<string, string | undefined> = process.env): string {
+  const explicit = env.NEXUS_PYTHON?.trim();
+  if (explicit) return explicit;
+
+  const nexusCli = resolveNexusCliPath(withLifecyclePathEnv(env));
+  if (nexusCli !== "nexus" && existsSync(nexusCli)) {
+    try {
+      const firstLine = readFileSync(nexusCli, "utf-8").split(/\r?\n/, 1)[0] ?? "";
+      if (firstLine.startsWith("#!")) {
+        const shebangParts = firstLine.slice(2).trim().split(/\s+/);
+        const executable = shebangParts[0];
+        if (executable && executable !== "/usr/bin/env") return executable;
+        const envExecutable = shebangParts[1];
+        if (envExecutable) return envExecutable;
+      }
+    } catch {
+      // Fall back to python3 below.
+    }
+  }
+
+  return "python3";
+}
+
+/** Check whether the `nexus` CLI is available on PATH or a known user install path. */
 export async function checkNexusCli(): Promise<boolean> {
   try {
-    const proc = Bun.spawn(["nexus", "--version"], {
+    const spawnEnv = withLifecyclePathEnv(process.env);
+    const proc = Bun.spawn([resolveNexusCliPath(spawnEnv), "--version"], {
+      env: spawnEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -220,13 +307,14 @@ export async function ensureNexusComposeFile(projectRoot: string): Promise<void>
   // 1. Try the nexus Python package bundled data directory.
   let sourceDir: string | undefined;
   try {
+    const spawnEnv = withLifecyclePathEnv(process.env);
     const proc = Bun.spawn(
       [
-        "python3",
+        resolveNexusPythonPath(spawnEnv),
         "-c",
         "import importlib.resources; p = importlib.resources.files('nexus.cli.data'); print(p)",
       ],
-      { stdout: "pipe", stderr: "pipe" },
+      { env: spawnEnv, stdout: "pipe", stderr: "pipe" },
     );
     const [code, out] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
     if (code === 0) {
@@ -322,16 +410,52 @@ function resolveNexusSource(explicit?: string): string | undefined {
  * the same flags, preventing silent divergence (e.g. missing --port-strategy).
  */
 function buildNexusUpArgs(opts: {
+  nexusCli: string;
   wantsBuild: boolean;
   sourceDir?: string | undefined;
   timeout?: number | undefined;
 }): string[] {
-  const args = ["nexus", "up", "--port-strategy", "auto"];
+  const args = [opts.nexusCli, "up", "--port-strategy", "auto"];
   if (opts.timeout != null) args.push("--timeout", String(opts.timeout));
   if (opts.wantsBuild && opts.sourceDir) {
     args.push("--build", "--compose-file", join(opts.sourceDir, "nexus-stack.yml"));
   }
   return args;
+}
+
+function coerceEnvString(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim() !== "") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return undefined;
+}
+
+function readNexusComposeEnv(projectRoot: string): Record<string, string> {
+  const yamlPath = join(projectRoot, "nexus.yaml");
+  if (!existsSync(yamlPath)) return {};
+  try {
+    const parsed = yamlParse(readFileSync(yamlPath, "utf-8")) as Record<string, unknown> | null;
+    const ports = parsed?.ports as Record<string, unknown> | undefined;
+    const env: Record<string, string> = {};
+    const http = coerceEnvString(ports?.http);
+    const grpc = coerceEnvString(ports?.grpc);
+    const postgres = coerceEnvString(ports?.postgres);
+    const dragonfly = coerceEnvString(ports?.dragonfly);
+    const zoekt = coerceEnvString(ports?.zoekt);
+    if (http) env.NEXUS_PORT = http;
+    if (grpc) env.NEXUS_GRPC_PORT = grpc;
+    if (postgres) env.POSTGRES_PORT = postgres;
+    if (dragonfly) env.DRAGONFLY_PORT = dragonfly;
+    if (zoekt) env.ZOEKT_PORT = zoekt;
+    const apiKey = coerceEnvString(parsed?.api_key);
+    const auth = coerceEnvString(parsed?.auth);
+    const dataDir = coerceEnvString(parsed?.data_dir);
+    if (apiKey) env.NEXUS_API_KEY = apiKey;
+    if (auth) env.NEXUS_AUTH_TYPE = auth;
+    if (dataDir) env.NEXUS_HOST_DATA_DIR = dataDir;
+    return env;
+  } catch {
+    return {};
+  }
 }
 
 /**
@@ -378,10 +502,13 @@ export async function nexusUp(_projectRoot: string, opts: NexusUpOptions = {}): 
     }
   }
 
-  const args = buildNexusUpArgs({ wantsBuild, sourceDir, timeout });
+  const spawnEnv = withLifecyclePathEnv({ ...process.env, ...readNexusComposeEnv(projectRoot) });
+  const nexusCli = resolveNexusCliPath(spawnEnv);
+  const args = buildNexusUpArgs({ nexusCli, wantsBuild, sourceDir, timeout });
 
   const proc = Bun.spawn(args, {
     cwd: projectRoot,
+    env: spawnEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -440,9 +567,15 @@ export async function nexusUp(_projectRoot: string, opts: NexusUpOptions = {}): 
     // Retry without --timeout if the flag is unsupported (nexus-ai-fs < 0.9.0).
     // Both primary and fallback use buildNexusUpArgs — no flag divergence.
     if (stderr.includes("no such option") || stderr.includes("unrecognized arguments")) {
-      const fallbackArgs = buildNexusUpArgs({ wantsBuild, sourceDir, timeout: undefined });
+      const fallbackArgs = buildNexusUpArgs({
+        nexusCli,
+        wantsBuild,
+        sourceDir,
+        timeout: undefined,
+      });
       const fallback = Bun.spawn(fallbackArgs, {
         cwd: projectRoot,
+        env: spawnEnv,
         stdout: "pipe",
         stderr: "pipe",
       });
@@ -470,8 +603,10 @@ export async function nexusUp(_projectRoot: string, opts: NexusUpOptions = {}): 
 export async function nexusDown(_projectRoot: string): Promise<void> {
   const cwd = _projectRoot;
   try {
-    const proc = Bun.spawn(["nexus", "down"], {
+    const spawnEnv = withLifecyclePathEnv(process.env);
+    const proc = Bun.spawn([resolveNexusCliPath(spawnEnv), "down"], {
       cwd,
+      env: spawnEnv,
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/src/core/acp-runtime.spawn.test.ts
+++ b/src/core/acp-runtime.spawn.test.ts
@@ -8,6 +8,8 @@ import {
 import { AcpRuntime, type LaunchOverride } from "./acp-runtime.js";
 
 interface AgentStubHandlers {
+  onNewSession?: (p: Parameters<Agent["newSession"]>[0]) => void;
+  onCancel?: () => Promise<void> | void;
   onPrompt?: (p: {
     sessionId: string;
     agentSide: AgentSideConnection;
@@ -34,7 +36,8 @@ function makeInProcessAgent(handlers: AgentStubHandlers = {}): {
           authMethods: [],
         };
       },
-      async newSession() {
+      async newSession(p) {
+        handlers.onNewSession?.(p);
         return { sessionId: `wire-${Date.now()}` };
       },
       async prompt(p) {
@@ -43,7 +46,9 @@ function makeInProcessAgent(handlers: AgentStubHandlers = {}): {
         }
         return { stopReason: "end_turn" };
       },
-      async cancel() {},
+      async cancel() {
+        await handlers.onCancel?.();
+      },
       async authenticate() {
         return {};
       },
@@ -54,10 +59,23 @@ function makeInProcessAgent(handlers: AgentStubHandlers = {}): {
 
     return {
       clientStream,
-      dispose: async () => {},
+      dispose: async () => undefined,
     };
   };
   return { launchOverride, ref };
+}
+
+function deferred<T = void>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {
+    /* assigned synchronously by Promise constructor */
+  };
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
 }
 
 describe("AcpRuntime.spawn", () => {
@@ -86,6 +104,78 @@ describe("AcpRuntime.spawn", () => {
     expect((await rt.listSessions()).length).toBe(1);
     await rt.close(session);
     expect(await rt.listSessions()).toEqual([]);
+  });
+
+  test("forwards Grove identity env to MCP servers", async () => {
+    let captured: Parameters<Agent["newSession"]>[0] | undefined;
+    const { launchOverride } = makeInProcessAgent({
+      onNewSession(p) {
+        captured = p;
+      },
+    });
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: process.cwd(),
+      env: {
+        GROVE_SESSION_ID: "session-1",
+        GROVE_ROUTING_TOKEN: "token-1",
+      },
+      mcpServers: [
+        {
+          name: "grove",
+          command: "bun",
+          args: ["run", "dist/mcp/serve.js"],
+          env: { GROVE_DIR: "/tmp/project/.grove" },
+        },
+      ],
+    });
+
+    const server = captured?.mcpServers?.[0];
+    expect(server?.name).toBe("grove");
+    expect(server?.env).toContainEqual({ name: "GROVE_DIR", value: "/tmp/project/.grove" });
+    expect(server?.env).toContainEqual({ name: "GROVE_SESSION_ID", value: "session-1" });
+    expect(server?.env).toContainEqual({ name: "GROVE_ROUTING_TOKEN", value: "token-1" });
+    expect(server?.env).toContainEqual({ name: "GROVE_AGENT_ID", value: session.id });
+    expect(server?.env).toContainEqual({ name: "GROVE_AGENT_ROLE", value: "coder" });
+    await rt.close(session);
+  });
+
+  test("does not forward Grove secrets to non-Grove MCP servers", async () => {
+    let captured: Parameters<Agent["newSession"]>[0] | undefined;
+    const { launchOverride } = makeInProcessAgent({
+      onNewSession(p) {
+        captured = p;
+      },
+    });
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: process.cwd(),
+      env: {
+        GROVE_SESSION_ID: "session-1",
+        GROVE_ROUTING_TOKEN: "token-1",
+        NEXUS_API_KEY: "sk-test",
+      },
+      mcpServers: [
+        {
+          name: "third-party",
+          command: "third-party-mcp",
+          env: { SAFE_VALUE: "ok" },
+        },
+      ],
+    });
+
+    const server = captured?.mcpServers?.[0];
+    expect(server?.name).toBe("third-party");
+    expect(server?.env).toContainEqual({ name: "SAFE_VALUE", value: "ok" });
+    expect(server?.env).not.toContainEqual({ name: "GROVE_SESSION_ID", value: "session-1" });
+    expect(server?.env).not.toContainEqual({ name: "GROVE_ROUTING_TOKEN", value: "token-1" });
+    expect(server?.env).not.toContainEqual({ name: "NEXUS_API_KEY", value: "sk-test" });
+    expect(server?.env).not.toContainEqual({ name: "GROVE_AGENT_ID", value: session.id });
+    await rt.close(session);
   });
 });
 
@@ -145,6 +235,34 @@ describe("AcpRuntime.send", () => {
     await collect;
     expect(chunks.join("")).toBe("hello world");
     await rt.close(session);
+  });
+
+  test("close cancels an in-flight prompt", async () => {
+    const promptStarted = deferred();
+    const cancelled = deferred();
+    const { launchOverride } = makeInProcessAgent({
+      async onPrompt() {
+        promptStarted.resolve();
+        await cancelled.promise;
+        return { stopReason: "cancelled" };
+      },
+      onCancel() {
+        cancelled.resolve();
+      },
+    });
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: process.cwd(),
+    });
+
+    const turn = await rt.send(session, "slow task");
+    await promptStarted.promise;
+    await rt.close(session);
+
+    const result = await turn.result;
+    expect(result.stopReason).toBe("cancelled");
   });
 });
 

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -92,6 +92,8 @@ async function launchSubprocess(
 }
 
 export class AcpRuntime implements AgentRuntime {
+  readonly sendsInitialPromptOnSpawn = true;
+
   private resolver: PermissionResolver;
   private readonly fsAuditor: AcpRuntimeOptions["fsAuditor"];
   private readonly logDir: string | undefined;
@@ -171,12 +173,21 @@ export class AcpRuntime implements AgentRuntime {
           terminal: false,
         },
       });
-      const mcpServers = (config.mcpServers ?? []).map((s) => ({
-        name: s.name,
-        command: s.command,
-        args: [...(s.args ?? [])],
-        env: s.env ? Object.entries(s.env).map(([name, value]) => ({ name, value })) : [],
-      }));
+      const groveMcpEnv = Object.fromEntries(
+        Object.entries(mergedEnv).filter(
+          ([key]) => key.startsWith("GROVE_") || key === "NEXUS_API_KEY",
+        ),
+      ) as Record<string, string>;
+      const mcpServers = (config.mcpServers ?? []).map((s) => {
+        const inheritedEnv = s.name === "grove" ? groveMcpEnv : {};
+        const env = { ...inheritedEnv, ...(s.env ?? {}) };
+        return {
+          name: s.name,
+          command: s.command,
+          args: [...(s.args ?? [])],
+          env: Object.entries(env).map(([name, value]) => ({ name, value })),
+        };
+      });
       created = await connection.newSession({ cwd: config.cwd, mcpServers });
     } catch (err) {
       try {
@@ -257,7 +268,7 @@ export class AcpRuntime implements AgentRuntime {
     if (entry.closed) throw new Error(`AcpRuntime.send: session ${session.id} is closed`);
 
     const turnId = `${session.id}-${Date.now().toString(36)}-${this.nextId++}`;
-    let resolveResult: (r: Result) => void = () => {};
+    let resolveResult: (r: Result) => void = () => undefined;
     const resultPromise = new Promise<Result>((r) => {
       resolveResult = r;
     });
@@ -328,6 +339,11 @@ export class AcpRuntime implements AgentRuntime {
     const entry = this.sessions.get(session.id);
     if (!entry) return;
     entry.closed = true;
+    try {
+      await entry.currentTurn?.cancel();
+    } catch {
+      /* best effort */
+    }
     // Drain any pending sends so we don't leak prompt() promises past dispose.
     try {
       await entry.sendChainTail;

--- a/src/core/agent-runtime.ts
+++ b/src/core/agent-runtime.ts
@@ -66,6 +66,12 @@ export interface AgentSession {
 /** Runtime for managing agent lifecycle. */
 export interface AgentRuntime {
   /**
+   * True when spawn(config.goal/config.prompt) starts the first turn itself.
+   * Runtimes without this capability rely on SessionOrchestrator to send the
+   * initial role goal after spawn.
+   */
+  readonly sendsInitialPromptOnSpawn?: boolean | undefined;
+  /**
    * Spawn a new agent session.
    *
    * The returned `session.id` MUST be produced via `buildSessionId(role, n)`

--- a/src/core/in-memory-session-store.ts
+++ b/src/core/in-memory-session-store.ts
@@ -32,7 +32,7 @@ export class InMemorySessionStore implements SessionStore {
 
   async updateSession(
     id: string,
-    updates: Partial<Pick<Session, "status" | "completedAt" | "stopReason">>,
+    updates: Partial<Pick<Session, "status" | "completedAt" | "stopReason" | "stopStatus">>,
   ): Promise<void> {
     const idx = this.sessions.findIndex((s) => s.id === id);
     if (idx === -1) return;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -178,6 +178,30 @@ export {
   LifecycleState,
 } from "./lifecycle.js";
 export { LocalEventBus } from "./local-event-bus.js";
+export type {
+  GroveLoopRunnerOptions,
+  ImprovementDirection,
+  InstalledInterruptHandlers,
+  InterruptController,
+  IterationRoadmap,
+  IterationStage,
+  LoopIterationContext,
+  LoopIterationRecord,
+  LoopIterationResult,
+  SessionAssessment,
+  WorkflowRunStatus,
+  WorkflowState,
+  WorkflowStateStore,
+} from "./loop-runner.js";
+export {
+  createFallbackRoadmap,
+  createInterruptController,
+  findFirstBalancedBraces,
+  GroveLoopRunner,
+  installProcessInterruptHandlers,
+  LoopStopStatus,
+  parseIterationRoadmap,
+} from "./loop-runner.js";
 export {
   CID_PATTERN,
   ContextSchema,

--- a/src/core/loop-runner.test.ts
+++ b/src/core/loop-runner.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createFallbackRoadmap,
+  createInterruptController,
+  findFirstBalancedBraces,
+  GroveLoopRunner,
+  LoopStopStatus,
+  parseIterationRoadmap,
+  type WorkflowState,
+  type WorkflowStateStore,
+} from "./loop-runner.js";
+
+const assessment = {
+  goal: "Fix the review loop",
+  roles: ["coder", "reviewer"],
+  successCriteria: ["reviewer approves", "tests pass"],
+  constraints: ["do not stop before review"],
+};
+
+class MemoryWorkflowStore implements WorkflowStateStore {
+  readonly states: WorkflowState[] = [];
+
+  async saveWorkflowState(state: WorkflowState): Promise<void> {
+    this.states.push(structuredClone(state));
+  }
+}
+
+describe("findFirstBalancedBraces", () => {
+  test("extracts the first balanced JSON object from prose", () => {
+    const text = 'before {"a":{"b":1},"text":"brace } in string"} after {"ignored":true}';
+
+    expect(findFirstBalancedBraces(text)).toBe('{"a":{"b":1},"text":"brace } in string"}');
+  });
+
+  test("returns undefined when no balanced object exists", () => {
+    expect(findFirstBalancedBraces('before {"a":1')).toBeUndefined();
+  });
+});
+
+describe("parseIterationRoadmap", () => {
+  test("parses planner JSON embedded in prose", () => {
+    const roadmap = parseIterationRoadmap(
+      `
+      Planner notes:
+      {
+        "stages": [
+          {
+            "id": "code",
+            "title": "Implement",
+            "role": "coder",
+            "prompt": "write the fix",
+            "successCriteria": ["tests pass"]
+          }
+        ]
+      }
+      `,
+      assessment,
+    );
+
+    expect(roadmap.source).toBe("planner");
+    expect(roadmap.stages).toHaveLength(1);
+    expect(roadmap.stages[0]?.id).toBe("code");
+  });
+
+  test("returns a default roadmap when planner JSON is invalid", () => {
+    const roadmap = parseIterationRoadmap("not json", assessment);
+
+    expect(roadmap.source).toBe("fallback");
+    expect(roadmap.stages.map((stage) => stage.role)).toEqual(["coder", "reviewer"]);
+  });
+});
+
+describe("createFallbackRoadmap", () => {
+  test("creates one stage per role with the goal and success criteria", () => {
+    const roadmap = createFallbackRoadmap(assessment);
+
+    expect(roadmap.source).toBe("fallback");
+    expect(roadmap.stages).toHaveLength(2);
+    expect(roadmap.stages[0]?.prompt).toContain("Fix the review loop");
+    expect(roadmap.stages[0]?.successCriteria).toEqual(assessment.successCriteria);
+  });
+});
+
+describe("GroveLoopRunner", () => {
+  test("stops with achieved when an iteration reports success", async () => {
+    const store = new MemoryWorkflowStore();
+    const runner = new GroveLoopRunner({
+      workflowId: "wf-achieved",
+      sessionId: "session-1",
+      assessment,
+      roadmap: createFallbackRoadmap(assessment),
+      workflowStore: store,
+      executeIteration: async () => ({
+        score: 0.5,
+        achieved: true,
+        summary: "review approved",
+      }),
+    });
+
+    const result = await runner.run();
+
+    expect(result.status).toBe(LoopStopStatus.Achieved);
+    expect(result.iterations).toHaveLength(1);
+    expect(store.states.at(-1)?.status).toBe(LoopStopStatus.Achieved);
+  });
+
+  test("stops with plateau after configured no-improvement rounds", async () => {
+    const scores = [1.0, 1.004, 1.006];
+    const runner = new GroveLoopRunner({
+      workflowId: "wf-plateau",
+      sessionId: "session-1",
+      assessment,
+      roadmap: createFallbackRoadmap(assessment),
+      maxNoImprovementRounds: 2,
+      improvementThreshold: 0.01,
+      executeIteration: async () => ({
+        score: scores.shift() ?? 1.006,
+        summary: "small change",
+      }),
+    });
+
+    const result = await runner.run();
+
+    expect(result.status).toBe(LoopStopStatus.Plateau);
+    expect(result.iterations).toHaveLength(3);
+    expect(result.noImprovementRounds).toBe(2);
+  });
+
+  test("stops with max_iterations at the hard cap", async () => {
+    const runner = new GroveLoopRunner({
+      workflowId: "wf-max",
+      sessionId: "session-1",
+      assessment,
+      roadmap: createFallbackRoadmap(assessment),
+      maxIterations: 2,
+      maxNoImprovementRounds: 10,
+      executeIteration: async ({ iteration }) => ({
+        score: iteration,
+        summary: `round ${iteration}`,
+      }),
+    });
+
+    const result = await runner.run();
+
+    expect(result.status).toBe(LoopStopStatus.MaxIterations);
+    expect(result.iterations.map((iteration) => iteration.iteration)).toEqual([1, 2]);
+  });
+
+  test("stops with interrupted before starting the next iteration", async () => {
+    const interrupt = createInterruptController();
+    let calls = 0;
+    const runner = new GroveLoopRunner({
+      workflowId: "wf-interrupted",
+      sessionId: "session-1",
+      assessment,
+      roadmap: createFallbackRoadmap(assessment),
+      interrupt,
+      maxIterations: 5,
+      executeIteration: async () => {
+        calls += 1;
+        interrupt.requestInterrupt("operator stop");
+        return { score: calls, summary: "requested stop" };
+      },
+    });
+
+    const result = await runner.run();
+
+    expect(result.status).toBe(LoopStopStatus.Interrupted);
+    expect(result.reason).toBe("operator stop");
+    expect(calls).toBe(1);
+  });
+
+  test("uses explicit terminal stop status from an iteration result", async () => {
+    const runner = new GroveLoopRunner({
+      workflowId: "wf-terminal",
+      sessionId: "session-1",
+      assessment,
+      roadmap: createFallbackRoadmap(assessment),
+      executeIteration: async () => ({
+        stopStatus: LoopStopStatus.MaxIterations,
+        summary: "session timed out",
+      }),
+    });
+
+    const result = await runner.run();
+
+    expect(result.status).toBe(LoopStopStatus.MaxIterations);
+    expect(result.reason).toBe("session timed out");
+    expect(result.iterations).toHaveLength(1);
+  });
+
+  test("stops with error when iteration throws and persists the final state", async () => {
+    const store = new MemoryWorkflowStore();
+    const runner = new GroveLoopRunner({
+      workflowId: "wf-error",
+      sessionId: "session-1",
+      assessment,
+      roadmap: createFallbackRoadmap(assessment),
+      workflowStore: store,
+      executeIteration: async () => {
+        throw new Error("provider failed");
+      },
+    });
+
+    const result = await runner.run();
+
+    expect(result.status).toBe(LoopStopStatus.Error);
+    expect(result.reason).toContain("provider failed");
+    expect(store.states.at(-1)?.status).toBe(LoopStopStatus.Error);
+  });
+});

--- a/src/core/loop-runner.ts
+++ b/src/core/loop-runner.ts
@@ -1,0 +1,468 @@
+import { z } from "zod";
+
+export const LoopStopStatus = {
+  Achieved: "achieved",
+  Plateau: "plateau",
+  MaxIterations: "max_iterations",
+  Interrupted: "interrupted",
+  Error: "error",
+} as const;
+
+export type LoopStopStatus = (typeof LoopStopStatus)[keyof typeof LoopStopStatus];
+export type WorkflowRunStatus = "running" | LoopStopStatus;
+export type ImprovementDirection = "maximize" | "minimize";
+
+export interface SessionAssessment {
+  readonly goal: string;
+  readonly roles: readonly string[];
+  readonly successCriteria: readonly string[];
+  readonly constraints: readonly string[];
+}
+
+export interface IterationStage {
+  readonly id: string;
+  readonly title: string;
+  readonly role?: string | undefined;
+  readonly prompt: string;
+  readonly successCriteria: readonly string[];
+}
+
+export interface IterationRoadmap {
+  readonly source: "planner" | "fallback";
+  readonly stages: readonly IterationStage[];
+}
+
+export interface LoopIterationRecord {
+  readonly iteration: number;
+  readonly stageId: string;
+  readonly startedAt: string;
+  readonly completedAt: string;
+  readonly score?: number | undefined;
+  readonly improved: boolean;
+  readonly summary?: string | undefined;
+  readonly error?: string | undefined;
+}
+
+export interface WorkflowState {
+  readonly workflowId: string;
+  readonly sessionId?: string | undefined;
+  readonly assessment: SessionAssessment;
+  readonly roadmap: IterationRoadmap;
+  readonly status: WorkflowRunStatus;
+  readonly reason?: string | undefined;
+  readonly currentIteration: number;
+  readonly iterations: readonly LoopIterationRecord[];
+  readonly bestScore?: number | undefined;
+  readonly noImprovementRounds: number;
+  readonly startedAt: string;
+  readonly updatedAt: string;
+  readonly completedAt?: string | undefined;
+}
+
+export interface WorkflowStateStore {
+  saveWorkflowState(state: WorkflowState): Promise<void>;
+}
+
+export interface InterruptController {
+  readonly interruptRequested: boolean;
+  readonly reason: string | undefined;
+  requestInterrupt(reason?: string): void;
+}
+
+export interface LoopIterationContext {
+  readonly workflowId: string;
+  readonly sessionId?: string | undefined;
+  readonly iteration: number;
+  readonly stage: IterationStage;
+  readonly state: WorkflowState;
+}
+
+export interface LoopIterationResult {
+  readonly score?: number | undefined;
+  readonly achieved?: boolean | undefined;
+  readonly stopStatus?: LoopStopStatus | undefined;
+  readonly summary?: string | undefined;
+}
+
+export interface GroveLoopRunnerOptions {
+  readonly workflowId: string;
+  readonly sessionId?: string | undefined;
+  readonly assessment: SessionAssessment;
+  readonly roadmap?: IterationRoadmap | undefined;
+  readonly plannerOutput?: string | undefined;
+  readonly maxIterations?: number | undefined;
+  readonly maxNoImprovementRounds?: number | undefined;
+  readonly improvementThreshold?: number | undefined;
+  readonly improvementDirection?: ImprovementDirection | undefined;
+  readonly interrupt?: InterruptController | undefined;
+  readonly workflowStore?: WorkflowStateStore | undefined;
+  readonly now?: (() => string) | undefined;
+  readonly executeIteration: (context: LoopIterationContext) => Promise<LoopIterationResult>;
+}
+
+const DEFAULT_MAX_ITERATIONS = 50;
+const DEFAULT_MAX_NO_IMPROVEMENT_ROUNDS = 5;
+const DEFAULT_IMPROVEMENT_THRESHOLD = 0.01;
+
+const IterationStageSchema = z
+  .object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    role: z.string().min(1).optional(),
+    prompt: z.string().min(1),
+    successCriteria: z.array(z.string()).optional(),
+    success_criteria: z.array(z.string()).optional(),
+  })
+  .strict();
+
+const IterationRoadmapSchema = z
+  .object({
+    stages: z.array(IterationStageSchema).min(1),
+  })
+  .strict();
+
+type ParsedIterationStage = z.infer<typeof IterationStageSchema>;
+
+export function findFirstBalancedBraces(text: string): string | undefined {
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+
+    if (start === -1) {
+      if (ch === "{") {
+        start = i;
+        depth = 1;
+      }
+      continue;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      depth += 1;
+      continue;
+    }
+    if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function createFallbackRoadmap(assessment: SessionAssessment): IterationRoadmap {
+  const roles = assessment.roles.length > 0 ? assessment.roles : ["worker"];
+  return {
+    source: "fallback",
+    stages: roles.map((role, index) => ({
+      id: `stage-${index + 1}-${sanitizeStageId(role)}`,
+      title: `Run ${role}`,
+      role,
+      prompt:
+        `Work toward goal: ${assessment.goal}. ` +
+        `Success criteria: ${assessment.successCriteria.join("; ") || "complete the goal"}.`,
+      successCriteria: [...assessment.successCriteria],
+    })),
+  };
+}
+
+export function parseIterationRoadmap(
+  plannerOutput: string,
+  assessment: SessionAssessment,
+): IterationRoadmap {
+  const jsonText = findFirstBalancedBraces(plannerOutput);
+  if (jsonText === undefined) return createFallbackRoadmap(assessment);
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(jsonText);
+  } catch {
+    return createFallbackRoadmap(assessment);
+  }
+
+  const parsed = IterationRoadmapSchema.safeParse(parsedJson);
+  if (!parsed.success) return createFallbackRoadmap(assessment);
+
+  return {
+    source: "planner",
+    stages: parsed.data.stages.map(normalizeStage),
+  };
+}
+
+export function createInterruptController(opts?: {
+  readonly forceExit?: ((reason: string) => void) | undefined;
+  readonly onInterrupt?: ((reason: string) => void) | undefined;
+}): InterruptController {
+  let requested = false;
+  let storedReason: string | undefined;
+
+  return {
+    get interruptRequested(): boolean {
+      return requested;
+    },
+    get reason(): string | undefined {
+      return storedReason;
+    },
+    requestInterrupt(reason = "Interrupted"): void {
+      if (requested) {
+        opts?.forceExit?.(reason);
+        return;
+      }
+      requested = true;
+      storedReason = reason;
+      opts?.onInterrupt?.(reason);
+    },
+  };
+}
+
+export interface SignalEmitter {
+  on(signal: "SIGINT" | "SIGTERM", handler: () => void): unknown;
+  removeListener(signal: "SIGINT" | "SIGTERM", handler: () => void): unknown;
+}
+
+export interface InstalledInterruptHandlers {
+  readonly interrupt: InterruptController;
+  dispose(): void;
+}
+
+export function installProcessInterruptHandlers(
+  emitter: SignalEmitter,
+  opts?: {
+    readonly forceExit?: ((code: number) => void) | undefined;
+    readonly onInterrupt?: ((reason: string) => void) | undefined;
+  },
+): InstalledInterruptHandlers {
+  const interrupt = createInterruptController({
+    forceExit: () => opts?.forceExit?.(130),
+    onInterrupt: opts?.onInterrupt,
+  });
+  const onSigint = (): void => interrupt.requestInterrupt("User interrupted (SIGINT)");
+  const onSigterm = (): void => interrupt.requestInterrupt("Terminated (SIGTERM)");
+
+  emitter.on("SIGINT", onSigint);
+  emitter.on("SIGTERM", onSigterm);
+
+  return {
+    interrupt,
+    dispose(): void {
+      emitter.removeListener("SIGINT", onSigint);
+      emitter.removeListener("SIGTERM", onSigterm);
+    },
+  };
+}
+
+export class GroveLoopRunner {
+  private readonly options: GroveLoopRunnerOptions;
+  private readonly maxIterations: number;
+  private readonly maxNoImprovementRounds: number;
+  private readonly improvementThreshold: number;
+  private readonly improvementDirection: ImprovementDirection;
+
+  constructor(options: GroveLoopRunnerOptions) {
+    this.options = options;
+    this.maxIterations = options.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+    this.maxNoImprovementRounds =
+      options.maxNoImprovementRounds ?? DEFAULT_MAX_NO_IMPROVEMENT_ROUNDS;
+    this.improvementThreshold = options.improvementThreshold ?? DEFAULT_IMPROVEMENT_THRESHOLD;
+    this.improvementDirection = options.improvementDirection ?? "maximize";
+  }
+
+  async run(): Promise<WorkflowState> {
+    const now = this.options.now ?? (() => new Date().toISOString());
+    const roadmap =
+      this.options.roadmap ??
+      parseIterationRoadmap(this.options.plannerOutput ?? "", this.options.assessment);
+
+    let state: WorkflowState = {
+      workflowId: this.options.workflowId,
+      sessionId: this.options.sessionId,
+      assessment: this.options.assessment,
+      roadmap,
+      status: "running",
+      currentIteration: 0,
+      iterations: [],
+      noImprovementRounds: 0,
+      startedAt: now(),
+      updatedAt: now(),
+    };
+
+    await this.persist(state);
+
+    if (hasInterruptRequest(this.options.interrupt)) {
+      return this.complete(state, LoopStopStatus.Interrupted, interruptReason(this.options), now);
+    }
+
+    while (state.status === "running") {
+      const iteration = state.currentIteration + 1;
+      const stage = roadmap.stages[(iteration - 1) % roadmap.stages.length];
+      if (stage === undefined) {
+        return this.complete(state, LoopStopStatus.Error, "Roadmap has no stages", now);
+      }
+
+      const startedAt = now();
+      let result: LoopIterationResult;
+      try {
+        result = await this.options.executeIteration({
+          workflowId: this.options.workflowId,
+          sessionId: this.options.sessionId,
+          iteration,
+          stage,
+          state,
+        });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        return this.complete(state, LoopStopStatus.Error, reason, now);
+      }
+
+      const improvement = calculateImprovement({
+        score: result.score,
+        bestScore: state.bestScore,
+        direction: this.improvementDirection,
+        threshold: this.improvementThreshold,
+      });
+      const completedAt = now();
+      const nextIterations: LoopIterationRecord[] = [
+        ...state.iterations,
+        {
+          iteration,
+          stageId: stage.id,
+          startedAt,
+          completedAt,
+          score: result.score,
+          improved: improvement.improved,
+          summary: result.summary,
+        },
+      ];
+
+      state = {
+        ...state,
+        currentIteration: iteration,
+        iterations: nextIterations,
+        bestScore: improvement.bestScore,
+        noImprovementRounds: improvement.improved ? 0 : state.noImprovementRounds + 1,
+        updatedAt: completedAt,
+      };
+      await this.persist(state);
+
+      if (hasInterruptRequest(this.options.interrupt)) {
+        return this.complete(state, LoopStopStatus.Interrupted, interruptReason(this.options), now);
+      }
+      if (result.stopStatus !== undefined) {
+        return this.complete(
+          state,
+          result.stopStatus,
+          result.summary ?? `Stopped with ${result.stopStatus}`,
+          now,
+        );
+      }
+      if (result.achieved === true) {
+        return this.complete(state, LoopStopStatus.Achieved, result.summary ?? "Achieved", now);
+      }
+      if (state.noImprovementRounds >= this.maxNoImprovementRounds) {
+        return this.complete(
+          state,
+          LoopStopStatus.Plateau,
+          `No improvement for ${state.noImprovementRounds} rounds`,
+          now,
+        );
+      }
+      if (iteration >= this.maxIterations) {
+        return this.complete(
+          state,
+          LoopStopStatus.MaxIterations,
+          `Reached max iterations (${this.maxIterations})`,
+          now,
+        );
+      }
+    }
+
+    return state;
+  }
+
+  private async complete(
+    state: WorkflowState,
+    status: LoopStopStatus,
+    reason: string,
+    now: () => string,
+  ): Promise<WorkflowState> {
+    const completedAt = now();
+    const completed: WorkflowState = {
+      ...state,
+      status,
+      reason,
+      updatedAt: completedAt,
+      completedAt,
+    };
+    await this.persist(completed);
+    return completed;
+  }
+
+  private async persist(state: WorkflowState): Promise<void> {
+    await this.options.workflowStore?.saveWorkflowState(state);
+  }
+}
+
+function normalizeStage(stage: ParsedIterationStage): IterationStage {
+  return {
+    id: stage.id,
+    title: stage.title,
+    role: stage.role,
+    prompt: stage.prompt,
+    successCriteria: [...(stage.successCriteria ?? stage.success_criteria ?? [])],
+  };
+}
+
+function sanitizeStageId(input: string): string {
+  const lowered = input.toLowerCase();
+  const safe = lowered.replaceAll(/[^a-z0-9]+/g, "-").replaceAll(/^-|-$/g, "");
+  return safe.length > 0 ? safe : "role";
+}
+
+function interruptReason(options: GroveLoopRunnerOptions): string {
+  return options.interrupt?.reason ?? "Interrupted";
+}
+
+function hasInterruptRequest(interrupt: InterruptController | undefined): boolean {
+  return interrupt?.interruptRequested === true;
+}
+
+function calculateImprovement(opts: {
+  readonly score: number | undefined;
+  readonly bestScore: number | undefined;
+  readonly direction: ImprovementDirection;
+  readonly threshold: number;
+}): { readonly improved: boolean; readonly bestScore: number | undefined } {
+  if (opts.score === undefined) {
+    return { improved: false, bestScore: opts.bestScore };
+  }
+  if (opts.bestScore === undefined) {
+    return { improved: true, bestScore: opts.score };
+  }
+
+  const delta =
+    opts.direction === "minimize" ? opts.bestScore - opts.score : opts.score - opts.bestScore;
+  if (delta >= opts.threshold) {
+    return { improved: true, bestScore: opts.score };
+  }
+  return { improved: false, bestScore: opts.bestScore };
+}

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -9,6 +9,7 @@
  *   next time: grove up              -> SessionManager.createSession(newGoal)
  */
 
+import type { LoopStopStatus } from "./loop-runner.js";
 import type {
   CreateSessionInput,
   Session,
@@ -47,18 +48,20 @@ export class SessionManager {
   }
 
   /** Mark a session as completed. */
-  async completeSession(id: string, reason?: string): Promise<void> {
+  async completeSession(id: string, reason?: string, stopStatus?: LoopStopStatus): Promise<void> {
     await this.transitionState(id, "completed", {
       completedAt: new Date().toISOString(),
       ...(reason !== undefined ? { stopReason: reason } : {}),
+      ...(stopStatus !== undefined ? { stopStatus } : {}),
     });
   }
 
   /** Cancel a session. */
-  async cancelSession(id: string, reason?: string): Promise<void> {
+  async cancelSession(id: string, reason?: string, stopStatus?: LoopStopStatus): Promise<void> {
     await this.transitionState(id, "cancelled", {
       completedAt: new Date().toISOString(),
       stopReason: reason ?? "User cancelled",
+      ...(stopStatus !== undefined ? { stopStatus } : {}),
     });
   }
 

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { GroveContract } from "./contract.js";
 import { LocalEventBus } from "./local-event-bus.js";
+import { LoopStopStatus } from "./loop-runner.js";
 import { MockRuntime } from "./mock-runtime.js";
 import {
   computeRoutingSignatureForContribution,
@@ -133,6 +134,37 @@ describe("SessionOrchestrator", () => {
     bus.close();
   });
 
+  test("start does not resend goals for runtimes that prompt during spawn", async () => {
+    const contract = makeContract();
+    const runtime = new MockRuntime();
+    Object.assign(runtime, { sendsInitialPromptOnSpawn: true });
+    const { orchestrator, bus } = makeOrchestrator(contract, { runtime });
+
+    await orchestrator.start();
+
+    expect(runtime.sendCalls).toHaveLength(0);
+    bus.close();
+  });
+
+  test("start forwards Grove MCP server through AgentConfig", async () => {
+    const contract = makeContract();
+    const { orchestrator, runtime, bus } = makeOrchestrator(contract, {
+      sessionId: "session-mcp-forward",
+    });
+
+    await orchestrator.start();
+
+    const coderConfig = runtime.spawnCalls.find((call) => call.role === "coder")?.config;
+    expect(coderConfig?.mcpServers).toHaveLength(1);
+    expect(coderConfig?.mcpServers?.[0]?.name).toBe("grove");
+    expect(coderConfig?.mcpServers?.[0]?.command).toBe("bun");
+    expect(coderConfig?.mcpServers?.[0]?.args?.join(" ")).toContain("mcp/serve");
+    expect(coderConfig?.mcpServers?.[0]?.env?.GROVE_DIR).toBe("/tmp/.grove");
+    expect(coderConfig?.mcpServers?.[0]?.env?.GROVE_AGENT_ROLE).toBe("coder");
+    expect(coderConfig?.mcpServers?.[0]?.env?.GROVE_SESSION_ID).toBe("session-mcp-forward");
+    bus.close();
+  });
+
   test("stop closes all agents", async () => {
     const contract = makeContract();
     const { orchestrator, runtime, bus } = makeOrchestrator(contract);
@@ -147,6 +179,20 @@ describe("SessionOrchestrator", () => {
     const status = orchestrator.getStatus();
     expect(status.stopped).toBe(true);
     expect(status.stopReason).toBe("Budget exceeded");
+    expect(runtime.closeCalls).toHaveLength(2);
+    bus.close();
+  });
+
+  test("stop records semantic stop status", async () => {
+    const contract = makeContract();
+    const { orchestrator, runtime, bus } = makeOrchestrator(contract);
+
+    await orchestrator.start();
+    await orchestrator.stop("Operator interrupted", LoopStopStatus.Interrupted);
+
+    const status = orchestrator.getStatus();
+    expect(status.stopped).toBe(true);
+    expect(status.stopStatus).toBe(LoopStopStatus.Interrupted);
     expect(runtime.closeCalls).toHaveLength(2);
     bus.close();
   });
@@ -304,6 +350,157 @@ describe("SessionOrchestrator", () => {
     // 2 initial goal sends + 1 routed handoff to reviewer.
     expect(runtime.sendCalls).toHaveLength(3);
     expect(runtime.sendCalls[2]!.message).toContain("local coder contribution");
+    bus.close();
+  });
+
+  test("polling waits for every role to signal done before stopping", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    const contract = makeContract();
+    const contributions: ReturnType<typeof makeContribution>[] = [];
+    const contributionStore = {
+      list: async () => contributions,
+    };
+
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract,
+      topology: contract.topology!,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+      contributionStore,
+    });
+    const internals = orchestrator as unknown as {
+      startContributionPolling: () => void;
+      pollContributions: () => Promise<void>;
+    };
+    internals.startContributionPolling = () => undefined;
+
+    const started = await orchestrator.start();
+    const coderSessionId = started.agents.find((a) => a.role === "coder")?.session.id;
+    const reviewerSessionId = started.agents.find((a) => a.role === "reviewer")?.session.id;
+    const coderToken = runtime.spawnCalls.find((c) => c.role === "coder")?.config.env
+      ?.GROVE_ROUTING_TOKEN;
+    const reviewerToken = runtime.spawnCalls.find((c) => c.role === "reviewer")?.config.env
+      ?.GROVE_ROUTING_TOKEN;
+
+    contributions.push(
+      signContributionForRouting(
+        makeContribution({
+          summary: "[DONE] coder done",
+          context: { done: true },
+          agent: { agentId: coderSessionId ?? "missing", role: "coder" },
+        }),
+        coderToken ?? "missing-token",
+      ),
+    );
+    await internals.pollContributions();
+
+    expect(orchestrator.getStatus().stopped).toBe(false);
+
+    contributions.push(
+      signContributionForRouting(
+        makeContribution({
+          summary: "[DONE] reviewer done",
+          context: { done: true },
+          agent: { agentId: reviewerSessionId ?? "missing", role: "reviewer" },
+        }),
+        reviewerToken ?? "missing-token",
+      ),
+    );
+    await internals.pollContributions();
+
+    const final = orchestrator.getStatus();
+    expect(final.stopped).toBe(true);
+    expect(final.stopStatus).toBe(LoopStopStatus.Achieved);
+    bus.close();
+  });
+
+  test("polling stops when terminal reviewer signals done but ignores non-terminal coder done", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    const contract = makeContract({
+      topology: {
+        structure: "graph",
+        roles: [
+          {
+            name: "coder",
+            description: "Write code",
+            command: "echo coder",
+            edges: [{ target: "reviewer", edgeType: "delegates" }],
+          },
+          {
+            name: "reviewer",
+            description: "Review code",
+            command: "echo reviewer",
+          },
+        ],
+      },
+    });
+    const contributions: ReturnType<typeof makeContribution>[] = [];
+    const contributionStore = {
+      list: async () => contributions,
+    };
+
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract,
+      topology: contract.topology!,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+      contributionStore,
+    });
+    const internals = orchestrator as unknown as {
+      startContributionPolling: () => void;
+      pollContributions: () => Promise<void>;
+    };
+    internals.startContributionPolling = () => undefined;
+
+    const started = await orchestrator.start();
+    const coderSessionId = started.agents.find((a) => a.role === "coder")?.session.id;
+    const reviewerSessionId = started.agents.find((a) => a.role === "reviewer")?.session.id;
+    const coderToken = runtime.spawnCalls.find((c) => c.role === "coder")?.config.env
+      ?.GROVE_ROUTING_TOKEN;
+    const reviewerToken = runtime.spawnCalls.find((c) => c.role === "reviewer")?.config.env
+      ?.GROVE_ROUTING_TOKEN;
+
+    contributions.push(
+      signContributionForRouting(
+        makeContribution({
+          summary: "[DONE] coder done",
+          context: { done: true },
+          agent: { agentId: coderSessionId ?? "missing", role: "coder" },
+        }),
+        coderToken ?? "missing-token",
+      ),
+    );
+    await internals.pollContributions();
+
+    expect(orchestrator.getStatus().stopped).toBe(false);
+
+    contributions.push(
+      signContributionForRouting(
+        makeContribution({
+          summary: "[DONE] reviewer done",
+          context: { done: true },
+          agent: { agentId: reviewerSessionId ?? "missing", role: "reviewer" },
+        }),
+        reviewerToken ?? "missing-token",
+      ),
+    );
+    await internals.pollContributions();
+
+    const final = orchestrator.getStatus();
+    expect(final.stopped).toBe(true);
+    expect(final.stopStatus).toBe(LoopStopStatus.Achieved);
     bus.close();
   });
 

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -13,6 +13,7 @@ import type { AgentProfile } from "./agent-profile.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
 import type { GroveContract } from "./contract.js";
 import type { EventBus, GroveEvent } from "./event-bus.js";
+import { LoopStopStatus, type LoopStopStatus as LoopStopStatusValue } from "./loop-runner.js";
 import { type ResolvedRepo, type ResolveRepoOptions, resolveRepo } from "./repo-cache.js";
 import type { RepoRef } from "./repo-ref.js";
 import { resolveBundledSkillsRoot, resolveMcpServePath } from "./resolve-mcp-serve-path.js";
@@ -101,6 +102,7 @@ export interface SessionStatus {
   readonly started: boolean;
   readonly stopped: boolean;
   readonly stopReason?: string | undefined;
+  readonly stopStatus?: LoopStopStatusValue | undefined;
 }
 
 /** Info about a single agent in the session. */
@@ -138,7 +140,9 @@ export class SessionOrchestrator {
   private eventHandlers?: Map<string, import("./event-bus.js").EventHandler>;
   private stopped = false;
   private stopReason: string | undefined;
+  private stopStatus: LoopStopStatusValue | undefined;
   private contributionCount = 0;
+  private readonly doneRoles = new Set<string>();
   private startedAt = 0;
   private readonly seenCids = new Set<string>();
   private contributionPollTimer: ReturnType<typeof setInterval> | null = null;
@@ -228,12 +232,10 @@ export class SessionOrchestrator {
 
     this.startedAt = Date.now();
 
-    // AcpxRuntime sends the initial goal during spawn(). MockRuntime does not.
-    // Send goals only to agents whose runtime status is still "running" but
-    // haven't received a prompt yet (i.e., non-acpx runtimes).
-    // We detect this by checking if the runtime exposes AcpxRuntime's
-    // `startTurn` internal helper.
-    if (!("startTurn" in this.config.runtime)) {
+    // Some runtimes start config.goal/config.prompt as part of spawn().
+    // Lightweight test/runtime adapters do not, so the orchestrator sends the
+    // initial role goal for them.
+    if (this.config.runtime.sendsInitialPromptOnSpawn !== true) {
       for (const agent of this.agents) {
         const turn = await this.config.runtime.send(agent.session, agent.goal);
         this.watchTurn(agent.role, turn);
@@ -269,9 +271,14 @@ export class SessionOrchestrator {
   }
 
   /** Stop the session gracefully. */
-  async stop(reason: string): Promise<void> {
+  async stop(
+    reason: string,
+    stopStatus: LoopStopStatusValue = LoopStopStatus.Achieved,
+  ): Promise<void> {
+    if (this.stopped) return;
     this.stopped = true;
     this.stopReason = reason;
+    this.stopStatus = stopStatus;
 
     // Stop contribution polling
     if (this.contributionPollStartTimer) {
@@ -390,19 +397,37 @@ export class SessionOrchestrator {
           }
         }
 
-        // Detect [DONE] signal — stop the session when any agent signals done.
-        // This mirrors what use-done-detection.ts does in the TUI layer.
+        // Detect [DONE] signal. A single role being done is not enough to end
+        // a multi-agent session; the runner stops only after all spawned roles
+        // have signaled done.
         if (
           c.summary.startsWith("[DONE]") ||
           (c.context && (c.context as Record<string, unknown>).done === true)
         ) {
-          void this.stop(`Agent ${sourceRole} signaled done: ${c.summary}`);
-          return;
+          this.doneRoles.add(sourceRole);
+          const requiredDoneRoles = this.doneRequiredRoleNames();
+          const requiredDone =
+            requiredDoneRoles.length > 0 &&
+            requiredDoneRoles.every((role) => this.doneRoles.has(role));
+          if (requiredDone) {
+            void this.stop("Required agents signaled done", LoopStopStatus.Achieved);
+            return;
+          }
         }
       }
-    } catch {
-      // Best effort — don't crash on poll errors
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[SessionOrchestrator] contribution poll failed: ${message}\n`);
     }
+  }
+
+  private doneRequiredRoleNames(): readonly string[] {
+    const spawnedRoleNames = new Set(this.agents.map((agent) => agent.role));
+    const terminalRoles = this.config.topology.roles
+      .filter((role) => spawnedRoleNames.has(role.name) && (role.edges?.length ?? 0) === 0)
+      .map((role) => role.name);
+    if (terminalRoles.length > 0) return terminalRoles;
+    return [...spawnedRoleNames];
   }
 
   /** Get current session status. */
@@ -414,6 +439,7 @@ export class SessionOrchestrator {
       started: this.agents.length > 0,
       stopped: this.stopped,
       stopReason: this.stopReason,
+      stopStatus: this.stopStatus,
     };
   }
 
@@ -449,6 +475,7 @@ export class SessionOrchestrator {
       model: resolved.model,
       cwd,
       goal: fullGoal,
+      mcpServers: [this.groveMcpServer(role.name)],
       env: {
         GROVE_SESSION_ID: this.sessionId,
         GROVE_ROLE: role.name,
@@ -466,6 +493,22 @@ export class SessionOrchestrator {
       session,
       goal: fullGoal,
       workspaceMode,
+    };
+  }
+
+  private groveMcpServer(roleName: string): NonNullable<AgentConfig["mcpServers"]>[number] {
+    const env: Record<string, string> = {
+      GROVE_DIR: join(this.config.projectRoot, ".grove"),
+      GROVE_AGENT_ROLE: roleName,
+      GROVE_SESSION_ID: this.sessionId,
+    };
+    if (process.env.GROVE_NEXUS_URL) env.GROVE_NEXUS_URL = process.env.GROVE_NEXUS_URL;
+    if (process.env.NEXUS_API_KEY) env.NEXUS_API_KEY = process.env.NEXUS_API_KEY;
+    return {
+      name: "grove",
+      command: "bun",
+      args: ["run", resolveMcpServePath(this.config.projectRoot)],
+      env,
     };
   }
 
@@ -570,7 +613,7 @@ export class SessionOrchestrator {
       if (!this.stopped) {
         const reason =
           typeof event.payload.reason === "string" ? event.payload.reason : "Stop condition met";
-        void this.stop(reason);
+        void this.stop(reason, LoopStopStatus.Achieved);
       }
       return;
     }
@@ -618,7 +661,7 @@ export class SessionOrchestrator {
       if (this.contributionCount === 0 && elapsed < GRACE_PERIOD_MS) {
         return; // Too early — wait for at least one contribution or grace period
       }
-      await this.stop("All agents idle — session complete");
+      await this.stop("All agents idle — session complete", LoopStopStatus.Achieved);
     }
   }
 
@@ -644,7 +687,7 @@ export class SessionOrchestrator {
         if (this.stopped || Date.now() >= deadline) {
           clearInterval(poll);
           if (!this.stopped) {
-            void this.stop("Session timed out");
+            void this.stop("Session timed out", LoopStopStatus.MaxIterations);
           }
           resolve(this.stopReason ?? "Timed out");
         }

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -6,6 +6,7 @@
  */
 
 import type { GroveContract } from "./contract.js";
+import type { LoopStopStatus } from "./loop-runner.js";
 import type { AgentTopology } from "./topology.js";
 
 // ---------------------------------------------------------------------------
@@ -36,6 +37,8 @@ export interface Session {
   readonly createdAt: string;
   readonly completedAt?: string | undefined;
   readonly stopReason?: string | undefined;
+  /** Machine-readable final loop status for operator UI and automation. */
+  readonly stopStatus?: LoopStopStatus | undefined;
   /** Resolved topology at session creation time (immutable once set). */
   readonly topology?: AgentTopology | undefined;
   /** Number of contributions linked to this session. */
@@ -93,10 +96,10 @@ export interface SessionStore {
   /** Get a session by ID. Returns undefined if not found. */
   getSession(id: string): Promise<Session | undefined>;
 
-  /** Update mutable session fields (status, completedAt, stopReason). */
+  /** Update mutable session fields (status, completedAt, stopReason, stopStatus). */
   updateSession(
     id: string,
-    updates: Partial<Pick<Session, "status" | "completedAt" | "stopReason">>,
+    updates: Partial<Pick<Session, "status" | "completedAt" | "stopReason" | "stopStatus">>,
   ): Promise<void>;
 
   /** List sessions with optional filters, ordered by creation time descending. */

--- a/src/core/subprocess-runtime.ts
+++ b/src/core/subprocess-runtime.ts
@@ -157,6 +157,8 @@ function splitCommand(command: string): string[] {
 }
 
 export class SubprocessRuntime implements AgentRuntime {
+  readonly sendsInitialPromptOnSpawn = true;
+
   private sessions = new Map<string, SessionEntry>();
   private nextId = 0;
 

--- a/src/core/tmux-runtime.ts
+++ b/src/core/tmux-runtime.ts
@@ -71,6 +71,8 @@ interface TmuxSessionEntry {
 }
 
 export class TmuxRuntime implements AgentRuntime {
+  readonly sendsInitialPromptOnSpawn = true;
+
   private sessions: Map<string, TmuxSessionEntry> = new Map();
   private nextId = 0;
 

--- a/src/local/sqlite-goal-session-store.test.ts
+++ b/src/local/sqlite-goal-session-store.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { LoopStopStatus } from "../core/loop-runner.js";
 import type { SessionStore } from "../core/session.js";
 import { sessionStoreConformance } from "../core/session-store.conformance.js";
 import { makeContribution } from "../core/test-helpers.js";
@@ -218,6 +219,23 @@ describe("updateSession", () => {
     expect(fetched!.status).toBe("completed");
     expect(fetched!.completedAt).toBe(completedAt);
     expect(fetched!.stopReason).toBe("done");
+  });
+
+  it("persists semantic stopStatus through getSession and listSessions", async () => {
+    const s = await store.createSession({});
+    const completedAt = new Date().toISOString();
+    await store.updateSession(s.id, {
+      status: "completed",
+      completedAt,
+      stopReason: "No improvement for 5 rounds",
+      stopStatus: LoopStopStatus.Plateau,
+    });
+
+    const fetched = await store.getSession(s.id);
+    expect(fetched!.stopStatus).toBe(LoopStopStatus.Plateau);
+
+    const listed = await store.listSessions({ includeArchived: true });
+    expect(listed.find((session) => session.id === s.id)?.stopStatus).toBe(LoopStopStatus.Plateau);
   });
 
   it("updateSession({ status: 'archived' }) delegates to archiveSession", async () => {

--- a/src/local/sqlite-goal-session-store.ts
+++ b/src/local/sqlite-goal-session-store.ts
@@ -272,6 +272,7 @@ export const GOAL_SESSION_DDL = `
     started_at TEXT NOT NULL,
     ended_at TEXT,
     stop_reason TEXT,
+    stop_status TEXT,
     archived_at INTEGER,
     contribution_count INTEGER NOT NULL DEFAULT 0
   );
@@ -326,6 +327,7 @@ interface SessionRow {
   started_at: string;
   ended_at: string | null;
   stop_reason: string | null;
+  stop_status: import("../core/loop-runner.js").LoopStopStatus | null;
   archived_at: number | null;
   contribution_count: number;
 }
@@ -342,6 +344,7 @@ interface SessionListRow {
   started_at: string;
   ended_at: string | null;
   stop_reason: string | null;
+  stop_status: import("../core/loop-runner.js").LoopStopStatus | null;
   contribution_count: number;
 }
 
@@ -366,10 +369,10 @@ export interface GoalSessionStore {
   /** Get a session by ID. */
   getSession(sessionId: string): Promise<Session | undefined>;
 
-  /** Update mutable session fields (status, completedAt, stopReason). */
+  /** Update mutable session fields (status, completedAt, stopReason, stopStatus). */
   updateSession(
     sessionId: string,
-    updates: Partial<Pick<Session, "status" | "completedAt" | "stopReason">>,
+    updates: Partial<Pick<Session, "status" | "completedAt" | "stopReason" | "stopStatus">>,
   ): Promise<void>;
 
   /** Archive a session, setting its ended_at timestamp and archived_at epoch. */
@@ -434,6 +437,7 @@ function rowToSession(row: SessionRow): Session {
     createdAt: row.started_at,
     completedAt: row.ended_at ?? undefined,
     stopReason: row.stop_reason ?? undefined,
+    stopStatus: row.stop_status ?? undefined,
     topology: row.topology_json ? (JSON.parse(row.topology_json) as AgentTopology) : undefined,
     contributionCount: row.contribution_count,
     config,
@@ -453,6 +457,7 @@ function listRowToSession(row: SessionListRow): Session {
     createdAt: row.started_at,
     completedAt: row.ended_at ?? undefined,
     stopReason: row.stop_reason ?? undefined,
+    stopStatus: row.stop_status ?? undefined,
     topology: undefined,
     contributionCount: row.contribution_count,
     // config intentionally omitted from list results for performance
@@ -544,7 +549,7 @@ export class SqliteGoalSessionStore implements GoalSessionStore {
   listSessions = async (query?: SessionQuery): Promise<readonly Session[]> => {
     const baseSelect = `
       SELECT s.session_id, s.goal, s.preset_name, s.status, s.started_at, s.ended_at,
-             s.stop_reason, s.contribution_count
+             s.stop_reason, s.stop_status, s.contribution_count
       FROM sessions s
     `;
 
@@ -689,20 +694,22 @@ export class SqliteGoalSessionStore implements GoalSessionStore {
    */
   updateSession = async (
     sessionId: string,
-    updates: Partial<Pick<Session, "status" | "completedAt" | "stopReason">>,
+    updates: Partial<Pick<Session, "status" | "completedAt" | "stopReason" | "stopStatus">>,
   ): Promise<void> => {
     const hasStatus = updates.status !== undefined;
     const hasCompletedAt = updates.completedAt !== undefined;
     const hasStopReason = updates.stopReason !== undefined;
+    const hasStopStatus = updates.stopStatus !== undefined;
 
     // Route archiving through archiveSession() for consistency
     if (hasStatus && updates.status === "archived") {
       await this.archiveSession(sessionId);
       // Also apply completedAt/stopReason overrides if provided
-      if (hasCompletedAt || hasStopReason) {
+      if (hasCompletedAt || hasStopReason || hasStopStatus) {
         await this.updateSession(sessionId, {
           ...(hasCompletedAt ? { completedAt: updates.completedAt } : {}),
           ...(hasStopReason ? { stopReason: updates.stopReason } : {}),
+          ...(hasStopStatus ? { stopStatus: updates.stopStatus } : {}),
         });
       }
       return;
@@ -711,9 +718,18 @@ export class SqliteGoalSessionStore implements GoalSessionStore {
     const status = updates.status;
     const completedAt = updates.completedAt;
     const stopReason = updates.stopReason;
+    const stopStatus = updates.stopStatus;
 
     // Pattern: all three fields — most common from session completion
-    if (hasStatus && hasCompletedAt && hasStopReason && status && completedAt && stopReason) {
+    if (
+      hasStatus &&
+      hasCompletedAt &&
+      hasStopReason &&
+      !hasStopStatus &&
+      status &&
+      completedAt &&
+      stopReason
+    ) {
       this.stmtCompleteSession ??= this.db.prepare(
         "UPDATE sessions SET status = ?, ended_at = ?, stop_reason = ? WHERE session_id = ?",
       );
@@ -754,6 +770,10 @@ export class SqliteGoalSessionStore implements GoalSessionStore {
     if (stopReason) {
       setClauses.push("stop_reason = ?");
       params.push(stopReason);
+    }
+    if (stopStatus) {
+      setClauses.push("stop_status = ?");
+      params.push(stopStatus);
     }
 
     if (setClauses.length === 0) return;

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -53,7 +53,7 @@ import { claimToEntity, contributionToEntity } from "../core/entity.js";
 import { ClaimConflictError, NotFoundError, StateConflictError } from "../core/errors.js";
 import { toUtcIso } from "../core/time.js";
 
-export const CURRENT_SCHEMA_VERSION = 12;
+export const CURRENT_SCHEMA_VERSION = 13;
 const SQLITE_BIND_LIMIT = 900;
 
 // ---------------------------------------------------------------------------
@@ -430,6 +430,9 @@ export function initSqliteDb(dbPath: string): Database {
         if (!sessionColNames.has("stop_reason")) {
           db.run("ALTER TABLE sessions ADD COLUMN stop_reason TEXT");
         }
+        if (!sessionColNames.has("stop_status")) {
+          db.run("ALTER TABLE sessions ADD COLUMN stop_status TEXT");
+        }
       }
     }
 
@@ -514,6 +517,23 @@ export function initSqliteDb(dbPath: string): Database {
     // Migration → v11: create project_settings table (key-value store for
     // per-grove settings like the migrated namespace from `grove migrate`).
     // Handled by SCHEMA_DDL CREATE TABLE IF NOT EXISTS — no ALTER needed.
+
+    // Migration → v13: add stop_status to sessions for semantic loop results.
+    {
+      const sessionTableExists =
+        (db
+          .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'")
+          .get() as { name: string } | null) !== null;
+      if (sessionTableExists) {
+        const sessionCols = db.prepare("PRAGMA table_info(sessions)").all() as readonly {
+          name: string;
+        }[];
+        const sessionColNames = new Set(sessionCols.map((c) => c.name));
+        if (!sessionColNames.has("stop_status")) {
+          db.run("ALTER TABLE sessions ADD COLUMN stop_status TEXT");
+        }
+      }
+    }
 
     db.run("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)", [
       CURRENT_SCHEMA_VERSION,

--- a/src/nexus/index.ts
+++ b/src/nexus/index.ts
@@ -33,4 +33,6 @@ export { NexusContributionStore } from "./nexus-contribution-store.js";
 export type { NexusHttpConfig } from "./nexus-http-client.js";
 export { NexusHttpClient } from "./nexus-http-client.js";
 export { NexusOutcomeStore } from "./nexus-outcome-store.js";
+export type { NexusWorkflowStoreConfig } from "./nexus-workflow-store.js";
+export { NexusWorkflowStore } from "./nexus-workflow-store.js";
 export { Semaphore } from "./semaphore.js";

--- a/src/nexus/nexus-http-client.ts
+++ b/src/nexus/nexus-http-client.ts
@@ -280,7 +280,12 @@ export class NexusHttpClient implements NexusClient {
       encoding: "utf8",
     };
     if (opts?.ifMatch !== undefined) body.if_match = opts.ifMatch;
-    if (opts?.ifNoneMatch !== undefined) body.if_none_match = opts.ifNoneMatch;
+    if (opts?.ifNoneMatch !== undefined) {
+      // Grove's storage port uses the HTTP If-None-Match "*" sentinel for
+      // create-only writes. Nexus REST v0.10 models the same condition as a
+      // boolean field instead of the raw header value.
+      body.if_none_match = opts.ifNoneMatch === "*";
+    }
 
     const result = await this.request("POST", "/api/v2/files/write", WriteResponseSchema, {
       body,

--- a/src/nexus/nexus-session-store.ts
+++ b/src/nexus/nexus-session-store.ts
@@ -74,7 +74,7 @@ export class NexusSessionStore implements SessionStore {
 
   async updateSession(
     id: string,
-    updates: Partial<Pick<Session, "status" | "completedAt" | "stopReason">>,
+    updates: Partial<Pick<Session, "status" | "completedAt" | "stopReason" | "stopStatus">>,
   ): Promise<void> {
     const existing = await this.getSession(id);
     if (!existing) return;

--- a/src/nexus/nexus-workflow-store.test.ts
+++ b/src/nexus/nexus-workflow-store.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createFallbackRoadmap,
+  LoopStopStatus,
+  type SessionAssessment,
+  type WorkflowState,
+} from "../core/loop-runner.js";
+import { MockNexusClient } from "./mock-client.js";
+import { NexusWorkflowStore } from "./nexus-workflow-store.js";
+import { workflowPath } from "./vfs-paths.js";
+
+const assessment: SessionAssessment = {
+  goal: "Run review loop",
+  roles: ["coder", "reviewer"],
+  successCriteria: ["approved"],
+  constraints: ["wait for reviewer"],
+};
+
+function makeState(overrides?: Partial<WorkflowState>): WorkflowState {
+  return {
+    workflowId: "workflow-1",
+    sessionId: "session-1",
+    assessment,
+    roadmap: createFallbackRoadmap(assessment),
+    status: "running",
+    currentIteration: 0,
+    iterations: [],
+    noImprovementRounds: 0,
+    startedAt: "2026-05-05T00:00:00.000Z",
+    updatedAt: "2026-05-05T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("NexusWorkflowStore", () => {
+  test("saves and reads workflow state from the workflows VFS brick", async () => {
+    const client = new MockNexusClient();
+    const store = new NexusWorkflowStore({ client, zoneId: "zone/a" });
+    const state = makeState({ workflowId: "wf/with/slash", bestScore: 0.42 });
+
+    await store.saveWorkflowState(state);
+
+    const loaded = await store.getWorkflowState("wf/with/slash");
+    expect(loaded?.workflowId).toBe("wf/with/slash");
+    expect(loaded?.bestScore).toBe(0.42);
+    expect(await client.exists(workflowPath("zone/a", "wf/with/slash"))).toBe(true);
+  });
+
+  test("overwrites state as the loop advances", async () => {
+    const client = new MockNexusClient();
+    const store = new NexusWorkflowStore({ client, zoneId: "zone-a" });
+
+    await store.saveWorkflowState(makeState({ currentIteration: 1 }));
+    await store.saveWorkflowState(
+      makeState({
+        status: LoopStopStatus.Achieved,
+        currentIteration: 2,
+        completedAt: "2026-05-05T00:01:00.000Z",
+      }),
+    );
+
+    const loaded = await store.getWorkflowState("workflow-1");
+    expect(loaded?.status).toBe(LoopStopStatus.Achieved);
+    expect(loaded?.currentIteration).toBe(2);
+  });
+
+  test("lists workflow states sorted by most recently updated", async () => {
+    const client = new MockNexusClient();
+    const store = new NexusWorkflowStore({ client, zoneId: "zone-a" });
+
+    await store.saveWorkflowState(
+      makeState({ workflowId: "older", updatedAt: "2026-05-05T00:00:00.000Z" }),
+    );
+    await store.saveWorkflowState(
+      makeState({ workflowId: "newer", updatedAt: "2026-05-05T00:02:00.000Z" }),
+    );
+
+    const states = await store.listWorkflowStates();
+    expect(states.map((state) => state.workflowId)).toEqual(["newer", "older"]);
+  });
+
+  test("returns undefined for missing workflow state", async () => {
+    const store = new NexusWorkflowStore({ client: new MockNexusClient(), zoneId: "zone-a" });
+
+    expect(await store.getWorkflowState("missing")).toBeUndefined();
+  });
+});

--- a/src/nexus/nexus-workflow-store.ts
+++ b/src/nexus/nexus-workflow-store.ts
@@ -1,0 +1,77 @@
+/**
+ * Nexus VFS-backed workflow state store.
+ *
+ * Stores deterministic loop-runner state under:
+ *   /zones/{zoneId}/workflows/{workflowId}.json
+ */
+
+import type { WorkflowState, WorkflowStateStore } from "../core/loop-runner.js";
+import type { NexusClient } from "./client.js";
+import { workflowPath, workflowsDir } from "./vfs-paths.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export interface NexusWorkflowStoreConfig {
+  readonly client: NexusClient;
+  readonly zoneId: string;
+}
+
+export class NexusWorkflowStore implements WorkflowStateStore {
+  private readonly client: NexusClient;
+  private readonly zoneId: string;
+
+  constructor(config: NexusWorkflowStoreConfig) {
+    this.client = config.client;
+    this.zoneId = config.zoneId;
+  }
+
+  async saveWorkflowState(state: WorkflowState): Promise<void> {
+    await this.client.write(
+      workflowPath(this.zoneId, state.workflowId),
+      encoder.encode(JSON.stringify(state, null, 2)),
+    );
+  }
+
+  async getWorkflowState(workflowId: string): Promise<WorkflowState | undefined> {
+    const bytes = await this.client.read(workflowPath(this.zoneId, workflowId));
+    if (bytes === undefined) return undefined;
+    return parseWorkflowState(bytes);
+  }
+
+  async listWorkflowStates(): Promise<readonly WorkflowState[]> {
+    const listing = await this.client.list(workflowsDir(this.zoneId));
+    const states: WorkflowState[] = [];
+    for (const file of listing.files) {
+      if (file.isDirectory === true || !file.name.endsWith(".json")) continue;
+      const bytes = await this.client.read(file.path);
+      if (bytes === undefined) continue;
+      const parsed = parseWorkflowState(bytes);
+      if (parsed !== undefined) states.push(parsed);
+    }
+    return states.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+  }
+}
+
+function parseWorkflowState(bytes: Uint8Array): WorkflowState | undefined {
+  try {
+    const parsed = JSON.parse(decoder.decode(bytes)) as unknown;
+    if (!isWorkflowState(parsed)) return undefined;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function isWorkflowState(value: unknown): value is WorkflowState {
+  if (value === null || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.workflowId === "string" &&
+    typeof record.status === "string" &&
+    typeof record.currentIteration === "number" &&
+    Array.isArray(record.iterations) &&
+    typeof record.startedAt === "string" &&
+    typeof record.updatedAt === "string"
+  );
+}

--- a/src/nexus/vfs-paths.test.ts
+++ b/src/nexus/vfs-paths.test.ts
@@ -26,6 +26,8 @@ import {
   relationIndexPath,
   tagIndexPath,
   targetLockPath,
+  workflowPath,
+  workflowsDir,
 } from "./vfs-paths.js";
 
 // ---------------------------------------------------------------------------
@@ -191,6 +193,7 @@ describe("path construction correctness", () => {
   const sourceCid = "blake3source";
   const status = "open";
   const targetRef = "ref-abc";
+  const workflowId = "workflow-001";
 
   test("casPath returns /zones/{zone}/cas/{hash}", () => {
     expect(casPath(zone, hash)).toBe(`/zones/${zone}/cas/${hash}`);
@@ -252,6 +255,14 @@ describe("path construction correctness", () => {
     expect(targetLockPath(zone, targetRef)).toBe(
       `/zones/${zone}/indexes/claims/target-lock/${targetRef}`,
     );
+  });
+
+  test("workflowPath returns /zones/{zone}/workflows/{workflowId}.json", () => {
+    expect(workflowPath(zone, workflowId)).toBe(`/zones/${zone}/workflows/${workflowId}.json`);
+  });
+
+  test("workflowsDir returns /zones/{zone}/workflows", () => {
+    expect(workflowsDir(zone)).toBe(`/zones/${zone}/workflows`);
   });
 });
 

--- a/src/nexus/vfs-paths.ts
+++ b/src/nexus/vfs-paths.ts
@@ -197,3 +197,17 @@ export function outcomeStatusIndexPath(zoneId: string, status: string, cid: stri
 export function outcomeStatusIndexDir(zoneId: string, status: string): string {
   return `/zones/${encodeSegment(zoneId)}/indexes/outcomes/status/${encodeSegment(status)}`;
 }
+
+// ---------------------------------------------------------------------------
+// Workflow paths
+// ---------------------------------------------------------------------------
+
+/** Path to a durable workflow state JSON file. */
+export function workflowPath(zoneId: string, workflowId: string): string {
+  return `/zones/${encodeSegment(zoneId)}/workflows/${encodeSegment(workflowId)}.json`;
+}
+
+/** Directory containing durable workflow state files. */
+export function workflowsDir(zoneId: string): string {
+  return `/zones/${encodeSegment(zoneId)}/workflows`;
+}

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -52,6 +52,8 @@ function toSessionResponse(session: Session) {
     status: session.status,
     startedAt: session.createdAt,
     endedAt: session.completedAt,
+    stopReason: session.stopReason,
+    stopStatus: session.stopStatus,
     contributionCount: session.contributionCount,
     ...(session.topology !== undefined && { topology: session.topology }),
     // Expose the frozen contract snapshot so clients (e.g. NexusProvider mirroring)

--- a/src/server/session-service.test.ts
+++ b/src/server/session-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { GroveContract } from "../core/contract.js";
 import { LocalEventBus } from "../core/local-event-bus.js";
+import { LoopStopStatus } from "../core/loop-runner.js";
 import { MockRuntime } from "../core/mock-runtime.js";
 import type { SessionEvent } from "./session-service.js";
 import { SessionService } from "./session-service.js";
@@ -238,7 +239,11 @@ describe("SessionService", () => {
 
     const completeEvents = events.filter((e) => e.type === "session_complete");
     expect(completeEvents.length).toBeGreaterThanOrEqual(1);
+    expect((completeEvents.at(-1) as { stopStatus: string } | undefined)?.stopStatus).toBe(
+      LoopStopStatus.Achieved,
+    );
     expect(service.getState().status).toBe("complete");
+    expect(service.getState().stopStatus).toBe(LoopStopStatus.Achieved);
 
     service.destroy();
     bus.close();
@@ -265,7 +270,11 @@ describe("SessionService", () => {
     const completeEvents = events.filter((e) => e.type === "session_complete");
     expect(completeEvents).toHaveLength(1);
     expect((completeEvents[0] as { reason: string }).reason).toBe("Budget exceeded");
+    expect((completeEvents[0] as { stopStatus: string }).stopStatus).toBe(
+      LoopStopStatus.Interrupted,
+    );
     expect(service.getState().status).toBe("complete");
+    expect(service.getState().stopStatus).toBe(LoopStopStatus.Interrupted);
     expect(runtime.closeCalls).toHaveLength(2);
 
     service.destroy();

--- a/src/server/session-service.ts
+++ b/src/server/session-service.ts
@@ -20,6 +20,7 @@
 import type { AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import type { GroveContract } from "../core/contract.js";
 import type { EventBus, EventHandler, GroveEvent } from "../core/event-bus.js";
+import { LoopStopStatus, type LoopStopStatus as LoopStopStatusValue } from "../core/loop-runner.js";
 import { SessionOrchestrator } from "../core/session-orchestrator.js";
 import type { AgentTopology } from "../core/topology.js";
 import type { WorkspaceIsolationPolicy } from "../core/workspace-provisioner.js";
@@ -57,6 +58,8 @@ export interface SessionState {
   readonly agents: readonly AgentInfo[];
   readonly contributions: number;
   readonly status: "pending" | "running" | "complete";
+  readonly stopReason?: string | undefined;
+  readonly stopStatus?: LoopStopStatusValue | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -74,7 +77,11 @@ export type SessionEvent =
       readonly role: string;
     }
   | { readonly type: "agent_done"; readonly role: string; readonly reason: string }
-  | { readonly type: "session_complete"; readonly reason: string }
+  | {
+      readonly type: "session_complete";
+      readonly reason: string;
+      readonly stopStatus: LoopStopStatusValue;
+    }
   | { readonly type: "error"; readonly message: string };
 
 /** Callback type for event listeners. */
@@ -93,6 +100,8 @@ export class SessionService {
   private goal = "";
   private sessionId = "";
   private sessionStatus: "pending" | "running" | "complete" = "pending";
+  private stopReason: string | undefined;
+  private stopStatus: LoopStopStatusValue | undefined;
   private contributionCount = 0;
   private readonly doneRoles: Set<string> = new Set();
   private readonly eventHandlers: Array<{ role: string; handler: EventHandler }> = [];
@@ -135,6 +144,8 @@ export class SessionService {
     this.goal = goal;
     this.sessionId = sessionId ?? `session-${Date.now()}`;
     this.sessionStatus = "running";
+    this.stopReason = undefined;
+    this.stopStatus = undefined;
     this.contributionCount = 0;
     this.doneRoles.clear();
 
@@ -170,11 +181,16 @@ export class SessionService {
   }
 
   /** Stop the session. */
-  async stopSession(reason: string): Promise<void> {
+  async stopSession(
+    reason: string,
+    stopStatus: LoopStopStatusValue = LoopStopStatus.Interrupted,
+  ): Promise<void> {
     if (this.orchestrator === undefined) return;
     this.sessionStatus = "complete";
-    await this.orchestrator.stop(reason);
-    this.emit({ type: "session_complete", reason });
+    this.stopReason = reason;
+    this.stopStatus = stopStatus;
+    await this.orchestrator.stop(reason, stopStatus);
+    this.emit({ type: "session_complete", reason, stopStatus });
   }
 
   /** Get current session state (serialisable snapshot). */
@@ -190,6 +206,8 @@ export class SessionService {
       agents,
       contributions: this.contributionCount,
       status: this.sessionStatus,
+      stopReason: this.stopReason,
+      stopStatus: this.stopStatus,
     };
   }
 
@@ -229,7 +247,13 @@ export class SessionService {
       const allDone = this.topology.roles.every((r) => this.doneRoles.has(r.name));
       if (allDone && this.sessionStatus === "running") {
         this.sessionStatus = "complete";
-        this.emit({ type: "session_complete", reason: "All agents done" });
+        this.stopReason = "All agents done";
+        this.stopStatus = LoopStopStatus.Achieved;
+        this.emit({
+          type: "session_complete",
+          reason: "All agents done",
+          stopStatus: LoopStopStatus.Achieved,
+        });
       }
     }
   }

--- a/src/server/ws-handler.test.ts
+++ b/src/server/ws-handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { GroveContract } from "../core/contract.js";
 import { LocalEventBus } from "../core/local-event-bus.js";
+import { LoopStopStatus } from "../core/loop-runner.js";
 import { MockRuntime } from "../core/mock-runtime.js";
 import { SessionService } from "./session-service.js";
 import type { WsSocket } from "./ws-handler.js";
@@ -169,6 +170,7 @@ describe("createWsHandler", () => {
       .map((s) => JSON.parse(s) as Record<string, unknown>)
       .filter((m) => m.type === "session_complete");
     expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events.at(-1)?.stopStatus).toBe(LoopStopStatus.Interrupted);
 
     handler.close(ws);
     service.destroy();

--- a/src/server/ws-handler.ts
+++ b/src/server/ws-handler.ts
@@ -39,6 +39,8 @@ function serialiseState(state: SessionState): string {
     agents: state.agents,
     contributions: state.contributions,
     status: state.status,
+    stopReason: state.stopReason,
+    stopStatus: state.stopStatus,
   });
 }
 

--- a/src/tui/debug-log.ts
+++ b/src/tui/debug-log.ts
@@ -1,14 +1,14 @@
 /**
  * Temporary debug logger for e2e trace validation.
- * Writes to /tmp/grove-debug.log so it doesn't corrupt the TUI.
+ * Writes outside the TUI alternate screen so it doesn't corrupt rendering.
  *
- * Gated behind GROVE_DEBUG=1 — no-op in normal operation.
+ * Gated behind GROVE_DEBUG=1 or GROVE_DEBUG_LOG — no-op in normal operation.
  */
 
 import { appendFileSync } from "node:fs";
 
-const LOG_PATH = "/tmp/grove-debug.log";
-const ENABLED = process.env.GROVE_DEBUG === "1";
+const LOG_PATH = process.env.GROVE_DEBUG_LOG ?? "/tmp/grove-debug.log";
+const ENABLED = process.env.GROVE_DEBUG === "1" || process.env.GROVE_DEBUG_LOG !== undefined;
 
 export function debugLog(tag: string, msg: string): void {
   if (!ENABLED) return;

--- a/src/tui/hooks/use-session-ws.ts
+++ b/src/tui/hooks/use-session-ws.ts
@@ -10,6 +10,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { LoopStopStatus } from "../../core/loop-runner.js";
 
 // ---------------------------------------------------------------------------
 // Types mirroring the server protocol (keep in sync with session-service.ts)
@@ -29,6 +30,8 @@ export interface WsSessionState {
   readonly agents: readonly WsAgentInfo[];
   readonly contributions: number;
   readonly status: "pending" | "running" | "complete";
+  readonly stopReason?: string | undefined;
+  readonly stopStatus?: LoopStopStatus | undefined;
 }
 
 /** Events pushed from the server. */
@@ -40,6 +43,8 @@ export type WsSessionEvent =
       readonly agents: readonly WsAgentInfo[];
       readonly contributions: number;
       readonly status: string;
+      readonly stopReason?: string | undefined;
+      readonly stopStatus?: LoopStopStatus | undefined;
     }
   | { readonly type: "agent_spawned"; readonly role: string; readonly agent: WsAgentInfo }
   | {
@@ -50,7 +55,11 @@ export type WsSessionEvent =
       readonly role: string;
     }
   | { readonly type: "agent_done"; readonly role: string; readonly reason: string }
-  | { readonly type: "session_complete"; readonly reason: string }
+  | {
+      readonly type: "session_complete";
+      readonly reason: string;
+      readonly stopStatus: LoopStopStatus;
+    }
   | { readonly type: "error"; readonly message: string };
 
 // ---------------------------------------------------------------------------
@@ -110,6 +119,8 @@ export function useSessionWs(serverUrl: string, active = true): UseSessionWsResu
               agents: stateMsg.agents,
               contributions: stateMsg.contributions,
               status: stateMsg.status as WsSessionState["status"],
+              stopReason: stateMsg.stopReason,
+              stopStatus: stateMsg.stopStatus,
             });
           }
 

--- a/src/tui/nexus-ws-bridge.test.ts
+++ b/src/tui/nexus-ws-bridge.test.ts
@@ -89,6 +89,13 @@ class TestableNexusWsBridge extends NexusWsBridge {
       this as unknown as { handleEvent: (r: string, e: string | null, d: string) => void }
     ).handleEvent(role, eventType, raw);
   }
+
+  /** Expose inbox drain for missed-SSE regression tests. */
+  async testDrainRoleInbox(role: string): Promise<void> {
+    await (
+      this as unknown as { drainRoleInbox: (r: string, reason: string) => Promise<void> }
+    ).drainRoleInbox(role, "test");
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -185,6 +192,47 @@ describe("NexusWsBridge", () => {
       cid: "blake3:abc",
       kind: "work",
     });
+
+    bridge.close();
+    bus.close();
+  });
+
+  test("handleEvent derives Nexus EventRecord message_id from inbox filename", async () => {
+    const runtime = makeMockRuntime();
+    const bus = new LocalEventBus();
+    const received: GroveEvent[] = [];
+    bus.subscribe("reviewer", (e) => received.push(e));
+
+    const bridge = new TestableNexusWsBridge(makeBridgeOpts({ runtime, eventBus: bus }));
+    const session = makeSession("reviewer");
+    bridge.registerSession("reviewer", session);
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          content: JSON.stringify({
+            sender: "coder",
+            payload: { cid: "blake3:eventrecord", kind: "work", summary: "from event record" },
+          }),
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+
+    bridge.testHandleEvent(
+      "reviewer",
+      "event",
+      JSON.stringify({
+        event_id: "nexus-event-id",
+        type: "write",
+        path: "/zone/test-zone/ipc/reviewer/inbox/message-file-id.json",
+        agent_id: "coder",
+      }),
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]!.payload.message_id).toBe("message-file-id");
 
     bridge.close();
     bus.close();
@@ -517,6 +565,69 @@ describe("NexusWsBridge", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(runtime.send).not.toHaveBeenCalled();
+    bridge.close();
+  });
+
+  test("drainRoleInbox delivers missed inbox file for registered session", async () => {
+    const runtime = makeMockRuntime();
+    const modifiedAt = new Date(Date.now() + 1000).toISOString();
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/api/v2/events/stream")) {
+        return new Response("", {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      if (url.includes("/api/v2/files/list")) {
+        return new Response(
+          JSON.stringify({
+            items: [
+              {
+                name: "missed-message.json",
+                path: "/ipc/reviewer/inbox/missed-message.json",
+                is_directory: false,
+                modified_at: modifiedAt,
+              },
+            ],
+            has_more: false,
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/api/v2/files/read")) {
+        return new Response(
+          JSON.stringify({
+            content: JSON.stringify({
+              sender: "coder",
+              recipient: "reviewer",
+              timestamp: modifiedAt,
+              payload: {
+                cid: "blake3:missed",
+                kind: "work",
+                summary: "missed SSE contribution",
+              },
+            }),
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const bridge = new TestableNexusWsBridge(makeBridgeOpts({ runtime }));
+    const session = makeSession("reviewer");
+    bridge.registerSession("reviewer", session);
+
+    await bridge.testDrainRoleInbox("reviewer");
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(runtime.send).toHaveBeenCalledTimes(1);
+    const notification = (runtime.send as ReturnType<typeof mock>).mock.calls[0]![1] as string;
+    expect(notification).toContain("blake3:missed");
+    expect(notification).toContain("missed SSE contribution");
+
     bridge.close();
   });
 

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -109,6 +109,16 @@ interface EventRecordPayload {
   sequence_number?: number | undefined;
 }
 
+interface InboxListPage {
+  readonly items: readonly Record<string, unknown>[];
+  readonly hasMore: boolean;
+  readonly nextCursor?: string | undefined;
+}
+
+const INBOX_DRAIN_INTERVAL_MS = 2000;
+const INBOX_DRAIN_TIMEOUT_MS = 5000;
+const INBOX_DRAIN_LIMIT = 100;
+
 /** URL builder for the per-role inbox subscription on the new events SSE. */
 function inboxStreamUrl(nexusUrl: string, role: string): string {
   // path_pattern is matched (SQL LIKE) against the stored zone-prefixed path.
@@ -139,9 +149,61 @@ function inboxFilePath(recipient: string, messageId: string): string {
   return `/ipc/${recipient}/inbox/${messageId}.json`;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(
+  record: Record<string, unknown>,
+  ...keys: readonly string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string") return value;
+  }
+  return undefined;
+}
+
+function booleanField(
+  record: Record<string, unknown>,
+  ...keys: readonly string[]
+): boolean | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "boolean") return value;
+  }
+  return undefined;
+}
+
+function messageIdFromInboxPath(path: string): string | undefined {
+  const clean = stripZonePrefix(path);
+  const file = clean
+    .split("/")
+    .filter((part) => part.length > 0)
+    .at(-1);
+  if (!file) return undefined;
+  return file.endsWith(".json") ? file.slice(0, -".json".length) : file;
+}
+
+function inboxPathFromListItem(role: string, item: Record<string, unknown>): string | undefined {
+  const path = stringField(item, "path");
+  if (path) return stripZonePrefix(path);
+  const name = stringField(item, "name");
+  if (!name) return undefined;
+  return `/ipc/${role}/inbox/${name}`;
+}
+
+function modifiedMsFromListItem(item: Record<string, unknown>): number | undefined {
+  const raw = stringField(item, "modified_at", "modifiedAt");
+  if (!raw) return undefined;
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
 export class NexusWsBridge {
   private readonly opts: NexusWsBridgeOptions;
   private readonly localInstanceId: string;
+  private readonly bridgeStartedAtMs = Date.now();
   private readonly sessions = new Map<string, AgentSession>();
   // Active per-connect controllers. Each connectSse attempt creates one
   // and removes it in finally so long-running bridges don't accumulate
@@ -162,6 +224,11 @@ export class NexusWsBridge {
   // the prompt twice. Bounded per role to keep memory flat.
   private recentMessageIds = new Map<string, Set<string>>();
   private static readonly RECENT_CAP = 256;
+  // SSE is the primary transport, but the Nexus event stream is intentionally
+  // best-effort around reconnects. A bounded inbox drain gives every registered
+  // role deterministic recovery for messages already materialized in VFS.
+  private inboxDrainStops = new Map<string, () => void>();
+  private inboxDrainInFlight = new Set<string>();
   // Unresolved-dead-letter queue: when a local push fails but correlation
   // could not be resolved even after in-line retry (linkage race or
   // transient store outage), the pending entry is queued here so a
@@ -244,9 +311,11 @@ export class NexusWsBridge {
       // reconnect loops against the same Nexus stream after a re-register.
       const prior = this.roleAborts.get(role);
       if (prior) prior.abort();
+      this.stopInboxDrain(role);
       const controller = new AbortController();
       this.roleAborts.set(role, controller);
       void this.startSseForRole(role, controller.signal);
+      this.startInboxDrain(role);
     }
   }
 
@@ -267,6 +336,7 @@ export class NexusWsBridge {
       if (!current || current.id !== expectedSessionId) return;
     }
     this.sessions.delete(role);
+    this.stopInboxDrain(role);
     const controller = this.roleAborts.get(role);
     if (controller) {
       controller.abort();
@@ -386,6 +456,11 @@ export class NexusWsBridge {
       ac.abort();
     }
     this.roleAborts.clear();
+    for (const stop of this.inboxDrainStops.values()) {
+      stop();
+    }
+    this.inboxDrainStops.clear();
+    this.inboxDrainInFlight.clear();
     this.recentMessageIds.clear();
     this.sessions.clear();
   }
@@ -432,6 +507,91 @@ export class NexusWsBridge {
       return resp.ok;
     } catch {
       return false;
+    }
+  }
+
+  private startInboxDrain(role: string): void {
+    this.stopInboxDrain(role);
+    void this.drainRoleInbox(role, "register");
+    const stop = startInterval(
+      () => {
+        void this.drainRoleInbox(role, "poll");
+      },
+      INBOX_DRAIN_INTERVAL_MS,
+      { unref: true },
+    );
+    this.inboxDrainStops.set(role, stop);
+  }
+
+  private stopInboxDrain(role: string): void {
+    const stop = this.inboxDrainStops.get(role);
+    if (!stop) return;
+    stop();
+    this.inboxDrainStops.delete(role);
+  }
+
+  private async drainRoleInbox(role: string, reason: string): Promise<void> {
+    if (this.closed || this.draining || !this.sessions.has(role)) return;
+    if (this.inboxDrainInFlight.has(role)) return;
+    this.inboxDrainInFlight.add(role);
+    try {
+      let cursor: string | undefined;
+      let pages = 0;
+      do {
+        const page = await this.listInboxFiles(role, cursor);
+        for (const item of page.items) {
+          const isDirectory = booleanField(item, "is_directory", "isDirectory");
+          if (isDirectory === true) continue;
+          const path = inboxPathFromListItem(role, item);
+          if (!path || !path.endsWith(".json")) continue;
+          const modifiedMs = modifiedMsFromListItem(item);
+          if (modifiedMs !== undefined && modifiedMs < this.bridgeStartedAtMs) continue;
+          const messageId = messageIdFromInboxPath(path);
+          this.dispatchInboxDelivery(path, role, undefined, messageId, this.bridgeStartedAtMs);
+        }
+        cursor = page.hasMore ? page.nextCursor : undefined;
+        pages += 1;
+      } while (cursor && pages < 10);
+    } catch (err) {
+      debugLog(
+        "wsBridge.drainRoleInbox",
+        `role=${role} reason=${reason} err=${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      this.inboxDrainInFlight.delete(role);
+    }
+  }
+
+  private async listInboxFiles(role: string, cursor?: string): Promise<InboxListPage> {
+    const params = new URLSearchParams({
+      path: `/ipc/${role}/inbox`,
+      limit: String(INBOX_DRAIN_LIMIT),
+    });
+    if (cursor) params.set("cursor", cursor);
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), INBOX_DRAIN_TIMEOUT_MS);
+    try {
+      const resp = await fetch(`${this.opts.nexusUrl}/api/v2/files/list?${params.toString()}`, {
+        headers: {
+          Authorization: `Bearer ${this.opts.apiKey}`,
+        },
+        signal: ac.signal,
+      });
+      if (!resp.ok) return { items: [], hasMore: false };
+      const json = (await resp.json()) as unknown;
+      if (!isRecord(json)) return { items: [], hasMore: false };
+      const rawItems = Array.isArray(json.items)
+        ? json.items
+        : Array.isArray(json.files)
+          ? json.files
+          : [];
+      return {
+        items: rawItems.filter(isRecord),
+        hasMore: booleanField(json, "has_more", "hasMore") ?? false,
+        nextCursor: stringField(json, "next_cursor", "nextCursor"),
+      };
+    } finally {
+      clearTimeout(timer);
     }
   }
 
@@ -617,6 +777,7 @@ export class NexusWsBridge {
       // the silent post-start outage the migration is supposed to surface.
       const ctype = resp.headers.get("content-type") ?? "";
       if (!ctype.toLowerCase().includes("text/event-stream")) return false;
+      void this.drainRoleInbox(role, "stream-open");
 
       const reader = resp.body.getReader();
       const decoder = new TextDecoder();
@@ -745,9 +906,10 @@ export class NexusWsBridge {
         // pattern drift or shared streams.
         if (rec.type !== "write") return;
         const relPath = stripZonePrefix(rec.path);
+        const messageId = messageIdFromInboxPath(relPath) ?? rec.event_id;
         event = {
           event: "message_delivered",
-          message_id: rec.event_id,
+          message_id: messageId,
           sender: rec.agent_id ?? "",
           recipient: role,
           type: "event",
@@ -762,44 +924,46 @@ export class NexusWsBridge {
         `role=${role} sender=${event.sender} path=${event.path} registeredSessions=[${[...this.sessions.keys()].join(",")}]`,
       );
 
-      // Per-role dedupe: re-register aborts the old loop but cannot
-      // force the in-flight dispatch to unwind before the new loop
-      // comes online. Both loops can see the same Nexus message_id in
-      // the handoff window — without this guard the runtime would
-      // receive the same prompt twice.
-      if (event.message_id) {
-        let seen = this.recentMessageIds.get(role);
-        if (!seen) {
-          seen = new Set<string>();
-          this.recentMessageIds.set(role, seen);
-        }
-        if (seen.has(event.message_id)) {
-          debugLog("wsBridge.handleEvent", `DEDUPE role=${role} message_id=${event.message_id}`);
-          return;
-        }
-        seen.add(event.message_id);
-        if (seen.size > NexusWsBridge.RECENT_CAP) {
-          const first = seen.values().next().value;
-          if (first !== undefined) seen.delete(first);
-        }
-      }
-
-      const session = this.sessions.get(role);
-      if (!session) {
-        debugLog("wsBridge.handleEvent", `NO SESSION for role=${role} — cannot deliver`);
-        return;
-      }
-
-      // Rsync workspace files before delivering — the callback syncs source→target workspace
-      try {
-        this.opts.onBeforeDeliver?.(event.sender, role);
-      } catch {
-        /* non-fatal */
-      }
-      void this.readAndPush(event.path, role, session, event.sender, event.message_id);
+      this.dispatchInboxDelivery(event.path, role, event.sender, event.message_id);
     } catch {
       // Skip malformed events
     }
+  }
+
+  private rememberMessageId(role: string, messageId: string): boolean {
+    let seen = this.recentMessageIds.get(role);
+    if (!seen) {
+      seen = new Set<string>();
+      this.recentMessageIds.set(role, seen);
+    }
+    if (seen.has(messageId)) {
+      debugLog("wsBridge.handleEvent", `DEDUPE role=${role} message_id=${messageId}`);
+      return false;
+    }
+    seen.add(messageId);
+    if (seen.size > NexusWsBridge.RECENT_CAP) {
+      const first = seen.values().next().value;
+      if (first !== undefined) seen.delete(first);
+    }
+    return true;
+  }
+
+  private dispatchInboxDelivery(
+    path: string,
+    role: string,
+    sender: string | undefined,
+    ipcMessageId: string | undefined,
+    minTimestampMs?: number,
+  ): void {
+    if (ipcMessageId && !this.rememberMessageId(role, ipcMessageId)) return;
+
+    const session = this.sessions.get(role);
+    if (!session) {
+      debugLog("wsBridge.handleEvent", `NO SESSION for role=${role} — cannot deliver`);
+      return;
+    }
+
+    void this.readAndPush(path, role, session, sender ?? "", ipcMessageId, minTimestampMs);
   }
 
   /**
@@ -1371,6 +1535,7 @@ export class NexusWsBridge {
     session: AgentSession,
     sender: string,
     ipcMessageId?: string,
+    minTimestampMs?: number,
   ): Promise<void> {
     try {
       // Shutdown teardown guard: refuse to push or retry once shutdown
@@ -1418,10 +1583,29 @@ export class NexusWsBridge {
       const msg = JSON.parse(raw) as {
         from?: string;
         sender?: string;
+        timestamp?: string;
         payload?: Record<string, unknown>;
       };
 
       const msgSender = msg.from ?? msg.sender ?? sender;
+      if (minTimestampMs !== undefined && typeof msg.timestamp === "string") {
+        const msgTimestampMs = Date.parse(msg.timestamp);
+        if (Number.isFinite(msgTimestampMs) && msgTimestampMs < minTimestampMs) {
+          debugLog(
+            "wsBridge.readAndPush",
+            `SKIP stale inbox message role=${_targetRole} path=${path} timestamp=${msg.timestamp}`,
+          );
+          return;
+        }
+      }
+
+      // Rsync workspace files before delivering — for event-stream delivery
+      // the sender is often only known after reading the inbox envelope.
+      try {
+        this.opts.onBeforeDeliver?.(msgSender, _targetRole);
+      } catch {
+        /* non-fatal */
+      }
 
       // Pre-dispatch: typed acp.* envelopes go to the typed consumer and
       // skip the runtime.send IPC-notification path. Pass wire-level

--- a/src/tui/provider-shared.ts
+++ b/src/tui/provider-shared.ts
@@ -250,6 +250,8 @@ interface ApiSessionResponse {
   readonly createdAt?: string;
   readonly endedAt?: string;
   readonly completedAt?: string;
+  readonly stopReason?: string;
+  readonly stopStatus?: import("../core/loop-runner.js").LoopStopStatus;
   readonly topology?: import("../core/topology.js").AgentTopology;
   readonly config?: import("../core/contract.js").GroveContract;
   readonly contributionCount?: number;
@@ -263,6 +265,8 @@ function mapApiSession(raw: ApiSessionResponse): SessionRecord {
     status: raw.status as SessionRecord["status"],
     createdAt: (raw.startedAt ?? raw.createdAt) as string,
     completedAt: raw.endedAt ?? raw.completedAt,
+    stopReason: raw.stopReason,
+    stopStatus: raw.stopStatus,
     topology: raw.topology,
     config: raw.config,
     contributionCount: raw.contributionCount ?? 0,

--- a/src/tui/spawn-manager.test.ts
+++ b/src/tui/spawn-manager.test.ts
@@ -14,6 +14,8 @@ import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 // that spawn multiple agents. Bump to 30s so CI and local runs are stable.
 setDefaultTimeout(30_000);
 
+import type { AcpxTurn } from "../acp/types.js";
+import type { AgentConfig, AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import type { Claim } from "../core/models.js";
 import type { SpawnOptions, TmuxManager } from "./agents/tmux-manager.js";
 import { MockTmuxManager } from "./agents/tmux-manager.js";
@@ -190,6 +192,38 @@ function makeMockTmux(shouldFail = false): TmuxManager & {
   };
 }
 
+function makeMockRuntime(): AgentRuntime & { readonly configs: AgentConfig[] } {
+  const configs: AgentConfig[] = [];
+  return {
+    sendsInitialPromptOnSpawn: true,
+    configs,
+    async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
+      configs.push(config);
+      return { id: `session-${role}`, role, status: "running", agent: "mock" };
+    },
+    async send(): Promise<AcpxTurn> {
+      throw new Error("mock runtime send should not be called by SpawnManager.spawn");
+    },
+    async close(): Promise<void> {
+      // No-op for test mock.
+    },
+    onIdle(): void {
+      // No-op for test mock.
+    },
+    async listSessions(): Promise<readonly AgentSession[]> {
+      return [];
+    },
+    async listSessionEntities(): Promise<
+      readonly import("../core/entity.js").AgentSessionEntity[]
+    > {
+      return [];
+    },
+    async isAvailable(): Promise<boolean> {
+      return true;
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -202,6 +236,31 @@ afterEach(() => {
 });
 
 describe("SpawnManager", () => {
+  test("does not suppress initial prompt just because role prompt says wait for feedback", async () => {
+    const provider = makeMockProvider();
+    const runtime = makeMockRuntime();
+    manager = new SpawnManager(
+      provider,
+      undefined,
+      () => {
+        // No-op for test mock.
+      },
+      [{ kind: "local" as const, path: "/tmp" }],
+      undefined,
+      "/tmp/no-grove",
+      runtime,
+    );
+
+    await manager.spawn("coder", "claude", undefined, 0, {
+      rolePrompt:
+        "Submit work immediately. After submitting work, wait for reviewer feedback and do nothing else.",
+    });
+
+    expect(runtime.configs).toHaveLength(1);
+    expect(runtime.configs[0]?.waitForPush).toBe(false);
+    expect(runtime.configs[0]?.prompt).toContain("Submit work immediately");
+  });
+
   test("spawn creates workspace and tmux session (no auto-claims)", async () => {
     const provider = makeMockProvider();
     const tmux = makeMockTmux();
@@ -982,7 +1041,9 @@ describe("SpawnManager — delivery state recovery", () => {
   const makeManager = () => {
     const provider = makeMockProvider();
     const tmux = new MockTmuxManager();
-    return new SpawnManager(provider, tmux, () => {}, [{ kind: "local" as const, path: "/tmp" }]);
+    return new SpawnManager(provider, tmux, () => undefined, [
+      { kind: "local" as const, path: "/tmp" },
+    ]);
   };
 
   test("markDeliveryRecovered flips disabled → ready", () => {

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -544,13 +544,17 @@ export class SpawnManager {
       let provisioned: import("../core/workspace-provisioner.js").ProvisionedWorkspace | undefined;
       try {
         await this.ensureReposResolved();
+        const primaryRepo = this.resolvedRepos[0];
+        if (primaryRepo === undefined) {
+          throw new Error("No repository resolved for workspace provisioning");
+        }
         // Use wsSessionId (stable session-level ID) so branch names are predictable
         // and match what resolveRoleWorkspaceStrategies() computes for dependents.
         provisioned = await provisionWorkspace({
           role: roleId,
           sessionId: wsSessionId,
           baseDir,
-          bareClonePath: this.resolvedRepos[0]!.bareClonePath,
+          bareClonePath: primaryRepo.bareClonePath,
           baseBranch,
         });
         workspacePath = provisioned.path;
@@ -683,10 +687,11 @@ export class SpawnManager {
 
       if (this.agentRuntime) {
         // Use AgentRuntime interface — works with acpx, subprocess, or any runtime
-        // Determine if this role should wait for IPC push instead of starting immediately.
-        // Detected from prompt content: "wait for" signals a reactive role.
-        const rolePromptText = String(context?.rolePrompt ?? "").toLowerCase();
-        const waitForPush = context?.waitForPush === true || rolePromptText.includes("wait for");
+        // Only an explicit launch context can suppress the initial prompt.
+        // Role prompts often say "wait for feedback" after the first action;
+        // treating that as passive mode prevents starter roles from ever
+        // receiving their first instruction.
+        const waitForPush = context?.waitForPush === true;
 
         // Extract platform/model from context (set by topology role or profile overlay)
         const platform = context?.platform as

--- a/src/tui/views/welcome/session-row.test.ts
+++ b/src/tui/views/welcome/session-row.test.ts
@@ -67,4 +67,16 @@ describe("computeSessionRowFields", () => {
     });
     expect(r.dot).toBe("○");
   });
+
+  test("completed session includes semantic stop status when present", () => {
+    const r = computeSessionRowFields(
+      session({ status: "completed", stopStatus: "plateau", stopReason: "No improvement" }),
+      {
+        focused: false,
+        now: NOW,
+      },
+    );
+
+    expect(r.primary).toContain("plateau");
+  });
 });

--- a/src/tui/views/welcome/session-row.tsx
+++ b/src/tui/views/welcome/session-row.tsx
@@ -39,9 +39,11 @@ export function computeSessionRowFields(
   const goal = (session.goal ?? "untitled").slice(0, GOAL_MAX);
   const when = formatRelativeTime(session.createdAt, opts.now);
   const count = `${session.contributionCount}c`;
+  const outcome = sessionOutcome(session);
+  const suffix = outcome ? ` · ${outcome}` : "";
 
   if (opts.focused) {
-    const primary = `${dot} "${goal}"  ${count} · ${when}`;
+    const primary = `${dot} "${goal}"  ${count} · ${when}${suffix}`;
     const secondary = session.presetName ? session.presetName : undefined;
     return { dot, rich: true, primary, secondary };
   }
@@ -49,9 +51,16 @@ export function computeSessionRowFields(
   return {
     dot,
     rich: false,
-    primary: `${dot} "${goal}"  ${count} · ${when}`,
+    primary: `${dot} "${goal}"  ${count} · ${when}${suffix}`,
     secondary: undefined,
   };
+}
+
+function sessionOutcome(session: SessionRecord): string | undefined {
+  if (session.status === "active") return undefined;
+  if (session.stopStatus !== undefined) return session.stopStatus;
+  if (session.status === "completed" || session.status === "cancelled") return session.status;
+  return undefined;
 }
 
 /** Render a single session row. */

--- a/tests/nexus/unit/nexus-http-client.test.ts
+++ b/tests/nexus/unit/nexus-http-client.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { NexusHttpClient } from "../../../src/nexus/nexus-http-client.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("NexusHttpClient", () => {
+  test('serializes ifNoneMatch="*" as Nexus REST create-only boolean', async () => {
+    let capturedBody: unknown;
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      capturedBody = JSON.parse(String(init?.body));
+      return new Response(
+        JSON.stringify({
+          content_id: "etag-1",
+          version: 1,
+          size: 4,
+          modified_at: "2026-05-06T00:00:00.000Z",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const client = new NexusHttpClient({ url: "http://nexus.test" });
+    await client.write("/work/item.json", new TextEncoder().encode("data"), {
+      ifNoneMatch: "*",
+    });
+
+    expect(capturedBody).toMatchObject({ if_none_match: true });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a deterministic Grove loop runner with roadmap parsing, semantic stop statuses, SIGINT interruption, plateau handling, and max-iteration handling.
- Persist workflow state through Nexus and local session storage, then expose stop status through session APIs and TUI rows.
- Harden the managed Nexus/TUI Codex-to-Claude delivery path, including lifecycle resolution, WebSocket bridge drain/backfill, REST serialization, prompt suppression, and debug logging.
- Address review feedback by including the new runner/store modules and scoping inherited Grove/Nexus secrets to the `grove` MCP server only.

Closes #340

## Validation
- `bun test` focused loop-runner/Nexus/TUI suites: 119 pass, 0 fail
- `bun test src/core/acp-runtime.spawn.test.ts src/core/loop-runner.test.ts src/nexus/nexus-workflow-store.test.ts tests/nexus/unit/nexus-http-client.test.ts`: 24 pass, 0 fail
- `bun run check`
- `bun run typecheck`
- `bun run build`
- Real tmux/TUI managed-Nexus smoke: Codex coder submitted work, Claude reviewer submitted review and `[DONE]`, then Nexus cleanup completed.

## Publishing Notes
The Codex app shell put its bundled Node ahead of Homebrew Node, which rejected Rollup native module loading under macOS library validation. The push hook passed after running with `/opt/homebrew/bin` before the Codex app resources in PATH.
