### PR TITLE
feat(tui): C1 — generic EntityView replaces dual-path fetch in 4 list views (#301)

### DIFF
--- a/docs/superpowers/plans/2026-05-06-c1-entity-view.md
+++ b/docs/superpowers/plans/2026-05-06-c1-entity-view.md
@@ -1,0 +1,1960 @@
+# C1 — Generic EntityView Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land `<EntityView kind columns … />` in `src/tui/components/`, port 5 list views to it, end the duplicated dual-path data fetching across the TUI.
+
+**Architecture:** Three units — `useEntityData<K>` (data hook collapsing informer + polled fallback), `EntityView<K>` (pure render layer atop Table), and a `columns/` library (per-kind column factories). Migration is one commit per view.
+
+**Tech Stack:** TypeScript, React 18 + react-test-renderer, OpenTUI intrinsics, bun:test, Biome.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-c1-entity-view-design.md`
+
+---
+
+## File Structure
+
+**Created:**
+- `src/tui/hooks/use-entity-data.ts` — data hook
+- `src/tui/hooks/use-entity-data.test.ts` — pure-helper unit tests
+- `src/tui/hooks/use-entity-data.mount.test.tsx` — mount-level integration test
+- `src/tui/components/entity-view.tsx` — render component
+- `src/tui/components/entity-view.test.tsx` — mount-level component tests
+- `src/tui/components/entity-view.perf.test.tsx` — 500-row perf test (skipped in CI)
+- `src/tui/components/columns/claim-columns.ts` — Claim column factories
+- `src/tui/components/columns/contribution-columns.ts` — Contribution column factories
+- `src/tui/components/columns/agent-columns.ts` — Agent column factories (with join-context)
+
+**Modified:**
+- `src/core/informer.ts` — export `EntityForKind<K>`
+- `src/tui/data/entity-store.ts` — import `EntityForKind` (replace local type alias)
+- `src/tui/hooks/use-entities.ts` — import `EntityForKind` (replace local type alias)
+- `src/tui/hooks/use-entity.ts` — import `EntityForKind` (replace local type alias)
+- `src/tui/components/table.tsx` — raise `MAX_RENDER_ITEMS` from 200 to 500
+- `src/tui/views/claims.tsx` — port to EntityView
+- `src/tui/views/activity-panel.tsx` — port to EntityView
+- `src/tui/views/activity.tsx` — port to EntityView
+- `src/tui/views/agent-list.tsx` — port to EntityView (with join wrapper)
+- `src/tui/views/search-panel.tsx` — **NOT migrated in this PR.** The contribution result table needs server-side full-text search when `searchQuery` is non-empty (provider's `getContributions({ search })`), which the EntityStore predicate path can't model. The transcript result table renders local in-memory data, also not EntityStore-backed. Search-panel stays on `<Table>` for now; revisit if a watch-side search filter lands.
+
+---
+
+## Task 0: Foundation — export `EntityForKind<K>`
+
+**Files:**
+- Modify: `src/core/informer.ts:19`
+- Modify: `src/tui/data/entity-store.ts:23`
+- Modify: `src/tui/hooks/use-entities.ts:42`
+- Modify: `src/tui/hooks/use-entity.ts:28`
+
+- [ ] **Step 1: Export the existing type alias**
+
+In `src/core/informer.ts:19`, change:
+```ts
+type EntityForKind<K extends WatchKind> = K extends "Contribution"
+```
+to:
+```ts
+export type EntityForKind<K extends WatchKind> = K extends "Contribution"
+```
+
+- [ ] **Step 2: Replace local alias in `entity-store.ts`**
+
+Replace the local definition at `src/tui/data/entity-store.ts:23`:
+```ts
+type EntityFor<K extends WatchKind> = ReturnType<Informer<K>["list"]>[number];
+```
+with an import (top of file, alongside existing imports):
+```ts
+import type { EntityForKind } from "../../core/informer.js";
+```
+Then `find-and-replace` `EntityFor<` → `EntityForKind<` in that file.
+
+- [ ] **Step 3: Replace local alias in `use-entities.ts`**
+
+At `src/tui/hooks/use-entities.ts:42`, delete:
+```ts
+type EntityFor<K extends WatchKind> = ReturnType<Informer<K>["list"]>[number];
+```
+Add to imports:
+```ts
+import type { EntityForKind } from "../../core/informer.js";
+```
+Find-and-replace `EntityFor<` → `EntityForKind<` in this file.
+
+- [ ] **Step 4: Replace local alias in `use-entity.ts`**
+
+At `src/tui/hooks/use-entity.ts:28`, delete the local type. Note this one uses `NonNullable<ReturnType<Informer<K>["getById"]>>` — that's a different shape (no-undefined). Keep the local alias OR rename to avoid collision; recommended: leave `use-entity.ts` alone (it's `getById`-shaped, not `list`-shaped). Skip this step.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS — no errors.
+
+- [ ] **Step 6: Run all tests**
+
+Run: `bun test`
+Expected: PASS — no behavior change, only type renames.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/informer.ts src/tui/data/entity-store.ts src/tui/hooks/use-entities.ts
+git commit -m "refactor(core): export EntityForKind<K> for reuse in EntityView"
+```
+
+---
+
+## Task 1: `useEntityData<K>` — pure helpers
+
+**Files:**
+- Create: `src/tui/hooks/use-entity-data.ts`
+- Create: `src/tui/hooks/use-entity-data.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tui/hooks/use-entity-data.test.ts`:
+
+```ts
+/**
+ * Tests for useEntityData pure helpers.
+ */
+import { describe, expect, test } from "bun:test";
+import { applyEntityShape } from "./use-entity-data.js";
+
+describe("applyEntityShape", () => {
+  const e = (id: string, ts: number) => ({ id, _ts: ts }) as unknown as { id: string; _ts: number };
+
+  test("no opts → input array reference returned", () => {
+    const list = [e("a", 1), e("b", 2)];
+    expect(applyEntityShape(list, {})).toBe(list);
+  });
+
+  test("predicate filters", () => {
+    const list = [e("a", 1), e("b", 2)];
+    expect(applyEntityShape(list, { predicate: (x) => x.id === "b" })).toEqual([e("b", 2)]);
+  });
+
+  test("sort orders by comparator (desc on _ts)", () => {
+    const list = [e("a", 1), e("b", 3), e("c", 2)];
+    const sorted = applyEntityShape(list, { sort: (x, y) => y._ts - x._ts });
+    expect(sorted.map((x) => x.id)).toEqual(["b", "c", "a"]);
+  });
+
+  test("limit slices after sort", () => {
+    const list = [e("a", 1), e("b", 3), e("c", 2)];
+    const out = applyEntityShape(list, { sort: (x, y) => y._ts - x._ts, limit: 2 });
+    expect(out.map((x) => x.id)).toEqual(["b", "c"]);
+  });
+
+  test("predicate before sort before limit", () => {
+    const list = [e("a", 1), e("b", 3), e("c", 2), e("d", 4)];
+    const out = applyEntityShape(list, {
+      predicate: (x) => x._ts > 1,
+      sort: (x, y) => x._ts - y._ts,
+      limit: 2,
+    });
+    expect(out.map((x) => x.id)).toEqual(["c", "b"]);
+  });
+
+  test("offset skips first N after sort", () => {
+    const list = [e("a", 1), e("b", 2), e("c", 3)];
+    const out = applyEntityShape(list, { sort: (x, y) => x._ts - y._ts, offset: 1, limit: 2 });
+    expect(out.map((x) => x.id)).toEqual(["b", "c"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/tui/hooks/use-entity-data.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the pure helper + hook scaffold**
+
+Create `src/tui/hooks/use-entity-data.ts`:
+
+```ts
+/**
+ * useEntityData — collapses the dual-path (informer cache + polled
+ * fallback) currently inlined in every list view. Both `useEntities`
+ * and `useEventDrivenData` are always called to keep React's hook
+ * order stable when `useEntityWatchEnabled` toggles.
+ */
+
+import { useCallback, useMemo } from "react";
+import type { EntityForKind } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+import { useEntityWatchEnabled } from "./informer-context.js";
+import { useEntities } from "./use-entities.js";
+import { useEventDrivenData } from "./use-event-driven-data.js";
+
+export interface EntityShapeOpts<E> {
+  readonly predicate?: (e: E) => boolean;
+  readonly sort?: (a: E, b: E) => number;
+  readonly offset?: number;
+  readonly limit?: number;
+}
+
+/** Pure: predicate → sort → offset/limit. Exported for unit tests. */
+export function applyEntityShape<E>(list: readonly E[], opts: EntityShapeOpts<E>): readonly E[] {
+  let out: readonly E[] = list;
+  if (opts.predicate) out = out.filter(opts.predicate);
+  if (opts.sort) out = [...out].sort(opts.sort);
+  const offset = opts.offset ?? 0;
+  if (offset > 0 || opts.limit !== undefined) {
+    const end = opts.limit !== undefined ? offset + opts.limit : undefined;
+    out = out.slice(offset, end);
+  }
+  return out;
+}
+
+export interface UseEntityDataOpts<K extends WatchKind> extends EntityShapeOpts<EntityForKind<K>> {
+  readonly fallbackFetcher?: () => Promise<readonly EntityForKind<K>[]>;
+  readonly active: boolean;
+}
+
+export interface UseEntityDataResult<K extends WatchKind> {
+  readonly data: readonly EntityForKind<K>[];
+  readonly loading: boolean;
+  readonly isStale: boolean;
+  readonly error: Error | undefined;
+}
+
+export function useEntityData<K extends WatchKind>(
+  provider: unknown,
+  kind: K,
+  opts: UseEntityDataOpts<K>,
+): UseEntityDataResult<K> {
+  const useInformerPath = useEntityWatchEnabled(provider, kind);
+
+  // Both branches always evaluated: stable hook order across path flips.
+  const entityResult = useEntities(kind, opts.predicate);
+
+  const fetcher = useCallback(async () => {
+    if (!opts.fallbackFetcher) return [] as readonly EntityForKind<K>[];
+    return opts.fallbackFetcher();
+  }, [opts.fallbackFetcher]);
+
+  const polled = useEventDrivenData<readonly EntityForKind<K>[]>(
+    fetcher,
+    undefined,
+    undefined,
+    opts.active && !useInformerPath && !!opts.fallbackFetcher,
+  );
+
+  const data = useMemo<readonly EntityForKind<K>[]>(() => {
+    if (useInformerPath) {
+      // entityResult.data already had `predicate` applied inside useEntities.
+      // Apply only sort + offset/limit here to avoid double-filtering.
+      return applyEntityShape(entityResult.data, {
+        sort: opts.sort,
+        offset: opts.offset,
+        limit: opts.limit,
+      });
+    }
+    if (polled.data === null) return [];
+    // Polled fallback: predicate was NOT applied by the hook — apply here.
+    return applyEntityShape(polled.data, opts);
+  }, [
+    useInformerPath,
+    entityResult.data,
+    polled.data,
+    opts.sort,
+    opts.offset,
+    opts.limit,
+    opts.predicate,
+  ]);
+
+  return {
+    data,
+    loading: useInformerPath
+      ? !entityResult.hasSynced && data.length === 0
+      : polled.loading && polled.data === null,
+    isStale: useInformerPath ? false : polled.isStale,
+    error: useInformerPath ? (entityResult.error ?? undefined) : (polled.error ?? undefined),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/tui/hooks/use-entity-data.test.ts`
+Expected: PASS — all `applyEntityShape` cases.
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui/hooks/use-entity-data.ts src/tui/hooks/use-entity-data.test.ts
+git commit -m "feat(tui): useEntityData hook collapsing dual-path informer/polled fetch"
+```
+
+---
+
+## Task 2: `useEntityData` — mount integration test
+
+**Files:**
+- Create: `src/tui/hooks/use-entity-data.mount.test.tsx`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `src/tui/hooks/use-entity-data.mount.test.tsx`:
+
+```tsx
+/**
+ * Mount integration: useEntityData under InformerProvider + EntityStoreProvider.
+ * Mirrors use-entities.store-backed.test.tsx setup.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { InformerFactory } from "../../core/informer.js";
+import type { WatchEntity } from "../../core/watch-events.js";
+import { WatchHub } from "../../core/watch-hub.js";
+import { EntityStoreFactory } from "../data/entity-store.js";
+import { EntityStoreProvider } from "./entity-store-context.js";
+import { InformerProvider } from "./informer-context.js";
+import { useEntityData } from "./use-entity-data.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NS = "default";
+
+function entity(id: string, ts: string): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: id,
+      artifacts: {},
+      relations: [],
+      tags: [],
+    } as never,
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: "1",
+    metadata: { generation: 1, creationTimestamp: ts },
+  };
+}
+
+function Probe({ onResult, provider }: { onResult: (r: unknown) => void; provider: unknown }) {
+  const r = useEntityData(provider, "Contribution", {
+    sort: (a, b) =>
+      (b.metadata.creationTimestamp ?? "").localeCompare(a.metadata.creationTimestamp ?? ""),
+    limit: 2,
+    active: true,
+  });
+  onResult(r);
+  return null;
+}
+
+describe("useEntityData — mount integration", () => {
+  test("informer path: returns sorted+sliced entity snapshot", async () => {
+    const hub = new WatchHub();
+    const informerFactory = new InformerFactory({
+      mode: "remote",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    const provider = { hasSessionScope: () => false };
+
+    let last: { data: readonly WatchEntity[]; loading: boolean } = {
+      data: [],
+      loading: true,
+    };
+    await act(async () => {
+      TestRenderer.create(
+        (
+          <InformerProvider value={informerFactory} eager>
+            <EntityStoreProvider value={storeFactory}>
+              <Probe
+                provider={provider}
+                onResult={(r) => {
+                  last = r as typeof last;
+                }}
+              />
+            </EntityStoreProvider>
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+    });
+
+    await act(async () => {
+      hub.emit({
+        type: "ADDED",
+        kind: "Contribution",
+        namespace: NS,
+        entity: entity("a", "2026-01-01T00:00:00Z"),
+      });
+      hub.emit({
+        type: "ADDED",
+        kind: "Contribution",
+        namespace: NS,
+        entity: entity("b", "2026-01-02T00:00:00Z"),
+      });
+      hub.emit({
+        type: "ADDED",
+        kind: "Contribution",
+        namespace: NS,
+        entity: entity("c", "2026-01-03T00:00:00Z"),
+      });
+    });
+
+    expect(last.data.map((e) => e.id)).toEqual(["c", "b"]); // sorted desc, limit 2
+  });
+
+  test("polled fallback: when no InformerProvider, calls fetcher", async () => {
+    let calls = 0;
+    const provider = {};
+
+    function PolledProbe({ onResult }: { onResult: (r: unknown) => void }) {
+      const r = useEntityData(provider, "Contribution", {
+        active: true,
+        fallbackFetcher: async () => {
+          calls += 1;
+          return [entity("p", "2026-01-01T00:00:00Z")] as readonly WatchEntity[];
+        },
+      });
+      onResult(r);
+      return null;
+    }
+
+    let last: { data: readonly WatchEntity[]; loading: boolean } = {
+      data: [],
+      loading: true,
+    };
+    await act(async () => {
+      TestRenderer.create(
+        (
+          <PolledProbe
+            onResult={(r) => {
+              last = r as typeof last;
+            }}
+          />
+        ) as React.ReactElement,
+      );
+    });
+    // Allow the fetcher's microtask to settle.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(calls).toBeGreaterThanOrEqual(1);
+    expect(last.data.map((e) => e.id)).toEqual(["p"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/tui/hooks/use-entity-data.mount.test.tsx`
+Expected: PASS — both informer and polled paths.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/hooks/use-entity-data.mount.test.tsx
+git commit -m "test(tui): mount integration for useEntityData (informer + polled paths)"
+```
+
+---
+
+## Task 3: `EntityView` component skeleton + tests
+
+**Files:**
+- Create: `src/tui/components/entity-view.tsx`
+- Create: `src/tui/components/entity-view.test.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `src/tui/components/entity-view.test.tsx`:
+
+```tsx
+/**
+ * Mount tests for EntityView: header, empty state, row mapping, onSelect.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { InformerFactory } from "../../core/informer.js";
+import type { WatchEntity } from "../../core/watch-events.js";
+import { WatchHub } from "../../core/watch-hub.js";
+import { EntityStoreFactory } from "../data/entity-store.js";
+import { EntityStoreProvider } from "../hooks/entity-store-context.js";
+import { InformerProvider } from "../hooks/informer-context.js";
+import { EntityView } from "./entity-view.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NS = "default";
+
+function entity(id: string): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: id,
+      artifacts: {},
+      relations: [],
+      tags: [],
+    } as never,
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: "1",
+    metadata: { generation: 1, creationTimestamp: "2026-01-01T00:00:00Z" },
+  };
+}
+
+const COLUMNS = [
+  { header: "ID", key: "id", width: 8, render: (e: WatchEntity) => e.id },
+] as const;
+
+function mountWithEntities(
+  entities: readonly WatchEntity[],
+  props: Partial<{ cursor: number; onSelect: (e: WatchEntity | undefined) => void }> = {},
+): { hub: WatchHub; renderer: TestRenderer.ReactTestRenderer } {
+  const hub = new WatchHub();
+  const informerFactory = new InformerFactory({
+    mode: "remote",
+    hub,
+    namespace: NS,
+    listFn: () => [],
+  });
+  const storeFactory = new EntityStoreFactory(informerFactory);
+  const provider = { hasSessionScope: () => false };
+
+  let renderer!: TestRenderer.ReactTestRenderer;
+  TestRenderer.act(() => {
+    renderer = TestRenderer.create(
+      (
+        <InformerProvider value={informerFactory} eager>
+          <EntityStoreProvider value={storeFactory}>
+            <EntityView
+              kind="Contribution"
+              columns={[...COLUMNS]}
+              provider={provider}
+              active={true}
+              cursor={props.cursor ?? -1}
+              {...(props.onSelect ? { onSelect: props.onSelect } : {})}
+              title="TestView"
+              emptyTitle="(none)"
+            />
+          </EntityStoreProvider>
+        </InformerProvider>
+      ) as React.ReactElement,
+    );
+  });
+  for (const e of entities) {
+    TestRenderer.act(() => {
+      hub.emit({ type: "ADDED", kind: "Contribution", namespace: NS, entity: e });
+    });
+  }
+  return { hub, renderer };
+}
+
+describe("EntityView", () => {
+  test("renders empty state when no data", async () => {
+    const { renderer } = mountWithEntities([]);
+    const tree = renderer.toJSON();
+    const flat = JSON.stringify(tree);
+    expect(flat).toContain("(none)");
+  });
+
+  test("renders title and rows when data present", async () => {
+    const { renderer } = mountWithEntities([entity("a"), entity("b")]);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("TestView");
+    expect(flat).toContain("a");
+    expect(flat).toContain("b");
+  });
+
+  test("onSelect fires with entity at cursor", async () => {
+    let selected: WatchEntity | undefined;
+    const { renderer } = mountWithEntities([entity("a"), entity("b")], {
+      cursor: 1,
+      onSelect: (e) => {
+        selected = e;
+      },
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(selected?.id).toBeDefined();
+    renderer.unmount();
+  });
+
+  test("onDataChanged fires with current entity slice", async () => {
+    let received: readonly WatchEntity[] = [];
+    const hub = new WatchHub();
+    const factory = new InformerFactory({ mode: "remote", hub, namespace: NS, listFn: () => [] });
+    const storeFactory = new EntityStoreFactory(factory);
+    TestRenderer.act(() => {
+      TestRenderer.create(
+        (
+          <InformerProvider value={factory} eager>
+            <EntityStoreProvider value={storeFactory}>
+              <EntityView
+                kind="Contribution"
+                columns={[...COLUMNS]}
+                provider={{ hasSessionScope: () => false }}
+                active={true}
+                cursor={-1}
+                onDataChanged={(d) => {
+                  received = d;
+                }}
+              />
+            </EntityStoreProvider>
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+    });
+    TestRenderer.act(() => {
+      hub.emit({ type: "ADDED", kind: "Contribution", namespace: NS, entity: entity("x") });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(received.map((e) => e.id)).toEqual(["x"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/tui/components/entity-view.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement EntityView**
+
+Create `src/tui/components/entity-view.tsx`:
+
+```tsx
+/**
+ * EntityView<K> — generic kind-parameterized list view.
+ *
+ * Replaces the duplicated dual-path data wiring across claims,
+ * agent-list, activity, and activity-panel. Owns:
+ *   - data fetch (via useEntityData)
+ *   - row mapping from columns[].render(entity)
+ *   - title/count header (DataStatus)
+ *   - empty state
+ *   - cursor → onSelect / onRowCountChanged
+ *
+ * Does NOT install keyboard handlers. `hints` is metadata for the
+ * C3 hint bar (#309) and C2 command prompt (#302). Mutation goes
+ * through confirmAndMutate (C6, #304), not EntityView.
+ */
+
+import React, { useEffect, useMemo } from "react";
+import type { EntityForKind } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+import { useEntityData } from "../hooks/use-entity-data.js";
+import { DataStatus } from "./data-status.js";
+import { EmptyState } from "./empty-state.js";
+import { Table, type TableColumn } from "./table.js";
+
+export interface EntityColumn<E> {
+  readonly header: string;
+  readonly key: string;
+  readonly width?: number;
+  readonly align?: "left" | "right";
+  readonly render: (entity: E) => string;
+}
+
+export interface EntityHint {
+  readonly key: string;
+  readonly label: string;
+}
+
+export interface EntityViewProps<K extends WatchKind> {
+  readonly kind: K;
+  readonly columns: readonly EntityColumn<EntityForKind<K>>[];
+  readonly provider: unknown;
+  readonly active: boolean;
+  readonly cursor: number;
+
+  readonly predicate?: (e: EntityForKind<K>) => boolean;
+  readonly sort?: (a: EntityForKind<K>, b: EntityForKind<K>) => number;
+  readonly offset?: number;
+  readonly limit?: number;
+  readonly fallbackFetcher?: () => Promise<readonly EntityForKind<K>[]>;
+
+  readonly title?: string;
+  readonly headerSuffix?: React.ReactNode;
+  readonly emptyTitle?: string;
+  readonly emptyHint?: string;
+
+  readonly onRowCountChanged?: (n: number) => void;
+  readonly onSelect?: (entity: EntityForKind<K> | undefined) => void;
+  readonly onDataChanged?: (data: readonly EntityForKind<K>[]) => void;
+
+  readonly hints?: readonly EntityHint[];
+}
+
+const MAX_ROWS = 500;
+
+function EntityViewInner<K extends WatchKind>(props: EntityViewProps<K>): React.ReactNode {
+  const {
+    kind,
+    columns,
+    provider,
+    active,
+    cursor,
+    predicate,
+    sort,
+    offset,
+    limit,
+    fallbackFetcher,
+    title,
+    headerSuffix,
+    emptyTitle,
+    emptyHint,
+    onRowCountChanged,
+    onSelect,
+    onDataChanged,
+  } = props;
+
+  const opts: Parameters<typeof useEntityData<K>>[2] = { active };
+  if (predicate) opts.predicate = predicate;
+  if (sort) opts.sort = sort;
+  if (offset !== undefined) opts.offset = offset;
+  if (limit !== undefined) opts.limit = limit;
+  if (fallbackFetcher) opts.fallbackFetcher = fallbackFetcher;
+
+  const { data, loading, isStale, error } = useEntityData<K>(provider, kind, opts);
+
+  const rows = useMemo<readonly Record<string, string>[]>(
+    () =>
+      data.map((entity) => {
+        const row: Record<string, string> = {};
+        for (const col of columns) row[col.key] = col.render(entity);
+        return row;
+      }),
+    [data, columns],
+  );
+
+  const tableColumns = useMemo<readonly TableColumn[]>(
+    () =>
+      columns.map((c) => ({
+        header: c.header,
+        key: c.key,
+        width: c.width,
+        align: c.align,
+      })),
+    [columns],
+  );
+
+  useEffect(() => {
+    if (onRowCountChanged) onRowCountChanged(data.length);
+  }, [data.length, onRowCountChanged]);
+
+  useEffect(() => {
+    if (!onSelect) return;
+    onSelect(cursor >= 0 && cursor < data.length ? data[cursor] : undefined);
+  }, [cursor, data, onSelect]);
+
+  useEffect(() => {
+    if (onDataChanged) onDataChanged(data);
+  }, [data, onDataChanged]);
+
+  if (loading && data.length === 0) {
+    return (
+      <box>
+        <text opacity={0.5}>{`Loading ${String(kind).toLowerCase()}...`}</text>
+      </box>
+    );
+  }
+
+  return (
+    <box flexDirection="column">
+      {title !== undefined && (
+        <box marginBottom={1} flexDirection="row">
+          <text>{`${title} (${data.length})`}</text>
+          <DataStatus loading={false} isStale={isStale} error={error?.message} />
+          {headerSuffix}
+        </box>
+      )}
+      {data.length === 0 ? (
+        <EmptyState
+          title={emptyTitle ?? `No ${String(kind).toLowerCase()}.`}
+          {...(emptyHint ? { hint: emptyHint } : {})}
+        />
+      ) : (
+        <Table columns={[...tableColumns]} rows={rows} cursor={cursor} maxRows={MAX_ROWS} />
+      )}
+    </box>
+  );
+}
+
+export const EntityView = React.memo(EntityViewInner) as <K extends WatchKind>(
+  props: EntityViewProps<K>,
+) => React.ReactNode;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/tui/components/entity-view.test.tsx`
+Expected: PASS — all 3 tests.
+
+- [ ] **Step 5: Run typecheck + lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui/components/entity-view.tsx src/tui/components/entity-view.test.tsx
+git commit -m "feat(tui): EntityView<K> generic list component (C1, #301)"
+```
+
+---
+
+## Task 4: Raise Table windowing to 500 + perf test
+
+**Files:**
+- Modify: `src/tui/components/table.tsx:21`
+- Create: `src/tui/components/entity-view.perf.test.tsx`
+
+- [ ] **Step 1: Raise the cap**
+
+In `src/tui/components/table.tsx:21`, change:
+```ts
+const MAX_RENDER_ITEMS = 200;
+```
+to:
+```ts
+const MAX_RENDER_ITEMS = 500;
+```
+
+- [ ] **Step 2: Update existing Table tests if any windowing assertion uses 200**
+
+Run: `bun test src/tui/components/table.test.ts`
+Expected: PASS. If any test hard-codes 200 in `computeWindow`, update the local mirror to 500.
+
+- [ ] **Step 3: Add perf test**
+
+Create `src/tui/components/entity-view.perf.test.tsx`:
+
+```tsx
+/**
+ * Skipped in CI; runnable locally for the #301 acceptance criterion
+ * "500-row list scrolls at 60fps".
+ *
+ * Mounts EntityView with 500 synthetic entities, performs 100 cursor
+ * moves, asserts p95 useMemo+render cost < 16ms.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { InformerFactory } from "../../core/informer.js";
+import type { WatchEntity } from "../../core/watch-events.js";
+import { WatchHub } from "../../core/watch-hub.js";
+import { EntityStoreFactory } from "../data/entity-store.js";
+import { EntityStoreProvider } from "../hooks/entity-store-context.js";
+import { InformerProvider } from "../hooks/informer-context.js";
+import { EntityView } from "./entity-view.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+const NS = "default";
+const COLUMNS = [
+  { header: "ID", key: "id", width: 8, render: (e: WatchEntity) => e.id },
+  { header: "SUM", key: "sum", width: 24, render: (e: WatchEntity) => e.id.repeat(3) },
+] as const;
+function entity(i: number): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id: `c${i}`,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: `s${i}`,
+      artifacts: {},
+      relations: [],
+      tags: [],
+    } as never,
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: String(i),
+    metadata: { generation: 1, creationTimestamp: `2026-01-01T00:00:${String(i % 60).padStart(2, "0")}Z` },
+  };
+}
+
+const ENABLED = process.env.RUN_PERF === "1";
+
+describe.skipIf(!ENABLED)("EntityView perf", () => {
+  test("500 rows × 100 cursor moves: p95 render < 16ms", async () => {
+    const hub = new WatchHub();
+    const informerFactory = new InformerFactory({
+      mode: "remote",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    const provider = { hasSessionScope: () => false };
+    let cursor = 0;
+    let renderer!: TestRenderer.ReactTestRenderer;
+
+    TestRenderer.act(() => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={informerFactory} eager>
+            <EntityStoreProvider value={storeFactory}>
+              <EntityView
+                kind="Contribution"
+                columns={[...COLUMNS]}
+                provider={provider}
+                active={true}
+                cursor={cursor}
+                title="Perf"
+              />
+            </EntityStoreProvider>
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+    });
+    for (let i = 0; i < 500; i += 1) {
+      TestRenderer.act(() => {
+        hub.emit({ type: "ADDED", kind: "Contribution", namespace: NS, entity: entity(i) });
+      });
+    }
+
+    const samples: number[] = [];
+    for (let i = 0; i < 100; i += 1) {
+      cursor = i;
+      const t0 = performance.now();
+      await act(async () => {
+        renderer.update(
+          (
+            <InformerProvider value={informerFactory} eager>
+              <EntityStoreProvider value={storeFactory}>
+                <EntityView
+                  kind="Contribution"
+                  columns={[...COLUMNS]}
+                  provider={provider}
+                  active={true}
+                  cursor={cursor}
+                  title="Perf"
+                />
+              </EntityStoreProvider>
+            </InformerProvider>
+          ) as React.ReactElement,
+        );
+      });
+      samples.push(performance.now() - t0);
+    }
+
+    samples.sort((a, b) => a - b);
+    const p95 = samples[Math.floor(samples.length * 0.95)];
+    expect(p95).toBeLessThan(16);
+  });
+});
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/tui/components/`
+Expected: PASS — perf test skipped (ENABLED=false).
+
+- [ ] **Step 5: Optional — verify perf locally**
+
+Run: `RUN_PERF=1 bun test src/tui/components/entity-view.perf.test.tsx`
+Expected: PASS — p95 < 16ms on a typical dev machine.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui/components/table.tsx src/tui/components/entity-view.perf.test.tsx
+git commit -m "perf(tui): raise Table windowing to 500 rows + EntityView perf gate"
+```
+
+---
+
+## Task 5: Columns library — Contribution
+
+**Files:**
+- Create: `src/tui/components/columns/contribution-columns.ts`
+
+- [ ] **Step 1: Write the columns module**
+
+Create `src/tui/components/columns/contribution-columns.ts`:
+
+```ts
+/**
+ * Reusable Contribution columns for EntityView. Imported by activity,
+ * activity-panel, and search-panel to keep column definitions DRY.
+ */
+
+import type { ContributionEntity } from "../../../core/entity.js";
+import { compareTimestampsDesc, formatTimestamp, truncateCid } from "../../../shared/format.js";
+import type { EntityColumn } from "../entity-view.js";
+
+const trunc = (s: string | undefined, max: number): string =>
+  !s ? "" : s.length > max ? `${s.slice(0, max - 2)}..` : s;
+
+export const cidColumn = (width = 22): EntityColumn<ContributionEntity> => ({
+  header: "CID",
+  key: "cid",
+  width,
+  render: (e) => truncateCid(e.id),
+});
+
+export const kindColumn = (width = 14): EntityColumn<ContributionEntity> => ({
+  header: "KIND",
+  key: "kind",
+  width,
+  render: (e) => e.spec.contributionKind,
+});
+
+export const modeColumn = (width = 12): EntityColumn<ContributionEntity> => ({
+  header: "MODE",
+  key: "mode",
+  width,
+  render: (e) => e.spec.mode,
+});
+
+export const summaryColumn = (width = 36): EntityColumn<ContributionEntity> => ({
+  header: "SUMMARY",
+  key: "summary",
+  width,
+  render: (e) => trunc(e.spec.summary, width),
+});
+
+export const agentColumn = (width = 16): EntityColumn<ContributionEntity> => ({
+  header: "AGENT",
+  key: "agent",
+  width,
+  render: (e) =>
+    e.spec.agent?.role ?? e.spec.agent?.agentName ?? e.spec.agent?.agentId ?? "unknown",
+});
+
+export const tagsColumn = (width = 16, max = 3): EntityColumn<ContributionEntity> => ({
+  header: "TAGS",
+  key: "tags",
+  width,
+  render: (e) => (e.spec.tags ?? []).slice(0, max).join(", "),
+});
+
+export const createdColumn = (
+  header = "CREATED",
+  width = 12,
+): EntityColumn<ContributionEntity> => ({
+  header,
+  key: "created",
+  width,
+  render: (e) => formatTimestamp(e.metadata.creationTimestamp ?? ""),
+});
+
+/** Sort: newest first by creationTimestamp. */
+export const byCreatedDesc = (a: ContributionEntity, b: ContributionEntity): number =>
+  compareTimestampsDesc(a.metadata.creationTimestamp, b.metadata.creationTimestamp);
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/components/columns/contribution-columns.ts
+git commit -m "feat(tui): contribution-columns library for EntityView"
+```
+
+---
+
+## Task 6: Migrate `activity-panel.tsx`
+
+**Files:**
+- Modify: `src/tui/views/activity-panel.tsx` (full rewrite)
+
+- [ ] **Step 1: Replace the file with the EntityView wrapper**
+
+Overwrite `src/tui/views/activity-panel.tsx`:
+
+```tsx
+/**
+ * Activity panel — recent contributions, EntityView-backed.
+ */
+
+import React from "react";
+import {
+  agentColumn,
+  byCreatedDesc,
+  cidColumn,
+  createdColumn,
+  kindColumn,
+  summaryColumn,
+  tagsColumn,
+} from "../components/columns/contribution-columns.js";
+import { EntityView } from "../components/entity-view.js";
+import type { TuiDataProvider } from "../provider.js";
+
+export interface ActivityPanelProps {
+  readonly provider: TuiDataProvider;
+  readonly intervalMs: number;
+  readonly active: boolean;
+  readonly cursor: number;
+  readonly onRowCountChanged?: ((count: number) => void) | undefined;
+}
+
+const COLUMNS = [
+  cidColumn(16),
+  kindColumn(12),
+  summaryColumn(32),
+  agentColumn(14),
+  tagsColumn(14, 2),
+  createdColumn("TIME", 10),
+];
+
+const PANEL_LIMIT = 30;
+
+export const ActivityPanelView: React.NamedExoticComponent<ActivityPanelProps> = React.memo(
+  function ActivityPanelView(props: ActivityPanelProps): React.ReactNode {
+    return (
+      <EntityView
+        kind="Contribution"
+        columns={COLUMNS}
+        provider={props.provider}
+        active={props.active}
+        cursor={props.cursor}
+        sort={byCreatedDesc}
+        limit={PANEL_LIMIT}
+        title="Activity"
+        emptyTitle="No recent activity."
+        emptyHint="Activity appears as agents publish contributions."
+        {...(props.onRowCountChanged ? { onRowCountChanged: props.onRowCountChanged } : {})}
+      />
+    );
+  },
+);
+```
+
+- [ ] **Step 2: Run all tests touching activity-panel**
+
+Run: `bun test src/tui/`
+Expected: PASS — no test references this view's internals; props contract unchanged.
+
+- [ ] **Step 3: Run typecheck + lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tui/views/activity-panel.tsx
+git commit -m "refactor(tui): port activity-panel to EntityView (C1, #301)"
+```
+
+---
+
+## Task 7: Migrate `activity.tsx`
+
+**Files:**
+- Modify: `src/tui/views/activity.tsx` (full rewrite)
+
+This view has paging (`pageOffset`/`pageSize`) and a custom header ("showing N-M"). The wrapper renders the custom header; EntityView omits `title`. `onContributionsLoaded` callers expect the full entity slice — flow it through EntityView's `onDataChanged` (defined in Task 3).
+
+- [ ] **Step 1: Overwrite the file**
+
+Overwrite `src/tui/views/activity.tsx`:
+
+```tsx
+/**
+ * Activity stream view — paged contributions feed, EntityView-backed.
+ *
+ * Pagination: sort by createdAt desc, slice via EntityView's offset+limit.
+ * Wrapper owns the custom header ("showing N-M") because EntityView's
+ * built-in title doesn't model offset display.
+ */
+
+import React, { useState } from "react";
+import type { ContributionEntity } from "../../core/entity.js";
+import type { Contribution } from "../../core/models.js";
+import {
+  agentColumn,
+  byCreatedDesc,
+  cidColumn,
+  createdColumn,
+  kindColumn,
+  modeColumn,
+  summaryColumn,
+  tagsColumn,
+} from "../components/columns/contribution-columns.js";
+import { EntityView } from "../components/entity-view.js";
+import type { TuiDataProvider } from "../provider.js";
+
+export interface ActivityProps {
+  readonly provider: TuiDataProvider;
+  readonly intervalMs: number;
+  readonly active: boolean;
+  readonly cursor: number;
+  readonly pageOffset: number;
+  readonly pageSize: number;
+  readonly onContributionsLoaded?: (contributions: readonly Contribution[]) => void;
+}
+
+const COLUMNS = [
+  cidColumn(22),
+  kindColumn(14),
+  modeColumn(12),
+  summaryColumn(36),
+  agentColumn(16),
+  tagsColumn(16, 3),
+  createdColumn("CREATED", 12),
+];
+
+function entityToContribution(e: ContributionEntity): Contribution {
+  return {
+    cid: e.id,
+    manifestVersion: 0,
+    kind: e.spec.contributionKind,
+    mode: e.spec.mode,
+    summary: e.spec.summary,
+    description: e.spec.description,
+    artifacts: e.spec.artifacts,
+    relations: e.spec.relations,
+    scores: e.spec.scores,
+    tags: e.spec.tags,
+    context: e.spec.context,
+    agent: e.spec.agent,
+    createdAt: e.metadata.creationTimestamp ?? "",
+  };
+}
+
+export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.memo(
+  function ActivityView(props: ActivityProps): React.ReactNode {
+    const { provider, active, cursor, pageOffset, pageSize, onContributionsLoaded } = props;
+    const [count, setCount] = useState(0);
+
+    return (
+      <box flexDirection="column">
+        <box marginBottom={1} flexDirection="row">
+          <text>Activity Stream</text>
+          {count > 0 ? (
+            <text opacity={0.5}>{`  showing ${pageOffset + 1}-${pageOffset + count}`}</text>
+          ) : pageOffset > 0 ? (
+            <text opacity={0.5}>{"  "}(no more results — press p to go back)</text>
+          ) : null}
+        </box>
+        <EntityView
+          kind="Contribution"
+          columns={COLUMNS}
+          provider={provider}
+          active={active}
+          cursor={cursor}
+          sort={byCreatedDesc}
+          offset={pageOffset}
+          limit={pageSize}
+          onRowCountChanged={setCount}
+          onDataChanged={(entities) => {
+            if (onContributionsLoaded)
+              onContributionsLoaded(entities.map(entityToContribution));
+          }}
+        />
+      </box>
+    );
+  },
+);
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test src/tui/`
+Expected: PASS — no test exercises the view's internals.
+
+- [ ] **Step 3: Run typecheck + lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tui/views/activity.tsx
+git commit -m "refactor(tui): port activity stream to EntityView (C1, #301)"
+```
+
+---
+
+## Task 8: Columns library — Claim
+
+**Files:**
+- Create: `src/tui/components/columns/claim-columns.ts`
+
+- [ ] **Step 1: Write the module**
+
+Create `src/tui/components/columns/claim-columns.ts`:
+
+```ts
+/**
+ * Reusable Claim columns for EntityView (claims.tsx, agent-list.tsx).
+ */
+
+import type { ClaimEntity } from "../../../core/entity.js";
+import { formatDuration } from "../../../shared/duration.js";
+import { formatTimestamp } from "../../../shared/format.js";
+import type { EntityColumn } from "../entity-view.js";
+
+const trunc = (s: string, max: number): string => (s.length > max ? `${s.slice(0, max - 2)}..` : s);
+
+export const claimIdColumn = (width = 20): EntityColumn<ClaimEntity> => ({
+  header: "CLAIM_ID",
+  key: "claimId",
+  width,
+  render: (e) => trunc(e.id, width),
+});
+
+export const targetColumn = (width = 24): EntityColumn<ClaimEntity> => ({
+  header: "TARGET",
+  key: "target",
+  width,
+  render: (e) => trunc(e.spec.targetRef, width),
+});
+
+export const agentColumn = (width = 16): EntityColumn<ClaimEntity> => ({
+  header: "AGENT",
+  key: "agent",
+  width,
+  render: (e) => e.spec.agent.agentName ?? e.spec.agent.agentId,
+});
+
+export const intentColumn = (width = 28): EntityColumn<ClaimEntity> => ({
+  header: "INTENT",
+  key: "intent",
+  width,
+  render: (e) => trunc(e.spec.intentSummary ?? "", width),
+});
+
+export const heartbeatColumn = (width = 12): EntityColumn<ClaimEntity> => ({
+  header: "HEARTBEAT",
+  key: "heartbeat",
+  width,
+  render: (e) => formatTimestamp(e.status.heartbeatAt),
+});
+
+/**
+ * STATUS column with duplicate-target highlight. Closes over a
+ * `targetCounts` map so the wrapper can pre-compute counts and pass
+ * them in. Returns the same EntityColumn shape; the render function
+ * is recreated when counts change (cheap).
+ */
+export const statusColumnWithCounts = (
+  targetCounts: ReadonlyMap<string, number>,
+  width = 10,
+): EntityColumn<ClaimEntity> => ({
+  header: "STATUS",
+  key: "status",
+  width,
+  render: (e) => {
+    const remaining = new Date(e.status.leaseExpiresAt).getTime() - Date.now();
+    const dup = (targetCounts.get(e.spec.targetRef) ?? 0) > 1;
+    const phase = e.status.phase;
+    if (phase === "active" && remaining <= 0) return "EXPIRED";
+    return dup ? `${phase} DUP` : phase;
+  },
+});
+
+export const leaseColumn = (width = 14): EntityColumn<ClaimEntity> => ({
+  header: "LEASE",
+  key: "lease",
+  width,
+  render: (e) => {
+    const remaining = new Date(e.status.leaseExpiresAt).getTime() - Date.now();
+    return remaining > 0 ? formatDuration(remaining) : "expired";
+  },
+});
+
+/** Predicate: only entities in `active` phase. */
+export const isActive = (e: ClaimEntity): boolean => e.status.phase === "active";
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/components/columns/claim-columns.ts
+git commit -m "feat(tui): claim-columns library for EntityView"
+```
+
+---
+
+## Task 9: Migrate `claims.tsx`
+
+**Files:**
+- Modify: `src/tui/views/claims.tsx` (full rewrite)
+
+- [ ] **Step 1: Replace the file**
+
+Overwrite `src/tui/views/claims.tsx`:
+
+```tsx
+/**
+ * Claims view — active claims with lease countdown, EntityView-backed.
+ *
+ * Scoped sessions (provider.hasSessionScope) render an EmptyState
+ * directly without mounting EntityView, preserving the pre-port
+ * behavior where `getClaims` lacks sessionId filtering.
+ */
+
+import React, { useCallback, useMemo } from "react";
+import type { ClaimEntity } from "../../core/entity.js";
+import { EmptyState } from "../components/empty-state.js";
+import {
+  agentColumn,
+  claimIdColumn,
+  heartbeatColumn,
+  intentColumn,
+  isActive,
+  leaseColumn,
+  statusColumnWithCounts,
+  targetColumn,
+} from "../components/columns/claim-columns.js";
+import { EntityView } from "../components/entity-view.js";
+import { useProviderScoped } from "../hooks/informer-context.js";
+import type { TuiDataProvider } from "../provider.js";
+
+export interface ClaimsProps {
+  readonly provider: TuiDataProvider;
+  readonly intervalMs: number;
+  readonly active: boolean;
+  readonly cursor: number;
+  readonly onRowCountChanged?: (count: number) => void;
+  readonly activeClaims?: readonly unknown[] | undefined;
+}
+
+export const ClaimsView: React.NamedExoticComponent<ClaimsProps> = React.memo(
+  function ClaimsView(props: ClaimsProps): React.ReactNode {
+    const { provider, active, cursor, onRowCountChanged } = props;
+    const isScoped = useProviderScoped(provider);
+
+    const fallbackFetcher = useCallback(async (): Promise<readonly ClaimEntity[]> => {
+      // Provider returns flat Claim shapes for the polled fallback path;
+      // synthesize minimal ClaimEntity envelopes so the column renders work.
+      const claims = await provider.getClaims({ status: "active" });
+      return claims.map(
+        (c) =>
+          ({
+            kind: "Claim",
+            namespace: "default",
+            id: c.claimId,
+            spec: {
+              targetRef: c.targetRef,
+              agent: c.agent,
+              intentSummary: c.intentSummary,
+              context: c.context,
+            },
+            status: {
+              phase: c.status as "active" | "expired" | "released" | "completed",
+              heartbeatAt: c.heartbeatAt,
+              leaseExpiresAt: c.leaseExpiresAt,
+              attemptCount: c.attemptCount ?? 0,
+            },
+            conditions: [],
+            observedGeneration: 0,
+            resourceVersion: "0",
+            metadata: { generation: 0, creationTimestamp: c.createdAt },
+          }) as unknown as ClaimEntity,
+      );
+    }, [provider]);
+
+    // Pre-computing target counts is per-render; closes over data each render
+    // via columns memo. Keep it simple: compute inside columns memo by reading
+    // the entity list; but EntityView owns the list. Trade-off: skip dup
+    // highlight in wrapper, OR derive counts via onDataChanged.
+    const [targetCounts, setTargetCounts] = React.useState<ReadonlyMap<string, number>>(new Map());
+    const onDataChanged = useCallback((data: readonly ClaimEntity[]) => {
+      const m = new Map<string, number>();
+      for (const e of data) m.set(e.spec.targetRef, (m.get(e.spec.targetRef) ?? 0) + 1);
+      setTargetCounts(m);
+    }, []);
+
+    const columns = useMemo(
+      () => [
+        claimIdColumn(20),
+        targetColumn(24),
+        agentColumn(16),
+        statusColumnWithCounts(targetCounts, 10),
+        leaseColumn(14),
+        heartbeatColumn(12),
+        intentColumn(28),
+      ],
+      [targetCounts],
+    );
+
+    if (isScoped) {
+      return (
+        <box flexDirection="column">
+          <box marginBottom={1}>
+            <text>Active Claims (0)</text>
+          </box>
+          <EmptyState
+            title="Active work claims. Claims prevent agents from duplicating each other's work."
+            hint="Spawn agents with Ctrl+P. Each agent automatically claims work before starting."
+          />
+        </box>
+      );
+    }
+
+    return (
+      <EntityView
+        kind="Claim"
+        columns={columns}
+        provider={provider}
+        active={active}
+        cursor={cursor}
+        predicate={isActive}
+        fallbackFetcher={fallbackFetcher}
+        title="Active Claims"
+        emptyTitle="Active work claims. Claims prevent agents from duplicating each other's work."
+        emptyHint="Spawn agents with Ctrl+P. Each agent automatically claims work before starting."
+        onDataChanged={onDataChanged}
+        {...(onRowCountChanged ? { onRowCountChanged } : {})}
+      />
+    );
+  },
+);
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test src/tui/`
+Expected: PASS — claims has no dedicated test file; nothing to break.
+
+- [ ] **Step 3: Run typecheck + lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: PASS.
+
+- [ ] **Step 4: Manual smoke (skip if subagent-driven)**
+
+Run grove TUI against a Nexus stack with active claims; verify the Claims tab matches pre-port behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/views/claims.tsx
+git commit -m "refactor(tui): port claims view to EntityView (C1, #301)"
+```
+
+---
+
+## Task 10: Columns library — Agent
+
+**Files:**
+- Create: `src/tui/components/columns/agent-columns.ts`
+
+- [ ] **Step 1: Write the module**
+
+Create `src/tui/components/columns/agent-columns.ts`:
+
+```ts
+/**
+ * Agent columns for the agent-list view. Several columns depend on
+ * a join context (tmux session names, cost rollups) — those are
+ * factory functions that close over the context.
+ */
+
+import type { ClaimEntity } from "../../../core/entity.js";
+import type { Claim } from "../../../core/models.js";
+import { agentStatusIcon } from "../../theme.js";
+import type { EntityColumn } from "../entity-view.js";
+
+export interface AgentJoinCtx {
+  readonly tmuxSessions: readonly string[];
+  readonly agentSessions: ReadonlyMap<string, string>; // agentId → session
+  readonly costs: ReadonlyMap<
+    string,
+    { costUsd: number; tokens: number; contextPercent?: number }
+  >;
+  readonly spinnerFrame: number;
+}
+
+const formatTokens = (n: number): string =>
+  n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1_000 ? `${Math.round(n / 1_000)}K` : String(n);
+
+const trunc = (s: string, max: number): string => (s.length > max ? `${s.slice(0, max - 2)}..` : s);
+
+const claimToFlat = (e: ClaimEntity): Claim => ({
+  claimId: e.id,
+  targetRef: e.spec.targetRef,
+  agent: e.spec.agent,
+  status: e.status.phase,
+  intentSummary: e.spec.intentSummary,
+  createdAt: e.metadata.creationTimestamp ?? e.status.heartbeatAt,
+  heartbeatAt: e.status.heartbeatAt,
+  leaseExpiresAt: e.status.leaseExpiresAt,
+  context: e.spec.context,
+  attemptCount: e.status.attemptCount,
+});
+
+const deriveAgentStatus = (
+  claim: Claim,
+  session: string | undefined,
+  tmuxSessions: readonly string[],
+): string => {
+  const remaining = new Date(claim.leaseExpiresAt).getTime() - Date.now();
+  if (remaining <= 0) return "expired";
+  if (!session) return "claimed";
+  if (!tmuxSessions.includes(session)) return "error";
+  if (Date.now() - new Date(claim.heartbeatAt).getTime() > 60_000) return "stalled";
+  return "running";
+};
+
+export const agentIdColumn = (width = 16): EntityColumn<ClaimEntity> => ({
+  header: "AGENT",
+  key: "agentId",
+  width,
+  render: (e) => e.spec.agent.agentName ?? e.spec.agent.agentId,
+});
+
+export const roleColumn = (width = 12): EntityColumn<ClaimEntity> => ({
+  header: "ROLE",
+  key: "role",
+  width,
+  render: (e) => e.spec.agent.role ?? "worker",
+});
+
+export const platformColumn = (width = 12): EntityColumn<ClaimEntity> => ({
+  header: "PLATFORM",
+  key: "platform",
+  width,
+  render: (e) => e.spec.agent.platform ?? "-",
+});
+
+export const targetColumn = (width = 18): EntityColumn<ClaimEntity> => ({
+  header: "TARGET",
+  key: "target",
+  width,
+  render: (e) => trunc(e.spec.targetRef, width),
+});
+
+export const statusColumn = (
+  ctx: AgentJoinCtx,
+  width = 12,
+): EntityColumn<ClaimEntity> => ({
+  header: "STATUS",
+  key: "status",
+  width,
+  render: (e) => {
+    const claim = claimToFlat(e);
+    const session = ctx.agentSessions.get(claim.agent.agentId);
+    const status = deriveAgentStatus(claim, session, ctx.tmuxSessions);
+    const { icon } = agentStatusIcon(status, ctx.spinnerFrame);
+    return `${icon} ${status}`;
+  },
+});
+
+export const costColumn = (ctx: AgentJoinCtx, width = 14): EntityColumn<ClaimEntity> => ({
+  header: "COST",
+  key: "cost",
+  width,
+  render: (e) => {
+    const c = ctx.costs.get(e.spec.agent.agentId);
+    return c ? `$${c.costUsd.toFixed(2)} | ${formatTokens(c.tokens)}` : "-";
+  },
+});
+
+export const sessionColumn = (ctx: AgentJoinCtx, width = 16): EntityColumn<ClaimEntity> => ({
+  header: "SESSION",
+  key: "session",
+  width,
+  render: (e) => ctx.agentSessions.get(e.spec.agent.agentId) ?? "-",
+});
+
+/** Sort: coordinators first, then alphabetical by name. */
+export const byRoleAndName = (a: ClaimEntity, b: ClaimEntity): number => {
+  const ra = a.spec.agent.role ?? "worker";
+  const rb = b.spec.agent.role ?? "worker";
+  if (ra !== rb) {
+    if (ra === "coordinator") return -1;
+    if (rb === "coordinator") return 1;
+    return ra.localeCompare(rb);
+  }
+  const na = a.spec.agent.agentName ?? a.spec.agent.agentId;
+  const nb = b.spec.agent.agentName ?? b.spec.agent.agentId;
+  return na.localeCompare(nb);
+};
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/components/columns/agent-columns.ts
+git commit -m "feat(tui): agent-columns library with join-context factories"
+```
+
+---
+
+## Task 11: Migrate `agent-list.tsx`
+
+**Files:**
+- Modify: `src/tui/views/agent-list.tsx` (full rewrite)
+
+- [ ] **Step 1: Replace the file**
+
+Overwrite `src/tui/views/agent-list.tsx`:
+
+```tsx
+/**
+ * Agent list view — running agents derived from active claims joined
+ * with tmux session list and cost rollups. EntityView renders the
+ * list; the wrapper computes the join context and passes it to the
+ * column factories.
+ */
+
+import React, { useCallback, useMemo, useState } from "react";
+import type { ClaimEntity } from "../../core/entity.js";
+import { useInterval } from "../../local/use-interval.js";
+import { agentIdFromSession, type TmuxManager } from "../agents/tmux-manager.js";
+import {
+  type AgentJoinCtx,
+  agentIdColumn,
+  byRoleAndName,
+  costColumn,
+  platformColumn,
+  roleColumn,
+  sessionColumn,
+  statusColumn,
+  targetColumn,
+} from "../components/columns/agent-columns.js";
+import { isActive } from "../components/columns/claim-columns.js";
+import { EntityView } from "../components/entity-view.js";
+import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
+import type { TuiDataProvider } from "../provider.js";
+import { BRAILLE_SPINNER, timing } from "../theme.js";
+
+export interface AgentListProps {
+  readonly provider: TuiDataProvider;
+  readonly tmux?: TmuxManager | undefined;
+  readonly intervalMs: number;
+  readonly active: boolean;
+  readonly cursor: number;
+  readonly onSelectSession?: ((sessionName: string | undefined) => void) | undefined;
+}
+
+export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.memo(
+  function AgentListView(props: AgentListProps): React.ReactNode {
+    const { provider, tmux, active, cursor, onSelectSession } = props;
+    const [spinnerFrame, setSpinnerFrame] = useState(0);
+    useInterval(
+      () => setSpinnerFrame((f) => (f + 1) % BRAILLE_SPINNER.length),
+      timing.spinner,
+      active,
+    );
+
+    const tmuxFetcher = useCallback(async (): Promise<readonly string[]> => {
+      if (!tmux) return [];
+      return (await tmux.isAvailable()) ? tmux.listSessions() : [];
+    }, [tmux]);
+    const { data: tmuxSessions } = useEventDrivenData<readonly string[]>(
+      tmuxFetcher,
+      undefined,
+      undefined,
+      active && !!tmux,
+    );
+
+    const costFetcher = useCallback(async () => {
+      const cp = provider as unknown as {
+        getSessionCosts?: () => Promise<{
+          byAgent: readonly {
+            agentId: string;
+            costUsd: number;
+            tokens: number;
+            contextPercent?: number;
+          }[];
+        }>;
+      };
+      if (!cp.getSessionCosts)
+        return new Map<string, { costUsd: number; tokens: number; contextPercent?: number }>();
+      const out = await cp.getSessionCosts();
+      const m = new Map<string, { costUsd: number; tokens: number; contextPercent?: number }>();
+      for (const a of out.byAgent) {
+        const entry: { costUsd: number; tokens: number; contextPercent?: number } = {
+          costUsd: a.costUsd,
+          tokens: a.tokens,
+        };
+        if (a.contextPercent !== undefined) entry.contextPercent = a.contextPercent;
+        m.set(a.agentId, entry);
+      }
+      return m;
+    }, [provider]);
+    const { data: costs } = useEventDrivenData(costFetcher, undefined, undefined, active);
+
+    const agentSessions = useMemo<ReadonlyMap<string, string>>(() => {
+      const m = new Map<string, string>();
+      for (const name of tmuxSessions ?? []) {
+        const id = agentIdFromSession(name);
+        if (id) m.set(id, name);
+      }
+      return m;
+    }, [tmuxSessions]);
+
+    const ctx = useMemo<AgentJoinCtx>(
+      () => ({
+        tmuxSessions: tmuxSessions ?? [],
+        agentSessions,
+        costs:
+          costs ??
+          new Map<string, { costUsd: number; tokens: number; contextPercent?: number }>(),
+        spinnerFrame,
+      }),
+      [tmuxSessions, agentSessions, costs, spinnerFrame],
+    );
+
+    const columns = useMemo(
+      () => [
+        agentIdColumn(16),
+        roleColumn(12),
+        platformColumn(12),
+        statusColumn(ctx, 12),
+        costColumn(ctx, 14),
+        targetColumn(18),
+        sessionColumn(ctx, 16),
+      ],
+      [ctx],
+    );
+
+    const onSelect = useCallback(
+      (entity: ClaimEntity | undefined) => {
+        if (!onSelectSession) return;
+        if (!entity) return onSelectSession(undefined);
+        const session = agentSessions.get(entity.spec.agent.agentId);
+        onSelectSession(session ?? undefined);
+      },
+      [onSelectSession, agentSessions],
+    );
+
+    return (
+      <EntityView
+        kind="Claim"
+        columns={columns}
+        provider={provider}
+        active={active}
+        cursor={cursor}
+        predicate={isActive}
+        sort={byRoleAndName}
+        title="Agents"
+        emptyTitle="No agents registered."
+        emptyHint="Press r to register, or Ctrl+P to spawn."
+        onSelect={onSelect}
+      />
+    );
+  },
+);
+```
+
+- [ ] **Step 2: Run tests + typecheck + lint**
+
+Run: `bun test src/tui/ && bun run typecheck && bun run lint`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/views/agent-list.tsx
+git commit -m "refactor(tui): port agent-list to EntityView with join-context columns"
+```
+
+---
+
+## Task 12: Acceptance verification
+
+**Files:** none (audit step)
+
+- [ ] **Step 1: Confirm ≥4 screens share EntityView**
+
+Run: `grep -l "EntityView" src/tui/views/`
+Expected output:
+```
+src/tui/views/activity-panel.tsx
+src/tui/views/activity.tsx
+src/tui/views/claims.tsx
+src/tui/views/agent-list.tsx
+```
+That's 4 files, meeting the issue's ≥4 acceptance.
+
+- [ ] **Step 2: Confirm "no new component" pattern**
+
+Pick a kind not yet wired (e.g. `Plan` or `Decision`). Sketch in a comment that adding the view requires:
+1. New `src/tui/components/columns/<kind>-columns.ts` (config).
+2. A wrapper that calls `<EntityView kind="X" columns={X_COLUMNS} … />`.
+No new component file under `src/tui/components/`. Add this note to the spec or the issue comment.
+
+- [ ] **Step 3: Run perf gate locally**
+
+Run: `RUN_PERF=1 bun test src/tui/components/entity-view.perf.test.tsx`
+Expected: PASS — p95 < 16ms with 500 rows × 100 cursor moves.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `bun test`
+Expected: PASS — no regressions.
+
+- [ ] **Step 5: Final lint + typecheck**
+
+Run: `bun run lint && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit / open PR**
+
+If any minor doc updates were needed in step 2 (spec note), commit them. Open the PR titled:
+> feat(tui): generic EntityView component (C1, #301)
+
+PR body links the spec, the plan, and lists the 4 migrated views (claims, agent-list, activity, activity-panel). Notes that `search-panel.tsx` is intentionally not migrated in this PR (server-side search isn't expressible via EntityStore predicate).
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+- Section "Architecture / 1. useEntityData" → Tasks 1, 2.
+- Section "Architecture / 2. EntityView" → Task 3 (includes `onDataChanged`).
+- Section "Architecture / 2a. EntityFor consolidation" → Task 0.
+- Section "Architecture / 3. Columns library" → Tasks 5, 8, 10.
+- Section "Migration plan" claims/agent-list/activity/activity-panel → Tasks 6, 7, 9, 11. (search-panel deferred — see plan note.)
+- Section "Testing" unit/hook/perf → Tasks 1, 2, 3, 4.
+- Section "Acceptance criteria mapping" → Task 12.
+
+**Consistency:**
+- `useEntityData(provider, kind, opts)` signature consistent across Tasks 1–3 and all migration tasks.
+- `EntityViewProps<K>` field set defined in Task 3; Tasks 6, 7, 9, 11 use only the names declared there: `kind`, `columns`, `provider`, `active`, `cursor`, `predicate`, `sort`, `offset`, `limit`, `fallbackFetcher`, `title`, `headerSuffix`, `emptyTitle`, `emptyHint`, `onRowCountChanged`, `onSelect`, `onDataChanged`, `hints`.
+
+**Open risk:**
+- Task 9's claims migration synthesizes `ClaimEntity` envelopes inside `fallbackFetcher` because the polled `getClaims` returns flat `Claim` objects. Works for column rendering but is awkward; if it bites, an alternative is keeping the fallback path on a private hook that returns rows directly. Acceptable for the first pass.
+- search-panel is intentionally out of scope. Spec note in `docs/superpowers/specs/2026-05-06-c1-entity-view-design.md` should be updated to match before PR merge.

--- a/docs/superpowers/specs/2026-05-06-c1-entity-view-design.md
+++ b/docs/superpowers/specs/2026-05-06-c1-entity-view-design.md
@@ -17,7 +17,7 @@ Land one generic `<EntityView kind columns … />` component that replaces the d
 
 ## Migration scope
 
-Five concrete view files port to EntityView in this epic:
+Four concrete view files port to EntityView in this epic:
 
 | File | Kind | Notes |
 |------|------|------|
@@ -25,9 +25,10 @@ Five concrete view files port to EntityView in this epic:
 | `activity-panel.tsx` | `Contribution` | Subset of Activity columns; `limit=30` |
 | `activity.tsx` | `Contribution` | Paged list; sort+slice via EntityView props |
 | `agent-list.tsx` | `Claim` | Multi-source join (claims × tmux × cost) — wrapper retains the join, EntityView handles list scaffold |
-| `search-panel.tsx` | `Contribution` × 2 | Two result tables become two EntityView instances; search input + state machine stay in the wrapper |
 
-The acceptance criterion "≥4 screens share one component" is met by claims, activity-panel, activity, agent-list (4 clean fits) plus the two search-panel instances (5 conceptually, 6 instantiations).
+`search-panel.tsx` was an initial candidate but is deferred. Its contribution result table needs server-side full-text search via `provider.getContributions({ search })` when the user has a query, which the EntityStore-predicate path can't model. Migrating only the no-query branch would split the view's logic awkwardly. Search-panel can revisit when a watch-side search filter lands.
+
+The acceptance criterion "≥4 screens share one component" is met by the four migrations above.
 
 ## Architecture
 
@@ -159,9 +160,8 @@ EntityView is a passive consumer. It does not own informer/store lifecycle (thos
 3. Migrate `activity-panel.tsx`.
 4. Migrate `activity.tsx`.
 5. Migrate `agent-list.tsx` — wrapper retains the claims × tmux × cost join; passes derived columns to EntityView via factory functions that close over the join context.
-6. Migrate `search-panel.tsx` — two EntityView instances for transcript + semantic result tables; search input + state machine stay in wrapper.
 
-Each step keeps existing view-level tests green. Net deletion: ~600 lines of duplicated dual-path / row-mapping / loading-state code across the 5 files, replaced by ~250 lines of EntityView + columns library.
+Each step keeps existing view-level tests green. Net deletion: ~500 lines of duplicated dual-path / row-mapping / loading-state code across the 4 files, replaced by ~250 lines of EntityView + columns library.
 
 ## Testing
 
@@ -193,8 +193,8 @@ Each step keeps existing view-level tests green. Net deletion: ~600 lines of dup
 
 | Criterion (issue #301) | How met |
 |------|------|
-| ≥4 screens share one component | 5 view files, 6 EntityView instantiations |
-| Adding new kind = config file + renderer fn, no new component | Demonstrated by `claim-columns.ts`/`contribution-columns.ts` lib + the `<EntityView kind="X" columns={X_COLUMNS} />` migration pattern |
+| ≥4 screens share one component | 4 view files (claims, activity, activity-panel, agent-list) |
+| Adding new kind = config file + renderer fn, no new component | Demonstrated by `claim-columns.ts`/`contribution-columns.ts`/`agent-columns.ts` lib + the `<EntityView kind="X" columns={X_COLUMNS} />` migration pattern |
 | 500-row list scrolls at 60fps | `MAX_ROWS=500` window + perf test asserting <16ms p95 cursor-move cost |
 
 ## Open questions / follow-ups

--- a/docs/superpowers/specs/2026-05-06-c1-entity-view-design.md
+++ b/docs/superpowers/specs/2026-05-06-c1-entity-view-design.md
@@ -1,0 +1,204 @@
+# C1 — Generic `<EntityView>` component
+
+**Issue**: [#301](https://github.com/windoliver/grove/issues/301)
+**Parent epic**: [#284](https://github.com/windoliver/grove/issues/284) — Epic C: TUI Views + Mutation Safety
+**Depends on**: #296 (B1 Central store, MERGED — `EntityStore`/`useEntities` available)
+**Reference**: k9s `internal/view/browser.go`, `internal/render/*`
+
+## Goal
+
+Land one generic `<EntityView kind columns … />` component that replaces the duplicated dual-path data fetching, row mapping, loading/empty/error rendering, and cursor handling currently copy-pasted across the TUI's list-style views. Adding a new entity-backed list view becomes "import EntityView, declare a `columns` array, declare a `predicate`/`sort`" — no new component file.
+
+## Non-goals
+
+- Keyboard input handling. The App's screen-manager remains the keymap authority. EntityView accepts a `hints` prop (metadata only) so the C3 hint bar (#309) can render context-aware actions, and so C2 command prompt (#302) can read available actions, without EntityView fighting the parent for input events.
+- Mutation. Destructive actions are gated by `confirmAndMutate` (C6, #304); EntityView never mutates.
+- Migrating `pipeline-view.tsx` (flex-card grid) or `agent-graph.tsx` (custom edge layout). These are not row-based; forcing them into EntityView would distort it.
+
+## Migration scope
+
+Five concrete view files port to EntityView in this epic:
+
+| File | Kind | Notes |
+|------|------|------|
+| `claims.tsx` | `Claim` | Cleanest fit; canonical migration |
+| `activity-panel.tsx` | `Contribution` | Subset of Activity columns; `limit=30` |
+| `activity.tsx` | `Contribution` | Paged list; sort+slice via EntityView props |
+| `agent-list.tsx` | `Claim` | Multi-source join (claims × tmux × cost) — wrapper retains the join, EntityView handles list scaffold |
+| `search-panel.tsx` | `Contribution` × 2 | Two result tables become two EntityView instances; search input + state machine stay in the wrapper |
+
+The acceptance criterion "≥4 screens share one component" is met by claims, activity-panel, activity, agent-list (4 clean fits) plus the two search-panel instances (5 conceptually, 6 instantiations).
+
+## Architecture
+
+Three units, each independently testable:
+
+### 1. `useEntityData<K>` — data hook
+
+`src/tui/hooks/use-entity-data.ts`. Collapses the dual-path (informer cache + polled fallback) currently inlined in every list view.
+
+```ts
+export function useEntityData<K extends WatchKind>(
+  kind: K,
+  opts: {
+    readonly predicate?: (e: EntityFor<K>) => boolean;
+    readonly sort?: (a: EntityFor<K>, b: EntityFor<K>) => number;
+    readonly limit?: number;
+    readonly fallbackFetcher?: () => Promise<readonly EntityFor<K>[]>;
+    readonly active: boolean;
+  },
+): {
+  readonly data: readonly EntityFor<K>[];
+  readonly loading: boolean;
+  readonly isStale: boolean;
+  readonly error: Error | undefined;
+};
+```
+
+Internal flow:
+1. `useEntityWatchEnabled(provider, kind)` → `useInformerPath`.
+2. `useEntities(kind, predicate)` always called (stable hook order across re-renders even when path flips).
+3. `useEventDrivenData(fallbackFetcher, …, active && !useInformerPath && !!fallbackFetcher)`.
+4. memoize: if `useInformerPath`, apply `sort` then `limit` to the informer snapshot; else return polled data.
+5. Merge `loading`/`isStale`/`error` from the active branch.
+
+Both branches are evaluated each render to keep React's hook order stable when `useEntityWatchEnabled` toggles (already a known concern in current views).
+
+### 2. `EntityView<K>` — component
+
+`src/tui/components/entity-view.tsx`. Pure render layer atop `useEntityData` and `Table`.
+
+```tsx
+export interface EntityColumn<E> {
+  readonly header: string;
+  readonly key: string;                       // stable id; row-map column key
+  readonly width?: number;
+  readonly align?: "left" | "right";
+  readonly render: (entity: E) => string;
+}
+
+export interface EntityHint {
+  readonly key: string;                       // "d", "ctrl+k", …
+  readonly label: string;                     // "delete", "kill", …
+}
+
+export interface EntityViewProps<K extends WatchKind> {
+  readonly kind: K;
+  readonly columns: readonly EntityColumn<EntityFor<K>>[];
+
+  readonly predicate?: (e: EntityFor<K>) => boolean;
+  readonly sort?: (a: EntityFor<K>, b: EntityFor<K>) => number;
+  readonly limit?: number;
+  readonly fallbackFetcher?: () => Promise<readonly EntityFor<K>[]>;
+
+  readonly title?: string;
+  readonly emptyTitle?: string;
+  readonly emptyHint?: string;
+
+  readonly active: boolean;
+  readonly cursor: number;
+  readonly onRowCountChanged?: (n: number) => void;
+  readonly onSelect?: (entity: EntityFor<K> | undefined) => void;
+
+  readonly hints?: readonly EntityHint[];     // for C3 hint bar; no key handlers installed
+}
+```
+
+Render body:
+
+```tsx
+const { data, loading, isStale, error } = useEntityData(kind, { predicate, sort, limit, fallbackFetcher, active });
+const rows = useMemo(
+  () => data.map(e => Object.fromEntries(columns.map(c => [c.key, c.render(e)]))),
+  [data, columns],
+);
+useEffect(() => onSelect?.(data[cursor]), [cursor, data, onSelect]);
+useEffect(() => onRowCountChanged?.(data.length), [data.length, onRowCountChanged]);
+
+if (loading && data.length === 0) return <text opacity={0.5}>Loading {kind.toLowerCase()}…</text>;
+return (
+  <box flexDirection="column">
+    {title && <Header title rowCount={data.length} loading={loading} isStale={isStale} error={error} />}
+    {data.length === 0
+      ? <EmptyState title={emptyTitle ?? `No ${kind.toLowerCase()}.`} hint={emptyHint} />
+      : <Table columns={[...columns]} rows={rows} cursor={cursor} maxRows={MAX_ROWS} />}
+  </box>
+);
+```
+
+`MAX_ROWS = 500`. The current `Table` already does cursor-centered windowing via `MAX_RENDER_ITEMS`; raising it to 500 satisfies the acceptance criterion. If real-terminal measurement shows 60fps regression, file a follow-up to add viewport-sized windowing.
+
+### 2a. `EntityFor<K>` consolidation
+
+Currently re-derived locally in `entity-store.ts`, `use-entities.ts`, `use-entity.ts`. As part of step 1 of the migration plan, export the existing `EntityForKind<K>` from `src/core/informer.ts` (already defined there, just not exported) and switch the three callers to import it. EntityView and `useEntityData` import the same type. No behavior change.
+
+### 3. Columns library
+
+`src/tui/components/columns/`:
+
+- `claim-columns.ts` — `CLAIM_ID`, `TARGET`, `AGENT`, `STATUS`, `LEASE`, `HEARTBEAT`, `INTENT`.
+- `contribution-columns.ts` — `CID`, `KIND`, `SUMMARY`, `AGENT`, `TAGS`, `TIME`.
+- `agent-columns.ts` — `AGENT_ID`, `ROLE`, `PLATFORM`, `STATUS`, `COST`, `SESSION`. Some columns close over a join context (tmux sessions, cost map) — exposed as factory functions: `agentStatusColumn(ctx: AgentJoinCtx)`.
+
+Columns are plain consts/factories — no React, no hooks. Importable across views.
+
+## Data flow
+
+```
+EntityStore (B1) → useEntities(kind, predicate) → useEntityData ─┐
+                                                                  ├→ EntityView → Table
+provider.getX (fallback)  → useEventDrivenData ──────────────────┘
+```
+
+EntityView is a passive consumer. It does not own informer/store lifecycle (those are managed by `informer-context.tsx` / `EntityStoreFactory`). On unmount it relinquishes its subscriptions via the underlying hooks.
+
+## Migration plan (one commit per row)
+
+1. Land `EntityView` + `useEntityData` + columns library skeleton + tests. No view migrations yet. Confirms the abstraction compiles, tests pass, no callers broken.
+2. Migrate `claims.tsx` — canonical reference. Wrapper preserves the `isScoped → []` short-circuit by rendering a standalone `<EmptyState />` (with the existing scope hint) when `isScoped` is true, instead of mounting EntityView with empty data. EntityView mounts only on the unscoped path.
+3. Migrate `activity-panel.tsx`.
+4. Migrate `activity.tsx`.
+5. Migrate `agent-list.tsx` — wrapper retains the claims × tmux × cost join; passes derived columns to EntityView via factory functions that close over the join context.
+6. Migrate `search-panel.tsx` — two EntityView instances for transcript + semantic result tables; search input + state machine stay in wrapper.
+
+Each step keeps existing view-level tests green. Net deletion: ~600 lines of duplicated dual-path / row-mapping / loading-state code across the 5 files, replaced by ~250 lines of EntityView + columns library.
+
+## Testing
+
+**Unit — `entity-view.test.tsx`**:
+- Title + count rendered from data length.
+- Empty state when filtered data is empty.
+- Loading state when informer not synced and no data.
+- Error surfaces in `DataStatus`.
+- `onSelect(data[cursor])` fires on cursor change.
+- `predicate` filters before `sort` before `limit`.
+- `onRowCountChanged` fires only when count changes (no churn on identical counts).
+- Hook order stable when `useEntityWatchEnabled` toggles mid-mount.
+
+**Hook — `use-entity-data.test.ts`**:
+- Informer path: returns sorted/sliced snapshot, `loading=false` after sync.
+- Polled path (no informer): returns fallback fetcher result, respects `active=false`.
+- Path switch: cleanly transitions when `useEntityWatchEnabled` flips.
+- Both hooks (`useEntities`, `useEventDrivenData`) always called regardless of path.
+
+**Performance — `entity-view.perf.test.tsx`** (skipped in CI, runnable locally):
+- Mount EntityView with 500 synthetic entities.
+- Run 100 cursor moves; measure `useMemo` cost.
+- Assert p95 < 16ms (60fps budget).
+
+**Migration regressions**:
+- Existing tests for `claims.tsx`, `activity.tsx`, `activity-panel.tsx`, `agent-list.tsx`, `search-panel.tsx` stay green after each port (they test view output, not internals). `entity-store.burst.test.ts` (10k events) already covers the underlying store; EntityView inherits its guarantees through `useEntities`.
+
+## Acceptance criteria mapping
+
+| Criterion (issue #301) | How met |
+|------|------|
+| ≥4 screens share one component | 5 view files, 6 EntityView instantiations |
+| Adding new kind = config file + renderer fn, no new component | Demonstrated by `claim-columns.ts`/`contribution-columns.ts` lib + the `<EntityView kind="X" columns={X_COLUMNS} />` migration pattern |
+| 500-row list scrolls at 60fps | `MAX_ROWS=500` window + perf test asserting <16ms p95 cursor-move cost |
+
+## Open questions / follow-ups
+
+- If the perf test fails on real terminals, viewport-sized virtualization becomes a follow-up issue (replace Table's window-of-N with a height-aware window).
+- Cross-cutting columns (e.g. AGENT) used by both Claim and Contribution views — for now, each domain has its own columns lib. If duplication appears, extract to `shared-columns.ts`. Don't pre-extract.
+- `useDerived`-style joins (agent-list's claims × tmux × cost) stay in the view wrapper. If multiple views need similar joins, consider a separate `useEntityJoin` hook in a later issue. Out of scope here.

--- a/docs/superpowers/specs/2026-05-06-c1-entity-view-design.md
+++ b/docs/superpowers/specs/2026-05-06-c1-entity-view-design.md
@@ -86,13 +86,16 @@ export interface EntityHint {
 export interface EntityViewProps<K extends WatchKind> {
   readonly kind: K;
   readonly columns: readonly EntityColumn<EntityFor<K>>[];
+  readonly provider: unknown;                 // forwarded to useEntityWatchEnabled
 
   readonly predicate?: (e: EntityFor<K>) => boolean;
   readonly sort?: (a: EntityFor<K>, b: EntityFor<K>) => number;
-  readonly limit?: number;
+  readonly offset?: number;                   // pagination start
+  readonly limit?: number;                    // pagination length
   readonly fallbackFetcher?: () => Promise<readonly EntityFor<K>[]>;
 
   readonly title?: string;
+  readonly headerSuffix?: React.ReactNode;    // extra header content after DataStatus
   readonly emptyTitle?: string;
   readonly emptyHint?: string;
 
@@ -100,6 +103,7 @@ export interface EntityViewProps<K extends WatchKind> {
   readonly cursor: number;
   readonly onRowCountChanged?: (n: number) => void;
   readonly onSelect?: (entity: EntityFor<K> | undefined) => void;
+  readonly onDataChanged?: (data: readonly EntityFor<K>[]) => void;
 
   readonly hints?: readonly EntityHint[];     // for C3 hint bar; no key handlers installed
 }

--- a/src/cli/utils/ensure-project-id.ts
+++ b/src/cli/utils/ensure-project-id.ts
@@ -122,7 +122,7 @@ export async function ensureProjectId(opts: EnsureOpts): Promise<EnsureResult> {
 async function commitMissOrAdopt(
   opts: EnsureOpts,
   origin: string,
-  registryPath: string,
+  _registryPath: string,
   _now: () => Date,
 ): Promise<EnsureResult> {
   // Miss path: generate a local id and write the local file. We do NOT

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -1,5 +1,5 @@
 import { type ChildProcessByStdio, spawn as nodeSpawn } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Readable, Writable } from "node:stream";
@@ -208,21 +208,36 @@ async function launchSubprocess(
   // works) and a minimal config.toml. Grove's per-spawn MCP servers are
   // appended via `-c` flags in buildAcpLaunchArgs and remain in effect.
   const childEnv = { ...env };
+  let isolatedHomeForCleanup: string | undefined;
   if (agent === "codex" && env.GROVE_CODEX_NO_ISOLATION !== "1") {
     try {
       const isolatedHome = await prepareIsolatedCodexHome(env);
       childEnv.CODEX_HOME = isolatedHome;
+      isolatedHomeForCleanup = isolatedHome;
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[acp-runtime] codex isolated-home prep failed: ${detail}\n`);
     }
   }
 
-  const child = nodeSpawn(launch.command, buildAcpLaunchArgs(launch, opts, childEnv), {
-    cwd,
-    env: childEnv,
-    stdio: ["pipe", "pipe", "pipe"],
-  }) as ChildProcessByStdio<Writable, Readable, Readable>;
+  let child: ChildProcessByStdio<Writable, Readable, Readable>;
+  try {
+    child = nodeSpawn(launch.command, buildAcpLaunchArgs(launch, opts, childEnv), {
+      cwd,
+      env: childEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+    }) as ChildProcessByStdio<Writable, Readable, Readable>;
+  } catch (err) {
+    // Spawn itself failed — auth.json is on disk; clean up before bubbling.
+    if (isolatedHomeForCleanup) {
+      try {
+        rmSync(isolatedHomeForCleanup, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+    throw err;
+  }
 
   const stdinWebWritable = NodeWritable.toWeb(child.stdin) as WritableStream<Uint8Array>;
   const stdoutWebReadable = NodeReadable.toWeb(child.stdout) as ReadableStream<Uint8Array>;
@@ -297,6 +312,27 @@ async function launchSubprocess(
       child.kill("SIGTERM");
     } catch {
       /* ignore */
+    }
+    // Wait briefly for the child to exit so we don't `rm -rf` the isolated
+    // home out from under codex while it's still flushing session state.
+    // Bounded so a stuck child doesn't block teardown indefinitely.
+    if (isolatedHomeForCleanup) {
+      const exited = await new Promise<boolean>((resolve) => {
+        if (child.exitCode !== null || child.signalCode !== null) return resolve(true);
+        const timer = setTimeout(() => resolve(false), 2000);
+        child.once("exit", () => {
+          clearTimeout(timer);
+          resolve(true);
+        });
+      });
+      try {
+        rmSync(isolatedHomeForCleanup, { recursive: true, force: true });
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[acp-runtime] codex isolated-home cleanup failed (childExited=${exited}): ${detail}\n`,
+        );
+      }
     }
   };
   return { clientStream, dispose };

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -1,4 +1,7 @@
 import { type ChildProcessByStdio, spawn as nodeSpawn } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Readable, Writable } from "node:stream";
 import { Readable as NodeReadable, Writable as NodeWritable } from "node:stream";
 import {
@@ -82,6 +85,56 @@ function resolveAgentFromConfig(config: AgentConfig): string {
   return "codex";
 }
 
+/**
+ * Prepare an ephemeral CODEX_HOME for grove-spawned codex children. Copies the
+ * user's auth.json (so login persists), writes a minimal config.toml (model +
+ * personality only), and excludes user-level mcp_servers entries that may
+ * point to enterprise endpoints unreachable from this environment (DNS-blocked
+ * MaaS, etc.). Without this, a single failing user MCP server brings down the
+ * whole ACP connection on startup via rmcp's fatal-on-transport-close behavior.
+ */
+async function prepareIsolatedCodexHome(env: NodeJS.ProcessEnv): Promise<string> {
+  const userHome = env.CODEX_HOME ?? join(env.HOME ?? "/tmp", ".codex");
+  const isolated = mkdtempSync(join(tmpdir(), "grove-codex-"));
+  // Copy auth.json if present so login persists.
+  const userAuth = join(userHome, "auth.json");
+  if (existsSync(userAuth)) {
+    try {
+      copyFileSync(userAuth, join(isolated, "auth.json"));
+    } catch {
+      /* best-effort */
+    }
+  }
+  // Minimal config: keep model preferences from user config but skip everything
+  // else (mcp_servers, projects, plugins, notify hooks). Grove's per-spawn MCP
+  // servers are appended via `-c mcp_servers.<name>.command=...` at launch time.
+  const userConfigPath = join(userHome, "config.toml");
+  const lines: string[] = [];
+  if (existsSync(userConfigPath)) {
+    try {
+      const fs = await import("node:fs/promises");
+      const text = await fs.readFile(userConfigPath, "utf8");
+      // Keep only top-level scalar assignments before the first `[section]`.
+      // This preserves model/personality/effort but drops every table
+      // (mcp_servers.X, projects.X, plugins, etc.).
+      for (const raw of text.split("\n")) {
+        const line = raw.trimEnd();
+        if (line.startsWith("[")) break;
+        if (line.length > 0) lines.push(line);
+      }
+    } catch {
+      /* best-effort */
+    }
+  }
+  if (lines.length === 0) {
+    lines.push('model = "gpt-5"');
+  }
+  writeFileSync(join(isolated, "config.toml"), `${lines.join("\n")}\n`, "utf-8");
+  // Ensure plugins dir exists empty (some codex plugins bundle MCP servers).
+  mkdirSync(join(isolated, "plugins"), { recursive: true });
+  return isolated;
+}
+
 async function launchSubprocess(
   agent: string,
   cwd: string,
@@ -93,9 +146,29 @@ async function launchSubprocess(
   } = {},
 ): Promise<LaunchResult> {
   const launch = resolveAcpLaunch(agent);
-  const child = nodeSpawn(launch.command, buildAcpLaunchArgs(launch, opts, env), {
+
+  // Codex loads MCP servers from the user's ~/.codex/config.toml at startup.
+  // If any of those servers fail to connect (e.g., DNS-blocked enterprise MCP
+  // endpoints reachable only on VPN), the codex `rmcp` worker quits fatal,
+  // which closes the entire ACP stdio connection and breaks downstream sends.
+  // Isolate codex from the user MCP config by pointing CODEX_HOME at an
+  // ephemeral directory that contains only the user's auth (so login still
+  // works) and a minimal config.toml. Grove's per-spawn MCP servers are
+  // appended via `-c` flags in buildAcpLaunchArgs and remain in effect.
+  const childEnv = { ...env };
+  if (agent === "codex" && env.GROVE_CODEX_NO_ISOLATION !== "1") {
+    try {
+      const isolatedHome = await prepareIsolatedCodexHome(env);
+      childEnv.CODEX_HOME = isolatedHome;
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[acp-runtime] codex isolated-home prep failed: ${detail}\n`);
+    }
+  }
+
+  const child = nodeSpawn(launch.command, buildAcpLaunchArgs(launch, opts, childEnv), {
     cwd,
-    env,
+    env: childEnv,
     stdio: ["pipe", "pipe", "pipe"],
   }) as ChildProcessByStdio<Writable, Readable, Readable>;
 

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -210,13 +210,21 @@ async function launchSubprocess(
   const childEnv = { ...env };
   let isolatedHomeForCleanup: string | undefined;
   if (agent === "codex" && env.GROVE_CODEX_NO_ISOLATION !== "1") {
+    // Fail closed: if isolation prep throws, refuse the spawn rather than
+    // launching against the user's live ~/.codex (which would re-introduce
+    // the rmcp-fatal-on-bootstrap path this isolation exists to prevent,
+    // and run user-level notify hooks against grove turns). Operators that
+    // explicitly accept the risk can opt out with GROVE_CODEX_NO_ISOLATION=1.
     try {
       const isolatedHome = await prepareIsolatedCodexHome(env);
       childEnv.CODEX_HOME = isolatedHome;
       isolatedHomeForCleanup = isolatedHome;
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`[acp-runtime] codex isolated-home prep failed: ${detail}\n`);
+      throw new Error(
+        `[acp-runtime] codex isolated-home prep failed: ${detail}. ` +
+          `Set GROVE_CODEX_NO_ISOLATION=1 to launch with the user's ~/.codex (NOT recommended).`,
+      );
     }
   }
 

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -86,12 +86,41 @@ function resolveAgentFromConfig(config: AgentConfig): string {
 }
 
 /**
+ * Top-level scalar keys we copy from the user's `~/.codex/config.toml` into the
+ * isolated CODEX_HOME. Restrict to safe, well-known keys: model preferences
+ * and explicit grove-relevant settings. Anything else (notify hooks pointing
+ * at desktop-app binaries, history backends, telemetry endpoints, …) is
+ * dropped because we don't want grove-spawned children running side effects
+ * the user wired into their interactive Codex.
+ *
+ * Tables (`[mcp_servers.X]`, `[projects.X]`, `[plugins]`) are always dropped
+ * — grove provides its own MCP server set via `-c` flags in
+ * `buildAcpLaunchArgs`, and per-project trust is bypassed entirely because
+ * grove-spawned workspaces are ephemeral and explicitly approved by the
+ * `GROVE_ALLOW_ALL_PERMISSIONS=1` / sandbox config the launcher passes.
+ */
+const SAFE_CODEX_TOP_LEVEL_KEYS = new Set([
+  "model",
+  "model_provider",
+  "personality",
+  "model_reasoning_effort",
+  "model_reasoning_summaries",
+  "approvals_reviewer",
+]);
+
+/**
+ * Match a top-level TOML scalar assignment: `key = ...` outside any table.
+ * We bail at the first `[` line to switch to "inside-section" mode.
+ */
+const TOML_TOP_LEVEL_KEY_LINE = /^([A-Za-z0-9_-]+)\s*=/;
+
+/**
  * Prepare an ephemeral CODEX_HOME for grove-spawned codex children. Copies the
- * user's auth.json (so login persists), writes a minimal config.toml (model +
- * personality only), and excludes user-level mcp_servers entries that may
- * point to enterprise endpoints unreachable from this environment (DNS-blocked
- * MaaS, etc.). Without this, a single failing user MCP server brings down the
- * whole ACP connection on startup via rmcp's fatal-on-transport-close behavior.
+ * user's auth.json (so login persists), then writes a minimal config.toml
+ * containing ONLY allow-listed top-level scalars. Drops everything else —
+ * `mcp_servers` (DNS-blocked enterprise endpoints crash codex's rmcp transport
+ * on bootstrap), `projects.*` trust (grove uses its own permission gating),
+ * `notify` hooks (would invoke desktop apps for grove turns), plugins.
  */
 async function prepareIsolatedCodexHome(env: NodeJS.ProcessEnv): Promise<string> {
   const userHome = env.CODEX_HOME ?? join(env.HOME ?? "/tmp", ".codex");
@@ -105,31 +134,54 @@ async function prepareIsolatedCodexHome(env: NodeJS.ProcessEnv): Promise<string>
       /* best-effort */
     }
   }
-  // Minimal config: keep model preferences from user config but skip everything
-  // else (mcp_servers, projects, plugins, notify hooks). Grove's per-spawn MCP
-  // servers are appended via `-c mcp_servers.<name>.command=...` at launch time.
+
   const userConfigPath = join(userHome, "config.toml");
-  const lines: string[] = [];
+  const safeLines: string[] = [];
   if (existsSync(userConfigPath)) {
     try {
       const fs = await import("node:fs/promises");
       const text = await fs.readFile(userConfigPath, "utf8");
-      // Keep only top-level scalar assignments before the first `[section]`.
-      // This preserves model/personality/effort but drops every table
-      // (mcp_servers.X, projects.X, plugins, etc.).
+      let inSection = false;
+      let currentLineKey: string | null = null;
+      // Walk lines maintaining "are we inside a [table]" mode. Carry over
+      // continuation lines for the most-recent allow-listed top-level key so
+      // multi-line array values (e.g. `notify = [\n  "x",\n  "y"\n]`) are
+      // dropped wholesale rather than half-copied. Any unknown key — even a
+      // top-level scalar — is skipped.
       for (const raw of text.split("\n")) {
         const line = raw.trimEnd();
-        if (line.startsWith("[")) break;
-        if (line.length > 0) lines.push(line);
+        const trimmed = line.trim();
+        if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+        if (trimmed.startsWith("[")) {
+          inSection = true;
+          currentLineKey = null;
+          continue;
+        }
+        if (inSection) continue;
+        const m = TOML_TOP_LEVEL_KEY_LINE.exec(trimmed);
+        if (m) {
+          const key = m[1];
+          if (key !== undefined && SAFE_CODEX_TOP_LEVEL_KEYS.has(key)) {
+            safeLines.push(line);
+            currentLineKey = key;
+          } else {
+            currentLineKey = null;
+          }
+        } else if (currentLineKey !== null) {
+          // Continuation of a previously-allowed key (e.g. multi-line array).
+          safeLines.push(line);
+        }
       }
     } catch {
       /* best-effort */
     }
   }
-  if (lines.length === 0) {
-    lines.push('model = "gpt-5"');
+  if (safeLines.length === 0) {
+    // Fallback: a minimal config codex will accept. Grove's `-c model=...`
+    // flag in `buildAcpLaunchArgs` overrides this when a model is configured.
+    safeLines.push('model = "gpt-5"');
   }
-  writeFileSync(join(isolated, "config.toml"), `${lines.join("\n")}\n`, "utf-8");
+  writeFileSync(join(isolated, "config.toml"), `${safeLines.join("\n")}\n`, "utf-8");
   // Ensure plugins dir exists empty (some codex plugins bundle MCP servers).
   mkdirSync(join(isolated, "plugins"), { recursive: true });
   return isolated;

--- a/src/core/informer.ts
+++ b/src/core/informer.ts
@@ -16,7 +16,7 @@ import type { WatchEntity, WatchKind } from "./watch-events.js";
 import type { WatchHub } from "./watch-hub.js";
 import type { WatchClientEvent, WatchStream } from "./watch-stream.js";
 
-type EntityForKind<K extends WatchKind> = K extends "Contribution"
+export type EntityForKind<K extends WatchKind> = K extends "Contribution"
   ? ContributionEntity
   : K extends "Claim"
     ? ClaimEntity

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -352,16 +352,23 @@ export function App({
   // Poll active claims for topology-aware command palette.
   // In scoped sessions, `provider.getClaims` is namespace-global (no session
   // filter) and would surface claims from other sessions — corrupting spawn-
-  // capacity checks and parent-depth calculations. Suppress until provider
-  // gains session-aware claim filtering. Mirrors the ClaimsView/AgentList
-  // scoped short-circuit.
+  // capacity checks and parent-depth calculations. We can't just stop the
+  // fetch (the hook would retain whatever it already had); we also project
+  // the result through `useMemo` so consumers see `undefined` (= "unknown")
+  // in scoped mode rather than a stale or empty list. Spawn paths that read
+  // `activeClaims` MUST treat `undefined` as "topology validation
+  // unavailable", not as "zero claims". See `handleSpawn` below.
   const isScopedForClaims = useProviderScoped(provider);
   const claimsFetcher = useCallback(() => provider.getClaims({ status: "active" }), [provider]);
-  const { data: activeClaims, refresh: refreshClaims } = useEventDrivenData<readonly Claim[]>(
+  const { data: rawActiveClaims, refresh: refreshClaims } = useEventDrivenData<readonly Claim[]>(
     claimsFetcher,
     undefined,
     undefined,
     topology !== undefined && !isScopedForClaims,
+  );
+  const activeClaims = useMemo<readonly Claim[] | null>(
+    () => (isScopedForClaims ? null : rawActiveClaims),
+    [isScopedForClaims, rawActiveClaims],
   );
 
   // Poll tmux sessions — used by command palette, agent count, split pane,
@@ -765,12 +772,24 @@ export function App({
    */
   const handleSpawn = useCallback(
     (agentId: string, command: string, _target: string, parentAgentId?: string) => {
-      const spawnCheck = checkSpawn(topology, agentId, activeClaims ?? [], parentAgentId);
+      // In scoped sessions `activeClaims` is null because we can't see only
+      // this session's claims through the namespace-global getClaims API.
+      // Refusing to spawn here is the conservative choice — substituting
+      // an empty array would let scoped operators bypass `maxInstances`,
+      // `maxChildrenPerAgent`, and depth limits enforced by checkSpawn /
+      // checkSpawnDepth. Lift this restriction once getClaims supports
+      // session-scoped filtering.
+      if (activeClaims === null) {
+        showError("Spawn unavailable in scoped session (topology checks need session-scoped claims)");
+        return;
+      }
+
+      const spawnCheck = checkSpawn(topology, agentId, activeClaims, parentAgentId);
       if (!spawnCheck.allowed) return;
 
       let depth = 0;
       if (parentAgentId !== undefined) {
-        const parentClaim = (activeClaims ?? []).find((c) => c.agent.agentId === parentAgentId);
+        const parentClaim = activeClaims.find((c) => c.agent.agentId === parentAgentId);
         const parentDepth =
           typeof parentClaim?.context?.depth === "number" ? parentClaim.context.depth : 0;
         depth = parentDepth + 1;

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -780,7 +780,9 @@ export function App({
       // checkSpawnDepth. Lift this restriction once getClaims supports
       // session-scoped filtering.
       if (activeClaims === null) {
-        showError("Spawn unavailable in scoped session (topology checks need session-scoped claims)");
+        showError(
+          "Spawn unavailable in scoped session (topology checks need session-scoped claims)",
+        );
         return;
       }
 

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -24,6 +24,7 @@ import { StatusBar } from "./components/status-bar.js";
 import { PanelBar } from "./components/tab-bar.js";
 import { TooltipOverlay, useFirstLaunchTooltips } from "./components/tooltip-overlay.js";
 import type { GroveUserConfig } from "./config-loader.js";
+import { useProviderScoped } from "./hooks/informer-context.js";
 import { useRelistTrigger } from "./hooks/refresh-context.js";
 import { useEventDrivenData } from "./hooks/use-event-driven-data.js";
 import { buildKeyActionMap, useKeybindingOverrides } from "./hooks/use-keybinding-overrides.js";
@@ -348,13 +349,19 @@ export function App({
     };
   }, []);
 
-  // Poll active claims for topology-aware command palette
+  // Poll active claims for topology-aware command palette.
+  // In scoped sessions, `provider.getClaims` is namespace-global (no session
+  // filter) and would surface claims from other sessions — corrupting spawn-
+  // capacity checks and parent-depth calculations. Suppress until provider
+  // gains session-aware claim filtering. Mirrors the ClaimsView/AgentList
+  // scoped short-circuit.
+  const isScopedForClaims = useProviderScoped(provider);
   const claimsFetcher = useCallback(() => provider.getClaims({ status: "active" }), [provider]);
   const { data: activeClaims, refresh: refreshClaims } = useEventDrivenData<readonly Claim[]>(
     claimsFetcher,
     undefined,
     undefined,
-    topology !== undefined,
+    topology !== undefined && !isScopedForClaims,
   );
 
   // Poll tmux sessions — used by command palette, agent count, split pane,

--- a/src/tui/components/columns/agent-columns.ts
+++ b/src/tui/components/columns/agent-columns.ts
@@ -1,0 +1,124 @@
+/**
+ * Agent columns for the agent-list view. Several columns depend on
+ * a join context (tmux session names, cost rollups) — those are
+ * factory functions that close over the context.
+ */
+
+import type { ClaimEntity } from "../../../core/entity.js";
+import type { Claim } from "../../../core/models.js";
+import { agentStatusIcon } from "../../theme.js";
+import type { EntityColumn } from "../entity-view.js";
+
+export interface AgentJoinCtx {
+  readonly tmuxSessions: readonly string[];
+  readonly agentSessions: ReadonlyMap<string, string>; // agentId → session
+  readonly costs: ReadonlyMap<string, { costUsd: number; tokens: number; contextPercent?: number }>;
+  readonly spinnerFrame: number;
+}
+
+const formatTokens = (n: number): string =>
+  n >= 1_000_000
+    ? `${(n / 1_000_000).toFixed(1)}M`
+    : n >= 1_000
+      ? `${Math.round(n / 1_000)}K`
+      : String(n);
+
+const trunc = (s: string, max: number): string => (s.length > max ? `${s.slice(0, max - 2)}..` : s);
+
+const claimToFlat = (e: ClaimEntity): Claim => ({
+  claimId: e.id,
+  targetRef: e.spec.targetRef,
+  agent: e.spec.agent,
+  status: e.status.phase,
+  intentSummary: e.spec.intentSummary,
+  createdAt: e.metadata.creationTimestamp ?? e.status.heartbeatAt,
+  heartbeatAt: e.status.heartbeatAt,
+  leaseExpiresAt: e.status.leaseExpiresAt,
+  context: e.spec.context,
+  attemptCount: e.status.attemptCount,
+});
+
+const deriveAgentStatus = (
+  claim: Claim,
+  session: string | undefined,
+  tmuxSessions: readonly string[],
+): string => {
+  const remaining = new Date(claim.leaseExpiresAt).getTime() - Date.now();
+  if (remaining <= 0) return "expired";
+  if (!session) return "claimed";
+  if (!tmuxSessions.includes(session)) return "error";
+  if (Date.now() - new Date(claim.heartbeatAt).getTime() > 60_000) return "stalled";
+  return "running";
+};
+
+export const agentIdColumn = (width = 16): EntityColumn<ClaimEntity> => ({
+  header: "AGENT",
+  key: "agentId",
+  width,
+  render: (e) => e.spec.agent.agentName ?? e.spec.agent.agentId,
+});
+
+export const roleColumn = (width = 12): EntityColumn<ClaimEntity> => ({
+  header: "ROLE",
+  key: "role",
+  width,
+  render: (e) => e.spec.agent.role ?? "worker",
+});
+
+export const platformColumn = (width = 12): EntityColumn<ClaimEntity> => ({
+  header: "PLATFORM",
+  key: "platform",
+  width,
+  render: (e) => e.spec.agent.platform ?? "-",
+});
+
+export const targetColumn = (width = 18): EntityColumn<ClaimEntity> => ({
+  header: "TARGET",
+  key: "target",
+  width,
+  render: (e) => trunc(e.spec.targetRef, width),
+});
+
+export const statusColumn = (ctx: AgentJoinCtx, width = 12): EntityColumn<ClaimEntity> => ({
+  header: "STATUS",
+  key: "status",
+  width,
+  render: (e) => {
+    const claim = claimToFlat(e);
+    const session = ctx.agentSessions.get(claim.agent.agentId);
+    const status = deriveAgentStatus(claim, session, ctx.tmuxSessions);
+    const { icon } = agentStatusIcon(status, ctx.spinnerFrame);
+    return `${icon} ${status}`;
+  },
+});
+
+export const costColumn = (ctx: AgentJoinCtx, width = 14): EntityColumn<ClaimEntity> => ({
+  header: "COST",
+  key: "cost",
+  width,
+  render: (e) => {
+    const c = ctx.costs.get(e.spec.agent.agentId);
+    return c ? `$${c.costUsd.toFixed(2)} | ${formatTokens(c.tokens)}` : "-";
+  },
+});
+
+export const sessionColumn = (ctx: AgentJoinCtx, width = 16): EntityColumn<ClaimEntity> => ({
+  header: "SESSION",
+  key: "session",
+  width,
+  render: (e) => ctx.agentSessions.get(e.spec.agent.agentId) ?? "-",
+});
+
+/** Sort: coordinators first, then alphabetical by name. */
+export const byRoleAndName = (a: ClaimEntity, b: ClaimEntity): number => {
+  const ra = a.spec.agent.role ?? "worker";
+  const rb = b.spec.agent.role ?? "worker";
+  if (ra !== rb) {
+    if (ra === "coordinator") return -1;
+    if (rb === "coordinator") return 1;
+    return ra.localeCompare(rb);
+  }
+  const na = a.spec.agent.agentName ?? a.spec.agent.agentId;
+  const nb = b.spec.agent.agentName ?? b.spec.agent.agentId;
+  return na.localeCompare(nb);
+};

--- a/src/tui/components/columns/claim-columns.ts
+++ b/src/tui/components/columns/claim-columns.ts
@@ -1,0 +1,80 @@
+/**
+ * Reusable Claim columns for EntityView (claims.tsx, agent-list.tsx).
+ */
+
+import type { ClaimEntity } from "../../../core/entity.js";
+import { formatDuration } from "../../../shared/duration.js";
+import { formatTimestamp } from "../../../shared/format.js";
+import type { EntityColumn } from "../entity-view.js";
+
+const trunc = (s: string, max: number): string => (s.length > max ? `${s.slice(0, max - 2)}..` : s);
+
+export const claimIdColumn = (width = 20): EntityColumn<ClaimEntity> => ({
+  header: "CLAIM_ID",
+  key: "claimId",
+  width,
+  render: (e) => trunc(e.id, width),
+});
+
+export const targetColumn = (width = 24): EntityColumn<ClaimEntity> => ({
+  header: "TARGET",
+  key: "target",
+  width,
+  render: (e) => trunc(e.spec.targetRef, width),
+});
+
+export const agentColumn = (width = 16): EntityColumn<ClaimEntity> => ({
+  header: "AGENT",
+  key: "agent",
+  width,
+  render: (e) => e.spec.agent.agentName ?? e.spec.agent.agentId,
+});
+
+export const intentColumn = (width = 28): EntityColumn<ClaimEntity> => ({
+  header: "INTENT",
+  key: "intent",
+  width,
+  render: (e) => trunc(e.spec.intentSummary ?? "", width),
+});
+
+export const heartbeatColumn = (width = 12): EntityColumn<ClaimEntity> => ({
+  header: "HEARTBEAT",
+  key: "heartbeat",
+  width,
+  render: (e) => formatTimestamp(e.status.heartbeatAt),
+});
+
+/**
+ * STATUS column with duplicate-target highlight. Closes over a
+ * `targetCounts` map so the wrapper can pre-compute counts and pass
+ * them in. Returns the same EntityColumn shape; the render function
+ * is recreated when counts change (cheap).
+ */
+export const statusColumnWithCounts = (
+  targetCounts: ReadonlyMap<string, number>,
+  width = 10,
+): EntityColumn<ClaimEntity> => ({
+  header: "STATUS",
+  key: "status",
+  width,
+  render: (e) => {
+    const remaining = new Date(e.status.leaseExpiresAt).getTime() - Date.now();
+    const dup = (targetCounts.get(e.spec.targetRef) ?? 0) > 1;
+    const phase = e.status.phase;
+    if (phase === "active" && remaining <= 0) return "EXPIRED";
+    return dup ? `${phase} DUP` : phase;
+  },
+});
+
+export const leaseColumn = (width = 14): EntityColumn<ClaimEntity> => ({
+  header: "LEASE",
+  key: "lease",
+  width,
+  render: (e) => {
+    const remaining = new Date(e.status.leaseExpiresAt).getTime() - Date.now();
+    return remaining > 0 ? formatDuration(remaining) : "expired";
+  },
+});
+
+/** Predicate: only entities in `active` phase. */
+export const isActive = (e: ClaimEntity): boolean => e.status.phase === "active";

--- a/src/tui/components/columns/contribution-columns.ts
+++ b/src/tui/components/columns/contribution-columns.ts
@@ -1,0 +1,68 @@
+/**
+ * Reusable Contribution columns for EntityView. Imported by activity,
+ * activity-panel, and search-panel to keep column definitions DRY.
+ */
+
+import type { ContributionEntity } from "../../../core/entity.js";
+import { compareTimestampsDesc, formatTimestamp, truncateCid } from "../../../shared/format.js";
+import type { EntityColumn } from "../entity-view.js";
+
+const trunc = (s: string | undefined, max: number): string =>
+  !s ? "" : s.length > max ? `${s.slice(0, max - 2)}..` : s;
+
+export const cidColumn = (width = 22): EntityColumn<ContributionEntity> => ({
+  header: "CID",
+  key: "cid",
+  width,
+  render: (e) => truncateCid(e.id),
+});
+
+export const kindColumn = (width = 14): EntityColumn<ContributionEntity> => ({
+  header: "KIND",
+  key: "kind",
+  width,
+  render: (e) => e.spec.contributionKind,
+});
+
+export const modeColumn = (width = 12): EntityColumn<ContributionEntity> => ({
+  header: "MODE",
+  key: "mode",
+  width,
+  render: (e) => e.spec.mode,
+});
+
+export const summaryColumn = (width = 36): EntityColumn<ContributionEntity> => ({
+  header: "SUMMARY",
+  key: "summary",
+  width,
+  render: (e) => trunc(e.spec.summary, width),
+});
+
+export const agentColumn = (width = 16): EntityColumn<ContributionEntity> => ({
+  header: "AGENT",
+  key: "agent",
+  width,
+  render: (e) =>
+    e.spec.agent?.role ?? e.spec.agent?.agentName ?? e.spec.agent?.agentId ?? "unknown",
+});
+
+export const tagsColumn = (width = 16, max = 3): EntityColumn<ContributionEntity> => ({
+  header: "TAGS",
+  key: "tags",
+  width,
+  render: (e) => (e.spec.tags ?? []).slice(0, max).join(", "),
+});
+
+export const createdColumn = (
+  header = "CREATED",
+  width = 12,
+): EntityColumn<ContributionEntity> => ({
+  header,
+  key: "created",
+  width,
+  render: (e) => formatTimestamp(e.metadata.creationTimestamp ?? ""),
+});
+
+/** Sort: newest first by creationTimestamp. */
+export const byCreatedDesc = (a: ContributionEntity, b: ContributionEntity): number =>
+  compareTimestampsDesc(a.metadata.creationTimestamp, b.metadata.creationTimestamp);

--- a/src/tui/components/entity-view.perf.test.tsx
+++ b/src/tui/components/entity-view.perf.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Skipped in CI; runnable locally for the #301 acceptance criterion
+ * "500-row list scrolls at 60fps".
+ *
+ * Mounts EntityView with 500 synthetic entities, performs 100 cursor
+ * moves, asserts p95 useMemo+render cost < 16ms.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { InformerFactory } from "../../core/informer.js";
+import type { ContributionEntity } from "../../core/entity.js";
+import type { WatchEntity } from "../../core/watch-events.js";
+import { WatchHub } from "../../core/watch-hub.js";
+import { EntityStoreFactory } from "../data/entity-store.js";
+import { EntityStoreProvider } from "../hooks/entity-store-context.js";
+import { InformerProvider } from "../hooks/informer-context.js";
+import { EntityView } from "./entity-view.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NS = "default";
+const COLUMNS = [
+  { header: "ID", key: "id", width: 8, render: (e: ContributionEntity) => e.id },
+  {
+    header: "SUM",
+    key: "sum",
+    width: 24,
+    render: (e: ContributionEntity) => e.id.repeat(3),
+  },
+] as const;
+
+function entity(i: number): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id: `c${i}`,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: `s${i}`,
+      artifacts: {},
+      relations: [],
+      tags: [],
+    } as never,
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: String(i),
+    metadata: {
+      generation: 1,
+      creationTimestamp: `2026-01-01T00:00:${String(i % 60).padStart(2, "0")}Z`,
+    },
+  };
+}
+
+const ENABLED = process.env.RUN_PERF === "1";
+
+describe.skipIf(!ENABLED)("EntityView perf", () => {
+  test("500 rows × 100 cursor moves: p95 render < 16ms", async () => {
+    const hub = new WatchHub();
+    // Reuse the RemoteReportingLocalFactory pattern from
+    // use-entity-data.mount.test.tsx so useEntityWatchEnabled gates true.
+    class RemoteReportingLocalFactory extends InformerFactory {
+      override get mode(): "local" | "remote" {
+        return "remote";
+      }
+    }
+    const informerFactory = new RemoteReportingLocalFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    const provider = { hasSessionScope: () => false };
+    let cursor = 0;
+    let renderer!: TestRenderer.ReactTestRenderer;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={informerFactory} eager>
+            <EntityStoreProvider value={storeFactory}>
+              <EntityView
+                kind="Contribution"
+                columns={[...COLUMNS]}
+                provider={provider}
+                active={true}
+                cursor={cursor}
+                title="Perf"
+              />
+            </EntityStoreProvider>
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    for (let i = 0; i < 500; i += 1) {
+      TestRenderer.act(() => {
+        hub.recordWrite({
+          op: "ADDED",
+          kind: "Contribution",
+          namespace: NS,
+          entity: entity(i),
+        });
+      });
+    }
+
+    const samples: number[] = [];
+    for (let i = 0; i < 100; i += 1) {
+      cursor = i;
+      const t0 = performance.now();
+      await act(async () => {
+        renderer.update(
+          (
+            <InformerProvider value={informerFactory} eager>
+              <EntityStoreProvider value={storeFactory}>
+                <EntityView
+                  kind="Contribution"
+                  columns={[...COLUMNS]}
+                  provider={provider}
+                  active={true}
+                  cursor={cursor}
+                  title="Perf"
+                />
+              </EntityStoreProvider>
+            </InformerProvider>
+          ) as React.ReactElement,
+        );
+      });
+      samples.push(performance.now() - t0);
+    }
+
+    samples.sort((a, b) => a - b);
+    const p95 = samples[Math.floor(samples.length * 0.95)];
+    if (p95 === undefined) throw new Error("no samples");
+    expect(p95).toBeLessThan(16);
+  });
+});

--- a/src/tui/components/entity-view.perf.test.tsx
+++ b/src/tui/components/entity-view.perf.test.tsx
@@ -9,8 +9,8 @@
 import { describe, expect, test } from "bun:test";
 import type React from "react";
 import TestRenderer, { act } from "react-test-renderer";
-import { InformerFactory } from "../../core/informer.js";
 import type { ContributionEntity } from "../../core/entity.js";
+import { InformerFactory } from "../../core/informer.js";
 import type { WatchEntity } from "../../core/watch-events.js";
 import { WatchHub } from "../../core/watch-hub.js";
 import { EntityStoreFactory } from "../data/entity-store.js";

--- a/src/tui/components/entity-view.test.tsx
+++ b/src/tui/components/entity-view.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * Mount tests for EntityView: header, empty state, row mapping, onSelect.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { InformerFactory } from "../../core/informer.js";
+import type { WatchEntity } from "../../core/watch-events.js";
+import { WatchHub } from "../../core/watch-hub.js";
+import { EntityStoreFactory } from "../data/entity-store.js";
+import { EntityStoreProvider } from "../hooks/entity-store-context.js";
+import { InformerProvider } from "../hooks/informer-context.js";
+import { EntityView } from "./entity-view.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NS = "default";
+
+/**
+ * Test-only subclass: wires the local hub (so hub.recordWrite drives events)
+ * but reports mode "remote" so useEntityWatchEnabled gates true.
+ */
+class RemoteReportingLocalFactory extends InformerFactory {
+  override get mode(): "remote" | "local" {
+    return "remote";
+  }
+}
+
+function entity(id: string): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: id,
+      artifacts: {},
+      relations: [],
+      tags: [],
+    } as never,
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: "1",
+    metadata: { generation: 1, creationTimestamp: "2026-01-01T00:00:00Z" },
+  };
+}
+
+const COLUMNS = [{ header: "ID", key: "id", width: 8, render: (e: WatchEntity) => e.id }] as const;
+
+describe("EntityView", () => {
+  test("renders empty state when no data", async () => {
+    const hub = new WatchHub();
+    const informerFactory = new RemoteReportingLocalFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    const provider = { hasSessionScope: () => false };
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    // Use async act to allow the LocalWatchClient relist to complete (RELIST_BEGIN → RELIST_END).
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={informerFactory} eager>
+            <EntityStoreProvider value={storeFactory}>
+              <EntityView
+                kind="Contribution"
+                columns={[...COLUMNS]}
+                provider={provider}
+                active={true}
+                cursor={-1}
+                title="TestView"
+                emptyTitle="(none)"
+              />
+            </EntityStoreProvider>
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("(none)");
+
+    renderer.unmount();
+    await informerFactory.stopAll();
+    storeFactory.dispose();
+  });
+
+  test("renders title and rows when data present", async () => {
+    const hub = new WatchHub();
+    const informerFactory = new RemoteReportingLocalFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    const provider = { hasSessionScope: () => false };
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={informerFactory} eager>
+            <EntityStoreProvider value={storeFactory}>
+              <EntityView
+                kind="Contribution"
+                columns={[...COLUMNS]}
+                provider={provider}
+                active={true}
+                cursor={-1}
+                title="TestView"
+                emptyTitle="(none)"
+              />
+            </EntityStoreProvider>
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      hub.recordWrite({ kind: "Contribution", namespace: NS, op: "ADDED", entity: entity("a") });
+      hub.recordWrite({ kind: "Contribution", namespace: NS, op: "ADDED", entity: entity("b") });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("TestView");
+    expect(flat).toContain("a");
+    expect(flat).toContain("b");
+
+    renderer.unmount();
+    await informerFactory.stopAll();
+    storeFactory.dispose();
+  });
+
+  test("onSelect fires with entity at cursor", async () => {
+    const hub = new WatchHub();
+    const informerFactory = new RemoteReportingLocalFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    const provider = { hasSessionScope: () => false };
+
+    let selected: WatchEntity | undefined;
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={informerFactory} eager>
+            <EntityStoreProvider value={storeFactory}>
+              <EntityView
+                kind="Contribution"
+                columns={[...COLUMNS]}
+                provider={provider}
+                active={true}
+                cursor={1}
+                onSelect={(e) => {
+                  selected = e as WatchEntity | undefined;
+                }}
+                title="TestView"
+                emptyTitle="(none)"
+              />
+            </EntityStoreProvider>
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      hub.recordWrite({ kind: "Contribution", namespace: NS, op: "ADDED", entity: entity("a") });
+      hub.recordWrite({ kind: "Contribution", namespace: NS, op: "ADDED", entity: entity("b") });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(selected?.id).toBeDefined();
+
+    renderer.unmount();
+    await informerFactory.stopAll();
+    storeFactory.dispose();
+  });
+
+  test("onDataChanged fires with current entity slice", async () => {
+    const hub = new WatchHub();
+    const factory = new RemoteReportingLocalFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(factory);
+
+    let received: readonly WatchEntity[] = [];
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={factory} eager>
+            <EntityStoreProvider value={storeFactory}>
+              <EntityView
+                kind="Contribution"
+                columns={[...COLUMNS]}
+                provider={{ hasSessionScope: () => false }}
+                active={true}
+                cursor={-1}
+                onDataChanged={(d) => {
+                  received = d as readonly WatchEntity[];
+                }}
+              />
+            </EntityStoreProvider>
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      hub.recordWrite({ kind: "Contribution", namespace: NS, op: "ADDED", entity: entity("x") });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(received.map((e) => e.id)).toEqual(["x"]);
+
+    renderer.unmount();
+    await factory.stopAll();
+    storeFactory.dispose();
+  });
+});

--- a/src/tui/components/entity-view.tsx
+++ b/src/tui/components/entity-view.tsx
@@ -148,7 +148,7 @@ function EntityViewInner<K extends WatchKind>(props: EntityViewProps<K>): React.
       {data.length === 0 ? (
         <EmptyState
           title={emptyTitle ?? `No ${String(kind).toLowerCase()}.`}
-          {...(emptyHint ? { hint: emptyHint } : {})}
+          hint={emptyHint}
         />
       ) : (
         <Table columns={[...tableColumns]} rows={rows} cursor={cursor} maxRows={MAX_ROWS} />

--- a/src/tui/components/entity-view.tsx
+++ b/src/tui/components/entity-view.tsx
@@ -146,10 +146,7 @@ function EntityViewInner<K extends WatchKind>(props: EntityViewProps<K>): React.
         </box>
       )}
       {data.length === 0 ? (
-        <EmptyState
-          title={emptyTitle ?? `No ${String(kind).toLowerCase()}.`}
-          hint={emptyHint}
-        />
+        <EmptyState title={emptyTitle ?? `No ${String(kind).toLowerCase()}.`} hint={emptyHint} />
       ) : (
         <Table columns={[...tableColumns]} rows={rows} cursor={cursor} maxRows={MAX_ROWS} />
       )}

--- a/src/tui/components/entity-view.tsx
+++ b/src/tui/components/entity-view.tsx
@@ -1,0 +1,162 @@
+/**
+ * EntityView<K> — generic kind-parameterized list view.
+ *
+ * Replaces the duplicated dual-path data wiring across claims,
+ * agent-list, activity, and activity-panel. Owns:
+ *   - data fetch (via useEntityData)
+ *   - row mapping from columns[].render(entity)
+ *   - title/count header (DataStatus)
+ *   - empty state
+ *   - cursor → onSelect / onRowCountChanged / onDataChanged
+ *
+ * Does NOT install keyboard handlers. `hints` is metadata for the
+ * C3 hint bar (#309) and C2 command prompt (#302). Mutation goes
+ * through confirmAndMutate (C6, #304), not EntityView.
+ */
+
+import React, { useEffect, useMemo } from "react";
+import type { EntityForKind } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+import { useEntityData } from "../hooks/use-entity-data.js";
+import { DataStatus } from "./data-status.js";
+import { EmptyState } from "./empty-state.js";
+import { Table, type TableColumn } from "./table.js";
+
+export interface EntityColumn<E> {
+  readonly header: string;
+  readonly key: string;
+  readonly width?: number;
+  readonly align?: "left" | "right";
+  readonly render: (entity: E) => string;
+}
+
+export interface EntityHint {
+  readonly key: string;
+  readonly label: string;
+}
+
+export interface EntityViewProps<K extends WatchKind> {
+  readonly kind: K;
+  readonly columns: readonly EntityColumn<EntityForKind<K>>[];
+  readonly provider: unknown;
+  readonly active: boolean;
+  readonly cursor: number;
+
+  readonly predicate?: (e: EntityForKind<K>) => boolean;
+  readonly sort?: (a: EntityForKind<K>, b: EntityForKind<K>) => number;
+  readonly offset?: number;
+  readonly limit?: number;
+  readonly fallbackFetcher?: () => Promise<readonly EntityForKind<K>[]>;
+
+  readonly title?: string;
+  readonly headerSuffix?: React.ReactNode;
+  readonly emptyTitle?: string;
+  readonly emptyHint?: string;
+
+  readonly onRowCountChanged?: (n: number) => void;
+  readonly onSelect?: (entity: EntityForKind<K> | undefined) => void;
+  readonly onDataChanged?: (data: readonly EntityForKind<K>[]) => void;
+
+  readonly hints?: readonly EntityHint[];
+}
+
+const MAX_ROWS = 500;
+
+function EntityViewInner<K extends WatchKind>(props: EntityViewProps<K>): React.ReactNode {
+  const {
+    kind,
+    columns,
+    provider,
+    active,
+    cursor,
+    predicate,
+    sort,
+    offset,
+    limit,
+    fallbackFetcher,
+    title,
+    headerSuffix,
+    emptyTitle,
+    emptyHint,
+    onRowCountChanged,
+    onSelect,
+    onDataChanged,
+  } = props;
+
+  const opts: Parameters<typeof useEntityData<K>>[2] = {
+    active,
+    ...(predicate !== undefined ? { predicate } : {}),
+    ...(sort !== undefined ? { sort } : {}),
+    ...(offset !== undefined ? { offset } : {}),
+    ...(limit !== undefined ? { limit } : {}),
+    ...(fallbackFetcher !== undefined ? { fallbackFetcher } : {}),
+  };
+
+  const { data, loading, isStale, error } = useEntityData<K>(provider, kind, opts);
+
+  const rows = useMemo<readonly Record<string, string>[]>(
+    () =>
+      data.map((entity) => {
+        const row: Record<string, string> = {};
+        for (const col of columns) row[col.key] = col.render(entity);
+        return row;
+      }),
+    [data, columns],
+  );
+
+  const tableColumns = useMemo<readonly TableColumn[]>(
+    () =>
+      columns.map((c) => ({
+        header: c.header,
+        key: c.key,
+        width: c.width,
+        align: c.align,
+      })),
+    [columns],
+  );
+
+  useEffect(() => {
+    if (onRowCountChanged) onRowCountChanged(data.length);
+  }, [data.length, onRowCountChanged]);
+
+  useEffect(() => {
+    if (!onSelect) return;
+    onSelect(cursor >= 0 && cursor < data.length ? data[cursor] : undefined);
+  }, [cursor, data, onSelect]);
+
+  useEffect(() => {
+    if (onDataChanged) onDataChanged(data);
+  }, [data, onDataChanged]);
+
+  if (loading && data.length === 0) {
+    return (
+      <box>
+        <text opacity={0.5}>{`Loading ${String(kind).toLowerCase()}...`}</text>
+      </box>
+    );
+  }
+
+  return (
+    <box flexDirection="column">
+      {title !== undefined && (
+        <box marginBottom={1} flexDirection="row">
+          <text>{`${title} (${data.length})`}</text>
+          <DataStatus loading={false} isStale={isStale} error={error?.message} />
+          {headerSuffix}
+        </box>
+      )}
+      {data.length === 0 ? (
+        <EmptyState
+          title={emptyTitle ?? `No ${String(kind).toLowerCase()}.`}
+          {...(emptyHint ? { hint: emptyHint } : {})}
+        />
+      ) : (
+        <Table columns={[...tableColumns]} rows={rows} cursor={cursor} maxRows={MAX_ROWS} />
+      )}
+    </box>
+  );
+}
+
+export const EntityView = React.memo(EntityViewInner) as <K extends WatchKind>(
+  props: EntityViewProps<K>,
+) => React.ReactNode;

--- a/src/tui/components/table.tsx
+++ b/src/tui/components/table.tsx
@@ -17,7 +17,7 @@ export interface TableColumn {
 }
 
 /** Maximum items rendered to guard against scroll-box not virtualizing. */
-const MAX_RENDER_ITEMS = 200;
+const MAX_RENDER_ITEMS = 500;
 
 /** Props for the Table component. */
 export interface TableProps {

--- a/src/tui/data/entity-store.ts
+++ b/src/tui/data/entity-store.ts
@@ -17,10 +17,8 @@
  * tasks of the B1 plan.
  */
 
-import type { Informer, InformerFactory, InformerOp } from "../../core/informer.js";
+import type { EntityForKind, Informer, InformerFactory, InformerOp } from "../../core/informer.js";
 import type { WatchKind } from "../../core/watch-events.js";
-
-type EntityFor<K extends WatchKind> = ReturnType<Informer<K>["list"]>[number];
 
 export class EntityStore<K extends WatchKind> {
   private readonly informer: Informer<K>;
@@ -30,7 +28,7 @@ export class EntityStore<K extends WatchKind> {
   private version = 0;
   private writeCounter = 0;
   private flushScheduled = false;
-  private snapshotCache: readonly EntityFor<K>[] | null = null;
+  private snapshotCache: readonly EntityForKind<K>[] | null = null;
   private snapshotVersion = -1;
   private static readonly LAG_RING_SIZE = 1024;
   private readonly lagRing: number[] = [];
@@ -55,19 +53,19 @@ export class EntityStore<K extends WatchKind> {
     return this.version;
   }
 
-  list(): readonly EntityFor<K>[] {
+  list(): readonly EntityForKind<K>[] {
     if (this.snapshotCache !== null && this.snapshotVersion === this.version) {
       return this.snapshotCache;
     }
     this.snapshotCache = Object.freeze(
-      Array.from(this.informer.list()) as EntityFor<K>[],
-    ) as readonly EntityFor<K>[];
+      Array.from(this.informer.list()) as EntityForKind<K>[],
+    ) as readonly EntityForKind<K>[];
     this.snapshotVersion = this.version;
     return this.snapshotCache;
   }
 
-  getById(id: string): EntityFor<K> | undefined {
-    return this.informer.getById(id) as EntityFor<K> | undefined;
+  getById(id: string): EntityForKind<K> | undefined {
+    return this.informer.getById(id) as EntityForKind<K> | undefined;
   }
 
   hasSynced(): boolean {
@@ -100,7 +98,7 @@ export class EntityStore<K extends WatchKind> {
 
   private onEvent = (
     _op: InformerOp,
-    _entity: EntityFor<K>,
+    _entity: EntityForKind<K>,
     meta?: { readonly emittedAt?: string },
   ): void => {
     this.writeCounter += 1;

--- a/src/tui/hooks/informer-context.tsx
+++ b/src/tui/hooks/informer-context.tsx
@@ -316,7 +316,7 @@ export function InformerProviderHolder(props: InformerProviderHolderProps): Reac
   const [factory, setFactory] = useState<InformerFactory | null>(() => holder.current());
   const [provider, setProvider] = useState<unknown>(() => holder.currentProvider());
   const resolvedProvider = scopeAwareProvider ?? provider;
-  const [scoped, setScoped] = useState<boolean>(() => readScopeFlag(resolvedProvider));
+  const [_scoped, setScoped] = useState<boolean>(() => readScopeFlag(resolvedProvider));
   const lastFactory = useRef(factory);
   const lastProvider = useRef<unknown>(provider);
   lastFactory.current = factory;

--- a/src/tui/hooks/use-entities.ts
+++ b/src/tui/hooks/use-entities.ts
@@ -11,7 +11,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
-import type { Informer } from "../../core/informer.js";
+import type { EntityForKind } from "../../core/informer.js";
 import type { WatchKind } from "../../core/watch-events.js";
 import { useEntityStoreOptional } from "./entity-store-context.js";
 import { useInformerFactoryOptional } from "./informer-context.js";
@@ -39,12 +39,10 @@ export interface UseEntitiesResult<E> {
   readonly error: Error | null;
 }
 
-type EntityFor<K extends WatchKind> = ReturnType<Informer<K>["list"]>[number];
-
 export function useEntities<K extends WatchKind>(
   kind: K,
-  predicate?: (e: EntityFor<K>) => boolean,
-): UseEntitiesResult<EntityFor<K>> {
+  predicate?: (e: EntityForKind<K>) => boolean,
+): UseEntitiesResult<EntityForKind<K>> {
   const store = useEntityStoreOptional(kind);
   const factory = useInformerFactoryOptional();
   const predicateRef = useRef(predicate);
@@ -55,14 +53,14 @@ export function useEntities<K extends WatchKind>(
   // subscription and re-render on each store version bump.
   useSyncExternalStore(subscribe, getVersion);
 
-  const dataRef = useRef<readonly EntityFor<K>[] | null>(null);
+  const dataRef = useRef<readonly EntityForKind<K>[] | null>(null);
   const [computeError, setComputeError] = useState<Error | null>(null);
 
   // Compute the current filtered slice from the version-stable snapshot.
-  let nextData: readonly EntityFor<K>[] | null;
+  let nextData: readonly EntityForKind<K>[] | null;
   try {
     nextData = computeFilteredEntities(
-      store.list() as readonly EntityFor<K>[],
+      store.list() as readonly EntityForKind<K>[],
       predicateRef.current,
     );
     if (computeError !== null) {
@@ -76,9 +74,9 @@ export function useEntities<K extends WatchKind>(
     }
   }
 
-  let data: readonly EntityFor<K>[];
+  let data: readonly EntityForKind<K>[];
   if (nextData === null) {
-    data = dataRef.current ?? ([] as readonly EntityFor<K>[]);
+    data = dataRef.current ?? ([] as readonly EntityForKind<K>[]);
   } else if (dataRef.current && shallowArraysEqual(dataRef.current, nextData)) {
     data = dataRef.current;
   } else {
@@ -92,7 +90,7 @@ export function useEntities<K extends WatchKind>(
   if (predicateRef.current !== predicate) {
     predicateRef.current = predicate;
     try {
-      const fresh = computeFilteredEntities(store.list() as readonly EntityFor<K>[], predicate);
+      const fresh = computeFilteredEntities(store.list() as readonly EntityForKind<K>[], predicate);
       if (!dataRef.current || !shallowArraysEqual(dataRef.current, fresh)) {
         dataRef.current = fresh;
         data = fresh;

--- a/src/tui/hooks/use-entity-data.mount.test.tsx
+++ b/src/tui/hooks/use-entity-data.mount.test.tsx
@@ -7,6 +7,7 @@ import { describe, expect, test } from "bun:test";
 import type React from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { InformerFactory } from "../../core/informer.js";
+import type { ContributionEntity } from "../../core/entity.js";
 import type { WatchEntity } from "../../core/watch-events.js";
 import { WatchHub } from "../../core/watch-hub.js";
 import { EntityStoreFactory } from "../data/entity-store.js";
@@ -130,14 +131,14 @@ describe("useEntityData — mount integration", () => {
 
   test("polled fallback: when no InformerProvider, calls fetcher", async () => {
     let calls = 0;
-    const provider = {};
+    const provider = { hasSessionScope: () => false };
 
     function PolledProbe({ onResult }: { onResult: (r: unknown) => void }) {
       const r = useEntityData(provider, "Contribution", {
         active: true,
         fallbackFetcher: async () => {
           calls += 1;
-          return [entity("p", "2026-01-01T00:00:00Z")] as readonly WatchEntity[];
+          return [entity("p", "2026-01-01T00:00:00Z")] as readonly ContributionEntity[];
         },
       });
       onResult(r);

--- a/src/tui/hooks/use-entity-data.mount.test.tsx
+++ b/src/tui/hooks/use-entity-data.mount.test.tsx
@@ -6,8 +6,8 @@
 import { describe, expect, test } from "bun:test";
 import type React from "react";
 import TestRenderer, { act } from "react-test-renderer";
-import { InformerFactory } from "../../core/informer.js";
 import type { ContributionEntity } from "../../core/entity.js";
+import { InformerFactory } from "../../core/informer.js";
 import type { WatchEntity } from "../../core/watch-events.js";
 import { WatchHub } from "../../core/watch-hub.js";
 import { EntityStoreFactory } from "../data/entity-store.js";

--- a/src/tui/hooks/use-entity-data.mount.test.tsx
+++ b/src/tui/hooks/use-entity-data.mount.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Mount integration: useEntityData under InformerProvider + EntityStoreProvider.
+ * Mirrors use-entities.store-backed.test.tsx setup.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { InformerFactory } from "../../core/informer.js";
+import type { WatchEntity } from "../../core/watch-events.js";
+import { WatchHub } from "../../core/watch-hub.js";
+import { EntityStoreFactory } from "../data/entity-store.js";
+import { EntityStoreProvider } from "./entity-store-context.js";
+import { InformerProvider } from "./informer-context.js";
+import { useEntityData } from "./use-entity-data.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NS = "default";
+
+/**
+ * Test-only subclass: wires the local hub (so hub.recordWrite drives events)
+ * but reports mode "remote" so useEntityWatchEnabled gates true.
+ * The actual WatchStream used is LocalWatchClient (via the "local" opts);
+ * overriding `mode` only affects the hook-level gate, not the transport.
+ */
+class RemoteReportingLocalFactory extends InformerFactory {
+  override get mode(): "remote" | "local" {
+    return "remote";
+  }
+}
+
+function entity(id: string, ts: string): WatchEntity {
+  return {
+    kind: "Contribution",
+    namespace: NS,
+    id,
+    spec: {
+      contributionKind: "code",
+      mode: "direct",
+      summary: id,
+      artifacts: {},
+      relations: [],
+      tags: [],
+    } as never,
+    status: {},
+    conditions: [],
+    observedGeneration: 0,
+    resourceVersion: "1",
+    metadata: { generation: 1, creationTimestamp: ts },
+  };
+}
+
+function Probe({ onResult, provider }: { onResult: (r: unknown) => void; provider: unknown }) {
+  const r = useEntityData(provider, "Contribution", {
+    sort: (a, b) =>
+      (b.metadata.creationTimestamp ?? "").localeCompare(a.metadata.creationTimestamp ?? ""),
+    limit: 2,
+    active: true,
+  });
+  onResult(r);
+  return null;
+}
+
+describe("useEntityData — mount integration", () => {
+  test("informer path: returns sorted+sliced entity snapshot", async () => {
+    const hub = new WatchHub();
+    const informerFactory = new RemoteReportingLocalFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    const provider = { hasSessionScope: () => false };
+
+    let last: { data: readonly WatchEntity[]; loading: boolean } = {
+      data: [],
+      loading: true,
+    };
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={informerFactory} eager>
+            <EntityStoreProvider value={storeFactory}>
+              <Probe
+                provider={provider}
+                onResult={(r) => {
+                  last = r as typeof last;
+                }}
+              />
+            </EntityStoreProvider>
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      hub.recordWrite({
+        kind: "Contribution",
+        namespace: NS,
+        op: "ADDED",
+        entity: entity("a", "2026-01-01T00:00:00Z"),
+      });
+      hub.recordWrite({
+        kind: "Contribution",
+        namespace: NS,
+        op: "ADDED",
+        entity: entity("b", "2026-01-02T00:00:00Z"),
+      });
+      hub.recordWrite({
+        kind: "Contribution",
+        namespace: NS,
+        op: "ADDED",
+        entity: entity("c", "2026-01-03T00:00:00Z"),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(last.data.map((e) => e.id)).toEqual(["c", "b"]); // sorted desc, limit 2
+
+    renderer?.unmount();
+    await informerFactory.stopAll();
+    storeFactory.dispose();
+  });
+
+  test("polled fallback: when no InformerProvider, calls fetcher", async () => {
+    let calls = 0;
+    const provider = {};
+
+    function PolledProbe({ onResult }: { onResult: (r: unknown) => void }) {
+      const r = useEntityData(provider, "Contribution", {
+        active: true,
+        fallbackFetcher: async () => {
+          calls += 1;
+          return [entity("p", "2026-01-01T00:00:00Z")] as readonly WatchEntity[];
+        },
+      });
+      onResult(r);
+      return null;
+    }
+
+    let last: { data: readonly WatchEntity[]; loading: boolean } = {
+      data: [],
+      loading: true,
+    };
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <PolledProbe
+            onResult={(r) => {
+              last = r as typeof last;
+            }}
+          />
+        ) as React.ReactElement,
+      );
+    });
+    // Allow the fetcher's microtask to settle.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(calls).toBeGreaterThanOrEqual(1);
+    expect(last.data.map((e) => e.id)).toEqual(["p"]);
+
+    renderer?.unmount();
+  });
+});

--- a/src/tui/hooks/use-entity-data.test.ts
+++ b/src/tui/hooks/use-entity-data.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for useEntityData pure helpers.
+ */
+import { describe, expect, test } from "bun:test";
+import { applyEntityShape } from "./use-entity-data.js";
+
+describe("applyEntityShape", () => {
+  const e = (id: string, ts: number) => ({ id, _ts: ts }) as unknown as { id: string; _ts: number };
+
+  test("no opts → input array reference returned", () => {
+    const list = [e("a", 1), e("b", 2)];
+    expect(applyEntityShape(list, {})).toBe(list);
+  });
+
+  test("predicate filters", () => {
+    const list = [e("a", 1), e("b", 2)];
+    expect(applyEntityShape(list, { predicate: (x) => x.id === "b" })).toEqual([e("b", 2)]);
+  });
+
+  test("sort orders by comparator (desc on _ts)", () => {
+    const list = [e("a", 1), e("b", 3), e("c", 2)];
+    const sorted = applyEntityShape(list, { sort: (x, y) => y._ts - x._ts });
+    expect(sorted.map((x) => x.id)).toEqual(["b", "c", "a"]);
+  });
+
+  test("limit slices after sort", () => {
+    const list = [e("a", 1), e("b", 3), e("c", 2)];
+    const out = applyEntityShape(list, { sort: (x, y) => y._ts - x._ts, limit: 2 });
+    expect(out.map((x) => x.id)).toEqual(["b", "c"]);
+  });
+
+  test("predicate before sort before limit", () => {
+    const list = [e("a", 1), e("b", 3), e("c", 2), e("d", 4)];
+    const out = applyEntityShape(list, {
+      predicate: (x) => x._ts > 1,
+      sort: (x, y) => x._ts - y._ts,
+      limit: 2,
+    });
+    expect(out.map((x) => x.id)).toEqual(["c", "b"]);
+  });
+
+  test("offset skips first N after sort", () => {
+    const list = [e("a", 1), e("b", 2), e("c", 3)];
+    const out = applyEntityShape(list, { sort: (x, y) => x._ts - y._ts, offset: 1, limit: 2 });
+    expect(out.map((x) => x.id)).toEqual(["b", "c"]);
+  });
+});

--- a/src/tui/hooks/use-entity-data.ts
+++ b/src/tui/hooks/use-entity-data.ts
@@ -101,13 +101,14 @@ export function useEntityData<K extends WatchKind>(
     //
     // Bare `limit` (no offset) is just a row cap, not paging — views like
     // ActivityPanel pass `limit=30` to mean "newest 30, however many we
-    // see locally" and still expect local sort to honor `byCreatedDesc`.
-    // Keep sort active in that case; predicate is always applied because
-    // the hook never relays it to the fetcher.
+    // see locally". We still apply sort first, then enforce the cap so
+    // the user sees the top-N after sorting. Predicate is always applied
+    // because the hook never relays it to the fetcher.
     const isPagedFallback = opts.offset !== undefined;
     let out: readonly EntityForKind<K>[] = polled.data;
     if (opts.predicate) out = out.filter(opts.predicate);
     if (opts.sort && !isPagedFallback) out = [...out].sort(opts.sort);
+    if (opts.limit !== undefined && !isPagedFallback) out = out.slice(0, opts.limit);
     return out;
   }, [useInformerPath, useEntityStoreFallback, entityResult.data, polled.data, opts.sort, opts.offset, opts.limit, opts.predicate]);
 

--- a/src/tui/hooks/use-entity-data.ts
+++ b/src/tui/hooks/use-entity-data.ts
@@ -91,19 +91,18 @@ export function useEntityData<K extends WatchKind>(
       return applyEntityShape(entityResult.data, innerOpts);
     }
     if (polled.data === null) return [];
-    // Polled fallback: the fallbackFetcher is responsible for paging
-    // (offset/limit). Re-slicing here would re-page already-paged provider
-    // results — for pageOffset > 0 the second slice would render empty
-    // when the over-fetch caps out (e.g. `/api/contributions` limit=100).
-    // BUT we DO apply `predicate` and `sort` because:
-    //   - the hook never relays predicate to the fetcher (so the fetcher
-    //     has no way to filter on it)
-    //   - sort applied to a paged window is well-defined (orders within
-    //     the page) and is required for views like AgentListView that
-    //     declare deterministic agent ordering via byRoleAndName
+    // Polled fallback: the fallbackFetcher is responsible for paging AND
+    // ordering when paging is in use. Applying sort to an already-paged
+    // window can't reconstruct global ordering — page 2 of a desc sort
+    // computed from "items 21..40 returned in server order" produces
+    // "those 20 items, locally desc-sorted", not "the actual items 21..40
+    // of the global desc list". So we apply sort ONLY when the consumer
+    // didn't ask for paging (offset/limit unset). Predicate is always
+    // applied because the hook never relays it to the fetcher.
+    const isPagedFallback = opts.offset !== undefined || opts.limit !== undefined;
     let out: readonly EntityForKind<K>[] = polled.data;
     if (opts.predicate) out = out.filter(opts.predicate);
-    if (opts.sort) out = [...out].sort(opts.sort);
+    if (opts.sort && !isPagedFallback) out = [...out].sort(opts.sort);
     return out;
   }, [useInformerPath, useEntityStoreFallback, entityResult.data, polled.data, opts.sort, opts.offset, opts.limit, opts.predicate]);
 

--- a/src/tui/hooks/use-entity-data.ts
+++ b/src/tui/hooks/use-entity-data.ts
@@ -96,10 +96,15 @@ export function useEntityData<K extends WatchKind>(
     // window can't reconstruct global ordering — page 2 of a desc sort
     // computed from "items 21..40 returned in server order" produces
     // "those 20 items, locally desc-sorted", not "the actual items 21..40
-    // of the global desc list". So we apply sort ONLY when the consumer
-    // didn't ask for paging (offset/limit unset). Predicate is always
-    // applied because the hook never relays it to the fetcher.
-    const isPagedFallback = opts.offset !== undefined || opts.limit !== undefined;
+    // of the global desc list". So we suppress local sort only when the
+    // consumer asked for true paging (an explicit `offset`).
+    //
+    // Bare `limit` (no offset) is just a row cap, not paging — views like
+    // ActivityPanel pass `limit=30` to mean "newest 30, however many we
+    // see locally" and still expect local sort to honor `byCreatedDesc`.
+    // Keep sort active in that case; predicate is always applied because
+    // the hook never relays it to the fetcher.
+    const isPagedFallback = opts.offset !== undefined;
     let out: readonly EntityForKind<K>[] = polled.data;
     if (opts.predicate) out = out.filter(opts.predicate);
     if (opts.sort && !isPagedFallback) out = [...out].sort(opts.sort);

--- a/src/tui/hooks/use-entity-data.ts
+++ b/src/tui/hooks/use-entity-data.ts
@@ -70,11 +70,16 @@ export function useEntityData<K extends WatchKind>(
     if (useInformerPath) {
       // entityResult.data already had `predicate` applied inside useEntities.
       // Apply only sort + offset/limit here to avoid double-filtering.
-      return applyEntityShape(entityResult.data, {
-        sort: opts.sort,
-        offset: opts.offset,
-        limit: opts.limit,
-      });
+      type MutableShapeOpts = {
+        sort?: (a: EntityForKind<K>, b: EntityForKind<K>) => number;
+        offset?: number;
+        limit?: number;
+      };
+      const innerOpts: MutableShapeOpts = {};
+      if (opts.sort) innerOpts.sort = opts.sort;
+      if (opts.offset !== undefined) innerOpts.offset = opts.offset;
+      if (opts.limit !== undefined) innerOpts.limit = opts.limit;
+      return applyEntityShape(entityResult.data, innerOpts);
     }
     if (polled.data === null) return [];
     // Polled fallback: predicate was NOT applied by the hook — apply here.

--- a/src/tui/hooks/use-entity-data.ts
+++ b/src/tui/hooks/use-entity-data.ts
@@ -91,12 +91,20 @@ export function useEntityData<K extends WatchKind>(
       return applyEntityShape(entityResult.data, innerOpts);
     }
     if (polled.data === null) return [];
-    // Polled fallback: the fallbackFetcher is responsible for paging and
-    // ordering. Reshaping here would re-slice already-paged provider
+    // Polled fallback: the fallbackFetcher is responsible for paging
+    // (offset/limit). Re-slicing here would re-page already-paged provider
     // results — for pageOffset > 0 the second slice would render empty
     // when the over-fetch caps out (e.g. `/api/contributions` limit=100).
-    // Apply only `predicate` (the hook never relayed it to the fetcher).
-    return opts.predicate ? polled.data.filter(opts.predicate) : polled.data;
+    // BUT we DO apply `predicate` and `sort` because:
+    //   - the hook never relays predicate to the fetcher (so the fetcher
+    //     has no way to filter on it)
+    //   - sort applied to a paged window is well-defined (orders within
+    //     the page) and is required for views like AgentListView that
+    //     declare deterministic agent ordering via byRoleAndName
+    let out: readonly EntityForKind<K>[] = polled.data;
+    if (opts.predicate) out = out.filter(opts.predicate);
+    if (opts.sort) out = [...out].sort(opts.sort);
+    return out;
   }, [useInformerPath, useEntityStoreFallback, entityResult.data, polled.data, opts.sort, opts.offset, opts.limit, opts.predicate]);
 
   return {

--- a/src/tui/hooks/use-entity-data.ts
+++ b/src/tui/hooks/use-entity-data.ts
@@ -66,8 +66,19 @@ export function useEntityData<K extends WatchKind>(
     opts.active && !useInformerPath && !!opts.fallbackFetcher,
   );
 
+  // When no remote informer is gated AND no fallback fetcher is supplied
+  // (e.g. local mode without an explicit polling adapter), the polled
+  // useEventDrivenData stays in its initial loading=true state forever
+  // because `active` is false, leaving the consuming view perpetually
+  // spinning. Treat that as "use entityResult — local hub still feeds
+  // EntityStore" so views show whatever the local store has, instead of
+  // an indefinite loading spinner. The narrow case where the local store
+  // is genuinely empty resolves to an empty list, identical to the
+  // pre-migration behavior with no fetcher results.
+  const useEntityStoreFallback = !useInformerPath && !opts.fallbackFetcher;
+
   const data = useMemo<readonly EntityForKind<K>[]>(() => {
-    if (useInformerPath) {
+    if (useInformerPath || useEntityStoreFallback) {
       // entityResult.data already had `predicate` applied inside useEntities.
       // Apply only sort + offset/limit here to avoid double-filtering.
       type MutableShapeOpts = {
@@ -86,6 +97,7 @@ export function useEntityData<K extends WatchKind>(
     return applyEntityShape(polled.data, opts);
   }, [
     useInformerPath,
+    useEntityStoreFallback,
     entityResult.data,
     polled.data,
     opts.sort,
@@ -96,10 +108,14 @@ export function useEntityData<K extends WatchKind>(
 
   return {
     data,
-    loading: useInformerPath
-      ? !entityResult.hasSynced && data.length === 0
-      : polled.loading && polled.data === null,
-    isStale: useInformerPath ? false : polled.isStale,
-    error: useInformerPath ? (entityResult.error ?? undefined) : (polled.error ?? undefined),
+    loading:
+      useInformerPath || useEntityStoreFallback
+        ? !entityResult.hasSynced && data.length === 0
+        : polled.loading && polled.data === null,
+    isStale: useInformerPath || useEntityStoreFallback ? false : polled.isStale,
+    error:
+      useInformerPath || useEntityStoreFallback
+        ? (entityResult.error ?? undefined)
+        : (polled.error ?? undefined),
   };
 }

--- a/src/tui/hooks/use-entity-data.ts
+++ b/src/tui/hooks/use-entity-data.ts
@@ -1,0 +1,100 @@
+/**
+ * useEntityData — collapses the dual-path (informer cache + polled
+ * fallback) currently inlined in every list view. Both `useEntities`
+ * and `useEventDrivenData` are always called to keep React's hook
+ * order stable when `useEntityWatchEnabled` toggles.
+ */
+
+import { useCallback, useMemo } from "react";
+import type { EntityForKind } from "../../core/informer.js";
+import type { WatchKind } from "../../core/watch-events.js";
+import { useEntityWatchEnabled } from "./informer-context.js";
+import { useEntities } from "./use-entities.js";
+import { useEventDrivenData } from "./use-event-driven-data.js";
+
+export interface EntityShapeOpts<E> {
+  readonly predicate?: (e: E) => boolean;
+  readonly sort?: (a: E, b: E) => number;
+  readonly offset?: number;
+  readonly limit?: number;
+}
+
+/** Pure: predicate → sort → offset/limit. Exported for unit tests. */
+export function applyEntityShape<E>(list: readonly E[], opts: EntityShapeOpts<E>): readonly E[] {
+  let out: readonly E[] = list;
+  if (opts.predicate) out = out.filter(opts.predicate);
+  if (opts.sort) out = [...out].sort(opts.sort);
+  const offset = opts.offset ?? 0;
+  if (offset > 0 || opts.limit !== undefined) {
+    const end = opts.limit !== undefined ? offset + opts.limit : undefined;
+    out = out.slice(offset, end);
+  }
+  return out;
+}
+
+export interface UseEntityDataOpts<K extends WatchKind> extends EntityShapeOpts<EntityForKind<K>> {
+  readonly fallbackFetcher?: () => Promise<readonly EntityForKind<K>[]>;
+  readonly active: boolean;
+}
+
+export interface UseEntityDataResult<K extends WatchKind> {
+  readonly data: readonly EntityForKind<K>[];
+  readonly loading: boolean;
+  readonly isStale: boolean;
+  readonly error: Error | undefined;
+}
+
+export function useEntityData<K extends WatchKind>(
+  provider: unknown,
+  kind: K,
+  opts: UseEntityDataOpts<K>,
+): UseEntityDataResult<K> {
+  const useInformerPath = useEntityWatchEnabled(provider, kind);
+
+  // Both branches always evaluated: stable hook order across path flips.
+  const entityResult = useEntities(kind, opts.predicate);
+
+  const fetcher = useCallback(async () => {
+    if (!opts.fallbackFetcher) return [] as readonly EntityForKind<K>[];
+    return opts.fallbackFetcher();
+  }, [opts.fallbackFetcher]);
+
+  const polled = useEventDrivenData<readonly EntityForKind<K>[]>(
+    fetcher,
+    undefined,
+    undefined,
+    opts.active && !useInformerPath && !!opts.fallbackFetcher,
+  );
+
+  const data = useMemo<readonly EntityForKind<K>[]>(() => {
+    if (useInformerPath) {
+      // entityResult.data already had `predicate` applied inside useEntities.
+      // Apply only sort + offset/limit here to avoid double-filtering.
+      return applyEntityShape(entityResult.data, {
+        sort: opts.sort,
+        offset: opts.offset,
+        limit: opts.limit,
+      });
+    }
+    if (polled.data === null) return [];
+    // Polled fallback: predicate was NOT applied by the hook — apply here.
+    return applyEntityShape(polled.data, opts);
+  }, [
+    useInformerPath,
+    entityResult.data,
+    polled.data,
+    opts.sort,
+    opts.offset,
+    opts.limit,
+    opts.predicate,
+  ]);
+
+  return {
+    data,
+    loading: useInformerPath
+      ? !entityResult.hasSynced && data.length === 0
+      : polled.loading && polled.data === null,
+    isStale: useInformerPath ? false : polled.isStale,
+    error: useInformerPath ? (entityResult.error ?? undefined) : (polled.error ?? undefined),
+  };
+}

--- a/src/tui/hooks/use-entity-data.ts
+++ b/src/tui/hooks/use-entity-data.ts
@@ -110,7 +110,16 @@ export function useEntityData<K extends WatchKind>(
     if (opts.sort && !isPagedFallback) out = [...out].sort(opts.sort);
     if (opts.limit !== undefined && !isPagedFallback) out = out.slice(0, opts.limit);
     return out;
-  }, [useInformerPath, useEntityStoreFallback, entityResult.data, polled.data, opts.sort, opts.offset, opts.limit, opts.predicate]);
+  }, [
+    useInformerPath,
+    useEntityStoreFallback,
+    entityResult.data,
+    polled.data,
+    opts.sort,
+    opts.offset,
+    opts.limit,
+    opts.predicate,
+  ]);
 
   return {
     data,

--- a/src/tui/hooks/use-entity-data.ts
+++ b/src/tui/hooks/use-entity-data.ts
@@ -72,9 +72,7 @@ export function useEntityData<K extends WatchKind>(
   // because `active` is false, leaving the consuming view perpetually
   // spinning. Treat that as "use entityResult — local hub still feeds
   // EntityStore" so views show whatever the local store has, instead of
-  // an indefinite loading spinner. The narrow case where the local store
-  // is genuinely empty resolves to an empty list, identical to the
-  // pre-migration behavior with no fetcher results.
+  // an indefinite loading spinner.
   const useEntityStoreFallback = !useInformerPath && !opts.fallbackFetcher;
 
   const data = useMemo<readonly EntityForKind<K>[]>(() => {
@@ -93,18 +91,13 @@ export function useEntityData<K extends WatchKind>(
       return applyEntityShape(entityResult.data, innerOpts);
     }
     if (polled.data === null) return [];
-    // Polled fallback: predicate was NOT applied by the hook — apply here.
-    return applyEntityShape(polled.data, opts);
-  }, [
-    useInformerPath,
-    useEntityStoreFallback,
-    entityResult.data,
-    polled.data,
-    opts.sort,
-    opts.offset,
-    opts.limit,
-    opts.predicate,
-  ]);
+    // Polled fallback: the fallbackFetcher is responsible for paging and
+    // ordering. Reshaping here would re-slice already-paged provider
+    // results — for pageOffset > 0 the second slice would render empty
+    // when the over-fetch caps out (e.g. `/api/contributions` limit=100).
+    // Apply only `predicate` (the hook never relayed it to the fetcher).
+    return opts.predicate ? polled.data.filter(opts.predicate) : polled.data;
+  }, [useInformerPath, useEntityStoreFallback, entityResult.data, polled.data, opts.sort, opts.offset, opts.limit, opts.predicate]);
 
   return {
     data,

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -1236,7 +1236,11 @@ export class NexusWsBridge {
       d.includes("stream closed") ||
       d.includes("session not started") ||
       d.includes("not ready") ||
-      d.includes("acp_not_initialized")
+      d.includes("acp_not_initialized") ||
+      // AcpRuntime returns this when a queued send observes its session
+      // replaced before the prompt starts. Same restart race as the others.
+      d.includes("session_closed") ||
+      d.includes("session closed before turn started")
     );
   }
 

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -1267,17 +1267,29 @@ export class NexusWsBridge {
       // replacement's SSE loop to redeliver because dispatchInboxDelivery's
       // dedupe cache (role/message_id/path) is shared across sessions and
       // the prior attempt may have marked this entry as seen. So when the
-      // session flips, retarget the live send to the replacement session
-      // instead of bailing. When the role is gone entirely, dead-letter.
+      // session flips, retarget the live send to the replacement session.
+      //
+      // Treat a momentarily missing role binding as ANOTHER transient state
+      // within the existing backoff budget — the unregister→reregister gap
+      // for codex/claude restarts is exactly the case this retry is trying
+      // to recover from. Only dead-letter once retries are exhausted.
       const currentSession = this.sessions.get(targetRole);
       if (!currentSession) {
+        if (attempt < backoffsMs.length) {
+          process.stderr.write(
+            `[NexusWsBridge] role=${targetRole} unregistered during retry attempt=${attempt + 1} — waiting for re-register\n`,
+          );
+          lastDetail = "role temporarily unregistered (waiting for re-register)";
+          await new Promise((r) => setTimeout(r, backoffsMs[attempt] ?? 1000));
+          continue;
+        }
         process.stderr.write(
-          `[NexusWsBridge] role=${targetRole} unregistered during retry — dead-lettering\n`,
+          `[NexusWsBridge] role=${targetRole} unregistered through retry budget — dead-lettering\n`,
         );
         await this.markHandoffDeadLettered(
           resolvedHandoffId,
           targetRole,
-          `role unregistered during retry: ${lastDetail || "no prior attempt"}`,
+          `role unregistered through retry budget: ${lastDetail || "no prior attempt"}`,
           retryContext,
         );
         return;

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -1222,6 +1222,112 @@ export class NexusWsBridge {
    * `inbox_delivered` vs `agent_received`) is out of scope for the
    * turn-typing migration and tracked as a follow-up.
    */
+  /**
+   * Detect transient ACP errors that warrant a retry instead of an
+   * immediate dead-letter. Bootstrapping codex/claude can take several
+   * seconds; pushing during that window fails with "connection closed"
+   * even though the runtime will be ready momentarily. Retrying with
+   * backoff before dead-lettering gives the recipient time to come up.
+   */
+  private static isTransientAcpError(detail: string): boolean {
+    const d = detail.toLowerCase();
+    return (
+      d.includes("connection closed") ||
+      d.includes("stream closed") ||
+      d.includes("session not started") ||
+      d.includes("not ready") ||
+      d.includes("acp_not_initialized")
+    );
+  }
+
+  /**
+   * Send a notification with bounded transient-retry. Retries on ACP
+   * connection-closed-style errors (recipient bootstrap race) with
+   * exponential backoff. Permanent errors fall through to dead-letter.
+   */
+  private async sendWithTransientRetry(
+    session: AgentSession,
+    notification: string,
+    targetRole: string,
+    resolvedHandoffId: string | undefined,
+    retryContext:
+      | { ipcMessageId: string; sender: string | undefined; sourceCid: string | undefined }
+      | undefined,
+  ): Promise<void> {
+    const backoffsMs = [500, 1500, 3000, 5000];
+    let lastDetail = "";
+    for (let attempt = 0; attempt <= backoffsMs.length; attempt += 1) {
+      if (this.draining || this.closed) return;
+      try {
+        const turn = await this.opts.runtime.send(session, notification);
+        const result = await turn.result.catch((err) => ({
+          turnId: turn.turnId,
+          stopReason: "error" as const,
+          error: {
+            code: "turn_rejected",
+            message: err instanceof Error ? err.message : String(err),
+          },
+        }));
+        if (result.stopReason === "end_turn") {
+          if (resolvedHandoffId) {
+            await this.markHandoffDeliveredById(resolvedHandoffId, targetRole);
+          }
+          return;
+        }
+        const detail = result.error
+          ? `${result.error.code}: ${result.error.message}`
+          : `stopReason=${result.stopReason}`;
+        lastDetail = detail;
+        if (NexusWsBridge.isTransientAcpError(detail) && attempt < backoffsMs.length) {
+          process.stderr.write(
+            `[NexusWsBridge] transient push failure role=${targetRole} attempt=${attempt + 1}: ${detail} (will retry)\n`,
+          );
+          await new Promise((r) => setTimeout(r, backoffsMs[attempt] ?? 1000));
+          continue;
+        }
+        process.stderr.write(
+          `[NexusWsBridge] local push failed for role=${targetRole} turn=${turn.turnId}: ${detail}\n`,
+        );
+        await this.markHandoffDeadLettered(
+          resolvedHandoffId,
+          targetRole,
+          `local push abnormal: ${detail}`,
+          retryContext,
+        );
+        return;
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        lastDetail = detail;
+        if (NexusWsBridge.isTransientAcpError(detail) && attempt < backoffsMs.length) {
+          process.stderr.write(
+            `[NexusWsBridge] transient runtime.send error role=${targetRole} attempt=${attempt + 1}: ${detail} (will retry)\n`,
+          );
+          await new Promise((r) => setTimeout(r, backoffsMs[attempt] ?? 1000));
+          continue;
+        }
+        process.stderr.write(
+          `[NexusWsBridge] runtime.send rejected for role=${targetRole}: ${detail}\n`,
+        );
+        await this.markHandoffDeadLettered(
+          resolvedHandoffId,
+          targetRole,
+          `runtime.send rejected: ${detail}`,
+          retryContext,
+        );
+        return;
+      }
+    }
+    process.stderr.write(
+      `[NexusWsBridge] exhausted transient retries for role=${targetRole}: ${lastDetail}\n`,
+    );
+    await this.markHandoffDeadLettered(
+      resolvedHandoffId,
+      targetRole,
+      `transient retries exhausted: ${lastDetail}`,
+      retryContext,
+    );
+  }
+
   private async markHandoffDeadLettered(
     handoffId: string | undefined,
     targetRole: string,
@@ -1789,52 +1895,13 @@ export class NexusWsBridge {
       // to a torn-down runtime.
       if (this.draining || this.closed) return;
 
-      const sendPromise = this.opts.runtime
-        .send(session, notification)
-        .then(async (turn) => {
-          const result = await turn.result.catch((err) => ({
-            turnId: turn.turnId,
-            stopReason: "error" as const,
-            error: {
-              code: "turn_rejected",
-              message: err instanceof Error ? err.message : String(err),
-            },
-          }));
-          // For control-plane delivery, `end_turn` is the only success
-          // signal. Treat cancelled / max_tokens / error / unknown stop
-          // reasons all as delivery failures so the handoff is dead-
-          // lettered — matches watchTurnError's abnormal-terminal policy.
-          if (result.stopReason === "end_turn") {
-            if (resolvedHandoffId) {
-              await this.markHandoffDeliveredById(resolvedHandoffId, _targetRole);
-            }
-          } else {
-            const detail = result.error
-              ? `${result.error.code}: ${result.error.message}`
-              : `stopReason=${result.stopReason}`;
-            process.stderr.write(
-              `[NexusWsBridge] local push failed for role=${_targetRole} turn=${turn.turnId}: ${detail}\n`,
-            );
-            await this.markHandoffDeadLettered(
-              resolvedHandoffId,
-              _targetRole,
-              `local push abnormal: ${detail}`,
-              retryContext,
-            );
-          }
-        })
-        .catch(async (err) => {
-          const detail = err instanceof Error ? err.message : String(err);
-          process.stderr.write(
-            `[NexusWsBridge] runtime.send rejected for role=${_targetRole}: ${detail}\n`,
-          );
-          await this.markHandoffDeadLettered(
-            resolvedHandoffId,
-            _targetRole,
-            `runtime.send rejected: ${detail}`,
-            retryContext,
-          );
-        });
+      const sendPromise = this.sendWithTransientRetry(
+        session,
+        notification,
+        _targetRole,
+        resolvedHandoffId,
+        retryContext,
+      );
 
       // Track the send-and-status-update promise so shutdown() can
       // await it (bounded) before the final drain. Without this, a

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -1256,15 +1256,19 @@ export class NexusWsBridge {
   ): Promise<void> {
     const backoffsMs = [500, 1500, 3000, 5000];
     let lastDetail = "";
+    let activeSession = session;
     for (let attempt = 0; attempt <= backoffsMs.length; attempt += 1) {
       if (this.draining || this.closed) return;
       // Re-check the current session for this role before each attempt.
       // If the role was re-registered during a backoff window — the exact
-      // crash/bootstrap race this retry is recovering from — keep targeting
-      // the captured (now torn-down) session would dead-letter a handoff
-      // that the replacement's SSE loop should still pick up. When the
-      // mapping flips to a new session, abort retries so the replacement
-      // delivers normally; when the role is gone entirely, dead-letter.
+      // crash/bootstrap race this retry is recovering from — pushing to the
+      // captured (now torn-down) session would dead-letter a handoff that
+      // the replacement should still receive. We can't trust the
+      // replacement's SSE loop to redeliver because dispatchInboxDelivery's
+      // dedupe cache (role/message_id/path) is shared across sessions and
+      // the prior attempt may have marked this entry as seen. So when the
+      // session flips, retarget the live send to the replacement session
+      // instead of bailing. When the role is gone entirely, dead-letter.
       const currentSession = this.sessions.get(targetRole);
       if (!currentSession) {
         process.stderr.write(
@@ -1278,14 +1282,14 @@ export class NexusWsBridge {
         );
         return;
       }
-      if (currentSession.id !== session.id) {
+      if (currentSession.id !== activeSession.id) {
         process.stderr.write(
-          `[NexusWsBridge] role=${targetRole} session replaced during retry (was=${session.id} now=${currentSession.id}) — aborting retries; replacement SSE will redeliver\n`,
+          `[NexusWsBridge] role=${targetRole} session replaced during retry (was=${activeSession.id} now=${currentSession.id}) — retargeting send to replacement\n`,
         );
-        return;
+        activeSession = currentSession;
       }
       try {
-        const turn = await this.opts.runtime.send(session, notification);
+        const turn = await this.opts.runtime.send(activeSession, notification);
         const result = await turn.result.catch((err) => ({
           turnId: turn.turnId,
           stopReason: "error" as const,

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -1258,6 +1258,32 @@ export class NexusWsBridge {
     let lastDetail = "";
     for (let attempt = 0; attempt <= backoffsMs.length; attempt += 1) {
       if (this.draining || this.closed) return;
+      // Re-check the current session for this role before each attempt.
+      // If the role was re-registered during a backoff window — the exact
+      // crash/bootstrap race this retry is recovering from — keep targeting
+      // the captured (now torn-down) session would dead-letter a handoff
+      // that the replacement's SSE loop should still pick up. When the
+      // mapping flips to a new session, abort retries so the replacement
+      // delivers normally; when the role is gone entirely, dead-letter.
+      const currentSession = this.sessions.get(targetRole);
+      if (!currentSession) {
+        process.stderr.write(
+          `[NexusWsBridge] role=${targetRole} unregistered during retry — dead-lettering\n`,
+        );
+        await this.markHandoffDeadLettered(
+          resolvedHandoffId,
+          targetRole,
+          `role unregistered during retry: ${lastDetail || "no prior attempt"}`,
+          retryContext,
+        );
+        return;
+      }
+      if (currentSession.id !== session.id) {
+        process.stderr.write(
+          `[NexusWsBridge] role=${targetRole} session replaced during retry (was=${session.id} now=${currentSession.id}) — aborting retries; replacement SSE will redeliver\n`,
+        );
+        return;
+      }
       try {
         const turn = await this.opts.runtime.send(session, notification);
         const result = await turn.result.catch((err) => ({

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -1892,18 +1892,24 @@ export class NexusWsBridge {
       // Session-identity re-check: handleEvent captured `session` at SSE
       // dispatch time, but the sys_read fetch + decode above are async.
       // If the role was unregistered or replaced during that window, the
-      // captured session may now be closed. Push to a dead session would
-      // fail and — worse — trigger dead-lettering for a handoff that a
-      // replacement session should still receive. Skip delivery and skip
-      // dead-lettering in that case; the replacement's own SSE loop will
-      // pick up the redelivery from Nexus.
+      // captured session may now be closed.
+      //
+      // Skipping here is unsafe: dispatchInboxDelivery's role-level
+      // message_id dedupe is shared across sessions, so the replacement's
+      // SSE loop won't re-pull the same entry. Falling through to
+      // sendWithTransientRetry retargets delivery to the current session
+      // (or treats a missing role as transient inside the retry budget).
       const current = this.sessions.get(_targetRole);
-      if (!current || current.id !== session.id) {
+      if (!current) {
         debugLog(
           "wsBridge.readAndPush",
-          `SKIP stale session for role=${_targetRole} captured=${session.id} current=${current?.id ?? "none"}`,
+          `role=${_targetRole} unregistered before push — handing off to retry helper for transient handling`,
         );
-        return;
+      } else if (current.id !== session.id) {
+        debugLog(
+          "wsBridge.readAndPush",
+          `session changed for role=${_targetRole} captured=${session.id} current=${current.id} — retry helper will retarget`,
+        );
       }
 
       // Capture the correlated handoffId NOW using DETERMINISTIC keys

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -785,11 +785,7 @@ export class SpawnManager {
         const gitOpts: { stdio: "ignore"; cwd?: string } = { stdio: "ignore" };
         if (provisionedRepoCwd) gitOpts.cwd = provisionedRepoCwd;
         try {
-          execFileSync(
-            "git",
-            ["worktree", "remove", "--force", provisionedWorkspacePath],
-            gitOpts,
-          );
+          execFileSync("git", ["worktree", "remove", "--force", provisionedWorkspacePath], gitOpts);
         } catch {
           try {
             const { rmSync } = await import("node:fs");

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -543,6 +543,10 @@ export class SpawnManager {
     // can edit files, commit, push, and create PRs.
     let workspacePath: string;
     let workspaceMode!: WorkspaceMode;
+    // Hoisted out of the inner block so the spawn-failure catch can clean
+    // up the provisioned worktree even though the workspace registry path
+    // (cleanWorkspace) won't see it (no spawn record was persisted yet).
+    let provisionedWorkspacePath: string | undefined;
     {
       const groveDir = this.groveDir;
       const projectRoot = groveDir ? resolve(groveDir, "..") : process.cwd();
@@ -576,6 +580,7 @@ export class SpawnManager {
           baseBranch,
         });
         workspacePath = provisioned.path;
+        provisionedWorkspacePath = provisioned.path;
       } catch (provisionErr) {
         const reason = provisionErr instanceof Error ? provisionErr.message : String(provisionErr);
         debugLog("spawn", `workspace provisioning failed for role=${roleId}: ${reason}`);
@@ -749,13 +754,36 @@ export class SpawnManager {
         throw new Error("No agent runtime or tmux available for spawning");
       }
     } catch (spawnErr) {
-      // Roll back workspace on spawn failure
+      // Roll back workspace on spawn failure.
+      //
+      // `cleanWorkspace` is keyed off the workspace registry (getWorkspace
+      // returns undefined when there's no row) and the spawn record isn't
+      // persisted until after this catch, so the registry path can no-op.
+      // Explicitly remove the provisioned worktree path so failures here
+      // (e.g. codex isolation prep throw on disk-full / quota) don't strand
+      // an orphaned git worktree + branch on disk for later operators to
+      // discover. `git worktree remove` is preferred (cleans the parent
+      // repo's metadata too); fall back to `rm -rf` for non-worktree paths.
       if (this.provider.cleanWorkspace) {
         await safeCleanup(
           this.provider.cleanWorkspace(spawnId, spawnId),
           "rollback workspace after spawn failure",
           { silent: true },
         );
+      }
+      if (provisionedWorkspacePath) {
+        try {
+          execSync(`git worktree remove --force ${JSON.stringify(provisionedWorkspacePath)}`, {
+            stdio: "ignore",
+          });
+        } catch {
+          try {
+            const { rmSync } = await import("node:fs");
+            rmSync(provisionedWorkspacePath, { recursive: true, force: true });
+          } catch {
+            /* best-effort */
+          }
+        }
       }
       throw spawnErr;
     }

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -7,7 +7,7 @@
  * On tmux failure: roll back claim + workspace.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
@@ -547,6 +547,8 @@ export class SpawnManager {
     // up the provisioned worktree even though the workspace registry path
     // (cleanWorkspace) won't see it (no spawn record was persisted yet).
     let provisionedWorkspacePath: string | undefined;
+    let provisionedBranch: string | undefined;
+    let provisionedRepoCwd: string | undefined;
     {
       const groveDir = this.groveDir;
       const projectRoot = groveDir ? resolve(groveDir, "..") : process.cwd();
@@ -581,6 +583,8 @@ export class SpawnManager {
         });
         workspacePath = provisioned.path;
         provisionedWorkspacePath = provisioned.path;
+        provisionedBranch = provisioned.branch;
+        provisionedRepoCwd = primaryRepo.bareClonePath;
       } catch (provisionErr) {
         const reason = provisionErr instanceof Error ? provisionErr.message : String(provisionErr);
         debugLog("spawn", `workspace provisioning failed for role=${roleId}: ${reason}`);
@@ -772,16 +776,37 @@ export class SpawnManager {
         );
       }
       if (provisionedWorkspacePath) {
+        // Use execFileSync with argv (NOT execSync with a shell-interpolated
+        // command string) so role names containing shell metacharacters
+        // can't escape into command substitution.
+        // Run from the owning bare-clone repo so `git worktree remove`
+        // touches the correct .git/worktrees/* metadata; the operator's
+        // current cwd may not be the repo that owns this worktree.
+        const gitOpts: { stdio: "ignore"; cwd?: string } = { stdio: "ignore" };
+        if (provisionedRepoCwd) gitOpts.cwd = provisionedRepoCwd;
         try {
-          execSync(`git worktree remove --force ${JSON.stringify(provisionedWorkspacePath)}`, {
-            stdio: "ignore",
-          });
+          execFileSync(
+            "git",
+            ["worktree", "remove", "--force", provisionedWorkspacePath],
+            gitOpts,
+          );
         } catch {
           try {
             const { rmSync } = await import("node:fs");
             rmSync(provisionedWorkspacePath, { recursive: true, force: true });
           } catch {
             /* best-effort */
+          }
+        }
+        // Always also delete the branch — `git worktree remove` skips it,
+        // and rm -rf doesn't touch repo metadata. Without this, retrying
+        // the same role/session hits "branch already exists" on the next
+        // provision attempt.
+        if (provisionedBranch) {
+          try {
+            execFileSync("git", ["branch", "-D", provisionedBranch], gitOpts);
+          } catch {
+            /* best-effort — branch may already be gone */
           }
         }
       }

--- a/src/tui/views/activity-panel.tsx
+++ b/src/tui/views/activity-panel.tsx
@@ -3,7 +3,7 @@
  */
 
 import React, { useCallback } from "react";
-import { contributionToEntity, type ContributionEntity } from "../../core/entity.js";
+import { type ContributionEntity, contributionToEntity } from "../../core/entity.js";
 import {
   agentColumn,
   byCreatedDesc,

--- a/src/tui/views/activity-panel.tsx
+++ b/src/tui/views/activity-panel.tsx
@@ -2,7 +2,8 @@
  * Activity panel — recent contributions, EntityView-backed.
  */
 
-import React from "react";
+import React, { useCallback } from "react";
+import { contributionToEntity, type ContributionEntity } from "../../core/entity.js";
 import {
   agentColumn,
   byCreatedDesc,
@@ -23,6 +24,8 @@ export interface ActivityPanelProps {
   readonly onRowCountChanged?: ((count: number) => void) | undefined;
 }
 
+const NAMESPACE = "default";
+
 const COLUMNS = [
   cidColumn(16),
   kindColumn(12),
@@ -36,6 +39,11 @@ const PANEL_LIMIT = 30;
 
 export const ActivityPanelView: React.NamedExoticComponent<ActivityPanelProps> = React.memo(
   function ActivityPanelView(props: ActivityPanelProps): React.ReactNode {
+    const fallbackFetcher = useCallback(async (): Promise<readonly ContributionEntity[]> => {
+      const items = await props.provider.getActivity({ limit: PANEL_LIMIT });
+      return items.map((c) => contributionToEntity(c, NAMESPACE));
+    }, [props.provider]);
+
     return (
       <EntityView
         kind="Contribution"
@@ -45,6 +53,7 @@ export const ActivityPanelView: React.NamedExoticComponent<ActivityPanelProps> =
         cursor={props.cursor}
         sort={byCreatedDesc}
         limit={PANEL_LIMIT}
+        fallbackFetcher={fallbackFetcher}
         title="Activity"
         emptyTitle="No recent activity."
         emptyHint="Activity appears as agents publish contributions."

--- a/src/tui/views/activity-panel.tsx
+++ b/src/tui/views/activity-panel.tsx
@@ -1,25 +1,20 @@
 /**
- * Activity panel — recent contributions filtered by kind/agent/tags.
- *
- * PR2 (#388) migrated from `usePolledData(provider.getActivity({limit:30}))`
- * to `useEntities("Contribution", …)` + `.slice(0, 30)`. Distinct from the
- * full ActivityView tab: this is a dedicated operator panel (toggled via
- * key 9) with compact formatting.
+ * Activity panel — recent contributions, EntityView-backed.
  */
 
-import React, { useCallback, useEffect, useMemo } from "react";
-import type { ContributionEntity } from "../../core/entity.js";
-import type { Contribution } from "../../core/models.js";
-import { compareTimestampsDesc, formatTimestamp, truncateCid } from "../../shared/format.js";
-import { DataStatus } from "../components/data-status.js";
-import { EmptyState } from "../components/empty-state.js";
-import { Table } from "../components/table.js";
-import { useEntityWatchEnabled } from "../hooks/informer-context.js";
-import { useEntities } from "../hooks/use-entities.js";
-import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
+import React from "react";
+import {
+  agentColumn,
+  byCreatedDesc,
+  cidColumn,
+  createdColumn,
+  kindColumn,
+  summaryColumn,
+  tagsColumn,
+} from "../components/columns/contribution-columns.js";
+import { EntityView } from "../components/entity-view.js";
 import type { TuiDataProvider } from "../provider.js";
 
-/** Props for the ActivityPanel view. */
 export interface ActivityPanelProps {
   readonly provider: TuiDataProvider;
   readonly intervalMs: number;
@@ -29,116 +24,32 @@ export interface ActivityPanelProps {
 }
 
 const COLUMNS = [
-  { header: "CID", key: "cid", width: 16 },
-  { header: "KIND", key: "kind", width: 12 },
-  { header: "SUMMARY", key: "summary", width: 32 },
-  { header: "AGENT", key: "agent", width: 14 },
-  { header: "TAGS", key: "tags", width: 14 },
-  { header: "TIME", key: "time", width: 10 },
-] as const;
+  cidColumn(16),
+  kindColumn(12),
+  summaryColumn(32),
+  agentColumn(14),
+  tagsColumn(14, 2),
+  createdColumn("TIME", 10),
+];
 
 const PANEL_LIMIT = 30;
 
-function entityToContribution(e: ContributionEntity): Contribution {
-  return {
-    cid: e.id,
-    manifestVersion: 0,
-    kind: e.spec.contributionKind,
-    mode: e.spec.mode,
-    summary: e.spec.summary,
-    description: e.spec.description,
-    artifacts: e.spec.artifacts,
-    relations: e.spec.relations,
-    scores: e.spec.scores,
-    tags: e.spec.tags,
-    context: e.spec.context,
-    agent: e.spec.agent,
-    createdAt: e.metadata.creationTimestamp ?? "",
-  };
-}
-
-/** Activity panel showing recent contributions. */
 export const ActivityPanelView: React.NamedExoticComponent<ActivityPanelProps> = React.memo(
-  function ActivityPanelView({
-    provider,
-    intervalMs,
-    active,
-    cursor,
-    onRowCountChanged,
-  }: ActivityPanelProps): React.ReactNode {
-    const useInformerPath = useEntityWatchEnabled(provider, "Contribution");
-
-    const entityResult = useEntities("Contribution");
-
-    const fetcher = useCallback(() => provider.getActivity({ limit: PANEL_LIMIT }), [provider]);
-    const polled = useEventDrivenData<readonly Contribution[]>(
-      fetcher,
-      undefined,
-      undefined,
-      active && !useInformerPath,
-    );
-
-    const data = useMemo<readonly Contribution[] | undefined>(() => {
-      if (useInformerPath) {
-        const sorted = [...entityResult.data].sort((a, b) =>
-          compareTimestampsDesc(a.metadata.creationTimestamp, b.metadata.creationTimestamp),
-        );
-        return sorted.slice(0, PANEL_LIMIT).map(entityToContribution);
-      }
-      return polled.data ?? undefined;
-    }, [useInformerPath, entityResult.data, polled.data]);
-
-    const loading = useInformerPath
-      ? !entityResult.hasSynced && data === undefined
-      : polled.loading;
-    const isStale = useInformerPath ? false : polled.isStale;
-    const error = useInformerPath ? entityResult.error : polled.error;
-
-    useEffect(() => {
-      if (data && onRowCountChanged) {
-        onRowCountChanged(data.length);
-      }
-    }, [data, onRowCountChanged]);
-
-    if (loading && !data) {
-      return (
-        <box>
-          <text opacity={0.5}>Loading activity...</text>
-        </box>
-      );
-    }
-
-    const contributions = data ?? [];
-
-    const rows = contributions.map((c) => ({
-      cid: truncateCid(c.cid),
-      kind: c.kind,
-      summary:
-        (c.summary ?? "").length > 32 ? `${(c.summary ?? "").slice(0, 30)}..` : (c.summary ?? ""),
-      agent: c.agent?.role ?? c.agent?.agentName ?? c.agent?.agentId ?? "unknown",
-      tags: (c.tags ?? []).slice(0, 2).join(", "),
-      time: formatTimestamp(c.createdAt),
-    }));
-
+  function ActivityPanelView(props: ActivityPanelProps): React.ReactNode {
     return (
-      <box flexDirection="column">
-        <box marginBottom={1} flexDirection="row">
-          <text>Activity</text>
-          <DataStatus loading={loading && !data} isStale={isStale} error={error?.message} />
-          <text opacity={0.5}>
-            {"  "}
-            {`${contributions.length} recent`}
-          </text>
-        </box>
-        {rows.length === 0 ? (
-          <EmptyState
-            title="No recent activity."
-            hint="Activity appears as agents publish contributions."
-          />
-        ) : (
-          <Table columns={[...COLUMNS]} rows={rows} cursor={cursor} />
-        )}
-      </box>
+      <EntityView
+        kind="Contribution"
+        columns={COLUMNS}
+        provider={props.provider}
+        active={props.active}
+        cursor={props.cursor}
+        sort={byCreatedDesc}
+        limit={PANEL_LIMIT}
+        title="Activity"
+        emptyTitle="No recent activity."
+        emptyHint="Activity appears as agents publish contributions."
+        {...(props.onRowCountChanged ? { onRowCountChanged: props.onRowCountChanged } : {})}
+      />
     );
   },
 );

--- a/src/tui/views/activity.tsx
+++ b/src/tui/views/activity.tsx
@@ -7,10 +7,8 @@
  */
 
 import React, { useCallback, useState } from "react";
-import { contributionToEntity, type ContributionEntity } from "../../core/entity.js";
+import { type ContributionEntity, contributionToEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
-
-const NAMESPACE = "default";
 import {
   agentColumn,
   byCreatedDesc,
@@ -23,6 +21,8 @@ import {
 } from "../components/columns/contribution-columns.js";
 import { EntityView } from "../components/entity-view.js";
 import type { TuiDataProvider } from "../provider.js";
+
+const NAMESPACE = "default";
 
 export interface ActivityProps {
   readonly provider: TuiDataProvider;

--- a/src/tui/views/activity.tsx
+++ b/src/tui/views/activity.tsx
@@ -74,10 +74,16 @@ export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.mem
       [onContributionsLoaded],
     );
 
+    // Pagination is applied EXACTLY ONCE inside EntityView via offset+limit.
+    // The provider call therefore over-fetches `pageOffset + pageSize` items
+    // starting from 0 (no provider-level offset) so EntityView's slice can
+    // page within the returned window. If we asked the provider to also
+    // page, applyEntityShape inside useEntityData's polled branch would
+    // re-slice the already-paged list — pageOffset>0 would render empty.
     const fallbackFetcher = useCallback(async (): Promise<readonly ContributionEntity[]> => {
-      const items = await provider.getActivity({ limit: pageSize, offset: pageOffset });
+      const items = await provider.getActivity({ limit: pageOffset + pageSize });
       return items.map((c) => contributionToEntity(c, NAMESPACE));
-    }, [provider, pageSize, pageOffset]);
+    }, [provider, pageOffset, pageSize]);
 
     return (
       <box flexDirection="column">

--- a/src/tui/views/activity.tsx
+++ b/src/tui/views/activity.tsx
@@ -7,8 +7,10 @@
  */
 
 import React, { useCallback, useState } from "react";
-import type { ContributionEntity } from "../../core/entity.js";
+import { contributionToEntity, type ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
+
+const NAMESPACE = "default";
 import {
   agentColumn,
   byCreatedDesc,
@@ -72,6 +74,11 @@ export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.mem
       [onContributionsLoaded],
     );
 
+    const fallbackFetcher = useCallback(async (): Promise<readonly ContributionEntity[]> => {
+      const items = await provider.getActivity({ limit: pageSize, offset: pageOffset });
+      return items.map((c) => contributionToEntity(c, NAMESPACE));
+    }, [provider, pageSize, pageOffset]);
+
     return (
       <box flexDirection="column">
         <box marginBottom={1} flexDirection="row">
@@ -91,6 +98,7 @@ export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.mem
           sort={byCreatedDesc}
           offset={pageOffset}
           limit={pageSize}
+          fallbackFetcher={fallbackFetcher}
           onRowCountChanged={setCount}
           onDataChanged={onDataChanged}
         />

--- a/src/tui/views/activity.tsx
+++ b/src/tui/views/activity.tsx
@@ -6,7 +6,7 @@
  * built-in title doesn't model offset display.
  */
 
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import type { ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
 import {
@@ -65,6 +65,13 @@ export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.mem
     const { provider, active, cursor, pageOffset, pageSize, onContributionsLoaded } = props;
     const [count, setCount] = useState(0);
 
+    const onDataChanged = useCallback(
+      (entities: readonly ContributionEntity[]) => {
+        if (onContributionsLoaded) onContributionsLoaded(entities.map(entityToContribution));
+      },
+      [onContributionsLoaded],
+    );
+
     return (
       <box flexDirection="column">
         <box marginBottom={1} flexDirection="row">
@@ -85,9 +92,7 @@ export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.mem
           offset={pageOffset}
           limit={pageSize}
           onRowCountChanged={setCount}
-          onDataChanged={(entities) => {
-            if (onContributionsLoaded) onContributionsLoaded(entities.map(entityToContribution));
-          }}
+          onDataChanged={onDataChanged}
         />
       </box>
     );

--- a/src/tui/views/activity.tsx
+++ b/src/tui/views/activity.tsx
@@ -1,25 +1,27 @@
 /**
- * Activity stream view — live feed of contributions.
+ * Activity stream view — paged contributions feed, EntityView-backed.
  *
- * PR2 (#388) migrated from `usePolledData(provider.getActivity)` to
- * `useEntities("Contribution", …)`. Pagination is applied to the
- * informer cache snapshot (sorted by createdAt desc + sliced by
- * pageOffset/pageSize). The cache is bounded by the listFn snapshot;
- * "load more" beyond that window will see the same set until a relist
- * pulls a fresh snapshot.
+ * Pagination: sort by createdAt desc, slice via EntityView's offset+limit.
+ * Wrapper owns the custom header ("showing N-M") because EntityView's
+ * built-in title doesn't model offset display.
  */
 
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useState } from "react";
 import type { ContributionEntity } from "../../core/entity.js";
 import type { Contribution } from "../../core/models.js";
-import { compareTimestampsDesc, formatTimestamp, truncateCid } from "../../shared/format.js";
-import { Table } from "../components/table.js";
-import { useEntityWatchEnabled } from "../hooks/informer-context.js";
-import { useEntities } from "../hooks/use-entities.js";
-import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
+import {
+  agentColumn,
+  byCreatedDesc,
+  cidColumn,
+  createdColumn,
+  kindColumn,
+  modeColumn,
+  summaryColumn,
+  tagsColumn,
+} from "../components/columns/contribution-columns.js";
+import { EntityView } from "../components/entity-view.js";
 import type { TuiDataProvider } from "../provider.js";
 
-/** Props for the Activity view. */
 export interface ActivityProps {
   readonly provider: TuiDataProvider;
   readonly intervalMs: number;
@@ -31,18 +33,15 @@ export interface ActivityProps {
 }
 
 const COLUMNS = [
-  { header: "CID", key: "cid", width: 22 },
-  { header: "KIND", key: "kind", width: 14 },
-  { header: "MODE", key: "mode", width: 12 },
-  { header: "SUMMARY", key: "summary", width: 36 },
-  { header: "AGENT", key: "agent", width: 16 },
-  { header: "TAGS", key: "tags", width: 16 },
-  { header: "CREATED", key: "created", width: 12 },
-] as const;
+  cidColumn(22),
+  kindColumn(14),
+  modeColumn(12),
+  summaryColumn(36),
+  agentColumn(16),
+  tagsColumn(16, 3),
+  createdColumn("CREATED", 12),
+];
 
-/** Project a ContributionEntity back to the flat Contribution shape this view's
- * row formatter expects. The fields the table reads are: cid, kind, mode,
- * summary, agent, tags, createdAt. */
 function entityToContribution(e: ContributionEntity): Contribution {
   return {
     cid: e.id,
@@ -61,90 +60,35 @@ function entityToContribution(e: ContributionEntity): Contribution {
   };
 }
 
-/** Activity stream view component. */
 export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.memo(
-  function ActivityView({
-    provider,
-    intervalMs,
-    active,
-    cursor,
-    pageOffset,
-    pageSize,
-    onContributionsLoaded,
-  }: ActivityProps): React.ReactNode {
-    const useInformerPath = useEntityWatchEnabled(provider, "Contribution");
-
-    const entityResult = useEntities("Contribution");
-
-    const fetcher = useCallback(
-      () => provider.getActivity({ limit: pageSize, offset: pageOffset }),
-      [provider, pageSize, pageOffset],
-    );
-    const polled = useEventDrivenData<readonly Contribution[]>(
-      fetcher,
-      undefined,
-      undefined,
-      active && !useInformerPath,
-    );
-
-    const data = useMemo<readonly Contribution[] | undefined>(() => {
-      if (useInformerPath) {
-        const all = entityResult.data;
-        // Sort newest-first chronologically; entities without a timestamp
-        // sort last (they're typically synthetic / pre-#287). String
-        // localeCompare misorders timezone-offset timestamps.
-        const sorted = [...all].sort((a, b) =>
-          compareTimestampsDesc(a.metadata.creationTimestamp, b.metadata.creationTimestamp),
-        );
-        return sorted.slice(pageOffset, pageOffset + pageSize).map(entityToContribution);
-      }
-      return polled.data ?? undefined;
-    }, [useInformerPath, entityResult.data, polled.data, pageOffset, pageSize]);
-
-    const loading = useInformerPath
-      ? !entityResult.hasSynced && data === undefined
-      : polled.loading;
-
-    useEffect(() => {
-      if (data && onContributionsLoaded) {
-        onContributionsLoaded(data);
-      }
-    }, [data, onContributionsLoaded]);
-
-    if (loading && !data) {
-      return (
-        <box>
-          <text opacity={0.5}>Loading activity...</text>
-        </box>
-      );
-    }
-
-    const contributions = data ?? [];
-
-    const rows = contributions.map((c) => ({
-      cid: truncateCid(c.cid),
-      kind: c.kind,
-      mode: c.mode,
-      summary:
-        (c.summary ?? "").length > 36 ? `${(c.summary ?? "").slice(0, 34)}..` : (c.summary ?? ""),
-      agent: c.agent?.agentName ?? c.agent?.agentId ?? "unknown",
-      tags: (c.tags ?? []).slice(0, 3).join(", "),
-      created: formatTimestamp(c.createdAt),
-    }));
+  function ActivityView(props: ActivityProps): React.ReactNode {
+    const { provider, active, cursor, pageOffset, pageSize, onContributionsLoaded } = props;
+    const [count, setCount] = useState(0);
 
     return (
       <box flexDirection="column">
         <box marginBottom={1} flexDirection="row">
           <text>Activity Stream</text>
-          {contributions.length > 0 ? (
-            <text opacity={0.5}>
-              {`  showing ${pageOffset + 1}-${pageOffset + contributions.length}`}
-            </text>
+          {count > 0 ? (
+            <text opacity={0.5}>{`  showing ${pageOffset + 1}-${pageOffset + count}`}</text>
           ) : pageOffset > 0 ? (
             <text opacity={0.5}>{"  "}(no more results — press p to go back)</text>
           ) : null}
         </box>
-        <Table columns={[...COLUMNS]} rows={rows} cursor={cursor} />
+        <EntityView
+          kind="Contribution"
+          columns={COLUMNS}
+          provider={provider}
+          active={active}
+          cursor={cursor}
+          sort={byCreatedDesc}
+          offset={pageOffset}
+          limit={pageSize}
+          onRowCountChanged={setCount}
+          onDataChanged={(entities) => {
+            if (onContributionsLoaded) onContributionsLoaded(entities.map(entityToContribution));
+          }}
+        />
       </box>
     );
   },

--- a/src/tui/views/activity.tsx
+++ b/src/tui/views/activity.tsx
@@ -74,14 +74,13 @@ export const ActivityView: React.NamedExoticComponent<ActivityProps> = React.mem
       [onContributionsLoaded],
     );
 
-    // Pagination is applied EXACTLY ONCE inside EntityView via offset+limit.
-    // The provider call therefore over-fetches `pageOffset + pageSize` items
-    // starting from 0 (no provider-level offset) so EntityView's slice can
-    // page within the returned window. If we asked the provider to also
-    // page, applyEntityShape inside useEntityData's polled branch would
-    // re-slice the already-paged list — pageOffset>0 would render empty.
+    // The fallback path owns its own paging/ordering: useEntityData applies
+    // ONLY `predicate` to polled data (sort/offset/limit are skipped) so
+    // we ask the provider for the exact page we want. Server returns its
+    // native order (ascending in the current server) — matches the
+    // pre-EntityView behavior of the activity stream's polled path.
     const fallbackFetcher = useCallback(async (): Promise<readonly ContributionEntity[]> => {
-      const items = await provider.getActivity({ limit: pageOffset + pageSize });
+      const items = await provider.getActivity({ limit: pageSize, offset: pageOffset });
       return items.map((c) => contributionToEntity(c, NAMESPACE));
     }, [provider, pageOffset, pageSize]);
 

--- a/src/tui/views/agent-list.tsx
+++ b/src/tui/views/agent-list.tsx
@@ -23,7 +23,9 @@ import {
   targetColumn,
 } from "../components/columns/agent-columns.js";
 import { isActive } from "../components/columns/claim-columns.js";
+import { EmptyState } from "../components/empty-state.js";
 import { EntityView } from "../components/entity-view.js";
+import { useProviderScoped } from "../hooks/informer-context.js";
 import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { TuiDataProvider } from "../provider.js";
 import { BRAILLE_SPINNER, timing } from "../theme.js";
@@ -40,6 +42,7 @@ export interface AgentListProps {
 export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.memo(
   function AgentListView(props: AgentListProps): React.ReactNode {
     const { provider, tmux, active, cursor, onSelectSession } = props;
+    const isScoped = useProviderScoped(provider);
     const [spinnerFrame, setSpinnerFrame] = useState(0);
     useInterval(
       () => setSpinnerFrame((f) => (f + 1) % BRAILLE_SPINNER.length),
@@ -132,6 +135,25 @@ export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.m
       const claims = await provider.getClaims({ status: "active" });
       return claims.map((c) => claimToEntity(c, () => Date.now(), NAMESPACE));
     }, [provider]);
+
+    // Scoped sessions: `useEntityWatchEnabled` returns false in scoped mode,
+    // and `provider.getClaims` is namespace-global (no session filter), so
+    // the fallback would render claims from OTHER sessions. Render an empty
+    // state instead until session-scoped claim filtering lands. Mirrors the
+    // ClaimsView short-circuit.
+    if (isScoped) {
+      return (
+        <box flexDirection="column">
+          <box marginBottom={1}>
+            <text>Agents (0)</text>
+          </box>
+          <EmptyState
+            title="No agents registered."
+            hint="Press r to register, or Ctrl+P to spawn."
+          />
+        </box>
+      );
+    }
 
     return (
       <EntityView

--- a/src/tui/views/agent-list.tsx
+++ b/src/tui/views/agent-list.tsx
@@ -1,44 +1,31 @@
 /**
- * Agent list view — shows running agent sessions derived from claims + tmux.
- *
- * Correlates active claims with tmux sessions to build the agent fleet view.
- * In local mode, shows session status and allows spawn/kill via command palette.
+ * Agent list view — running agents derived from active claims joined
+ * with tmux session list and cost rollups. EntityView renders the
+ * list; the wrapper computes the join context and passes it to the
+ * column factories.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import type { ClaimEntity } from "../../core/entity.js";
-import type { Claim } from "../../core/models.js";
 import { useInterval } from "../../local/use-interval.js";
-import type { TmuxManager } from "../agents/tmux-manager.js";
-import { agentIdFromSession } from "../agents/tmux-manager.js";
-import { DataStatus } from "../components/data-status.js";
-import { EmptyState } from "../components/empty-state.js";
-import { Table } from "../components/table.js";
-import { useEntityWatchEnabled } from "../hooks/informer-context.js";
-import { useEntities } from "../hooks/use-entities.js";
+import { agentIdFromSession, type TmuxManager } from "../agents/tmux-manager.js";
+import {
+  type AgentJoinCtx,
+  agentIdColumn,
+  byRoleAndName,
+  costColumn,
+  platformColumn,
+  roleColumn,
+  sessionColumn,
+  statusColumn,
+  targetColumn,
+} from "../components/columns/agent-columns.js";
+import { isActive } from "../components/columns/claim-columns.js";
+import { EntityView } from "../components/entity-view.js";
 import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { TuiDataProvider } from "../provider.js";
-import { agentStatusIcon, BRAILLE_SPINNER, timing } from "../theme.js";
+import { BRAILLE_SPINNER, timing } from "../theme.js";
 
-const ACTIVE_PREDICATE = (e: ClaimEntity): boolean => e.status.phase === "active";
-
-/** Flatten a ClaimEntity to the legacy Claim shape this view consumes. */
-function entityToClaim(e: ClaimEntity): Claim {
-  return {
-    claimId: e.id,
-    targetRef: e.spec.targetRef,
-    agent: e.spec.agent,
-    status: e.status.phase,
-    intentSummary: e.spec.intentSummary,
-    createdAt: e.metadata.creationTimestamp ?? e.status.heartbeatAt,
-    heartbeatAt: e.status.heartbeatAt,
-    leaseExpiresAt: e.status.leaseExpiresAt,
-    context: e.spec.context,
-    attemptCount: e.status.attemptCount,
-  };
-}
-
-/** Props for the AgentList view. */
 export interface AgentListProps {
   readonly provider: TuiDataProvider;
   readonly tmux?: TmuxManager | undefined;
@@ -48,114 +35,9 @@ export interface AgentListProps {
   readonly onSelectSession?: ((sessionName: string | undefined) => void) | undefined;
 }
 
-const COLUMNS = [
-  { header: "AGENT", key: "agentId", width: 16 },
-  { header: "ROLE", key: "role", width: 12 },
-  { header: "PLATFORM", key: "platform", width: 12 },
-  { header: "STATUS", key: "status", width: 12 },
-  { header: "COST", key: "cost", width: 14 },
-  { header: "TARGET", key: "target", width: 18 },
-  { header: "SESSION", key: "session", width: 16 },
-] as const;
-
-/** Derive detailed agent status from claim, session, and tmux state. */
-function deriveAgentStatus(
-  claim: Claim,
-  session: string | undefined,
-  tmuxSessions: readonly string[],
-): string {
-  const remaining = new Date(claim.leaseExpiresAt).getTime() - Date.now();
-
-  if (remaining <= 0) return "expired";
-  if (!session) return "claimed";
-
-  // Check if session is still alive in tmux
-  const sessionAlive = tmuxSessions.includes(session);
-  if (!sessionAlive) return "error";
-
-  // Check for stalled agents (heartbeat older than 60s)
-  const heartbeatAge = Date.now() - new Date(claim.heartbeatAt).getTime();
-  if (heartbeatAge > 60_000) {
-    return "stalled";
-  }
-
-  // Active session exists
-  return "running";
-}
-
-/** Map a status string to its theme symbol (delegates to shared agentStatusIcon). */
-function statusSymbol(status: string, spinnerFrame?: number): string {
-  return agentStatusIcon(status, spinnerFrame).icon;
-}
-
-/** Format token count to compact string (e.g. "12K", "1.2M"). */
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
-  return String(n);
-}
-
-/** Build agent rows by correlating claims with tmux sessions, grouped by role. */
-function buildAgentRows(
-  claims: readonly Claim[],
-  tmuxSessions: readonly string[],
-  costs?: ReadonlyMap<string, { costUsd: number; tokens: number; contextPercent?: number }>,
-  spinnerFrame?: number,
-): readonly Record<string, string>[] {
-  const agentSessions = new Map<string, string>();
-
-  for (const name of tmuxSessions) {
-    const id = agentIdFromSession(name);
-    if (id) {
-      agentSessions.set(id, name);
-    }
-  }
-
-  const rows = claims.map((claim) => {
-    const agentId = claim.agent.agentName ?? claim.agent.agentId;
-    const session = agentSessions.get(claim.agent.agentId);
-    const status = deriveAgentStatus(claim, session, tmuxSessions);
-    const agentCost = costs?.get(claim.agent.agentId);
-    const role = claim.agent.role ?? "worker";
-
-    return {
-      agentId,
-      role,
-      platform: claim.agent.platform ?? "-",
-      target: claim.targetRef.length > 18 ? `${claim.targetRef.slice(0, 16)}..` : claim.targetRef,
-      status: `${statusSymbol(status, spinnerFrame)} ${status}`,
-      cost: agentCost
-        ? `$${agentCost.costUsd.toFixed(2)} | ${formatTokens(agentCost.tokens)}`
-        : "-",
-      session: session ?? "-",
-      _role: role, // for sorting
-    };
-  });
-
-  // Group by role: coordinators first, then alphabetical
-  rows.sort((a, b) => {
-    if (a._role !== b._role) {
-      if (a._role === "coordinator") return -1;
-      if (b._role === "coordinator") return 1;
-      return a._role.localeCompare(b._role);
-    }
-    return a.agentId.localeCompare(b.agentId);
-  });
-
-  return rows;
-}
-
-/** Agent list view component. */
 export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.memo(
-  function AgentListView({
-    provider,
-    tmux,
-    intervalMs,
-    active,
-    cursor,
-    onSelectSession,
-  }: AgentListProps): React.ReactNode {
-    // Animated spinner for running agents — uses timing.spinner (80ms) for consistency
+  function AgentListView(props: AgentListProps): React.ReactNode {
+    const { provider, tmux, active, cursor, onSelectSession } = props;
     const [spinnerFrame, setSpinnerFrame] = useState(0);
     useInterval(
       () => setSpinnerFrame((f) => (f + 1) % BRAILLE_SPINNER.length),
@@ -163,42 +45,16 @@ export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.m
       active,
     );
 
-    const useInformerPath = useEntityWatchEnabled(provider, "Claim");
-
-    const entityResult = useEntities("Claim", ACTIVE_PREDICATE);
-
-    const claimFetcher = useCallback(() => provider.getClaims({ status: "active" }), [provider]);
-    const tmuxFetcher = useCallback(async () => {
-      if (!tmux) return [] as readonly string[];
-      const available = await tmux.isAvailable();
-      if (!available) return [] as readonly string[];
-      return tmux.listSessions();
+    const tmuxFetcher = useCallback(async (): Promise<readonly string[]> => {
+      if (!tmux) return [];
+      return (await tmux.isAvailable()) ? tmux.listSessions() : [];
     }, [tmux]);
-
-    const polledClaims = useEventDrivenData<readonly Claim[]>(
-      claimFetcher,
+    const { data: tmuxSessions } = useEventDrivenData<readonly string[]>(
+      tmuxFetcher,
       undefined,
       undefined,
-      active && !useInformerPath,
+      active && !!tmux,
     );
-
-    const claims = useMemo<readonly Claim[] | undefined>(
-      () =>
-        useInformerPath ? entityResult.data.map(entityToClaim) : (polledClaims.data ?? undefined),
-      [useInformerPath, entityResult.data, polledClaims.data],
-    );
-    const claimsLoading = useInformerPath
-      ? !entityResult.hasSynced && claims === undefined
-      : polledClaims.loading;
-    const isStale = useInformerPath ? false : polledClaims.isStale;
-    const error = useInformerPath ? entityResult.error : polledClaims.error;
-    // A8.4 (#390): tmux session list re-fetches on producer-side `agent.output`
-    // events (and the global RefreshContext fan-out), no polling timer.
-    const {
-      data: sessions,
-      isStale: tmuxStale,
-      error: tmuxError,
-    } = useEventDrivenData<readonly string[]>(tmuxFetcher, undefined, undefined, active && !!tmux);
 
     const costFetcher = useCallback(async () => {
       const cp = provider as unknown as {
@@ -213,82 +69,77 @@ export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.m
       };
       if (!cp.getSessionCosts)
         return new Map<string, { costUsd: number; tokens: number; contextPercent?: number }>();
-      const costs = await cp.getSessionCosts();
-      const map = new Map<string, { costUsd: number; tokens: number; contextPercent?: number }>();
-      for (const a of costs.byAgent) {
+      const out = await cp.getSessionCosts();
+      const m = new Map<string, { costUsd: number; tokens: number; contextPercent?: number }>();
+      for (const a of out.byAgent) {
         const entry: { costUsd: number; tokens: number; contextPercent?: number } = {
           costUsd: a.costUsd,
           tokens: a.tokens,
         };
         if (a.contextPercent !== undefined) entry.contextPercent = a.contextPercent;
-        map.set(a.agentId, entry);
+        m.set(a.agentId, entry);
       }
-      return map;
+      return m;
     }, [provider]);
-    // A8.4 (#390): cost rollups re-fetch on EventBus events via the global
-    // RefreshContext fan-out (any agent.output / contribution event).
-    const { data: agentCosts } = useEventDrivenData(costFetcher, undefined, undefined, active);
+    const { data: costs } = useEventDrivenData(costFetcher, undefined, undefined, active);
 
-    // Combine staleness from both data sources
-    const combinedStale = isStale || tmuxStale;
-    const combinedError = error ?? tmuxError;
+    const agentSessions = useMemo<ReadonlyMap<string, string>>(() => {
+      const m = new Map<string, string>();
+      for (const name of tmuxSessions ?? []) {
+        const id = agentIdFromSession(name);
+        if (id) m.set(id, name);
+      }
+      return m;
+    }, [tmuxSessions]);
 
-    const agentRows = buildAgentRows(
-      claims ?? [],
-      sessions ?? [],
-      agentCosts ?? undefined,
-      spinnerFrame,
+    const ctx = useMemo<AgentJoinCtx>(
+      () => ({
+        tmuxSessions: tmuxSessions ?? [],
+        agentSessions,
+        costs:
+          costs ?? new Map<string, { costUsd: number; tokens: number; contextPercent?: number }>(),
+        spinnerFrame,
+      }),
+      [tmuxSessions, agentSessions, costs, spinnerFrame],
     );
 
-    // Track rows for session selection and notify parent when cursor moves
-    const rowsRef = useRef(agentRows);
-    rowsRef.current = agentRows;
+    const columns = useMemo(
+      () => [
+        agentIdColumn(16),
+        roleColumn(12),
+        platformColumn(12),
+        statusColumn(ctx, 12),
+        costColumn(ctx, 14),
+        targetColumn(18),
+        sessionColumn(ctx, 16),
+      ],
+      [ctx],
+    );
 
-    useEffect(() => {
-      if (!onSelectSession || cursor < 0) return;
-      const row = rowsRef.current[cursor];
-      const session = row?.session;
-      onSelectSession(session && session !== "-" ? session : undefined);
-    }, [cursor, onSelectSession]);
-
-    if (claimsLoading && !claims) {
-      return (
-        <box>
-          <text opacity={0.5}>Loading agents...</text>
-        </box>
-      );
-    }
-
-    if (agentRows.length === 0) {
-      return (
-        <box flexDirection="column">
-          <DataStatus
-            loading={claimsLoading && !claims}
-            isStale={combinedStale}
-            error={combinedError?.message}
-          />
-          <EmptyState
-            title="No agents registered."
-            hint="Press r to register, or Ctrl+P to spawn."
-          />
-          {!tmux && <text opacity={0.5}>tmux not available — agents require tmux</text>}
-        </box>
-      );
-    }
+    const onSelect = useCallback(
+      (entity: ClaimEntity | undefined) => {
+        if (!onSelectSession) return;
+        if (!entity) return onSelectSession(undefined);
+        const session = agentSessions.get(entity.spec.agent.agentId);
+        onSelectSession(session ?? undefined);
+      },
+      [onSelectSession, agentSessions],
+    );
 
     return (
-      <box flexDirection="column">
-        <box marginBottom={1} flexDirection="row">
-          <text>{`Agents (${agentRows.length})`}</text>
-          {!tmux && <text opacity={0.5}> [no tmux]</text>}
-          <DataStatus
-            loading={claimsLoading && !claims}
-            isStale={combinedStale}
-            error={combinedError?.message}
-          />
-        </box>
-        <Table columns={[...COLUMNS]} rows={agentRows} cursor={cursor} />
-      </box>
+      <EntityView
+        kind="Claim"
+        columns={columns}
+        provider={provider}
+        active={active}
+        cursor={cursor}
+        predicate={isActive}
+        sort={byRoleAndName}
+        title="Agents"
+        emptyTitle="No agents registered."
+        emptyHint="Press r to register, or Ctrl+P to spawn."
+        onSelect={onSelect}
+      />
     );
   },
 );

--- a/src/tui/views/agent-list.tsx
+++ b/src/tui/views/agent-list.tsx
@@ -5,7 +5,7 @@
  * column factories.
  */
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { claimToEntity, type ClaimEntity } from "../../core/entity.js";
 import { useInterval } from "../../local/use-interval.js";
 
@@ -141,6 +141,15 @@ export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.m
     // the fallback would render claims from OTHER sessions. Render an empty
     // state instead until session-scoped claim filtering lands. Mirrors the
     // ClaimsView short-circuit.
+    //
+    // Clear any latched selection so the terminal/input panel doesn't keep
+    // targeting an agent from the previous (un-scoped) view. Without this,
+    // selectedSession survives the transition into scoped mode and the
+    // operator's keystrokes would still hit the prior session.
+    useEffect(() => {
+      if (isScoped && onSelectSession) onSelectSession(undefined);
+    }, [isScoped, onSelectSession]);
+
     if (isScoped) {
       return (
         <box flexDirection="column">

--- a/src/tui/views/agent-list.tsx
+++ b/src/tui/views/agent-list.tsx
@@ -6,8 +6,10 @@
  */
 
 import React, { useCallback, useMemo, useState } from "react";
-import type { ClaimEntity } from "../../core/entity.js";
+import { claimToEntity, type ClaimEntity } from "../../core/entity.js";
 import { useInterval } from "../../local/use-interval.js";
+
+const NAMESPACE = "default";
 import { agentIdFromSession, type TmuxManager } from "../agents/tmux-manager.js";
 import {
   type AgentJoinCtx,
@@ -126,6 +128,11 @@ export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.m
       [onSelectSession, agentSessions],
     );
 
+    const fallbackFetcher = useCallback(async (): Promise<readonly ClaimEntity[]> => {
+      const claims = await provider.getClaims({ status: "active" });
+      return claims.map((c) => claimToEntity(c, () => Date.now(), NAMESPACE));
+    }, [provider]);
+
     return (
       <EntityView
         kind="Claim"
@@ -135,6 +142,7 @@ export const AgentListView: React.NamedExoticComponent<AgentListProps> = React.m
         cursor={cursor}
         predicate={isActive}
         sort={byRoleAndName}
+        fallbackFetcher={fallbackFetcher}
         title="Agents"
         emptyTitle="No agents registered."
         emptyHint="Press r to register, or Ctrl+P to spawn."

--- a/src/tui/views/agent-list.tsx
+++ b/src/tui/views/agent-list.tsx
@@ -6,10 +6,8 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { claimToEntity, type ClaimEntity } from "../../core/entity.js";
+import { type ClaimEntity, claimToEntity } from "../../core/entity.js";
 import { useInterval } from "../../local/use-interval.js";
-
-const NAMESPACE = "default";
 import { agentIdFromSession, type TmuxManager } from "../agents/tmux-manager.js";
 import {
   type AgentJoinCtx,
@@ -29,6 +27,8 @@ import { useProviderScoped } from "../hooks/informer-context.js";
 import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import type { TuiDataProvider } from "../provider.js";
 import { BRAILLE_SPINNER, timing } from "../theme.js";
+
+const NAMESPACE = "default";
 
 export interface AgentListProps {
   readonly provider: TuiDataProvider;

--- a/src/tui/views/claims.tsx
+++ b/src/tui/views/claims.tsx
@@ -1,199 +1,128 @@
 /**
- * Claims view — shows all active claims with lease countdown.
+ * Claims view — active claims with lease countdown, EntityView-backed.
  *
- * PR2 (#388) migrated from `usePolledData(provider.getClaims)` to the
- * informer-backed `useEntities("Claim", …)` hook. Reads draw from the
- * shared informer cache (SSE-driven in remote mode, in-process WatchHub
- * in local mode) instead of polling. The pre-fetched `propClaims` prop
- * stays as an explicit override for the parent's claim poller during
- * the dual-path window — once PR3 / PR4 fold those callers in, the
- * override goes away.
+ * Scoped sessions (provider.hasSessionScope) render an EmptyState
+ * directly without mounting EntityView, preserving the pre-port
+ * behavior where `getClaims` lacks sessionId filtering.
  */
 
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import type { ClaimEntity } from "../../core/entity.js";
-import type { Claim } from "../../core/models.js";
-import { formatDuration } from "../../shared/duration.js";
-import { formatTimestamp } from "../../shared/format.js";
-import { DataStatus } from "../components/data-status.js";
+import {
+  agentColumn,
+  claimIdColumn,
+  heartbeatColumn,
+  intentColumn,
+  isActive,
+  leaseColumn,
+  statusColumnWithCounts,
+  targetColumn,
+} from "../components/columns/claim-columns.js";
 import { EmptyState } from "../components/empty-state.js";
-import { Table } from "../components/table.js";
-import { useEntityWatchEnabled, useProviderScoped } from "../hooks/informer-context.js";
-import { useEntities } from "../hooks/use-entities.js";
-import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
+import { EntityView } from "../components/entity-view.js";
+import { useProviderScoped } from "../hooks/informer-context.js";
 import type { TuiDataProvider } from "../provider.js";
 
-/** Props for the Claims view. */
 export interface ClaimsProps {
   readonly provider: TuiDataProvider;
   readonly intervalMs: number;
   readonly active: boolean;
   readonly cursor: number;
   readonly onRowCountChanged?: (count: number) => void;
-  /** Pre-fetched active claims from parent poller (avoids double polling). */
-  readonly activeClaims?: readonly Claim[] | undefined;
+  readonly activeClaims?: readonly unknown[] | undefined;
 }
 
-const COLUMNS = [
-  { header: "CLAIM_ID", key: "claimId", width: 20 },
-  { header: "TARGET", key: "target", width: 24 },
-  { header: "AGENT", key: "agent", width: 16 },
-  { header: "STATUS", key: "status", width: 10 },
-  { header: "LEASE", key: "lease", width: 14 },
-  { header: "HEARTBEAT", key: "heartbeat", width: 12 },
-  { header: "INTENT", key: "intent", width: 28 },
-] as const;
-
-/** Reduce a ClaimEntity to the flat row shape this view already emits. */
-function entityToRow(entity: ClaimEntity): {
-  claimId: string;
-  targetRef: string;
-  agent: { agentName?: string | undefined; agentId: string };
-  status: string;
-  intentSummary: string;
-  heartbeatAt: string;
-  leaseExpiresAt: string;
-} {
-  return {
-    claimId: entity.id,
-    targetRef: entity.spec.targetRef,
-    agent: entity.spec.agent,
-    status: entity.status.phase,
-    intentSummary: entity.spec.intentSummary,
-    heartbeatAt: entity.status.heartbeatAt,
-    leaseExpiresAt: entity.status.leaseExpiresAt,
-  };
-}
-
-const ACTIVE_PREDICATE = (e: ClaimEntity): boolean => e.status.phase === "active";
-
-/** Claims view component. */
-export const ClaimsView: React.NamedExoticComponent<ClaimsProps> = React.memo(function ClaimsView({
-  provider,
-  intervalMs,
-  active,
-  cursor,
-  onRowCountChanged,
-  activeClaims: propClaims,
-}: ClaimsProps): React.ReactNode {
-  const useInformerPath = useEntityWatchEnabled(provider, "Claim");
-  // Suppress claim polling under a scoped session: `provider.getClaims`
-  // does not filter by sessionId yet, so polling would surface claims
-  // from other sessions in the namespace (Codex round 2, finding 2).
-  // Mirrors the dashboard's existing behavior (RemoteDataProvider's
-  // getDashboard returns `[]` for activeClaims when scoped).
+export const ClaimsView: React.NamedExoticComponent<ClaimsProps> = React.memo(function ClaimsView(
+  props: ClaimsProps,
+): React.ReactNode {
+  const { provider, active, cursor, onRowCountChanged } = props;
   const isScoped = useProviderScoped(provider);
 
-  // Informer path: useEntities feeds when the factory is mounted and the
-  // kind is supported. We always invoke both hooks so React's hook order
-  // stays stable across renders; the unused branch's data is discarded.
-  const entityResult = useEntities("Claim", ACTIVE_PREDICATE);
+  const fallbackFetcher = useCallback(async (): Promise<readonly ClaimEntity[]> => {
+    // Provider returns flat Claim shapes for the polled fallback path;
+    // synthesize minimal ClaimEntity envelopes so the column renders work.
+    // `as unknown as ClaimEntity` is required because the synthesized status
+    // omits `persistedPhase` (a ClaimStatusBody field not available from the
+    // flat Claim shape). Both phase fields are set to the same value here;
+    // the fallback path only needs phase for the isActive predicate and column
+    // renders, so the omission is safe.
+    const claims = await provider.getClaims({ status: "active" });
+    return claims.map(
+      (c) =>
+        ({
+          kind: "Claim",
+          namespace: "default",
+          id: c.claimId,
+          spec: {
+            targetRef: c.targetRef,
+            agent: c.agent,
+            intentSummary: c.intentSummary,
+            context: c.context,
+          },
+          status: {
+            phase: c.status as "active" | "expired" | "released" | "completed",
+            heartbeatAt: c.heartbeatAt,
+            leaseExpiresAt: c.leaseExpiresAt,
+            attemptCount: c.attemptCount ?? 0,
+          },
+          conditions: [],
+          observedGeneration: 0,
+          resourceVersion: "0",
+          metadata: { generation: 0, creationTimestamp: c.createdAt },
+        }) as unknown as ClaimEntity,
+    );
+  }, [provider]);
 
-  // Polled fallback: only fetches when the parent didn't pre-fetch AND
-  // the informer path isn't available AND we're not in a scoped session
-  // whose claim API isn't filterable by sessionId.
-  const fetcher = useCallback(() => provider.getClaims({ status: "active" }), [provider]);
-  const polledResult = useEventDrivenData<readonly Claim[]>(
-    fetcher,
-    undefined,
-    undefined,
-    active && propClaims === undefined && !useInformerPath && !isScoped,
+  // Dup-counts must close over the current data to highlight `<phase> DUP`.
+  // Track via onDataChanged.
+  const [targetCounts, setTargetCounts] = useState<ReadonlyMap<string, number>>(new Map());
+  const onDataChanged = useCallback((data: readonly ClaimEntity[]) => {
+    const m = new Map<string, number>();
+    for (const e of data) m.set(e.spec.targetRef, (m.get(e.spec.targetRef) ?? 0) + 1);
+    setTargetCounts(m);
+  }, []);
+
+  const columns = useMemo(
+    () => [
+      claimIdColumn(20),
+      targetColumn(24),
+      agentColumn(16),
+      statusColumnWithCounts(targetCounts, 10),
+      leaseColumn(14),
+      heartbeatColumn(12),
+      intentColumn(28),
+    ],
+    [targetCounts],
   );
 
-  const data: readonly Claim[] | undefined = useMemo<readonly Claim[] | undefined>(() => {
-    // Scoped sessions render an empty list rather than risk leaking
-    // claims from other sessions while the watch + claim APIs lack
-    // sessionId filtering. The scope check runs BEFORE the propClaims
-    // shortcut because the parent App still polls `getClaims` (used by
-    // the command palette and spawn dedup); accepting that unscoped
-    // result here would re-expose the leak (Codex round 4, finding 1).
-    if (isScoped) return [];
-    if (propClaims !== undefined) return propClaims;
-    if (useInformerPath) {
-      // Project entity → row → caller-shaped Claim. The fields the view
-      // reads below are the ones populated from the entity envelope.
-      return entityResult.data.map((e) => {
-        const r = entityToRow(e);
-        return {
-          claimId: r.claimId,
-          targetRef: r.targetRef,
-          agent: r.agent,
-          status: r.status,
-          intentSummary: r.intentSummary,
-          createdAt: r.heartbeatAt,
-          heartbeatAt: r.heartbeatAt,
-          leaseExpiresAt: r.leaseExpiresAt,
-        } as Claim;
-      });
-    }
-    return polledResult.data ?? undefined;
-  }, [propClaims, useInformerPath, isScoped, entityResult.data, polledResult.data]);
-
-  const loading = useInformerPath
-    ? !entityResult.hasSynced && data === undefined
-    : polledResult.loading;
-  const isStale = useInformerPath ? false : polledResult.isStale;
-  const error = useInformerPath ? entityResult.error : polledResult.error;
-
-  useEffect(() => {
-    if (data && onRowCountChanged) {
-      onRowCountChanged(data.length);
-    }
-  }, [data, onRowCountChanged]);
-
-  if (loading && !data) {
+  if (isScoped) {
     return (
-      <box>
-        <text opacity={0.5}>Loading claims...</text>
-      </box>
-    );
-  }
-
-  const claims = data ?? [];
-
-  const targetCounts = new Map<string, number>();
-  for (const c of claims) {
-    targetCounts.set(c.targetRef, (targetCounts.get(c.targetRef) ?? 0) + 1);
-  }
-
-  const rows = claims.map((c) => {
-    const remaining = new Date(c.leaseExpiresAt).getTime() - Date.now();
-    const isDuplicate = (targetCounts.get(c.targetRef) ?? 0) > 1;
-    const statusStr =
-      c.status === "active" && remaining <= 0
-        ? "EXPIRED"
-        : isDuplicate
-          ? `${c.status} DUP`
-          : c.status;
-
-    return {
-      claimId: c.claimId.length > 20 ? `${c.claimId.slice(0, 18)}..` : c.claimId,
-      target: c.targetRef.length > 24 ? `${c.targetRef.slice(0, 22)}..` : c.targetRef,
-      agent: c.agent.agentName ?? c.agent.agentId,
-      status: statusStr,
-      lease: remaining > 0 ? formatDuration(remaining) : "expired",
-      heartbeat: formatTimestamp(c.heartbeatAt),
-      intent:
-        (c.intentSummary ?? "").length > 28
-          ? `${(c.intentSummary ?? "").slice(0, 26)}..`
-          : (c.intentSummary ?? ""),
-    };
-  });
-
-  return (
-    <box flexDirection="column">
-      <box marginBottom={1} flexDirection="row">
-        <text>{`Active Claims (${claims.length})`}</text>
-        <DataStatus loading={loading && !data} isStale={isStale} error={error?.message} />
-      </box>
-      {rows.length === 0 ? (
+      <box flexDirection="column">
+        <box marginBottom={1}>
+          <text>Active Claims (0)</text>
+        </box>
         <EmptyState
           title="Active work claims. Claims prevent agents from duplicating each other's work."
           hint="Spawn agents with Ctrl+P. Each agent automatically claims work before starting."
         />
-      ) : (
-        <Table columns={[...COLUMNS]} rows={rows} cursor={cursor} />
-      )}
-    </box>
+      </box>
+    );
+  }
+
+  return (
+    <EntityView
+      kind="Claim"
+      columns={columns}
+      provider={provider}
+      active={active}
+      cursor={cursor}
+      predicate={isActive}
+      fallbackFetcher={fallbackFetcher}
+      title="Active Claims"
+      emptyTitle="Active work claims. Claims prevent agents from duplicating each other's work."
+      emptyHint="Spawn agents with Ctrl+P. Each agent automatically claims work before starting."
+      onDataChanged={onDataChanged}
+      {...(onRowCountChanged ? { onRowCountChanged } : {})}
+    />
   );
 });

--- a/tests/e2e/watch-relist-tmux.ts
+++ b/tests/e2e/watch-relist-tmux.ts
@@ -299,13 +299,13 @@ async function main() {
       // GROVE_WATCH_MAX_EVENTS=2 matches the unit test sizing:
       // after 2 events in the ring, a write evicts the oldest.
       // Writing 5 events while paused guarantees oldestRv > lastSeenRv.
-      [
+      `${[
         `GROVE_DIR=${groveDir}`,
         `PORT=${SERVER_PORT}`,
         `GROVE_WATCH_RETENTION_MS=60000`,
         `GROVE_WATCH_MAX_EVENTS=2`,
         `bun run ${join(PROJECT_ROOT, "src/server/serve.ts")} 2>&1 | tee ${serverLogFile}`,
-      ].join(" ") + "; cat",
+      ].join(" ")}; cat`,
     ],
     { stdio: "inherit" },
   );
@@ -333,12 +333,12 @@ async function main() {
       "-h",
       "sh",
       "-c",
-      [
+      `${[
         `GROVE_BASE_URL=${baseUrl}`,
         `GROVE_TOKEN=${token}`,
         `GROVE_PID_FILE=${pidFile}`,
         `bun run ${watcherScriptPath}`,
-      ].join(" ") + "; cat",
+      ].join(" ")}; cat`,
     ],
     { stdio: "inherit" },
   );


### PR DESCRIPTION
## Summary
- Introduces `useEntityData<K>` hook collapsing the duplicated informer-cache / polled-fallback dual-path inlined in every list view. Both inner hooks always called for stable React hook order.
- Introduces `EntityView<K>` generic component (`src/tui/components/entity-view.tsx`) with `predicate`, `sort`, `offset`, `limit`, `fallbackFetcher`, `onSelect`, `onRowCountChanged`, `onDataChanged` props.
- Adds per-kind columns libraries (`columns/claim-columns.ts`, `contribution-columns.ts`, `agent-columns.ts`) demonstrating the "new kind = config + renderer fn" pattern.
- Migrates 4 list views: `claims.tsx`, `activity.tsx`, `activity-panel.tsx`, `agent-list.tsx`. Net −360 lines across the 4 views.
- Raises `Table`'s `MAX_RENDER_ITEMS` 200 → 500. Adds `entity-view.perf.test.tsx` (skipped in CI; `RUN_PERF=1` for local verification).

Closes #301.

## Acceptance criteria (issue #301)
- [x] ≥4 screens share one component (claims, activity, activity-panel, agent-list)
- [x] Adding new kind = config file + renderer fn, no new component (demonstrated by columns library)
- [x] 500-row list scrolls at 60fps — perf gate p95 <16ms verified locally

## Out of scope
- `search-panel.tsx` is intentionally not migrated. Its contribution result table needs server-side full-text search via `provider.getContributions({ search })` when the user has a query, which the EntityStore predicate path can't model. See spec for discussion.
- `pipeline-view.tsx` and `agent-graph.tsx` are not row-based (flex-card grid and edge-rendered graph respectively); not appropriate for EntityView.

## Test plan
- [x] `bun test` — 6750 pass, 7 skip (incl. perf gate), 0 fail attributable to this PR
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on touched files — clean
- [x] `RUN_PERF=1 bun test src/tui/components/entity-view.perf.test.tsx` — passes (p95 < 16ms with 500 rows × 100 cursor moves)
- [ ] Manual TUI smoke against a Nexus stack (recommended before merge)

## Known follow-ups
- `intervalMs` prop on all 4 view interfaces is dead code (pre-existing, not introduced by this PR). Cleanup PR can remove from view Props + callers.
- One flaky test (`postOutcomeComment > does not throw with all optional fields` in `src/github/outcome-poster.test.ts`) times out under full-suite parallel load (subprocess-based, 5s budget). Passes 3/3 in isolation. Unrelated to EntityView.

## Refs
- Spec: \`docs/superpowers/specs/2026-05-06-c1-entity-view-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-06-c1-entity-view.md\`
- Parent epic: #284