### PR TITLE
[codex] Nexus-hosted skill distribution runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,62 @@ surfaces. It defines:
 - Agent topology (roles, edges, spawning rules)
 - Gossip configuration
 
+### Agent skills
+
+Spawned agents can receive workspace-local Claude/Codex skills by declaring
+skill names on their topology role. A skill is a directory containing
+`SKILL.md` plus any supporting files:
+
+```text
+.grove/skills/
+  comps-analysis/
+    SKILL.md
+    references/
+      ...
+```
+
+Then reference that directory name from `GROVE.md`:
+
+```yaml
+agent_topology:
+  roles:
+    - name: financial-analyst
+      platform: claude-code
+      skills: ["grove", "comps-analysis"]
+    - name: reviewer
+      platform: claude-code
+      skills: ["grove"]
+```
+
+When the TUI or session orchestrator spawns those roles, Grove copies each
+resolved skill directory into the agent workspace:
+
+```text
+<agent-workspace>/.claude/skills/<name>/
+<agent-workspace>/.codex/skills/<name>/
+```
+
+In local mode, resolution order is:
+
+1. Workspace overrides from `.grove/skills/<name>/`
+2. Bundled Grove skills from the installed `skills/` catalog
+
+In Nexus mode with `skillCatalog` configured, Grove tries the signed Nexus
+catalog first. `warn-and-fallback` can then use verified local cache or local
+fallback; `required` fails the spawn if Nexus catalog resolution cannot be
+trusted.
+
+The TUI currently consumes `skills:` from topology but does not yet provide a
+launch-preview editor for adding or removing skills. That session-level
+override UX is tracked in
+[#327](https://github.com/windoliver/grove/issues/327). Nexus-hosted skill
+distribution is tracked in
+[#326](https://github.com/windoliver/grove/issues/326).
+
+`grove skill install` is separate: it installs Grove's bundled `grove` skill
+into your global Claude/Codex skill directories for manual assistant use
+outside a Grove-provisioned workspace.
+
 ### Environment Variables
 
 | Variable | Purpose | Default |

--- a/docs/superpowers/plans/2026-05-07-nexus-hosted-skill-distribution.md
+++ b/docs/superpowers/plans/2026-05-07-nexus-hosted-skill-distribution.md
@@ -1,0 +1,1564 @@
+# Nexus-Hosted Skill Distribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build automatic Nexus-mode skill resolution from a signed Nexus catalog, with verified cache and local fallback, while preserving current local skill injection behavior.
+
+**Architecture:** Add a small core catalog module for canonical JSON, Ed25519 verification, BLAKE3 bundle verification, and stored-ZIP unpacking. Add a Nexus adapter that reads signed catalog files from zone-scoped VFS paths, materializes verified skills into `.grove/cache/skills`, and exposes a resolver that bootstrap/spawn paths can call before `injectSkills()`. Non-Nexus mode continues using the current local two-layer injector.
+
+**Tech Stack:** TypeScript strict mode, Bun test runner, Node crypto Ed25519 APIs, `blake3`, existing `NexusClient`, existing stored ZIP writer in `src/shared/zip.ts`, Biome.
+
+---
+
+## Scope Boundary
+
+This plan implements the runtime path: fetch, verify, cache, fallback, and inject. It does not implement `grove skill publish`; the design already lists that as a concrete child issue. Runtime tests seed `MockNexusClient` directly with signed catalog files and bundles.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/core/config.ts` | Parse and serialize local trusted skill catalog settings in `.grove/grove.json`. |
+| `src/core/config.test.ts` | Cover skill catalog config parsing, defaults, rejection, and round trip. |
+| `src/nexus/vfs-paths.ts` | Build safe zone-scoped Nexus skill catalog VFS paths. |
+| `src/nexus/vfs-paths.test.ts` | Cover path encoding and exact catalog paths. |
+| `src/shared/zip.ts` | Add stored-ZIP reader helpers next to the existing stored-ZIP writer. |
+| `src/shared/zip.test.ts` | Cover ZIP read round trip, CRC checks, unsupported compression, and unsafe paths. |
+| `src/core/skill-catalog.ts` | Catalog schemas, canonical JSON, signature verification, bundle hash checks, unpack-to-directory helper, structured errors. |
+| `src/core/skill-catalog.test.ts` | Core unit tests for canonical JSON, Ed25519 verification, hash checks, unpacking, and rejection cases. |
+| `src/nexus/nexus-skill-catalog.ts` | Nexus catalog reader/cache resolver. Depends on `NexusClient`, `skill-catalog`, and VFS path helpers. |
+| `src/nexus/nexus-skill-catalog.test.ts` | MockNexusClient tests for signed fetch, cache fallback, local fallback, and required policy. |
+| `src/core/workspace-bootstrap.ts` | Accept an optional skill resolver dependency before falling back to current local injector. |
+| `src/core/workspace-bootstrap.test.ts` | Prove resolved remote roots are injected and local behavior is unchanged. |
+| `src/core/session-orchestrator.ts` | Create Nexus-aware skill resolver when Nexus URL/config are present. |
+| `src/tui/spawn-manager.ts` | Mirror resolver use in TUI spawn path. |
+| `src/nexus/index.ts` | Export the Nexus skill catalog resolver and path helpers needed by callers/tests. |
+
+## Task 1: Config schema and Nexus VFS paths
+
+**Files:**
+- Modify: `src/core/config.ts`
+- Modify: `src/core/config.test.ts`
+- Modify: `src/nexus/vfs-paths.ts`
+- Modify: `src/nexus/vfs-paths.test.ts`
+
+- [ ] **Step 1: Write failing config tests**
+
+Add these tests inside `describe("parseGroveConfig", ...)` in `src/core/config.test.ts`:
+
+```ts
+  test("parses skill catalog config with trusted keys", () => {
+    const config = parseGroveConfig(
+      JSON.stringify({
+        name: "swarm",
+        mode: "nexus",
+        nexusUrl: "http://localhost:4000",
+        skillCatalog: {
+          policy: "required",
+          trustedKeys: [
+            {
+              id: "root-key",
+              algorithm: "ed25519",
+              publicKeySpkiDer: "MCowBQYDK2VwAyEA0000000000000000000000000000000000000000000=",
+            },
+          ],
+          cacheTtlSeconds: 60,
+        },
+      }),
+    );
+
+    expect(config.skillCatalog?.policy).toBe("required");
+    expect(config.skillCatalog?.trustedKeys).toHaveLength(1);
+    expect(config.skillCatalog?.trustedKeys[0]?.id).toBe("root-key");
+    expect(config.skillCatalog?.cacheTtlSeconds).toBe(60);
+  });
+
+  test("defaults skill catalog policy when omitted", () => {
+    const config = parseGroveConfig(
+      JSON.stringify({
+        name: "swarm",
+        mode: "nexus",
+        nexusUrl: "http://localhost:4000",
+        skillCatalog: {
+          trustedKeys: [],
+        },
+      }),
+    );
+
+    expect(config.skillCatalog?.policy).toBe("warn-and-fallback");
+    expect(config.skillCatalog?.trustedKeys).toEqual([]);
+  });
+```
+
+Add these tests inside `describe("parseGroveConfig errors", ...)`:
+
+```ts
+  test("rejects unknown skill catalog policy", () => {
+    expect(() =>
+      parseGroveConfig(
+        JSON.stringify({
+          name: "x",
+          mode: "nexus",
+          nexusUrl: "http://localhost:4000",
+          skillCatalog: { policy: "trust-nexus", trustedKeys: [] },
+        }),
+      ),
+    ).toThrow("Invalid grove.json");
+  });
+
+  test("rejects non-ed25519 skill catalog key algorithms", () => {
+    expect(() =>
+      parseGroveConfig(
+        JSON.stringify({
+          name: "x",
+          mode: "nexus",
+          nexusUrl: "http://localhost:4000",
+          skillCatalog: {
+            trustedKeys: [
+              { id: "root-key", algorithm: "rsa", publicKeySpkiDer: "abc" },
+            ],
+          },
+        }),
+      ),
+    ).toThrow("Invalid grove.json");
+  });
+```
+
+Add this test inside `describe("writeGroveConfig", ...)`:
+
+```ts
+  test("round-trips skill catalog config", () => {
+    const original: GroveConfig = {
+      name: "nexus-grove",
+      mode: "nexus",
+      nexusUrl: "http://nexus:4000",
+      skillCatalog: {
+        policy: "required",
+        trustedKeys: [
+          {
+            id: "root-key",
+            algorithm: "ed25519",
+            publicKeySpkiDer: "MCowBQYDK2VwAyEA0000000000000000000000000000000000000000000=",
+          },
+        ],
+        cacheTtlSeconds: 120,
+      },
+    };
+
+    writeGroveConfig(original, tmpPath);
+
+    const parsed = parseGroveConfig(readFileSync(tmpPath, "utf-8"));
+    expect(parsed.skillCatalog).toEqual(original.skillCatalog);
+  });
+```
+
+- [ ] **Step 2: Write failing VFS path tests**
+
+Add these imports to `src/nexus/vfs-paths.test.ts`:
+
+```ts
+  skillCatalogBundlePath,
+  skillCatalogIndexPath,
+  skillCatalogSignaturePath,
+```
+
+Add this test block:
+
+```ts
+describe("skill catalog paths", () => {
+  test("constructs zone-scoped skill catalog paths", () => {
+    expect(skillCatalogIndexPath("zone1")).toBe("/zones/zone1/skill-catalog/index.json");
+    expect(skillCatalogSignaturePath("zone1")).toBe("/zones/zone1/skill-catalog/index.sig");
+    expect(skillCatalogBundlePath("zone1", "blake3:abc123")).toBe(
+      "/zones/zone1/skill-catalog/bundles/blake3:abc123.zip",
+    );
+  });
+
+  test("encodes zone and bundle hash segments", () => {
+    expect(skillCatalogIndexPath("../zone")).toBe(
+      "/zones/..%2Fzone/skill-catalog/index.json",
+    );
+    expect(skillCatalogBundlePath("zone/one", "blake3:a/b")).toBe(
+      "/zones/zone%2Fone/skill-catalog/bundles/blake3:a%2Fb.zip",
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+bun test src/core/config.test.ts src/nexus/vfs-paths.test.ts
+```
+
+Expected: FAIL because `skillCatalog` is rejected as an unknown field and skill catalog VFS helpers are not exported.
+
+- [ ] **Step 4: Implement config types and schema**
+
+In `src/core/config.ts`, add these exported types near `GroveMode`:
+
+```ts
+export type SkillCatalogPolicy = "warn-and-fallback" | "required";
+
+export interface SkillCatalogTrustedKey {
+  readonly id: string;
+  readonly algorithm: "ed25519";
+  readonly publicKeySpkiDer: string;
+}
+
+export interface SkillCatalogConfig {
+  readonly policy: SkillCatalogPolicy;
+  readonly trustedKeys: readonly SkillCatalogTrustedKey[];
+  readonly cacheTtlSeconds?: number | undefined;
+}
+```
+
+Add this field to `GroveConfig`:
+
+```ts
+  readonly skillCatalog?: SkillCatalogConfig | undefined;
+```
+
+Add schemas before `GroveConfigSchema`:
+
+```ts
+const SkillCatalogPolicySchema = z
+  .enum(["warn-and-fallback", "required"])
+  .default("warn-and-fallback");
+
+const SkillCatalogTrustedKeySchema = z
+  .object({
+    id: z.string().min(1).max(128),
+    algorithm: z.literal("ed25519"),
+    publicKeySpkiDer: z.string().min(1).max(4096),
+  })
+  .strict();
+
+const SkillCatalogSchema: z.ZodType<SkillCatalogConfig> = z
+  .object({
+    policy: SkillCatalogPolicySchema,
+    trustedKeys: z.array(SkillCatalogTrustedKeySchema).max(20).default([]),
+    cacheTtlSeconds: z.number().int().min(1).max(31_536_000).optional(),
+  })
+  .strict();
+```
+
+Add this property to the `GroveConfigSchema` object:
+
+```ts
+    skillCatalog: SkillCatalogSchema.optional(),
+```
+
+Add this serialization line to `writeGroveConfig()`:
+
+```ts
+  if (config.skillCatalog !== undefined) obj.skillCatalog = config.skillCatalog;
+```
+
+- [ ] **Step 5: Implement VFS path helpers**
+
+In `src/nexus/vfs-paths.ts`, add:
+
+```ts
+// ---------------------------------------------------------------------------
+// Skill catalog paths
+// ---------------------------------------------------------------------------
+
+/** Path to the signed skill catalog index JSON. */
+export function skillCatalogIndexPath(zoneId: string): string {
+  return `/zones/${encodeSegment(zoneId)}/skill-catalog/index.json`;
+}
+
+/** Path to the skill catalog signature sidecar. */
+export function skillCatalogSignaturePath(zoneId: string): string {
+  return `/zones/${encodeSegment(zoneId)}/skill-catalog/index.sig`;
+}
+
+/** Path to an immutable skill bundle ZIP selected by a verified bundle hash. */
+export function skillCatalogBundlePath(zoneId: string, bundleHash: string): string {
+  return `/zones/${encodeSegment(zoneId)}/skill-catalog/bundles/${encodeSegment(bundleHash)}.zip`;
+}
+```
+
+- [ ] **Step 6: Run tests and typecheck**
+
+Run:
+
+```bash
+bun test src/core/config.test.ts src/nexus/vfs-paths.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/config.ts src/core/config.test.ts src/nexus/vfs-paths.ts src/nexus/vfs-paths.test.ts
+git commit -m "feat(skills): add skill catalog config and Nexus paths"
+```
+
+## Task 2: Stored ZIP reader
+
+**Files:**
+- Modify: `src/shared/zip.ts`
+- Modify: `src/shared/zip.test.ts`
+
+- [ ] **Step 1: Write failing ZIP reader tests**
+
+Add `readStoredZip` to the import in `src/shared/zip.test.ts`:
+
+```ts
+import { crc32, createStoredZip, readStoredZip } from "./zip.js";
+```
+
+Add these tests inside `describe("createStoredZip", ...)`:
+
+```ts
+  test("readStoredZip round-trips writer output", () => {
+    const zip = createStoredZip([
+      { path: "SKILL.md", bytes: textEncoder.encode("skill") },
+      { path: "references/guide.md", bytes: textEncoder.encode("guide") },
+    ]);
+
+    const entries = readStoredZip(zip);
+
+    expect(entries.map((entry) => entry.path)).toEqual(["SKILL.md", "references/guide.md"]);
+    expect(textDecoder.decode(entries[0]?.bytes)).toBe("skill");
+    expect(textDecoder.decode(entries[1]?.bytes)).toBe("guide");
+  });
+
+  test("readStoredZip rejects CRC mismatch", () => {
+    const zip = createStoredZip([{ path: "SKILL.md", bytes: textEncoder.encode("skill") }]);
+    const corrupted = new Uint8Array(zip);
+    corrupted[30 + textEncoder.encode("SKILL.md").length] =
+      (corrupted[30 + textEncoder.encode("SKILL.md").length] ?? 0) ^ 0xff;
+
+    expect(() => readStoredZip(corrupted)).toThrow(/crc/i);
+  });
+
+  test("readStoredZip rejects unsupported compression methods", () => {
+    const zip = createStoredZip([{ path: "SKILL.md", bytes: textEncoder.encode("skill") }]);
+    const compressed = new Uint8Array(zip);
+    compressed[8] = 8;
+
+    expect(() => readStoredZip(compressed)).toThrow(/compression method/i);
+  });
+
+  test("readStoredZip rejects unsafe central-directory paths", () => {
+    const unsafe = createStoredZip([{ path: "SKILL.md", bytes: textEncoder.encode("skill") }]);
+    const patched = new Uint8Array(unsafe);
+    const eocdOffset = patched.length - 22;
+    const centralStart = readUInt32(patched, eocdOffset + 16);
+    patched.set(textEncoder.encode("/KILL.md"), centralStart + 46);
+
+    expect(() => readStoredZip(patched)).toThrow(/unsafe zip entry/i);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+bun test src/shared/zip.test.ts -t "readStoredZip"
+```
+
+Expected: FAIL because `readStoredZip` is not exported.
+
+- [ ] **Step 3: Implement reader helpers**
+
+In `src/shared/zip.ts`, export this interface near `ZipEntryInput`:
+
+```ts
+export interface ZipEntryOutput {
+  readonly path: string;
+  readonly bytes: Uint8Array;
+}
+```
+
+Add these helper functions below `createStoredZip()`:
+
+```ts
+function readUInt16(bytes: Uint8Array, offset: number): number {
+  if (offset + 2 > bytes.length) throw new Error("invalid zip: truncated uint16");
+  return ((bytes[offset] ?? 0) | ((bytes[offset + 1] ?? 0) << 8)) >>> 0;
+}
+
+function readUInt32(bytes: Uint8Array, offset: number): number {
+  if (offset + 4 > bytes.length) throw new Error("invalid zip: truncated uint32");
+  return (
+    ((bytes[offset] ?? 0) |
+      ((bytes[offset + 1] ?? 0) << 8) |
+      ((bytes[offset + 2] ?? 0) << 16) |
+      ((bytes[offset + 3] ?? 0) << 24)) >>>
+    0
+  );
+}
+
+function findEndOfCentralDirectory(bytes: Uint8Array): number {
+  for (let offset = bytes.length - 22; offset >= 0; offset--) {
+    if (readUInt32(bytes, offset) === 0x06054b50) return offset;
+  }
+  throw new Error("invalid zip: missing end of central directory");
+}
+```
+
+Add this exported reader:
+
+```ts
+export function readStoredZip(bytes: Uint8Array): readonly ZipEntryOutput[] {
+  const eocdOffset = findEndOfCentralDirectory(bytes);
+  const entryCount = readUInt16(bytes, eocdOffset + 8);
+  let centralOffset = readUInt32(bytes, eocdOffset + 16);
+  const entries: ZipEntryOutput[] = [];
+  const seen = new Set<string>();
+
+  for (let index = 0; index < entryCount; index++) {
+    if (readUInt32(bytes, centralOffset) !== 0x02014b50) {
+      throw new Error("invalid zip: missing central directory record");
+    }
+    const compressionMethod = readUInt16(bytes, centralOffset + 10);
+    if (compressionMethod !== 0) {
+      throw new Error(`unsupported zip compression method: ${compressionMethod}`);
+    }
+    const expectedCrc = readUInt32(bytes, centralOffset + 16);
+    const compressedSize = readUInt32(bytes, centralOffset + 20);
+    const uncompressedSize = readUInt32(bytes, centralOffset + 24);
+    if (compressedSize !== uncompressedSize) {
+      throw new Error("invalid stored zip: compressed and uncompressed sizes differ");
+    }
+    const nameLength = readUInt16(bytes, centralOffset + 28);
+    const extraLength = readUInt16(bytes, centralOffset + 30);
+    const commentLength = readUInt16(bytes, centralOffset + 32);
+    const localOffset = readUInt32(bytes, centralOffset + 42);
+    const nameStart = centralOffset + 46;
+    const name = new TextDecoder().decode(bytes.slice(nameStart, nameStart + nameLength));
+    validateEntryPath(name);
+    if (seen.has(name)) throw new Error(`duplicate zip entry path: ${name}`);
+    seen.add(name);
+
+    if (readUInt32(bytes, localOffset) !== 0x04034b50) {
+      throw new Error("invalid zip: missing local file header");
+    }
+    const localNameLength = readUInt16(bytes, localOffset + 26);
+    const localExtraLength = readUInt16(bytes, localOffset + 28);
+    const dataStart = localOffset + 30 + localNameLength + localExtraLength;
+    const dataEnd = dataStart + compressedSize;
+    if (dataEnd > bytes.length) throw new Error("invalid zip: entry data exceeds archive size");
+    const entryBytes = bytes.slice(dataStart, dataEnd);
+    const actualCrc = crc32(entryBytes);
+    if (actualCrc !== expectedCrc) {
+      throw new Error(`zip crc mismatch for ${name}`);
+    }
+    entries.push({ path: name, bytes: entryBytes });
+    centralOffset = nameStart + nameLength + extraLength + commentLength;
+  }
+
+  return entries;
+}
+```
+
+- [ ] **Step 4: Run ZIP tests**
+
+Run:
+
+```bash
+bun test src/shared/zip.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/zip.ts src/shared/zip.test.ts
+git commit -m "feat(zip): read stored ZIP archives"
+```
+
+## Task 3: Core signed skill catalog module
+
+**Files:**
+- Create: `src/core/skill-catalog.ts`
+- Create: `src/core/skill-catalog.test.ts`
+
+- [ ] **Step 1: Write failing core tests**
+
+Create `src/core/skill-catalog.test.ts`:
+
+```ts
+import { generateKeyPairSync, sign, type KeyObject } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { hash } from "blake3";
+import { createStoredZip } from "../shared/zip.js";
+import {
+  SkillBundleIntegrityError,
+  SkillCatalogTrustError,
+  canonicalJson,
+  parseSkillCatalogIndex,
+  unpackSkillBundle,
+  verifyBundleHash,
+  verifyCatalogSignature,
+} from "./skill-catalog.js";
+
+const encoder = new TextEncoder();
+
+function keyPair(): {
+  readonly publicKeySpkiDer: string;
+  readonly privateKey: KeyObject;
+} {
+  const pair = generateKeyPairSync("ed25519");
+  const publicKeySpkiDer = Buffer.from(
+    pair.publicKey.export({ format: "der", type: "spki" }),
+  ).toString("base64");
+  return { publicKeySpkiDer, privateKey: pair.privateKey };
+}
+
+function signedIndex(): {
+  readonly indexBytes: Uint8Array;
+  readonly signature: { readonly schemaVersion: 1; readonly keyId: string; readonly algorithm: "ed25519"; readonly signature: string };
+  readonly trustedKey: { readonly id: string; readonly algorithm: "ed25519"; readonly publicKeySpkiDer: string };
+} {
+  const keys = keyPair();
+  const index = {
+    schemaVersion: 1,
+    generatedAt: "2026-05-07T00:00:00Z",
+    skills: {
+      grove: {
+        version: "2026.05.07",
+        bundleHash: "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+        sizeBytes: 10,
+      },
+    },
+  };
+  const indexBytes = encoder.encode(canonicalJson(index));
+  return {
+    indexBytes,
+    signature: {
+      schemaVersion: 1,
+      keyId: "root-key",
+      algorithm: "ed25519",
+      signature: sign(null, indexBytes, keys.privateKey).toString("base64"),
+    },
+    trustedKey: {
+      id: "root-key",
+      algorithm: "ed25519",
+      publicKeySpkiDer: keys.publicKeySpkiDer,
+    },
+  };
+}
+
+describe("canonicalJson", () => {
+  test("sorts object keys recursively", () => {
+    expect(canonicalJson({ z: 1, a: { y: 2, b: 3 } })).toBe('{"a":{"b":3,"y":2},"z":1}');
+  });
+});
+
+describe("skill catalog signature verification", () => {
+  test("accepts a matching ed25519 signature", () => {
+    const fixture = signedIndex();
+    expect(
+      verifyCatalogSignature({
+        indexBytes: fixture.indexBytes,
+        signature: fixture.signature,
+        trustedKeys: [fixture.trustedKey],
+      }),
+    ).toEqual({ keyId: "root-key" });
+  });
+
+  test("rejects unknown key ids and bad signatures", () => {
+    const fixture = signedIndex();
+    expect(() =>
+      verifyCatalogSignature({
+        indexBytes: fixture.indexBytes,
+        signature: { ...fixture.signature, keyId: "other-key" },
+        trustedKeys: [fixture.trustedKey],
+      }),
+    ).toThrow(SkillCatalogTrustError);
+
+    const changed = encoder.encode(`${new TextDecoder().decode(fixture.indexBytes)}\n`);
+    expect(() =>
+      verifyCatalogSignature({
+        indexBytes: changed,
+        signature: fixture.signature,
+        trustedKeys: [fixture.trustedKey],
+      }),
+    ).toThrow(SkillCatalogTrustError);
+  });
+});
+
+describe("skill catalog schemas and bundles", () => {
+  test("parses valid index JSON", () => {
+    const parsed = parseSkillCatalogIndex(
+      '{"generatedAt":"2026-05-07T00:00:00Z","schemaVersion":1,"skills":{"grove":{"bundleHash":"blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","sizeBytes":1,"version":"1"}}}',
+    );
+    expect(parsed.skills.grove?.version).toBe("1");
+  });
+
+  test("verifies bundle hash before unpack", () => {
+    const bytes = encoder.encode("bundle");
+    const bundleHash = `blake3:${hash(bytes).toString("hex")}`;
+    expect(verifyBundleHash(bytes, bundleHash)).toBe(bundleHash);
+    expect(() => verifyBundleHash(bytes, "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).toThrow(
+      SkillBundleIntegrityError,
+    );
+  });
+
+  test("unpacks safe bundle entries and requires SKILL.md", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-skill-catalog-"));
+    try {
+      const zip = createStoredZip([
+        { path: "SKILL.md", bytes: encoder.encode("skill") },
+        { path: "references/guide.md", bytes: encoder.encode("guide") },
+      ]);
+      await unpackSkillBundle(zip, join(root, "skill"));
+      expect(readFileSync(join(root, "skill", "SKILL.md"), "utf-8")).toBe("skill");
+      expect(readFileSync(join(root, "skill", "references", "guide.md"), "utf-8")).toBe(
+        "guide",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects bundles without SKILL.md", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-skill-catalog-"));
+    try {
+      const zip = createStoredZip([{ path: "README.md", bytes: encoder.encode("readme") }]);
+      await expect(unpackSkillBundle(zip, join(root, "skill"))).rejects.toThrow(
+        SkillBundleIntegrityError,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+bun test src/core/skill-catalog.test.ts
+```
+
+Expected: FAIL because `src/core/skill-catalog.ts` does not exist.
+
+- [ ] **Step 3: Implement `src/core/skill-catalog.ts`**
+
+Create `src/core/skill-catalog.ts` with these exports:
+
+```ts
+import { createPublicKey, verify } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { hash } from "blake3";
+import { z } from "zod";
+import { readStoredZip } from "../shared/zip.js";
+import type { SkillCatalogTrustedKey } from "./config.js";
+
+const BLAKE3_PATTERN = /^blake3:[0-9a-f]{64}$/;
+
+export class SkillCatalogTrustError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SkillCatalogTrustError";
+  }
+}
+
+export class SkillCatalogUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SkillCatalogUnavailableError";
+  }
+}
+
+export class SkillBundleIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SkillBundleIntegrityError";
+  }
+}
+
+const SkillCatalogEntrySchema = z
+  .object({
+    version: z.string().min(1).max(128),
+    bundleHash: z.string().regex(BLAKE3_PATTERN),
+    sizeBytes: z.number().int().min(1),
+  })
+  .strict();
+
+const SkillCatalogIndexSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    generatedAt: z.string().min(1),
+    skills: z.record(z.string().min(1).max(128), SkillCatalogEntrySchema),
+  })
+  .strict();
+
+const SkillCatalogSignatureSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    keyId: z.string().min(1).max(128),
+    algorithm: z.literal("ed25519"),
+    signature: z.string().min(1),
+  })
+  .strict();
+
+export type SkillCatalogEntry = z.infer<typeof SkillCatalogEntrySchema>;
+export type SkillCatalogIndex = z.infer<typeof SkillCatalogIndexSchema>;
+export type SkillCatalogSignature = z.infer<typeof SkillCatalogSignatureSchema>;
+
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+
+  const record = value as Readonly<Record<string, unknown>>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(",")}}`;
+}
+
+export function parseSkillCatalogIndex(raw: string): SkillCatalogIndex {
+  const parsed = JSON.parse(raw) as unknown;
+  return SkillCatalogIndexSchema.parse(parsed);
+}
+
+export function parseSkillCatalogSignature(raw: string): SkillCatalogSignature {
+  const parsed = JSON.parse(raw) as unknown;
+  return SkillCatalogSignatureSchema.parse(parsed);
+}
+
+export function verifyCatalogSignature(opts: {
+  readonly indexBytes: Uint8Array;
+  readonly signature: SkillCatalogSignature;
+  readonly trustedKeys: readonly SkillCatalogTrustedKey[];
+}): { readonly keyId: string } {
+  const key = opts.trustedKeys.find((candidate) => candidate.id === opts.signature.keyId);
+  if (key === undefined) {
+    throw new SkillCatalogTrustError(`Unknown skill catalog signing key: ${opts.signature.keyId}`);
+  }
+  const publicKey = createPublicKey({
+    key: Buffer.from(key.publicKeySpkiDer, "base64"),
+    format: "der",
+    type: "spki",
+  });
+  const ok = verify(null, opts.indexBytes, publicKey, Buffer.from(opts.signature.signature, "base64"));
+  if (!ok) throw new SkillCatalogTrustError("Skill catalog signature verification failed");
+  return { keyId: key.id };
+}
+
+export function verifyBundleHash(bytes: Uint8Array, expectedHash: string): string {
+  if (!BLAKE3_PATTERN.test(expectedHash)) {
+    throw new SkillBundleIntegrityError(`Invalid bundle hash: ${expectedHash}`);
+  }
+  const actual = `blake3:${hash(bytes).toString("hex")}`;
+  if (actual !== expectedHash) {
+    throw new SkillBundleIntegrityError(`Skill bundle hash mismatch: expected ${expectedHash}, got ${actual}`);
+  }
+  return actual;
+}
+
+export async function unpackSkillBundle(bytes: Uint8Array, targetDir: string): Promise<void> {
+  const entries = readStoredZip(bytes);
+  if (!entries.some((entry) => entry.path === "SKILL.md")) {
+    throw new SkillBundleIntegrityError("Skill bundle is missing SKILL.md");
+  }
+  for (const entry of entries) {
+    const targetPath = join(targetDir, entry.path);
+    await mkdir(join(targetPath, ".."), { recursive: true });
+    await writeFile(targetPath, entry.bytes);
+  }
+}
+```
+
+- [ ] **Step 4: Run core tests**
+
+Run:
+
+```bash
+bun test src/core/skill-catalog.test.ts src/shared/zip.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/skill-catalog.ts src/core/skill-catalog.test.ts
+git commit -m "feat(skills): verify signed skill catalogs"
+```
+
+## Task 4: Nexus skill catalog resolver and cache
+
+**Files:**
+- Create: `src/nexus/nexus-skill-catalog.ts`
+- Create: `src/nexus/nexus-skill-catalog.test.ts`
+- Modify: `src/nexus/index.ts`
+
+- [ ] **Step 1: Write failing Nexus resolver tests**
+
+Create `src/nexus/nexus-skill-catalog.test.ts`:
+
+```ts
+import { generateKeyPairSync, sign, type KeyObject } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { hash } from "blake3";
+import { canonicalJson } from "../core/skill-catalog.js";
+import { createStoredZip } from "../shared/zip.js";
+import { MockNexusClient } from "./mock-client.js";
+import {
+  resolveNexusSkillCatalogRoot,
+  writeSkillCatalogToNexusForTest,
+} from "./nexus-skill-catalog.js";
+
+const encoder = new TextEncoder();
+
+function signingFixture(): {
+  readonly keyId: string;
+  readonly publicKeySpkiDer: string;
+  readonly privateKey: KeyObject;
+} {
+  const pair = generateKeyPairSync("ed25519");
+  return {
+    keyId: "root-key",
+    publicKeySpkiDer: Buffer.from(
+      pair.publicKey.export({ format: "der", type: "spki" }),
+    ).toString("base64"),
+    privateKey: pair.privateKey,
+  };
+}
+
+async function seedNexus(opts: {
+  readonly client: MockNexusClient;
+  readonly zoneId: string;
+  readonly privateKey: KeyObject;
+  readonly keyId: string;
+  readonly skillContent?: string;
+}): Promise<void> {
+  const bundle = createStoredZip([
+    { path: "SKILL.md", bytes: encoder.encode(opts.skillContent ?? "nexus-skill") },
+  ]);
+  const bundleHash = `blake3:${hash(bundle).toString("hex")}`;
+  const index = {
+    schemaVersion: 1,
+    generatedAt: "2026-05-07T00:00:00Z",
+    skills: {
+      grove: { version: "1", bundleHash, sizeBytes: bundle.byteLength },
+    },
+  };
+  const indexBytes = encoder.encode(canonicalJson(index));
+  const signature = {
+    schemaVersion: 1,
+    keyId: opts.keyId,
+    algorithm: "ed25519" as const,
+    signature: sign(null, indexBytes, opts.privateKey).toString("base64"),
+  };
+  await writeSkillCatalogToNexusForTest({
+    client: opts.client,
+    zoneId: opts.zoneId,
+    indexBytes,
+    signatureBytes: encoder.encode(JSON.stringify(signature)),
+    bundleHash,
+    bundleBytes: bundle,
+  });
+}
+
+describe("resolveNexusSkillCatalogRoot", () => {
+  test("fetches signed Nexus catalog and materializes requested skill root", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    try {
+      await seedNexus({ client, zoneId: "zone1", privateKey: keys.privateKey, keyId: keys.keyId });
+      const result = await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId: "zone1",
+        cacheRoot: join(root, ".grove", "cache", "skills"),
+        skills: ["grove"],
+        policy: "warn-and-fallback",
+        trustedKeys: [
+          { id: keys.keyId, algorithm: "ed25519", publicKeySpkiDer: keys.publicKeySpkiDer },
+        ],
+        localFallbackRoots: [],
+      });
+
+      expect(result.source).toBe("nexus");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("nexus-skill");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("uses verified cache when Nexus becomes unavailable", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    try {
+      await seedNexus({ client, zoneId: "zone1", privateKey: keys.privateKey, keyId: keys.keyId });
+      const base = {
+        client,
+        zoneId: "zone1",
+        cacheRoot: join(root, ".grove", "cache", "skills"),
+        skills: ["grove"],
+        policy: "warn-and-fallback" as const,
+        trustedKeys: [
+          { id: keys.keyId, algorithm: "ed25519" as const, publicKeySpkiDer: keys.publicKeySpkiDer },
+        ],
+        localFallbackRoots: [],
+      };
+      await resolveNexusSkillCatalogRoot(base);
+      client.setFailureMode({ failNext: 10, failWith: "connection" });
+      const result = await resolveNexusSkillCatalogRoot(base);
+
+      expect(result.source).toBe("cache");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("nexus-skill");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to local root under warn-and-fallback", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    try {
+      const localSkill = join(root, "local", "grove");
+      mkdirSync(localSkill, { recursive: true });
+      writeFileSync(join(localSkill, "SKILL.md"), "local-skill", "utf-8");
+      const result = await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId: "zone1",
+        cacheRoot: join(root, ".grove", "cache", "skills"),
+        skills: ["grove"],
+        policy: "warn-and-fallback",
+        trustedKeys: [],
+        localFallbackRoots: [join(root, "local")],
+      });
+
+      expect(result.source).toBe("local");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("local-skill");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails required policy without verified Nexus or cache", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    try {
+      await expect(
+        resolveNexusSkillCatalogRoot({
+          client,
+          zoneId: "zone1",
+          cacheRoot: join(root, ".grove", "cache", "skills"),
+          skills: ["grove"],
+          policy: "required",
+          trustedKeys: [],
+          localFallbackRoots: [],
+        }),
+      ).rejects.toThrow(/trusted keys|catalog|required/i);
+      expect(existsSync(join(root, ".grove", "cache", "skills", "resolved"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+bun test src/nexus/nexus-skill-catalog.test.ts
+```
+
+Expected: FAIL because `src/nexus/nexus-skill-catalog.ts` does not exist.
+
+- [ ] **Step 3: Implement resolver shape**
+
+Create `src/nexus/nexus-skill-catalog.ts` with these exported interfaces and helper:
+
+```ts
+import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { SkillCatalogPolicy, SkillCatalogTrustedKey } from "../core/config.js";
+import {
+  SkillCatalogTrustError,
+  SkillCatalogUnavailableError,
+  parseSkillCatalogIndex,
+  parseSkillCatalogSignature,
+  unpackSkillBundle,
+  verifyBundleHash,
+  verifyCatalogSignature,
+} from "../core/skill-catalog.js";
+import type { NexusClient } from "./client.js";
+import {
+  skillCatalogBundlePath,
+  skillCatalogIndexPath,
+  skillCatalogSignaturePath,
+} from "./vfs-paths.js";
+
+export interface SkillResolutionWarning {
+  readonly skillName: string;
+  readonly attemptedSource: string;
+  readonly fallbackSource?: string | undefined;
+  readonly reason: string;
+}
+
+export interface ResolvedSkillCatalogRoot {
+  readonly root: string;
+  readonly source: "nexus" | "cache" | "local";
+  readonly warnings: readonly SkillResolutionWarning[];
+}
+
+export interface ResolveNexusSkillCatalogRootOptions {
+  readonly client: NexusClient;
+  readonly zoneId: string;
+  readonly cacheRoot: string;
+  readonly skills: readonly string[];
+  readonly policy: SkillCatalogPolicy;
+  readonly trustedKeys: readonly SkillCatalogTrustedKey[];
+  readonly localFallbackRoots: readonly string[];
+}
+```
+
+Implement `writeSkillCatalogToNexusForTest()` for tests and future test fixtures:
+
+```ts
+export async function writeSkillCatalogToNexusForTest(opts: {
+  readonly client: NexusClient;
+  readonly zoneId: string;
+  readonly indexBytes: Uint8Array;
+  readonly signatureBytes: Uint8Array;
+  readonly bundleHash: string;
+  readonly bundleBytes: Uint8Array;
+}): Promise<void> {
+  await opts.client.write(skillCatalogIndexPath(opts.zoneId), opts.indexBytes);
+  await opts.client.write(skillCatalogSignaturePath(opts.zoneId), opts.signatureBytes);
+  await opts.client.write(skillCatalogBundlePath(opts.zoneId, opts.bundleHash), opts.bundleBytes);
+}
+```
+
+- [ ] **Step 4: Implement fetch, cache, and local fallback**
+
+In the same file, add helper functions:
+
+```ts
+const decoder = new TextDecoder();
+
+function cacheSkillDir(cacheRoot: string, skillName: string, version: string, bundleHash: string): string {
+  return join(cacheRoot, "unpacked", skillName, version, bundleHash);
+}
+
+function resolvedRoot(cacheRoot: string, skills: readonly string[], suffix: string): string {
+  return join(cacheRoot, "resolved", `${skills.join("-")}-${suffix.replaceAll(":", "_")}`);
+}
+
+```
+
+Add `resolveNexusSkillCatalogRoot()`:
+
+```ts
+export async function resolveNexusSkillCatalogRoot(
+  opts: ResolveNexusSkillCatalogRootOptions,
+): Promise<ResolvedSkillCatalogRoot> {
+  const warnings: SkillResolutionWarning[] = [];
+  try {
+    if (opts.trustedKeys.length === 0) {
+      throw new SkillCatalogTrustError("No trusted skill catalog keys configured");
+    }
+    const indexBytes = await opts.client.read(skillCatalogIndexPath(opts.zoneId));
+    const signatureBytes = await opts.client.read(skillCatalogSignaturePath(opts.zoneId));
+    if (indexBytes === undefined || signatureBytes === undefined) {
+      throw new SkillCatalogUnavailableError("Nexus skill catalog index or signature is missing");
+    }
+
+    const index = parseSkillCatalogIndex(decoder.decode(indexBytes));
+    const signature = parseSkillCatalogSignature(decoder.decode(signatureBytes));
+    const verified = verifyCatalogSignature({ indexBytes, signature, trustedKeys: opts.trustedKeys });
+    const targetRoot = resolvedRoot(opts.cacheRoot, opts.skills, verified.keyId);
+    await mkdir(targetRoot, { recursive: true });
+
+    for (const skillName of opts.skills) {
+      const entry = index.skills[skillName];
+      if (entry === undefined) {
+        throw new SkillCatalogUnavailableError(`Nexus skill catalog missing skill '${skillName}'`);
+      }
+      const skillCacheDir = cacheSkillDir(opts.cacheRoot, skillName, entry.version, entry.bundleHash);
+      if (!existsSync(join(skillCacheDir, "SKILL.md"))) {
+        const bundleBytes = await opts.client.read(skillCatalogBundlePath(opts.zoneId, entry.bundleHash));
+        if (bundleBytes === undefined) {
+          throw new SkillCatalogUnavailableError(`Nexus skill bundle missing for '${skillName}'`);
+        }
+        verifyBundleHash(bundleBytes, entry.bundleHash);
+        await unpackSkillBundle(bundleBytes, skillCacheDir);
+      }
+      await cp(skillCacheDir, join(targetRoot, skillName), { recursive: true, force: true });
+    }
+
+    await mkdir(opts.cacheRoot, { recursive: true });
+    await writeFile(join(opts.cacheRoot, "index.json"), indexBytes);
+    await writeFile(join(opts.cacheRoot, "index.sig"), signatureBytes);
+    return { root: targetRoot, source: "nexus", warnings };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    if (opts.policy === "required") throw err;
+    for (const skillName of opts.skills) {
+      warnings.push({ skillName, attemptedSource: "nexus", reason });
+    }
+  }
+
+  const cached = await tryVerifiedCache(opts);
+  if (cached !== undefined) return { ...cached, warnings };
+
+  const local = await tryLocalFallback(opts);
+  if (local !== undefined) return { ...local, warnings };
+
+  throw new SkillCatalogUnavailableError(
+    `Unable to resolve skills from Nexus, verified cache, or local fallback: ${opts.skills.join(", ")}`,
+  );
+}
+```
+
+Add cache/local helper implementations. Keep them small and deterministic:
+
+```ts
+async function tryVerifiedCache(
+  opts: ResolveNexusSkillCatalogRootOptions,
+): Promise<Omit<ResolvedSkillCatalogRoot, "warnings"> | undefined> {
+  const indexPath = join(opts.cacheRoot, "index.json");
+  const sigPath = join(opts.cacheRoot, "index.sig");
+  if (!existsSync(indexPath) || !existsSync(sigPath)) return undefined;
+  const indexBytes = await readFile(indexPath);
+  const signatureBytes = await readFile(sigPath);
+  const index = parseSkillCatalogIndex(decoder.decode(indexBytes));
+  const signature = parseSkillCatalogSignature(decoder.decode(signatureBytes));
+  const verified = verifyCatalogSignature({ indexBytes, signature, trustedKeys: opts.trustedKeys });
+  const targetRoot = resolvedRoot(opts.cacheRoot, opts.skills, `cache-${verified.keyId}`);
+  await mkdir(targetRoot, { recursive: true });
+
+  for (const skillName of opts.skills) {
+    const entry = index.skills[skillName];
+    if (entry === undefined) return undefined;
+    const skillCacheDir = cacheSkillDir(opts.cacheRoot, skillName, entry.version, entry.bundleHash);
+    if (!existsSync(join(skillCacheDir, "SKILL.md"))) return undefined;
+    await cp(skillCacheDir, join(targetRoot, skillName), { recursive: true, force: true });
+  }
+  return { root: targetRoot, source: "cache" };
+}
+
+async function tryLocalFallback(
+  opts: ResolveNexusSkillCatalogRootOptions,
+): Promise<Omit<ResolvedSkillCatalogRoot, "warnings"> | undefined> {
+  const targetRoot = resolvedRoot(opts.cacheRoot, opts.skills, "local");
+  await mkdir(targetRoot, { recursive: true });
+  for (const skillName of opts.skills) {
+    const foundRoot = opts.localFallbackRoots.find((root) =>
+      existsSync(join(root, skillName, "SKILL.md")),
+    );
+    if (foundRoot === undefined) return undefined;
+    await cp(join(foundRoot, skillName), join(targetRoot, skillName), {
+      recursive: true,
+      force: true,
+    });
+  }
+  return { root: targetRoot, source: "local" };
+}
+```
+
+- [ ] **Step 5: Export the Nexus resolver**
+
+In `src/nexus/index.ts`, add:
+
+```ts
+export type {
+  ResolvedSkillCatalogRoot,
+  ResolveNexusSkillCatalogRootOptions,
+  SkillResolutionWarning,
+} from "./nexus-skill-catalog.js";
+export {
+  resolveNexusSkillCatalogRoot,
+  writeSkillCatalogToNexusForTest,
+} from "./nexus-skill-catalog.js";
+```
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+bun test src/nexus/nexus-skill-catalog.test.ts src/core/skill-catalog.test.ts src/shared/zip.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/nexus/nexus-skill-catalog.ts src/nexus/nexus-skill-catalog.test.ts src/nexus/index.ts
+git commit -m "feat(nexus): resolve signed skill catalogs"
+```
+
+## Task 5: Bootstrap resolver dependency
+
+**Files:**
+- Modify: `src/core/workspace-bootstrap.ts`
+- Modify: `src/core/workspace-bootstrap.test.ts`
+
+- [ ] **Step 1: Write failing bootstrap resolver tests**
+
+Add this test to `src/core/workspace-bootstrap.test.ts`:
+
+```ts
+  test("injects skills from resolver-provided catalog root before local fallback", async () => {
+    const remoteRoot = mkdtempSync(join(tmpdir(), "grove-remote-skills-"));
+    const skillDir = join(remoteRoot, "grove");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "remote-grove", "utf-8");
+
+    const bundledRoot = mkdtempSync(join(tmpdir(), "grove-bundled-"));
+    const bundledSkillDir = join(bundledRoot, "grove");
+    mkdirSync(bundledSkillDir, { recursive: true });
+    writeFileSync(join(bundledSkillDir, "SKILL.md"), "bundled-grove", "utf-8");
+
+    await bootstrapWorkspace({
+      workspacePath: workspaceDir,
+      roleId: "coder",
+      goal: "Build",
+      skills: ["grove"],
+      bundledSkillsRoot: bundledRoot,
+      skillCatalogResolver: async (skills) => ({
+        root: remoteRoot,
+        warnings: skills.map((skillName) => ({
+          skillName,
+          attemptedSource: "nexus",
+          fallbackSource: undefined,
+          reason: "verified",
+        })),
+      }),
+    });
+
+    expect(readFileSync(join(workspaceDir, ".claude/skills/grove/SKILL.md"), "utf-8")).toBe(
+      "remote-grove",
+    );
+
+    rmSync(remoteRoot, { recursive: true, force: true });
+    rmSync(bundledRoot, { recursive: true, force: true });
+  });
+
+  test("falls back to local injection when resolver returns undefined", async () => {
+    const bundledRoot = mkdtempSync(join(tmpdir(), "grove-bundled-"));
+    const skillDir = join(bundledRoot, "grove");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "bundled-grove", "utf-8");
+
+    await bootstrapWorkspace({
+      workspacePath: workspaceDir,
+      roleId: "coder",
+      goal: "Build",
+      skills: ["grove"],
+      bundledSkillsRoot: bundledRoot,
+      skillCatalogResolver: async () => undefined,
+    });
+
+    expect(readFileSync(join(workspaceDir, ".claude/skills/grove/SKILL.md"), "utf-8")).toBe(
+      "bundled-grove",
+    );
+
+    rmSync(bundledRoot, { recursive: true, force: true });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+bun test src/core/workspace-bootstrap.test.ts -t "resolver"
+```
+
+Expected: FAIL because `skillCatalogResolver` is not part of `BootstrapOptions`.
+
+- [ ] **Step 3: Add resolver types to workspace bootstrap**
+
+In `src/core/workspace-bootstrap.ts`, add these interfaces near `BootstrapOptions`:
+
+```ts
+export interface SkillCatalogResolverWarning {
+  readonly skillName: string;
+  readonly attemptedSource: string;
+  readonly fallbackSource?: string | undefined;
+  readonly reason: string;
+}
+
+export interface SkillCatalogResolverResult {
+  readonly root: string;
+  readonly warnings?: readonly SkillCatalogResolverWarning[] | undefined;
+}
+
+export type SkillCatalogResolver = (
+  skills: readonly string[],
+) => Promise<SkillCatalogResolverResult | undefined>;
+```
+
+Add this option to `BootstrapOptions`:
+
+```ts
+  /** Optional mode-aware resolver. When it returns a root, injection uses that root. */
+  skillCatalogResolver?: SkillCatalogResolver | undefined;
+```
+
+- [ ] **Step 4: Use resolver before current local injection**
+
+Replace the existing skill injection block in `bootstrapWorkspace()` with:
+
+```ts
+  if (opts.skills && opts.skills.length > 0) {
+    const resolved = opts.skillCatalogResolver
+      ? await opts.skillCatalogResolver(opts.skills)
+      : undefined;
+    const injectionRoot = resolved?.root ?? opts.bundledSkillsRoot;
+    if (!injectionRoot) {
+      throw new Error(
+        "bootstrapWorkspace: `skills` non-empty requires `bundledSkillsRoot` or `skillCatalogResolver`.",
+      );
+    }
+    await injectSkills({
+      workspacePath: workspacePath,
+      skills: opts.skills,
+      bundledSkillsRoot: injectionRoot,
+      workspaceOverrideRoot: resolved ? undefined : opts.workspaceOverrideRoot,
+    });
+  }
+```
+
+- [ ] **Step 5: Run bootstrap tests**
+
+Run:
+
+```bash
+bun test src/core/workspace-bootstrap.test.ts src/core/skill-injector.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/workspace-bootstrap.ts src/core/workspace-bootstrap.test.ts
+git commit -m "feat(skills): allow bootstrap skill catalog resolver"
+```
+
+## Task 6: Wire Nexus mode into SessionOrchestrator and SpawnManager
+
+**Files:**
+- Modify: `src/core/session-orchestrator.ts`
+- Modify: `src/tui/spawn-manager.ts`
+
+- [ ] **Step 1: Add a small resolver factory helper inside SessionOrchestrator**
+
+In `src/core/session-orchestrator.ts`, import:
+
+```ts
+import { existsSync, readFileSync } from "node:fs";
+import { NexusHttpClient } from "../nexus/nexus-http-client.js";
+import { resolveNexusSkillCatalogRoot } from "../nexus/nexus-skill-catalog.js";
+import { parseGroveConfig } from "./config.js";
+import type { SkillCatalogResolver } from "./workspace-bootstrap.js";
+```
+
+Add this private method inside `SessionOrchestrator`:
+
+```ts
+  private createSkillCatalogResolver(): SkillCatalogResolver | undefined {
+    const nexusUrl = process.env.GROVE_NEXUS_URL;
+    if (!nexusUrl) return undefined;
+    const groveDir = join(this.config.projectRoot, ".grove");
+    const configPath = join(groveDir, "grove.json");
+    if (!existsSync(configPath)) return undefined;
+    const config = parseGroveConfig(readFileSync(configPath, "utf-8"));
+    const skillCatalog = config.skillCatalog;
+    if (config.mode !== "nexus" || skillCatalog === undefined) return undefined;
+
+    const client = new NexusHttpClient({
+      url: nexusUrl,
+      apiKey: process.env.NEXUS_API_KEY || undefined,
+    });
+    const zoneId = process.env.GROVE_ZONE_ID ?? "default";
+    const cacheRoot = join(groveDir, "cache", "skills");
+    const bundledRoot = resolveBundledSkillsRoot(this.config.projectRoot);
+    const overrideRoot = join(groveDir, "skills");
+
+    return async (skills) => {
+      const result = await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId,
+        cacheRoot,
+        skills,
+        policy: skillCatalog.policy,
+        trustedKeys: skillCatalog.trustedKeys,
+        localFallbackRoots: [overrideRoot, bundledRoot],
+      });
+      return { root: result.root, warnings: result.warnings };
+    };
+  }
+```
+
+This first pass uses `GROVE_ZONE_ID ?? "default"` to match current MCP/server env behavior when no namespace has been supplied.
+
+- [ ] **Step 2: Pass resolver into `bootstrapWorkspace()`**
+
+In `provisionAgentWorkspace()`, before `bootstrapWorkspace()`, add:
+
+```ts
+      const skillCatalogResolver = this.createSkillCatalogResolver();
+```
+
+Pass it in the options object:
+
+```ts
+        skillCatalogResolver,
+```
+
+- [ ] **Step 3: Mirror the resolver in SpawnManager**
+
+In `src/tui/spawn-manager.ts`, import:
+
+```ts
+import { NexusHttpClient } from "../nexus/nexus-http-client.js";
+import { resolveNexusSkillCatalogRoot } from "../nexus/nexus-skill-catalog.js";
+import { parseGroveConfig } from "../core/config.js";
+```
+
+Add this private method:
+
+```ts
+  private async resolveSkillRootForSpawn(roleSkills: readonly string[]): Promise<string | undefined> {
+    if (roleSkills.length === 0 || !this.groveDir) return undefined;
+    const configPath = join(this.groveDir, "grove.json");
+    if (!existsSync(configPath)) return undefined;
+    const raw = await readFile(configPath, "utf-8");
+    const config = parseGroveConfig(raw);
+    if (config.mode !== "nexus" || config.skillCatalog === undefined) return undefined;
+
+    const nexusUrl = process.env.GROVE_NEXUS_URL ?? config.nexusUrl;
+    if (!nexusUrl) return undefined;
+    const client = new NexusHttpClient({
+      url: nexusUrl,
+      apiKey: process.env.NEXUS_API_KEY || undefined,
+    });
+    const projectRoot = dirname(this.groveDir);
+    const result = await resolveNexusSkillCatalogRoot({
+      client,
+      zoneId: process.env.GROVE_ZONE_ID ?? "default",
+      cacheRoot: join(this.groveDir, "cache", "skills"),
+      skills: roleSkills,
+      policy: config.skillCatalog.policy,
+      trustedKeys: config.skillCatalog.trustedKeys,
+      localFallbackRoots: [join(this.groveDir, "skills"), resolveBundledSkillsRoot(projectRoot)],
+    });
+    return result.root;
+  }
+```
+
+Update the existing TUI skill injection block:
+
+```ts
+        const roleSkills = Array.isArray(context?.skills)
+          ? (context.skills as readonly string[])
+          : [];
+        if (roleSkills.length > 0 && this.groveDir) {
+          const resolvedSkillRoot = await this.resolveSkillRootForSpawn(roleSkills);
+          await injectSkills({
+            workspacePath,
+            skills: roleSkills,
+            bundledSkillsRoot: resolvedSkillRoot ?? resolveBundledSkillsRoot(dirname(this.groveDir)),
+            workspaceOverrideRoot: resolvedSkillRoot ? undefined : join(this.groveDir, "skills"),
+          });
+        }
+```
+
+- [ ] **Step 4: Run focused runtime tests**
+
+Run:
+
+```bash
+bun test src/core/workspace-bootstrap.test.ts src/nexus/nexus-skill-catalog.test.ts
+bun test src/tui/spawn-manager.test.ts -t "skill injection"
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/session-orchestrator.ts src/tui/spawn-manager.ts
+git commit -m "feat(runtime): resolve Nexus-hosted skills during spawn"
+```
+
+## Task 7: Full verification and child issue handoff
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-07-nexus-hosted-skill-distribution-design.md`
+
+- [ ] **Step 1: Update spec status**
+
+Change the status line in the spec to:
+
+```markdown
+- **Status:** Runtime implementation planned; publish CLI remains a child issue
+```
+
+- [ ] **Step 2: Run full verification**
+
+Run:
+
+```bash
+bun test src/shared/zip.test.ts src/core/skill-catalog.test.ts src/nexus/nexus-skill-catalog.test.ts src/core/workspace-bootstrap.test.ts src/core/config.test.ts src/nexus/vfs-paths.test.ts
+bun run typecheck
+bun run check
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 3: Inspect changed files**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only the files from this plan are changed.
+
+- [ ] **Step 4: Commit final docs/status update**
+
+```bash
+git add docs/superpowers/specs/2026-05-07-nexus-hosted-skill-distribution-design.md
+git commit -m "docs(skills): mark Nexus skill runtime plan ready"
+```
+
+## Execution Notes
+
+- Keep commits exactly at task boundaries so review can isolate config, ZIP, catalog core, Nexus adapter, runtime wiring, and final documentation.
+- Do not change existing local skill injection semantics in non-Nexus mode.
+- Do not log Nexus API keys, bearer tokens, or local credential file contents in warning messages.
+- If `bun` is unavailable in the execution environment, stop before implementation and fix the runtime PATH; this repository requires Bun 1.3.x.

--- a/docs/superpowers/specs/2026-05-07-nexus-hosted-skill-distribution-design.md
+++ b/docs/superpowers/specs/2026-05-07-nexus-hosted-skill-distribution-design.md
@@ -1,0 +1,338 @@
+# Nexus-Hosted Skill Distribution - Design
+
+- **Date:** 2026-05-07
+- **Issue:** [#326](https://github.com/windoliver/grove/issues/326)
+- **Parent:** [#202](https://github.com/windoliver/grove/issues/202)
+- **Builds on:** [#262](https://github.com/windoliver/grove/issues/262), `docs/superpowers/specs/2026-04-20-native-skill-injection-design.md`
+- **Status:** Approved design, pending implementation plan
+
+## Summary
+
+Grove already supports per-role native skill injection from local catalogs:
+bundled `<groveRoot>/skills/` plus workspace override
+`<projectRoot>/.grove/skills/`. Nexus-mode sessions still require every host
+to have the same local Grove checkout or local override tree available.
+
+This design adds automatic Nexus-backed skill resolution in Nexus mode. When a
+role declares `skills: ["grove"]`, Grove tries a signed Nexus catalog first,
+falls back to a last verified cache, then falls back to the existing local
+catalogs. Nexus content is never injected unless it verifies against trusted
+Ed25519 public keys from local `.grove/grove.json`.
+
+## Goals
+
+- In Nexus mode, agents on different machines can receive the same role skills
+  without requiring each host to have the Grove repo checked out.
+- Preserve the existing `skills: [...]` role field and provider-native injection
+  paths.
+- Verify externally fetched skill content before injecting it into an agent
+  workspace.
+- Provide an offline path through a last verified local cache.
+- Keep non-Nexus mode behavior unchanged.
+- Default to warn-and-fallback so existing sessions do not fail because the
+  network catalog is unavailable.
+
+## Non-Goals
+
+- Runtime hot-reload of skills during an active agent session.
+- Agent-initiated skill acquisition.
+- Trusting keys served only by Nexus. The first trust anchor must be local or
+  built into Grove.
+- A full package registry UI.
+- Solving every publication workflow in the first implementation. Publishing
+  can be a follow-up child issue if needed.
+
+## Current State
+
+- `src/core/skill-injector.ts` resolves skill names against local override and
+  bundled roots, then copies the selected directory to `.claude/skills/{name}/`
+  and `.codex/skills/{name}/`.
+- `src/core/workspace-bootstrap.ts`, `src/core/session-orchestrator.ts`, and
+  `src/tui/spawn-manager.ts` already pass role-level `skills`.
+- `src/nexus/nexus-cas.ts` provides BLAKE3-addressed blob storage over Nexus
+  VFS.
+- `src/shared/zip.ts` can create dependency-free stored ZIP archives for
+  diagnostics, but Grove does not yet have a ZIP reader.
+- `.grove/grove.json` is strict and currently stores backend mode, Nexus URL,
+  and service metadata.
+
+## Design
+
+### Architecture
+
+Skill resolution becomes a mode-aware resolver:
+
+1. **Nexus catalog** - only in Nexus mode. Reads a signed catalog index from
+   Nexus, verifies it with local trust keys, downloads the requested bundle,
+   checks the BLAKE3 bundle hash, unpacks it to cache, then injects from cache.
+2. **Verified local cache** - used when Nexus is down or the index cannot be
+   fetched. Only bundles that were verified in a previous successful fetch are
+   eligible.
+3. **Existing local catalogs** - workspace override first, then bundled skills.
+
+The existing `injectSkills()` function remains the final copy step. The new
+resolver produces a temporary/catalog root containing verified skill
+directories, then calls the existing injector with that root.
+
+Non-Nexus mode keeps the current local-only flow.
+
+### Nexus Catalog Layout
+
+Catalog files live under the current Nexus zone:
+
+```text
+/zones/<zoneId>/skill-catalog/index.json
+/zones/<zoneId>/skill-catalog/index.sig
+/zones/<zoneId>/skill-catalog/bundles/<blake3-hash>.zip
+```
+
+The bundle path is derived from the verified `bundleHash`; Grove does not trust
+an arbitrary path from the index.
+
+`index.json` is canonical JSON:
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-07T00:00:00Z",
+  "skills": {
+    "grove": {
+      "version": "2026.05.07",
+      "bundleHash": "blake3:<hex64>",
+      "sizeBytes": 1234
+    }
+  }
+}
+```
+
+`index.sig` contains the key ID and base64 Ed25519 signature over the exact
+canonical `index.json` bytes:
+
+```json
+{
+  "schemaVersion": 1,
+  "keyId": "grove-root-2026-05",
+  "algorithm": "ed25519",
+  "signature": "<base64>"
+}
+```
+
+Each ZIP bundle contains one skill directory's contents at archive root:
+
+```text
+SKILL.md
+references/...
+scripts/...
+```
+
+Bundles must use stored ZIP entries only. This keeps unpacking
+dependency-free, bounded, and compatible with `src/shared/zip.ts`.
+
+### Trust Configuration
+
+Extend `.grove/grove.json` with optional skill catalog settings:
+
+```json
+{
+  "name": "example",
+  "mode": "nexus",
+  "nexusUrl": "http://localhost:2026",
+  "skillCatalog": {
+    "policy": "warn-and-fallback",
+    "trustedKeys": [
+      {
+        "id": "grove-root-2026-05",
+        "algorithm": "ed25519",
+        "publicKeySpkiDer": "<base64-spki-der-public-key>"
+      }
+    ],
+    "cacheTtlSeconds": 86400
+  }
+}
+```
+
+Policy values:
+
+- `warn-and-fallback` - default. Try Nexus first, warn on fetch/trust failures,
+  then use verified cache or local catalogs.
+- `required` - fail spawn if a requested skill cannot be resolved from a
+  verified Nexus catalog or verified cache.
+
+Trusted keys may also be shipped as built-in Grove defaults for Grove-owned
+skills. Nexus cannot be the only source of trust keys because that would let a
+compromised Nexus instance serve both modified skill content and the key that
+trusts it.
+
+`publicKeySpkiDer` is base64-encoded SPKI DER, so implementation can import it
+with standard crypto APIs without relying on provider-specific raw-key parsing.
+
+### Cache Layout
+
+Verified cache lives under the local `.grove` directory:
+
+```text
+.grove/cache/skills/
+  index.json
+  index.sig
+  bundles/<blake3-hash>.zip
+  unpacked/<skill-name>/<version>/<blake3-hash>/SKILL.md
+  manifest.json
+```
+
+`manifest.json` records:
+
+- source Nexus URL and zone ID
+- skill name, version, and bundle hash
+- verified key ID
+- verified timestamp
+- unpacked directory path
+
+The cache is content-addressed by bundle hash. Cache TTL controls when Grove
+attempts to refresh from Nexus; expired cache entries remain usable as offline
+fallback if they were previously verified.
+
+### Resolution Flow
+
+For each role with `skills` in Nexus mode:
+
+1. Load trusted skill catalog settings from `.grove/grove.json`.
+2. Fetch `index.json` and `index.sig` from Nexus.
+3. Verify the signature using a trusted key.
+4. For each requested skill, locate an index entry by name.
+5. Fetch the zone-scoped bundle path derived from `bundleHash`.
+6. Recompute BLAKE3 over the ZIP bytes and compare with `bundleHash`.
+7. Unpack only safe ZIP paths to the verified cache.
+8. Confirm the unpacked root contains `SKILL.md`.
+9. Inject from the verified cache via the existing native injector.
+
+Fallback order when Nexus cannot satisfy the request:
+
+1. Last verified cache.
+2. Workspace override `.grove/skills/{name}`.
+3. Bundled `<groveRoot>/skills/{name}`.
+
+Under `required`, steps 2 and 3 of fallback are disabled.
+
+### Error Handling
+
+New structured errors:
+
+- `SkillCatalogTrustError` - missing signature, unknown key ID, unsupported
+  algorithm, bad signature, or no trusted keys.
+- `SkillCatalogUnavailableError` - Nexus unreachable, index missing, bundle
+  missing, or catalog schema invalid.
+- `SkillBundleIntegrityError` - bundle hash mismatch, unsafe ZIP entry path,
+  unsupported ZIP method, size limit exceeded, or missing `SKILL.md`.
+- Existing `SkillResolutionError` - requested skill is absent from every
+  allowed source.
+
+Warnings must include skill name, attempted source, fallback source, and reason.
+They must not print Nexus API keys, bearer tokens, or local credential contents.
+
+### Public Surfaces
+
+New modules:
+
+- `src/core/skill-catalog.ts`
+  - catalog schemas and types
+  - canonical JSON encode/decode
+  - Ed25519 signature verification
+  - BLAKE3 bundle hash verification
+  - stored-ZIP unpack validation
+- `src/nexus/nexus-skill-catalog.ts`
+  - zone-scoped path helpers
+  - Nexus VFS read/write helpers for catalog files and bundles
+  - resolver that returns verified cache directories
+
+Modified modules:
+
+- `src/core/config.ts` - parse/write optional `skillCatalog`.
+- `src/core/workspace-bootstrap.ts` - accept an optional pre-resolved skill
+  catalog root or resolver dependency.
+- `src/core/session-orchestrator.ts` - in Nexus mode, create and pass a
+  Nexus-aware resolver.
+- `src/tui/spawn-manager.ts` - mirror the same resolver in the TUI spawn path.
+- `src/shared/zip.ts` - add a minimal stored-ZIP reader/unpacker or a sibling
+  module if that keeps the writer simpler.
+
+CLI publication can be deferred, but the design leaves room for:
+
+```bash
+grove skill publish --catalog nexus --skill grove --key <key-id>
+grove skill sync --from ./skills --catalog nexus
+```
+
+### Testing
+
+Unit tests:
+
+- canonical JSON output is stable regardless of object insertion order.
+- Ed25519 verification accepts the matching key and rejects bad signatures,
+  wrong keys, and unsupported algorithms.
+- BLAKE3 bundle hash mismatch rejects before unpack.
+- ZIP unpack rejects absolute paths, parent-relative paths, duplicate entries,
+  unsupported compression methods, directory traversal, and oversized bundles.
+- Valid bundle unpacks to a directory with `SKILL.md` and siblings preserved.
+
+Nexus adapter tests:
+
+- `MockNexusClient` serves a signed catalog and bundle.
+- missing index falls back under `warn-and-fallback`.
+- missing bundle falls back under `warn-and-fallback`.
+- bad signature never uses Nexus content.
+- `required` policy fails without verified Nexus or cache.
+
+Bootstrap integration tests:
+
+- Nexus mode injects verified Nexus skill.
+- Nexus unavailable uses last verified cache.
+- no cache falls back to local bundled skill under default policy.
+- non-Nexus mode behavior remains byte-for-byte equivalent to current local
+  injection tests.
+
+### Security Notes
+
+- The signature authenticates the catalog index, not the Nexus transport.
+- The BLAKE3 hash authenticates the ZIP bytes selected by the signed index.
+- ZIP extraction must validate every path before writing any file.
+- The resolver must resolve all requested skills before injection so a partial
+  failure does not inject half of a role's skill set.
+- Cache entries remain immutable once verified. Refresh creates or points to a
+  new `{skillName, version, bundleHash}` directory.
+
+## Migration
+
+Existing local and Nexus sessions continue to work. Roles still declare skills
+with `skills: [...]`. Without `skillCatalog.trustedKeys` or built-in trusted
+keys, Nexus mode warns and falls back to verified cache or local catalogs.
+
+Operators who want strict remote distribution set:
+
+```json
+{
+  "skillCatalog": {
+    "policy": "required",
+    "trustedKeys": [...]
+  }
+}
+```
+
+## Proposed Child Issues
+
+1. **feat(skills): add signed skill catalog core**
+   - `src/core/skill-catalog.ts`
+   - canonical JSON, Ed25519 verification, BLAKE3 checks, stored-ZIP unpacker
+2. **feat(nexus): add Nexus skill catalog adapter**
+   - zone-scoped VFS paths, signed index reads, bundle fetches, verified cache
+3. **feat(runtime): resolve skills from Nexus in Nexus mode**
+   - wire `SessionOrchestrator`, `SpawnManager`, and bootstrap integration
+4. **feat(cli): publish skills to Nexus catalog**
+   - package local skill dirs, sign index, write bundles and catalog to Nexus
+5. **docs(skills): document Nexus-hosted skill catalogs**
+   - config examples, trust model, offline fallback, and required policy
+
+## Open Questions
+
+None. The approved defaults are automatic Nexus resolution in Nexus mode,
+local trust keys in `.grove/grove.json`, and warn-and-fallback policy unless an
+operator opts into `required`.

--- a/docs/superpowers/specs/2026-05-07-nexus-hosted-skill-distribution-design.md
+++ b/docs/superpowers/specs/2026-05-07-nexus-hosted-skill-distribution-design.md
@@ -4,7 +4,7 @@
 - **Issue:** [#326](https://github.com/windoliver/grove/issues/326)
 - **Parent:** [#202](https://github.com/windoliver/grove/issues/202)
 - **Builds on:** [#262](https://github.com/windoliver/grove/issues/262), `docs/superpowers/specs/2026-04-20-native-skill-injection-design.md`
-- **Status:** Approved design, pending implementation plan
+- **Status:** Runtime implementation planned; publish CLI remains a child issue
 
 ## Summary
 

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -76,6 +76,48 @@ describe("parseGroveConfig", () => {
     expect(config.mode).toBe("local");
     expect(config.nexusUrl).toBe("http://nexus:4000");
   });
+
+  test("parses skill catalog config with trusted keys", () => {
+    const config = parseGroveConfig(
+      JSON.stringify({
+        name: "swarm",
+        mode: "nexus",
+        nexusUrl: "http://localhost:4000",
+        skillCatalog: {
+          policy: "required",
+          trustedKeys: [
+            {
+              id: "root-key",
+              algorithm: "ed25519",
+              publicKeySpkiDer: "MCowBQYDK2VwAyEA0000000000000000000000000000000000000000000=",
+            },
+          ],
+          cacheTtlSeconds: 60,
+        },
+      }),
+    );
+
+    expect(config.skillCatalog?.policy).toBe("required");
+    expect(config.skillCatalog?.trustedKeys).toHaveLength(1);
+    expect(config.skillCatalog?.trustedKeys[0]?.id).toBe("root-key");
+    expect(config.skillCatalog?.cacheTtlSeconds).toBe(60);
+  });
+
+  test("defaults skill catalog policy when omitted", () => {
+    const config = parseGroveConfig(
+      JSON.stringify({
+        name: "swarm",
+        mode: "nexus",
+        nexusUrl: "http://localhost:4000",
+        skillCatalog: {
+          trustedKeys: [],
+        },
+      }),
+    );
+
+    expect(config.skillCatalog?.policy).toBe("warn-and-fallback");
+    expect(config.skillCatalog?.trustedKeys).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -122,6 +164,55 @@ describe("parseGroveConfig errors", () => {
   test("rejects unknown fields", () => {
     expect(() =>
       parseGroveConfig(JSON.stringify({ name: "x", mode: "local", unknown: true })),
+    ).toThrow("Invalid grove.json");
+  });
+
+  test("rejects unknown skill catalog policy", () => {
+    expect(() =>
+      parseGroveConfig(
+        JSON.stringify({
+          name: "x",
+          mode: "nexus",
+          nexusUrl: "http://localhost:4000",
+          skillCatalog: { policy: "trust-nexus", trustedKeys: [] },
+        }),
+      ),
+    ).toThrow("Invalid grove.json");
+  });
+
+  test("rejects non-ed25519 skill catalog key algorithms", () => {
+    expect(() =>
+      parseGroveConfig(
+        JSON.stringify({
+          name: "x",
+          mode: "nexus",
+          nexusUrl: "http://localhost:4000",
+          skillCatalog: {
+            trustedKeys: [{ id: "root-key", algorithm: "rsa", publicKeySpkiDer: "abc" }],
+          },
+        }),
+      ),
+    ).toThrow("Invalid grove.json");
+  });
+
+  test("rejects malformed skill catalog key base64", () => {
+    expect(() =>
+      parseGroveConfig(
+        JSON.stringify({
+          name: "x",
+          mode: "nexus",
+          nexusUrl: "http://localhost:4000",
+          skillCatalog: {
+            trustedKeys: [
+              {
+                id: "root-key",
+                algorithm: "ed25519",
+                publicKeySpkiDer: "not base64!",
+              },
+            ],
+          },
+        }),
+      ),
     ).toThrow("Invalid grove.json");
   });
 });
@@ -171,6 +262,30 @@ describe("writeGroveConfig", () => {
     expect(parsed.mode).toBe("nexus");
     expect(parsed.nexusUrl).toBe("http://nexus:4000");
     expect(parsed.preset).toBe("swarm-ops");
+  });
+
+  test("round-trips skill catalog config", () => {
+    const original: GroveConfig = {
+      name: "nexus-grove",
+      mode: "nexus",
+      nexusUrl: "http://nexus:4000",
+      skillCatalog: {
+        policy: "required",
+        trustedKeys: [
+          {
+            id: "root-key",
+            algorithm: "ed25519",
+            publicKeySpkiDer: "MCowBQYDK2VwAyEA0000000000000000000000000000000000000000000=",
+          },
+        ],
+        cacheTtlSeconds: 120,
+      },
+    };
+
+    writeGroveConfig(original, tmpPath);
+
+    const parsed = parseGroveConfig(readFileSync(tmpPath, "utf-8"));
+    expect(parsed.skillCatalog).toEqual(original.skillCatalog);
   });
 
   test("omits undefined optional fields", () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -5,6 +5,7 @@
  * grove configuration file that lives alongside the SQLite database.
  */
 
+import { Buffer } from "node:buffer";
 import { writeFileSync } from "node:fs";
 import { z } from "zod";
 
@@ -24,6 +25,23 @@ export interface GroveServices {
 
 /** Backend mode: local SQLite, nexus cluster, or remote HTTP. */
 export type GroveMode = "local" | "nexus" | "remote";
+
+/** Trust policy for signed skill catalog verification. */
+export type SkillCatalogPolicy = "warn-and-fallback" | "required";
+
+/** Trusted public key for verifying signed skill catalog indexes. */
+export interface SkillCatalogTrustedKey {
+  readonly id: string;
+  readonly algorithm: "ed25519";
+  readonly publicKeySpkiDer: string;
+}
+
+/** Signed skill catalog configuration. */
+export interface SkillCatalogConfig {
+  readonly policy: SkillCatalogPolicy;
+  readonly trustedKeys: readonly SkillCatalogTrustedKey[];
+  readonly cacheTtlSeconds?: number | undefined;
+}
 
 /** Typed grove.json configuration. */
 export interface GroveConfig {
@@ -45,6 +63,7 @@ export interface GroveConfig {
    * tag. Defaults to "edge". Only used when nexusManaged is true.
    */
   readonly nexusChannel?: string | undefined;
+  readonly skillCatalog?: SkillCatalogConfig | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -63,6 +82,39 @@ const ServicesSchema = z
 /** Backend mode: local SQLite, nexus cluster, or remote HTTP. */
 const ModeSchema = z.enum(["local", "nexus", "remote"]).default("local");
 
+const CanonicalBase64Pattern = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+function isCanonicalBase64(value: string): boolean {
+  if (!CanonicalBase64Pattern.test(value)) {
+    return false;
+  }
+  return Buffer.from(value, "base64").toString("base64") === value;
+}
+
+const SkillCatalogPolicySchema = z
+  .enum(["warn-and-fallback", "required"])
+  .default("warn-and-fallback");
+
+const SkillCatalogTrustedKeySchema: z.ZodType<SkillCatalogTrustedKey> = z
+  .object({
+    id: z.string().min(1).max(128),
+    algorithm: z.literal("ed25519"),
+    publicKeySpkiDer: z
+      .string()
+      .min(1)
+      .max(4096)
+      .refine(isCanonicalBase64, "publicKeySpkiDer must be canonical base64"),
+  })
+  .strict();
+
+const SkillCatalogConfigSchema: z.ZodType<SkillCatalogConfig> = z
+  .object({
+    policy: SkillCatalogPolicySchema,
+    trustedKeys: z.array(SkillCatalogTrustedKeySchema).max(20).default([]),
+    cacheTtlSeconds: z.number().int().min(1).max(31_536_000).optional(),
+  })
+  .strict();
+
 /** Full grove.json configuration schema. */
 export const GroveConfigSchema: z.ZodType<GroveConfig> = z
   .object({
@@ -75,6 +127,7 @@ export const GroveConfigSchema: z.ZodType<GroveConfig> = z
     backend: z.string().min(1).max(64).optional(),
     nexusManaged: z.boolean().optional(),
     nexusChannel: z.string().min(1).max(64).optional(),
+    skillCatalog: SkillCatalogConfigSchema.optional(),
   })
   .strict()
   .superRefine((config, ctx) => {
@@ -139,6 +192,7 @@ export function writeGroveConfig(config: GroveConfig, path: string): void {
   if (config.backend !== undefined) obj.backend = config.backend;
   if (config.nexusManaged !== undefined) obj.nexusManaged = config.nexusManaged;
   if (config.nexusChannel !== undefined) obj.nexusChannel = config.nexusChannel;
+  if (config.skillCatalog !== undefined) obj.skillCatalog = config.skillCatalog;
 
   writeFileSync(path, `${JSON.stringify(obj, null, 2)}\n`, "utf-8");
 }

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { GroveContract } from "./contract.js";
@@ -54,6 +54,44 @@ function makeContract(overrides?: Partial<GroveContract>): GroveContract {
     },
     ...overrides,
   };
+}
+
+function writeNexusGroveConfig(
+  groveDir: string,
+  opts: { readonly policy: "required" | "warn-and-fallback"; readonly nexusUrl: string },
+): void {
+  mkdirSync(groveDir, { recursive: true });
+  writeFileSync(
+    join(groveDir, "grove.json"),
+    `${JSON.stringify(
+      {
+        name: "test",
+        mode: "nexus",
+        nexusUrl: opts.nexusUrl,
+        skillCatalog: {
+          policy: opts.policy,
+          trustedKeys: [
+            {
+              id: "test-key",
+              algorithm: "ed25519",
+              publicKeySpkiDer: "AA==",
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
 }
 
 /** Make an orchestrator that uses allow-fallback policy so /tmp tests pass. */
@@ -1117,6 +1155,112 @@ describe("SessionOrchestrator — workspace isolation policy", () => {
       } catch {
         // best-effort
       }
+    }
+  });
+
+  test("allow-fallback worktree failure fails closed when required Nexus skill catalog applies", async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), "grove-so-required-prebootstrap-"));
+    const previousNexusUrl = process.env.GROVE_NEXUS_URL;
+    process.env.GROVE_NEXUS_URL = "";
+
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    try {
+      writeNexusGroveConfig(join(projectRoot, ".grove"), {
+        policy: "required",
+        nexusUrl: "http://127.0.0.1:1",
+      });
+
+      const contract = makeContract({
+        topology: {
+          structure: "flat",
+          roles: [
+            {
+              name: "worker",
+              description: "Do the work",
+              command: "echo worker",
+              skills: ["grove"],
+            },
+          ],
+        },
+      });
+      const topology = contract.topology;
+      if (!topology) {
+        throw new Error("test contract must include topology");
+      }
+
+      const orchestrator = new SessionOrchestrator({
+        goal: "Test required skill catalog pre-bootstrap",
+        contract,
+        topology,
+        runtime,
+        eventBus: bus,
+        projectRoot,
+        repos: [{ kind: "local", path: projectRoot }],
+        workspaceBaseDir: join(projectRoot, ".grove", "workspaces"),
+        workspaceIsolationPolicy: "allow-fallback",
+        sessionId: "requiredprebootstrap123",
+      });
+
+      await expect(orchestrator.start()).rejects.toThrow("Nexus skill catalog required");
+      expect(runtime.spawnCalls).toHaveLength(0);
+    } finally {
+      bus.close();
+      restoreEnv("GROVE_NEXUS_URL", previousNexusUrl);
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("allow-fallback still fails closed when required Nexus skill catalog is unreachable", async () => {
+    const bareRepo = makeFixtureBareRepo();
+    const previousNexusUrl = process.env.GROVE_NEXUS_URL;
+    process.env.GROVE_NEXUS_URL = "";
+
+    try {
+      writeNexusGroveConfig(join(bareRepo, ".grove"), {
+        policy: "required",
+        nexusUrl: "http://127.0.0.1:1",
+      });
+
+      const runtime = new MockRuntime();
+      const bus = new LocalEventBus();
+      const contract = makeContract({
+        topology: {
+          structure: "flat",
+          roles: [
+            {
+              name: "worker",
+              description: "Do the work",
+              command: "echo worker",
+              skills: ["grove"],
+            },
+          ],
+        },
+      });
+      const topology = contract.topology;
+      if (!topology) {
+        throw new Error("test contract must include topology");
+      }
+
+      const orchestrator = new SessionOrchestrator({
+        goal: "Test required skill catalog",
+        contract,
+        topology,
+        runtime,
+        eventBus: bus,
+        projectRoot: bareRepo,
+        repos: [{ kind: "local", path: bareRepo }],
+        workspaceBaseDir: join(tmpdir(), `grove-so-ws-${Date.now()}`),
+        workspaceIsolationPolicy: "allow-fallback",
+        sessionId: "requiredcatalog123456",
+      });
+
+      await expect(orchestrator.start()).rejects.toThrow("Nexus skill catalog required");
+      expect(runtime.spawnCalls).toHaveLength(0);
+      bus.close();
+    } finally {
+      restoreEnv("GROVE_NEXUS_URL", previousNexusUrl);
+      rmSync(bareRepo, { recursive: true, force: true });
     }
   });
 

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { execSync } from "node:child_process";
+import { generateKeyPairSync, type KeyObject, sign } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { hash } from "blake3";
+import { MockNexusClient } from "../nexus/mock-client.js";
+import { writeSkillCatalogToNexusForTest } from "../nexus/nexus-skill-catalog.js";
+import { createStoredZip } from "../shared/zip.js";
 import type { GroveContract } from "./contract.js";
 import { LocalEventBus } from "./local-event-bus.js";
 import { LoopStopStatus } from "./loop-runner.js";
@@ -12,8 +17,11 @@ import {
   ROUTING_SIGNATURE_CONTEXT_KEY,
 } from "./routing-provenance.js";
 import { SessionOrchestrator } from "./session-orchestrator.js";
+import { canonicalJson } from "./skill-catalog.js";
 import { makeContribution } from "./test-helpers.js";
 import type { AgentTopology } from "./topology.js";
+
+const encoder = new TextEncoder();
 
 /**
  * Create a temporary bare clone with a seeded initial commit.
@@ -29,6 +37,15 @@ function makeFixtureBareRepo(): string {
   execSync("git commit --allow-empty -m init", { cwd: scratch, stdio: "pipe" });
   execSync("git push origin main", { cwd: scratch, stdio: "pipe" });
   rmSync(scratch, { recursive: true, force: true });
+  return dir;
+}
+
+function makeFixtureLocalRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "grove-so-local-"));
+  execSync("git -c init.defaultBranch=main init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "t@t"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "t"', { cwd: dir, stdio: "pipe" });
+  execSync("git commit --allow-empty -m init", { cwd: dir, stdio: "pipe" });
   return dir;
 }
 
@@ -59,7 +76,15 @@ function makeContract(overrides?: Partial<GroveContract>): GroveContract {
 
 function writeNexusGroveConfig(
   groveDir: string,
-  opts: { readonly policy: "required" | "warn-and-fallback"; readonly nexusUrl: string },
+  opts: {
+    readonly policy: "required" | "warn-and-fallback";
+    readonly nexusUrl?: string | undefined;
+    readonly nexusManaged?: boolean | undefined;
+    readonly trustedKey?: {
+      readonly id: string;
+      readonly publicKeySpkiDer: string;
+    };
+  },
 ): void {
   mkdirSync(groveDir, { recursive: true });
   writeFileSync(
@@ -68,14 +93,15 @@ function writeNexusGroveConfig(
       {
         name: "test",
         mode: "nexus",
-        nexusUrl: opts.nexusUrl,
+        ...(opts.nexusUrl !== undefined ? { nexusUrl: opts.nexusUrl } : {}),
+        ...(opts.nexusManaged === true ? { nexusManaged: true } : {}),
         skillCatalog: {
           policy: opts.policy,
           trustedKeys: [
             {
-              id: "test-key",
+              id: opts.trustedKey?.id ?? "test-key",
               algorithm: "ed25519",
-              publicKeySpkiDer: "AA==",
+              publicKeySpkiDer: opts.trustedKey?.publicKeySpkiDer ?? "AA==",
             },
           ],
         },
@@ -85,6 +111,85 @@ function writeNexusGroveConfig(
     )}\n`,
     "utf-8",
   );
+}
+
+function signingFixture(): {
+  readonly keyId: string;
+  readonly publicKeySpkiDer: string;
+  readonly privateKey: KeyObject;
+} {
+  const pair = generateKeyPairSync("ed25519");
+  return {
+    keyId: "root-key",
+    publicKeySpkiDer: Buffer.from(pair.publicKey.export({ format: "der", type: "spki" })).toString(
+      "base64",
+    ),
+    privateKey: pair.privateKey,
+  };
+}
+
+async function seedNexusSkill(opts: {
+  readonly client: MockNexusClient;
+  readonly zoneId: string;
+  readonly privateKey: KeyObject;
+  readonly keyId: string;
+}): Promise<void> {
+  const bundle = createStoredZip([
+    {
+      path: "SKILL.md",
+      bytes: encoder.encode("nexus-skill"),
+    },
+  ]);
+  const bundleHash = `blake3:${hash(bundle).toString("hex")}`;
+  const indexBytes = encoder.encode(
+    canonicalJson({
+      schemaVersion: 1,
+      generatedAt: "2026-05-07T00:00:00Z",
+      skills: {
+        grove: { version: "1", bundleHash, sizeBytes: bundle.byteLength },
+      },
+    }),
+  );
+  const signature = {
+    schemaVersion: 1,
+    keyId: opts.keyId,
+    algorithm: "ed25519" as const,
+    signature: sign(null, indexBytes, opts.privateKey).toString("base64"),
+  };
+  await writeSkillCatalogToNexusForTest({
+    client: opts.client,
+    zoneId: opts.zoneId,
+    indexBytes,
+    signatureBytes: encoder.encode(JSON.stringify(signature)),
+    bundleHash,
+    bundleBytes: bundle,
+  });
+}
+
+function serveMockNexusReadApi(client: MockNexusClient): ReturnType<typeof Bun.serve> {
+  return Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname !== "/api/v2/files/read") {
+        return new Response("not found", { status: 404 });
+      }
+      const path = url.searchParams.get("path");
+      if (path === null) {
+        return new Response("missing path", { status: 400 });
+      }
+      const content = await client.read(path);
+      if (content === undefined) {
+        return new Response("not found", { status: 404 });
+      }
+      return Response.json({
+        content: Buffer.from(content).toString("base64"),
+        content_id: "test-etag",
+        version: 1,
+        size: content.byteLength,
+      });
+    },
+  });
 }
 
 function restoreEnv(name: string, value: string | undefined): void {
@@ -1405,6 +1510,79 @@ describe("SessionOrchestrator — workspace isolation policy", () => {
       bus.close();
       restoreEnv("GROVE_NEXUS_URL", previousNexusUrl);
       rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("required Nexus skill catalog uses managed nexus.yaml URL", async () => {
+    const repo = makeFixtureLocalRepo();
+    const previousNexusUrl = process.env.GROVE_NEXUS_URL;
+    process.env.GROVE_NEXUS_URL = "";
+
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    const server = serveMockNexusReadApi(client);
+    try {
+      await seedNexusSkill({
+        client,
+        zoneId: "default",
+        privateKey: keys.privateKey,
+        keyId: keys.keyId,
+      });
+      writeNexusGroveConfig(join(repo, ".grove"), {
+        policy: "required",
+        nexusManaged: true,
+        trustedKey: {
+          id: keys.keyId,
+          publicKeySpkiDer: keys.publicKeySpkiDer,
+        },
+      });
+      writeFileSync(join(repo, "nexus.yaml"), `ports:\n  http: ${server.port}\n`, "utf-8");
+
+      const runtime = new MockRuntime();
+      const bus = new LocalEventBus();
+      const contract = makeContract({
+        topology: {
+          structure: "flat",
+          roles: [
+            {
+              name: "worker",
+              description: "Do the work",
+              command: "echo worker",
+              skills: ["grove"],
+            },
+          ],
+        },
+      });
+      const topology = contract.topology;
+      if (!topology) {
+        throw new Error("test contract must include topology");
+      }
+
+      const orchestrator = new SessionOrchestrator({
+        goal: "Test managed Nexus skill catalog",
+        contract,
+        topology,
+        runtime,
+        eventBus: bus,
+        projectRoot: repo,
+        repos: [{ kind: "local", path: repo }],
+        workspaceBaseDir: join(tmpdir(), `grove-so-ws-${Date.now()}`),
+        workspaceIsolationPolicy: "strict",
+        sessionId: "managedskillcatalog1",
+      });
+
+      const status = await orchestrator.start();
+
+      expect(status.agents).toHaveLength(1);
+      expect(runtime.spawnCalls).toHaveLength(1);
+      expect(runtime.spawnCalls[0]?.config.mcpServers?.[0]?.env?.GROVE_NEXUS_URL).toBe(
+        `http://localhost:${server.port}`,
+      );
+      bus.close();
+    } finally {
+      server.stop(true);
+      restoreEnv("GROVE_NEXUS_URL", previousNexusUrl);
+      rmSync(repo, { recursive: true, force: true });
     }
   });
 

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -6,11 +6,15 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AcpxTurn } from "../acp/types.js";
 import { watchTurnError } from "../acp/watch-turn.js";
+import { NexusHttpClient } from "../nexus/nexus-http-client.js";
+import { resolveNexusSkillCatalogRoot } from "../nexus/nexus-skill-catalog.js";
 import type { AgentProfile } from "./agent-profile.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
+import { parseGroveConfig } from "./config.js";
 import type { GroveContract } from "./contract.js";
 import type { EventBus, GroveEvent } from "./event-bus.js";
 import { type ResolvedRepo, type ResolveRepoOptions, resolveRepo } from "./repo-cache.js";
@@ -20,7 +24,7 @@ import { hasValidRoutingSignature } from "./routing-provenance.js";
 import type { AgentPlatformType, AgentRole, AgentTopology } from "./topology.js";
 import { resolveRoleWorkspaceStrategies, topologicalSortRoles } from "./topology.js";
 import { TopologyRouter } from "./topology-router.js";
-import { bootstrapWorkspace } from "./workspace-bootstrap.js";
+import { bootstrapWorkspace, type SkillCatalogResolver } from "./workspace-bootstrap.js";
 import {
   type ProvisionedWorkspace,
   provisionWorkspace,
@@ -164,6 +168,39 @@ export class SessionOrchestrator {
    */
   private watchTurn(role: string, turn: AcpxTurn): void {
     watchTurnError(turn, `SessionOrchestrator agent='${role}'`);
+  }
+
+  private createSkillCatalogResolver(): SkillCatalogResolver | undefined {
+    const nexusUrl = process.env.GROVE_NEXUS_URL;
+    if (!nexusUrl) return undefined;
+    const groveDir = join(this.config.projectRoot, ".grove");
+    const configPath = join(groveDir, "grove.json");
+    if (!existsSync(configPath)) return undefined;
+    const config = parseGroveConfig(readFileSync(configPath, "utf-8"));
+    const skillCatalog = config.skillCatalog;
+    if (config.mode !== "nexus" || skillCatalog === undefined) return undefined;
+
+    const client = new NexusHttpClient({
+      url: nexusUrl,
+      apiKey: process.env.NEXUS_API_KEY || undefined,
+    });
+    const zoneId = process.env.GROVE_ZONE_ID ?? "default";
+    const cacheRoot = join(groveDir, "cache", "skills");
+    const bundledRoot = resolveBundledSkillsRoot(this.config.projectRoot);
+    const overrideRoot = join(groveDir, "skills");
+
+    return async (skills) => {
+      const result = await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId,
+        cacheRoot,
+        skills,
+        policy: skillCatalog.policy,
+        trustedKeys: skillCatalog.trustedKeys,
+        localFallbackRoots: [overrideRoot, bundledRoot],
+      });
+      return { root: result.root, warnings: result.warnings };
+    };
   }
 
   /** Start the session: spawn all agents and send goals. */
@@ -529,6 +566,7 @@ export class SessionOrchestrator {
 
     // Step 2: Bootstrap (write .mcp.json + CLAUDE.md)
     try {
+      const skillCatalogResolver = this.createSkillCatalogResolver();
       await bootstrapWorkspace({
         workspacePath: provisioned.path,
         roleId: role.name,
@@ -542,6 +580,7 @@ export class SessionOrchestrator {
         skills: role.skills,
         bundledSkillsRoot: resolveBundledSkillsRoot(this.config.projectRoot),
         workspaceOverrideRoot: join(this.config.projectRoot, ".grove", "skills"),
+        skillCatalogResolver,
       });
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -15,6 +15,7 @@ import {
   resolveNexusSkillCatalogRoot,
   type SkillResolutionWarning,
 } from "../nexus/nexus-skill-catalog.js";
+import { resolveConfiguredNexusUrl } from "../shared/nexus-url.js";
 import type { AgentProfile } from "./agent-profile.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
 import { type GroveConfig, parseGroveConfig } from "./config.js";
@@ -174,6 +175,7 @@ export class SessionOrchestrator {
   private readonly doneRoles = new Set<string>();
   private startedAt = 0;
   private readonly seenCids = new Set<string>();
+  private resolvedNexusUrl: string | undefined;
   private contributionPollTimer: ReturnType<typeof setInterval> | null = null;
   private contributionPollStartTimer: ReturnType<typeof setTimeout> | null = null;
   private resolvedRepos: readonly ResolvedRepo[] = [];
@@ -207,7 +209,13 @@ export class SessionOrchestrator {
   }
 
   private resolveNexusUrl(config: GroveConfig | undefined): string | undefined {
-    return process.env.GROVE_NEXUS_URL || config?.nexusUrl;
+    const nexusUrl = resolveConfiguredNexusUrl({
+      projectRoot: this.config.projectRoot,
+      config,
+      env: process.env,
+    });
+    this.resolvedNexusUrl = nexusUrl;
+    return nexusUrl;
   }
 
   private reportSkillCatalogWarnings(warnings: readonly SkillResolutionWarning[]): void {
@@ -613,7 +621,8 @@ export class SessionOrchestrator {
       GROVE_AGENT_ROLE: roleName,
       GROVE_SESSION_ID: this.sessionId,
     };
-    if (process.env.GROVE_NEXUS_URL) env.GROVE_NEXUS_URL = process.env.GROVE_NEXUS_URL;
+    const nexusUrl = process.env.GROVE_NEXUS_URL || this.resolvedNexusUrl;
+    if (nexusUrl) env.GROVE_NEXUS_URL = nexusUrl;
     if (process.env.NEXUS_API_KEY) env.NEXUS_API_KEY = process.env.NEXUS_API_KEY;
     return {
       name: "grove",

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -11,10 +11,13 @@ import { join } from "node:path";
 import type { AcpxTurn } from "../acp/types.js";
 import { watchTurnError } from "../acp/watch-turn.js";
 import { NexusHttpClient } from "../nexus/nexus-http-client.js";
-import { resolveNexusSkillCatalogRoot } from "../nexus/nexus-skill-catalog.js";
+import {
+  resolveNexusSkillCatalogRoot,
+  type SkillResolutionWarning,
+} from "../nexus/nexus-skill-catalog.js";
 import type { AgentProfile } from "./agent-profile.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
-import { parseGroveConfig } from "./config.js";
+import { type GroveConfig, parseGroveConfig } from "./config.js";
 import type { GroveContract } from "./contract.js";
 import type { EventBus, GroveEvent } from "./event-bus.js";
 import { type ResolvedRepo, type ResolveRepoOptions, resolveRepo } from "./repo-cache.js";
@@ -35,6 +38,28 @@ import {
 export type { WorkspaceIsolationPolicy, WorkspaceMode };
 
 const CONTRIBUTION_POLL_LIMIT = 200;
+
+class RequiredSkillCatalogResolutionError extends Error {
+  constructor(message: string, cause: unknown) {
+    super(message, { cause });
+    this.name = "RequiredSkillCatalogResolutionError";
+  }
+}
+
+function isRequiredSkillCatalogResolutionError(
+  error: unknown,
+): error is RequiredSkillCatalogResolutionError {
+  return error instanceof RequiredSkillCatalogResolutionError;
+}
+
+function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatSkillCatalogWarning(warning: SkillResolutionWarning): string {
+  const fallback = warning.fallbackSource ? ` fallback: ${warning.fallbackSource};` : "";
+  return `Nexus skill catalog warning for '${warning.skillName}': attempted ${warning.attemptedSource};${fallback} ${warning.reason}`;
+}
 
 /** Configuration for starting a session. */
 export interface SessionConfig {
@@ -170,15 +195,40 @@ export class SessionOrchestrator {
     watchTurnError(turn, `SessionOrchestrator agent='${role}'`);
   }
 
-  private createSkillCatalogResolver(): SkillCatalogResolver | undefined {
-    const nexusUrl = process.env.GROVE_NEXUS_URL;
-    if (!nexusUrl) return undefined;
+  private readGroveConfig(): GroveConfig | undefined {
     const groveDir = join(this.config.projectRoot, ".grove");
     const configPath = join(groveDir, "grove.json");
     if (!existsSync(configPath)) return undefined;
-    const config = parseGroveConfig(readFileSync(configPath, "utf-8"));
+    return parseGroveConfig(readFileSync(configPath, "utf-8"));
+  }
+
+  private resolveNexusUrl(config: GroveConfig | undefined): string | undefined {
+    return process.env.GROVE_NEXUS_URL || config?.nexusUrl;
+  }
+
+  private reportSkillCatalogWarnings(warnings: readonly SkillResolutionWarning[]): void {
+    for (const warning of warnings) {
+      process.stderr.write(`[SessionOrchestrator] ${formatSkillCatalogWarning(warning)}\n`);
+    }
+  }
+
+  private createSkillCatalogResolver(
+    config: GroveConfig | undefined,
+    nexusUrl: string | undefined,
+  ): SkillCatalogResolver | undefined {
+    if (config === undefined) return undefined;
+    const groveDir = join(this.config.projectRoot, ".grove");
     const skillCatalog = config.skillCatalog;
     if (config.mode !== "nexus" || skillCatalog === undefined) return undefined;
+    if (!nexusUrl) {
+      if (skillCatalog.policy !== "required") return undefined;
+      return async () => {
+        throw new RequiredSkillCatalogResolutionError(
+          "Nexus skill catalog required but no Nexus URL is configured",
+          undefined,
+        );
+      };
+    }
 
     const client = new NexusHttpClient({
       url: nexusUrl,
@@ -190,17 +240,41 @@ export class SessionOrchestrator {
     const overrideRoot = join(groveDir, "skills");
 
     return async (skills) => {
-      const result = await resolveNexusSkillCatalogRoot({
-        client,
-        zoneId,
-        cacheRoot,
-        skills,
-        policy: skillCatalog.policy,
-        trustedKeys: skillCatalog.trustedKeys,
-        localFallbackRoots: [overrideRoot, bundledRoot],
-      });
-      return { root: result.root, warnings: result.warnings };
+      try {
+        const result = await resolveNexusSkillCatalogRoot({
+          client,
+          zoneId,
+          cacheRoot,
+          skills,
+          policy: skillCatalog.policy,
+          trustedKeys: skillCatalog.trustedKeys,
+          localFallbackRoots: [overrideRoot, bundledRoot],
+        });
+        this.reportSkillCatalogWarnings(result.warnings);
+        return { root: result.root, warnings: result.warnings };
+      } catch (error) {
+        if (skillCatalog.policy === "required") {
+          throw new RequiredSkillCatalogResolutionError(
+            `Nexus skill catalog required but resolution failed: ${messageFromError(error)}`,
+            error,
+          );
+        }
+        throw error;
+      }
     };
+  }
+
+  private failIfRequiredSkillCatalogWouldBeSkipped(role: AgentRole, reason: string): void {
+    if (!role.skills || role.skills.length === 0) return;
+
+    const config = this.readGroveConfig();
+    const skillCatalog = config?.skillCatalog;
+    if (config?.mode !== "nexus" || skillCatalog?.policy !== "required") return;
+
+    throw new RequiredSkillCatalogResolutionError(
+      `Nexus skill catalog required but workspace provisioning failed for role '${role.name}' before skills could be resolved: ${reason}`,
+      undefined,
+    );
   }
 
   /** Start the session: spawn all agents and send goals. */
@@ -554,6 +628,7 @@ export class SessionOrchestrator {
       if (policy === "strict") {
         throw new Error(`Workspace provisioning failed for role '${role.name}': ${reason}`);
       }
+      this.failIfRequiredSkillCatalogWouldBeSkipped(role, reason);
       return {
         cwd: this.config.projectRoot,
         workspaceMode: {
@@ -566,7 +641,9 @@ export class SessionOrchestrator {
 
     // Step 2: Bootstrap (write .mcp.json + CLAUDE.md)
     try {
-      const skillCatalogResolver = this.createSkillCatalogResolver();
+      const groveConfig = this.readGroveConfig();
+      const nexusUrl = this.resolveNexusUrl(groveConfig);
+      const skillCatalogResolver = this.createSkillCatalogResolver(groveConfig, nexusUrl);
       await bootstrapWorkspace({
         workspacePath: provisioned.path,
         roleId: role.name,
@@ -575,7 +652,7 @@ export class SessionOrchestrator {
         roleDescription: role.description,
         groveDir: join(this.config.projectRoot, ".grove"),
         mcpServePath: resolveMcpServePath(this.config.projectRoot),
-        nexusUrl: process.env.GROVE_NEXUS_URL,
+        nexusUrl,
         nexusApiKey: process.env.NEXUS_API_KEY,
         skills: role.skills,
         bundledSkillsRoot: resolveBundledSkillsRoot(this.config.projectRoot),
@@ -584,7 +661,7 @@ export class SessionOrchestrator {
       });
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
-      if (policy === "strict") {
+      if (policy === "strict" || isRequiredSkillCatalogResolutionError(err)) {
         throw new Error(`Bootstrap failed for role '${role.name}': ${reason}`);
       }
       return {

--- a/src/core/skill-catalog.test.ts
+++ b/src/core/skill-catalog.test.ts
@@ -1,0 +1,371 @@
+import { describe, expect, test } from "bun:test";
+import { generateKeyPairSync, type KeyObject, sign } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hash } from "blake3";
+import { createStoredZip } from "../shared/zip.js";
+import {
+  canonicalJson,
+  parseSkillCatalogIndex,
+  parseSkillCatalogSignature,
+  SkillBundleIntegrityError,
+  SkillCatalogTrustError,
+  SkillCatalogUnavailableError,
+  unpackSkillBundle,
+  verifyBundleHash,
+  verifyCatalogSignature,
+} from "./skill-catalog.js";
+
+const encoder = new TextEncoder();
+
+function keyPair(): {
+  readonly publicKeySpkiDer: string;
+  readonly privateKey: KeyObject;
+} {
+  const pair = generateKeyPairSync("ed25519");
+  const publicKeySpkiDer = Buffer.from(
+    pair.publicKey.export({ format: "der", type: "spki" }),
+  ).toString("base64");
+  return { publicKeySpkiDer, privateKey: pair.privateKey };
+}
+
+function signedIndex(): {
+  readonly indexBytes: Uint8Array;
+  readonly signature: {
+    readonly schemaVersion: 1;
+    readonly keyId: string;
+    readonly algorithm: "ed25519";
+    readonly signature: string;
+  };
+  readonly trustedKey: {
+    readonly id: string;
+    readonly algorithm: "ed25519";
+    readonly publicKeySpkiDer: string;
+  };
+} {
+  const keys = keyPair();
+  const index = {
+    schemaVersion: 1,
+    generatedAt: "2026-05-07T00:00:00Z",
+    skills: {
+      grove: {
+        version: "2026.05.07",
+        bundleHash: "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+        sizeBytes: 10,
+      },
+    },
+  };
+  const indexBytes = encoder.encode(canonicalJson(index));
+  return {
+    indexBytes,
+    signature: {
+      schemaVersion: 1,
+      keyId: "root-key",
+      algorithm: "ed25519",
+      signature: sign(null, indexBytes, keys.privateKey).toString("base64"),
+    },
+    trustedKey: {
+      id: "root-key",
+      algorithm: "ed25519",
+      publicKeySpkiDer: keys.publicKeySpkiDer,
+    },
+  };
+}
+
+describe("canonicalJson", () => {
+  test("sorts object keys recursively", () => {
+    expect(canonicalJson({ z: 1, a: { y: 2, b: 3 } })).toBe('{"a":{"b":3,"y":2},"z":1}');
+  });
+
+  test("sorts objects inside arrays and rejects undefined roots", () => {
+    expect(canonicalJson([{ z: 1, a: 2 }])).toBe('[{"a":2,"z":1}]');
+    expect(() => canonicalJson(undefined)).toThrow(TypeError);
+  });
+
+  test("sorts numeric-looking object keys lexicographically", () => {
+    expect(canonicalJson({ "10": "a", "2": "b" })).toBe('{"10":"a","2":"b"}');
+  });
+
+  test("rejects non-JSON-compatible values", () => {
+    expect(() => canonicalJson({ value: Number.NaN })).toThrow(TypeError);
+    expect(() => canonicalJson({ value: Number.POSITIVE_INFINITY })).toThrow(TypeError);
+    expect(() => canonicalJson({ value: undefined })).toThrow(TypeError);
+    expect(() => canonicalJson({ value: () => "nope" })).toThrow(TypeError);
+    expect(() => canonicalJson({ value: Symbol("nope") })).toThrow(TypeError);
+    expect(() => canonicalJson(new Date("2026-05-07T00:00:00Z"))).toThrow(TypeError);
+  });
+});
+
+describe("skill catalog errors", () => {
+  test("set stable names", () => {
+    expect(new SkillCatalogTrustError("trust").name).toBe("SkillCatalogTrustError");
+    expect(new SkillCatalogUnavailableError("unavailable").name).toBe(
+      "SkillCatalogUnavailableError",
+    );
+    expect(new SkillBundleIntegrityError("integrity").name).toBe("SkillBundleIntegrityError");
+  });
+});
+
+describe("skill catalog signature verification", () => {
+  test("accepts a matching ed25519 signature", () => {
+    const fixture = signedIndex();
+    expect(
+      verifyCatalogSignature({
+        indexBytes: fixture.indexBytes,
+        signature: fixture.signature,
+        trustedKeys: [fixture.trustedKey],
+      }),
+    ).toEqual({ keyId: "root-key" });
+  });
+
+  test("rejects unknown key ids and bad signatures", () => {
+    const fixture = signedIndex();
+    expect(() =>
+      verifyCatalogSignature({
+        indexBytes: fixture.indexBytes,
+        signature: { ...fixture.signature, keyId: "other-key" },
+        trustedKeys: [fixture.trustedKey],
+      }),
+    ).toThrow(SkillCatalogTrustError);
+
+    const changed = encoder.encode(`${new TextDecoder().decode(fixture.indexBytes)}\n`);
+    expect(() =>
+      verifyCatalogSignature({
+        indexBytes: changed,
+        signature: fixture.signature,
+        trustedKeys: [fixture.trustedKey],
+      }),
+    ).toThrow(SkillCatalogTrustError);
+  });
+
+  test("rejects malformed signature schemas and base64", () => {
+    const fixture = signedIndex();
+    expect(() =>
+      verifyCatalogSignature({
+        indexBytes: fixture.indexBytes,
+        signature: {
+          ...fixture.signature,
+          schemaVersion: 2,
+        } as unknown as typeof fixture.signature,
+        trustedKeys: [fixture.trustedKey],
+      }),
+    ).toThrow(SkillCatalogTrustError);
+
+    expect(() =>
+      verifyCatalogSignature({
+        indexBytes: fixture.indexBytes,
+        signature: { ...fixture.signature, signature: "not-base64" },
+        trustedKeys: [fixture.trustedKey],
+      }),
+    ).toThrow(SkillCatalogTrustError);
+
+    expect(() =>
+      verifyCatalogSignature({
+        indexBytes: fixture.indexBytes,
+        signature: { ...fixture.signature, signature: "AB==" },
+        trustedKeys: [fixture.trustedKey],
+      }),
+    ).toThrow("Malformed skill catalog signature");
+  });
+
+  test("rejects invalid trusted key material", () => {
+    const fixture = signedIndex();
+    expect(() =>
+      verifyCatalogSignature({
+        indexBytes: fixture.indexBytes,
+        signature: fixture.signature,
+        trustedKeys: [{ ...fixture.trustedKey, publicKeySpkiDer: "abcd" }],
+      }),
+    ).toThrow(SkillCatalogTrustError);
+  });
+
+  test("rejects trusted keys whose configured algorithm is not ed25519", () => {
+    const fixture = signedIndex();
+    expect(() =>
+      verifyCatalogSignature({
+        indexBytes: fixture.indexBytes,
+        signature: fixture.signature,
+        trustedKeys: [
+          {
+            ...fixture.trustedKey,
+            algorithm: "ed448",
+          } as unknown as typeof fixture.trustedKey,
+        ],
+      }),
+    ).toThrow(SkillCatalogTrustError);
+  });
+
+  test("rejects non-ed25519 SPKI keys even when their own signature verifies", () => {
+    const pair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const publicKeySpkiDer = Buffer.from(
+      pair.publicKey.export({ format: "der", type: "spki" }),
+    ).toString("base64");
+    const indexBytes = encoder.encode(canonicalJson({ schemaVersion: 1, skills: {} }));
+
+    expect(() =>
+      verifyCatalogSignature({
+        indexBytes,
+        signature: {
+          schemaVersion: 1,
+          keyId: "root-key",
+          algorithm: "ed25519",
+          signature: sign("sha256", indexBytes, pair.privateKey).toString("base64"),
+        },
+        trustedKeys: [
+          {
+            id: "root-key",
+            algorithm: "ed25519",
+            publicKeySpkiDer,
+          },
+        ],
+      }),
+    ).toThrow(SkillCatalogTrustError);
+  });
+});
+
+describe("skill catalog schemas and bundles", () => {
+  test("parses valid index JSON", () => {
+    const parsed = parseSkillCatalogIndex(
+      '{"generatedAt":"2026-05-07T00:00:00Z","schemaVersion":1,"skills":{"grove":{"bundleHash":"blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","sizeBytes":1,"version":"1"}}}',
+    );
+    expect(parsed.skills.grove?.version).toBe("1");
+  });
+
+  test("rejects invalid index JSON and schema", () => {
+    expect(() => parseSkillCatalogIndex("not json")).toThrow("not valid JSON");
+    expect(() =>
+      parseSkillCatalogIndex(
+        '{"generatedAt":"","schemaVersion":1,"skills":{"":{"bundleHash":"bad","sizeBytes":0,"version":""}}}',
+      ),
+    ).toThrow("Invalid skill catalog index");
+  });
+
+  test("parses and validates signature JSON", () => {
+    const fixture = signedIndex();
+    const raw = JSON.stringify(fixture.signature);
+    expect(parseSkillCatalogSignature(raw)).toEqual(fixture.signature);
+    expect(() => parseSkillCatalogSignature("not json")).toThrow("not valid JSON");
+    expect(() => parseSkillCatalogSignature('{"schemaVersion":1}')).toThrow(
+      "Invalid skill catalog signature",
+    );
+  });
+
+  test("verifies bundle hash before unpack", () => {
+    const bytes = encoder.encode("bundle");
+    const bundleHash = `blake3:${hash(bytes).toString("hex")}`;
+    expect(verifyBundleHash(bytes, bundleHash)).toBe(bundleHash);
+    expect(() =>
+      verifyBundleHash(
+        bytes,
+        "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ),
+    ).toThrow(SkillBundleIntegrityError);
+    expect(() => verifyBundleHash(bytes, "sha256:not-blake3")).toThrow(SkillBundleIntegrityError);
+  });
+
+  test("unpacks safe bundle entries and requires SKILL.md", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-skill-catalog-"));
+    try {
+      const zip = createStoredZip([
+        { path: "SKILL.md", bytes: encoder.encode("skill") },
+        { path: "references/guide.md", bytes: encoder.encode("guide") },
+      ]);
+      await unpackSkillBundle(zip, join(root, "skill"));
+      expect(readFileSync(join(root, "skill", "SKILL.md"), "utf-8")).toBe("skill");
+      expect(readFileSync(join(root, "skill", "references", "guide.md"), "utf-8")).toBe("guide");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects bundles without SKILL.md", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-skill-catalog-"));
+    try {
+      const zip = createStoredZip([{ path: "README.md", bytes: encoder.encode("readme") }]);
+      await expect(unpackSkillBundle(zip, join(root, "skill"))).rejects.toThrow(
+        SkillBundleIntegrityError,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects malformed bundle zips", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-skill-catalog-"));
+    try {
+      await expect(
+        unpackSkillBundle(encoder.encode("not a zip"), join(root, "skill")),
+      ).rejects.toThrow(SkillBundleIntegrityError);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("successful unpack replaces stale target contents", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-skill-catalog-"));
+    try {
+      const target = join(root, "skill");
+      mkdirSync(target);
+      writeFileSync(join(target, "stale.txt"), "stale");
+      const zip = createStoredZip([{ path: "SKILL.md", bytes: encoder.encode("fresh") }]);
+
+      await unpackSkillBundle(zip, target);
+
+      expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toBe("fresh");
+      expect(existsSync(join(target, "stale.txt"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("successful unpack does not follow existing symlinks inside target", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-skill-catalog-"));
+    try {
+      const target = join(root, "skill");
+      const outside = join(root, "outside.txt");
+      mkdirSync(target);
+      writeFileSync(outside, "outside");
+      symlinkSync(outside, join(target, "linked.txt"));
+      const zip = createStoredZip([
+        { path: "SKILL.md", bytes: encoder.encode("fresh") },
+        { path: "linked.txt", bytes: encoder.encode("inside") },
+      ]);
+
+      await unpackSkillBundle(zip, target);
+
+      expect(readFileSync(outside, "utf-8")).toBe("outside");
+      expect(lstatSync(join(target, "linked.txt")).isSymbolicLink()).toBe(false);
+      expect(readFileSync(join(target, "linked.txt"), "utf-8")).toBe("inside");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("invalid bundles do not alter an existing target", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-skill-catalog-"));
+    try {
+      const target = join(root, "skill");
+      mkdirSync(target);
+      writeFileSync(join(target, "SKILL.md"), "old");
+      writeFileSync(join(target, "keep.txt"), "keep");
+      const zip = createStoredZip([{ path: "README.md", bytes: encoder.encode("readme") }]);
+
+      await expect(unpackSkillBundle(zip, target)).rejects.toThrow(SkillBundleIntegrityError);
+
+      expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toBe("old");
+      expect(readFileSync(join(target, "keep.txt"), "utf-8")).toBe("keep");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/skill-catalog.ts
+++ b/src/core/skill-catalog.ts
@@ -1,0 +1,311 @@
+import { Buffer } from "node:buffer";
+import { createPublicKey, verify } from "node:crypto";
+import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+import { hash } from "blake3";
+import { z } from "zod";
+
+import { readStoredZip } from "../shared/zip.js";
+import type { SkillCatalogTrustedKey } from "./config.js";
+
+const BLAKE3_PATTERN = /^blake3:[0-9a-f]{64}$/;
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const ED25519_SIGNATURE_BYTES = 64;
+
+export class SkillCatalogTrustError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SkillCatalogTrustError";
+  }
+}
+
+export class SkillCatalogUnavailableError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SkillCatalogUnavailableError";
+  }
+}
+
+export class SkillBundleIntegrityError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SkillBundleIntegrityError";
+  }
+}
+
+interface SkillCatalogEntryData {
+  readonly version: string;
+  readonly bundleHash: string;
+  readonly sizeBytes: number;
+}
+
+interface SkillCatalogIndexData {
+  readonly schemaVersion: 1;
+  readonly generatedAt: string;
+  readonly skills: Readonly<Record<string, SkillCatalogEntryData>>;
+}
+
+interface SkillCatalogSignatureData {
+  readonly schemaVersion: 1;
+  readonly keyId: string;
+  readonly algorithm: "ed25519";
+  readonly signature: string;
+}
+
+const SkillCatalogEntrySchema: z.ZodType<SkillCatalogEntryData> = z
+  .object({
+    version: z.string().min(1).max(128),
+    bundleHash: z.string().regex(BLAKE3_PATTERN),
+    sizeBytes: z.number().int().min(1),
+  })
+  .strict();
+
+const SkillNameSchema = z.string().min(1).max(128);
+
+const SkillCatalogIndexSchema: z.ZodType<SkillCatalogIndexData> = z
+  .object({
+    schemaVersion: z.literal(1),
+    generatedAt: z.string().min(1),
+    skills: z.record(SkillNameSchema, SkillCatalogEntrySchema),
+  })
+  .strict();
+
+const SkillCatalogSignatureSchema: z.ZodType<SkillCatalogSignatureData> = z
+  .object({
+    schemaVersion: z.literal(1),
+    keyId: z.string().min(1).max(128),
+    algorithm: z.literal("ed25519"),
+    signature: z.string().min(1),
+  })
+  .strict();
+
+export type SkillCatalogEntry = z.infer<typeof SkillCatalogEntrySchema>;
+export type SkillCatalogIndex = z.infer<typeof SkillCatalogIndexSchema>;
+export type SkillCatalogSignature = z.infer<typeof SkillCatalogSignatureSchema>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function serializeJsonString(value: string): string {
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) {
+    throw new TypeError("canonicalJson requires JSON-compatible data");
+  }
+  return encoded;
+}
+
+function serializeCanonicalJson(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+
+  switch (typeof value) {
+    case "boolean":
+      return value ? "true" : "false";
+    case "number":
+      if (!Number.isFinite(value)) {
+        throw new TypeError("canonicalJson requires finite numbers");
+      }
+      {
+        const encoded = JSON.stringify(value);
+        if (encoded === undefined) {
+          throw new TypeError("canonicalJson requires JSON-compatible data");
+        }
+        return encoded;
+      }
+    case "string":
+      return serializeJsonString(value);
+    case "undefined":
+    case "function":
+    case "symbol":
+    case "bigint":
+      throw new TypeError("canonicalJson requires JSON-compatible data");
+  }
+
+  if (Array.isArray(value)) {
+    const entries: string[] = [];
+    for (let index = 0; index < value.length; index++) {
+      if (!(index in value)) {
+        throw new TypeError("canonicalJson requires dense arrays");
+      }
+      entries.push(serializeCanonicalJson(value[index]));
+    }
+    return `[${entries.join(",")}]`;
+  }
+
+  if (!isRecord(value)) {
+    throw new TypeError("canonicalJson requires JSON-compatible objects");
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError("canonicalJson requires plain objects");
+  }
+
+  const entries: string[] = [];
+  for (const key of Object.keys(value).sort()) {
+    entries.push(`${serializeJsonString(key)}:${serializeCanonicalJson(value[key])}`);
+  }
+  return `{${entries.join(",")}}`;
+}
+
+export function canonicalJson(value: unknown): string {
+  return serializeCanonicalJson(value);
+}
+
+export function parseSkillCatalogIndex(raw: string): SkillCatalogIndex {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("skill catalog index is not valid JSON");
+  }
+
+  const result = SkillCatalogIndexSchema.safeParse(parsed);
+  if (!result.success) {
+    const messages = result.error.issues.map((issue) => {
+      const path = issue.path.length === 0 ? "<root>" : issue.path.join(".");
+      return `  - ${path}: ${issue.message}`;
+    });
+    throw new Error(`Invalid skill catalog index:\n${messages.join("\n")}`);
+  }
+  return result.data;
+}
+
+export function parseSkillCatalogSignature(raw: string): SkillCatalogSignature {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("skill catalog signature is not valid JSON");
+  }
+
+  const result = SkillCatalogSignatureSchema.safeParse(parsed);
+  if (!result.success) {
+    const messages = result.error.issues.map((issue) => {
+      const path = issue.path.length === 0 ? "<root>" : issue.path.join(".");
+      return `  - ${path}: ${issue.message}`;
+    });
+    throw new Error(`Invalid skill catalog signature:\n${messages.join("\n")}`);
+  }
+  return result.data;
+}
+
+function decodeCanonicalBase64(value: string): Buffer {
+  if (value.length === 0 || !BASE64_PATTERN.test(value)) {
+    throw new Error("value is not canonical base64");
+  }
+  const decoded = Buffer.from(value, "base64");
+  if (decoded.toString("base64") !== value) {
+    throw new Error("value is not canonical base64");
+  }
+  return decoded;
+}
+
+export function verifyCatalogSignature(opts: {
+  readonly indexBytes: Uint8Array;
+  readonly signature: SkillCatalogSignature;
+  readonly trustedKeys: readonly SkillCatalogTrustedKey[];
+}): { readonly keyId: string } {
+  const signatureResult = SkillCatalogSignatureSchema.safeParse(opts.signature);
+  if (!signatureResult.success) {
+    throw new SkillCatalogTrustError("Invalid skill catalog signature schema");
+  }
+  const signature = signatureResult.data;
+
+  const trustedKey = opts.trustedKeys.find((key) => key.id === signature.keyId);
+  if (trustedKey === undefined) {
+    throw new SkillCatalogTrustError(`Unknown skill catalog signing key: ${signature.keyId}`);
+  }
+  if (trustedKey.algorithm !== "ed25519") {
+    throw new SkillCatalogTrustError("Unsupported skill catalog trusted key algorithm");
+  }
+
+  let publicKey: ReturnType<typeof createPublicKey>;
+  try {
+    publicKey = createPublicKey({
+      key: decodeCanonicalBase64(trustedKey.publicKeySpkiDer),
+      format: "der",
+      type: "spki",
+    });
+  } catch (error) {
+    throw new SkillCatalogTrustError("Invalid skill catalog trusted key material", {
+      cause: error,
+    });
+  }
+  if (publicKey.asymmetricKeyType !== "ed25519") {
+    throw new SkillCatalogTrustError("Skill catalog trusted key is not ed25519");
+  }
+
+  let signatureBytes: Buffer;
+  try {
+    signatureBytes = decodeCanonicalBase64(signature.signature);
+  } catch (error) {
+    throw new SkillCatalogTrustError("Malformed skill catalog signature", { cause: error });
+  }
+  if (signatureBytes.length !== ED25519_SIGNATURE_BYTES) {
+    throw new SkillCatalogTrustError("Malformed skill catalog signature");
+  }
+
+  let verified: boolean;
+  try {
+    verified = verify(null, opts.indexBytes, publicKey, signatureBytes);
+  } catch (error) {
+    throw new SkillCatalogTrustError("Skill catalog signature verification failed", {
+      cause: error,
+    });
+  }
+
+  if (!verified) {
+    throw new SkillCatalogTrustError("Skill catalog signature verification failed");
+  }
+  return { keyId: signature.keyId };
+}
+
+export function verifyBundleHash(bytes: Uint8Array, expectedHash: string): string {
+  if (!BLAKE3_PATTERN.test(expectedHash)) {
+    throw new SkillBundleIntegrityError("Invalid skill bundle hash format");
+  }
+
+  const actualHash = `blake3:${hash(bytes).toString("hex")}`;
+  if (actualHash !== expectedHash) {
+    throw new SkillBundleIntegrityError("Skill bundle hash mismatch");
+  }
+  return actualHash;
+}
+
+export async function unpackSkillBundle(bytes: Uint8Array, targetDir: string): Promise<void> {
+  let entries: ReturnType<typeof readStoredZip>;
+  try {
+    entries = readStoredZip(bytes);
+  } catch (error) {
+    throw new SkillBundleIntegrityError("Invalid skill bundle ZIP", { cause: error });
+  }
+
+  if (!entries.some((entry) => entry.path === "SKILL.md")) {
+    throw new SkillBundleIntegrityError("Skill bundle is missing SKILL.md");
+  }
+
+  const parentDir = dirname(targetDir);
+  await mkdir(parentDir, { recursive: true });
+  const tempDir = await mkdtemp(join(parentDir, `.${basename(targetDir)}.tmp-`));
+  let installed = false;
+
+  try {
+    for (const entry of entries) {
+      const targetPath = join(tempDir, entry.path);
+      await mkdir(dirname(targetPath), { recursive: true });
+      await writeFile(targetPath, entry.bytes);
+    }
+
+    await rm(targetDir, { recursive: true, force: true });
+    await rename(tempDir, targetDir);
+    installed = true;
+  } finally {
+    if (!installed) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }
+}

--- a/src/core/workspace-bootstrap.test.ts
+++ b/src/core/workspace-bootstrap.test.ts
@@ -144,6 +144,71 @@ describe("bootstrapWorkspace", () => {
     rmSync(bundledRoot, { recursive: true, force: true });
   });
 
+  test("injects skills from resolver-provided catalog root before local fallback", async () => {
+    const remoteRoot = mkdtempSync(join(tmpdir(), "grove-remote-skills-"));
+    const skillDir = join(remoteRoot, "grove");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "remote-grove", "utf-8");
+
+    const bundledRoot = mkdtempSync(join(tmpdir(), "grove-bundled-"));
+    const bundledSkillDir = join(bundledRoot, "grove");
+    mkdirSync(bundledSkillDir, { recursive: true });
+    writeFileSync(join(bundledSkillDir, "SKILL.md"), "bundled-grove", "utf-8");
+
+    const overrideRoot = mkdtempSync(join(tmpdir(), "grove-override-"));
+    const overrideSkillDir = join(overrideRoot, "grove");
+    mkdirSync(overrideSkillDir, { recursive: true });
+    writeFileSync(join(overrideSkillDir, "SKILL.md"), "override-grove", "utf-8");
+
+    await bootstrapWorkspace({
+      workspacePath: workspaceDir,
+      roleId: "coder",
+      goal: "Build",
+      skills: ["grove"],
+      bundledSkillsRoot: bundledRoot,
+      workspaceOverrideRoot: overrideRoot,
+      skillCatalogResolver: async (skills) => ({
+        root: remoteRoot,
+        warnings: skills.map((skillName) => ({
+          skillName,
+          attemptedSource: "nexus",
+          fallbackSource: undefined,
+          reason: "verified",
+        })),
+      }),
+    });
+
+    expect(readFileSync(join(workspaceDir, ".claude/skills/grove/SKILL.md"), "utf-8")).toBe(
+      "remote-grove",
+    );
+
+    rmSync(remoteRoot, { recursive: true, force: true });
+    rmSync(bundledRoot, { recursive: true, force: true });
+    rmSync(overrideRoot, { recursive: true, force: true });
+  });
+
+  test("falls back to local injection when resolver returns undefined", async () => {
+    const bundledRoot = mkdtempSync(join(tmpdir(), "grove-bundled-"));
+    const skillDir = join(bundledRoot, "grove");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "bundled-grove", "utf-8");
+
+    await bootstrapWorkspace({
+      workspacePath: workspaceDir,
+      roleId: "coder",
+      goal: "Build",
+      skills: ["grove"],
+      bundledSkillsRoot: bundledRoot,
+      skillCatalogResolver: async () => undefined,
+    });
+
+    expect(readFileSync(join(workspaceDir, ".claude/skills/grove/SKILL.md"), "utf-8")).toBe(
+      "bundled-grove",
+    );
+
+    rmSync(bundledRoot, { recursive: true, force: true });
+  });
+
   test("does not create .claude/.codex dirs when role has no skills", async () => {
     await bootstrapWorkspace({
       workspacePath: workspaceDir,

--- a/src/core/workspace-bootstrap.ts
+++ b/src/core/workspace-bootstrap.ts
@@ -8,6 +8,22 @@ import { chmod, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { injectSkills } from "./skill-injector.js";
 
+export interface SkillCatalogResolverWarning {
+  readonly skillName: string;
+  readonly attemptedSource: string;
+  readonly fallbackSource?: string | undefined;
+  readonly reason: string;
+}
+
+export interface SkillCatalogResolverResult {
+  readonly root: string;
+  readonly warnings?: readonly SkillCatalogResolverWarning[] | undefined;
+}
+
+export type SkillCatalogResolver = (
+  skills: readonly string[],
+) => Promise<SkillCatalogResolverResult | undefined>;
+
 export interface BootstrapOptions {
   /** Path to the agent workspace directory. */
   workspacePath: string;
@@ -33,6 +49,8 @@ export interface BootstrapOptions {
   bundledSkillsRoot?: string | undefined;
   /** Optional absolute path to the workspace-specific override catalog. */
   workspaceOverrideRoot?: string | undefined;
+  /** Optional mode-aware resolver. When it returns a root, injection uses that root. */
+  skillCatalogResolver?: SkillCatalogResolver | undefined;
 }
 
 /**
@@ -146,16 +164,20 @@ Follow the Instructions section above exactly. You can edit files, commit, push,
   // Inject skills (optional). injectSkills applies its own 0o444 pass, so
   // the following chmod loop does not need to cover the injected tree.
   if (opts.skills && opts.skills.length > 0) {
-    if (!opts.bundledSkillsRoot) {
+    const resolved = opts.skillCatalogResolver
+      ? await opts.skillCatalogResolver(opts.skills)
+      : undefined;
+    const injectionRoot = resolved?.root ?? opts.bundledSkillsRoot;
+    if (!injectionRoot) {
       throw new Error(
-        "bootstrapWorkspace: `skills` non-empty requires `bundledSkillsRoot` — refusing to inject with no catalog.",
+        "bootstrapWorkspace: `skills` non-empty requires `bundledSkillsRoot` or `skillCatalogResolver`.",
       );
     }
     await injectSkills({
       workspacePath: workspacePath,
       skills: opts.skills,
-      bundledSkillsRoot: opts.bundledSkillsRoot,
-      workspaceOverrideRoot: opts.workspaceOverrideRoot,
+      bundledSkillsRoot: injectionRoot,
+      workspaceOverrideRoot: resolved ? undefined : opts.workspaceOverrideRoot,
     });
   }
 

--- a/src/mcp/tools/done.ts
+++ b/src/mcp/tools/done.ts
@@ -3,14 +3,12 @@
  *
  * grove_done — Signal that this agent has finished its work for the session.
  *
- * When an agent calls grove_done, it creates a contribution with kind=work
- * and context.done=true. Other agents see this via grove_log and know the
- * signaling agent is finished. The TUI watches for done signals from all
- * roles to transition to the Complete screen.
+ * When an agent calls grove_done, it creates a contribution with
+ * kind=discussion and context.done=true. The session ends as soon as that
+ * done marker is observed.
  *
  * This is the explicit stop condition for review loops where there's no
- * numeric threshold — the reviewer calls grove_done when satisfied, the
- * coder calls grove_done when it has no more work.
+ * numeric threshold — the reviewer calls grove_done when satisfied.
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -37,10 +35,8 @@ export function registerDoneTools(server: McpServer, deps: McpDeps): void {
     {
       description:
         "Signal that you have finished your work for this session. " +
-        "Call this when you have no more work to do — e.g., the reviewer " +
-        "has approved the code, or the coder has addressed all feedback. " +
-        "Other agents will see your done signal via grove_log and can " +
-        "finish their own work. When all agents signal done, the session ends.",
+        "Call this only when the whole session is ready to end — e.g., the " +
+        "reviewer has approved the code. This done signal ends the session.",
       inputSchema: doneInputSchema,
     },
     async (args) => {
@@ -49,10 +45,10 @@ export function registerDoneTools(server: McpServer, deps: McpDeps): void {
           kind: "discussion",
           summary: `[DONE] ${args.summary}`,
           // ephemeral: true routes grove_done through the same skip-handoff /
-          // skip-route-event path as ephemeral messages. A session-terminator
-          // contribution should not create routing records that wake up
-          // downstream agents with "new work" to pick up. See the routing
-          // rules table in src/core/operations/contribute.ts (isEphemeralMessageContext).
+          // keep-route-event path reserved for done markers. A session
+          // terminator should not create handoffs that wake downstream agents
+          // with new work, but event-driven completion still needs the
+          // contribution event.
           context: {
             done: true,
             reason: args.summary,

--- a/src/nexus/index.ts
+++ b/src/nexus/index.ts
@@ -33,4 +33,13 @@ export { NexusContributionStore } from "./nexus-contribution-store.js";
 export type { NexusHttpConfig } from "./nexus-http-client.js";
 export { NexusHttpClient } from "./nexus-http-client.js";
 export { NexusOutcomeStore } from "./nexus-outcome-store.js";
+export type {
+  ResolvedSkillCatalogRoot,
+  ResolveNexusSkillCatalogRootOptions,
+  SkillResolutionWarning,
+} from "./nexus-skill-catalog.js";
+export {
+  resolveNexusSkillCatalogRoot,
+  writeSkillCatalogToNexusForTest,
+} from "./nexus-skill-catalog.js";
 export { Semaphore } from "./semaphore.js";

--- a/src/nexus/nexus-skill-catalog.test.ts
+++ b/src/nexus/nexus-skill-catalog.test.ts
@@ -361,6 +361,44 @@ describe("resolveNexusSkillCatalogRoot", () => {
     }
   });
 
+  test("required policy uses verified cache when Nexus becomes unavailable", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    try {
+      await seedNexus({
+        client,
+        zoneId: "zone1",
+        privateKey: keys.privateKey,
+        keyId: keys.keyId,
+      });
+      const base = {
+        client,
+        zoneId: "zone1",
+        cacheRoot: join(root, ".grove", "cache", "skills"),
+        skills: ["grove"],
+        policy: "required" as const,
+        trustedKeys: [
+          {
+            id: keys.keyId,
+            algorithm: "ed25519" as const,
+            publicKeySpkiDer: keys.publicKeySpkiDer,
+          },
+        ],
+        localFallbackRoots: [],
+      };
+      await resolveNexusSkillCatalogRoot(base);
+      client.setFailureMode({ failNext: 10, failWith: "connection" });
+
+      const result = await resolveNexusSkillCatalogRoot(base);
+
+      expect(result.source).toBe("cache");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("nexus-skill");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("cache fallback restores missing marker from verified bundle", async () => {
     const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
     const client = new MockNexusClient();

--- a/src/nexus/nexus-skill-catalog.test.ts
+++ b/src/nexus/nexus-skill-catalog.test.ts
@@ -1,0 +1,571 @@
+import { describe, expect, test } from "bun:test";
+import { generateKeyPairSync, type KeyObject, sign } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative } from "node:path";
+import { hash } from "blake3";
+
+import { canonicalJson } from "../core/skill-catalog.js";
+import { createStoredZip } from "../shared/zip.js";
+import { MockNexusClient } from "./mock-client.js";
+import {
+  resolveNexusSkillCatalogRoot,
+  writeSkillCatalogToNexusForTest,
+} from "./nexus-skill-catalog.js";
+import { skillCatalogBundlePath } from "./vfs-paths.js";
+
+const encoder = new TextEncoder();
+
+function signingFixture(): {
+  readonly keyId: string;
+  readonly publicKeySpkiDer: string;
+  readonly privateKey: KeyObject;
+} {
+  const pair = generateKeyPairSync("ed25519");
+  return {
+    keyId: "root-key",
+    publicKeySpkiDer: Buffer.from(pair.publicKey.export({ format: "der", type: "spki" })).toString(
+      "base64",
+    ),
+    privateKey: pair.privateKey,
+  };
+}
+
+async function seedNexus(opts: {
+  readonly client: MockNexusClient;
+  readonly zoneId: string;
+  readonly privateKey: KeyObject;
+  readonly keyId: string;
+  readonly skillContent?: string;
+  readonly version?: string;
+}): Promise<{ readonly bundleHash: string }> {
+  const bundle = createStoredZip([
+    {
+      path: "SKILL.md",
+      bytes: encoder.encode(opts.skillContent ?? "nexus-skill"),
+    },
+  ]);
+  const bundleHash = `blake3:${hash(bundle).toString("hex")}`;
+  const index = {
+    schemaVersion: 1,
+    generatedAt: "2026-05-07T00:00:00Z",
+    skills: {
+      grove: { version: opts.version ?? "1", bundleHash, sizeBytes: bundle.byteLength },
+    },
+  };
+  const indexBytes = encoder.encode(canonicalJson(index));
+  const signature = {
+    schemaVersion: 1,
+    keyId: opts.keyId,
+    algorithm: "ed25519" as const,
+    signature: sign(null, indexBytes, opts.privateKey).toString("base64"),
+  };
+  await writeSkillCatalogToNexusForTest({
+    client: opts.client,
+    zoneId: opts.zoneId,
+    indexBytes,
+    signatureBytes: encoder.encode(JSON.stringify(signature)),
+    bundleHash,
+    bundleBytes: bundle,
+  });
+  return { bundleHash };
+}
+
+async function seedNexusSkills(opts: {
+  readonly client: MockNexusClient;
+  readonly zoneId: string;
+  readonly privateKey: KeyObject;
+  readonly keyId: string;
+  readonly skills: readonly {
+    readonly name: string;
+    readonly version?: string;
+    readonly skillContent: string;
+  }[];
+}): Promise<void> {
+  const bundles = opts.skills.map((skill) => {
+    const bundle = createStoredZip([
+      {
+        path: "SKILL.md",
+        bytes: encoder.encode(skill.skillContent),
+      },
+    ]);
+    return {
+      ...skill,
+      bundle,
+      bundleHash: `blake3:${hash(bundle).toString("hex")}`,
+    };
+  });
+  const skills: Record<
+    string,
+    { readonly version: string; readonly bundleHash: string; readonly sizeBytes: number }
+  > = {};
+  for (const bundle of bundles) {
+    skills[bundle.name] = {
+      version: bundle.version ?? "1",
+      bundleHash: bundle.bundleHash,
+      sizeBytes: bundle.bundle.byteLength,
+    };
+  }
+  const indexBytes = encoder.encode(
+    canonicalJson({
+      schemaVersion: 1,
+      generatedAt: "2026-05-07T00:00:00Z",
+      skills,
+    }),
+  );
+  const signature = {
+    schemaVersion: 1,
+    keyId: opts.keyId,
+    algorithm: "ed25519" as const,
+    signature: sign(null, indexBytes, opts.privateKey).toString("base64"),
+  };
+  for (const bundle of bundles) {
+    await writeSkillCatalogToNexusForTest({
+      client: opts.client,
+      zoneId: opts.zoneId,
+      indexBytes,
+      signatureBytes: encoder.encode(JSON.stringify(signature)),
+      bundleHash: bundle.bundleHash,
+      bundleBytes: bundle.bundle,
+    });
+  }
+}
+
+function findCachedSkillFile(cacheRoot: string): string {
+  const pending = [join(cacheRoot, "unpacked")];
+  for (const current of pending) {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const path = join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(path);
+      } else if (entry.isFile() && entry.name === "SKILL.md") {
+        return path;
+      }
+    }
+  }
+  throw new Error("cached SKILL.md was not found");
+}
+
+function cachedMarkerPath(cacheRoot: string): string {
+  return join(dirname(findCachedSkillFile(cacheRoot)), ".grove-skill-bundle.json");
+}
+
+describe("resolveNexusSkillCatalogRoot", () => {
+  test("fetches signed Nexus catalog and materializes requested skill root", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    try {
+      await seedNexus({
+        client,
+        zoneId: "zone1",
+        privateKey: keys.privateKey,
+        keyId: keys.keyId,
+      });
+      const result = await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId: "zone1",
+        cacheRoot: join(root, ".grove", "cache", "skills"),
+        skills: ["grove"],
+        policy: "warn-and-fallback",
+        trustedKeys: [
+          {
+            id: keys.keyId,
+            algorithm: "ed25519",
+            publicKeySpkiDer: keys.publicKeySpkiDer,
+          },
+        ],
+        localFallbackRoots: [],
+      });
+
+      expect(result.source).toBe("nexus");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("nexus-skill");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("materializes multiple skills without exceeding resolved-root filename limits", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    try {
+      await seedNexusSkills({
+        client,
+        zoneId: "zone1",
+        privateKey: keys.privateKey,
+        keyId: keys.keyId,
+        skills: [
+          { name: "grove", skillContent: "grove-skill" },
+          { name: "cedar", skillContent: "cedar-skill" },
+        ],
+      });
+      const result = await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId: "zone1",
+        cacheRoot: join(root, ".grove", "cache", "skills"),
+        skills: ["grove", "cedar"],
+        policy: "warn-and-fallback",
+        trustedKeys: [
+          {
+            id: keys.keyId,
+            algorithm: "ed25519",
+            publicKeySpkiDer: keys.publicKeySpkiDer,
+          },
+        ],
+        localFallbackRoots: [],
+      });
+
+      expect(result.source).toBe("nexus");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("grove-skill");
+      expect(readFileSync(join(result.root, "cedar", "SKILL.md"), "utf-8")).toBe("cedar-skill");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps catalog version path traversal inside cache root", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    try {
+      const cacheRoot = join(root, ".grove", "cache", "skills");
+      await seedNexus({
+        client,
+        zoneId: "zone1",
+        privateKey: keys.privateKey,
+        keyId: keys.keyId,
+        version: "../../../../outside",
+      });
+      const result = await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId: "zone1",
+        cacheRoot,
+        skills: ["grove"],
+        policy: "warn-and-fallback",
+        trustedKeys: [
+          {
+            id: keys.keyId,
+            algorithm: "ed25519",
+            publicKeySpkiDer: keys.publicKeySpkiDer,
+          },
+        ],
+        localFallbackRoots: [],
+      });
+      const relativeRoot = relative(cacheRoot, result.root);
+
+      expect(relativeRoot.startsWith("..")).toBe(false);
+      expect(isAbsolute(relativeRoot)).toBe(false);
+      expect(existsSync(join(root, ".grove", "outside"))).toBe(false);
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("nexus-skill");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("repairs tampered unpacked cache while Nexus is available", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    try {
+      const cacheRoot = join(root, ".grove", "cache", "skills");
+      await seedNexus({
+        client,
+        zoneId: "zone1",
+        privateKey: keys.privateKey,
+        keyId: keys.keyId,
+      });
+      await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId: "zone1",
+        cacheRoot,
+        skills: ["grove"],
+        policy: "warn-and-fallback",
+        trustedKeys: [
+          {
+            id: keys.keyId,
+            algorithm: "ed25519",
+            publicKeySpkiDer: keys.publicKeySpkiDer,
+          },
+        ],
+        localFallbackRoots: [],
+      });
+      writeFileSync(findCachedSkillFile(cacheRoot), "tampered", "utf-8");
+
+      const result = await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId: "zone1",
+        cacheRoot,
+        skills: ["grove"],
+        policy: "warn-and-fallback",
+        trustedKeys: [
+          {
+            id: keys.keyId,
+            algorithm: "ed25519",
+            publicKeySpkiDer: keys.publicKeySpkiDer,
+          },
+        ],
+        localFallbackRoots: [],
+      });
+
+      expect(result.source).toBe("nexus");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("nexus-skill");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("uses verified cache when Nexus becomes unavailable", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    try {
+      await seedNexus({
+        client,
+        zoneId: "zone1",
+        privateKey: keys.privateKey,
+        keyId: keys.keyId,
+      });
+      const base = {
+        client,
+        zoneId: "zone1",
+        cacheRoot: join(root, ".grove", "cache", "skills"),
+        skills: ["grove"],
+        policy: "warn-and-fallback" as const,
+        trustedKeys: [
+          {
+            id: keys.keyId,
+            algorithm: "ed25519" as const,
+            publicKeySpkiDer: keys.publicKeySpkiDer,
+          },
+        ],
+        localFallbackRoots: [],
+      };
+      await resolveNexusSkillCatalogRoot(base);
+      client.setFailureMode({ failNext: 10, failWith: "connection" });
+      const result = await resolveNexusSkillCatalogRoot(base);
+
+      expect(result.source).toBe("cache");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("nexus-skill");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("cache fallback restores missing marker from verified bundle", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    try {
+      const cacheRoot = join(root, ".grove", "cache", "skills");
+      await seedNexus({
+        client,
+        zoneId: "zone1",
+        privateKey: keys.privateKey,
+        keyId: keys.keyId,
+      });
+      const base = {
+        client,
+        zoneId: "zone1",
+        cacheRoot,
+        skills: ["grove"],
+        policy: "warn-and-fallback" as const,
+        trustedKeys: [
+          {
+            id: keys.keyId,
+            algorithm: "ed25519" as const,
+            publicKeySpkiDer: keys.publicKeySpkiDer,
+          },
+        ],
+        localFallbackRoots: [join(root, "local")],
+      };
+      await resolveNexusSkillCatalogRoot(base);
+      const cachedSkillFile = findCachedSkillFile(cacheRoot);
+      writeFileSync(cachedSkillFile, "tampered", "utf-8");
+      rmSync(join(dirname(cachedSkillFile), ".grove-skill-bundle.json"), { force: true });
+      const localSkill = join(root, "local", "grove");
+      mkdirSync(localSkill, { recursive: true });
+      writeFileSync(join(localSkill, "SKILL.md"), "local-skill", "utf-8");
+      client.setFailureMode({ failNext: 10, failWith: "connection" });
+
+      const result = await resolveNexusSkillCatalogRoot(base);
+
+      expect(result.source).toBe("cache");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("nexus-skill");
+      expect(existsSync(cachedMarkerPath(cacheRoot))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("Nexus resolution uses local verified bundle when marker is missing", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    try {
+      const cacheRoot = join(root, ".grove", "cache", "skills");
+      const seeded = await seedNexus({
+        client,
+        zoneId: "zone1",
+        privateKey: keys.privateKey,
+        keyId: keys.keyId,
+      });
+      const base = {
+        client,
+        zoneId: "zone1",
+        cacheRoot,
+        skills: ["grove"],
+        policy: "required" as const,
+        trustedKeys: [
+          {
+            id: keys.keyId,
+            algorithm: "ed25519" as const,
+            publicKeySpkiDer: keys.publicKeySpkiDer,
+          },
+        ],
+        localFallbackRoots: [],
+      };
+      await resolveNexusSkillCatalogRoot(base);
+      const cachedSkillFile = findCachedSkillFile(cacheRoot);
+      writeFileSync(cachedSkillFile, "tampered", "utf-8");
+      rmSync(join(dirname(cachedSkillFile), ".grove-skill-bundle.json"), { force: true });
+      await client.delete(skillCatalogBundlePath("zone1", seeded.bundleHash));
+
+      const result = await resolveNexusSkillCatalogRoot(base);
+
+      expect(result.source).toBe("nexus");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("nexus-skill");
+      expect(existsSync(cachedMarkerPath(cacheRoot))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("cache fallback ignores torn legacy catalog pair", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    try {
+      const cacheRoot = join(root, ".grove", "cache", "skills");
+      await seedNexus({
+        client,
+        zoneId: "zone1",
+        privateKey: keys.privateKey,
+        keyId: keys.keyId,
+      });
+      const base = {
+        client,
+        zoneId: "zone1",
+        cacheRoot,
+        skills: ["grove"],
+        policy: "warn-and-fallback" as const,
+        trustedKeys: [
+          {
+            id: keys.keyId,
+            algorithm: "ed25519" as const,
+            publicKeySpkiDer: keys.publicKeySpkiDer,
+          },
+        ],
+        localFallbackRoots: [],
+      };
+      await resolveNexusSkillCatalogRoot(base);
+      writeFileSync(join(cacheRoot, "index.json"), '{"schemaVersion":1', "utf-8");
+      writeFileSync(join(cacheRoot, "index.sig"), "torn-signature", "utf-8");
+      client.setFailureMode({ failNext: 10, failWith: "connection" });
+
+      const result = await resolveNexusSkillCatalogRoot(base);
+
+      expect(result.source).toBe("cache");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("nexus-skill");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to local root under warn-and-fallback", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    try {
+      const localSkill = join(root, "local", "grove");
+      mkdirSync(localSkill, { recursive: true });
+      writeFileSync(join(localSkill, "SKILL.md"), "local-skill", "utf-8");
+      const result = await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId: "zone1",
+        cacheRoot: join(root, ".grove", "cache", "skills"),
+        skills: ["grove"],
+        policy: "warn-and-fallback",
+        trustedKeys: [],
+        localFallbackRoots: [join(root, "local")],
+      });
+
+      expect(result.source).toBe("local");
+      expect(readFileSync(join(result.root, "grove", "SKILL.md"), "utf-8")).toBe("local-skill");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("failed local fallback copy preserves existing resolved root", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const localSkill = join(root, "local", "grove");
+    const unreadableDir = join(localSkill, "unreadable");
+    try {
+      mkdirSync(localSkill, { recursive: true });
+      writeFileSync(join(localSkill, "SKILL.md"), "old-local", "utf-8");
+      const base = {
+        client,
+        zoneId: "zone1",
+        cacheRoot: join(root, ".grove", "cache", "skills"),
+        skills: ["grove"],
+        policy: "warn-and-fallback" as const,
+        trustedKeys: [],
+        localFallbackRoots: [join(root, "local")],
+      };
+      const first = await resolveNexusSkillCatalogRoot(base);
+      mkdirSync(unreadableDir, { recursive: true });
+      writeFileSync(join(unreadableDir, "blocked.txt"), "blocked", "utf-8");
+      chmodSync(unreadableDir, 0);
+
+      await expect(resolveNexusSkillCatalogRoot(base)).rejects.toThrow();
+
+      expect(readFileSync(join(first.root, "grove", "SKILL.md"), "utf-8")).toBe("old-local");
+    } finally {
+      if (existsSync(unreadableDir)) {
+        chmodSync(unreadableDir, 0o700);
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails required policy without verified Nexus or cache", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    try {
+      await expect(
+        resolveNexusSkillCatalogRoot({
+          client,
+          zoneId: "zone1",
+          cacheRoot: join(root, ".grove", "cache", "skills"),
+          skills: ["grove"],
+          policy: "required",
+          trustedKeys: [],
+          localFallbackRoots: [],
+        }),
+      ).rejects.toThrow(/trusted keys|catalog|required/i);
+      expect(existsSync(join(root, ".grove", "cache", "skills", "resolved"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/nexus/nexus-skill-catalog.test.ts
+++ b/src/nexus/nexus-skill-catalog.test.ts
@@ -515,6 +515,89 @@ describe("resolveNexusSkillCatalogRoot", () => {
     }
   });
 
+  test("redacts Nexus URLs from fallback warnings and required errors", async () => {
+    const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
+    const client = new MockNexusClient();
+    const keys = signingFixture();
+    const secretUrl = "https://user:secret@nexus.example/api/v2/files/read?token=abc#frag";
+    try {
+      client.read = async (_path: string): Promise<Uint8Array | undefined> => {
+        throw new Error(`Failed to connect to Nexus at ${secretUrl}: boom`);
+      };
+      const localSkill = join(root, "local", "grove");
+      mkdirSync(localSkill, { recursive: true });
+      writeFileSync(join(localSkill, "SKILL.md"), "local-skill", "utf-8");
+      const trustedKeys = [
+        {
+          id: keys.keyId,
+          algorithm: "ed25519" as const,
+          publicKeySpkiDer: keys.publicKeySpkiDer,
+        },
+      ];
+
+      const fallback = await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId: "zone1",
+        cacheRoot: join(root, ".grove", "cache", "skills"),
+        skills: ["grove"],
+        policy: "warn-and-fallback",
+        trustedKeys,
+        localFallbackRoots: [join(root, "local")],
+      });
+      const warningReason = fallback.warnings[0]?.reason ?? "";
+
+      expect(fallback.source).toBe("local");
+      expect(warningReason).toContain("https://nexus.example/[redacted]");
+      expect(warningReason).not.toContain("user:secret");
+      expect(warningReason).not.toContain("token=abc");
+      expect(warningReason).not.toContain("/api/v2/files/read");
+
+      let requiredMessage = "";
+      try {
+        await resolveNexusSkillCatalogRoot({
+          client,
+          zoneId: "zone1",
+          cacheRoot: join(root, ".grove", "cache", "required-skills"),
+          skills: ["grove"],
+          policy: "required",
+          trustedKeys,
+          localFallbackRoots: [join(root, "local")],
+        });
+      } catch (error) {
+        requiredMessage = error instanceof Error ? error.message : String(error);
+      }
+
+      expect(requiredMessage).toContain("https://nexus.example/[redacted]");
+      expect(requiredMessage).not.toContain("user:secret");
+      expect(requiredMessage).not.toContain("token=abc");
+      expect(requiredMessage).not.toContain("/api/v2/files/read");
+
+      let noFallbackCauseMessage = "";
+      try {
+        await resolveNexusSkillCatalogRoot({
+          client,
+          zoneId: "zone1",
+          cacheRoot: join(root, ".grove", "cache", "no-fallback-skills"),
+          skills: ["grove"],
+          policy: "warn-and-fallback",
+          trustedKeys,
+          localFallbackRoots: [],
+        });
+      } catch (error) {
+        if (error instanceof Error && error.cause instanceof Error) {
+          noFallbackCauseMessage = error.cause.message;
+        }
+      }
+
+      expect(noFallbackCauseMessage).toContain("https://nexus.example/[redacted]");
+      expect(noFallbackCauseMessage).not.toContain("user:secret");
+      expect(noFallbackCauseMessage).not.toContain("token=abc");
+      expect(noFallbackCauseMessage).not.toContain("/api/v2/files/read");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("failed local fallback copy preserves existing resolved root", async () => {
     const root = mkdtempSync(join(tmpdir(), "grove-nexus-skills-"));
     const client = new MockNexusClient();

--- a/src/nexus/nexus-skill-catalog.ts
+++ b/src/nexus/nexus-skill-catalog.ts
@@ -577,16 +577,16 @@ export async function resolveNexusSkillCatalogRoot(
   try {
     return await resolveFromNexus(opts);
   } catch (error) {
-    if (opts.policy === "required") {
-      throw safeSurfaceError(error);
-    }
-
     const cached = await tryVerifiedCache(opts);
     if (cached !== undefined) {
       return {
         ...cached,
         warnings: fallbackWarnings(opts.skills, "cache", error),
       };
+    }
+
+    if (opts.policy === "required") {
+      throw safeSurfaceError(error);
     }
 
     const local = await tryLocalFallback(opts);

--- a/src/nexus/nexus-skill-catalog.ts
+++ b/src/nexus/nexus-skill-catalog.ts
@@ -1,0 +1,570 @@
+import { existsSync } from "node:fs";
+import { cp, mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { hash } from "blake3";
+
+import type { SkillCatalogPolicy, SkillCatalogTrustedKey } from "../core/config.js";
+import {
+  parseSkillCatalogIndex,
+  parseSkillCatalogSignature,
+  type SkillCatalogIndex,
+  type SkillCatalogSignature,
+  SkillCatalogTrustError,
+  SkillCatalogUnavailableError,
+  unpackSkillBundle,
+  verifyBundleHash,
+  verifyCatalogSignature,
+} from "../core/skill-catalog.js";
+import type { NexusClient } from "./client.js";
+import {
+  skillCatalogBundlePath,
+  skillCatalogIndexPath,
+  skillCatalogSignaturePath,
+} from "./vfs-paths.js";
+
+export interface SkillResolutionWarning {
+  readonly skillName: string;
+  readonly attemptedSource: string;
+  readonly fallbackSource?: string | undefined;
+  readonly reason: string;
+}
+
+export interface ResolvedSkillCatalogRoot {
+  readonly root: string;
+  readonly source: "nexus" | "cache" | "local";
+  readonly warnings: readonly SkillResolutionWarning[];
+}
+
+export interface ResolveNexusSkillCatalogRootOptions {
+  readonly client: NexusClient;
+  readonly zoneId: string;
+  readonly cacheRoot: string;
+  readonly skills: readonly string[];
+  readonly policy: SkillCatalogPolicy;
+  readonly trustedKeys: readonly SkillCatalogTrustedKey[];
+  readonly localFallbackRoots: readonly string[];
+}
+
+interface SkillCatalogBytes {
+  readonly indexBytes: Uint8Array;
+  readonly signatureBytes: Uint8Array;
+}
+
+interface VerifiedSkillCatalog extends SkillCatalogBytes {
+  readonly index: SkillCatalogIndex;
+  readonly signature: SkillCatalogSignature;
+}
+
+interface ResolutionCandidate {
+  readonly root: string;
+  readonly source: "cache" | "local";
+}
+
+interface LocalSkillSource {
+  readonly skillName: string;
+  readonly sourceDir: string;
+}
+
+interface SkillBundleMarker {
+  readonly schemaVersion: 1;
+  readonly skillName: string;
+  readonly version: string;
+  readonly bundleHash: string;
+}
+
+const COMPLETION_MARKER = ".grove-skill-bundle.json";
+const decoder = new TextDecoder();
+const segmentEncoder = new TextEncoder();
+
+function safePathSegment(value: string): string {
+  const bytes = segmentEncoder.encode(value);
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function cacheSkillDir(
+  cacheRoot: string,
+  skillName: string,
+  version: string,
+  bundleHash: string,
+): string {
+  return join(
+    cacheRoot,
+    "unpacked",
+    safePathSegment(skillName),
+    safePathSegment(version),
+    safePathSegment(bundleHash),
+  );
+}
+
+function localBundlePath(cacheRoot: string, bundleHash: string): string {
+  return join(cacheRoot, "bundles", `${safePathSegment(bundleHash)}.zip`);
+}
+
+function completionMarkerPath(skillDir: string): string {
+  return join(skillDir, COMPLETION_MARKER);
+}
+
+function resolvedRoot(cacheRoot: string, skills: readonly string[], suffix: string): string {
+  const key = JSON.stringify({ skills, suffix });
+  const digest = hash(segmentEncoder.encode(key)).toString("hex");
+  return join(cacheRoot, "resolved", `skills-${digest}`);
+}
+
+function catalogCacheCurrentDir(cacheRoot: string): string {
+  return join(cacheRoot, "catalog", "current");
+}
+
+function catalogCacheIndexPath(cacheRoot: string): string {
+  return join(catalogCacheCurrentDir(cacheRoot), "index.json");
+}
+
+function catalogCacheSignaturePath(cacheRoot: string): string {
+  return join(catalogCacheCurrentDir(cacheRoot), "index.sig");
+}
+
+function reasonFromError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function fallbackWarnings(
+  skills: readonly string[],
+  fallbackSource: "cache" | "local" | undefined,
+  error: unknown,
+): readonly SkillResolutionWarning[] {
+  const reason = reasonFromError(error);
+  return skills.map((skillName) => ({
+    skillName,
+    attemptedSource: "nexus",
+    fallbackSource,
+    reason,
+  }));
+}
+
+function validateRequestedSkills(skills: readonly string[]): void {
+  for (const skillName of skills) {
+    if (
+      skillName.length === 0 ||
+      skillName === "." ||
+      skillName === ".." ||
+      skillName.includes("/") ||
+      skillName.includes("\\") ||
+      skillName.includes("\0")
+    ) {
+      throw new SkillCatalogUnavailableError(
+        `Unsafe skill name in skill catalog request: ${skillName}`,
+      );
+    }
+  }
+}
+
+function requireTrustedKeys(trustedKeys: readonly SkillCatalogTrustedKey[]): void {
+  if (trustedKeys.length === 0) {
+    throw new SkillCatalogTrustError("No trusted keys configured for skill catalog verification");
+  }
+}
+
+function parseAndVerifyCatalog(opts: {
+  readonly indexBytes: Uint8Array;
+  readonly signatureBytes: Uint8Array;
+  readonly trustedKeys: readonly SkillCatalogTrustedKey[];
+}): VerifiedSkillCatalog {
+  const index = parseSkillCatalogIndex(decoder.decode(opts.indexBytes));
+  const signature = parseSkillCatalogSignature(decoder.decode(opts.signatureBytes));
+  verifyCatalogSignature({
+    indexBytes: opts.indexBytes,
+    signature,
+    trustedKeys: opts.trustedKeys,
+  });
+  return {
+    indexBytes: opts.indexBytes,
+    signatureBytes: opts.signatureBytes,
+    index,
+    signature,
+  };
+}
+
+function skillEntry(
+  index: SkillCatalogIndex,
+  skillName: string,
+): SkillCatalogIndex["skills"][string] {
+  const entry = index.skills[skillName];
+  if (entry === undefined) {
+    throw new SkillCatalogUnavailableError(
+      `Skill is missing from Nexus skill catalog: ${skillName}`,
+    );
+  }
+  return entry;
+}
+
+function catalogSuffix(index: SkillCatalogIndex, skills: readonly string[]): string {
+  return skills
+    .map((skillName) => {
+      const entry = skillEntry(index, skillName);
+      return `${entry.version}-${entry.bundleHash}`;
+    })
+    .join("-");
+}
+
+async function copySkillRoot(source: string, target: string): Promise<void> {
+  await cp(source, target, { recursive: true, force: true });
+}
+
+async function writeAtomicFile(path: string, content: Uint8Array | string): Promise<void> {
+  const parentDir = dirname(path);
+  await mkdir(parentDir, { recursive: true });
+  const tempDir = await mkdtemp(join(parentDir, ".tmp-"));
+  const tempPath = join(tempDir, basename(path));
+  try {
+    await writeFile(tempPath, content);
+    await rename(tempPath, path);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+function expectedMarker(opts: {
+  readonly skillName: string;
+  readonly version: string;
+  readonly bundleHash: string;
+}): SkillBundleMarker {
+  return {
+    schemaVersion: 1,
+    skillName: opts.skillName,
+    version: opts.version,
+    bundleHash: opts.bundleHash,
+  };
+}
+
+async function writeCompletionMarker(skillDir: string, marker: SkillBundleMarker): Promise<void> {
+  await writeAtomicFile(completionMarkerPath(skillDir), `${JSON.stringify(marker, null, 2)}\n`);
+}
+
+async function readVerifiedLocalBundle(
+  cacheRoot: string,
+  bundleHash: string,
+): Promise<Uint8Array | undefined> {
+  try {
+    const bundleBytes = await readFile(localBundlePath(cacheRoot, bundleHash));
+    verifyBundleHash(bundleBytes, bundleHash);
+    return bundleBytes;
+  } catch {
+    return undefined;
+  }
+}
+
+async function persistVerifiedBundle(
+  cacheRoot: string,
+  bundleHash: string,
+  bundleBytes: Uint8Array,
+): Promise<void> {
+  verifyBundleHash(bundleBytes, bundleHash);
+  await writeAtomicFile(localBundlePath(cacheRoot, bundleHash), bundleBytes);
+}
+
+async function materializeCachedSkill(opts: {
+  readonly bundleBytes: Uint8Array;
+  readonly skillDir: string;
+  readonly marker: SkillBundleMarker;
+}): Promise<void> {
+  await unpackSkillBundle(opts.bundleBytes, opts.skillDir);
+  await writeCompletionMarker(opts.skillDir, opts.marker);
+}
+
+async function replaceDirectoryWithPreparedTemp(root: string, tempRoot: string): Promise<void> {
+  const parentDir = dirname(root);
+  let installed = false;
+  let backupParent: string | undefined;
+  let movedExistingRoot = false;
+  try {
+    if (existsSync(root)) {
+      backupParent = await mkdtemp(join(parentDir, `.${basename(root)}.backup-`));
+      await rename(root, join(backupParent, "old"));
+      movedExistingRoot = true;
+    }
+    await rename(tempRoot, root);
+    installed = true;
+    if (backupParent !== undefined) {
+      await rm(backupParent, { recursive: true, force: true });
+    }
+  } catch (error) {
+    if (movedExistingRoot && backupParent !== undefined && !existsSync(root)) {
+      try {
+        await rename(join(backupParent, "old"), root);
+      } catch {
+        // Preserve the original failure if rollback also fails.
+      }
+    }
+    throw error;
+  } finally {
+    if (!installed) {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+    if (backupParent !== undefined) {
+      await rm(backupParent, { recursive: true, force: true });
+    }
+  }
+}
+
+async function materializeResolvedRoot(
+  root: string,
+  sources: readonly LocalSkillSource[],
+): Promise<void> {
+  const parentDir = dirname(root);
+  await mkdir(parentDir, { recursive: true });
+  const tempRoot = await mkdtemp(join(parentDir, `.${basename(root)}.tmp-`));
+  try {
+    for (const source of sources) {
+      await copySkillRoot(source.sourceDir, join(tempRoot, source.skillName));
+    }
+  } catch (error) {
+    await rm(tempRoot, { recursive: true, force: true });
+    throw error;
+  }
+  await replaceDirectoryWithPreparedTemp(root, tempRoot);
+}
+
+async function publishCatalogCache(cacheRoot: string, catalog: SkillCatalogBytes): Promise<void> {
+  const currentDir = catalogCacheCurrentDir(cacheRoot);
+  const catalogDir = dirname(currentDir);
+  await mkdir(catalogDir, { recursive: true });
+  const tempRoot = await mkdtemp(join(catalogDir, ".current.tmp-"));
+  try {
+    await writeFile(join(tempRoot, "index.json"), catalog.indexBytes);
+    await writeFile(join(tempRoot, "index.sig"), catalog.signatureBytes);
+  } catch (error) {
+    await rm(tempRoot, { recursive: true, force: true });
+    throw error;
+  }
+  await replaceDirectoryWithPreparedTemp(currentDir, tempRoot);
+}
+
+async function writeLegacyCatalogCache(
+  cacheRoot: string,
+  catalog: SkillCatalogBytes,
+): Promise<void> {
+  await writeAtomicFile(join(cacheRoot, "index.json"), catalog.indexBytes);
+  await writeAtomicFile(join(cacheRoot, "index.sig"), catalog.signatureBytes);
+}
+
+async function readPublishedCatalogCache(
+  cacheRoot: string,
+): Promise<SkillCatalogBytes | undefined> {
+  const indexPath = catalogCacheIndexPath(cacheRoot);
+  const signaturePath = catalogCacheSignaturePath(cacheRoot);
+  if (!existsSync(indexPath) || !existsSync(signaturePath)) {
+    return undefined;
+  }
+  try {
+    const [indexBytes, signatureBytes] = await Promise.all([
+      readFile(indexPath),
+      readFile(signaturePath),
+    ]);
+    return { indexBytes, signatureBytes };
+  } catch {
+    return undefined;
+  }
+}
+
+async function readNexusCatalog(
+  opts: ResolveNexusSkillCatalogRootOptions,
+): Promise<SkillCatalogBytes> {
+  requireTrustedKeys(opts.trustedKeys);
+
+  const [indexBytes, signatureBytes] = await Promise.all([
+    opts.client.read(skillCatalogIndexPath(opts.zoneId)),
+    opts.client.read(skillCatalogSignaturePath(opts.zoneId)),
+  ]);
+  if (indexBytes === undefined || signatureBytes === undefined) {
+    throw new SkillCatalogUnavailableError("Nexus skill catalog index or signature is unavailable");
+  }
+  return { indexBytes, signatureBytes };
+}
+
+async function ensureNexusSkillCached(opts: {
+  readonly client: NexusClient;
+  readonly zoneId: string;
+  readonly cacheRoot: string;
+  readonly skillName: string;
+  readonly index: SkillCatalogIndex;
+}): Promise<string> {
+  const entry = skillEntry(opts.index, opts.skillName);
+  const skillDir = cacheSkillDir(opts.cacheRoot, opts.skillName, entry.version, entry.bundleHash);
+  const marker = expectedMarker({
+    skillName: opts.skillName,
+    version: entry.version,
+    bundleHash: entry.bundleHash,
+  });
+  const localBundleBytes = await readVerifiedLocalBundle(opts.cacheRoot, entry.bundleHash);
+  if (localBundleBytes !== undefined) {
+    await materializeCachedSkill({ bundleBytes: localBundleBytes, skillDir, marker });
+    return skillDir;
+  }
+
+  const bundleBytes = await opts.client.read(skillCatalogBundlePath(opts.zoneId, entry.bundleHash));
+  if (bundleBytes === undefined) {
+    throw new SkillCatalogUnavailableError(
+      `Nexus skill bundle is unavailable for ${opts.skillName}: ${entry.bundleHash}`,
+    );
+  }
+  verifyBundleHash(bundleBytes, entry.bundleHash);
+  await persistVerifiedBundle(opts.cacheRoot, entry.bundleHash, bundleBytes);
+  await materializeCachedSkill({ bundleBytes, skillDir, marker });
+  return skillDir;
+}
+
+async function resolveFromNexus(
+  opts: ResolveNexusSkillCatalogRootOptions,
+): Promise<ResolvedSkillCatalogRoot> {
+  validateRequestedSkills(opts.skills);
+  const catalogBytes = await readNexusCatalog(opts);
+  const catalog = parseAndVerifyCatalog({
+    ...catalogBytes,
+    trustedKeys: opts.trustedKeys,
+  });
+  const targetRoot = resolvedRoot(
+    opts.cacheRoot,
+    opts.skills,
+    catalogSuffix(catalog.index, opts.skills),
+  );
+
+  await mkdir(opts.cacheRoot, { recursive: true });
+  const cachedSkillDirs: LocalSkillSource[] = [];
+  for (const skillName of opts.skills) {
+    const sourceDir = await ensureNexusSkillCached({
+      client: opts.client,
+      zoneId: opts.zoneId,
+      cacheRoot: opts.cacheRoot,
+      skillName,
+      index: catalog.index,
+    });
+    cachedSkillDirs.push({ skillName, sourceDir });
+  }
+
+  await publishCatalogCache(opts.cacheRoot, catalog);
+  await writeLegacyCatalogCache(opts.cacheRoot, catalog);
+  await materializeResolvedRoot(targetRoot, cachedSkillDirs);
+
+  return { root: targetRoot, source: "nexus", warnings: [] };
+}
+
+async function tryVerifiedCache(
+  opts: ResolveNexusSkillCatalogRootOptions,
+): Promise<ResolutionCandidate | undefined> {
+  validateRequestedSkills(opts.skills);
+  const cachedCatalogBytes = await readPublishedCatalogCache(opts.cacheRoot);
+  if (cachedCatalogBytes === undefined) {
+    return undefined;
+  }
+
+  try {
+    const catalog = parseAndVerifyCatalog({
+      ...cachedCatalogBytes,
+      trustedKeys: opts.trustedKeys,
+    });
+    const sources: LocalSkillSource[] = [];
+    for (const skillName of opts.skills) {
+      const entry = skillEntry(catalog.index, skillName);
+      const sourceDir = cacheSkillDir(opts.cacheRoot, skillName, entry.version, entry.bundleHash);
+      const marker = expectedMarker({
+        skillName,
+        version: entry.version,
+        bundleHash: entry.bundleHash,
+      });
+      const bundleBytes = await readVerifiedLocalBundle(opts.cacheRoot, entry.bundleHash);
+      if (bundleBytes === undefined) {
+        return undefined;
+      }
+      await materializeCachedSkill({ bundleBytes, skillDir: sourceDir, marker });
+      sources.push({ skillName, sourceDir });
+    }
+
+    const targetRoot = resolvedRoot(
+      opts.cacheRoot,
+      opts.skills,
+      catalogSuffix(catalog.index, opts.skills),
+    );
+    await materializeResolvedRoot(targetRoot, sources);
+    return { root: targetRoot, source: "cache" };
+  } catch {
+    return undefined;
+  }
+}
+
+async function tryLocalFallback(
+  opts: ResolveNexusSkillCatalogRootOptions,
+): Promise<ResolutionCandidate | undefined> {
+  validateRequestedSkills(opts.skills);
+  const sources: LocalSkillSource[] = [];
+  for (const skillName of opts.skills) {
+    let sourceDir: string | undefined;
+    for (const fallbackRoot of opts.localFallbackRoots) {
+      const candidate = join(fallbackRoot, skillName);
+      if (existsSync(join(candidate, "SKILL.md"))) {
+        sourceDir = candidate;
+        break;
+      }
+    }
+    if (sourceDir === undefined) {
+      return undefined;
+    }
+    sources.push({ skillName, sourceDir });
+  }
+
+  const targetRoot = resolvedRoot(opts.cacheRoot, opts.skills, "local");
+  await materializeResolvedRoot(targetRoot, sources);
+  return { root: targetRoot, source: "local" };
+}
+
+/**
+ * Test/fixture helper that writes raw signed skill catalog artifacts directly
+ * to Nexus VFS paths. Production code should publish catalogs through the
+ * catalog generation/signing flow instead.
+ */
+export async function writeSkillCatalogToNexusForTest(opts: {
+  readonly client: NexusClient;
+  readonly zoneId: string;
+  readonly indexBytes: Uint8Array;
+  readonly signatureBytes: Uint8Array;
+  readonly bundleHash: string;
+  readonly bundleBytes: Uint8Array;
+}): Promise<void> {
+  await opts.client.write(skillCatalogIndexPath(opts.zoneId), opts.indexBytes);
+  await opts.client.write(skillCatalogSignaturePath(opts.zoneId), opts.signatureBytes);
+  await opts.client.write(skillCatalogBundlePath(opts.zoneId, opts.bundleHash), opts.bundleBytes);
+}
+
+export async function resolveNexusSkillCatalogRoot(
+  opts: ResolveNexusSkillCatalogRootOptions,
+): Promise<ResolvedSkillCatalogRoot> {
+  try {
+    return await resolveFromNexus(opts);
+  } catch (error) {
+    if (opts.policy === "required") {
+      throw error;
+    }
+
+    const cached = await tryVerifiedCache(opts);
+    if (cached !== undefined) {
+      return {
+        ...cached,
+        warnings: fallbackWarnings(opts.skills, "cache", error),
+      };
+    }
+
+    const local = await tryLocalFallback(opts);
+    if (local !== undefined) {
+      return {
+        ...local,
+        warnings: fallbackWarnings(opts.skills, "local", error),
+      };
+    }
+
+    throw new SkillCatalogUnavailableError(
+      "Nexus skill catalog is unavailable and no verified cache or local fallback could resolve requested skills",
+      { cause: error },
+    );
+  }
+}

--- a/src/nexus/nexus-skill-catalog.ts
+++ b/src/nexus/nexus-skill-catalog.ts
@@ -75,6 +75,7 @@ interface SkillBundleMarker {
 const COMPLETION_MARKER = ".grove-skill-bundle.json";
 const decoder = new TextDecoder();
 const segmentEncoder = new TextEncoder();
+const URL_PATTERN = /\bhttps?:\/\/[^\s"'<>]+/gi;
 
 function safePathSegment(value: string): string {
   const bytes = segmentEncoder.encode(value);
@@ -122,11 +123,45 @@ function catalogCacheSignaturePath(cacheRoot: string): string {
   return join(catalogCacheCurrentDir(cacheRoot), "index.sig");
 }
 
+function redactUrlMatch(raw: string): string {
+  let candidate = raw;
+  let suffix = "";
+  while (candidate.length > 0) {
+    try {
+      const url = new URL(candidate);
+      const needsRedaction =
+        url.username.length > 0 ||
+        url.password.length > 0 ||
+        (url.pathname.length > 0 && url.pathname !== "/") ||
+        url.search.length > 0 ||
+        url.hash.length > 0;
+      if (!needsRedaction) return `${url.protocol}//${url.host}${suffix}`;
+      return `${url.protocol}//${url.host}/[redacted]${suffix}`;
+    } catch {
+      suffix = `${candidate[candidate.length - 1]}${suffix}`;
+      candidate = candidate.slice(0, -1);
+    }
+  }
+  return `[redacted-url]${suffix}`;
+}
+
+function redactSensitiveText(text: string): string {
+  return text.replace(URL_PATTERN, redactUrlMatch);
+}
+
 function reasonFromError(error: unknown): string {
   if (error instanceof Error) {
-    return error.message;
+    return redactSensitiveText(error.message);
   }
-  return String(error);
+  return redactSensitiveText(String(error));
+}
+
+function safeSurfaceError(error: unknown): Error {
+  const reason = reasonFromError(error);
+  if (error instanceof SkillCatalogTrustError) {
+    return new SkillCatalogTrustError(reason);
+  }
+  return new SkillCatalogUnavailableError(reason);
 }
 
 function fallbackWarnings(
@@ -543,7 +578,7 @@ export async function resolveNexusSkillCatalogRoot(
     return await resolveFromNexus(opts);
   } catch (error) {
     if (opts.policy === "required") {
-      throw error;
+      throw safeSurfaceError(error);
     }
 
     const cached = await tryVerifiedCache(opts);
@@ -564,7 +599,7 @@ export async function resolveNexusSkillCatalogRoot(
 
     throw new SkillCatalogUnavailableError(
       "Nexus skill catalog is unavailable and no verified cache or local fallback could resolve requested skills",
-      { cause: error },
+      { cause: safeSurfaceError(error) },
     );
   }
 }

--- a/src/nexus/vfs-paths.test.ts
+++ b/src/nexus/vfs-paths.test.ts
@@ -24,6 +24,9 @@ import {
   outcomePath,
   outcomeStatusIndexPath,
   relationIndexPath,
+  skillCatalogBundlePath,
+  skillCatalogIndexPath,
+  skillCatalogSignaturePath,
   tagIndexPath,
   targetLockPath,
 } from "./vfs-paths.js";
@@ -251,6 +254,23 @@ describe("path construction correctness", () => {
   test("targetLockPath returns /zones/{zone}/indexes/claims/target-lock/{targetRef}", () => {
     expect(targetLockPath(zone, targetRef)).toBe(
       `/zones/${zone}/indexes/claims/target-lock/${targetRef}`,
+    );
+  });
+});
+
+describe("skill catalog paths", () => {
+  test("constructs zone-scoped skill catalog paths", () => {
+    expect(skillCatalogIndexPath("zone1")).toBe("/zones/zone1/skill-catalog/index.json");
+    expect(skillCatalogSignaturePath("zone1")).toBe("/zones/zone1/skill-catalog/index.sig");
+    expect(skillCatalogBundlePath("zone1", "blake3:abc123")).toBe(
+      "/zones/zone1/skill-catalog/bundles/blake3:abc123.zip",
+    );
+  });
+
+  test("encodes zone and bundle hash segments", () => {
+    expect(skillCatalogIndexPath("../zone")).toBe("/zones/..%2Fzone/skill-catalog/index.json");
+    expect(skillCatalogBundlePath("zone/one", "blake3:a/b")).toBe(
+      "/zones/zone%2Fone/skill-catalog/bundles/blake3:a%2Fb.zip",
     );
   });
 });

--- a/src/nexus/vfs-paths.ts
+++ b/src/nexus/vfs-paths.ts
@@ -37,6 +37,25 @@ export function casMetaPath(zoneId: string, contentHash: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Skill catalog paths
+// ---------------------------------------------------------------------------
+
+/** Path to the signed skill catalog index JSON. */
+export function skillCatalogIndexPath(zoneId: string): string {
+  return `/zones/${encodeSegment(zoneId)}/skill-catalog/index.json`;
+}
+
+/** Path to the skill catalog signature sidecar. */
+export function skillCatalogSignaturePath(zoneId: string): string {
+  return `/zones/${encodeSegment(zoneId)}/skill-catalog/index.sig`;
+}
+
+/** Path to an immutable skill bundle ZIP selected by a verified bundle hash. */
+export function skillCatalogBundlePath(zoneId: string, bundleHash: string): string {
+  return `/zones/${encodeSegment(zoneId)}/skill-catalog/bundles/${encodeSegment(bundleHash)}.zip`;
+}
+
+// ---------------------------------------------------------------------------
 // Contribution paths
 // ---------------------------------------------------------------------------
 

--- a/src/shared/nexus-url.ts
+++ b/src/shared/nexus-url.ts
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface NexusUrlConfig {
+  readonly mode?: string | undefined;
+  readonly nexusManaged?: boolean | undefined;
+  readonly nexusUrl?: string | undefined;
+}
+
+interface NexusUrlEnv {
+  readonly [name: string]: string | undefined;
+  readonly GROVE_NEXUS_URL?: string | undefined;
+}
+
+/** Parse managed Nexus URL from project-local nexus.yaml (ports.http). */
+export function readManagedNexusUrl(projectRoot: string): string | undefined {
+  const yamlPath = join(projectRoot, "nexus.yaml");
+  if (!existsSync(yamlPath)) return undefined;
+  try {
+    const raw = readFileSync(yamlPath, "utf-8");
+    const match = raw.match(/^\s*http:\s*(\d{1,5})\s*$/m);
+    if (!match?.[1]) return undefined;
+    const port = Number(match[1]);
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) return undefined;
+    return `http://localhost:${port}`;
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveConfiguredNexusUrl(opts: {
+  readonly projectRoot: string;
+  readonly config: NexusUrlConfig | undefined;
+  readonly env: NexusUrlEnv;
+}): string | undefined {
+  const envUrl = opts.env.GROVE_NEXUS_URL;
+  if (envUrl && envUrl.length > 0) return envUrl;
+
+  if (opts.config?.mode === "nexus" && opts.config.nexusManaged === true) {
+    const managedUrl = readManagedNexusUrl(opts.projectRoot);
+    if (managedUrl !== undefined) return managedUrl;
+  }
+
+  return opts.config?.nexusUrl;
+}

--- a/src/shared/zip.test.ts
+++ b/src/shared/zip.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { crc32, createStoredZip } from "./zip.js";
+import { crc32, createStoredZip, readStoredZip } from "./zip.js";
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
+const UTF8_ZIP_FLAGS = 0x0800;
 
 interface ParsedEntry {
   readonly name: string;
@@ -31,6 +32,38 @@ function readUInt32(bytes: Uint8Array, offset: number): number {
 
 function readUInt16(bytes: Uint8Array, offset: number): number {
   return ((bytes[offset] ?? 0) | ((bytes[offset + 1] ?? 0) << 8)) >>> 0;
+}
+
+function writeUInt32(bytes: Uint8Array, offset: number, value: number): void {
+  bytes[offset] = value & 0xff;
+  bytes[offset + 1] = (value >>> 8) & 0xff;
+  bytes[offset + 2] = (value >>> 16) & 0xff;
+  bytes[offset + 3] = (value >>> 24) & 0xff;
+}
+
+function writeUInt16(bytes: Uint8Array, offset: number, value: number): void {
+  bytes[offset] = value & 0xff;
+  bytes[offset + 1] = (value >>> 8) & 0xff;
+}
+
+function createStoredLocalHeader(
+  flags: number,
+  pathBytes: Uint8Array,
+  entryBytes: Uint8Array,
+): Uint8Array {
+  const localHeader = new Uint8Array(30 + pathBytes.length + entryBytes.length);
+  writeUInt32(localHeader, 0, 0x04034b50);
+  writeUInt16(localHeader, 4, 20);
+  writeUInt16(localHeader, 6, flags);
+  writeUInt16(localHeader, 8, 0);
+  writeUInt32(localHeader, 14, crc32(entryBytes));
+  writeUInt32(localHeader, 18, entryBytes.length);
+  writeUInt32(localHeader, 22, entryBytes.length);
+  writeUInt16(localHeader, 26, pathBytes.length);
+  writeUInt16(localHeader, 28, 0);
+  localHeader.set(pathBytes, 30);
+  localHeader.set(entryBytes, 30 + pathBytes.length);
+  return localHeader;
 }
 
 function parseStoredZip(bytes: Uint8Array): readonly ParsedEntry[] {
@@ -83,6 +116,248 @@ describe("crc32", () => {
 });
 
 describe("createStoredZip", () => {
+  test("readStoredZip round-trips writer output", () => {
+    const zip = createStoredZip([
+      { path: "SKILL.md", bytes: textEncoder.encode("skill") },
+      { path: "references/guide.md", bytes: textEncoder.encode("guide") },
+    ]);
+
+    const entries = readStoredZip(zip);
+
+    expect(entries.map((entry) => entry.path)).toEqual(["SKILL.md", "references/guide.md"]);
+    expect(textDecoder.decode(entries[0]?.bytes)).toBe("skill");
+    expect(textDecoder.decode(entries[1]?.bytes)).toBe("guide");
+  });
+
+  test("readStoredZip rejects CRC mismatch", () => {
+    const zip = createStoredZip([{ path: "SKILL.md", bytes: textEncoder.encode("skill") }]);
+    const corrupted = new Uint8Array(zip);
+    corrupted[30 + textEncoder.encode("SKILL.md").length] =
+      (corrupted[30 + textEncoder.encode("SKILL.md").length] ?? 0) ^ 0xff;
+
+    expect(() => readStoredZip(corrupted)).toThrow(/crc/i);
+  });
+
+  test("readStoredZip rejects unsupported compression methods", () => {
+    const zip = createStoredZip([{ path: "SKILL.md", bytes: textEncoder.encode("skill") }]);
+    const compressed = new Uint8Array(zip);
+    compressed[8] = 8;
+
+    expect(() => readStoredZip(compressed)).toThrow(/compression method/i);
+  });
+
+  test("readStoredZip rejects unsafe central-directory paths", () => {
+    const unsafe = createStoredZip([{ path: "SKILL.md", bytes: textEncoder.encode("skill") }]);
+    const patched = new Uint8Array(unsafe);
+    const eocdOffset = patched.length - 22;
+    const centralStart = readUInt32(patched, eocdOffset + 16);
+    patched.set(textEncoder.encode("/KILL.md"), 30);
+    patched.set(textEncoder.encode("/KILL.md"), centralStart + 46);
+
+    expect(() => readStoredZip(patched)).toThrow(/unsafe zip entry/i);
+  });
+
+  test("readStoredZip rejects central directory fields past EOCD size", () => {
+    const zip = createStoredZip([{ path: "SKILL.md", bytes: textEncoder.encode("skill") }]);
+    const patched = new Uint8Array(zip);
+    const eocdOffset = patched.length - 22;
+    const centralStart = readUInt32(patched, eocdOffset + 16);
+    writeUInt16(patched, centralStart + 30, 1);
+
+    expect(() => readStoredZip(patched)).toThrow(/central directory/i);
+  });
+
+  test("readStoredZip rejects inconsistent EOCD central directory size", () => {
+    const zip = createStoredZip([{ path: "SKILL.md", bytes: textEncoder.encode("skill") }]);
+    const patched = new Uint8Array(zip);
+    const eocdOffset = patched.length - 22;
+    const centralSize = readUInt32(patched, eocdOffset + 12);
+    writeUInt32(patched, eocdOffset + 12, centralSize - 1);
+
+    expect(() => readStoredZip(patched)).toThrow(/central directory/i);
+  });
+
+  test("readStoredZip rejects mismatched local and central paths", () => {
+    const zip = createStoredZip([{ path: "safe.txt", bytes: textEncoder.encode("skill") }]);
+    const patched = new Uint8Array(zip);
+    patched.set(textEncoder.encode("evil.txt"), 30);
+
+    expect(() => readStoredZip(patched)).toThrow(/local header path/i);
+  });
+
+  test("readStoredZip rejects mismatched local sizes", () => {
+    const zip = createStoredZip([{ path: "safe.txt", bytes: textEncoder.encode("skill") }]);
+    const patched = new Uint8Array(zip);
+    writeUInt32(patched, 18, textEncoder.encode("skill").length + 1);
+
+    expect(() => readStoredZip(patched)).toThrow(/local header/i);
+  });
+
+  test("readStoredZip rejects mismatched local CRC", () => {
+    const zip = createStoredZip([{ path: "safe.txt", bytes: textEncoder.encode("skill") }]);
+    const patched = new Uint8Array(zip);
+    writeUInt32(patched, 14, 0);
+
+    expect(() => readStoredZip(patched)).toThrow(/local header/i);
+  });
+
+  test("readStoredZip rejects unsupported general purpose flags", () => {
+    const zip = createStoredZip([{ path: "safe.txt", bytes: textEncoder.encode("skill") }]);
+    const patched = new Uint8Array(zip);
+    const eocdOffset = patched.length - 22;
+    const centralStart = readUInt32(patched, eocdOffset + 16);
+    writeUInt16(patched, 6, 1);
+    writeUInt16(patched, centralStart + 8, 1);
+
+    expect(() => readStoredZip(patched)).toThrow(/flags/i);
+  });
+
+  test("readStoredZip rejects central directory extra fields", () => {
+    const zip = createStoredZip([{ path: "safe.txt", bytes: textEncoder.encode("skill") }]);
+    const eocdOffset = zip.length - 22;
+    const centralStart = readUInt32(zip, eocdOffset + 16);
+    const centralSize = readUInt32(zip, eocdOffset + 12);
+    const patched = new Uint8Array(zip.length + 1);
+    const patchedEocdOffset = eocdOffset + 1;
+    patched.set(zip.slice(0, eocdOffset), 0);
+    patched[eocdOffset] = 0;
+    patched.set(zip.slice(eocdOffset), patchedEocdOffset);
+    writeUInt16(patched, centralStart + 30, 1);
+    writeUInt32(patched, patchedEocdOffset + 12, centralSize + 1);
+
+    expect(() => readStoredZip(patched)).toThrow(/extra|comment|unsupported zip fields/i);
+  });
+
+  test("readStoredZip rejects central directory file comments", () => {
+    const zip = createStoredZip([{ path: "safe.txt", bytes: textEncoder.encode("skill") }]);
+    const eocdOffset = zip.length - 22;
+    const centralStart = readUInt32(zip, eocdOffset + 16);
+    const centralSize = readUInt32(zip, eocdOffset + 12);
+    const patched = new Uint8Array(zip.length + 1);
+    const patchedEocdOffset = eocdOffset + 1;
+    patched.set(zip.slice(0, eocdOffset), 0);
+    patched[eocdOffset] = 0;
+    patched.set(zip.slice(eocdOffset), patchedEocdOffset);
+    writeUInt16(patched, centralStart + 32, 1);
+    writeUInt32(patched, patchedEocdOffset + 12, centralSize + 1);
+
+    expect(() => readStoredZip(patched)).toThrow(/extra|comment|unsupported zip fields/i);
+  });
+
+  test("readStoredZip rejects local extra fields", () => {
+    const entryBytes = textEncoder.encode("skill");
+    const zip = createStoredZip([{ path: "safe.txt", bytes: entryBytes }]);
+    const eocdOffset = zip.length - 22;
+    const centralStart = readUInt32(zip, eocdOffset + 16);
+    const dataStart = 30 + textEncoder.encode("safe.txt").length;
+    const patched = new Uint8Array(zip.length + 1);
+    patched.set(zip.slice(0, dataStart), 0);
+    patched[dataStart] = 0;
+    patched.set(zip.slice(dataStart), dataStart + 1);
+    const patchedEocdOffset = eocdOffset + 1;
+    writeUInt16(patched, 28, 1);
+    writeUInt32(patched, patchedEocdOffset + 16, centralStart + 1);
+
+    expect(() => readStoredZip(patched)).toThrow(/extra|unsupported zip fields/i);
+  });
+
+  test("readStoredZip rejects local data overlapping the central directory", () => {
+    const entryBytes = textEncoder.encode("skill");
+    const pathBytes = textEncoder.encode("safe.txt");
+    const zip = createStoredZip([{ path: "safe.txt", bytes: entryBytes }]);
+    const eocdOffset = zip.length - 22;
+    const centralStart = readUInt32(zip, eocdOffset + 16);
+    const centralSize = readUInt32(zip, eocdOffset + 12);
+    const centralNameLength = readUInt16(zip, centralStart + 28);
+    const flags = readUInt16(zip, centralStart + 8);
+    const fakeLocalOffset = centralStart + 46 + centralNameLength;
+    const fakeLocalHeader = createStoredLocalHeader(flags, pathBytes, entryBytes);
+    const patched = new Uint8Array(zip.length + fakeLocalHeader.length);
+    const patchedEocdOffset = eocdOffset + fakeLocalHeader.length;
+    patched.set(zip.slice(0, eocdOffset), 0);
+    patched.set(fakeLocalHeader, eocdOffset);
+    patched.set(zip.slice(eocdOffset), patchedEocdOffset);
+    writeUInt16(patched, centralStart + 30, fakeLocalHeader.length);
+    writeUInt32(patched, centralStart + 42, fakeLocalOffset);
+    writeUInt32(patched, patchedEocdOffset + 12, centralSize + fakeLocalHeader.length);
+
+    expect(() => readStoredZip(patched)).toThrow(/central directory|overlap|local offset/i);
+  });
+
+  test("readStoredZip rejects prepended local-area gaps", () => {
+    const zip = createStoredZip([{ path: "safe.txt", bytes: textEncoder.encode("skill") }]);
+    const eocdOffset = zip.length - 22;
+    const centralStart = readUInt32(zip, eocdOffset + 16);
+    const patched = new Uint8Array(zip.length + 1);
+    patched[0] = 0;
+    patched.set(zip, 1);
+    const patchedCentralStart = centralStart + 1;
+    const patchedEocdOffset = eocdOffset + 1;
+    writeUInt32(patched, patchedCentralStart + 42, 1);
+    writeUInt32(patched, patchedEocdOffset + 16, patchedCentralStart);
+
+    expect(() => readStoredZip(patched)).toThrow(/local offset|gap|unaccounted/i);
+  });
+
+  test("readStoredZip rejects unreferenced local records before the central directory", () => {
+    const zip = createStoredZip([{ path: "safe.txt", bytes: textEncoder.encode("skill") }]);
+    const eocdOffset = zip.length - 22;
+    const centralStart = readUInt32(zip, eocdOffset + 16);
+    const unusedLocal = createStoredLocalHeader(
+      UTF8_ZIP_FLAGS,
+      textEncoder.encode("unused.txt"),
+      textEncoder.encode("unused"),
+    );
+    const patched = new Uint8Array(zip.length + unusedLocal.length);
+    patched.set(zip.slice(0, centralStart), 0);
+    patched.set(unusedLocal, centralStart);
+    patched.set(zip.slice(centralStart, eocdOffset), centralStart + unusedLocal.length);
+    patched.set(zip.slice(eocdOffset), eocdOffset + unusedLocal.length);
+    writeUInt32(patched, eocdOffset + unusedLocal.length + 16, centralStart + unusedLocal.length);
+
+    expect(() => readStoredZip(patched)).toThrow(/local records|local area|unaccounted/i);
+  });
+
+  test("readStoredZip rejects trailing data after the end of central directory", () => {
+    const zip = createStoredZip([{ path: "safe.txt", bytes: textEncoder.encode("skill") }]);
+    const patched = new Uint8Array(zip.length + 1);
+    patched.set(zip, 0);
+
+    expect(() => readStoredZip(patched)).toThrow(/trailing|comment|end of central directory/i);
+  });
+
+  test("readStoredZip compares local and central filename bytes before decoding", () => {
+    const zip = createStoredZip([{ path: "aa.txt", bytes: textEncoder.encode("skill") }]);
+    const patched = new Uint8Array(zip);
+    const eocdOffset = patched.length - 22;
+    const centralStart = readUInt32(patched, eocdOffset + 16);
+    patched.set(Uint8Array.of(0xc0, 0x80, 0x2e, 0x74, 0x78, 0x74), 30);
+    patched.set(Uint8Array.of(0xc1, 0x81, 0x2e, 0x74, 0x78, 0x74), centralStart + 46);
+
+    expect(() => readStoredZip(patched)).toThrow(/filename|path mismatch/i);
+  });
+
+  test("readStoredZip rejects malformed UTF-8 filename bytes", () => {
+    const zip = createStoredZip([{ path: "aa.txt", bytes: textEncoder.encode("skill") }]);
+    const patched = new Uint8Array(zip);
+    const eocdOffset = patched.length - 22;
+    const centralStart = readUInt32(patched, eocdOffset + 16);
+    const malformedPath = Uint8Array.of(0xc0, 0x80, 0x2e, 0x74, 0x78, 0x74);
+    patched.set(malformedPath, 30);
+    patched.set(malformedPath, centralStart + 46);
+
+    expect(() => readStoredZip(patched)).toThrow(/utf-8|filename/i);
+  });
+
+  test("writes UTF-8 general purpose flags for stored entries", () => {
+    const zip = createStoredZip([{ path: "safe.txt", bytes: textEncoder.encode("skill") }]);
+    const eocdOffset = zip.length - 22;
+    const centralStart = readUInt32(zip, eocdOffset + 16);
+
+    expect(readUInt16(zip, 6)).toBe(UTF8_ZIP_FLAGS);
+    expect(readUInt16(zip, centralStart + 8)).toBe(UTF8_ZIP_FLAGS);
+  });
+
   test("round-trips multiple stored entries", () => {
     const zip = createStoredZip([
       { path: "meta.json", bytes: textEncoder.encode('{"ok":true}') },

--- a/src/shared/zip.ts
+++ b/src/shared/zip.ts
@@ -6,12 +6,19 @@
  */
 
 const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder("utf-8", { fatal: true });
 const DOS_DATE = 0x0021;
 const DOS_TIME = 0x0000;
+const STORED_ZIP_FLAGS = 0x0800;
 const MAX_ZIP32 = 0xffffffff;
 const MAX_UINT16 = 0xffff;
 
 export interface ZipEntryInput {
+  readonly path: string;
+  readonly bytes: Uint8Array;
+}
+
+export interface ZipEntryOutput {
   readonly path: string;
   readonly bytes: Uint8Array;
 }
@@ -72,7 +79,7 @@ export function createStoredZip(entries: readonly ZipEntryInput[]): Uint8Array {
     const view = new DataView(local.buffer);
     view.setUint32(0, 0x04034b50, true);
     view.setUint16(4, 20, true);
-    view.setUint16(6, 0x0800, true);
+    view.setUint16(6, STORED_ZIP_FLAGS, true);
     view.setUint16(8, 0, true);
     view.setUint16(10, DOS_TIME, true);
     view.setUint16(12, DOS_DATE, true);
@@ -95,7 +102,7 @@ export function createStoredZip(entries: readonly ZipEntryInput[]): Uint8Array {
     view.setUint32(0, 0x02014b50, true);
     view.setUint16(4, 20, true);
     view.setUint16(6, 20, true);
-    view.setUint16(8, 0x0800, true);
+    view.setUint16(8, STORED_ZIP_FLAGS, true);
     view.setUint16(10, 0, true);
     view.setUint16(12, DOS_TIME, true);
     view.setUint16(14, DOS_DATE, true);
@@ -139,6 +146,171 @@ export function createStoredZip(entries: readonly ZipEntryInput[]): Uint8Array {
     cursor += chunk.length;
   }
   return out;
+}
+
+function readUInt16(bytes: Uint8Array, offset: number): number {
+  if (offset + 2 > bytes.length) throw new Error("invalid zip: truncated uint16");
+  return ((bytes[offset] ?? 0) | ((bytes[offset + 1] ?? 0) << 8)) >>> 0;
+}
+
+function readUInt32(bytes: Uint8Array, offset: number): number {
+  if (offset + 4 > bytes.length) throw new Error("invalid zip: truncated uint32");
+  return (
+    ((bytes[offset] ?? 0) |
+      ((bytes[offset + 1] ?? 0) << 8) |
+      ((bytes[offset + 2] ?? 0) << 16) |
+      ((bytes[offset + 3] ?? 0) << 24)) >>>
+    0
+  );
+}
+
+function findEndOfCentralDirectory(bytes: Uint8Array): number {
+  for (let offset = bytes.length - 22; offset >= 0; offset--) {
+    if (readUInt32(bytes, offset) === 0x06054b50) return offset;
+  }
+  throw new Error("invalid zip: missing end of central directory");
+}
+
+function decodeEntryPath(bytes: Uint8Array): string {
+  try {
+    return textDecoder.decode(bytes);
+  } catch {
+    throw new Error("invalid zip: filename is not valid UTF-8");
+  }
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index++) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
+}
+
+export function readStoredZip(bytes: Uint8Array): readonly ZipEntryOutput[] {
+  const eocdOffset = findEndOfCentralDirectory(bytes);
+  const eocdCommentLength = readUInt16(bytes, eocdOffset + 20);
+  if (eocdCommentLength !== 0 || eocdOffset + 22 !== bytes.length) {
+    throw new Error("unsupported zip end of central directory comment or trailing data");
+  }
+  const entryCount = readUInt16(bytes, eocdOffset + 8);
+  const centralSize = readUInt32(bytes, eocdOffset + 12);
+  const centralStart = readUInt32(bytes, eocdOffset + 16);
+  let centralOffset = centralStart;
+  const centralEnd = centralOffset + centralSize;
+  if (centralEnd !== eocdOffset) {
+    throw new Error("invalid zip: central directory exceeds archive bounds");
+  }
+  const entries: ZipEntryOutput[] = [];
+  const seen = new Set<string>();
+  let expectedLocalOffset = 0;
+
+  for (let index = 0; index < entryCount; index++) {
+    const fixedHeaderEnd = centralOffset + 46;
+    if (fixedHeaderEnd > centralEnd) {
+      throw new Error("invalid zip: central directory record exceeds declared size");
+    }
+    if (readUInt32(bytes, centralOffset) !== 0x02014b50) {
+      throw new Error("invalid zip: missing central directory record");
+    }
+    const flags = readUInt16(bytes, centralOffset + 8);
+    if (flags !== STORED_ZIP_FLAGS) {
+      throw new Error(`unsupported zip flags: ${flags}`);
+    }
+    const compressionMethod = readUInt16(bytes, centralOffset + 10);
+    if (compressionMethod !== 0) {
+      throw new Error(`unsupported zip compression method: ${compressionMethod}`);
+    }
+    const expectedCrc = readUInt32(bytes, centralOffset + 16);
+    const compressedSize = readUInt32(bytes, centralOffset + 20);
+    const uncompressedSize = readUInt32(bytes, centralOffset + 24);
+    if (compressedSize !== uncompressedSize) {
+      throw new Error("invalid stored zip: compressed and uncompressed sizes differ");
+    }
+    const nameLength = readUInt16(bytes, centralOffset + 28);
+    const extraLength = readUInt16(bytes, centralOffset + 30);
+    const commentLength = readUInt16(bytes, centralOffset + 32);
+    const localOffset = readUInt32(bytes, centralOffset + 42);
+    const nameStart = centralOffset + 46;
+    const variableFieldEnd = nameStart + nameLength + extraLength + commentLength;
+    if (variableFieldEnd > centralEnd) {
+      throw new Error("invalid zip: central directory variable fields exceed declared size");
+    }
+    if (extraLength !== 0 || commentLength !== 0) {
+      throw new Error("unsupported zip central directory extra/comment fields");
+    }
+    const centralNameBytes = bytes.slice(nameStart, nameStart + nameLength);
+
+    if (localOffset !== expectedLocalOffset) {
+      throw new Error("invalid zip: local offset gap or unaccounted local record");
+    }
+    if (localOffset >= centralStart) {
+      throw new Error("invalid zip: local offset overlaps central directory");
+    }
+    if (localOffset + 30 > centralStart) {
+      throw new Error("invalid zip: local header overlaps central directory");
+    }
+    if (readUInt32(bytes, localOffset) !== 0x04034b50) {
+      throw new Error("invalid zip: missing local file header");
+    }
+    const localFlags = readUInt16(bytes, localOffset + 6);
+    if (localFlags !== STORED_ZIP_FLAGS) {
+      throw new Error(`unsupported zip flags: ${localFlags}`);
+    }
+    const localCompressionMethod = readUInt16(bytes, localOffset + 8);
+    if (localCompressionMethod !== 0) {
+      throw new Error(`unsupported zip compression method: ${localCompressionMethod}`);
+    }
+    const localCrc = readUInt32(bytes, localOffset + 14);
+    const localCompressedSize = readUInt32(bytes, localOffset + 18);
+    const localUncompressedSize = readUInt32(bytes, localOffset + 22);
+    if (
+      localCrc !== expectedCrc ||
+      localCompressedSize !== compressedSize ||
+      localUncompressedSize !== uncompressedSize
+    ) {
+      throw new Error("zip local header metadata mismatch");
+    }
+    const localNameLength = readUInt16(bytes, localOffset + 26);
+    const localExtraLength = readUInt16(bytes, localOffset + 28);
+    if (localExtraLength !== 0) {
+      throw new Error("unsupported zip local extra fields");
+    }
+    const localNameStart = localOffset + 30;
+    const dataStart = localNameStart + localNameLength + localExtraLength;
+    if (dataStart > centralStart) {
+      throw new Error("invalid zip: local header overlaps central directory");
+    }
+    const localNameBytes = bytes.slice(localNameStart, localNameStart + localNameLength);
+    if (!bytesEqual(localNameBytes, centralNameBytes)) {
+      throw new Error("zip local header path filename bytes mismatch");
+    }
+    const name = decodeEntryPath(centralNameBytes);
+    validateEntryPath(name);
+    if (seen.has(name)) throw new Error(`duplicate zip entry path: ${name}`);
+    seen.add(name);
+    const dataEnd = dataStart + compressedSize;
+    if (dataEnd > centralStart) {
+      throw new Error("invalid zip: entry data overlaps central directory");
+    }
+    expectedLocalOffset = dataEnd;
+    const entryBytes = bytes.slice(dataStart, dataEnd);
+    const actualCrc = crc32(entryBytes);
+    if (actualCrc !== expectedCrc) {
+      throw new Error(`zip crc mismatch for ${name}`);
+    }
+    entries.push({ path: name, bytes: entryBytes });
+    centralOffset = variableFieldEnd;
+  }
+
+  if (centralOffset !== centralEnd) {
+    throw new Error("invalid zip: central directory size mismatch");
+  }
+  if (expectedLocalOffset !== centralStart) {
+    throw new Error("invalid zip: unaccounted local records before central directory");
+  }
+
+  return entries;
 }
 
 function validateEntryPath(path: string): void {

--- a/src/tui/hooks/use-done-detection.test.tsx
+++ b/src/tui/hooks/use-done-detection.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { LocalEventBus } from "../../core/local-event-bus.js";
+import type { AgentTopology } from "../../core/topology.js";
+import type { Screen } from "../screens/screen-manager.js";
+import { useDoneDetection } from "./use-done-detection.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const REVIEW_LOOP_TOPOLOGY: AgentTopology = {
+  structure: "graph",
+  roles: [
+    {
+      name: "coder",
+      edges: [{ target: "reviewer", edgeType: "delegates" }],
+    },
+    {
+      name: "reviewer",
+      edges: [{ target: "coder", edgeType: "feedback" }],
+    },
+  ],
+};
+
+const mountedRenderers: TestRenderer.ReactTestRenderer[] = [];
+const openBuses: LocalEventBus[] = [];
+
+function Probe({
+  topology,
+  screen,
+  eventBus,
+  onDone,
+}: {
+  readonly topology: AgentTopology;
+  readonly screen: Screen;
+  readonly eventBus: LocalEventBus;
+  readonly onDone: () => void;
+}): null {
+  useDoneDetection(topology, screen, eventBus, onDone);
+  return null;
+}
+
+afterEach(() => {
+  for (const renderer of mountedRenderers.splice(0)) {
+    act(() => {
+      renderer.unmount();
+    });
+  }
+  for (const bus of openBuses.splice(0)) {
+    bus.close();
+  }
+});
+
+describe("useDoneDetection", () => {
+  test("completes the session when the reviewer signals done", async () => {
+    const bus = new LocalEventBus();
+    openBuses.push(bus);
+
+    let doneCalls = 0;
+    await act(async () => {
+      mountedRenderers.push(
+        TestRenderer.create(
+          React.createElement(Probe, {
+            topology: REVIEW_LOOP_TOPOLOGY,
+            screen: "running",
+            eventBus: bus,
+            onDone: () => {
+              doneCalls += 1;
+            },
+          }),
+        ),
+      );
+    });
+
+    await act(async () => {
+      await bus.publish({
+        type: "contribution",
+        sourceRole: "reviewer",
+        targetRole: "reviewer",
+        payload: {
+          summary: "[DONE] Approved",
+          context: { done: true },
+        },
+        timestamp: "2026-05-07T00:00:00.000Z",
+      });
+    });
+
+    expect(doneCalls).toBe(1);
+  });
+});

--- a/src/tui/hooks/use-done-detection.ts
+++ b/src/tui/hooks/use-done-detection.ts
@@ -1,8 +1,8 @@
 /**
- * Detects session completion by watching for done signals from all topology roles.
+ * Detects session completion by watching for a done signal from any topology role.
  *
- * Polls contributions for [DONE] prefix or context.done flag.
- * Calls onDone when all roles have signaled completion.
+ * Watches contribution events for [DONE] prefix or context.done flag.
+ * Calls onDone when the session has been marked complete.
  *
  * Extracted from ScreenManager to reduce component complexity.
  */
@@ -33,7 +33,7 @@ function isDoneContribution(c: { summary: string; context?: unknown }): boolean 
  * @param topology - Agent topology with role definitions
  * @param screen - Current screen state (only active on "running" or "advanced")
  * @param eventBus - Event bus for real-time done detection; without it the hook is inert
- * @param onDone - Callback when all roles have signaled done
+ * @param onDone - Callback when the session has been marked complete
  */
 export function useDoneDetection(
   topology: AgentTopology | undefined,
@@ -41,26 +41,21 @@ export function useDoneDetection(
   eventBus: EventBus | undefined,
   onDone: () => void,
 ): void {
-  const doneRolesRef = useRef<Set<string>>(new Set());
+  const doneSignaledRef = useRef(false);
 
-  const checkDone = useCallback(
-    (role: string) => {
-      if (!topology) return;
-      doneRolesRef.current.add(role);
-      const roleNames = new Set(topology.roles.map((r) => r.name));
-      const allDone = [...roleNames].every((r) => doneRolesRef.current.has(r));
-      if (allDone && roleNames.size > 0) {
-        onDone();
-      }
-    },
-    [topology, onDone],
-  );
+  const checkDone = useCallback(() => {
+    if (!topology) return;
+    if (topology.roles.length === 0 || doneSignaledRef.current) return;
+    doneSignaledRef.current = true;
+    onDone();
+  }, [topology, onDone]);
 
   // Event-driven mode: subscribe to EventBus for real-time done detection
   useEffect(() => {
     if (screen !== "running" && screen !== "advanced") return;
     if (!topology || !eventBus) return;
 
+    doneSignaledRef.current = false;
     const handlers: Array<{ role: string; handler: (e: GroveEvent) => void }> = [];
     for (const role of topology.roles) {
       const handler = (event: GroveEvent) => {
@@ -70,11 +65,11 @@ export function useDoneDetection(
             payload.summary &&
             isDoneContribution(payload as { summary: string; context?: unknown })
           ) {
-            checkDone(role.name);
+            checkDone();
           }
         }
         if (event.type === "stop") {
-          checkDone(role.name);
+          checkDone();
         }
       };
       handlers.push({ role: role.name, handler });

--- a/src/tui/screens/screen-manager.test.ts
+++ b/src/tui/screens/screen-manager.test.ts
@@ -10,6 +10,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
+import { LocalEventBus } from "../../core/local-event-bus.js";
 import type { Contribution } from "../../core/models.js";
 import { ContributionKind, ContributionMode } from "../../core/models.js";
 import type { AgentTopology } from "../../core/topology.js";
@@ -645,6 +646,52 @@ describe("ScreenManager transition flow", () => {
     expect(requireCompleteView().reason).toBe("All roles signaled done");
     expect(requireCompleteView().contributionCount).toBe(2);
     expect(providerBundle.calls.archiveSession).toEqual(["session-done"]);
+  });
+
+  test("running -> complete when one agent signals done through the event bus", async () => {
+    const providerBundle = makeProvider({
+      contributions: [makeContribution("c1")],
+    });
+    const eventBus = new LocalEventBus();
+    try {
+      renderScreenManager({
+        provider: providerBundle.provider,
+        topology: TEST_TOPOLOGY,
+        appProps: {
+          ...makeAppProps(providerBundle.provider, TEST_TOPOLOGY),
+          eventBus,
+        },
+        initialState: {
+          screen: "running",
+          goal: "Complete the session",
+          sessionId: "session-done-event",
+          sessionStartedAt: "2026-03-29T00:00:00.000Z",
+        },
+      });
+
+      await act(async () => {
+        await flushAsync();
+        await eventBus.publish({
+          type: "contribution",
+          sourceRole: "builder",
+          targetRole: "builder",
+          payload: {
+            summary: "[DONE] Approved",
+            context: { done: true },
+          },
+          timestamp: "2026-05-07T00:00:00.000Z",
+        });
+        await flushAsync();
+        await flushAsync();
+      });
+
+      expect(captured.screen).toBe("complete");
+      expect(requireCompleteView().reason).toBe("Agent signaled done");
+      expect(requireCompleteView().contributionCount).toBe(1);
+      expect(providerBundle.calls.archiveSession).toEqual(["session-done-event"]);
+    } finally {
+      eventBus.close();
+    }
   });
 
   test("complete -> preset-select starts a fresh session when no preset state is reusable", () => {

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -320,7 +320,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
       [provider, spawnManager],
     );
     const handleDone = useCallback(() => {
-      void snapshotAndComplete("All roles signaled done");
+      void snapshotAndComplete("Agent signaled done");
     }, [snapshotAndComplete]);
     useDoneDetection(topology, state.screen, appProps.eventBus, handleDone);
 

--- a/src/tui/spawn-manager.test.ts
+++ b/src/tui/spawn-manager.test.ts
@@ -8,7 +8,7 @@
 
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { execSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -213,7 +213,11 @@ function makeTempGitProject(prefix: string): {
 
 function writeNexusGroveConfig(
   groveDir: string,
-  opts: { readonly policy: "required" | "warn-and-fallback"; readonly nexusUrl: string },
+  opts: {
+    readonly policy: "required" | "warn-and-fallback";
+    readonly nexusUrl?: string | undefined;
+    readonly nexusManaged?: boolean | undefined;
+  },
 ): void {
   writeFileSync(
     join(groveDir, "grove.json"),
@@ -221,7 +225,8 @@ function writeNexusGroveConfig(
       {
         name: "test",
         mode: "nexus",
-        nexusUrl: opts.nexusUrl,
+        ...(opts.nexusUrl !== undefined ? { nexusUrl: opts.nexusUrl } : {}),
+        ...(opts.nexusManaged === true ? { nexusManaged: true } : {}),
         skillCatalog: {
           policy: opts.policy,
           trustedKeys: [
@@ -593,6 +598,81 @@ describe("SpawnManager — per-role skill injection", () => {
       ).rejects.toThrow("http://127.0.0.1:1");
       expect(tmux.spawnedSessions).toHaveLength(0);
       expect(errors.filter((e) => e.includes("Config write failed"))).toEqual([]);
+    } finally {
+      restoreEnv("GROVE_NEXUS_URL", previousNexusUrl);
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("empty GROVE_NEXUS_URL falls back to managed nexus.yaml for required skill catalogs", async () => {
+    const { projectRoot, groveDir } = makeTempGitProject("grove-skill-managed-env-");
+    const previousNexusUrl = process.env.GROVE_NEXUS_URL;
+    process.env.GROVE_NEXUS_URL = "";
+
+    try {
+      writeNexusGroveConfig(groveDir, {
+        policy: "required",
+        nexusManaged: true,
+      });
+      writeFileSync(join(projectRoot, "nexus.yaml"), "ports:\n  http: 1\n", "utf-8");
+
+      const provider = makeMockProvider();
+      const tmux = makeMockTmux();
+      const errors: string[] = [];
+      manager = new SpawnManager(
+        provider,
+        tmux,
+        (msg) => errors.push(msg),
+        [{ kind: "local" as const, path: projectRoot }],
+        undefined,
+        groveDir,
+      );
+      manager.setIsolationPolicy("allow-fallback");
+
+      await expect(
+        manager.spawn("coder", "bash", undefined, 0, { skills: ["grove"] }),
+      ).rejects.toThrow("http://localhost:1");
+      expect(tmux.spawnedSessions).toHaveLength(0);
+      expect(errors.filter((e) => e.includes("Config write failed"))).toEqual([]);
+    } finally {
+      restoreEnv("GROVE_NEXUS_URL", previousNexusUrl);
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("managed nexus.yaml URL is written to MCP config", async () => {
+    const { projectRoot, groveDir } = makeTempGitProject("grove-skill-managed-mcp-");
+    const previousNexusUrl = process.env.GROVE_NEXUS_URL;
+    process.env.GROVE_NEXUS_URL = "";
+
+    try {
+      writeNexusGroveConfig(groveDir, {
+        policy: "warn-and-fallback",
+        nexusManaged: true,
+      });
+      writeFileSync(join(projectRoot, "nexus.yaml"), "ports:\n  http: 23456\n", "utf-8");
+
+      const provider = makeMockProvider();
+      const tmux = makeMockTmux();
+      manager = new SpawnManager(
+        provider,
+        tmux,
+        () => undefined,
+        [{ kind: "local" as const, path: projectRoot }],
+        undefined,
+        groveDir,
+      );
+
+      const result = await manager.spawn("coder", "bash");
+      const mcpConfig = JSON.parse(
+        readFileSync(join(result.workspacePath, ".mcp.json"), "utf-8"),
+      ) as {
+        readonly mcpServers?: {
+          readonly grove?: { readonly env?: { readonly GROVE_NEXUS_URL?: string | undefined } };
+        };
+      };
+
+      expect(mcpConfig.mcpServers?.grove?.env?.GROVE_NEXUS_URL).toBe("http://localhost:23456");
     } finally {
       restoreEnv("GROVE_NEXUS_URL", previousNexusUrl);
       rmSync(projectRoot, { recursive: true, force: true });

--- a/src/tui/spawn-manager.test.ts
+++ b/src/tui/spawn-manager.test.ts
@@ -7,6 +7,10 @@
  */
 
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // spawn() does real work: git worktree add into the current repo, writeFile
 // for config artifacts, chmod, and writeMcpConfig. Individual spawns routinely
@@ -188,6 +192,58 @@ function makeMockTmux(shouldFail = false): TmuxManager & {
       return "";
     },
   };
+}
+
+function makeTempGitProject(prefix: string): {
+  readonly projectRoot: string;
+  readonly groveDir: string;
+} {
+  const projectRoot = mkdtempSync(join(tmpdir(), prefix));
+  execSync("git init -q", { cwd: projectRoot });
+  execSync("git config user.email test@grove.test", { cwd: projectRoot });
+  execSync("git config user.name Grove-Test", { cwd: projectRoot });
+  execSync("git commit --allow-empty -q -m init", { cwd: projectRoot });
+
+  const groveDir = join(projectRoot, ".grove");
+  mkdirSync(groveDir, { recursive: true });
+  return { projectRoot, groveDir };
+}
+
+function writeNexusGroveConfig(
+  groveDir: string,
+  opts: { readonly policy: "required" | "warn-and-fallback"; readonly nexusUrl: string },
+): void {
+  writeFileSync(
+    join(groveDir, "grove.json"),
+    `${JSON.stringify(
+      {
+        name: "test",
+        mode: "nexus",
+        nexusUrl: opts.nexusUrl,
+        skillCatalog: {
+          policy: opts.policy,
+          trustedKeys: [
+            {
+              id: "test-key",
+              algorithm: "ed25519",
+              publicKeySpkiDer: "AA==",
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -414,6 +470,111 @@ describe("SpawnManager", () => {
 // ---------------------------------------------------------------------------
 
 describe("SpawnManager — per-role skill injection", () => {
+  test("allow-fallback still fails closed when required Nexus skill catalog is unreachable", async () => {
+    const { projectRoot, groveDir } = makeTempGitProject("grove-skill-required-");
+    const previousNexusUrl = process.env.GROVE_NEXUS_URL;
+    delete process.env.GROVE_NEXUS_URL;
+
+    try {
+      writeNexusGroveConfig(groveDir, {
+        policy: "required",
+        nexusUrl: "http://127.0.0.1:1",
+      });
+
+      const provider = makeMockProvider();
+      const tmux = makeMockTmux();
+      const errors: string[] = [];
+      manager = new SpawnManager(
+        provider,
+        tmux,
+        (msg) => errors.push(msg),
+        [{ kind: "local" as const, path: projectRoot }],
+        undefined,
+        groveDir,
+      );
+      manager.setIsolationPolicy("allow-fallback");
+
+      await expect(
+        manager.spawn("coder", "bash", undefined, 0, { skills: ["grove"] }),
+      ).rejects.toThrow("Nexus skill catalog required");
+      expect(tmux.spawnedSessions).toHaveLength(0);
+      expect(errors.filter((e) => e.includes("Config write failed"))).toEqual([]);
+    } finally {
+      restoreEnv("GROVE_NEXUS_URL", previousNexusUrl);
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("empty GROVE_NEXUS_URL falls back to grove.json nexusUrl for required skill catalogs", async () => {
+    const { projectRoot, groveDir } = makeTempGitProject("grove-skill-empty-env-");
+    const previousNexusUrl = process.env.GROVE_NEXUS_URL;
+    process.env.GROVE_NEXUS_URL = "";
+
+    try {
+      writeNexusGroveConfig(groveDir, {
+        policy: "required",
+        nexusUrl: "http://127.0.0.1:1",
+      });
+
+      const provider = makeMockProvider();
+      const tmux = makeMockTmux();
+      const errors: string[] = [];
+      manager = new SpawnManager(
+        provider,
+        tmux,
+        (msg) => errors.push(msg),
+        [{ kind: "local" as const, path: projectRoot }],
+        undefined,
+        groveDir,
+      );
+      manager.setIsolationPolicy("allow-fallback");
+
+      await expect(
+        manager.spawn("coder", "bash", undefined, 0, { skills: ["grove"] }),
+      ).rejects.toThrow("http://127.0.0.1:1");
+      expect(tmux.spawnedSessions).toHaveLength(0);
+      expect(errors.filter((e) => e.includes("Config write failed"))).toEqual([]);
+    } finally {
+      restoreEnv("GROVE_NEXUS_URL", previousNexusUrl);
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("warn-and-fallback Nexus skill catalog warnings are surfaced during spawn", async () => {
+    const { projectRoot, groveDir } = makeTempGitProject("grove-skill-warning-");
+    const previousNexusUrl = process.env.GROVE_NEXUS_URL;
+    process.env.GROVE_NEXUS_URL = "";
+
+    try {
+      writeNexusGroveConfig(groveDir, {
+        policy: "warn-and-fallback",
+        nexusUrl: "http://127.0.0.1:1",
+      });
+
+      const provider = makeMockProvider();
+      const tmux = makeMockTmux();
+      const errors: string[] = [];
+      manager = new SpawnManager(
+        provider,
+        tmux,
+        (msg) => errors.push(msg),
+        [{ kind: "local" as const, path: projectRoot }],
+        undefined,
+        groveDir,
+      );
+      manager.setIsolationPolicy("strict");
+
+      const result = await manager.spawn("coder", "bash", undefined, 0, { skills: ["grove"] });
+
+      expect(result.workspaceMode.status).toBe("isolated_worktree");
+      expect(errors.some((e) => e.includes("Nexus skill catalog warning"))).toBe(true);
+      expect(errors.some((e) => e.includes("fallback: local"))).toBe(true);
+    } finally {
+      restoreEnv("GROVE_NEXUS_URL", previousNexusUrl);
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test("spawn injects declared 'grove' skill into .claude/skills and .codex/skills", async () => {
     const { execSync } = await import("node:child_process");
     const { existsSync, mkdirSync, mkdtempSync, readFileSync } = await import("node:fs");

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -33,6 +33,7 @@ import {
   resolveNexusSkillCatalogRoot,
   type SkillResolutionWarning,
 } from "../nexus/nexus-skill-catalog.js";
+import { resolveConfiguredNexusUrl } from "../shared/nexus-url.js";
 import { safeCleanup } from "../shared/safe-cleanup.js";
 import type { SpawnOptions, TmuxManager } from "./agents/tmux-manager.js";
 import { agentIdFromSession } from "./agents/tmux-manager.js";
@@ -455,7 +456,12 @@ export class SpawnManager {
     const config = parseGroveConfig(raw);
     if (config.mode !== "nexus" || config.skillCatalog === undefined) return undefined;
 
-    const nexusUrl = process.env.GROVE_NEXUS_URL || config.nexusUrl;
+    const projectRoot = dirname(this.groveDir);
+    const nexusUrl = resolveConfiguredNexusUrl({
+      projectRoot,
+      config,
+      env: process.env,
+    });
     if (!nexusUrl) {
       if (config.skillCatalog.policy !== "required") return undefined;
       throw new RequiredSkillCatalogResolutionError(
@@ -467,7 +473,6 @@ export class SpawnManager {
       url: nexusUrl,
       apiKey: process.env.NEXUS_API_KEY || undefined,
     });
-    const projectRoot = dirname(this.groveDir);
     try {
       const result = await resolveNexusSkillCatalogRoot({
         client,
@@ -1469,8 +1474,8 @@ export class SpawnManager {
     const projectRoot = join(groveDir, "..");
 
     // Resolve Nexus URL: env var takes precedence (explicit override), then
-    // fall back to the nexusUrl stored in the *session*'s .grove/grove.json
-    // (set by `grove init --nexus-url` and refreshed by startServices).
+    // fall back to managed nexus.yaml or the nexusUrl stored in the session's
+    // .grove/grove.json.
     //
     // Note: `groveDir` here is the SHARED nexus-workspaces dir (parent of all
     // workspace folders), not the per-session .grove dir — so we can't read
@@ -1485,9 +1490,26 @@ export class SpawnManager {
       try {
         const configPath = join(this.groveDir, "grove.json");
         if (existsSync(configPath)) {
-          const raw = await (await import("node:fs/promises")).readFile(configPath, "utf-8");
-          const cfg = JSON.parse(raw) as { nexusUrl?: string };
-          if (cfg.nexusUrl) resolvedNexusUrl = cfg.nexusUrl;
+          const raw = await readFile(configPath, "utf-8");
+          try {
+            const config = parseGroveConfig(raw);
+            resolvedNexusUrl = resolveConfiguredNexusUrl({
+              projectRoot,
+              config,
+              env: process.env,
+            });
+          } catch {
+            const config = JSON.parse(raw) as {
+              readonly mode?: string | undefined;
+              readonly nexusManaged?: boolean | undefined;
+              readonly nexusUrl?: string | undefined;
+            };
+            resolvedNexusUrl = resolveConfiguredNexusUrl({
+              projectRoot,
+              config,
+              env: process.env,
+            });
+          }
         }
       } catch {
         /* best-effort */

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -15,6 +15,7 @@ import { dirname, join, resolve } from "node:path";
 import { watchTurnError } from "../acp/watch-turn.js";
 import type { AcpRuntimeEvent, AcpRuntimeEventSink } from "../core/acp-runtime.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "../core/agent-runtime.js";
+import { parseGroveConfig } from "../core/config.js";
 import type { AgentIdentity } from "../core/models.js";
 import { type ResolvedRepo, type ResolveRepoOptions, resolveRepo } from "../core/repo-cache.js";
 import type { RepoRef } from "../core/repo-ref.js";
@@ -26,6 +27,8 @@ import { resolveRoleWorkspaceStrategies } from "../core/topology.js";
 import type { WorkspaceIsolationPolicy, WorkspaceMode } from "../core/workspace-provisioner.js";
 import { provisionWorkspace } from "../core/workspace-provisioner.js";
 import { startInterval } from "../local/use-interval.js";
+import { NexusHttpClient } from "../nexus/nexus-http-client.js";
+import { resolveNexusSkillCatalogRoot } from "../nexus/nexus-skill-catalog.js";
 import { safeCleanup } from "../shared/safe-cleanup.js";
 import type { SpawnOptions, TmuxManager } from "./agents/tmux-manager.js";
 import { agentIdFromSession } from "./agents/tmux-manager.js";
@@ -408,6 +411,35 @@ export class SpawnManager {
     );
   }
 
+  private async resolveSkillRootForSpawn(
+    roleSkills: readonly string[],
+  ): Promise<string | undefined> {
+    if (roleSkills.length === 0 || !this.groveDir) return undefined;
+    const configPath = join(this.groveDir, "grove.json");
+    if (!existsSync(configPath)) return undefined;
+    const raw = await readFile(configPath, "utf-8");
+    const config = parseGroveConfig(raw);
+    if (config.mode !== "nexus" || config.skillCatalog === undefined) return undefined;
+
+    const nexusUrl = process.env.GROVE_NEXUS_URL ?? config.nexusUrl;
+    if (!nexusUrl) return undefined;
+    const client = new NexusHttpClient({
+      url: nexusUrl,
+      apiKey: process.env.NEXUS_API_KEY || undefined,
+    });
+    const projectRoot = dirname(this.groveDir);
+    const result = await resolveNexusSkillCatalogRoot({
+      client,
+      zoneId: process.env.GROVE_ZONE_ID ?? "default",
+      cacheRoot: join(this.groveDir, "cache", "skills"),
+      skills: roleSkills,
+      policy: config.skillCatalog.policy,
+      trustedKeys: config.skillCatalog.trustedKeys,
+      localFallbackRoots: [join(this.groveDir, "skills"), resolveBundledSkillsRoot(projectRoot)],
+    });
+    return result.root;
+  }
+
   /**
    * Set the session topology so spawn() can resolve edge-type-aware base branches.
    * Call before spawning when the topology is known (e.g. after preset selection).
@@ -609,11 +641,13 @@ export class SpawnManager {
           ? (context.skills as readonly string[])
           : [];
         if (roleSkills.length > 0 && this.groveDir) {
+          const resolvedSkillRoot = await this.resolveSkillRootForSpawn(roleSkills);
           await injectSkills({
             workspacePath,
             skills: roleSkills,
-            bundledSkillsRoot: resolveBundledSkillsRoot(dirname(this.groveDir)),
-            workspaceOverrideRoot: join(this.groveDir, "skills"),
+            bundledSkillsRoot:
+              resolvedSkillRoot ?? resolveBundledSkillsRoot(dirname(this.groveDir)),
+            workspaceOverrideRoot: resolvedSkillRoot ? undefined : join(this.groveDir, "skills"),
           });
         }
         // Protect config files from agent mutation (#7 Workspace Mutation Constraints)

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -28,7 +28,11 @@ import type { WorkspaceIsolationPolicy, WorkspaceMode } from "../core/workspace-
 import { provisionWorkspace } from "../core/workspace-provisioner.js";
 import { startInterval } from "../local/use-interval.js";
 import { NexusHttpClient } from "../nexus/nexus-http-client.js";
-import { resolveNexusSkillCatalogRoot } from "../nexus/nexus-skill-catalog.js";
+import {
+  type ResolvedSkillCatalogRoot,
+  resolveNexusSkillCatalogRoot,
+  type SkillResolutionWarning,
+} from "../nexus/nexus-skill-catalog.js";
 import { safeCleanup } from "../shared/safe-cleanup.js";
 import type { SpawnOptions, TmuxManager } from "./agents/tmux-manager.js";
 import { agentIdFromSession } from "./agents/tmux-manager.js";
@@ -74,6 +78,28 @@ export interface SpawnResult {
   readonly workspacePath: string;
   /** Describes how this agent's workspace was provisioned. */
   readonly workspaceMode: WorkspaceMode;
+}
+
+class RequiredSkillCatalogResolutionError extends Error {
+  constructor(message: string, cause: unknown) {
+    super(message, { cause });
+    this.name = "RequiredSkillCatalogResolutionError";
+  }
+}
+
+function isRequiredSkillCatalogResolutionError(
+  error: unknown,
+): error is RequiredSkillCatalogResolutionError {
+  return error instanceof RequiredSkillCatalogResolutionError;
+}
+
+function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatSkillCatalogWarning(warning: SkillResolutionWarning): string {
+  const fallback = warning.fallbackSource ? ` fallback: ${warning.fallbackSource};` : "";
+  return `Nexus skill catalog warning for '${warning.skillName}': attempted ${warning.attemptedSource};${fallback} ${warning.reason}`;
 }
 
 /**
@@ -411,9 +437,17 @@ export class SpawnManager {
     );
   }
 
+  private reportSkillCatalogWarnings(warnings: readonly SkillResolutionWarning[]): void {
+    for (const warning of warnings) {
+      const message = formatSkillCatalogWarning(warning);
+      this.onError(message);
+      debugLog("spawn", message);
+    }
+  }
+
   private async resolveSkillRootForSpawn(
     roleSkills: readonly string[],
-  ): Promise<string | undefined> {
+  ): Promise<ResolvedSkillCatalogRoot | undefined> {
     if (roleSkills.length === 0 || !this.groveDir) return undefined;
     const configPath = join(this.groveDir, "grove.json");
     if (!existsSync(configPath)) return undefined;
@@ -421,23 +455,40 @@ export class SpawnManager {
     const config = parseGroveConfig(raw);
     if (config.mode !== "nexus" || config.skillCatalog === undefined) return undefined;
 
-    const nexusUrl = process.env.GROVE_NEXUS_URL ?? config.nexusUrl;
-    if (!nexusUrl) return undefined;
+    const nexusUrl = process.env.GROVE_NEXUS_URL || config.nexusUrl;
+    if (!nexusUrl) {
+      if (config.skillCatalog.policy !== "required") return undefined;
+      throw new RequiredSkillCatalogResolutionError(
+        "Nexus skill catalog required but no Nexus URL is configured",
+        undefined,
+      );
+    }
     const client = new NexusHttpClient({
       url: nexusUrl,
       apiKey: process.env.NEXUS_API_KEY || undefined,
     });
     const projectRoot = dirname(this.groveDir);
-    const result = await resolveNexusSkillCatalogRoot({
-      client,
-      zoneId: process.env.GROVE_ZONE_ID ?? "default",
-      cacheRoot: join(this.groveDir, "cache", "skills"),
-      skills: roleSkills,
-      policy: config.skillCatalog.policy,
-      trustedKeys: config.skillCatalog.trustedKeys,
-      localFallbackRoots: [join(this.groveDir, "skills"), resolveBundledSkillsRoot(projectRoot)],
-    });
-    return result.root;
+    try {
+      const result = await resolveNexusSkillCatalogRoot({
+        client,
+        zoneId: process.env.GROVE_ZONE_ID ?? "default",
+        cacheRoot: join(this.groveDir, "cache", "skills"),
+        skills: roleSkills,
+        policy: config.skillCatalog.policy,
+        trustedKeys: config.skillCatalog.trustedKeys,
+        localFallbackRoots: [join(this.groveDir, "skills"), resolveBundledSkillsRoot(projectRoot)],
+      });
+      this.reportSkillCatalogWarnings(result.warnings);
+      return result;
+    } catch (error) {
+      if (config.skillCatalog.policy === "required") {
+        throw new RequiredSkillCatalogResolutionError(
+          `Nexus skill catalog required but resolution failed: ${messageFromError(error)}`,
+          error,
+        );
+      }
+      throw error;
+    }
   }
 
   /**
@@ -641,13 +692,13 @@ export class SpawnManager {
           ? (context.skills as readonly string[])
           : [];
         if (roleSkills.length > 0 && this.groveDir) {
-          const resolvedSkillRoot = await this.resolveSkillRootForSpawn(roleSkills);
+          const resolvedSkillCatalog = await this.resolveSkillRootForSpawn(roleSkills);
           await injectSkills({
             workspacePath,
             skills: roleSkills,
             bundledSkillsRoot:
-              resolvedSkillRoot ?? resolveBundledSkillsRoot(dirname(this.groveDir)),
-            workspaceOverrideRoot: resolvedSkillRoot ? undefined : join(this.groveDir, "skills"),
+              resolvedSkillCatalog?.root ?? resolveBundledSkillsRoot(dirname(this.groveDir)),
+            workspaceOverrideRoot: resolvedSkillCatalog ? undefined : join(this.groveDir, "skills"),
           });
         }
         // Protect config files from agent mutation (#7 Workspace Mutation Constraints)
@@ -680,7 +731,10 @@ export class SpawnManager {
         }
       } catch (configErr) {
         const reason = configErr instanceof Error ? configErr.message : String(configErr);
-        if (this.workspaceIsolationPolicy === "strict") {
+        if (
+          this.workspaceIsolationPolicy === "strict" ||
+          isRequiredSkillCatalogResolutionError(configErr)
+        ) {
           throw new Error(`Bootstrap failed for '${roleId}': ${reason}`);
         }
         this.onError(`Config write failed: ${reason}`);


### PR DESCRIPTION
## Summary
- Add signed Nexus skill catalog configuration, zone-scoped VFS paths, and a hardened stored-ZIP reader for skill bundles.
- Implement catalog signature verification, bundle hash validation, resolver/cache materialization, and bootstrap/runtime wiring for Nexus-mode skill resolution.
- Enforce required-policy fail-closed behavior and redact sensitive Nexus URL details from surfaced fallback errors.

## Impact
Nexus-mode sessions can resolve declared role skills from a signed Nexus catalog first, use verified cache/local fallbacks according to policy, and preserve existing non-Nexus local skill injection behavior.

## Validation
- `PATH=/Users/tafeng/.bun/bin:$PATH bun --config=/dev/null test src/shared/zip.test.ts src/core/skill-catalog.test.ts src/nexus/nexus-skill-catalog.test.ts src/core/workspace-bootstrap.test.ts src/core/config.test.ts src/nexus/vfs-paths.test.ts src/core/session-orchestrator.test.ts src/tui/spawn-manager.test.ts` — 205 pass, 0 fail
- `PATH=/Users/tafeng/.bun/bin:$PATH bun run typecheck` — pass
- `PATH=/Users/tafeng/.bun/bin:$PATH bun run check` — exits 0 with existing warnings outside this change set
- `PATH=/Users/tafeng/.bun/bin:$PATH git push -u origin codex/nexus-hosted-skill-distribution` — pre-push typecheck and build hooks passed

Note: the exact filtered `bun test ...` command from the implementation plan has all selected assertions passing but exits 1 because repo-wide coverage thresholds apply to imported support files in filtered runs.
