### PR TITLE
[codex] split claim spec and status storage

### DIFF
--- a/docs/superpowers/plans/2026-05-07-claim-spec-status-split.md
+++ b/docs/superpowers/plans/2026-05-07-claim-spec-status-split.md
@@ -1,0 +1,2240 @@
+# Claim Spec/Status Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #270 by splitting claim spec and status ownership in core contracts, SQLite storage, HTTP routes, and adapter stores while preserving legacy flat `Claim` compatibility.
+
+**Architecture:** Add explicit `ClaimSpec`, `ClaimStatusRecord`, `ClaimStatusPatch`, and `ClaimView` DTOs to core models/store contracts, then make every `ClaimStore` implementation expose spec/status methods. SQLite physically stores `claim_spec` and `claim_status`; in-memory and Nexus enforce the same logical ownership while keeping their existing storage shape. Existing flat claim methods become compatibility adapters over the new split DTOs, and new Hono routes expose spec-only and controller-only status writes.
+
+**Tech Stack:** TypeScript strict mode, Bun 1.3.x, `bun:test`, Hono, Zod, Bun SQLite, Nexus VFS adapter tests, Biome.
+
+---
+
+## File Structure
+
+- Modify `src/core/models.ts` — add claim spec/status DTOs and keep legacy `Claim` type.
+- Modify `src/core/store.ts` — extend `ClaimStore` with split methods and status patch type.
+- Modify `src/core/entity.ts` — project richer spec/status fields from flat claims and claim views.
+- Modify `src/core/claim-store.conformance.ts` — add backend-neutral spec/status ownership tests.
+- Modify `src/core/reconciler.test.ts` — update local mock `ClaimStore` to implement new methods.
+- Modify `src/server/test-helpers.ts` — update `InMemoryClaimStore` with split methods and controller-token test setup.
+- Modify `tests/server/helpers.ts` — pass controller token through `ServerDeps` for route tests.
+- Modify `tests/server/claims.test.ts` — add HTTP route tests for `PUT`, `GET`, and status subresource auth.
+- Modify `src/server/deps.ts` — add optional `controllerToken`.
+- Modify `src/server/serve.ts` — wire `GROVE_CONTROLLER_TOKEN` into `ServerDeps`.
+- Modify `src/server/routes/claims.ts` — add spec/status schemas and new routes.
+- Modify `src/local/sqlite-store.ts` — add split table DDL, migration backfill, row helpers, split methods, and legacy method rewrites.
+- Modify `src/local/sqlite-store.migration.test.ts` — add split table and legacy backfill migration tests.
+- Modify `src/local/sqlite-store.test.ts` — add SQLite adapter-specific split ownership tests for watch fan-out and route compatibility.
+- Modify `src/nexus/nexus-claim-store.ts` — add logical split methods over existing claim JSON files.
+- Modify `tests/nexus/unit/nexus-claim-store.test.ts` — rely on updated conformance and add one adapter-specific cache/status test.
+
+## Environment Note
+
+This worktree currently does not have `bun` on PATH. Before executing tests, install or expose Bun 1.3.x, then run `bun install` if `node_modules` is absent.
+
+---
+
+### Task 1: Core Claim DTOs and Store Contract
+
+**Files:**
+- Modify: `src/core/models.ts`
+- Modify: `src/core/store.ts`
+- Test: `src/core/claim-store.conformance.ts`
+
+- [ ] **Step 1: Write failing conformance tests for split ownership**
+
+Add these tests near the start of `runClaimStoreTests()` after `beforeEach`/`afterEach`, before the existing `createClaim / getClaim` section:
+
+```ts
+    test("putClaimSpec creates a claim view with default status", async () => {
+      const now = new Date().toISOString();
+      const view = await store.putClaimSpec({
+        id: "spec-create",
+        roleName: "coder",
+        platform: "codex",
+        blueprint: "implement issue",
+        assignee: makeAgent({ agentId: "agent-spec", platform: "codex", role: "coder" }),
+        leaseDeadlineSec: 600,
+        priority: 7,
+        maxIterations: 3,
+        generation: 99,
+        targetRef: "target-spec",
+        agent: makeAgent({ agentId: "agent-spec", platform: "codex", role: "coder" }),
+        intentSummary: "Implement claim split",
+        context: { issue: 270 },
+        createdAt: now,
+      });
+
+      expect(view.spec.id).toBe("spec-create");
+      expect(view.spec.generation).toBe(1);
+      expect(view.spec.roleName).toBe("coder");
+      expect(view.status.id).toBe("spec-create");
+      expect(view.status.phase).toBe(ClaimStatus.Active);
+      expect(view.status.observedGeneration).toBe(0);
+      expect(view.status.revision).toBe(1);
+    });
+
+    test("putClaimSpec increments generation without changing status revision", async () => {
+      const created = await store.putClaimSpec({
+        id: "spec-update",
+        targetRef: "target-spec-update",
+        agent: makeAgent({ agentId: "agent-spec-update" }),
+        intentSummary: "first spec",
+        createdAt: new Date().toISOString(),
+        generation: 1,
+      });
+      const statusUpdated = await store.patchClaimStatus("spec-update", {
+        phase: ClaimStatus.Active,
+        observedGeneration: created.spec.generation,
+        lastHeartbeatAt: "2026-01-01T00:01:00.000Z",
+      });
+
+      const updated = await store.putClaimSpec({
+        ...statusUpdated.spec,
+        intentSummary: "second spec",
+        generation: 1,
+      });
+
+      expect(updated.spec.generation).toBe(created.spec.generation + 1);
+      expect(updated.spec.intentSummary).toBe("second spec");
+      expect(updated.status.revision).toBe(statusUpdated.status.revision);
+      expect(updated.status.lastHeartbeatAt).toBe(statusUpdated.status.lastHeartbeatAt);
+    });
+
+    test("patchClaimStatus changes status without changing spec generation", async () => {
+      const created = await store.putClaimSpec({
+        id: "status-update",
+        targetRef: "target-status-update",
+        agent: makeAgent({ agentId: "agent-status-update" }),
+        intentSummary: "status-only write",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        generation: 1,
+      });
+
+      const patched = await store.patchClaimStatus("status-update", {
+        phase: ClaimStatus.Completed,
+        observedGeneration: created.spec.generation,
+        agentSessionId: "session-1",
+        lastHeartbeatAt: "2026-01-01T00:05:00.000Z",
+        leaseExpiresAt: "2026-01-01T00:10:00.000Z",
+        currentContributionCid:
+          "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        conditions: [
+          {
+            type: "Completed",
+            status: "True",
+            observedGeneration: created.spec.generation,
+            lastTransitionTime: "2026-01-01T00:05:00.000Z",
+            reason: "controller",
+            message: "done",
+          },
+        ],
+        lastTransitionAt: "2026-01-01T00:05:00.000Z",
+      });
+
+      expect(patched.spec.generation).toBe(created.spec.generation);
+      expect(patched.spec.intentSummary).toBe(created.spec.intentSummary);
+      expect(patched.status.phase).toBe(ClaimStatus.Completed);
+      expect(patched.status.observedGeneration).toBe(created.spec.generation);
+      expect(patched.status.agentSessionId).toBe("session-1");
+      expect(patched.status.revision).toBe(created.status.revision + 1);
+      expect(patched.status.conditions[0]?.type).toBe("Completed");
+    });
+
+    test("getClaimView returns undefined for a missing claim", async () => {
+      await expect(store.getClaimView("missing-view")).resolves.toBeUndefined();
+    });
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+bun test src/local/sqlite-store.test.ts tests/nexus/unit/nexus-claim-store.test.ts
+```
+
+Expected: TypeScript/test failure because `ClaimStore` does not have `putClaimSpec`, `patchClaimStatus`, or `getClaimView`.
+
+- [ ] **Step 3: Add core DTO types**
+
+In `src/core/models.ts`, add this type-only import:
+
+```ts
+import type { Condition } from "./entity.js";
+```
+
+Then add this after the existing `Claim` interface:
+
+```ts
+/** User-owned desired state for a claim. */
+export interface ClaimSpecRecord {
+  readonly id: string;
+  readonly roleName?: string | undefined;
+  readonly platform?: string | undefined;
+  readonly blueprint?: string | undefined;
+  readonly assignee?: AgentIdentity | undefined;
+  readonly leaseDeadlineSec?: number | undefined;
+  readonly priority?: number | undefined;
+  readonly maxIterations?: number | undefined;
+  readonly generation: number;
+  readonly targetRef: string;
+  readonly agent: AgentIdentity;
+  readonly intentSummary: string;
+  readonly context?: Readonly<Record<string, JsonValue>> | undefined;
+  readonly createdAt: string;
+}
+
+/** Controller-owned observed state for a claim. */
+export interface ClaimStatusRecord {
+  readonly id: string;
+  readonly phase: ClaimStatus;
+  readonly observedGeneration: number;
+  readonly agentSessionId?: string | undefined;
+  readonly lastHeartbeatAt: string;
+  readonly leaseExpiresAt: string;
+  readonly currentContributionCid?: string | undefined;
+  readonly conditions: readonly Condition[];
+  readonly lastTransitionAt: string;
+  readonly attemptCount: number;
+  readonly revision: number;
+}
+
+/** Merged split claim view. */
+export interface ClaimView {
+  readonly spec: ClaimSpecRecord;
+  readonly status: ClaimStatusRecord;
+}
+```
+
+- [ ] **Step 4: Add status patch and store methods**
+
+In `src/core/store.ts`, update the model import to include `ClaimSpecRecord`, `ClaimStatusRecord`, and `ClaimView`, and add this type-only import:
+
+```ts
+import type { Condition } from "./entity.js";
+```
+
+Then add this interface before `ClaimStore`:
+
+```ts
+/** Status-only patch accepted by controller-owned claim status writes. */
+export interface ClaimStatusPatch {
+  readonly phase?: ClaimStatus | undefined;
+  readonly observedGeneration?: number | undefined;
+  readonly agentSessionId?: string | undefined;
+  readonly lastHeartbeatAt?: string | undefined;
+  readonly leaseExpiresAt?: string | undefined;
+  readonly currentContributionCid?: string | undefined;
+  readonly conditions?: readonly Condition[] | undefined;
+  readonly lastTransitionAt?: string | undefined;
+}
+```
+
+Then add these methods to `ClaimStore` immediately after `readonly storeIdentity?: string | undefined;`:
+
+```ts
+  /** Create or update user-owned claim spec. Store controls generation. */
+  putClaimSpec(spec: ClaimSpecRecord): Promise<ClaimView>;
+
+  /** Get the merged split claim view by ID. */
+  getClaimView(claimId: string): Promise<ClaimView | undefined>;
+
+  /** Patch controller-owned claim status fields only. */
+  patchClaimStatus(claimId: string, patch: ClaimStatusPatch): Promise<ClaimView>;
+```
+
+- [ ] **Step 5: Run tests to verify RED moved to implementations**
+
+Run:
+
+```bash
+bun test src/local/sqlite-store.test.ts tests/nexus/unit/nexus-claim-store.test.ts
+```
+
+Expected: TypeScript failures in `SqliteClaimStore`, `InMemoryClaimStore`, Nexus test mocks, and `NexusClaimStore` because they do not implement the new methods.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/models.ts src/core/store.ts src/core/claim-store.conformance.ts
+git commit -m "feat: add claim spec status store contract"
+```
+
+---
+
+### Task 2: Shared Conversion Helpers
+
+**Files:**
+- Modify: `src/core/models.ts`
+- Modify: `src/core/entity.ts`
+- Test: `src/core/entity.test.ts`
+
+- [ ] **Step 1: Write failing entity projection test**
+
+In `src/core/entity.test.ts`, add this test in the claim entity section:
+
+```ts
+  test("claimToEntity projects split-compatible spec and status fields", () => {
+    const claim = makeClaim({
+      claimId: "claim-rich",
+      targetRef: "target-rich",
+      agent: {
+        agentId: "agent-rich",
+        platform: "codex",
+        role: "coder",
+      },
+      intentSummary: "rich claim",
+      context: { issue: 270 },
+      createdAt: "2026-01-01T00:00:00.000Z",
+      heartbeatAt: "2026-01-01T00:01:00.000Z",
+      leaseExpiresAt: "2026-01-01T00:06:00.000Z",
+      revision: 4,
+    });
+
+    const entity = claimToEntity(claim, () => Date.parse("2026-01-01T00:02:00.000Z"), "ns/test");
+
+    expect(entity.spec.roleName).toBe("coder");
+    expect(entity.spec.platform).toBe("codex");
+    expect(entity.spec.assignee).toEqual(claim.agent);
+    expect(entity.spec.leaseDeadlineSec).toBe(360);
+    expect(entity.status.observedGeneration).toBe(4);
+    expect(entity.status.lastHeartbeatAt).toBe("2026-01-01T00:01:00.000Z");
+    expect(entity.status.leaseExpiresAt).toBe("2026-01-01T00:06:00.000Z");
+    expect(entity.metadata.generation).toBe(4);
+  });
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+bun test src/core/entity.test.ts
+```
+
+Expected: FAIL because `ClaimEntity.spec` lacks `roleName`, `platform`, `assignee`, and `leaseDeadlineSec`, and status uses `heartbeatAt` rather than `lastHeartbeatAt`.
+
+- [ ] **Step 3: Add conversion helpers**
+
+In `src/core/models.ts`, after the new DTO interfaces, add these exported helpers:
+
+```ts
+/** Derive a split claim spec from a legacy flat claim snapshot. */
+export function claimToSpecRecord(claim: Claim): ClaimSpecRecord {
+  const createdMs = Date.parse(claim.createdAt);
+  const expiresMs = Date.parse(claim.leaseExpiresAt);
+  const leaseDeadlineSec =
+    Number.isFinite(createdMs) && Number.isFinite(expiresMs) && expiresMs > createdMs
+      ? Math.round((expiresMs - createdMs) / 1000)
+      : undefined;
+  return {
+    id: claim.claimId,
+    roleName: claim.agent.role,
+    platform: claim.agent.platform,
+    assignee: claim.agent,
+    leaseDeadlineSec,
+    generation: claim.revision ?? 1,
+    targetRef: claim.targetRef,
+    agent: claim.agent,
+    intentSummary: claim.intentSummary,
+    context: claim.context,
+    createdAt: claim.createdAt,
+  };
+}
+
+/** Derive a split claim status from a legacy flat claim snapshot. */
+export function claimToStatusRecord(
+  claim: Claim,
+  conditions: readonly import("./entity.js").Condition[] = [],
+): ClaimStatusRecord {
+  const revision = claim.revision ?? 1;
+  return {
+    id: claim.claimId,
+    phase: claim.status,
+    observedGeneration: revision,
+    lastHeartbeatAt: claim.heartbeatAt,
+    leaseExpiresAt: claim.leaseExpiresAt,
+    conditions,
+    lastTransitionAt: claim.heartbeatAt,
+    attemptCount: claim.attemptCount ?? 0,
+    revision,
+  };
+}
+
+/** Merge split claim records into the legacy flat claim shape. */
+export function claimViewToClaim(view: ClaimView): Claim {
+  const base: Claim = {
+    claimId: view.spec.id,
+    targetRef: view.spec.targetRef,
+    agent: view.spec.agent,
+    status: view.status.phase,
+    intentSummary: view.spec.intentSummary,
+    createdAt: view.spec.createdAt,
+    heartbeatAt: view.status.lastHeartbeatAt,
+    leaseExpiresAt: view.status.leaseExpiresAt,
+    revision: view.status.revision,
+  };
+  return {
+    ...base,
+    ...(view.spec.context !== undefined ? { context: view.spec.context } : {}),
+    ...(view.status.attemptCount > 0 ? { attemptCount: view.status.attemptCount } : {}),
+  };
+}
+```
+
+- [ ] **Step 4: Update entity projection**
+
+In `src/core/entity.ts`, update `ClaimSpec`:
+
+```ts
+export interface ClaimSpec {
+  readonly targetRef: string;
+  readonly agent: AgentIdentity;
+  readonly intentSummary: string;
+  readonly context?: Readonly<Record<string, JsonValue>> | undefined;
+  readonly roleName?: string | undefined;
+  readonly platform?: string | undefined;
+  readonly blueprint?: string | undefined;
+  readonly assignee?: AgentIdentity | undefined;
+  readonly leaseDeadlineSec?: number | undefined;
+  readonly priority?: number | undefined;
+  readonly maxIterations?: number | undefined;
+}
+```
+
+Update `ClaimStatusBody` to include aliases without removing existing fields:
+
+```ts
+  readonly heartbeatAt: string;
+  readonly lastHeartbeatAt: string;
+  readonly leaseExpiresAt: string;
+  readonly currentContributionCid?: string | undefined;
+  readonly agentSessionId?: string | undefined;
+  readonly attemptCount: number;
+```
+
+In `claimToEntity`, add derived spec fields:
+
+```ts
+  const createdMs = Date.parse(c.createdAt);
+  const expiresMs = Date.parse(c.leaseExpiresAt);
+  const leaseDeadlineSec =
+    Number.isFinite(createdMs) && Number.isFinite(expiresMs) && expiresMs > createdMs
+      ? Math.round((expiresMs - createdMs) / 1000)
+      : undefined;
+```
+
+Then update returned `spec` and `status`:
+
+```ts
+    spec: {
+      targetRef: c.targetRef,
+      agent: c.agent,
+      intentSummary: c.intentSummary,
+      context: c.context,
+      roleName: c.agent.role,
+      platform: c.agent.platform,
+      assignee: c.agent,
+      leaseDeadlineSec,
+    },
+    status: {
+      phase: effectivePhase,
+      persistedPhase,
+      heartbeatAt: c.heartbeatAt,
+      lastHeartbeatAt: c.heartbeatAt,
+      leaseExpiresAt: c.leaseExpiresAt,
+      attemptCount: c.attemptCount ?? 0,
+    },
+```
+
+- [ ] **Step 5: Run test to verify GREEN**
+
+Run:
+
+```bash
+bun test src/core/entity.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/models.ts src/core/entity.ts src/core/entity.test.ts
+git commit -m "feat: add claim split conversion helpers"
+```
+
+---
+
+### Task 3: In-Memory ClaimStore Split Methods
+
+**Files:**
+- Modify: `src/server/test-helpers.ts`
+- Modify: `src/core/reconciler.test.ts`
+- Test: `src/server/test-helpers.ts`
+- Test: `src/core/reconciler.test.ts`
+- Test: `src/local/sqlite-store.test.ts`
+- Test: `tests/nexus/unit/nexus-claim-store.test.ts`
+
+- [ ] **Step 1: Run compile to verify missing methods**
+
+Run:
+
+```bash
+bun test src/core/reconciler.test.ts src/server/watch-wiring.test.ts
+```
+
+Expected: TypeScript failure because mock `ClaimStore` objects lack `putClaimSpec`, `getClaimView`, and `patchClaimStatus`.
+
+- [ ] **Step 2: Implement InMemoryClaimStore split maps and methods**
+
+In `src/server/test-helpers.ts`, update imports to include `ClaimSpecRecord`, `ClaimStatusPatch`, `ClaimStatusRecord`, `ClaimView`, `claimToSpecRecord`, `claimToStatusRecord`, and `claimViewToClaim` from `../core/models.js`.
+
+Replace the private flat map:
+
+```ts
+  private readonly claims = new Map<string, Claim>();
+```
+
+with split maps:
+
+```ts
+  private readonly specs = new Map<string, ClaimSpecRecord>();
+  private readonly statuses = new Map<string, ClaimStatusRecord>();
+```
+
+Add these helpers inside `InMemoryClaimStore` before `createClaim`:
+
+```ts
+  private toClaim(view: ClaimView): Claim {
+    return claimViewToClaim(view);
+  }
+
+  private viewFor(claimId: string): ClaimView | undefined {
+    const spec = this.specs.get(claimId);
+    const status = this.statuses.get(claimId);
+    if (spec === undefined || status === undefined) return undefined;
+    return { spec, status };
+  }
+
+  private allViews(): ClaimView[] {
+    const views: ClaimView[] = [];
+    for (const id of this.specs.keys()) {
+      const view = this.viewFor(id);
+      if (view !== undefined) views.push(view);
+    }
+    return views;
+  }
+
+  private putView(view: ClaimView): void {
+    this.specs.set(view.spec.id, view.spec);
+    this.statuses.set(view.status.id, view.status);
+  }
+
+  async putClaimSpec(spec: ClaimSpecRecord): Promise<ClaimView> {
+    const existing = this.viewFor(spec.id);
+    const now = new Date().toISOString();
+    const leaseDurationMs = (spec.leaseDeadlineSec ?? 300) * 1000;
+    const nextSpec: ClaimSpecRecord = {
+      ...spec,
+      generation: existing === undefined ? 1 : existing.spec.generation + 1,
+      createdAt: existing?.spec.createdAt ?? spec.createdAt,
+    };
+    const nextStatus: ClaimStatusRecord =
+      existing?.status ?? {
+        id: spec.id,
+        phase: "active",
+        observedGeneration: 0,
+        lastHeartbeatAt: now,
+        leaseExpiresAt: new Date(Date.parse(spec.createdAt) + leaseDurationMs).toISOString(),
+        conditions: [],
+        lastTransitionAt: now,
+        attemptCount: 0,
+        revision: 1,
+      };
+    const view: ClaimView = {
+      spec: nextSpec,
+      status: nextStatus,
+    };
+    this.putView(view);
+    return view;
+  }
+
+  async getClaimView(claimId: string): Promise<ClaimView | undefined> {
+    return this.viewFor(claimId);
+  }
+
+  async patchClaimStatus(claimId: string, patch: ClaimStatusPatch): Promise<ClaimView> {
+    const view = this.viewFor(claimId);
+    if (view === undefined) {
+      throw new NotFoundError({
+        resource: "Claim",
+        identifier: claimId,
+        message: `Claim ${claimId} does not exist`,
+      });
+    }
+    const updated: ClaimView = {
+      spec: view.spec,
+      status: {
+        ...view.status,
+        phase: patch.phase ?? view.status.phase,
+        observedGeneration: patch.observedGeneration ?? view.status.observedGeneration,
+        agentSessionId: patch.agentSessionId ?? view.status.agentSessionId,
+        lastHeartbeatAt: patch.lastHeartbeatAt ?? view.status.lastHeartbeatAt,
+        leaseExpiresAt: patch.leaseExpiresAt ?? view.status.leaseExpiresAt,
+        currentContributionCid: patch.currentContributionCid ?? view.status.currentContributionCid,
+        conditions: patch.conditions ?? view.status.conditions,
+        lastTransitionAt: patch.lastTransitionAt ?? view.status.lastTransitionAt,
+        revision: view.status.revision + 1,
+      },
+    };
+    this.putView(updated);
+    return updated;
+  }
+```
+
+Then rewrite legacy methods in the same class to use `viewFor`, `putView`, and `toClaim`. These are the important replacements:
+
+```ts
+  async createClaim(claim: Claim): Promise<Claim> {
+    if (this.specs.has(claim.claimId)) {
+      throw new StateConflictError({
+        resource: "Claim",
+        reason: "already exists",
+        message: `Claim ${claim.claimId} already exists`,
+      });
+    }
+    const created: ClaimView = {
+      spec: { ...claimToSpecRecord(claim), generation: 1 },
+      status: { ...claimToStatusRecord({ ...claim, revision: 1 }), observedGeneration: 0 },
+    };
+    this.putView(created);
+    return this.toClaim(created);
+  }
+
+  async getClaim(claimId: string): Promise<Claim | undefined> {
+    const view = this.viewFor(claimId);
+    return view === undefined ? undefined : this.toClaim(view);
+  }
+
+  async listClaims(query?: ClaimQuery): Promise<readonly Claim[]> {
+    let results = this.allViews().map((view) => this.toClaim(view));
+    if (query?.status) {
+      const statuses = Array.isArray(query.status) ? query.status : [query.status];
+      results = results.filter((c) => statuses.includes(c.status));
+    }
+    if (query?.agentId) {
+      results = results.filter((c) => c.agent.agentId === query.agentId);
+    }
+    if (query?.targetRef) {
+      results = results.filter((c) => c.targetRef === query.targetRef);
+    }
+    return results;
+  }
+```
+
+Update `claimOrRenew`, `heartbeat`, `release`, `complete`, `expireStale`, `activeClaims`, `countActiveClaims`, `detectStalled`, and `listEntities` by reading views and writing either `specs` or `statuses`; do not reintroduce a flat `claims` map.
+
+- [ ] **Step 3: Update reconciler test mock**
+
+In `src/core/reconciler.test.ts`, add imports:
+
+```ts
+import {
+  claimToSpecRecord,
+  claimToStatusRecord,
+  claimViewToClaim,
+  type ClaimSpecRecord,
+  type ClaimStatusPatch,
+} from "./models.js";
+```
+
+Inside `makeClaimStore`, add methods to the returned object:
+
+```ts
+    putClaimSpec: async (spec: ClaimSpecRecord) => {
+      const existing = claimsById.get(spec.id);
+      const now = new Date().toISOString();
+      const view = {
+        spec: {
+          ...spec,
+          generation: existing === undefined ? 1 : (existing.revision ?? 1) + 1,
+        },
+        status:
+          existing === undefined
+            ? {
+                id: spec.id,
+                phase: ClaimStatus.Active,
+                observedGeneration: 0,
+                lastHeartbeatAt: now,
+                leaseExpiresAt: new Date(Date.now() + 300_000).toISOString(),
+                conditions: [],
+                lastTransitionAt: now,
+                attemptCount: 0,
+                revision: 1,
+              }
+            : claimToStatusRecord(existing),
+      };
+      claimsById.set(spec.id, claimViewToClaim(view));
+      return view;
+    },
+    getClaimView: async (claimId) => {
+      const claim = claimsById.get(claimId);
+      return claim === undefined
+        ? undefined
+        : { spec: claimToSpecRecord(claim), status: claimToStatusRecord(claim) };
+    },
+    patchClaimStatus: async (claimId, patch: ClaimStatusPatch) => {
+      const claim = claimsById.get(claimId);
+      if (!claim) throw new Error("missing claim");
+      const updated = {
+        ...claim,
+        status: patch.phase ?? claim.status,
+        heartbeatAt: patch.lastHeartbeatAt ?? claim.heartbeatAt,
+        leaseExpiresAt: patch.leaseExpiresAt ?? claim.leaseExpiresAt,
+        revision: (claim.revision ?? 1) + 1,
+      };
+      claimsById.set(claimId, updated);
+      return { spec: claimToSpecRecord(claim), status: claimToStatusRecord(updated) };
+    },
+```
+
+- [ ] **Step 4: Run tests to verify GREEN for mocks**
+
+Run:
+
+```bash
+bun test src/core/reconciler.test.ts src/server/watch-wiring.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/test-helpers.ts src/core/reconciler.test.ts
+git commit -m "test: support split claim store in mocks"
+```
+
+---
+
+### Task 4: SQLite Migration Tests
+
+**Files:**
+- Modify: `src/local/sqlite-store.migration.test.ts`
+- Modify: `src/local/sqlite-store.ts`
+
+- [ ] **Step 1: Write failing migration tests**
+
+In `src/local/sqlite-store.migration.test.ts`, add these tests near the other schema migration tests:
+
+```ts
+  test("fresh DB creates split claim tables", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-claim-split-"));
+    try {
+      const dbPath = join(dir, "test.db");
+      const stores = createSqliteStores(dbPath);
+      stores.close();
+
+      const db = new Database(dbPath);
+      const tableNames = (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as readonly {
+          name: string;
+        }[]
+      ).map((r) => r.name);
+      expect(tableNames).toContain("claim_spec");
+      expect(tableNames).toContain("claim_status");
+      db.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("legacy claims rows backfill into claim_spec and claim_status", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-claim-split-legacy-"));
+    try {
+      const dbPath = join(dir, "test.db");
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+          version INTEGER PRIMARY KEY,
+          applied_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS contributions (
+          cid TEXT PRIMARY KEY,
+          kind TEXT NOT NULL,
+          mode TEXT NOT NULL,
+          summary TEXT NOT NULL,
+          description TEXT,
+          agent_id TEXT NOT NULL,
+          agent_name TEXT,
+          created_at TEXT NOT NULL,
+          tags_json TEXT NOT NULL DEFAULT '[]',
+          manifest_json TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS relations (
+          source_cid TEXT NOT NULL,
+          target_cid TEXT NOT NULL,
+          relation_type TEXT NOT NULL,
+          metadata_json TEXT
+        );
+        CREATE TABLE IF NOT EXISTS claims (
+          claim_id TEXT PRIMARY KEY,
+          target_ref TEXT NOT NULL,
+          agent_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'active',
+          intent_summary TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          heartbeat_at TEXT NOT NULL,
+          lease_expires_at TEXT NOT NULL,
+          context_json TEXT,
+          agent_json TEXT NOT NULL,
+          attempt_count INTEGER NOT NULL DEFAULT 0,
+          revision INTEGER NOT NULL DEFAULT 1
+        );
+      `);
+      db.prepare(
+        `INSERT INTO claims (
+          claim_id, target_ref, agent_id, status, intent_summary, created_at,
+          heartbeat_at, lease_expires_at, context_json, agent_json, attempt_count, revision
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "legacy-split",
+        "target-legacy",
+        "agent-legacy",
+        "active",
+        "legacy intent",
+        "2026-01-01T00:00:00.000Z",
+        "2026-01-01T00:02:00.000Z",
+        "2026-01-01T00:07:00.000Z",
+        JSON.stringify({ migrated: true }),
+        JSON.stringify({ agentId: "agent-legacy", platform: "codex", role: "coder" }),
+        2,
+        5,
+      );
+      db.close();
+
+      const stores = createSqliteStores(dbPath);
+      const claim = await stores.claimStore.getClaim("legacy-split");
+      const view = await stores.claimStore.getClaimView("legacy-split");
+
+      expect(claim?.claimId).toBe("legacy-split");
+      expect(claim?.status).toBe("active");
+      expect(claim?.attemptCount).toBe(2);
+      expect(claim?.revision).toBe(5);
+      expect(view?.spec.targetRef).toBe("target-legacy");
+      expect(view?.spec.agent.platform).toBe("codex");
+      expect(view?.spec.generation).toBe(5);
+      expect(view?.status.phase).toBe("active");
+      expect(view?.status.observedGeneration).toBe(5);
+      expect(view?.status.lastHeartbeatAt).toBe("2026-01-01T00:02:00.000Z");
+
+      stores.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+bun test src/local/sqlite-store.migration.test.ts
+```
+
+Expected: FAIL because split tables and `getClaimView` are not implemented.
+
+- [ ] **Step 3: Add schema DDL and migration backfill**
+
+In `src/local/sqlite-store.ts`, increment:
+
+```ts
+export const CURRENT_SCHEMA_VERSION = 14;
+```
+
+In `SCHEMA_DDL`, after the legacy `claims` table and indexes, add the `claim_spec` and `claim_status` tables and indexes from the design doc:
+
+```sql
+  CREATE TABLE IF NOT EXISTS claim_spec (
+    id TEXT PRIMARY KEY,
+    role_name TEXT,
+    platform TEXT,
+    blueprint TEXT,
+    assignee_json TEXT,
+    lease_deadline_sec INTEGER,
+    priority INTEGER,
+    max_iterations INTEGER,
+    generation INTEGER NOT NULL DEFAULT 1,
+    target_ref TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    agent_json TEXT NOT NULL,
+    intent_summary TEXT NOT NULL,
+    context_json TEXT,
+    created_at TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS claim_status (
+    id TEXT PRIMARY KEY,
+    phase TEXT NOT NULL DEFAULT 'active',
+    observed_generation INTEGER NOT NULL DEFAULT 0,
+    agent_session_id TEXT,
+    last_heartbeat_at TEXT NOT NULL,
+    lease_expires_at TEXT NOT NULL,
+    current_contribution_cid TEXT,
+    conditions_json TEXT NOT NULL DEFAULT '[]',
+    last_transition_at TEXT NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    revision INTEGER NOT NULL DEFAULT 1,
+    FOREIGN KEY (id) REFERENCES claim_spec(id) ON DELETE CASCADE
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_claim_spec_target ON claim_spec(target_ref);
+  CREATE INDEX IF NOT EXISTS idx_claim_spec_agent ON claim_spec(agent_id);
+  CREATE INDEX IF NOT EXISTS idx_claim_status_phase ON claim_status(phase);
+  CREATE INDEX IF NOT EXISTS idx_claim_status_phase_lease ON claim_status(phase, lease_expires_at);
+```
+
+After the existing claim column-safe migration block, add this backfill:
+
+```ts
+    // Migration -> v14: split legacy claims into claim_spec and claim_status.
+    db.run(`
+      INSERT OR IGNORE INTO claim_spec (
+        id, role_name, platform, assignee_json, lease_deadline_sec, generation,
+        target_ref, agent_id, agent_json, intent_summary, context_json, created_at
+      )
+      SELECT
+        claim_id,
+        json_extract(agent_json, '$.role'),
+        json_extract(agent_json, '$.platform'),
+        agent_json,
+        CASE
+          WHEN strftime('%s', lease_expires_at) > strftime('%s', created_at)
+          THEN CAST(strftime('%s', lease_expires_at) - strftime('%s', created_at) AS INTEGER)
+          ELSE NULL
+        END,
+        revision,
+        target_ref,
+        agent_id,
+        agent_json,
+        intent_summary,
+        context_json,
+        created_at
+      FROM claims
+      WHERE NOT EXISTS (
+        SELECT 1 FROM claim_spec WHERE claim_spec.id = claims.claim_id
+      )
+    `);
+    db.run(`
+      INSERT OR IGNORE INTO claim_status (
+        id, phase, observed_generation, last_heartbeat_at, lease_expires_at,
+        conditions_json, last_transition_at, attempt_count, revision
+      )
+      SELECT
+        claim_id,
+        status,
+        revision,
+        heartbeat_at,
+        lease_expires_at,
+        '[]',
+        heartbeat_at,
+        attempt_count,
+        revision
+      FROM claims
+      WHERE NOT EXISTS (
+        SELECT 1 FROM claim_status WHERE claim_status.id = claims.claim_id
+      )
+    `);
+```
+
+- [ ] **Step 4: Run migration tests**
+
+Run:
+
+```bash
+bun test src/local/sqlite-store.migration.test.ts
+```
+
+Expected: still FAIL because `SqliteClaimStore.getClaimView` is missing. That is correct; schema migration should be in place before store implementation.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/local/sqlite-store.ts src/local/sqlite-store.migration.test.ts
+git commit -m "feat: add sqlite claim split schema"
+```
+
+---
+
+### Task 5: SQLite Split Store Implementation
+
+**Files:**
+- Modify: `src/local/sqlite-store.ts`
+- Test: `src/core/claim-store.conformance.ts`
+- Test: `src/local/sqlite-store.test.ts`
+- Test: `src/local/sqlite-store.migration.test.ts`
+
+- [ ] **Step 1: Run conformance to verify RED**
+
+Run:
+
+```bash
+bun test src/local/sqlite-store.test.ts
+```
+
+Expected: FAIL because `SqliteClaimStore` does not implement split methods and still reads/writes the legacy `claims` table.
+
+- [ ] **Step 2: Add split row types and helpers**
+
+In `src/local/sqlite-store.ts`, update imports from `../core/models.js`:
+
+```ts
+  ClaimSpecRecord,
+  ClaimStatusRecord,
+  ClaimView,
+  claimToSpecRecord,
+  claimToStatusRecord,
+  claimViewToClaim,
+```
+
+Update imports from `../core/store.js`:
+
+```ts
+  ClaimStatusPatch,
+```
+
+After `interface ClaimRow`, add:
+
+```ts
+interface ClaimSpecRow {
+  readonly id: string;
+  readonly role_name: string | null;
+  readonly platform: string | null;
+  readonly blueprint: string | null;
+  readonly assignee_json: string | null;
+  readonly lease_deadline_sec: number | null;
+  readonly priority: number | null;
+  readonly max_iterations: number | null;
+  readonly generation: number;
+  readonly target_ref: string;
+  readonly agent_id: string;
+  readonly agent_json: string;
+  readonly intent_summary: string;
+  readonly context_json: string | null;
+  readonly created_at: string;
+}
+
+interface ClaimStatusRow {
+  readonly id: string;
+  readonly phase: string;
+  readonly observed_generation: number;
+  readonly agent_session_id: string | null;
+  readonly last_heartbeat_at: string;
+  readonly lease_expires_at: string;
+  readonly current_contribution_cid: string | null;
+  readonly conditions_json: string;
+  readonly last_transition_at: string;
+  readonly attempt_count: number;
+  readonly revision: number;
+}
+
+interface ClaimViewRow extends ClaimSpecRow, ClaimStatusRow {}
+```
+
+Add row converters:
+
+```ts
+function rowToClaimSpec(row: ClaimSpecRow): ClaimSpecRecord {
+  return {
+    id: row.id,
+    roleName: row.role_name ?? undefined,
+    platform: row.platform ?? undefined,
+    blueprint: row.blueprint ?? undefined,
+    assignee:
+      row.assignee_json !== null
+        ? (JSON.parse(row.assignee_json) as AgentIdentity)
+        : undefined,
+    leaseDeadlineSec: row.lease_deadline_sec ?? undefined,
+    priority: row.priority ?? undefined,
+    maxIterations: row.max_iterations ?? undefined,
+    generation: row.generation,
+    targetRef: row.target_ref,
+    agent: JSON.parse(row.agent_json) as AgentIdentity,
+    intentSummary: row.intent_summary,
+    context:
+      row.context_json !== null
+        ? (JSON.parse(row.context_json) as Readonly<Record<string, JsonValue>>)
+        : undefined,
+    createdAt: row.created_at,
+  };
+}
+
+function rowToClaimStatus(row: ClaimStatusRow): ClaimStatusRecord {
+  return {
+    id: row.id,
+    phase: row.phase as ClaimStatus,
+    observedGeneration: row.observed_generation,
+    agentSessionId: row.agent_session_id ?? undefined,
+    lastHeartbeatAt: row.last_heartbeat_at,
+    leaseExpiresAt: row.lease_expires_at,
+    currentContributionCid: row.current_contribution_cid ?? undefined,
+    conditions: JSON.parse(row.conditions_json) as readonly import("../core/entity.js").Condition[],
+    lastTransitionAt: row.last_transition_at,
+    attemptCount: row.attempt_count,
+    revision: row.revision,
+  };
+}
+
+function rowToClaimView(row: ClaimViewRow): ClaimView {
+  return {
+    spec: rowToClaimSpec(row),
+    status: rowToClaimStatus(row),
+  };
+}
+```
+
+- [ ] **Step 3: Replace claim select constants with joined split select**
+
+Keep `ClaimRow` for migration helper compatibility. Add:
+
+```ts
+const CLAIM_VIEW_SELECT_COLS = `
+  s.id AS id,
+  s.role_name AS role_name,
+  s.platform AS platform,
+  s.blueprint AS blueprint,
+  s.assignee_json AS assignee_json,
+  s.lease_deadline_sec AS lease_deadline_sec,
+  s.priority AS priority,
+  s.max_iterations AS max_iterations,
+  s.generation AS generation,
+  s.target_ref AS target_ref,
+  s.agent_id AS agent_id,
+  s.agent_json AS agent_json,
+  s.intent_summary AS intent_summary,
+  s.context_json AS context_json,
+  s.created_at AS created_at,
+  st.phase AS phase,
+  st.observed_generation AS observed_generation,
+  st.agent_session_id AS agent_session_id,
+  st.last_heartbeat_at AS last_heartbeat_at,
+  st.lease_expires_at AS lease_expires_at,
+  st.current_contribution_cid AS current_contribution_cid,
+  st.conditions_json AS conditions_json,
+  st.last_transition_at AS last_transition_at,
+  st.attempt_count AS attempt_count,
+  st.revision AS revision
+`;
+```
+
+In the constructor, replace `stmtGetClaim` with:
+
+```ts
+    this.stmtGetClaim = db.query(
+      `SELECT ${CLAIM_VIEW_SELECT_COLS}
+       FROM claim_spec s
+       JOIN claim_status st ON st.id = s.id
+       WHERE s.id = ?`,
+    );
+```
+
+- [ ] **Step 4: Add split write helpers**
+
+Inside `SqliteClaimStore`, add:
+
+```ts
+  private insertSpecAndDefaultStatus(claim: Claim): void {
+    const spec = claimToSpecRecord(claim);
+    const status = claimToStatusRecord({ ...claim, revision: 1 });
+    this.insertSpecRow({ ...spec, generation: 1 });
+    this.insertStatusRow(status);
+  }
+
+  private insertSpecRow(spec: ClaimSpecRecord): void {
+    this.db
+      .prepare(
+        `INSERT INTO claim_spec (
+          id, role_name, platform, blueprint, assignee_json, lease_deadline_sec,
+          priority, max_iterations, generation, target_ref, agent_id, agent_json,
+          intent_summary, context_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        spec.id,
+        spec.roleName ?? null,
+        spec.platform ?? null,
+        spec.blueprint ?? null,
+        spec.assignee !== undefined ? JSON.stringify(spec.assignee) : null,
+        spec.leaseDeadlineSec ?? null,
+        spec.priority ?? null,
+        spec.maxIterations ?? null,
+        spec.generation,
+        spec.targetRef,
+        spec.agent.agentId,
+        JSON.stringify(spec.agent),
+        spec.intentSummary,
+        spec.context !== undefined ? JSON.stringify(spec.context) : null,
+        toUtcIso(spec.createdAt),
+      );
+  }
+
+  private insertStatusRow(status: ClaimStatusRecord): void {
+    this.db
+      .prepare(
+        `INSERT INTO claim_status (
+          id, phase, observed_generation, agent_session_id, last_heartbeat_at,
+          lease_expires_at, current_contribution_cid, conditions_json,
+          last_transition_at, attempt_count, revision
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        status.id,
+        status.phase,
+        status.observedGeneration,
+        status.agentSessionId ?? null,
+        toUtcIso(status.lastHeartbeatAt),
+        toUtcIso(status.leaseExpiresAt),
+        status.currentContributionCid ?? null,
+        JSON.stringify(status.conditions),
+        toUtcIso(status.lastTransitionAt),
+        status.attemptCount,
+        status.revision,
+      );
+  }
+```
+
+- [ ] **Step 5: Implement split methods**
+
+Add methods to `SqliteClaimStore` before `createClaim`:
+
+```ts
+  putClaimSpec = async (spec: ClaimSpecRecord): Promise<ClaimView> => {
+    if (spec.context !== undefined) {
+      const result = ContextSchema.safeParse(spec.context);
+      if (!result.success) {
+        throw new Error(`Invalid claim context: ${result.error.message}`);
+      }
+    }
+    const now = new Date().toISOString();
+    const tx = this.db.transaction(() => {
+      const existing = this.readClaimView(spec.id);
+      if (existing === null) {
+        const createdSpec: ClaimSpecRecord = { ...spec, generation: 1 };
+        this.insertSpecRow(createdSpec);
+        const leaseMs = (spec.leaseDeadlineSec ?? DEFAULT_LEASE_DURATION_MS / 1000) * 1000;
+        this.insertStatusRow({
+          id: spec.id,
+          phase: "active" as ClaimStatus,
+          observedGeneration: 0,
+          lastHeartbeatAt: now,
+          leaseExpiresAt: new Date(Date.parse(spec.createdAt) + leaseMs).toISOString(),
+          conditions: [],
+          lastTransitionAt: now,
+          attemptCount: 0,
+          revision: 1,
+        });
+        return;
+      }
+      this.db
+        .prepare(
+          `UPDATE claim_spec
+           SET role_name = ?, platform = ?, blueprint = ?, assignee_json = ?,
+               lease_deadline_sec = ?, priority = ?, max_iterations = ?,
+               generation = generation + 1, target_ref = ?, agent_id = ?,
+               agent_json = ?, intent_summary = ?, context_json = ?
+           WHERE id = ?`,
+        )
+        .run(
+          spec.roleName ?? null,
+          spec.platform ?? null,
+          spec.blueprint ?? null,
+          spec.assignee !== undefined ? JSON.stringify(spec.assignee) : null,
+          spec.leaseDeadlineSec ?? null,
+          spec.priority ?? null,
+          spec.maxIterations ?? null,
+          spec.targetRef,
+          spec.agent.agentId,
+          JSON.stringify(spec.agent),
+          spec.intentSummary,
+          spec.context !== undefined ? JSON.stringify(spec.context) : null,
+          spec.id,
+        );
+    });
+    tx.immediate();
+    const view = this.readClaimView(spec.id);
+    if (view === null) throw new Error(`Failed to read back claim view '${spec.id}'`);
+    this.onClaimWrite?.(view.status.revision === 1 ? "ADDED" : "MODIFIED", claimViewToClaim(view));
+    return view;
+  };
+
+  getClaimView = async (claimId: string): Promise<ClaimView | undefined> => {
+    return this.readClaimView(claimId) ?? undefined;
+  };
+
+  patchClaimStatus = async (claimId: string, patch: ClaimStatusPatch): Promise<ClaimView> => {
+    const existing = this.readClaimView(claimId);
+    if (existing === null) {
+      throw new NotFoundError({
+        resource: "Claim",
+        identifier: claimId,
+        message: `Claim '${claimId}' not found`,
+      });
+    }
+    const next = {
+      phase: patch.phase ?? existing.status.phase,
+      observedGeneration: patch.observedGeneration ?? existing.status.observedGeneration,
+      agentSessionId: patch.agentSessionId ?? existing.status.agentSessionId,
+      lastHeartbeatAt: patch.lastHeartbeatAt ?? existing.status.lastHeartbeatAt,
+      leaseExpiresAt: patch.leaseExpiresAt ?? existing.status.leaseExpiresAt,
+      currentContributionCid:
+        patch.currentContributionCid ?? existing.status.currentContributionCid,
+      conditions: patch.conditions ?? existing.status.conditions,
+      lastTransitionAt: patch.lastTransitionAt ?? existing.status.lastTransitionAt,
+    };
+    this.db
+      .prepare(
+        `UPDATE claim_status
+         SET phase = ?, observed_generation = ?, agent_session_id = ?,
+             last_heartbeat_at = ?, lease_expires_at = ?, current_contribution_cid = ?,
+             conditions_json = ?, last_transition_at = ?, revision = revision + 1
+         WHERE id = ?`,
+      )
+      .run(
+        next.phase,
+        next.observedGeneration,
+        next.agentSessionId ?? null,
+        toUtcIso(next.lastHeartbeatAt),
+        toUtcIso(next.leaseExpiresAt),
+        next.currentContributionCid ?? null,
+        JSON.stringify(next.conditions),
+        toUtcIso(next.lastTransitionAt),
+        claimId,
+      );
+    const view = this.readClaimView(claimId);
+    if (view === null) throw new Error(`Failed to read back claim view '${claimId}'`);
+    this.onClaimWrite?.("MODIFIED", claimViewToClaim(view));
+    return view;
+  };
+```
+
+Add private read helper:
+
+```ts
+  private readClaimView(claimId: string): ClaimView | null {
+    const row = this.stmtGetClaim.get(claimId) as ClaimViewRow | null;
+    if (row === null) return null;
+    return rowToClaimView(row);
+  }
+```
+
+- [ ] **Step 6: Rewrite legacy methods to use split tables**
+
+Make these replacements:
+
+```ts
+  getClaim = async (claimId: string): Promise<Claim | undefined> => {
+    const view = this.readClaimView(claimId);
+    return view === null ? undefined : claimViewToClaim(view);
+  };
+```
+
+In `createClaim`, replace `this.insertClaimRow(...)` with:
+
+```ts
+      this.insertSpecAndDefaultStatus({
+        ...claim,
+        createdAt: createdAtUtc,
+        heartbeatAt: heartbeatUtc,
+        leaseExpiresAt: leaseExpiresUtc,
+        revision: 1,
+      });
+```
+
+In `claimOrRenew`, update the active query to join split tables:
+
+```sql
+SELECT s.id AS claim_id, s.agent_id AS agent_id
+FROM claim_spec s
+JOIN claim_status st ON st.id = s.id
+WHERE s.target_ref = ? AND st.phase = 'active' AND st.lease_expires_at >= ?
+```
+
+For renewal, update only `claim_status.last_heartbeat_at`, `claim_status.lease_expires_at`, `claim_status.revision`, and the compatibility `claim_spec.intent_summary`:
+
+```sql
+UPDATE claim_status
+SET last_heartbeat_at = ?, lease_expires_at = ?, revision = revision + 1
+WHERE id = ?
+```
+
+```sql
+UPDATE claim_spec
+SET intent_summary = ?
+WHERE id = ?
+```
+
+Replace all remaining `claims` queries in `heartbeat`, `transitionClaim`, `expireStale`, `activeClaims`, `listClaims`, `cleanCompleted`, `countActiveClaims`, and `detectStalled` with joined split queries using `CLAIM_VIEW_SELECT_COLS`. Status mutations update only `claim_status`.
+
+- [ ] **Step 7: Run SQLite tests to verify GREEN**
+
+Run:
+
+```bash
+bun test src/local/sqlite-store.test.ts src/local/sqlite-store.migration.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/local/sqlite-store.ts src/local/sqlite-store.test.ts src/local/sqlite-store.migration.test.ts
+git commit -m "feat: store claims as sqlite spec status records"
+```
+
+---
+
+### Task 6: Nexus Logical Split Methods
+
+**Files:**
+- Modify: `src/nexus/nexus-claim-store.ts`
+- Modify: `tests/nexus/unit/nexus-claim-store.test.ts`
+- Test: `tests/nexus/unit/nexus-claim-store.test.ts`
+
+- [ ] **Step 1: Run Nexus tests to verify RED**
+
+Run:
+
+```bash
+bun test tests/nexus/unit/nexus-claim-store.test.ts
+```
+
+Expected: FAIL because `NexusClaimStore` does not implement split methods.
+
+- [ ] **Step 2: Add imports**
+
+In `src/nexus/nexus-claim-store.ts`, update imports from `../core/models.js`:
+
+```ts
+import {
+  claimToSpecRecord,
+  claimToStatusRecord,
+  claimViewToClaim,
+  type Claim,
+  type ClaimSpecRecord,
+  type ClaimStatus,
+  type ClaimStatusRecord,
+  type ClaimView,
+} from "../core/models.js";
+```
+
+Update store imports:
+
+```ts
+  ClaimStatusPatch,
+```
+
+- [ ] **Step 3: Add Nexus claim document helpers**
+
+Replace the current flat claim JSON encoding with a version-tolerant document. Keep the same `claimPath()` so existing files remain readable.
+
+Add near the encoder/decoder helpers:
+
+```ts
+interface ClaimDocument {
+  readonly spec: ClaimSpecRecord;
+  readonly status: ClaimStatusRecord;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isClaimDocument(value: unknown): value is ClaimDocument {
+  return (
+    isRecord(value) &&
+    isRecord(value.spec) &&
+    isRecord(value.status) &&
+    typeof value.spec.id === "string" &&
+    typeof value.status.id === "string"
+  );
+}
+
+function claimToDocument(claim: Claim): ClaimDocument {
+  return {
+    spec: claimToSpecRecord(claim),
+    status: claimToStatusRecord(claim),
+  };
+}
+
+function decodeClaimDocument(data: Uint8Array): ClaimDocument {
+  const parsed = JSON.parse(decoder.decode(data)) as unknown;
+  if (isClaimDocument(parsed)) return parsed;
+  return claimToDocument(parsed as Claim);
+}
+
+function encodeClaimDocument(document: ClaimDocument): Uint8Array {
+  return encoder.encode(JSON.stringify(document));
+}
+```
+
+Replace `ClaimWithEtag` with:
+
+```ts
+interface ClaimDocumentWithEtag {
+  readonly document: ClaimDocument;
+  readonly etag: string;
+}
+```
+
+Update the private read/write helpers so `readClaim(claimId)` returns `claimViewToClaim(document)`, `readClaimWithEtag(claimId)` returns `ClaimDocumentWithEtag`, and `writeClaim`, `writeClaimCas`, and `writeClaimConditional` convert flat claims through `claimToDocument(claim)` before writing. This preserves legacy callers while letting split methods keep independent `spec.generation` and `status.revision` in the stored JSON.
+
+- [ ] **Step 4: Implement split methods over claim documents**
+
+Add these public methods before `createClaim`:
+
+```ts
+  async putClaimSpec(spec: ClaimSpecRecord): Promise<ClaimView> {
+    const existing = await this.readClaimWithEtag(spec.id);
+    const now = new Date().toISOString();
+    if (existing === undefined) {
+      const leaseMs = (spec.leaseDeadlineSec ?? DEFAULT_LEASE_DURATION_MS / 1000) * 1000;
+      const document: ClaimDocument = {
+        spec: { ...spec, generation: 1, createdAt: toUtcIso(spec.createdAt) },
+        status: {
+          id: spec.id,
+          phase: "active" as ClaimStatus,
+          observedGeneration: 0,
+          lastHeartbeatAt: now,
+          leaseExpiresAt: new Date(Date.parse(spec.createdAt) + leaseMs).toISOString(),
+          conditions: [],
+          lastTransitionAt: now,
+          attemptCount: 0,
+          revision: 1,
+        },
+      };
+      await this.writeClaimDocumentConditional(spec.id, document, { ifNoneMatch: "*" });
+      const claim = claimViewToClaim(document);
+      await this.writeActiveIndexExclusive(claim);
+      this.claimCache.set(spec.id, claim);
+      this.invalidateActiveClaimsCache();
+      this.publishWatch(claim, "ADDED");
+      return document;
+    }
+
+    const document: ClaimDocument = {
+      spec: {
+        ...spec,
+        generation: existing.document.spec.generation + 1,
+        createdAt: existing.document.spec.createdAt,
+      },
+      status: existing.document.status,
+    };
+    await this.writeClaimDocumentCas(spec.id, document, existing.etag);
+    const claim = claimViewToClaim(document);
+    this.claimCache.set(claim.claimId, claim);
+    this.invalidateActiveClaimsCache();
+    this.publishWatch(claim, "MODIFIED");
+    return document;
+  }
+
+  async getClaimView(claimId: string): Promise<ClaimView | undefined> {
+    const result = await this.readClaimWithEtag(claimId);
+    return result?.document;
+  }
+
+  async patchClaimStatus(claimId: string, patch: ClaimStatusPatch): Promise<ClaimView> {
+    const result = await this.readClaimWithEtag(claimId);
+    if (result === undefined) {
+      throw new NotFoundError({
+        resource: "Claim",
+        identifier: claimId,
+        message: `Claim '${claimId}' not found`,
+      });
+    }
+    const document: ClaimDocument = {
+      spec: result.document.spec,
+      status: {
+        ...result.document.status,
+        phase: patch.phase ?? result.document.status.phase,
+        observedGeneration: patch.observedGeneration ?? result.document.status.observedGeneration,
+        agentSessionId: patch.agentSessionId ?? result.document.status.agentSessionId,
+        lastHeartbeatAt: patch.lastHeartbeatAt ?? result.document.status.lastHeartbeatAt,
+        leaseExpiresAt: patch.leaseExpiresAt ?? result.document.status.leaseExpiresAt,
+        currentContributionCid:
+          patch.currentContributionCid ?? result.document.status.currentContributionCid,
+        conditions: patch.conditions ?? result.document.status.conditions,
+        lastTransitionAt: patch.lastTransitionAt ?? result.document.status.lastTransitionAt,
+        revision: result.document.status.revision + 1,
+      },
+    };
+    await this.writeClaimDocumentCas(claimId, document, result.etag);
+    const claim = claimViewToClaim(document);
+    this.claimCache.set(claim.claimId, claim);
+    this.invalidateActiveClaimsCache();
+    this.publishWatch(claim, "MODIFIED");
+    return document;
+  }
+```
+
+Import `NotFoundError` from `../core/errors.js` alongside the existing error imports.
+
+- [ ] **Step 5: Add document write helpers**
+
+Add these private write helpers near existing claim write helpers:
+
+```ts
+  private async writeClaimDocumentConditional(
+    claimId: string,
+    document: ClaimDocument,
+    opts: { readonly ifNoneMatch: "*" },
+  ): Promise<void> {
+    await withRetry(
+      () =>
+        withSemaphore(this.semaphore, () =>
+          this.client.write(claimPath(this.zoneId, claimId), encodeClaimDocument(document), opts),
+        ),
+      "writeClaimDocumentConditional",
+      this.config,
+    );
+  }
+
+  private async writeClaimDocumentCas(
+    claimId: string,
+    document: ClaimDocument,
+    etag: string,
+  ): Promise<void> {
+    await withRetry(
+      () =>
+        withSemaphore(this.semaphore, () =>
+          this.client.write(claimPath(this.zoneId, claimId), encodeClaimDocument(document), {
+            ifMatch: etag,
+          }),
+        ),
+      "writeClaimDocumentCas",
+      this.config,
+    );
+  }
+```
+
+- [ ] **Step 6: Add Nexus adapter-specific status test**
+
+In `tests/nexus/unit/nexus-claim-store.test.ts`, add:
+
+```ts
+  test("patchClaimStatus preserves spec fields in Nexus compatibility storage", async () => {
+    const created = await store.putClaimSpec({
+      id: "nexus-split",
+      roleName: "coder",
+      platform: "codex",
+      targetRef: "target-nexus-split",
+      agent: { agentId: "agent-nexus", role: "coder", platform: "codex" },
+      intentSummary: "nexus split",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      generation: 1,
+    });
+
+    const patched = await store.patchClaimStatus("nexus-split", {
+      phase: "completed",
+      observedGeneration: created.spec.generation,
+      lastHeartbeatAt: "2026-01-01T00:05:00.000Z",
+    });
+
+    expect(patched.spec.intentSummary).toBe("nexus split");
+    expect(patched.spec.generation).toBe(created.spec.generation);
+    expect(patched.status.phase).toBe("completed");
+    expect(patched.status.revision).toBe(created.status.revision + 1);
+  });
+```
+
+- [ ] **Step 7: Run Nexus tests to verify GREEN**
+
+Run:
+
+```bash
+bun test tests/nexus/unit/nexus-claim-store.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/nexus/nexus-claim-store.ts tests/nexus/unit/nexus-claim-store.test.ts
+git commit -m "feat: add nexus claim spec status methods"
+```
+
+---
+
+### Task 7: HTTP Split Routes and Controller Auth
+
+**Files:**
+- Modify: `src/server/deps.ts`
+- Modify: `src/server/serve.ts`
+- Modify: `src/server/routes/claims.ts`
+- Modify: `tests/server/helpers.ts`
+- Modify: `tests/server/claims.test.ts`
+
+- [ ] **Step 1: Write failing HTTP tests**
+
+In `tests/server/helpers.ts`, add:
+
+```ts
+export const TEST_CONTROLLER_TOKEN = "controller-token-test";
+export const TEST_CONTROLLER_HEADERS = {
+  "X-Grove-Controller-Token": TEST_CONTROLLER_TOKEN,
+} as const;
+```
+
+Add `controllerToken: TEST_CONTROLLER_TOKEN` to `deps`.
+
+In `tests/server/claims.test.ts`, update imports:
+
+```ts
+import {
+  claimBody,
+  createTestContext,
+  TEST_AUTH_HEADERS,
+  TEST_CONTROLLER_HEADERS,
+} from "./helpers.js";
+```
+
+Add these tests after the `POST /api/claims` block and before legacy `PATCH /api/claims/:id`:
+
+```ts
+describe("split claim routes", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    ctx = await createTestContext();
+  });
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  test("PUT /api/claims/:id writes spec only and returns merged view", async () => {
+    const res = await ctx.app.request("/api/claims/spec-route", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify({
+        roleName: "coder",
+        platform: "codex",
+        targetRef: "target-spec-route",
+        agent: { agentId: "agent-spec-route", role: "coder", platform: "codex" },
+        intentSummary: "write spec route",
+        leaseDeadlineSec: 600,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.spec.id).toBe("spec-route");
+    expect(data.spec.roleName).toBe("coder");
+    expect(data.status.phase).toBe("active");
+    expect(data.status.observedGeneration).toBe(0);
+  });
+
+  test("PUT /api/claims/:id rejects status-owned fields", async () => {
+    const res = await ctx.app.request("/api/claims/spec-reject", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify({
+        targetRef: "target-spec-reject",
+        agent: { agentId: "agent-spec-reject" },
+        intentSummary: "bad spec",
+        phase: "completed",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  test("GET /api/claims/:id returns merged view", async () => {
+    await ctx.app.request("/api/claims/get-route", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify({
+        targetRef: "target-get-route",
+        agent: { agentId: "agent-get-route" },
+        intentSummary: "read merged",
+      }),
+    });
+
+    const res = await ctx.app.request("/api/claims/get-route", { headers: TEST_AUTH_HEADERS });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.spec.id).toBe("get-route");
+    expect(data.status.id).toBe("get-route");
+  });
+
+  test("PATCH /api/claims/:id/status requires controller token", async () => {
+    await ctx.app.request("/api/claims/status-auth", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify({
+        targetRef: "target-status-auth",
+        agent: { agentId: "agent-status-auth" },
+        intentSummary: "status auth",
+      }),
+    });
+
+    const res = await ctx.app.request("/api/claims/status-auth/status", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify({ phase: "completed" }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  test("PATCH /api/claims/:id/status writes status only with controller token", async () => {
+    const create = await ctx.app.request("/api/claims/status-route", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify({
+        targetRef: "target-status-route",
+        agent: { agentId: "agent-status-route" },
+        intentSummary: "status route",
+      }),
+    });
+    const created = await create.json();
+
+    const res = await ctx.app.request("/api/claims/status-route/status", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...TEST_AUTH_HEADERS,
+        ...TEST_CONTROLLER_HEADERS,
+      },
+      body: JSON.stringify({
+        phase: "completed",
+        observedGeneration: created.spec.generation,
+        lastHeartbeatAt: "2026-01-01T00:05:00.000Z",
+        conditions: [
+          {
+            type: "Completed",
+            status: "True",
+            observedGeneration: created.spec.generation,
+            lastTransitionTime: "2026-01-01T00:05:00.000Z",
+            reason: "controller",
+            message: "done",
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.spec.intentSummary).toBe("status route");
+    expect(data.spec.generation).toBe(created.spec.generation);
+    expect(data.status.phase).toBe("completed");
+    expect(data.status.observedGeneration).toBe(created.spec.generation);
+    expect(data.status.conditions[0].type).toBe("Completed");
+  });
+
+  test("PATCH /api/claims/:id/status rejects spec-owned fields", async () => {
+    await ctx.app.request("/api/claims/status-reject", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify({
+        targetRef: "target-status-reject",
+        agent: { agentId: "agent-status-reject" },
+        intentSummary: "status reject",
+      }),
+    });
+
+    const res = await ctx.app.request("/api/claims/status-reject/status", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...TEST_AUTH_HEADERS,
+        ...TEST_CONTROLLER_HEADERS,
+      },
+      body: JSON.stringify({ intentSummary: "bad status" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run HTTP tests to verify RED**
+
+Run:
+
+```bash
+bun test tests/server/claims.test.ts
+```
+
+Expected: FAIL because routes and controller token are not implemented.
+
+- [ ] **Step 3: Add controller token dependency**
+
+In `src/server/deps.ts`, add to `ServerDeps`:
+
+```ts
+  /** Optional controller token required by controller-owned status subresource writes. */
+  readonly controllerToken?: string | undefined;
+```
+
+In `src/server/serve.ts`, when building `deps`, set:
+
+```ts
+  controllerToken: process.env.GROVE_CONTROLLER_TOKEN,
+```
+
+- [ ] **Step 4: Add route schemas and auth helper**
+
+In `src/server/routes/claims.ts`, add:
+
+```ts
+const statusOwnedFields = new Set([
+  "status",
+  "phase",
+  "observedGeneration",
+  "agentSessionId",
+  "lastHeartbeatAt",
+  "heartbeatAt",
+  "leaseExpiresAt",
+  "currentContributionCid",
+  "conditions",
+  "lastTransitionAt",
+  "revision",
+]);
+
+const specOwnedFields = new Set([
+  "roleName",
+  "platform",
+  "blueprint",
+  "assignee",
+  "leaseDeadlineSec",
+  "priority",
+  "maxIterations",
+  "targetRef",
+  "agent",
+  "intentSummary",
+  "context",
+  "generation",
+  "revision",
+]);
+
+function rejectFields(
+  body: Record<string, unknown>,
+  forbidden: ReadonlySet<string>,
+  ctx: z.RefinementCtx,
+): void {
+  for (const key of Object.keys(body)) {
+    if (forbidden.has(key)) {
+      ctx.addIssue({
+        code: "custom",
+        path: [key],
+        message: `Field '${key}' belongs to the other claim subresource`,
+      });
+    }
+  }
+}
+```
+
+Add schemas:
+
+```ts
+const specBodySchema = z
+  .object({
+    roleName: z.string().min(1).optional(),
+    platform: z.string().min(1).optional(),
+    blueprint: z.string().min(1).optional(),
+    assignee: createBodySchema.shape.agent.optional(),
+    leaseDeadlineSec: z.number().int().positive().optional(),
+    priority: z.number().int().optional(),
+    maxIterations: z.number().int().positive().optional(),
+    targetRef: z.string().min(1),
+    agent: createBodySchema.shape.agent,
+    intentSummary: z.string().min(1),
+    context: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough()
+  .superRefine((body, ctx) => rejectFields(body, statusOwnedFields, ctx));
+
+const statusBodySchema = z
+  .object({
+    phase: z.enum(["active", "released", "expired", "completed"]).optional(),
+    observedGeneration: z.number().int().min(0).optional(),
+    agentSessionId: z.string().min(1).optional(),
+    lastHeartbeatAt: z.string().datetime().optional(),
+    leaseExpiresAt: z.string().datetime().optional(),
+    currentContributionCid: z.string().min(1).optional(),
+    conditions: z
+      .array(
+        z.object({
+          type: z.string(),
+          status: z.enum(["True", "False", "Unknown"]),
+          observedGeneration: z.number().int().min(0),
+          lastTransitionTime: z.string(),
+          reason: z.string(),
+          message: z.string(),
+        }),
+      )
+      .optional(),
+    lastTransitionAt: z.string().datetime().optional(),
+  })
+  .passthrough()
+  .superRefine((body, ctx) => rejectFields(body, specOwnedFields, ctx));
+```
+
+- [ ] **Step 5: Add routes before legacy `PATCH /:id`**
+
+In `src/server/routes/claims.ts`, after `claims.post("/", ...)`, add:
+
+```ts
+claims.put("/:id", zValidator("json", specBodySchema), async (c) => {
+  const claimId = c.req.param("id");
+  const body = c.req.valid("json");
+  const existing = await c.get("deps").claimStore.getClaimView(claimId);
+  const now = new Date().toISOString();
+  const view = await c.get("deps").claimStore.putClaimSpec({
+    id: claimId,
+    roleName: body.roleName,
+    platform: body.platform,
+    blueprint: body.blueprint,
+    assignee: body.assignee as AgentIdentity | undefined,
+    leaseDeadlineSec: body.leaseDeadlineSec,
+    priority: body.priority,
+    maxIterations: body.maxIterations,
+    generation: 0,
+    targetRef: body.targetRef,
+    agent: body.agent as AgentIdentity,
+    intentSummary: body.intentSummary,
+    ...(body.context !== undefined
+      ? { context: body.context as Readonly<Record<string, JsonValue>> }
+      : {}),
+    createdAt: existing?.spec.createdAt ?? now,
+  });
+  return c.json(view, existing === undefined ? 201 : 200);
+});
+
+claims.get("/:id", async (c) => {
+  const claimId = c.req.param("id");
+  const view = await c.get("deps").claimStore.getClaimView(claimId);
+  if (view === undefined) {
+    return c.json({ error: { code: "NOT_FOUND", message: `Claim '${claimId}' not found` } }, 404);
+  }
+  return c.json(view);
+});
+
+claims.patch("/:id/status", zValidator("json", statusBodySchema), async (c) => {
+  const deps = c.get("deps");
+  if (
+    deps.controllerToken === undefined ||
+    c.req.header("X-Grove-Controller-Token") !== deps.controllerToken
+  ) {
+    return c.json({ error: { code: "FORBIDDEN", message: "Controller token required" } }, 403);
+  }
+  const claimId = c.req.param("id");
+  const body = c.req.valid("json");
+  const view = await deps.claimStore.patchClaimStatus(claimId, {
+    phase: body.phase,
+    observedGeneration: body.observedGeneration,
+    agentSessionId: body.agentSessionId,
+    lastHeartbeatAt: body.lastHeartbeatAt,
+    leaseExpiresAt: body.leaseExpiresAt,
+    currentContributionCid: body.currentContributionCid,
+    conditions: body.conditions,
+    lastTransitionAt: body.lastTransitionAt,
+  });
+  return c.json(view);
+});
+```
+
+- [ ] **Step 6: Run HTTP tests to verify GREEN**
+
+Run:
+
+```bash
+bun test tests/server/claims.test.ts
+```
+
+Expected: PASS, including existing legacy route tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/server/deps.ts src/server/serve.ts src/server/routes/claims.ts tests/server/helpers.ts tests/server/claims.test.ts
+git commit -m "feat: add claim spec status routes"
+```
+
+---
+
+### Task 8: Watch, Entity, and Legacy Compatibility Verification
+
+**Files:**
+- Modify: `src/local/sqlite-store.test.ts`
+- Modify: `src/core/operations/claim.test.ts`
+- Test: `src/local/sqlite-store.test.ts`
+- Test: `src/core/operations/claim.test.ts`
+
+- [ ] **Step 1: Add SQLite watch/status ownership test**
+
+In `src/local/sqlite-store.test.ts`, add in the claim watch describe block:
+
+```ts
+  test("spec writes and status writes emit claim watch snapshots without cross-owned field drift", async () => {
+    const events: Array<{ op: string; claim: import("../core/models.js").Claim }> = [];
+    claimStore.onClaimWrite = (op, c) => events.push({ op, claim: c });
+
+    const created = await claimStore.putClaimSpec({
+      id: "watch-split",
+      targetRef: "target-watch-split",
+      agent: { agentId: "agent-watch-split" },
+      intentSummary: "initial split spec",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      generation: 1,
+    });
+    const patched = await claimStore.patchClaimStatus("watch-split", {
+      phase: "completed",
+      observedGeneration: created.spec.generation,
+      lastHeartbeatAt: "2026-01-01T00:05:00.000Z",
+    });
+
+    expect(events.map((e) => e.op)).toEqual(["ADDED", "MODIFIED"]);
+    expect(events[0]?.claim.intentSummary).toBe("initial split spec");
+    expect(events[1]?.claim.intentSummary).toBe("initial split spec");
+    expect(events[1]?.claim.status).toBe("completed");
+    expect(patched.spec.intentSummary).toBe("initial split spec");
+  });
+```
+
+- [ ] **Step 2: Run test to verify RED or GREEN**
+
+Run:
+
+```bash
+bun test src/local/sqlite-store.test.ts
+```
+
+Expected: PASS. The watch callbacks should emit `claimViewToClaim(view)` snapshots.
+
+- [ ] **Step 3: Add operation compatibility test**
+
+In `src/core/operations/claim.test.ts`, add a test near existing claim operation tests:
+
+```ts
+  test("claimOperation remains compatible with split claim store methods", async () => {
+    const result = await claimOperation(
+      {
+        targetRef: "target-operation-split",
+        agent: { agentId: "agent-operation-split", role: "coder", platform: "codex" },
+        intentSummary: "operation split",
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("claim operation failed");
+    const claimId = result.value.claimId;
+    const view = await deps.claimStore?.getClaimView(claimId);
+    expect(view?.spec.targetRef).toBe("target-operation-split");
+    expect(view?.spec.roleName).toBe("coder");
+    expect(view?.status.phase).toBe("active");
+  });
+```
+
+Use the existing `deps` variable from the `beforeEach` in `describe("claimOperation", ...)`.
+
+- [ ] **Step 4: Run operation tests**
+
+Run:
+
+```bash
+bun test src/core/operations/claim.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/local/sqlite-store.test.ts src/core/operations/claim.test.ts
+git commit -m "test: verify claim split compatibility"
+```
+
+---
+
+### Task 9: Full Verification and Cleanup
+
+**Files:**
+- Modify only files needed for compile, lint, or test failures discovered in this task.
+
+- [ ] **Step 1: Run focused test suite**
+
+Run:
+
+```bash
+bun test tests/server/claims.test.ts src/local/sqlite-store.test.ts src/local/sqlite-store.migration.test.ts src/core/entity.test.ts src/core/operations/claim.test.ts tests/nexus/unit/nexus-claim-store.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Biome**
+
+Run:
+
+```bash
+bun run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD
+git diff --check
+```
+
+Expected: `git diff --check` prints nothing. Diff stat includes only claim split implementation, tests, and docs.
+
+- [ ] **Step 5: Commit final fixes if any**
+
+If Step 1, 2, or 3 required changes, commit them:
+
+```bash
+git add src tests docs
+git commit -m "chore: stabilize claim spec status split"
+```
+
+If no changes were needed, do not create an empty commit.
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Split DTOs and `ClaimStore` methods: Tasks 1 and 2.
+  - SQLite physical tables and migration: Tasks 4 and 5.
+  - In-memory and Nexus logical adapters: Tasks 3 and 6.
+  - New HTTP routes and controller token: Task 7.
+  - Legacy flat route/store compatibility: Tasks 5, 7, and 8.
+  - Watch/entity behavior: Tasks 2 and 8.
+- Type consistency:
+  - `ClaimSpecRecord`, `ClaimStatusRecord`, `ClaimStatusPatch`, and `ClaimView` are the names used consistently across tasks.
+  - HTTP status body uses `phase`, not legacy `status`.
+  - Store status patch uses `lastHeartbeatAt`, while flat `Claim` keeps `heartbeatAt`.
+- Verification:
+  - Every implementation task has a failing test command before code changes.
+  - Final verification uses `bun test`, `bun run typecheck`, and `bun run check`.

--- a/docs/superpowers/specs/2026-05-07-claim-spec-status-split-design.md
+++ b/docs/superpowers/specs/2026-05-07-claim-spec-status-split-design.md
@@ -1,0 +1,416 @@
+# Claim Spec/Status Split Design
+
+## Summary
+
+Issue #270 splits claim ownership into user-editable desired state and controller-owned observed state. Grove will store claims as `claim_spec` plus `claim_status`, expose explicit spec and status subresource routes, and keep the existing flat `Claim` API compatible for CLI, TUI, MCP, bounty, and legacy HTTP consumers.
+
+This is a storage and write-surface change, not a full claim lifecycle rewrite. The reconciler work in issue #268 can build on the new status-only write path.
+
+## Goals
+
+- Separate user-owned claim fields from controller-owned status fields at the store boundary.
+- Add spec-only and status-only HTTP routes:
+  - `PUT /api/claims/:id`
+  - `PATCH /api/claims/:id/status`
+  - `GET /api/claims/:id`
+- Require a controller token for status writes while preserving namespace bearer auth for all `/api/*` routes.
+- Keep existing flat claim reads and legacy mutation methods compatible.
+- Migrate existing SQLite `claims` rows into split tables without data loss.
+- Ensure controllers never mutate spec and user writes cannot clobber status.
+
+## Non-Goals
+
+- Do not replace the whole claim lifecycle with the issue #268 reconciler loop.
+- Do not remove existing `POST /api/claims`, `PATCH /api/claims/:id`, or `GET /api/claims` behavior.
+- Do not change the external flat `Claim` shape returned by existing legacy routes.
+- Do not add CRD machinery, code generation, finalizers, or owner refs.
+- Do not redesign Nexus VFS storage beyond what is needed to implement the new `ClaimStore` methods. Nexus must preserve logical spec/status write ownership, but SQLite is the backend that gets the physical `claim_spec` and `claim_status` tables from this issue.
+
+## Current State
+
+The local SQLite backend stores one `claims` row containing desired state and observed state together:
+
+- Desired state: `target_ref`, `agent_json`, `intent_summary`, `context_json`, lease duration implied by timestamps.
+- Observed state: `status`, `heartbeat_at`, `lease_expires_at`, `attempt_count`, `revision`.
+
+The Entity adapter already projects claims into `spec` and `status`, but this projection happens after reads. Store writers can still update mixed fields in one row.
+
+The HTTP server has namespace bearer-token auth only. There is no existing controller-token role, so #270 needs a narrow controller-auth check for the status subresource.
+
+## Approach
+
+Use a compatibility-first split:
+
+1. Add explicit core DTOs for `ClaimSpec`, `ClaimStatusRecord`, and `ClaimView`.
+2. Extend `ClaimStore` with spec/status methods.
+3. Implement the split physically in SQLite with `claim_spec` and `claim_status`.
+4. Update in-memory and Nexus claim stores to satisfy the same logical spec/status method contract.
+5. Reimplement existing flat `ClaimStore` methods as adapters over split DTOs.
+6. Add HTTP routes for spec/status writes and merged reads.
+7. Keep legacy routes backed by the same split storage or adapter contract.
+
+This gives #270 real isolation without forcing every caller to migrate immediately.
+
+## Data Model
+
+### ClaimSpec
+
+`ClaimSpec` is the user-editable desired state. It contains the issue #270 fields plus compatibility fields needed to preserve the current flat claim API.
+
+```ts
+export interface ClaimSpec {
+  readonly id: string;
+  readonly roleName?: string | undefined;
+  readonly platform?: string | undefined;
+  readonly blueprint?: string | undefined;
+  readonly assignee?: AgentIdentity | undefined;
+  readonly leaseDeadlineSec?: number | undefined;
+  readonly priority?: number | undefined;
+  readonly maxIterations?: number | undefined;
+  readonly generation: number;
+
+  // Compatibility fields for existing Claim consumers.
+  readonly targetRef: string;
+  readonly agent: AgentIdentity;
+  readonly intentSummary: string;
+  readonly context?: Readonly<Record<string, JsonValue>> | undefined;
+  readonly createdAt: string;
+}
+```
+
+Spec writes increment `generation` monotonically. Clients cannot set `generation` directly through HTTP; the store controls it.
+
+Legacy claim writes derive missing spec fields:
+
+- `roleName` from `agent.role` when present.
+- `platform` from `agent.platform` when present.
+- `assignee` from `agent`.
+- `leaseDeadlineSec` from `leaseExpiresAt - createdAt`.
+
+### ClaimStatusRecord
+
+`ClaimStatusRecord` is controller-owned observed state.
+
+```ts
+export interface ClaimStatusRecord {
+  readonly id: string;
+  readonly phase: ClaimStatus;
+  readonly observedGeneration: number;
+  readonly agentSessionId?: string | undefined;
+  readonly lastHeartbeatAt: string;
+  readonly leaseExpiresAt: string;
+  readonly currentContributionCid?: string | undefined;
+  readonly conditions: readonly Condition[];
+  readonly lastTransitionAt: string;
+  readonly attemptCount: number;
+  readonly revision: number;
+}
+```
+
+The issue #270 `phase` names are mapped onto the existing flat lifecycle for compatibility:
+
+- `active` stays active.
+- `released`, `expired`, and `completed` stay terminal flat states.
+- Reconciler-specific phases can be added later if #268 broadens `ClaimStatus`.
+
+### ClaimView
+
+Merged reads return the split shape:
+
+```ts
+export interface ClaimView {
+  readonly spec: ClaimSpec;
+  readonly status: ClaimStatusRecord;
+}
+```
+
+Legacy reads still return flat `Claim`. The adapter derives:
+
+- `claimId` from `spec.id`
+- `targetRef`, `agent`, `intentSummary`, `context`, `createdAt` from `spec`
+- `status`, `heartbeatAt`, `leaseExpiresAt`, `attemptCount`, `revision` from `status`
+
+No caller should mutate DTOs returned by the store. Any mutation path must structured-clone or build a new object before writing.
+
+## SQLite Schema
+
+Add `claim_spec`:
+
+```sql
+CREATE TABLE IF NOT EXISTS claim_spec (
+  id TEXT PRIMARY KEY,
+  role_name TEXT,
+  platform TEXT,
+  blueprint TEXT,
+  assignee_json TEXT,
+  lease_deadline_sec INTEGER,
+  priority INTEGER,
+  max_iterations INTEGER,
+  generation INTEGER NOT NULL DEFAULT 1,
+  target_ref TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  agent_json TEXT NOT NULL,
+  intent_summary TEXT NOT NULL,
+  context_json TEXT,
+  created_at TEXT NOT NULL
+);
+```
+
+Add `claim_status`:
+
+```sql
+CREATE TABLE IF NOT EXISTS claim_status (
+  id TEXT PRIMARY KEY,
+  phase TEXT NOT NULL DEFAULT 'active',
+  observed_generation INTEGER NOT NULL DEFAULT 0,
+  agent_session_id TEXT,
+  last_heartbeat_at TEXT NOT NULL,
+  lease_expires_at TEXT NOT NULL,
+  current_contribution_cid TEXT,
+  conditions_json TEXT NOT NULL DEFAULT '[]',
+  last_transition_at TEXT NOT NULL,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  revision INTEGER NOT NULL DEFAULT 1,
+  FOREIGN KEY (id) REFERENCES claim_spec(id) ON DELETE CASCADE
+);
+```
+
+Indexes:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_claim_spec_target ON claim_spec(target_ref);
+CREATE INDEX IF NOT EXISTS idx_claim_spec_agent ON claim_spec(agent_id);
+CREATE INDEX IF NOT EXISTS idx_claim_status_phase ON claim_status(phase);
+CREATE INDEX IF NOT EXISTS idx_claim_status_phase_lease ON claim_status(phase, lease_expires_at);
+```
+
+The legacy `claims` table is left in place during migration for rollback safety, but SQLite store methods stop writing it after split migration. A later cleanup can drop it once all backends and releases have crossed the migration boundary.
+
+## Migration
+
+`CURRENT_SCHEMA_VERSION` increments by one.
+
+On open:
+
+1. Create `claim_spec` and `claim_status` if missing.
+2. If legacy `claims` contains rows not present in `claim_spec`, copy them:
+   - `claim_id` -> `claim_spec.id` and `claim_status.id`
+   - `target_ref`, `agent_id`, `agent_json`, `intent_summary`, `context_json`, `created_at` -> `claim_spec`
+   - `status`, `heartbeat_at`, `lease_expires_at`, `attempt_count`, `revision` -> `claim_status`
+   - `generation` defaults to `revision` when present, otherwise `1`
+   - `observed_generation` defaults to copied `generation`
+   - `last_transition_at` defaults to `heartbeat_at`
+   - `conditions_json` defaults to `[]`
+3. Ensure re-opening an already migrated database does not duplicate rows or alter generations.
+
+Fresh databases create only the split tables for active store behavior, while keeping legacy table creation harmless if older tests or manual tools inspect it.
+
+## Store Contract
+
+Extend `ClaimStore`:
+
+```ts
+putClaimSpec(spec: ClaimSpec): Promise<ClaimView>;
+getClaimView(claimId: string): Promise<ClaimView | undefined>;
+patchClaimStatus(claimId: string, patch: ClaimStatusPatch): Promise<ClaimView>;
+```
+
+`ClaimStatusPatch` is partial and status-only:
+
+```ts
+export interface ClaimStatusPatch {
+  readonly phase?: ClaimStatus | undefined;
+  readonly observedGeneration?: number | undefined;
+  readonly agentSessionId?: string | undefined;
+  readonly lastHeartbeatAt?: string | undefined;
+  readonly leaseExpiresAt?: string | undefined;
+  readonly currentContributionCid?: string | undefined;
+  readonly conditions?: readonly Condition[] | undefined;
+  readonly lastTransitionAt?: string | undefined;
+}
+```
+
+Rules:
+
+- `putClaimSpec` creates or replaces spec fields and increments `generation` for existing specs.
+- `putClaimSpec` creates a default status row when creating a new claim.
+- `putClaimSpec` never updates status columns.
+- `patchClaimStatus` updates only status columns and increments `revision`.
+- `patchClaimStatus` does not mutate spec or increment spec `generation`.
+- `patchClaimStatus` may set `observedGeneration = spec.generation`.
+- `getClaim`, `listClaims`, `activeClaims`, `heartbeat`, `release`, `complete`, `expireStale`, `countActiveClaims`, and `detectStalled` continue to work through joined split tables.
+
+## HTTP Routes
+
+All routes keep namespace bearer auth through existing middleware.
+
+### `PUT /api/claims/:id`
+
+Writes spec only.
+
+Accepted body fields:
+
+- `roleName`
+- `platform`
+- `blueprint`
+- `assignee`
+- `leaseDeadlineSec`
+- `priority`
+- `maxIterations`
+- `targetRef`
+- `agent`
+- `intentSummary`
+- `context`
+
+Rejected body fields:
+
+- `status`
+- `phase`
+- `observedGeneration`
+- `agentSessionId`
+- `lastHeartbeatAt`
+- `heartbeatAt`
+- `leaseExpiresAt`
+- `currentContributionCid`
+- `conditions`
+- `lastTransitionAt`
+- `revision`
+
+Response: `200` with `{ spec, status }` for update, `201` with `{ spec, status }` for create.
+
+### `PATCH /api/claims/:id/status`
+
+Writes status only. Requires:
+
+- existing namespace bearer token in `Authorization`
+- controller token in `X-Grove-Controller-Token`
+
+The token is configured by the server from `GROVE_CONTROLLER_TOKEN` and passed through `ServerDeps.controllerToken`. Missing or mismatched controller token returns `403`.
+
+Accepted body fields:
+
+- `phase`
+- `observedGeneration`
+- `agentSessionId`
+- `lastHeartbeatAt`
+- `leaseExpiresAt`
+- `currentContributionCid`
+- `conditions`
+- `lastTransitionAt`
+
+Rejected body fields:
+
+- `roleName`
+- `platform`
+- `blueprint`
+- `assignee`
+- `leaseDeadlineSec`
+- `priority`
+- `maxIterations`
+- `targetRef`
+- `agent`
+- `intentSummary`
+- `context`
+- `generation`
+- `revision`
+
+Response: `200` with `{ spec, status }`.
+
+### `GET /api/claims/:id`
+
+Returns merged split view:
+
+```json
+{
+  "spec": {},
+  "status": {}
+}
+```
+
+Missing claim returns `404`.
+
+### Legacy Routes
+
+- `POST /api/claims` remains create-or-renew and returns flat `Claim`.
+- `PATCH /api/claims/:id` remains heartbeat, release, or complete and returns flat `Claim`.
+- `GET /api/claims` remains list and returns flat claims.
+
+These routes internally use split storage.
+
+## Watch and Entity Behavior
+
+Spec writes emit `ADDED` for new claims and `MODIFIED` for existing claims. Status writes emit `MODIFIED`.
+
+The Entity projection updates:
+
+- `ClaimEntity.spec` includes the richer spec fields.
+- `ClaimEntity.status` reads from `ClaimStatusRecord`.
+- `metadata.generation` comes from `ClaimSpec.generation`.
+- `observedGeneration` comes from `ClaimStatusRecord.observedGeneration`.
+- `resourceVersion` comes from `ClaimStatusRecord.revision`, preserving the current lease-expired derived version behavior.
+
+Existing watch consumers that use flat claims through `claimToEntity` continue to receive compatible condition and phase values.
+
+## Auth Design
+
+Controller authorization is intentionally narrow:
+
+- Namespace auth remains the global gate for `/api/*`.
+- Only `PATCH /api/claims/:id/status` checks the controller token.
+- The token is not a namespace key and does not grant read access by itself.
+- The token is compared exactly to `X-Grove-Controller-Token`.
+
+This avoids changing `server-keys.yaml` semantics while giving #268 a protected status-write surface.
+
+## Testing
+
+### SQLite Migration Tests
+
+- Fresh database has `claim_spec` and `claim_status`.
+- Legacy database with populated `claims` backfills both split tables.
+- Re-open after migration does not duplicate rows.
+- Existing legacy claim remains readable through `getClaim`.
+
+### Store Conformance Tests
+
+- `putClaimSpec` creates spec and default status.
+- `putClaimSpec` increments `generation` without changing status `revision`.
+- `patchClaimStatus` updates status and increments `revision` without changing spec `generation`.
+- `getClaimView` returns `{ spec, status }`.
+- Legacy `heartbeat`, `release`, and `complete` update status only.
+- Legacy `claimOrRenew` renews same-agent active claims without rewriting spec-owned fields except the intended `intentSummary` compatibility field.
+
+### HTTP Tests
+
+- `PUT /api/claims/:id` rejects status-owned fields.
+- `PATCH /api/claims/:id/status` rejects spec-owned fields.
+- `PATCH /api/claims/:id/status` returns `403` with missing or wrong controller token.
+- `PATCH /api/claims/:id/status` succeeds with namespace auth plus controller token.
+- `GET /api/claims/:id` returns `{ spec, status }`.
+- Legacy routes keep existing response shape.
+
+### Verification Commands
+
+Once Bun is available:
+
+```bash
+bun test tests/server/claims.test.ts src/local/sqlite-store.test.ts src/local/sqlite-store.migration.test.ts src/core/claim-store.conformance.ts src/core/entity.test.ts
+bun run typecheck
+bun run check
+```
+
+## Risks
+
+- The split introduces duplicated compatibility semantics between flat `Claim` and split `ClaimView`. Keep conversion helpers centralized to avoid drift.
+- Nexus is VFS-backed, so it will enforce spec/status ownership through the new `ClaimStore` methods rather than SQLite tables. Its compatibility path must pass the same store contract tests without breaking existing Nexus consumers.
+- Controller-token config is new operational surface. Missing config should fail status writes clearly without affecting normal claim use.
+
+## Acceptance Criteria
+
+- `claim_spec` and `claim_status` exist and are used by SQLite claim writes.
+- User spec writes cannot update status-owned fields.
+- Controller status writes cannot update spec-owned fields.
+- Status writes require a controller token.
+- `GET /api/claims/:id` returns `{ spec, status }`.
+- Legacy claim routes and store methods remain compatible.
+- The reconciler can read a claim view and write status only with `observedGeneration = spec.generation`.

--- a/src/core/acp-runtime.test.ts
+++ b/src/core/acp-runtime.test.ts
@@ -122,6 +122,35 @@ describe("buildAcpLaunchArgs", () => {
     ]);
   });
 
+  test("skips codex MCP argv overrides when CODEX_HOME config is authoritative", () => {
+    expect(
+      buildAcpLaunchArgs(
+        codexLaunch,
+        {
+          model: "gpt-5.4-mini",
+          command: "codex --full-auto",
+          mcpServers: [
+            {
+              name: "grove",
+              command: "/Users/example/.bun/bin/bun",
+              args: ["run", "/tmp/grove/dist/mcp/serve.js"],
+              env: { GROVE_DIR: "/tmp/grove/.grove" },
+            },
+          ],
+        },
+        { GROVE_CODEX_WRITE_MCP_CONFIG: "1" },
+      ),
+    ).toEqual([
+      "codex-acp.js",
+      "-c",
+      'model="gpt-5.4-mini"',
+      "-c",
+      'sandbox_mode="danger-full-access"',
+      "-c",
+      'approval_policy="never"',
+    ]);
+  });
+
   test("does not pass codex config flags to non-codex adapters", () => {
     expect(
       buildAcpLaunchArgs(

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -142,7 +142,9 @@ export function buildAcpLaunchArgs(
   if (allowAll) {
     args.push("-c", 'sandbox_mode="danger-full-access"', "-c", 'approval_policy="never"');
   }
-  appendCodexMcpServerOverrides(args, opts.mcpServers);
+  if (env.GROVE_CODEX_WRITE_MCP_CONFIG !== "1") {
+    appendCodexMcpServerOverrides(args, opts.mcpServers);
+  }
   return args;
 }
 

--- a/src/core/claim-store.conformance.ts
+++ b/src/core/claim-store.conformance.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { ClaimStatus } from "./models.js";
 import type { ClaimStore } from "./store.js";
-import { makeClaim } from "./test-helpers.js";
+import { makeAgent, makeClaim } from "./test-helpers.js";
 
 /** Factory that creates a fresh ClaimStore and returns a cleanup function. */
 export type ClaimStoreFactory = () => Promise<{
@@ -52,6 +52,105 @@ export function runClaimStoreTests(
     afterEach(async () => {
       store.close();
       await cleanup();
+    });
+
+    test("putClaimSpec creates a claim view with default status", async () => {
+      const now = new Date().toISOString();
+      const view = await store.putClaimSpec({
+        id: "spec-create",
+        roleName: "coder",
+        platform: "codex",
+        blueprint: "implement issue",
+        assignee: makeAgent({ agentId: "agent-spec", platform: "codex", role: "coder" }),
+        leaseDeadlineSec: 600,
+        priority: 7,
+        maxIterations: 3,
+        generation: 99,
+        targetRef: "target-spec",
+        agent: makeAgent({ agentId: "agent-spec", platform: "codex", role: "coder" }),
+        intentSummary: "Implement claim split",
+        context: { issue: 270 },
+        createdAt: now,
+      });
+
+      expect(view.spec.id).toBe("spec-create");
+      expect(view.spec.generation).toBe(1);
+      expect(view.spec.roleName).toBe("coder");
+      expect(view.status.id).toBe("spec-create");
+      expect(view.status.phase).toBe(ClaimStatus.Active);
+      expect(view.status.observedGeneration).toBe(0);
+      expect(view.status.revision).toBe(1);
+    });
+
+    test("putClaimSpec increments generation without changing status revision", async () => {
+      const created = await store.putClaimSpec({
+        id: "spec-update",
+        targetRef: "target-spec-update",
+        agent: makeAgent({ agentId: "agent-spec-update" }),
+        intentSummary: "first spec",
+        createdAt: new Date().toISOString(),
+        generation: 1,
+      });
+      const statusUpdated = await store.patchClaimStatus("spec-update", {
+        phase: ClaimStatus.Active,
+        observedGeneration: created.spec.generation,
+        lastHeartbeatAt: "2026-01-01T00:01:00.000Z",
+      });
+
+      const updated = await store.putClaimSpec({
+        ...statusUpdated.spec,
+        intentSummary: "second spec",
+        generation: 1,
+      });
+
+      expect(updated.spec.generation).toBe(created.spec.generation + 1);
+      expect(updated.spec.intentSummary).toBe("second spec");
+      expect(updated.status.revision).toBe(statusUpdated.status.revision);
+      expect(updated.status.lastHeartbeatAt).toBe(statusUpdated.status.lastHeartbeatAt);
+    });
+
+    test("patchClaimStatus changes status without changing spec generation", async () => {
+      const created = await store.putClaimSpec({
+        id: "status-update",
+        targetRef: "target-status-update",
+        agent: makeAgent({ agentId: "agent-status-update" }),
+        intentSummary: "status-only write",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        generation: 1,
+      });
+
+      const patched = await store.patchClaimStatus("status-update", {
+        phase: ClaimStatus.Completed,
+        observedGeneration: created.spec.generation,
+        agentSessionId: "session-1",
+        lastHeartbeatAt: "2026-01-01T00:05:00.000Z",
+        leaseExpiresAt: "2026-01-01T00:10:00.000Z",
+        currentContributionCid:
+          "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        conditions: [
+          {
+            type: "Completed",
+            status: "True",
+            observedGeneration: created.spec.generation,
+            lastTransitionTime: "2026-01-01T00:05:00.000Z",
+            reason: "controller",
+            message: "done",
+          },
+        ],
+        lastTransitionAt: "2026-01-01T00:05:00.000Z",
+      });
+
+      expect(patched.spec.generation).toBe(created.spec.generation);
+      expect(patched.spec.intentSummary).toBe(created.spec.intentSummary);
+      expect(patched.status.phase).toBe(ClaimStatus.Completed);
+      expect(patched.status.observedGeneration).toBe(created.spec.generation);
+      expect(patched.status.agentSessionId).toBe("session-1");
+      expect(patched.status.revision).toBe(created.status.revision + 1);
+      expect(patched.status.conditions[0]?.type).toBe("Completed");
+    });
+
+    test("getClaimView returns undefined for a missing claim", async () => {
+      await expect(store.getClaimView("missing-view")).resolves.toBeUndefined();
     });
 
     // ------------------------------------------------------------------

--- a/src/core/enforcing-store.test.ts
+++ b/src/core/enforcing-store.test.ts
@@ -745,6 +745,75 @@ describe("EnforcingClaimStore", () => {
       }
     });
 
+    test("putClaimSpec enforces global limit for new active claims", async () => {
+      const { dir, db, claimStore } = await setupStores();
+      try {
+        const contract = makeContract({
+          concurrency: { maxActiveClaims: 1 },
+        });
+        const store = new EnforcingClaimStore(claimStore, contract);
+
+        await store.createClaim(
+          makeClaim({ claimId: "c1", targetRef: "t1", agent: { agentId: "a1" } }),
+        );
+
+        try {
+          await store.putClaimSpec({
+            id: "split-c2",
+            generation: 0,
+            targetRef: "t2",
+            agent: { agentId: "a2" },
+            intentSummary: "split claim",
+            createdAt: new Date().toISOString(),
+          });
+          expect.unreachable("should have thrown");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConcurrencyLimitError);
+          const err = e as ConcurrencyLimitError;
+          expect(err.limitType).toBe("global");
+          expect(err.current).toBe(1);
+          expect(err.limit).toBe(1);
+        }
+      } finally {
+        await cleanup(dir, db);
+      }
+    });
+
+    test("patchClaimStatus enforces global limit when activating a split claim", async () => {
+      const { dir, db, claimStore } = await setupStores();
+      try {
+        const contract = makeContract({
+          concurrency: { maxActiveClaims: 1 },
+        });
+        const store = new EnforcingClaimStore(claimStore, contract);
+
+        await store.createClaim(
+          makeClaim({ claimId: "c1", targetRef: "t1", agent: { agentId: "a1" } }),
+        );
+        await claimStore.createClaim(
+          makeClaim({ claimId: "c2", targetRef: "t2", agent: { agentId: "a2" } }),
+        );
+        await claimStore.release("c2");
+
+        try {
+          await store.patchClaimStatus("c2", {
+            phase: "active",
+            lastHeartbeatAt: new Date().toISOString(),
+            leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+          });
+          expect.unreachable("should have thrown");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConcurrencyLimitError);
+          const err = e as ConcurrencyLimitError;
+          expect(err.limitType).toBe("global");
+          expect(err.current).toBe(1);
+          expect(err.limit).toBe(1);
+        }
+      } finally {
+        await cleanup(dir, db);
+      }
+    });
+
     test("expired claims do not count toward global limit", async () => {
       const { dir, db, claimStore } = await setupStores();
       try {

--- a/src/core/enforcing-store.ts
+++ b/src/core/enforcing-store.ts
@@ -22,11 +22,21 @@ import {
   LeaseViolationError,
   RateLimitError,
 } from "./errors.js";
-import type { Claim, Contribution, ContributionKind, Relation, RelationType } from "./models.js";
+import {
+  type Claim,
+  type ClaimSpecRecord,
+  type ClaimView,
+  type Contribution,
+  type ContributionKind,
+  claimViewToClaim,
+  type Relation,
+  type RelationType,
+} from "./models.js";
 import type { SessionRuntimeConfig } from "./session-config.js";
 import type {
   ActiveClaimFilter,
   ClaimQuery,
+  ClaimStatusPatch,
   ClaimStore,
   ContributionPutManyOutcome,
   ContributionPutOutcome,
@@ -548,6 +558,59 @@ export class EnforcingClaimStore implements ClaimStore {
     return this.inner.heartbeat(claimId, effectiveDurationMs);
   };
 
+  putClaimSpec = async (spec: ClaimSpecRecord): Promise<ClaimView> => {
+    return this.writeMutex.runExclusive(async () => {
+      const existing = await this.inner.getClaimView(spec.id);
+      const existingClaim = existing !== undefined ? claimViewToClaim(existing) : undefined;
+      const existingActive =
+        existingClaim !== undefined &&
+        existingClaim.status === "active" &&
+        new Date(existingClaim.leaseExpiresAt).getTime() >= this.clockTime();
+
+      if (existingClaim === undefined) {
+        await this.enforceConcurrencyLimitsFor(spec.targetRef, spec.agent.agentId);
+      } else if (existingActive) {
+        await this.enforceConcurrencyLimitsFor(spec.targetRef, spec.agent.agentId, {
+          global: false,
+          perAgent: existingClaim.agent.agentId !== spec.agent.agentId,
+          perTarget: existingClaim.targetRef !== spec.targetRef,
+        });
+      }
+      this.enforceSpecLeaseLimit(spec);
+
+      return await this.inner.putClaimSpec(spec);
+    });
+  };
+
+  getClaimView = (claimId: string): Promise<ClaimView | undefined> =>
+    this.inner.getClaimView(claimId);
+
+  patchClaimStatus = async (claimId: string, patch: ClaimStatusPatch): Promise<ClaimView> => {
+    return this.writeMutex.runExclusive(async () => {
+      const existing = await this.inner.getClaimView(claimId);
+      if (existing !== undefined) {
+        const nowMs = this.clockTime();
+        const existingClaim = claimViewToClaim(existing);
+        const existingActive =
+          existingClaim.status === "active" &&
+          new Date(existingClaim.leaseExpiresAt).getTime() >= nowMs;
+        const patchedPhase = patch.phase ?? existing.status.phase;
+        const patchedLeaseExpiresAt = patch.leaseExpiresAt ?? existing.status.leaseExpiresAt;
+        const patchedActive =
+          patchedPhase === "active" && new Date(patchedLeaseExpiresAt).getTime() >= nowMs;
+
+        if (patchedActive && !existingActive) {
+          await this.enforceConcurrencyLimitsFor(
+            existing.spec.targetRef,
+            existing.spec.agent.agentId,
+          );
+        }
+      }
+
+      return await this.inner.patchClaimStatus(claimId, patch);
+    });
+  };
+
   // claimOrRenew — enforced via mutex with concurrency + lease checks
   claimOrRenew = async (claim: Claim): Promise<Claim> => {
     return this.writeMutex.runExclusive(async () => {
@@ -592,11 +655,26 @@ export class EnforcingClaimStore implements ClaimStore {
   // ========================================================================
 
   private async enforceConcurrencyLimits(claim: Claim): Promise<void> {
+    await this.enforceConcurrencyLimitsFor(claim.targetRef, claim.agent.agentId);
+  }
+
+  private async enforceConcurrencyLimitsFor(
+    targetRef: string,
+    agentId: string,
+    checks: {
+      readonly global?: boolean | undefined;
+      readonly perAgent?: boolean | undefined;
+      readonly perTarget?: boolean | undefined;
+    } = {},
+  ): Promise<void> {
     const concurrency = this.config.concurrency;
     if (concurrency === undefined) return;
+    const checkGlobal = checks.global ?? true;
+    const checkPerAgent = checks.perAgent ?? true;
+    const checkPerTarget = checks.perTarget ?? true;
 
     // Check global active claim limit
-    if (concurrency.maxActiveClaims !== undefined) {
+    if (checkGlobal && concurrency.maxActiveClaims !== undefined) {
       const globalCount = await this.inner.countActiveClaims();
       if (globalCount >= concurrency.maxActiveClaims) {
         throw new ConcurrencyLimitError({
@@ -608,9 +686,13 @@ export class EnforcingClaimStore implements ClaimStore {
     }
 
     // Check per-agent claim limit (0 means unlimited)
-    if (concurrency.maxClaimsPerAgent !== undefined && concurrency.maxClaimsPerAgent > 0) {
+    if (
+      checkPerAgent &&
+      concurrency.maxClaimsPerAgent !== undefined &&
+      concurrency.maxClaimsPerAgent > 0
+    ) {
       const agentCount = await this.inner.countActiveClaims({
-        agentId: claim.agent.agentId,
+        agentId,
       });
       if (agentCount >= concurrency.maxClaimsPerAgent) {
         throw new ConcurrencyLimitError({
@@ -622,9 +704,9 @@ export class EnforcingClaimStore implements ClaimStore {
     }
 
     // Check per-target claim limit
-    if (concurrency.maxClaimsPerTarget !== undefined) {
+    if (checkPerTarget && concurrency.maxClaimsPerTarget !== undefined) {
       const targetCount = await this.inner.countActiveClaims({
-        targetRef: claim.targetRef,
+        targetRef,
       });
       if (targetCount >= concurrency.maxClaimsPerTarget) {
         throw new ConcurrencyLimitError({
@@ -634,6 +716,22 @@ export class EnforcingClaimStore implements ClaimStore {
         });
       }
     }
+  }
+
+  private enforceSpecLeaseLimit(spec: ClaimSpecRecord): void {
+    const maxLeaseSeconds = this.config.execution?.maxLeaseSeconds;
+    if (maxLeaseSeconds === undefined || spec.leaseDeadlineSec === undefined) return;
+
+    if (spec.leaseDeadlineSec > maxLeaseSeconds) {
+      throw new LeaseViolationError({
+        requestedSeconds: spec.leaseDeadlineSec,
+        maxSeconds: maxLeaseSeconds,
+      });
+    }
+  }
+
+  private clockTime(): number {
+    return Date.now();
   }
 
   private enforceLeaseLimit(claim: Claim): void {

--- a/src/core/entity.test.ts
+++ b/src/core/entity.test.ts
@@ -10,8 +10,15 @@ import type {
   EntityMetadata,
 } from "./entity.js";
 import { agentSessionToEntity, claimToEntity, contributionToEntity } from "./entity.js";
-import type { Claim, Contribution } from "./models.js";
-import { ClaimStatus, ContributionKind, ContributionMode } from "./models.js";
+import type { Claim, ClaimView, Contribution } from "./models.js";
+import {
+  ClaimStatus,
+  ContributionKind,
+  ContributionMode,
+  claimToSpecRecord,
+  claimToStatusRecord,
+  claimViewToClaim,
+} from "./models.js";
 
 describe("Entity envelope types", () => {
   test("Condition has six required fields", () => {
@@ -143,6 +150,104 @@ function makeClaim(overrides: Partial<Claim> = {}): Claim {
   };
 }
 
+describe("claim split conversion helpers", () => {
+  test("claimToSpecRecord projects desired-state fields from flat claim", () => {
+    const claim = makeClaim({
+      claimId: "claim-rich",
+      agent: { agentId: "agent-rich", platform: "codex", role: "coder" },
+      context: { issue: 270 },
+      createdAt: "2026-01-01T00:00:00.000Z",
+      leaseExpiresAt: "2026-01-01T00:06:00.000Z",
+      revision: 4,
+    });
+
+    const spec = claimToSpecRecord(claim);
+
+    expect(spec.id).toBe("claim-rich");
+    expect(spec.roleName).toBe("coder");
+    expect(spec.platform).toBe("codex");
+    expect(spec.assignee).toEqual(claim.agent);
+    expect(spec.leaseDeadlineSec).toBe(360);
+    expect(spec.generation).toBe(4);
+    expect(spec.targetRef).toBe(claim.targetRef);
+    expect(spec.context).toEqual({ issue: 270 });
+  });
+
+  test("claimToSpecRecord omits leaseDeadlineSec for invalid or non-forward leases", () => {
+    const invalid = claimToSpecRecord(
+      makeClaim({
+        createdAt: "not-a-date",
+        leaseExpiresAt: "2026-01-01T00:06:00.000Z",
+      }),
+    );
+    expect(invalid.leaseDeadlineSec).toBeUndefined();
+
+    const nonForward = claimToSpecRecord(
+      makeClaim({
+        createdAt: "2026-01-01T00:06:00.000Z",
+        leaseExpiresAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    expect(nonForward.leaseDeadlineSec).toBeUndefined();
+  });
+
+  test("claimToStatusRecord projects observed state and supplied conditions", () => {
+    const claim = makeClaim({
+      claimId: "claim-status",
+      heartbeatAt: "2026-01-01T00:01:00.000Z",
+      leaseExpiresAt: "2026-01-01T00:06:00.000Z",
+      attemptCount: 3,
+      revision: 4,
+    });
+    const condition: Condition = {
+      type: "Active",
+      status: "True",
+      observedGeneration: 4,
+      lastTransitionTime: "2026-01-01T00:01:00.000Z",
+      reason: "active",
+      message: "",
+    };
+
+    const status = claimToStatusRecord(claim, [condition]);
+
+    expect(status.id).toBe("claim-status");
+    expect(status.phase).toBe("active");
+    expect(status.observedGeneration).toBe(4);
+    expect(status.lastHeartbeatAt).toBe("2026-01-01T00:01:00.000Z");
+    expect(status.leaseExpiresAt).toBe("2026-01-01T00:06:00.000Z");
+    expect(status.conditions).toEqual([condition]);
+    expect(status.lastTransitionAt).toBe("2026-01-01T00:01:00.000Z");
+    expect(status.attemptCount).toBe(3);
+    expect(status.revision).toBe(4);
+  });
+
+  test("claimViewToClaim merges split records and only preserves optional fields when set", () => {
+    const claim = makeClaim({
+      claimId: "claim-view",
+      context: { issue: 270 },
+      attemptCount: 2,
+      revision: 5,
+    });
+    const view: ClaimView = {
+      spec: claimToSpecRecord(claim),
+      status: claimToStatusRecord(claim),
+    };
+
+    expect(claimViewToClaim(view)).toEqual(claim);
+
+    const minimalClaim = makeClaim({ context: undefined, attemptCount: undefined });
+    const minimalView: ClaimView = {
+      spec: claimToSpecRecord(minimalClaim),
+      status: claimToStatusRecord(minimalClaim),
+    };
+    const merged = claimViewToClaim(minimalView);
+
+    expect("context" in merged).toBe(false);
+    expect("attemptCount" in merged).toBe(false);
+    expect(merged.revision).toBe(1);
+  });
+});
+
 // Fixed clock a minute before the default leaseExpiresAt — keeps legacy
 // tests deterministic without relying on the wall clock.
 const claimClock = (): number => Date.parse("2026-04-23T00:04:00Z");
@@ -162,6 +267,35 @@ describe("claimToEntity", () => {
     expect(e.spec.targetRef).toBe("target-x");
     expect(e.spec.intentSummary).toBe("do x");
     expect(e.spec.context).toEqual({ k: "v" });
+  });
+
+  test("claimToEntity projects split-compatible spec and status fields", () => {
+    const claim = makeClaim({
+      claimId: "claim-rich",
+      targetRef: "target-rich",
+      agent: {
+        agentId: "agent-rich",
+        platform: "codex",
+        role: "coder",
+      },
+      intentSummary: "rich claim",
+      context: { issue: 270 },
+      createdAt: "2026-01-01T00:00:00.000Z",
+      heartbeatAt: "2026-01-01T00:01:00.000Z",
+      leaseExpiresAt: "2026-01-01T00:06:00.000Z",
+      revision: 4,
+    });
+
+    const entity = claimToEntity(claim, () => Date.parse("2026-01-01T00:02:00.000Z"), "ns/test");
+
+    expect(entity.spec.roleName).toBe("coder");
+    expect(entity.spec.platform).toBe("codex");
+    expect(entity.spec.assignee).toEqual(claim.agent);
+    expect(entity.spec.leaseDeadlineSec).toBe(360);
+    expect(entity.status.observedGeneration).toBe(4);
+    expect(entity.status.lastHeartbeatAt).toBe("2026-01-01T00:01:00.000Z");
+    expect(entity.status.leaseExpiresAt).toBe("2026-01-01T00:06:00.000Z");
+    expect(entity.metadata.generation).toBe(4);
   });
 
   test("status carries phase/heartbeatAt/leaseExpiresAt/attemptCount", () => {

--- a/src/core/entity.test.ts
+++ b/src/core/entity.test.ts
@@ -9,7 +9,12 @@ import type {
   Entity,
   EntityMetadata,
 } from "./entity.js";
-import { agentSessionToEntity, claimToEntity, contributionToEntity } from "./entity.js";
+import {
+  agentSessionToEntity,
+  claimToEntity,
+  claimViewToEntity,
+  contributionToEntity,
+} from "./entity.js";
 import type { Claim, ClaimView, Contribution } from "./models.js";
 import {
   ClaimStatus,
@@ -296,6 +301,62 @@ describe("claimToEntity", () => {
     expect(entity.status.lastHeartbeatAt).toBe("2026-01-01T00:01:00.000Z");
     expect(entity.status.leaseExpiresAt).toBe("2026-01-01T00:06:00.000Z");
     expect(entity.metadata.generation).toBe(4);
+  });
+
+  test("claimViewToEntity preserves split spec generation and controller status fields", () => {
+    const conditions: readonly Condition[] = [
+      {
+        type: "Completed",
+        status: "True",
+        observedGeneration: 9,
+        lastTransitionTime: "2026-01-01T00:05:00.000Z",
+        reason: "controller",
+        message: "done",
+      },
+    ];
+    const view: ClaimView = {
+      spec: {
+        id: "claim-view-rich",
+        roleName: "coder",
+        platform: "codex",
+        assignee: { agentId: "agent-view", role: "reviewer" },
+        generation: 9,
+        targetRef: "target-view",
+        agent: { agentId: "agent-view", role: "coder", platform: "codex" },
+        intentSummary: "view claim",
+        context: { issue: 270 },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      status: {
+        id: "claim-view-rich",
+        phase: ClaimStatus.Completed,
+        observedGeneration: 9,
+        agentSessionId: "session-view",
+        lastHeartbeatAt: "2026-01-01T00:04:00.000Z",
+        leaseExpiresAt: "2026-01-01T00:10:00.000Z",
+        currentContributionCid:
+          "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        conditions,
+        lastTransitionAt: "2026-01-01T00:05:00.000Z",
+        attemptCount: 3,
+        revision: 4,
+      },
+    };
+
+    const entity = claimViewToEntity(view, () => Date.parse("2026-01-01T00:06:00.000Z"), "ns/view");
+
+    expect(entity.id).toBe("claim-view-rich");
+    expect(entity.namespace).toBe("ns/view");
+    expect(entity.metadata.generation).toBe(9);
+    expect(entity.observedGeneration).toBe(9);
+    expect(entity.resourceVersion).toBe("4");
+    expect(entity.status.observedGeneration).toBe(9);
+    expect(entity.status.agentSessionId).toBe("session-view");
+    expect(entity.status.currentContributionCid).toBe(
+      "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    expect(entity.status.attemptCount).toBe(3);
+    expect(entity.conditions).toEqual(conditions);
   });
 
   test("status carries phase/heartbeatAt/leaseExpiresAt/attemptCount", () => {

--- a/src/core/entity.ts
+++ b/src/core/entity.ts
@@ -11,6 +11,9 @@ import type {
   AgentIdentity,
   Claim,
   ClaimStatus as ClaimPhase,
+  ClaimSpecRecord,
+  ClaimStatusRecord,
+  ClaimView,
   Contribution,
   ContributionKind,
   ContributionMode,
@@ -169,17 +172,41 @@ export function claimToEntity(
   now: () => number = () => Date.now(),
   namespace = "default",
 ): ClaimEntity {
-  const rev = c.revision ?? 0;
-  const metaGen = c.revision ?? 1;
-  const persistedPhase = c.status;
-  const createdAtMs = Date.parse(c.createdAt);
-  const leaseExpiresAtMs = Date.parse(c.leaseExpiresAt);
-  const leaseDeadlineSec =
-    Number.isFinite(createdAtMs) &&
-    Number.isFinite(leaseExpiresAtMs) &&
-    leaseExpiresAtMs > createdAtMs
-      ? Math.floor((leaseExpiresAtMs - createdAtMs) / 1000)
-      : undefined;
+  const leaseDeadlineSec = computeLeaseDeadlineSec(c.createdAt, c.leaseExpiresAt);
+  const spec: ClaimSpecRecord = {
+    id: c.claimId,
+    roleName: c.agent.role,
+    platform: c.agent.platform,
+    assignee: c.agent,
+    ...(leaseDeadlineSec === undefined ? {} : { leaseDeadlineSec }),
+    generation: c.revision ?? 1,
+    targetRef: c.targetRef,
+    agent: c.agent,
+    intentSummary: c.intentSummary,
+    context: c.context,
+    createdAt: c.createdAt,
+  };
+  const status: ClaimStatusRecord = {
+    id: c.claimId,
+    phase: c.status,
+    observedGeneration: c.revision ?? 0,
+    lastHeartbeatAt: c.heartbeatAt,
+    leaseExpiresAt: c.leaseExpiresAt,
+    conditions: [],
+    lastTransitionAt: c.heartbeatAt,
+    attemptCount: c.attemptCount ?? 0,
+    revision: c.revision ?? 0,
+  };
+  return claimViewToEntity({ spec, status }, now, namespace);
+}
+
+export function claimViewToEntity(
+  view: ClaimView,
+  now: () => number = () => Date.now(),
+  namespace = "default",
+): ClaimEntity {
+  const persistedPhase = view.status.phase;
+  const leaseExpiresAtMs = Date.parse(view.status.leaseExpiresAt);
 
   const leaseIsExpired =
     Number.isFinite(leaseExpiresAtMs) && leaseExpiresAtMs <= now() && persistedPhase === "active";
@@ -196,7 +223,7 @@ export function claimToEntity(
   ): Condition => ({
     type,
     status: active ? "True" : "False",
-    observedGeneration: rev,
+    observedGeneration: view.status.observedGeneration,
     lastTransitionTime,
     reason,
     message: "",
@@ -205,36 +232,42 @@ export function claimToEntity(
   const activeCondition: Condition = mkCond(
     "Active",
     effectivePhase === "active",
-    c.heartbeatAt,
+    view.status.lastHeartbeatAt,
     leaseIsExpired ? "lease-expired" : effectivePhase,
   );
   const expiredCondition: Condition = mkCond(
     "Expired",
     effectivePhase === "expired",
-    c.leaseExpiresAt,
+    view.status.leaseExpiresAt,
     leaseIsExpired ? "lease-expired" : effectivePhase,
   );
   const completedCondition: Condition = mkCond(
     "Completed",
     effectivePhase === "completed",
-    c.heartbeatAt,
+    view.status.lastTransitionAt,
   );
 
-  const conditions: readonly Condition[] = [activeCondition, expiredCondition, completedCondition];
+  const conditions: readonly Condition[] =
+    view.status.conditions.length > 0
+      ? view.status.conditions
+      : [activeCondition, expiredCondition, completedCondition];
 
   return {
     kind: "Claim",
     namespace,
-    id: c.claimId,
+    id: view.spec.id,
     spec: {
-      targetRef: c.targetRef,
-      agent: c.agent,
-      intentSummary: c.intentSummary,
-      context: c.context,
-      roleName: c.agent.role,
-      platform: c.agent.platform,
-      assignee: c.agent,
-      leaseDeadlineSec,
+      targetRef: view.spec.targetRef,
+      agent: view.spec.agent,
+      intentSummary: view.spec.intentSummary,
+      context: view.spec.context,
+      roleName: view.spec.roleName,
+      platform: view.spec.platform,
+      blueprint: view.spec.blueprint,
+      assignee: view.spec.assignee,
+      leaseDeadlineSec: view.spec.leaseDeadlineSec,
+      priority: view.spec.priority,
+      maxIterations: view.spec.maxIterations,
     },
     status: {
       // phase = effective, lease-aware view so consumers that filter
@@ -243,25 +276,39 @@ export function claimToEntity(
       // callers that need to decide whether expireStale should run.
       phase: effectivePhase,
       persistedPhase,
-      heartbeatAt: c.heartbeatAt,
-      lastHeartbeatAt: c.heartbeatAt,
-      leaseExpiresAt: c.leaseExpiresAt,
-      observedGeneration: metaGen,
-      attemptCount: c.attemptCount ?? 0,
+      heartbeatAt: view.status.lastHeartbeatAt,
+      lastHeartbeatAt: view.status.lastHeartbeatAt,
+      leaseExpiresAt: view.status.leaseExpiresAt,
+      observedGeneration: view.status.observedGeneration,
+      agentSessionId: view.status.agentSessionId,
+      currentContributionCid: view.status.currentContributionCid,
+      attemptCount: view.status.attemptCount,
     },
     conditions,
-    observedGeneration: rev,
+    observedGeneration: view.status.observedGeneration,
     // When lease expiry is derived from wall-clock (not yet persisted by
     // expireStale), the logical Entity state has changed even though
     // `revision` has not. Encode the lease-crossed boundary in the
     // resourceVersion so caches/informers see a version change at the
     // boundary and do not conflate the two snapshots.
-    resourceVersion: leaseIsExpired ? `${rev}-lease-expired` : String(rev),
+    resourceVersion: leaseIsExpired
+      ? `${view.status.revision}-lease-expired`
+      : String(view.status.revision),
     metadata: {
-      generation: metaGen,
-      creationTimestamp: c.createdAt,
+      generation: view.spec.generation,
+      creationTimestamp: view.spec.createdAt,
     },
   };
+}
+
+function computeLeaseDeadlineSec(createdAt: string, leaseExpiresAt: string): number | undefined {
+  const createdAtMs = Date.parse(createdAt);
+  const leaseExpiresAtMs = Date.parse(leaseExpiresAt);
+  return Number.isFinite(createdAtMs) &&
+    Number.isFinite(leaseExpiresAtMs) &&
+    leaseExpiresAtMs > createdAtMs
+    ? Math.floor((leaseExpiresAtMs - createdAtMs) / 1000)
+    : undefined;
 }
 
 export interface AgentSessionSpec {

--- a/src/core/entity.ts
+++ b/src/core/entity.ts
@@ -115,6 +115,13 @@ export interface ClaimSpec {
   readonly agent: AgentIdentity;
   readonly intentSummary: string;
   readonly context?: Readonly<Record<string, JsonValue>> | undefined;
+  readonly roleName?: string | undefined;
+  readonly platform?: string | undefined;
+  readonly blueprint?: string | undefined;
+  readonly assignee?: AgentIdentity | undefined;
+  readonly leaseDeadlineSec?: number | undefined;
+  readonly priority?: number | undefined;
+  readonly maxIterations?: number | undefined;
 }
 
 export interface ClaimStatusBody {
@@ -135,7 +142,11 @@ export interface ClaimStatusBody {
    */
   readonly persistedPhase: ClaimPhase;
   readonly heartbeatAt: string;
+  readonly lastHeartbeatAt: string;
   readonly leaseExpiresAt: string;
+  readonly observedGeneration: number;
+  readonly currentContributionCid?: string | undefined;
+  readonly agentSessionId?: string | undefined;
   readonly attemptCount: number;
 }
 
@@ -161,10 +172,17 @@ export function claimToEntity(
   const rev = c.revision ?? 0;
   const metaGen = c.revision ?? 1;
   const persistedPhase = c.status;
+  const createdAtMs = Date.parse(c.createdAt);
+  const leaseExpiresAtMs = Date.parse(c.leaseExpiresAt);
+  const leaseDeadlineSec =
+    Number.isFinite(createdAtMs) &&
+    Number.isFinite(leaseExpiresAtMs) &&
+    leaseExpiresAtMs > createdAtMs
+      ? Math.floor((leaseExpiresAtMs - createdAtMs) / 1000)
+      : undefined;
 
-  const leaseExpiredAt = Date.parse(c.leaseExpiresAt);
   const leaseIsExpired =
-    Number.isFinite(leaseExpiredAt) && leaseExpiredAt <= now() && persistedPhase === "active";
+    Number.isFinite(leaseExpiresAtMs) && leaseExpiresAtMs <= now() && persistedPhase === "active";
 
   // Effective view: if persisted phase is `active` but lease is past,
   // act as if phase transitioned to `expired` for Entity consumers.
@@ -213,6 +231,10 @@ export function claimToEntity(
       agent: c.agent,
       intentSummary: c.intentSummary,
       context: c.context,
+      roleName: c.agent.role,
+      platform: c.agent.platform,
+      assignee: c.agent,
+      leaseDeadlineSec,
     },
     status: {
       // phase = effective, lease-aware view so consumers that filter
@@ -222,7 +244,9 @@ export function claimToEntity(
       phase: effectivePhase,
       persistedPhase,
       heartbeatAt: c.heartbeatAt,
+      lastHeartbeatAt: c.heartbeatAt,
       leaseExpiresAt: c.leaseExpiresAt,
+      observedGeneration: metaGen,
       attemptCount: c.attemptCount ?? 0,
     },
     conditions,

--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -8,6 +8,8 @@
  * See spec/schemas/contribution.json for the canonical wire format.
  */
 
+import type { Condition } from "./entity.js";
+
 /** Contribution kinds — the type of work being contributed. */
 export const ContributionKind = {
   Work: "work",
@@ -185,4 +187,43 @@ export interface Claim {
    * operations. Local stores may track it but are not required to.
    */
   readonly revision?: number | undefined;
+}
+
+/** User-owned desired state for a claim. */
+export interface ClaimSpecRecord {
+  readonly id: string;
+  readonly roleName?: string | undefined;
+  readonly platform?: string | undefined;
+  readonly blueprint?: string | undefined;
+  readonly assignee?: AgentIdentity | undefined;
+  readonly leaseDeadlineSec?: number | undefined;
+  readonly priority?: number | undefined;
+  readonly maxIterations?: number | undefined;
+  readonly generation: number;
+  readonly targetRef: string;
+  readonly agent: AgentIdentity;
+  readonly intentSummary: string;
+  readonly context?: Readonly<Record<string, JsonValue>> | undefined;
+  readonly createdAt: string;
+}
+
+/** Controller-owned observed state for a claim. */
+export interface ClaimStatusRecord {
+  readonly id: string;
+  readonly phase: ClaimStatus;
+  readonly observedGeneration: number;
+  readonly agentSessionId?: string | undefined;
+  readonly lastHeartbeatAt: string;
+  readonly leaseExpiresAt: string;
+  readonly currentContributionCid?: string | undefined;
+  readonly conditions: readonly Condition[];
+  readonly lastTransitionAt: string;
+  readonly attemptCount: number;
+  readonly revision: number;
+}
+
+/** Merged split claim view. */
+export interface ClaimView {
+  readonly spec: ClaimSpecRecord;
+  readonly status: ClaimStatusRecord;
 }

--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -227,3 +227,61 @@ export interface ClaimView {
   readonly spec: ClaimSpecRecord;
   readonly status: ClaimStatusRecord;
 }
+
+export function claimToSpecRecord(claim: Claim): ClaimSpecRecord {
+  const createdAtMs = Date.parse(claim.createdAt);
+  const leaseExpiresAtMs = Date.parse(claim.leaseExpiresAt);
+  const leaseDeadlineSec =
+    Number.isFinite(createdAtMs) &&
+    Number.isFinite(leaseExpiresAtMs) &&
+    leaseExpiresAtMs > createdAtMs
+      ? Math.floor((leaseExpiresAtMs - createdAtMs) / 1000)
+      : undefined;
+
+  return {
+    id: claim.claimId,
+    roleName: claim.agent.role,
+    platform: claim.agent.platform,
+    assignee: claim.agent,
+    leaseDeadlineSec,
+    generation: claim.revision ?? 1,
+    targetRef: claim.targetRef,
+    agent: claim.agent,
+    intentSummary: claim.intentSummary,
+    context: claim.context,
+    createdAt: claim.createdAt,
+  };
+}
+
+export function claimToStatusRecord(
+  claim: Claim,
+  conditions: readonly Condition[] = [],
+): ClaimStatusRecord {
+  return {
+    id: claim.claimId,
+    phase: claim.status,
+    observedGeneration: claim.revision ?? 1,
+    lastHeartbeatAt: claim.heartbeatAt,
+    leaseExpiresAt: claim.leaseExpiresAt,
+    conditions,
+    lastTransitionAt: claim.heartbeatAt,
+    attemptCount: claim.attemptCount ?? 0,
+    revision: claim.revision ?? 1,
+  };
+}
+
+export function claimViewToClaim(view: ClaimView): Claim {
+  return {
+    claimId: view.spec.id,
+    targetRef: view.spec.targetRef,
+    agent: view.spec.agent,
+    status: view.status.phase,
+    intentSummary: view.spec.intentSummary,
+    createdAt: view.spec.createdAt,
+    heartbeatAt: view.status.lastHeartbeatAt,
+    leaseExpiresAt: view.status.leaseExpiresAt,
+    revision: view.status.revision,
+    ...(view.spec.context === undefined ? {} : { context: view.spec.context }),
+    ...(view.status.attemptCount > 0 ? { attemptCount: view.status.attemptCount } : {}),
+  };
+}

--- a/src/core/operations/claim.test.ts
+++ b/src/core/operations/claim.test.ts
@@ -41,6 +41,27 @@ describe("claimOperation", () => {
     expect(result.value.renewed).toBe(false);
   });
 
+  test("stores claimOperation output as split claim spec and active status", async () => {
+    const result = await claimOperation(
+      {
+        targetRef: "target-operation-split",
+        agent: { agentId: "agent-operation-split", role: "coder", platform: "codex" },
+        intentSummary: "operation split",
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const claimId = result.value.claimId;
+    const view = await deps.claimStore?.getClaimView(claimId);
+
+    expect(view?.spec.targetRef).toBe("target-operation-split");
+    expect(view?.spec.roleName).toBe("coder");
+    expect(view?.status.phase).toBe("active");
+  });
+
   test("renews an existing claim by the same agent", async () => {
     // First claim
     const first = await claimOperation(

--- a/src/core/reconciler.test.ts
+++ b/src/core/reconciler.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, test } from "bun:test";
 import type { ClaimEntity } from "./entity.js";
 import { claimToEntity } from "./entity.js";
-import { ClaimStatus } from "./models.js";
+import { NotFoundError } from "./errors.js";
+import {
+  type ClaimSpecRecord,
+  ClaimStatus,
+  type ClaimStatusRecord,
+  type ClaimView,
+  claimToSpecRecord,
+  claimToStatusRecord,
+  claimViewToClaim,
+} from "./models.js";
 import { DefaultReconciler } from "./reconciler.js";
-import type { ClaimQuery, ClaimStore, ExpiredClaim } from "./store.js";
+import type { ClaimQuery, ClaimStatusPatch, ClaimStore, ExpiredClaim } from "./store.js";
 import { ExpiryReason } from "./store.js";
 import type {
   CheckoutOptions,
@@ -20,9 +29,94 @@ function makeClaimStore(overrides?: {
   cleanCompleted?: () => Promise<number>;
 }): ClaimStore {
   const claimsById = new Map<string, import("./models.js").Claim>();
+  const viewsById = new Map<string, ClaimView>();
+  const viewFromClaim = (claim: import("./models.js").Claim): ClaimView => ({
+    spec: claimToSpecRecord(claim),
+    status: claimToStatusRecord(claim),
+  });
+  const viewFor = (claimId: string): ClaimView | undefined => {
+    const view = viewsById.get(claimId);
+    if (view !== undefined) return view;
+    const claim = claimsById.get(claimId);
+    return claim === undefined ? undefined : viewFromClaim(claim);
+  };
+  const putView = (view: ClaimView): void => {
+    viewsById.set(view.spec.id, view);
+    claimsById.set(view.spec.id, claimViewToClaim(view));
+  };
+  const putClaim = (claim: import("./models.js").Claim): void => {
+    claimsById.set(claim.claimId, claim);
+    viewsById.set(claim.claimId, viewFromClaim(claim));
+  };
+
   return {
+    putClaimSpec: async (spec: ClaimSpecRecord) => {
+      const existing = viewFor(spec.id);
+      const now = new Date().toISOString();
+      const createdAtMs = Date.parse(spec.createdAt);
+      const leaseBaseMs = Number.isFinite(createdAtMs) ? createdAtMs : Date.now();
+      const view: ClaimView =
+        existing === undefined
+          ? {
+              spec: {
+                ...spec,
+                generation: 1,
+              },
+              status: {
+                id: spec.id,
+                phase: ClaimStatus.Active,
+                observedGeneration: 0,
+                lastHeartbeatAt: now,
+                leaseExpiresAt: new Date(
+                  leaseBaseMs + (spec.leaseDeadlineSec ?? 300) * 1000,
+                ).toISOString(),
+                conditions: [],
+                lastTransitionAt: now,
+                attemptCount: 0,
+                revision: 1,
+              },
+            }
+          : {
+              spec: {
+                ...spec,
+                createdAt: existing.spec.createdAt,
+                generation: existing.spec.generation + 1,
+              },
+              status: existing.status,
+            };
+      putView(view);
+      return view;
+    },
+    getClaimView: async (claimId) => {
+      return viewFor(claimId);
+    },
+    patchClaimStatus: async (claimId, patch: ClaimStatusPatch) => {
+      const view = viewFor(claimId);
+      if (view === undefined) {
+        throw new NotFoundError({
+          resource: "Claim",
+          identifier: claimId,
+          message: `Claim ${claimId} does not exist`,
+        });
+      }
+      const updatedStatus: ClaimStatusRecord = {
+        ...view.status,
+        phase: patch.phase ?? view.status.phase,
+        observedGeneration: patch.observedGeneration ?? view.status.observedGeneration,
+        agentSessionId: patch.agentSessionId ?? view.status.agentSessionId,
+        lastHeartbeatAt: patch.lastHeartbeatAt ?? view.status.lastHeartbeatAt,
+        leaseExpiresAt: patch.leaseExpiresAt ?? view.status.leaseExpiresAt,
+        currentContributionCid: patch.currentContributionCid ?? view.status.currentContributionCid,
+        conditions: patch.conditions ?? view.status.conditions,
+        lastTransitionAt: patch.lastTransitionAt ?? view.status.lastTransitionAt,
+        revision: view.status.revision + 1,
+      };
+      const updated = { spec: view.spec, status: updatedStatus };
+      putView(updated);
+      return updated;
+    },
     createClaim: async (claim) => {
-      claimsById.set(claim.claimId, claim);
+      putClaim(claim);
       return claim;
     },
     claimOrRenew: async (claim) => claim,
@@ -38,14 +132,14 @@ function makeClaimStore(overrides?: {
         const claim = claimsById.get(claimId);
         if (!claim) throw new Error("missing claim");
         const released = { ...claim, status: ClaimStatus.Released };
-        claimsById.set(claimId, released);
+        putClaim(released);
         return released;
       }),
     complete: async (claimId) => {
       const claim = claimsById.get(claimId);
       if (!claim) throw new Error("missing claim");
       const completed = { ...claim, status: ClaimStatus.Completed };
-      claimsById.set(claimId, completed);
+      putClaim(completed);
       return completed;
     },
     expireStale: overrides?.expireStale ?? (async () => []),
@@ -104,6 +198,108 @@ function makeWorkspaceManager(overrides?: {
     close: () => undefined,
   };
 }
+
+describe("makeClaimStore split claim adapters", () => {
+  test("putClaimSpec derives default status lease from createdAt and lease deadline", async () => {
+    const claimStore = makeClaimStore();
+
+    const view = await claimStore.putClaimSpec({
+      id: "split-created",
+      targetRef: "target-split",
+      agent: { agentId: "agent-split" },
+      intentSummary: "create split claim",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      leaseDeadlineSec: 120,
+      generation: 99,
+    });
+
+    expect(view.spec.generation).toBe(1);
+    expect(view.status.leaseExpiresAt).toBe("2026-01-01T00:02:00.000Z");
+  });
+
+  test("putClaimSpec updates preserve original createdAt and status", async () => {
+    const claimStore = makeClaimStore();
+
+    const created = await claimStore.putClaimSpec({
+      id: "split-updated",
+      targetRef: "target-split",
+      agent: { agentId: "agent-split" },
+      intentSummary: "first intent",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      generation: 1,
+    });
+    const patched = await claimStore.patchClaimStatus("split-updated", {
+      phase: ClaimStatus.Completed,
+      observedGeneration: created.spec.generation,
+      lastHeartbeatAt: "2026-01-01T00:05:00.000Z",
+      leaseExpiresAt: "2026-01-01T00:10:00.000Z",
+      lastTransitionAt: "2026-01-01T00:05:00.000Z",
+    });
+
+    const updated = await claimStore.putClaimSpec({
+      ...created.spec,
+      intentSummary: "second intent",
+      createdAt: "2026-02-01T00:00:00.000Z",
+      generation: 99,
+    });
+
+    expect(updated.spec.createdAt).toBe(created.spec.createdAt);
+    expect(updated.spec.generation).toBe(created.spec.generation + 1);
+    expect(updated.spec.intentSummary).toBe("second intent");
+    expect(updated.status).toEqual(patched.status);
+  });
+
+  test("patchClaimStatus preserves split-only status fields in later views", async () => {
+    const claimStore = makeClaimStore();
+    await claimStore.putClaimSpec({
+      id: "split-status",
+      targetRef: "target-split",
+      agent: { agentId: "agent-split" },
+      intentSummary: "status patch",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      generation: 1,
+    });
+
+    const patched = await claimStore.patchClaimStatus("split-status", {
+      phase: ClaimStatus.Active,
+      observedGeneration: 7,
+      agentSessionId: "session-1",
+      lastHeartbeatAt: "2026-01-01T00:03:00.000Z",
+      leaseExpiresAt: "2026-01-01T00:08:00.000Z",
+      currentContributionCid:
+        "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      conditions: [
+        {
+          type: "Ready",
+          status: "True",
+          observedGeneration: 7,
+          lastTransitionTime: "2026-01-01T00:03:00.000Z",
+          reason: "Heartbeat",
+          message: "claim heartbeat observed",
+        },
+      ],
+      lastTransitionAt: "2026-01-01T00:03:00.000Z",
+    });
+
+    const current = await claimStore.getClaimView("split-status");
+
+    expect(patched.status.revision).toBe(2);
+    expect(patched.status.observedGeneration).toBe(7);
+    expect(patched.status.agentSessionId).toBe("session-1");
+    expect(patched.status.currentContributionCid).toBe(
+      "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    expect(patched.status.conditions).toHaveLength(1);
+    expect(patched.status.lastTransitionAt).toBe("2026-01-01T00:03:00.000Z");
+    expect(current?.status).toEqual(patched.status);
+  });
+
+  test("patchClaimStatus throws NotFoundError for missing claims", async () => {
+    const claimStore = makeClaimStore();
+
+    await expect(claimStore.patchClaimStatus("missing", {})).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
 
 describe("DefaultReconciler", () => {
   test("deduplicateActiveClaims keeps newest by actual timestamp, not lexical string", async () => {

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -5,10 +5,13 @@
  * The local SQLite adapter and the Nexus adapter both satisfy these protocols.
  */
 
-import type { ClaimEntity, ContributionEntity } from "./entity.js";
+import type { ClaimEntity, Condition, ContributionEntity } from "./entity.js";
 import type {
   Claim,
+  ClaimSpecRecord,
   ClaimStatus,
+  ClaimStatusRecord,
+  ClaimView,
   Contribution,
   ContributionKind,
   ContributionMode,
@@ -256,10 +259,31 @@ export interface ClaimQuery {
   readonly targetRef?: string | undefined;
 }
 
+/** Status-only patch accepted by controller-owned claim status writes. */
+export interface ClaimStatusPatch {
+  readonly phase?: ClaimStatus | undefined;
+  readonly observedGeneration?: number | undefined;
+  readonly agentSessionId?: string | undefined;
+  readonly lastHeartbeatAt?: string | undefined;
+  readonly leaseExpiresAt?: string | undefined;
+  readonly currentContributionCid?: string | undefined;
+  readonly conditions?: (readonly Condition[] & ClaimStatusRecord["conditions"]) | undefined;
+  readonly lastTransitionAt?: string | undefined;
+}
+
 /** Store for mutable claims (coordination objects). */
 export interface ClaimStore {
   /** Optional persistent-state identity string. See ContributionStore.storeIdentity. */
   readonly storeIdentity?: string | undefined;
+
+  /** Create or update user-owned claim spec. Store controls generation. */
+  putClaimSpec(spec: ClaimSpecRecord): Promise<ClaimView>;
+
+  /** Get the merged split claim view by ID. */
+  getClaimView(claimId: string): Promise<ClaimView | undefined>;
+
+  /** Patch controller-owned claim status fields only. */
+  patchClaimStatus(claimId: string, patch: ClaimStatusPatch): Promise<ClaimView>;
 
   /** Create a new claim. Throws if claimId already exists. */
   createClaim(claim: Claim): Promise<Claim>;

--- a/src/local/sqlite-store.migration.test.ts
+++ b/src/local/sqlite-store.migration.test.ts
@@ -70,6 +70,200 @@ describe("schema migration", () => {
     }
   });
 
+  test("fresh DB creates split claim tables", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-claim-split-"));
+    try {
+      const dbPath = join(dir, "test.db");
+      const store = new SqliteStore(dbPath);
+      store.close();
+
+      const db = new Database(dbPath);
+      const tableNames = (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as readonly {
+          name: string;
+        }[]
+      ).map((r) => r.name);
+      const indexNames = (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='index'").all() as readonly {
+          name: string;
+        }[]
+      ).map((r) => r.name);
+      expect(tableNames).toContain("claim_spec");
+      expect(tableNames).toContain("claim_status");
+      expect(indexNames).toContain("idx_claim_spec_target");
+      expect(indexNames).toContain("idx_claim_spec_agent");
+      expect(indexNames).toContain("idx_claim_status_phase");
+      expect(indexNames).toContain("idx_claim_status_phase_lease");
+      db.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("legacy claims rows backfill into claim_spec and claim_status", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-claim-split-legacy-"));
+    try {
+      const dbPath = join(dir, "test.db");
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+          version INTEGER PRIMARY KEY,
+          applied_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS contributions (
+          cid TEXT PRIMARY KEY,
+          kind TEXT NOT NULL,
+          mode TEXT NOT NULL,
+          summary TEXT NOT NULL,
+          description TEXT,
+          agent_id TEXT NOT NULL,
+          agent_name TEXT,
+          created_at TEXT NOT NULL,
+          tags_json TEXT NOT NULL DEFAULT '[]',
+          manifest_json TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS relations (
+          source_cid TEXT NOT NULL,
+          target_cid TEXT NOT NULL,
+          relation_type TEXT NOT NULL,
+          metadata_json TEXT
+        );
+        CREATE TABLE IF NOT EXISTS claims (
+          claim_id TEXT PRIMARY KEY,
+          target_ref TEXT NOT NULL,
+          agent_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'active',
+          intent_summary TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          heartbeat_at TEXT NOT NULL,
+          lease_expires_at TEXT NOT NULL,
+          context_json TEXT,
+          agent_json TEXT NOT NULL,
+          attempt_count INTEGER NOT NULL DEFAULT 0,
+          revision INTEGER NOT NULL DEFAULT 1
+        );
+      `);
+      db.prepare(
+        `INSERT INTO claims (
+          claim_id, target_ref, agent_id, status, intent_summary, created_at,
+          heartbeat_at, lease_expires_at, context_json, agent_json, attempt_count, revision
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "legacy-split",
+        "target-legacy",
+        "agent-legacy",
+        "active",
+        "legacy intent",
+        "2026-01-01T00:00:00.000Z",
+        "2026-01-01T00:02:00.000Z",
+        "2026-01-01T00:07:00.000Z",
+        JSON.stringify({ migrated: true }),
+        JSON.stringify({ agentId: "agent-legacy", platform: "codex", role: "coder" }),
+        2,
+        5,
+      );
+      db.close();
+
+      const contextJson = JSON.stringify({ migrated: true });
+      const agentJson = JSON.stringify({
+        agentId: "agent-legacy",
+        platform: "codex",
+        role: "coder",
+      });
+
+      const store = new SqliteStore(dbPath);
+      const claim = await store.getClaim("legacy-split");
+      const migratedDb = new Database(dbPath, { readonly: true });
+      const spec = migratedDb
+        .prepare(
+          `SELECT role_name, platform, assignee_json, lease_deadline_sec, generation,
+            target_ref, agent_id, agent_json, intent_summary, context_json, created_at
+           FROM claim_spec WHERE id = ?`,
+        )
+        .get("legacy-split") as {
+        role_name: string;
+        platform: string;
+        assignee_json: string;
+        lease_deadline_sec: number;
+        generation: number;
+        target_ref: string;
+        agent_id: string;
+        agent_json: string;
+        intent_summary: string;
+        context_json: string;
+        created_at: string;
+      };
+      const status = migratedDb
+        .prepare(
+          `SELECT phase, observed_generation, last_heartbeat_at, lease_expires_at,
+            conditions_json, last_transition_at, attempt_count, revision
+           FROM claim_status WHERE id = ?`,
+        )
+        .get("legacy-split") as {
+        phase: string;
+        observed_generation: number;
+        last_heartbeat_at: string;
+        lease_expires_at: string;
+        conditions_json: string;
+        last_transition_at: string;
+        attempt_count: number;
+        revision: number;
+      };
+      migratedDb.close();
+      const specAssignee = JSON.parse(spec.assignee_json) as {
+        agentId: string;
+        platform: string;
+        role: string;
+      };
+      const specAgent = JSON.parse(spec.agent_json) as {
+        agentId: string;
+        platform: string;
+        role: string;
+      };
+      const specContext = JSON.parse(spec.context_json) as { migrated: boolean };
+      const statusConditions = JSON.parse(status.conditions_json) as readonly unknown[];
+
+      expect(claim?.claimId).toBe("legacy-split");
+      expect(claim?.status).toBe("active");
+      expect(claim?.attemptCount).toBe(2);
+      expect(claim?.revision).toBe(5);
+      expect(spec.role_name).toBe("coder");
+      expect(spec.platform).toBe("codex");
+      expect(specAssignee).toEqual({ agentId: "agent-legacy", platform: "codex", role: "coder" });
+      expect(spec.lease_deadline_sec).toBe(420);
+      expect(spec.generation).toBe(5);
+      expect(spec.target_ref).toBe("target-legacy");
+      expect(spec.agent_id).toBe("agent-legacy");
+      expect(spec.agent_json).toBe(agentJson);
+      expect(specAgent).toEqual({ agentId: "agent-legacy", platform: "codex", role: "coder" });
+      expect(spec.intent_summary).toBe("legacy intent");
+      expect(spec.context_json).toBe(contextJson);
+      expect(specContext).toEqual({ migrated: true });
+      expect(spec.created_at).toBe("2026-01-01T00:00:00.000Z");
+      expect(status.phase).toBe("active");
+      expect(status.observed_generation).toBe(5);
+      expect(status.last_heartbeat_at).toBe("2026-01-01T00:02:00.000Z");
+      expect(status.lease_expires_at).toBe("2026-01-01T00:07:00.000Z");
+      expect(status.conditions_json).toBe("[]");
+      expect(statusConditions).toEqual([]);
+      expect(status.last_transition_at).toBe("2026-01-01T00:02:00.000Z");
+      expect(status.attempt_count).toBe(2);
+      expect(status.revision).toBe(5);
+
+      const view = await store.claims.getClaimView("legacy-split");
+      expect(view?.spec.targetRef).toBe("target-legacy");
+      expect(view?.spec.agent.platform).toBe("codex");
+      expect(view?.spec.generation).toBe(5);
+      expect(view?.status.phase).toBe("active");
+      expect(view?.status.observedGeneration).toBe(5);
+      expect(view?.status.lastHeartbeatAt).toBe("2026-01-01T00:02:00.000Z");
+
+      store.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("re-opening existing DB does not corrupt contributions", async () => {
     const dir = await mkdtemp(join(tmpdir(), "sqlite-migration-"));
     const dbPath = join(dir, "test.db");

--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -14,6 +14,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runClaimStoreTests } from "../core/claim-store.conformance.js";
+import type { Claim } from "../core/models.js";
 import { ClaimStatus, ContributionKind, RelationType } from "../core/models.js";
 import { runContributionStoreTests } from "../core/store.conformance.js";
 import { makeAgent, makeClaim, makeContribution } from "../core/test-helpers.js";
@@ -823,6 +824,31 @@ describe("SqliteClaimStore onClaimWrite hook", () => {
     const claim = makeClaim({ targetRef: "watch-create" });
     await claimStore.createClaim(claim);
     expect(events).toEqual([{ op: "ADDED", id: claim.claimId }]);
+  });
+
+  test("split spec and status writes preserve spec ownership in watch snapshots", async () => {
+    const events: Array<{ op: string; claim: Claim }> = [];
+    claimStore.onClaimWrite = (op, c) => events.push({ op, claim: c });
+
+    const created = await claimStore.putClaimSpec({
+      id: "watch-split",
+      targetRef: "target-watch-split",
+      agent: { agentId: "agent-watch-split" },
+      intentSummary: "initial split spec",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      generation: 1,
+    });
+    const patched = await claimStore.patchClaimStatus("watch-split", {
+      phase: ClaimStatus.Completed,
+      observedGeneration: created.spec.generation,
+      lastHeartbeatAt: "2026-01-01T00:05:00.000Z",
+    });
+
+    expect(events.map((event) => event.op)).toEqual(["ADDED", "MODIFIED"]);
+    expect(events[0]?.claim.intentSummary).toBe("initial split spec");
+    expect(events[1]?.claim.intentSummary).toBe("initial split spec");
+    expect(events[1]?.claim.status).toBe(ClaimStatus.Completed);
+    expect(patched.spec.intentSummary).toBe("initial split spec");
   });
 
   test("heartbeat fires MODIFIED so cached lease fields stay fresh", async () => {

--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -198,6 +198,79 @@ describe("SqliteClaimStore split API", () => {
     }
   });
 
+  test("putClaimSpec allows terminal and expired claim spec edits despite an active claim on the same target", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-split-api-terminal-edit-"));
+    const dbPath = join(dir, "test.db");
+    const { claimStore, close } = createSqliteStores(dbPath);
+    try {
+      const now = new Date();
+      const activeLeaseExpiresAt = new Date(now.getTime() + 600_000).toISOString();
+
+      const terminal = await claimStore.putClaimSpec({
+        id: "terminal-edit",
+        targetRef: "shared-terminal-target",
+        agent: makeAgent({ agentId: "agent-terminal" }),
+        intentSummary: "terminal before edit",
+        createdAt: now.toISOString(),
+        generation: 1,
+      });
+      await claimStore.patchClaimStatus("terminal-edit", {
+        phase: ClaimStatus.Completed,
+        lastHeartbeatAt: new Date(now.getTime() + 1_000).toISOString(),
+        leaseExpiresAt: activeLeaseExpiresAt,
+        lastTransitionAt: new Date(now.getTime() + 1_000).toISOString(),
+      });
+      await claimStore.putClaimSpec({
+        id: "terminal-active-holder",
+        targetRef: "shared-terminal-target",
+        agent: makeAgent({ agentId: "agent-terminal-holder" }),
+        intentSummary: "active holder",
+        createdAt: new Date(now.getTime() + 2_000).toISOString(),
+        generation: 1,
+      });
+
+      const terminalEdited = await claimStore.putClaimSpec({
+        ...terminal.spec,
+        intentSummary: "terminal after edit",
+      });
+
+      expect(terminalEdited.spec.generation).toBe(terminal.spec.generation + 1);
+      expect(terminalEdited.spec.intentSummary).toBe("terminal after edit");
+      expect(terminalEdited.status.phase).toBe(ClaimStatus.Completed);
+
+      const expired = await claimStore.putClaimSpec({
+        id: "expired-edit",
+        targetRef: "shared-expired-target",
+        agent: makeAgent({ agentId: "agent-expired" }),
+        intentSummary: "expired before edit",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        generation: 1,
+        leaseDeadlineSec: 60,
+      });
+      await claimStore.putClaimSpec({
+        id: "expired-active-holder",
+        targetRef: "shared-expired-target",
+        agent: makeAgent({ agentId: "agent-expired-holder" }),
+        intentSummary: "active holder",
+        createdAt: now.toISOString(),
+        generation: 1,
+      });
+
+      const expiredEdited = await claimStore.putClaimSpec({
+        ...expired.spec,
+        intentSummary: "expired after edit",
+      });
+
+      expect(expiredEdited.spec.generation).toBe(expired.spec.generation + 1);
+      expect(expiredEdited.spec.intentSummary).toBe("expired after edit");
+      expect(expiredEdited.status.phase).toBe(ClaimStatus.Active);
+      expect(new Date(expiredEdited.status.leaseExpiresAt).getTime()).toBeLessThan(Date.now());
+    } finally {
+      close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("patchClaimStatus merges split-only fields and getClaimView reflects the patch", async () => {
     const dir = await mkdtemp(join(tmpdir(), "sqlite-split-api-patch-"));
     const dbPath = join(dir, "test.db");
@@ -297,6 +370,42 @@ describe("SqliteClaimStore split API", () => {
 
       const active = await claimStore.activeClaims("activation-target");
       expect(active.map((claim) => claim.claimId)).toEqual(["activation-new"]);
+    } finally {
+      close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("claimOrRenew same-agent renewal bumps spec generation when intent changes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-claim-renew-generation-"));
+    const dbPath = join(dir, "test.db");
+    const { claimStore, close } = createSqliteStores(dbPath);
+    try {
+      const first = await claimStore.claimOrRenew(
+        makeClaim({
+          claimId: "renew-generation-first",
+          targetRef: "renew-generation-target",
+          agent: makeAgent({ agentId: "agent-renew-generation" }),
+          intentSummary: "first intent",
+        }),
+      );
+      const firstView = await claimStore.getClaimView(first.claimId);
+      expect(firstView?.spec.generation).toBe(1);
+
+      const renewed = await claimStore.claimOrRenew(
+        makeClaim({
+          claimId: "renew-generation-second",
+          targetRef: "renew-generation-target",
+          agent: makeAgent({ agentId: "agent-renew-generation" }),
+          intentSummary: "renewed intent",
+        }),
+      );
+      const renewedView = await claimStore.getClaimView(renewed.claimId);
+
+      expect(renewed.claimId).toBe(first.claimId);
+      expect(renewedView?.spec.intentSummary).toBe("renewed intent");
+      expect(renewedView?.spec.generation).toBe((firstView?.spec.generation ?? 0) + 1);
+      expect(renewedView?.status.revision).toBe((firstView?.status.revision ?? 0) + 1);
     } finally {
       close();
       await rm(dir, { recursive: true, force: true });

--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -250,6 +250,58 @@ describe("SqliteClaimStore split API", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  test("patchClaimStatus rejects activation when target already has an active claim", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-split-api-activate-conflict-"));
+    const dbPath = join(dir, "test.db");
+    const { claimStore, close } = createSqliteStores(dbPath);
+    try {
+      const now = Date.now();
+      const oldCreatedAt = new Date(now).toISOString();
+      const oldReleasedAt = new Date(now + 1_000).toISOString();
+      const newCreatedAt = new Date(now + 2_000).toISOString();
+      const oldReactivatedAt = new Date(now + 3_000).toISOString();
+      const activeLeaseExpiresAt = new Date(now + 600_000).toISOString();
+
+      await claimStore.putClaimSpec({
+        id: "activation-old",
+        targetRef: "activation-target",
+        agent: makeAgent({ agentId: "agent-old" }),
+        intentSummary: "old claim",
+        createdAt: oldCreatedAt,
+        generation: 1,
+      });
+      await claimStore.patchClaimStatus("activation-old", {
+        phase: ClaimStatus.Released,
+        lastHeartbeatAt: oldReleasedAt,
+        lastTransitionAt: oldReleasedAt,
+      });
+
+      await claimStore.putClaimSpec({
+        id: "activation-new",
+        targetRef: "activation-target",
+        agent: makeAgent({ agentId: "agent-new" }),
+        intentSummary: "new claim",
+        createdAt: newCreatedAt,
+        generation: 1,
+      });
+
+      await expect(
+        claimStore.patchClaimStatus("activation-old", {
+          phase: ClaimStatus.Active,
+          lastHeartbeatAt: oldReactivatedAt,
+          leaseExpiresAt: activeLeaseExpiresAt,
+          lastTransitionAt: oldReactivatedAt,
+        }),
+      ).rejects.toThrow(/active claim/);
+
+      const active = await claimStore.activeClaims("activation-target");
+      expect(active.map((claim) => claim.claimId)).toEqual(["activation-new"]);
+    } finally {
+      close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("SqliteIdempotencyStore", () => {

--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -14,9 +14,9 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runClaimStoreTests } from "../core/claim-store.conformance.js";
-import { ContributionKind, RelationType } from "../core/models.js";
+import { ClaimStatus, ContributionKind, RelationType } from "../core/models.js";
 import { runContributionStoreTests } from "../core/store.conformance.js";
-import { makeClaim, makeContribution } from "../core/test-helpers.js";
+import { makeAgent, makeClaim, makeContribution } from "../core/test-helpers.js";
 import { createSqliteStores, SqliteStore } from "./sqlite-store.js";
 
 function sqliteBindLimit(db: Database): number {
@@ -106,6 +106,149 @@ runClaimStoreTests(async () => {
       await rm(dir, { recursive: true, force: true });
     },
   };
+});
+
+describe("SqliteClaimStore split API", () => {
+  test("putClaimSpec creates default status and rejects duplicate active target", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-split-api-target-"));
+    const dbPath = join(dir, "test.db");
+    const { claimStore, close } = createSqliteStores(dbPath);
+    try {
+      const first = await claimStore.putClaimSpec({
+        id: "split-target-first",
+        targetRef: "split-target",
+        agent: makeAgent({ agentId: "agent-first" }),
+        intentSummary: "first active spec",
+        createdAt: new Date().toISOString(),
+        generation: 1,
+      });
+
+      expect(first.status.phase).toBe(ClaimStatus.Active);
+      expect(first.status.revision).toBe(1);
+
+      await expect(
+        claimStore.putClaimSpec({
+          id: "split-target-second",
+          targetRef: "split-target",
+          agent: makeAgent({ agentId: "agent-second" }),
+          intentSummary: "second active spec",
+          createdAt: new Date().toISOString(),
+          generation: 1,
+        }),
+      ).rejects.toThrow(/active claim/);
+
+      const movable = await claimStore.putClaimSpec({
+        id: "split-target-move",
+        targetRef: "other-target",
+        agent: makeAgent({ agentId: "agent-move" }),
+        intentSummary: "move candidate",
+        createdAt: new Date().toISOString(),
+        generation: 1,
+      });
+      await expect(
+        claimStore.putClaimSpec({
+          ...movable.spec,
+          targetRef: "split-target",
+          intentSummary: "invalid move",
+        }),
+      ).rejects.toThrow(/active claim/);
+    } finally {
+      close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("putClaimSpec update preserves createdAt and status while incrementing generation", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-split-api-update-"));
+    const dbPath = join(dir, "test.db");
+    const { claimStore, close } = createSqliteStores(dbPath);
+    try {
+      const created = await claimStore.putClaimSpec({
+        id: "split-update",
+        targetRef: "split-update-target",
+        agent: makeAgent({ agentId: "agent-update" }),
+        intentSummary: "initial spec",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        generation: 99,
+      });
+      const patched = await claimStore.patchClaimStatus("split-update", {
+        phase: ClaimStatus.Completed,
+        observedGeneration: created.spec.generation,
+        lastHeartbeatAt: "2026-01-01T00:05:00.000Z",
+        leaseExpiresAt: "2026-01-01T00:10:00.000Z",
+        lastTransitionAt: "2026-01-01T00:05:00.000Z",
+      });
+
+      const updated = await claimStore.putClaimSpec({
+        ...patched.spec,
+        intentSummary: "updated spec",
+        createdAt: "2030-01-01T00:00:00.000Z",
+      });
+
+      expect(updated.spec.generation).toBe(created.spec.generation + 1);
+      expect(updated.spec.createdAt).toBe(created.spec.createdAt);
+      expect(updated.spec.intentSummary).toBe("updated spec");
+      expect(updated.status.phase).toBe(patched.status.phase);
+      expect(updated.status.revision).toBe(patched.status.revision);
+      expect(updated.status.lastHeartbeatAt).toBe(patched.status.lastHeartbeatAt);
+    } finally {
+      close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("patchClaimStatus merges split-only fields and getClaimView reflects the patch", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sqlite-split-api-patch-"));
+    const dbPath = join(dir, "test.db");
+    const { claimStore, close } = createSqliteStores(dbPath);
+    try {
+      const created = await claimStore.putClaimSpec({
+        id: "split-patch",
+        targetRef: "split-patch-target",
+        agent: makeAgent({ agentId: "agent-patch" }),
+        intentSummary: "patch spec",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        generation: 1,
+      });
+
+      const firstPatch = await claimStore.patchClaimStatus("split-patch", {
+        observedGeneration: created.spec.generation,
+        agentSessionId: "session-1",
+        currentContributionCid:
+          "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      });
+      const secondPatch = await claimStore.patchClaimStatus("split-patch", {
+        phase: ClaimStatus.Completed,
+        lastHeartbeatAt: "2026-01-01T00:05:00.000Z",
+        leaseExpiresAt: "2026-01-01T00:10:00.000Z",
+        conditions: [
+          {
+            type: "Completed",
+            status: "True",
+            observedGeneration: created.spec.generation,
+            lastTransitionTime: "2026-01-01T00:05:00.000Z",
+            reason: "controller",
+            message: "done",
+          },
+        ],
+        lastTransitionAt: "2026-01-01T00:05:00.000Z",
+      });
+      const readBack = await claimStore.getClaimView("split-patch");
+
+      expect(secondPatch.spec).toEqual(created.spec);
+      expect(secondPatch.status.revision).toBe(firstPatch.status.revision + 1);
+      expect(secondPatch.status.agentSessionId).toBe("session-1");
+      expect(secondPatch.status.currentContributionCid).toBe(
+        "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      );
+      expect(secondPatch.status.phase).toBe(ClaimStatus.Completed);
+      expect(secondPatch.status.conditions[0]?.type).toBe("Completed");
+      expect(readBack).toEqual(secondPatch);
+    } finally {
+      close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("SqliteIdempotencyStore", () => {

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -54,7 +54,7 @@ import { SqliteOutcomeStore } from "./sqlite-outcome-store.js";
 import { DEFAULT_LEASE_DURATION_MS } from "../core/claim-logic.js";
 import { computeContributionContentHash } from "../core/content-dedup.js";
 import type { ClaimEntity, ContributionEntity } from "../core/entity.js";
-import { claimToEntity, contributionToEntity } from "../core/entity.js";
+import { claimViewToEntity, contributionToEntity } from "../core/entity.js";
 import { ClaimConflictError, NotFoundError, StateConflictError } from "../core/errors.js";
 import { toUtcIso } from "../core/time.js";
 
@@ -1777,6 +1777,34 @@ export class SqliteClaimStore implements ClaimStore {
         });
       }
 
+      const nowIso = new Date().toISOString();
+      const updatedPhase = patch.phase ?? existing.status.phase;
+      const updatedLeaseExpiresAt =
+        patch.leaseExpiresAt !== undefined
+          ? toUtcIso(patch.leaseExpiresAt)
+          : existing.status.leaseExpiresAt;
+      if (updatedPhase === "active" && updatedLeaseExpiresAt >= nowIso) {
+        const activeOnTarget = this.db
+          .prepare(
+            `SELECT s.id AS claim_id
+             FROM claim_spec s
+             JOIN claim_status st ON st.id = s.id
+             WHERE s.target_ref = ?
+               AND st.phase = 'active'
+               AND st.lease_expires_at >= ?
+               AND s.id <> ?`,
+          )
+          .get(existing.spec.targetRef, nowIso, claimId) as { claim_id: string } | null;
+
+        if (activeOnTarget !== null) {
+          throw new StateConflictError({
+            resource: "Claim",
+            reason: "target already has an active claim",
+            message: `Target '${existing.spec.targetRef}' already has an active claim '${activeOnTarget.claim_id}'`,
+          });
+        }
+      }
+
       this.db
         .prepare(`UPDATE claim_status SET ${assignments.join(", ")} WHERE id = ?`)
         .run(...params);
@@ -2092,6 +2120,10 @@ export class SqliteClaimStore implements ClaimStore {
   };
 
   listClaims = async (query?: ClaimQuery): Promise<readonly Claim[]> => {
+    return this.queryClaimViews(query).map((view) => claimViewToClaim(view));
+  };
+
+  private queryClaimViews(query?: ClaimQuery): readonly ClaimView[] {
     let sql = `SELECT ${CLAIM_VIEW_SELECT_COLS}
       FROM claim_spec s
       JOIN claim_status st ON st.id = s.id
@@ -2115,8 +2147,8 @@ export class SqliteClaimStore implements ClaimStore {
 
     sql += " ORDER BY s.created_at DESC";
     const rows = this.db.prepare(sql).all(...params) as readonly ClaimViewRow[];
-    return rows.map((row) => claimViewToClaim(rowToClaimView(row)));
-  };
+    return rows.map((row) => rowToClaimView(row));
+  }
 
   cleanCompleted = async (retentionMs: number): Promise<number> => {
     const cutoff = new Date(Date.now() - retentionMs).toISOString();
@@ -2191,9 +2223,9 @@ export class SqliteClaimStore implements ClaimStore {
     // should call listClaims() directly.
     const baseQuery: ClaimQuery | undefined =
       query === undefined ? undefined : { ...query, status: undefined };
-    const items = await this.listClaims(baseQuery);
+    const items = this.queryClaimViews(baseQuery);
     const namespace = readStoreNamespace(this.db);
-    const entities = items.map((c) => claimToEntity(c, () => Date.now(), namespace));
+    const entities = items.map((view) => claimViewToEntity(view, () => Date.now(), namespace));
     if (query?.status === undefined) return entities;
     const wanted = Array.isArray(query.status) ? new Set(query.status) : new Set([query.status]);
     return entities.filter((e) => wanted.has(e.status.phase));

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -53,7 +53,7 @@ import { claimToEntity, contributionToEntity } from "../core/entity.js";
 import { ClaimConflictError, NotFoundError, StateConflictError } from "../core/errors.js";
 import { toUtcIso } from "../core/time.js";
 
-export const CURRENT_SCHEMA_VERSION = 13;
+export const CURRENT_SCHEMA_VERSION = 14;
 const SQLITE_BIND_LIMIT = 900;
 
 // ---------------------------------------------------------------------------
@@ -144,6 +144,44 @@ const SCHEMA_DDL = `
   CREATE INDEX IF NOT EXISTS idx_claims_status ON claims(status);
   -- Composite index for active-claim queries: WHERE status = 'active' AND lease_expires_at >= ?
   CREATE INDEX IF NOT EXISTS idx_claims_status_lease ON claims(status, lease_expires_at);
+
+  CREATE TABLE IF NOT EXISTS claim_spec (
+    id TEXT PRIMARY KEY,
+    role_name TEXT,
+    platform TEXT,
+    blueprint TEXT,
+    assignee_json TEXT,
+    lease_deadline_sec INTEGER,
+    priority INTEGER,
+    max_iterations INTEGER,
+    generation INTEGER NOT NULL DEFAULT 1,
+    target_ref TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    agent_json TEXT NOT NULL,
+    intent_summary TEXT NOT NULL,
+    context_json TEXT,
+    created_at TEXT NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS claim_status (
+    id TEXT PRIMARY KEY,
+    phase TEXT NOT NULL DEFAULT 'active',
+    observed_generation INTEGER NOT NULL DEFAULT 0,
+    agent_session_id TEXT,
+    last_heartbeat_at TEXT NOT NULL,
+    lease_expires_at TEXT NOT NULL,
+    current_contribution_cid TEXT,
+    conditions_json TEXT NOT NULL DEFAULT '[]',
+    last_transition_at TEXT NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    revision INTEGER NOT NULL DEFAULT 1,
+    FOREIGN KEY (id) REFERENCES claim_spec(id) ON DELETE CASCADE
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_claim_spec_target ON claim_spec(target_ref);
+  CREATE INDEX IF NOT EXISTS idx_claim_spec_agent ON claim_spec(agent_id);
+  CREATE INDEX IF NOT EXISTS idx_claim_status_phase ON claim_status(phase);
+  CREATE INDEX IF NOT EXISTS idx_claim_status_phase_lease ON claim_status(phase, lease_expires_at);
 
   -- Workspaces table for agent session isolation (per-agent isolation)
   CREATE TABLE IF NOT EXISTS workspaces (
@@ -309,6 +347,55 @@ export function initSqliteDb(dbPath: string): Database {
         db.run("UPDATE claims SET revision = 1 WHERE revision = 0");
       }
     }
+
+    // Migration -> v14: split legacy claims into claim_spec and claim_status.
+    db.run(`
+      INSERT OR IGNORE INTO claim_spec (
+        id, role_name, platform, assignee_json, lease_deadline_sec, generation,
+        target_ref, agent_id, agent_json, intent_summary, context_json, created_at
+      )
+      SELECT
+        claim_id,
+        json_extract(agent_json, '$.role'),
+        json_extract(agent_json, '$.platform'),
+        agent_json,
+        CASE
+          WHEN strftime('%s', lease_expires_at) > strftime('%s', created_at)
+          THEN CAST(strftime('%s', lease_expires_at) - strftime('%s', created_at) AS INTEGER)
+          ELSE NULL
+        END,
+        revision,
+        target_ref,
+        agent_id,
+        agent_json,
+        intent_summary,
+        context_json,
+        created_at
+      FROM claims
+      WHERE NOT EXISTS (
+        SELECT 1 FROM claim_spec WHERE claim_spec.id = claims.claim_id
+      )
+    `);
+    db.run(`
+      INSERT OR IGNORE INTO claim_status (
+        id, phase, observed_generation, last_heartbeat_at, lease_expires_at,
+        conditions_json, last_transition_at, attempt_count, revision
+      )
+      SELECT
+        claim_id,
+        status,
+        revision,
+        heartbeat_at,
+        lease_expires_at,
+        '[]',
+        heartbeat_at,
+        attempt_count,
+        revision
+      FROM claims
+      WHERE NOT EXISTS (
+        SELECT 1 FROM claim_status WHERE claim_status.id = claims.claim_id
+      )
+    `);
 
     // Composite index — idempotent via IF NOT EXISTS (from v4→v5)
     db.run(

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -1644,18 +1644,27 @@ export class SqliteClaimStore implements ClaimStore {
     let op: "ADDED" | "MODIFIED" = "MODIFIED";
     const tx = this.db.transaction(() => {
       const existing = this.readClaimView(spec.id);
-      const nowIso = new Date().toISOString();
-      const activeOnTarget = this.db
-        .prepare(
-          `SELECT s.id AS claim_id
-           FROM claim_spec s
-           JOIN claim_status st ON st.id = s.id
-           WHERE s.target_ref = ?
-             AND st.phase = 'active'
-             AND st.lease_expires_at >= ?
-             AND s.id <> ?`,
-        )
-        .get(spec.targetRef, nowIso, spec.id) as { claim_id: string } | null;
+      const now = new Date();
+      const nowIso = now.toISOString();
+      const existingActiveUnexpired =
+        existing !== null &&
+        existing.status.phase === "active" &&
+        new Date(existing.status.leaseExpiresAt).getTime() >= now.getTime();
+
+      const activeOnTarget =
+        existing === null || existingActiveUnexpired
+          ? (this.db
+              .prepare(
+                `SELECT s.id AS claim_id
+                 FROM claim_spec s
+                 JOIN claim_status st ON st.id = s.id
+                 WHERE s.target_ref = ?
+                   AND st.phase = 'active'
+                   AND st.lease_expires_at >= ?
+                   AND s.id <> ?`,
+              )
+              .get(spec.targetRef, nowIso, spec.id) as { claim_id: string } | null)
+          : null;
 
       if (activeOnTarget !== null) {
         throw new StateConflictError({
@@ -1926,7 +1935,9 @@ export class SqliteClaimStore implements ClaimStore {
             )
             .run(nowIso, freshExpiry, activeOnTarget.claim_id);
           this.db
-            .prepare("UPDATE claim_spec SET intent_summary = ? WHERE id = ?")
+            .prepare(
+              "UPDATE claim_spec SET intent_summary = ?, generation = generation + 1 WHERE id = ?",
+            )
             .run(claim.intentSummary, activeOnTarget.claim_id);
           resultClaimId = activeOnTarget.claim_id;
           return;

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -16,16 +16,21 @@ import { ContextSchema, fromManifest, toManifest, verifyCid } from "../core/mani
 import type {
   AgentIdentity,
   Claim,
+  ClaimSpecRecord,
   ClaimStatus,
+  ClaimStatusRecord,
+  ClaimView,
   Contribution,
   ContributionKind,
   JsonValue,
   Relation,
   RelationType,
 } from "../core/models.js";
+import { claimToSpecRecord, claimToStatusRecord, claimViewToClaim } from "../core/models.js";
 import type {
   ActiveClaimFilter,
   ClaimQuery,
+  ClaimStatusPatch,
   ClaimStore,
   ContributionPutResult,
   ContributionQuery,
@@ -914,41 +919,86 @@ function rowToContribution(row: { manifest_json: string }): Contribution {
   return fromManifest(JSON.parse(row.manifest_json) as unknown, { verify: false });
 }
 
-interface ClaimRow {
-  readonly claim_id: string;
+interface ClaimSpecRow {
+  readonly id: string;
+  readonly role_name: string | null;
+  readonly platform: string | null;
+  readonly blueprint: string | null;
+  readonly assignee_json: string | null;
+  readonly lease_deadline_sec: number | null;
+  readonly priority: number | null;
+  readonly max_iterations: number | null;
+  readonly generation: number;
   readonly target_ref: string;
   readonly agent_id: string;
-  readonly status: string;
-  readonly intent_summary: string;
-  readonly created_at: string;
-  readonly heartbeat_at: string;
-  readonly lease_expires_at: string;
-  readonly context_json: string | null;
   readonly agent_json: string;
+  readonly intent_summary: string;
+  readonly context_json: string | null;
+  readonly created_at: string;
+}
+
+interface ClaimStatusRow {
+  readonly id: string;
+  readonly phase: string;
+  readonly observed_generation: number;
+  readonly agent_session_id: string | null;
+  readonly last_heartbeat_at: string;
+  readonly lease_expires_at: string;
+  readonly current_contribution_cid: string | null;
+  readonly conditions_json: string;
+  readonly last_transition_at: string;
   readonly attempt_count: number;
   readonly revision: number;
 }
 
-function rowToClaim(row: ClaimRow, statusOverride?: ClaimStatus): Claim {
-  const base: Claim = {
-    claimId: row.claim_id,
+interface ClaimViewRow extends ClaimSpecRow, ClaimStatusRow {}
+
+function rowToClaimSpec(row: ClaimSpecRow): ClaimSpecRecord {
+  return {
+    id: row.id,
+    ...(row.role_name === null ? {} : { roleName: row.role_name }),
+    ...(row.platform === null ? {} : { platform: row.platform }),
+    ...(row.blueprint === null ? {} : { blueprint: row.blueprint }),
+    ...(row.assignee_json === null
+      ? {}
+      : { assignee: JSON.parse(row.assignee_json) as AgentIdentity }),
+    ...(row.lease_deadline_sec === null ? {} : { leaseDeadlineSec: row.lease_deadline_sec }),
+    ...(row.priority === null ? {} : { priority: row.priority }),
+    ...(row.max_iterations === null ? {} : { maxIterations: row.max_iterations }),
+    generation: row.generation,
     targetRef: row.target_ref,
     agent: JSON.parse(row.agent_json) as AgentIdentity,
-    status: (statusOverride ?? row.status) as ClaimStatus,
     intentSummary: row.intent_summary,
+    ...(row.context_json === null
+      ? {}
+      : { context: JSON.parse(row.context_json) as Readonly<Record<string, JsonValue>> }),
     createdAt: row.created_at,
-    heartbeatAt: row.heartbeat_at,
+  };
+}
+
+function rowToClaimStatus(row: ClaimStatusRow): ClaimStatusRecord {
+  return {
+    id: row.id,
+    phase: row.phase as ClaimStatus,
+    observedGeneration: row.observed_generation,
+    ...(row.agent_session_id === null ? {} : { agentSessionId: row.agent_session_id }),
+    lastHeartbeatAt: row.last_heartbeat_at,
     leaseExpiresAt: row.lease_expires_at,
-    ...(row.attempt_count > 0 && { attemptCount: row.attempt_count }),
+    ...(row.current_contribution_cid === null
+      ? {}
+      : { currentContributionCid: row.current_contribution_cid }),
+    conditions: JSON.parse(row.conditions_json) as ClaimStatusRecord["conditions"],
+    lastTransitionAt: row.last_transition_at,
+    attemptCount: row.attempt_count,
     revision: row.revision,
   };
-  if (row.context_json !== null) {
-    return {
-      ...base,
-      context: JSON.parse(row.context_json) as Readonly<Record<string, JsonValue>>,
-    };
-  }
-  return base;
+}
+
+function rowToClaimView(row: ClaimViewRow): ClaimView {
+  return {
+    spec: rowToClaimSpec(row),
+    status: rowToClaimStatus(row),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1527,8 +1577,33 @@ export class SqliteContributionStore implements ContributionStore {
 // SqliteClaimStore
 // ---------------------------------------------------------------------------
 
-const CLAIM_SELECT_COLS = `claim_id, target_ref, agent_id, status, intent_summary,
-  created_at, heartbeat_at, lease_expires_at, context_json, agent_json, attempt_count, revision`;
+const CLAIM_VIEW_SELECT_COLS = `
+  s.id AS id,
+  s.role_name AS role_name,
+  s.platform AS platform,
+  s.blueprint AS blueprint,
+  s.assignee_json AS assignee_json,
+  s.lease_deadline_sec AS lease_deadline_sec,
+  s.priority AS priority,
+  s.max_iterations AS max_iterations,
+  s.generation AS generation,
+  s.target_ref AS target_ref,
+  s.agent_id AS agent_id,
+  s.agent_json AS agent_json,
+  s.intent_summary AS intent_summary,
+  s.context_json AS context_json,
+  s.created_at AS created_at,
+  st.phase AS phase,
+  st.observed_generation AS observed_generation,
+  st.agent_session_id AS agent_session_id,
+  st.last_heartbeat_at AS last_heartbeat_at,
+  st.lease_expires_at AS lease_expires_at,
+  st.current_contribution_cid AS current_contribution_cid,
+  st.conditions_json AS conditions_json,
+  st.last_transition_at AS last_transition_at,
+  st.attempt_count AS attempt_count,
+  st.revision AS revision
+`;
 
 /**
  * SQLite-backed ClaimStore with lease-based coordination.
@@ -1555,8 +1630,166 @@ export class SqliteClaimStore implements ClaimStore {
     this.db = db;
     this.storeIdentity = db.filename;
 
-    this.stmtGetClaim = db.query(`SELECT ${CLAIM_SELECT_COLS} FROM claims WHERE claim_id = ?`);
+    this.stmtGetClaim = db.query(`
+      SELECT ${CLAIM_VIEW_SELECT_COLS}
+      FROM claim_spec s
+      JOIN claim_status st ON st.id = s.id
+      WHERE s.id = ?
+    `);
   }
+
+  putClaimSpec = async (spec: ClaimSpecRecord): Promise<ClaimView> => {
+    this.validateSpecContext(spec);
+
+    let op: "ADDED" | "MODIFIED" = "MODIFIED";
+    const tx = this.db.transaction(() => {
+      const existing = this.readClaimView(spec.id);
+      const nowIso = new Date().toISOString();
+      const activeOnTarget = this.db
+        .prepare(
+          `SELECT s.id AS claim_id
+           FROM claim_spec s
+           JOIN claim_status st ON st.id = s.id
+           WHERE s.target_ref = ?
+             AND st.phase = 'active'
+             AND st.lease_expires_at >= ?
+             AND s.id <> ?`,
+        )
+        .get(spec.targetRef, nowIso, spec.id) as { claim_id: string } | null;
+
+      if (activeOnTarget !== null) {
+        throw new StateConflictError({
+          resource: "Claim",
+          reason: "target already has an active claim",
+          message: `Target '${spec.targetRef}' already has an active claim '${activeOnTarget.claim_id}'`,
+        });
+      }
+
+      if (existing === null) {
+        op = "ADDED";
+        const leaseDeadlineSec = spec.leaseDeadlineSec ?? DEFAULT_LEASE_DURATION_MS / 1000;
+        const createdAtMs = new Date(spec.createdAt).getTime();
+        const leaseExpiresAt = new Date(createdAtMs + leaseDeadlineSec * 1000).toISOString();
+        this.insertSpecRow({ ...spec, generation: 1 });
+        this.insertStatusRow({
+          id: spec.id,
+          phase: "active",
+          observedGeneration: 0,
+          lastHeartbeatAt: nowIso,
+          leaseExpiresAt,
+          conditions: [],
+          lastTransitionAt: nowIso,
+          attemptCount: 0,
+          revision: 1,
+        });
+        return;
+      }
+
+      this.db
+        .prepare(
+          `UPDATE claim_spec
+           SET role_name = ?,
+               platform = ?,
+               blueprint = ?,
+               assignee_json = ?,
+               lease_deadline_sec = ?,
+               priority = ?,
+               max_iterations = ?,
+               generation = generation + 1,
+               target_ref = ?,
+               agent_id = ?,
+               agent_json = ?,
+               intent_summary = ?,
+               context_json = ?
+           WHERE id = ?`,
+        )
+        .run(
+          spec.roleName ?? null,
+          spec.platform ?? null,
+          spec.blueprint ?? null,
+          spec.assignee !== undefined ? JSON.stringify(spec.assignee) : null,
+          spec.leaseDeadlineSec ?? null,
+          spec.priority ?? null,
+          spec.maxIterations ?? null,
+          spec.targetRef,
+          spec.agent.agentId,
+          JSON.stringify(spec.agent),
+          spec.intentSummary,
+          spec.context !== undefined ? JSON.stringify(spec.context) : null,
+          spec.id,
+        );
+    });
+    tx.immediate();
+
+    const view = this.readClaimView(spec.id);
+    if (view === null) throw new Error(`Failed to read back claim '${spec.id}'`);
+    this.onClaimWrite?.(op, claimViewToClaim(view));
+    return view;
+  };
+
+  getClaimView = async (claimId: string): Promise<ClaimView | undefined> => {
+    return this.readClaimView(claimId) ?? undefined;
+  };
+
+  patchClaimStatus = async (claimId: string, patch: ClaimStatusPatch): Promise<ClaimView> => {
+    const assignments: string[] = [];
+    const params: SQLQueryBindings[] = [];
+    const addAssignment = (column: string, value: SQLQueryBindings): void => {
+      assignments.push(`${column} = ?`);
+      params.push(value);
+    };
+
+    if (patch.phase !== undefined) {
+      addAssignment("phase", patch.phase);
+    }
+    if (patch.observedGeneration !== undefined) {
+      addAssignment("observed_generation", patch.observedGeneration);
+    }
+    if (patch.agentSessionId !== undefined) {
+      addAssignment("agent_session_id", patch.agentSessionId);
+    }
+    if (patch.lastHeartbeatAt !== undefined) {
+      addAssignment("last_heartbeat_at", toUtcIso(patch.lastHeartbeatAt));
+    }
+    if (patch.leaseExpiresAt !== undefined) {
+      addAssignment("lease_expires_at", toUtcIso(patch.leaseExpiresAt));
+    }
+    if (patch.currentContributionCid !== undefined) {
+      addAssignment("current_contribution_cid", patch.currentContributionCid);
+    }
+    if (patch.conditions !== undefined) {
+      addAssignment("conditions_json", JSON.stringify(patch.conditions));
+    }
+    if (patch.lastTransitionAt !== undefined) {
+      addAssignment("last_transition_at", toUtcIso(patch.lastTransitionAt));
+    }
+
+    assignments.push("revision = revision + 1");
+    params.push(claimId);
+
+    const tx = this.db.transaction(() => {
+      const existing = this.readClaimView(claimId);
+      if (existing === null) {
+        throw new NotFoundError({
+          resource: "Claim",
+          identifier: claimId,
+          message: `Claim '${claimId}' not found`,
+        });
+      }
+
+      this.db
+        .prepare(`UPDATE claim_status SET ${assignments.join(", ")} WHERE id = ?`)
+        .run(...params);
+
+      const view = this.readClaimView(claimId);
+      if (view === null) throw new Error(`Failed to read back claim '${claimId}'`);
+      return view;
+    });
+
+    const view = tx.immediate();
+    this.onClaimWrite?.("MODIFIED", claimViewToClaim(view));
+    return view;
+  };
 
   createClaim = async (claim: Claim): Promise<Claim> => {
     this.validateClaimContext(claim);
@@ -1568,8 +1801,8 @@ export class SqliteClaimStore implements ClaimStore {
     // Atomic check-and-insert: IMMEDIATE transaction prevents TOCTOU races
     const createTx = this.db.transaction(() => {
       const existing = this.db
-        .prepare("SELECT claim_id FROM claims WHERE claim_id = ?")
-        .get(claim.claimId) as { claim_id: string } | null;
+        .prepare("SELECT id FROM claim_spec WHERE id = ?")
+        .get(claim.claimId) as { id: string } | null;
 
       if (existing !== null) {
         throw new StateConflictError({
@@ -1583,7 +1816,10 @@ export class SqliteClaimStore implements ClaimStore {
       const now = new Date().toISOString();
       const activeOnTarget = this.db
         .prepare(
-          "SELECT claim_id FROM claims WHERE target_ref = ? AND status = 'active' AND lease_expires_at >= ?",
+          `SELECT s.id AS claim_id
+           FROM claim_spec s
+           JOIN claim_status st ON st.id = s.id
+           WHERE s.target_ref = ? AND st.phase = 'active' AND st.lease_expires_at >= ?`,
         )
         .get(claim.targetRef, now) as { claim_id: string } | null;
 
@@ -1595,7 +1831,13 @@ export class SqliteClaimStore implements ClaimStore {
         });
       }
 
-      this.insertClaimRow(claim, createdAtUtc, heartbeatUtc, leaseExpiresUtc);
+      this.insertSpecAndDefaultStatus({
+        ...claim,
+        createdAt: createdAtUtc,
+        heartbeatAt: heartbeatUtc,
+        leaseExpiresAt: leaseExpiresUtc,
+        revision: 1,
+      });
     });
     try {
       createTx.immediate();
@@ -1608,8 +1850,9 @@ export class SqliteClaimStore implements ClaimStore {
       }
     }
 
-    const created = this.readClaim(claim.claimId);
-    if (created === null) throw new Error(`Failed to read back claim '${claim.claimId}'`);
+    const view = this.readClaimView(claim.claimId);
+    if (view === null) throw new Error(`Failed to read back claim '${claim.claimId}'`);
+    const created = claimViewToClaim(view);
     this.onClaimWrite?.("ADDED", created);
     return created;
   };
@@ -1629,8 +1872,10 @@ export class SqliteClaimStore implements ClaimStore {
       const nowIso = now.toISOString();
       const activeOnTarget = this.db
         .prepare(
-          `SELECT claim_id, agent_id FROM claims
-           WHERE target_ref = ? AND status = 'active' AND lease_expires_at >= ?`,
+          `SELECT s.id AS claim_id, s.agent_id AS agent_id
+           FROM claim_spec s
+           JOIN claim_status st ON st.id = s.id
+           WHERE s.target_ref = ? AND st.phase = 'active' AND st.lease_expires_at >= ?`,
         )
         .get(claim.targetRef, nowIso) as { claim_id: string; agent_id: string } | null;
 
@@ -1647,11 +1892,14 @@ export class SqliteClaimStore implements ClaimStore {
           const freshExpiry = new Date(now.getTime() + durationMs).toISOString();
           this.db
             .prepare(
-              `UPDATE claims SET heartbeat_at = ?, lease_expires_at = ?, intent_summary = ?,
-                 revision = revision + 1
-               WHERE claim_id = ?`,
+              `UPDATE claim_status
+               SET last_heartbeat_at = ?, lease_expires_at = ?, revision = revision + 1
+               WHERE id = ?`,
             )
-            .run(nowIso, freshExpiry, claim.intentSummary, activeOnTarget.claim_id);
+            .run(nowIso, freshExpiry, activeOnTarget.claim_id);
+          this.db
+            .prepare("UPDATE claim_spec SET intent_summary = ? WHERE id = ?")
+            .run(claim.intentSummary, activeOnTarget.claim_id);
           resultClaimId = activeOnTarget.claim_id;
           return;
         }
@@ -1665,8 +1913,8 @@ export class SqliteClaimStore implements ClaimStore {
 
       // No active claim → create new
       const existingId = this.db
-        .prepare("SELECT claim_id FROM claims WHERE claim_id = ?")
-        .get(claim.claimId) as { claim_id: string } | null;
+        .prepare("SELECT id FROM claim_spec WHERE id = ?")
+        .get(claim.claimId) as { id: string } | null;
       if (existingId !== null) {
         throw new StateConflictError({
           resource: "Claim",
@@ -1675,7 +1923,13 @@ export class SqliteClaimStore implements ClaimStore {
         });
       }
 
-      this.insertClaimRow(claim, createdAtUtc, heartbeatUtc, leaseExpiresUtc);
+      this.insertSpecAndDefaultStatus({
+        ...claim,
+        createdAt: createdAtUtc,
+        heartbeatAt: heartbeatUtc,
+        leaseExpiresAt: leaseExpiresUtc,
+        revision: 1,
+      });
     });
     try {
       tx.immediate();
@@ -1688,8 +1942,9 @@ export class SqliteClaimStore implements ClaimStore {
       }
     }
 
-    const result = this.readClaim(resultClaimId);
-    if (result === null) throw new Error(`Failed to read back claim '${resultClaimId}'`);
+    const view = this.readClaimView(resultClaimId);
+    if (view === null) throw new Error(`Failed to read back claim '${resultClaimId}'`);
+    const result = claimViewToClaim(view);
     // Renew anchors the lease forward — that IS the lease boundary moving,
     // which the watch protocol cares about, so fire MODIFIED. New insert
     // path fires ADDED.
@@ -1698,7 +1953,8 @@ export class SqliteClaimStore implements ClaimStore {
   };
 
   getClaim = async (claimId: string): Promise<Claim | undefined> => {
-    return this.readClaim(claimId) ?? undefined;
+    const view = this.readClaimView(claimId);
+    return view === null ? undefined : claimViewToClaim(view);
   };
 
   heartbeat = async (claimId: string, leaseDurationMs?: number): Promise<Claim> => {
@@ -1707,22 +1963,18 @@ export class SqliteClaimStore implements ClaimStore {
     const newExpiry = new Date(now.getTime() + duration);
 
     // Atomic UPDATE WHERE: only succeeds if claim is active with valid lease
-    const rows = this.db
+    const result = this.db
       .prepare(
-        `UPDATE claims
-         SET heartbeat_at = ?, lease_expires_at = ?, revision = revision + 1
-         WHERE claim_id = ? AND status = 'active' AND lease_expires_at >= ?
-         RETURNING ${CLAIM_SELECT_COLS}`,
+        `UPDATE claim_status
+         SET last_heartbeat_at = ?, lease_expires_at = ?, revision = revision + 1
+         WHERE id = ? AND phase = 'active' AND lease_expires_at >= ?`,
       )
-      .all(
-        now.toISOString(),
-        newExpiry.toISOString(),
-        claimId,
-        now.toISOString(),
-      ) as readonly ClaimRow[];
+      .run(now.toISOString(), newExpiry.toISOString(), claimId, now.toISOString());
 
-    if (rows.length > 0 && rows[0] !== undefined) {
-      const claim = rowToClaim(rows[0]);
+    if (result.changes > 0) {
+      const view = this.readClaimView(claimId);
+      if (view === null) throw new Error(`Failed to read back claim '${claimId}'`);
+      const claim = claimViewToClaim(view);
       // Heartbeat advances heartbeat_at + lease_expires_at + revision; views
       // render the lease deadline from the cached entity, so without firing
       // a MODIFIED write the cache would still show the prior lease and the
@@ -1736,7 +1988,7 @@ export class SqliteClaimStore implements ClaimStore {
     }
 
     // UPDATE matched nothing — determine why for a specific error message
-    const existing = this.readClaim(claimId);
+    const existing = this.readClaimView(claimId);
     if (existing === null) {
       throw new NotFoundError({
         resource: "Claim",
@@ -1744,17 +1996,17 @@ export class SqliteClaimStore implements ClaimStore {
         message: `Claim '${claimId}' not found`,
       });
     }
-    if (existing.status !== "active") {
+    if (existing.status.phase !== "active") {
       throw new StateConflictError({
         resource: "Claim",
-        reason: `status is '${existing.status}'`,
-        message: `Cannot heartbeat claim '${claimId}' with status '${existing.status}' (must be active)`,
+        reason: `status is '${existing.status.phase}'`,
+        message: `Cannot heartbeat claim '${claimId}' with status '${existing.status.phase}' (must be active)`,
       });
     }
     throw new StateConflictError({
       resource: "Claim",
       reason: "lease expired",
-      message: `Cannot heartbeat claim '${claimId}': lease expired at ${existing.leaseExpiresAt}`,
+      message: `Cannot heartbeat claim '${claimId}': lease expired at ${existing.status.leaseExpiresAt}`,
     });
   };
 
@@ -1778,15 +2030,18 @@ export class SqliteClaimStore implements ClaimStore {
       // Step 1: Expire claims with expired leases
       const leaseExpired = this.db
         .prepare(
-          `UPDATE claims SET status = 'expired', revision = revision + 1
-           WHERE status = 'active' AND lease_expires_at < ?
-           RETURNING claim_id, target_ref, agent_id, status, intent_summary,
-                     created_at, heartbeat_at, lease_expires_at, context_json, agent_json, attempt_count, revision`,
+          `UPDATE claim_status
+           SET phase = 'expired', last_transition_at = ?, revision = revision + 1
+           WHERE phase = 'active' AND lease_expires_at < ?
+           RETURNING id`,
         )
-        .all(nowIso) as readonly ClaimRow[];
+        .all(nowIso, nowIso) as readonly { id: string }[];
 
       for (const row of leaseExpired) {
-        results.push({ claim: rowToClaim(row), reason: ExpiryReason.LeaseExpired });
+        const view = this.readClaimView(row.id);
+        if (view !== null) {
+          results.push({ claim: claimViewToClaim(view), reason: ExpiryReason.LeaseExpired });
+        }
       }
 
       // Step 2: Expire stalled agents (heartbeat gap exceeds threshold)
@@ -1794,15 +2049,18 @@ export class SqliteClaimStore implements ClaimStore {
         const stallCutoff = new Date(now.getTime() - options.stallThresholdMs).toISOString();
         const stalled = this.db
           .prepare(
-            `UPDATE claims SET status = 'expired', revision = revision + 1
-             WHERE status = 'active' AND heartbeat_at < ?
-             RETURNING claim_id, target_ref, agent_id, status, intent_summary,
-                       created_at, heartbeat_at, lease_expires_at, context_json, agent_json, attempt_count, revision`,
+            `UPDATE claim_status
+             SET phase = 'expired', last_transition_at = ?, revision = revision + 1
+             WHERE phase = 'active' AND last_heartbeat_at < ?
+             RETURNING id`,
           )
-          .all(stallCutoff) as readonly ClaimRow[];
+          .all(nowIso, stallCutoff) as readonly { id: string }[];
 
         for (const row of stalled) {
-          results.push({ claim: rowToClaim(row), reason: ExpiryReason.Stalled });
+          const view = this.readClaimView(row.id);
+          if (view !== null) {
+            results.push({ claim: claimViewToClaim(view), reason: ExpiryReason.Stalled });
+          }
         }
       }
 
@@ -1818,40 +2076,46 @@ export class SqliteClaimStore implements ClaimStore {
 
   activeClaims = async (targetRef?: string): Promise<readonly Claim[]> => {
     const now = new Date().toISOString();
-    let sql = `SELECT ${CLAIM_SELECT_COLS} FROM claims WHERE status = 'active' AND lease_expires_at >= ?`;
+    let sql = `SELECT ${CLAIM_VIEW_SELECT_COLS}
+      FROM claim_spec s
+      JOIN claim_status st ON st.id = s.id
+      WHERE st.phase = 'active' AND st.lease_expires_at >= ?`;
     const params: SQLQueryBindings[] = [now];
 
     if (targetRef !== undefined) {
-      sql += " AND target_ref = ?";
+      sql += " AND s.target_ref = ?";
       params.push(targetRef);
     }
 
-    const rows = this.db.prepare(sql).all(...params) as readonly ClaimRow[];
-    return rows.map((row) => rowToClaim(row));
+    const rows = this.db.prepare(sql).all(...params) as readonly ClaimViewRow[];
+    return rows.map((row) => claimViewToClaim(rowToClaimView(row)));
   };
 
   listClaims = async (query?: ClaimQuery): Promise<readonly Claim[]> => {
-    let sql = `SELECT ${CLAIM_SELECT_COLS} FROM claims WHERE 1=1`;
+    let sql = `SELECT ${CLAIM_VIEW_SELECT_COLS}
+      FROM claim_spec s
+      JOIN claim_status st ON st.id = s.id
+      WHERE 1=1`;
     const params: SQLQueryBindings[] = [];
 
     if (query?.status !== undefined) {
       const statuses = Array.isArray(query.status) ? query.status : [query.status];
       const placeholders = statuses.map(() => "?").join(", ");
-      sql += ` AND status IN (${placeholders})`;
+      sql += ` AND st.phase IN (${placeholders})`;
       params.push(...statuses);
     }
     if (query?.agentId !== undefined) {
-      sql += " AND agent_id = ?";
+      sql += " AND s.agent_id = ?";
       params.push(query.agentId);
     }
     if (query?.targetRef !== undefined) {
-      sql += " AND target_ref = ?";
+      sql += " AND s.target_ref = ?";
       params.push(query.targetRef);
     }
 
-    sql += " ORDER BY created_at DESC";
-    const rows = this.db.prepare(sql).all(...params) as readonly ClaimRow[];
-    return rows.map((row) => rowToClaim(row));
+    sql += " ORDER BY s.created_at DESC";
+    const rows = this.db.prepare(sql).all(...params) as readonly ClaimViewRow[];
+    return rows.map((row) => claimViewToClaim(rowToClaimView(row)));
   };
 
   cleanCompleted = async (retentionMs: number): Promise<number> => {
@@ -1860,28 +2124,39 @@ export class SqliteClaimStore implements ClaimStore {
     // A long-running claim that completed moments ago has a recent heartbeat_at,
     // so it won't be prematurely deleted. An old expired claim whose agent died
     // long ago has a stale heartbeat_at, so it gets cleaned up correctly.
-    const result = this.db
-      .prepare(
-        `DELETE FROM claims
-         WHERE status IN ('completed', 'expired', 'released')
-         AND heartbeat_at < ?`,
-      )
-      .run(cutoff);
-    return result.changes;
+    const tx = this.db.transaction(() => {
+      const ids = this.db
+        .prepare(
+          `SELECT s.id
+           FROM claim_spec s
+           JOIN claim_status st ON st.id = s.id
+           WHERE st.phase IN ('completed', 'expired', 'released')
+             AND st.last_heartbeat_at < ?`,
+        )
+        .all(cutoff) as readonly { id: string }[];
+      const deleteSpec = this.db.prepare("DELETE FROM claim_spec WHERE id = ?");
+      for (const row of ids) {
+        deleteSpec.run(row.id);
+      }
+      return ids.length;
+    });
+    return tx.immediate();
   };
 
   countActiveClaims = async (filter?: ActiveClaimFilter): Promise<number> => {
     const now = new Date().toISOString();
-    let sql =
-      "SELECT COUNT(*) as cnt FROM claims WHERE status = 'active' AND lease_expires_at >= ?";
+    let sql = `SELECT COUNT(*) as cnt
+       FROM claim_spec s
+       JOIN claim_status st ON st.id = s.id
+       WHERE st.phase = 'active' AND st.lease_expires_at >= ?`;
     const params: SQLQueryBindings[] = [now];
 
     if (filter?.agentId !== undefined) {
-      sql += " AND agent_id = ?";
+      sql += " AND s.agent_id = ?";
       params.push(filter.agentId);
     }
     if (filter?.targetRef !== undefined) {
-      sql += " AND target_ref = ?";
+      sql += " AND s.target_ref = ?";
       params.push(filter.targetRef);
     }
 
@@ -1896,14 +2171,16 @@ export class SqliteClaimStore implements ClaimStore {
 
     const rows = this.db
       .prepare(
-        `SELECT ${CLAIM_SELECT_COLS} FROM claims
-         WHERE status = 'active'
-           AND lease_expires_at >= ?
-           AND heartbeat_at < ?`,
+        `SELECT ${CLAIM_VIEW_SELECT_COLS}
+         FROM claim_spec s
+         JOIN claim_status st ON st.id = s.id
+         WHERE st.phase = 'active'
+           AND st.lease_expires_at >= ?
+           AND st.last_heartbeat_at < ?`,
       )
-      .all(nowIso, stallCutoff) as readonly ClaimRow[];
+      .all(nowIso, stallCutoff) as readonly ClaimViewRow[];
 
-    return rows.map((row) => rowToClaim(row));
+    return rows.map((row) => claimViewToClaim(rowToClaimView(row)));
   };
 
   async listEntities(query?: ClaimQuery): Promise<readonly ClaimEntity[]> {
@@ -1943,37 +2220,91 @@ export class SqliteClaimStore implements ClaimStore {
     }
   }
 
-  private insertClaimRow(
-    claim: Claim,
-    createdAtUtc: string,
-    heartbeatUtc: string,
-    leaseExpiresUtc: string,
-  ): void {
+  private validateSpecContext(spec: ClaimSpecRecord): void {
+    if (spec.context !== undefined) {
+      const result = ContextSchema.safeParse(spec.context);
+      if (!result.success) {
+        throw new Error(`Invalid claim context: ${result.error.message}`);
+      }
+    }
+  }
+
+  private insertSpecAndDefaultStatus(claim: Claim): void {
+    const spec = claimToSpecRecord(claim);
+    const status = claimToStatusRecord({ ...claim, revision: 1 });
+    this.insertSpecRow({ ...spec, generation: 1 });
+    this.insertStatusRow(status);
+  }
+
+  private insertSpecRow(spec: ClaimSpecRecord): void {
     this.db
       .prepare(
-        `INSERT INTO claims (claim_id, target_ref, agent_id, status, intent_summary,
-         created_at, heartbeat_at, lease_expires_at, context_json, agent_json, attempt_count)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO claim_spec (
+          id, role_name, platform, blueprint, assignee_json, lease_deadline_sec,
+          priority, max_iterations, generation, target_ref, agent_id, agent_json,
+          intent_summary, context_json, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
-        claim.claimId,
-        claim.targetRef,
-        claim.agent.agentId,
-        claim.status,
-        claim.intentSummary,
-        createdAtUtc,
-        heartbeatUtc,
-        leaseExpiresUtc,
-        claim.context !== undefined ? JSON.stringify(claim.context) : null,
-        JSON.stringify(claim.agent),
-        claim.attemptCount ?? 0,
+        spec.id,
+        spec.roleName ?? null,
+        spec.platform ?? null,
+        spec.blueprint ?? null,
+        spec.assignee !== undefined ? JSON.stringify(spec.assignee) : null,
+        spec.leaseDeadlineSec ?? null,
+        spec.priority ?? null,
+        spec.maxIterations ?? null,
+        spec.generation,
+        spec.targetRef,
+        spec.agent.agentId,
+        JSON.stringify(spec.agent),
+        spec.intentSummary,
+        spec.context !== undefined ? JSON.stringify(spec.context) : null,
+        toUtcIso(spec.createdAt),
       );
   }
 
-  private readClaim(claimId: string): Claim | null {
-    const row = this.stmtGetClaim.get(claimId) as ClaimRow | null;
+  private insertStatusRow(status: ClaimStatusRecord): void {
+    this.db
+      .prepare(
+        `INSERT INTO claim_status (
+          id, phase, observed_generation, agent_session_id, last_heartbeat_at,
+          lease_expires_at, current_contribution_cid, conditions_json,
+          last_transition_at, attempt_count, revision
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          phase = excluded.phase,
+          observed_generation = excluded.observed_generation,
+          agent_session_id = excluded.agent_session_id,
+          last_heartbeat_at = excluded.last_heartbeat_at,
+          lease_expires_at = excluded.lease_expires_at,
+          current_contribution_cid = excluded.current_contribution_cid,
+          conditions_json = excluded.conditions_json,
+          last_transition_at = excluded.last_transition_at,
+          attempt_count = excluded.attempt_count,
+          revision = excluded.revision`,
+      )
+      .run(
+        status.id,
+        status.phase,
+        status.observedGeneration,
+        status.agentSessionId ?? null,
+        toUtcIso(status.lastHeartbeatAt),
+        toUtcIso(status.leaseExpiresAt),
+        status.currentContributionCid ?? null,
+        JSON.stringify(status.conditions),
+        toUtcIso(status.lastTransitionAt),
+        status.attemptCount,
+        status.revision,
+      );
+  }
+
+  private readClaimView(claimId: string): ClaimView | null {
+    const row = this.stmtGetClaim.get(claimId) as ClaimViewRow | null;
     if (row === null) return null;
-    return rowToClaim(row);
+    return rowToClaimView(row);
   }
 
   private transitionClaim(claimId: string, newStatus: ClaimStatus): Claim {
@@ -1983,22 +2314,24 @@ export class SqliteClaimStore implements ClaimStore {
     // target lock may already belong to another agent (finding: Codex
     // round-3 one-active-claim-per-target invariant).
     const nowIso = new Date().toISOString();
-    const rows = this.db
+    const result = this.db
       .prepare(
-        `UPDATE claims SET status = ?, revision = revision + 1
-         WHERE claim_id = ? AND status = 'active' AND lease_expires_at >= ?
-         RETURNING ${CLAIM_SELECT_COLS}`,
+        `UPDATE claim_status
+         SET phase = ?, last_transition_at = ?, revision = revision + 1
+         WHERE id = ? AND phase = 'active' AND lease_expires_at >= ?`,
       )
-      .all(newStatus, claimId, nowIso) as readonly ClaimRow[];
+      .run(newStatus, nowIso, claimId, nowIso);
 
-    if (rows.length > 0 && rows[0] !== undefined) {
-      const claim = rowToClaim(rows[0]);
+    if (result.changes > 0) {
+      const view = this.readClaimView(claimId);
+      if (view === null) throw new Error(`Failed to read back claim '${claimId}'`);
+      const claim = claimViewToClaim(view);
       this.onClaimWrite?.("MODIFIED", claim);
       return claim;
     }
 
     // UPDATE matched nothing — determine why
-    const existing = this.readClaim(claimId);
+    const existing = this.readClaimView(claimId);
     if (existing === null) {
       throw new NotFoundError({
         resource: "Claim",
@@ -2006,17 +2339,17 @@ export class SqliteClaimStore implements ClaimStore {
         message: `Claim '${claimId}' not found`,
       });
     }
-    if (existing.status !== "active") {
+    if (existing.status.phase !== "active") {
       throw new StateConflictError({
         resource: "Claim",
-        reason: `status is '${existing.status}'`,
-        message: `Cannot transition claim '${claimId}' from '${existing.status}' to '${newStatus}' (must be active)`,
+        reason: `status is '${existing.status.phase}'`,
+        message: `Cannot transition claim '${claimId}' from '${existing.status.phase}' to '${newStatus}' (must be active)`,
       });
     }
     throw new StateConflictError({
       resource: "Claim",
       reason: "lease expired",
-      message: `Cannot ${newStatus === "completed" ? "complete" : "release"} claim '${claimId}': lease expired at ${existing.leaseExpiresAt}`,
+      message: `Cannot ${newStatus === "completed" ? "complete" : "release"} claim '${claimId}': lease expired at ${existing.status.leaseExpiresAt}`,
     });
   }
 }

--- a/src/local/workspace.ts
+++ b/src/local/workspace.ts
@@ -328,9 +328,11 @@ export class LocalWorkspaceManager implements WorkspaceManager {
       // Check if there's an active claim for this CID
       const activeClaim = this.db
         .prepare(
-          `SELECT claim_id FROM claims
-           WHERE target_ref = ? AND agent_id = ? AND status = 'active'
-           AND lease_expires_at >= ?`,
+          `SELECT s.id AS claim_id
+           FROM claim_spec s
+           JOIN claim_status st ON st.id = s.id
+           WHERE s.target_ref = ? AND s.agent_id = ? AND st.phase = 'active'
+           AND st.lease_expires_at >= ?`,
         )
         .get(cid, agentId, new Date().toISOString()) as { claim_id: string } | null;
 

--- a/src/nexus/nexus-claim-store.ts
+++ b/src/nexus/nexus-claim-store.ts
@@ -18,7 +18,7 @@ import {
   validateTransition,
 } from "../core/claim-logic.js";
 import type { ClaimEntity } from "../core/entity.js";
-import { claimToEntity } from "../core/entity.js";
+import { claimToEntity, claimViewToEntity } from "../core/entity.js";
 import { NotFoundError, StateConflictError } from "../core/errors.js";
 import {
   type Claim,
@@ -382,7 +382,20 @@ export class NexusClaimStore implements ClaimStore {
     const needsActiveDelete = !updatedActiveUnexpired && existingClaim.status === "active";
 
     if (needsActiveAcquire) {
-      await this.writeActiveIndexExclusive(updatedClaim);
+      try {
+        await this.writeActiveIndexExclusive(updatedClaim);
+      } catch (err) {
+        if (err instanceof NexusConflictError) {
+          const activeOnTarget = await this.findActiveOnTarget(updatedClaim.targetRef, now);
+          const existingId = activeOnTarget?.claimId ?? "(unknown)";
+          throw new StateConflictError({
+            resource: "Claim",
+            reason: "target already has an active claim",
+            message: `Target '${updatedClaim.targetRef}' already has an active claim '${existingId}'`,
+          });
+        }
+        throw err;
+      }
     }
 
     try {
@@ -792,11 +805,31 @@ export class NexusClaimStore implements ClaimStore {
     // and excluded from "active" queries.
     const baseQuery: ClaimQuery | undefined =
       query === undefined ? undefined : { ...query, status: undefined };
-    const items = await this.listClaims(baseQuery);
-    const entities = items.map((c) => claimToEntity(c, () => Date.now(), this.zoneId));
+    const items = await this.listClaimViews(baseQuery);
+    const entities = items.map((view) => claimViewToEntity(view, () => Date.now(), this.zoneId));
     if (query?.status === undefined) return entities;
     const wanted = Array.isArray(query.status) ? new Set(query.status) : new Set([query.status]);
     return entities.filter((e) => wanted.has(e.status.phase));
+  }
+
+  private async listClaimViews(query?: ClaimQuery): Promise<readonly ClaimView[]> {
+    let views = (await this.listAllClaimsWithEtags()).map((result) => result.document);
+
+    if (query?.status !== undefined) {
+      const statuses = Array.isArray(query.status) ? query.status : [query.status];
+      views = views.filter((view) => statuses.includes(view.status.phase));
+    }
+    if (query?.agentId !== undefined) {
+      views = views.filter((view) => view.spec.agent.agentId === query.agentId);
+    }
+    if (query?.targetRef !== undefined) {
+      views = views.filter((view) => view.spec.targetRef === query.targetRef);
+    }
+
+    views.sort(
+      (a, b) => new Date(b.spec.createdAt).getTime() - new Date(a.spec.createdAt).getTime(),
+    );
+    return views;
   }
 
   close(): void {

--- a/src/nexus/nexus-claim-store.ts
+++ b/src/nexus/nexus-claim-store.ts
@@ -19,11 +19,21 @@ import {
 } from "../core/claim-logic.js";
 import type { ClaimEntity } from "../core/entity.js";
 import { claimToEntity } from "../core/entity.js";
-import { StateConflictError } from "../core/errors.js";
-import type { Claim, ClaimStatus } from "../core/models.js";
+import { NotFoundError, StateConflictError } from "../core/errors.js";
+import {
+  type Claim,
+  type ClaimSpecRecord,
+  type ClaimStatus,
+  type ClaimStatusRecord,
+  type ClaimView,
+  claimToSpecRecord,
+  claimToStatusRecord,
+  claimViewToClaim,
+} from "../core/models.js";
 import type {
   ActiveClaimFilter,
   ClaimQuery,
+  ClaimStatusPatch,
   ClaimStore,
   ExpiredClaim,
   ExpireStaleOptions,
@@ -54,17 +64,88 @@ import {
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
-function encodeClaim(claim: Claim): Uint8Array {
-  return encoder.encode(JSON.stringify(claim));
+interface ClaimDocument {
+  readonly spec: ClaimSpecRecord;
+  readonly status: ClaimStatusRecord;
 }
 
-function decodeClaim(data: Uint8Array): Claim {
-  return JSON.parse(decoder.decode(data)) as Claim;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
-/** A claim bundled with its VFS ETag for CAS writes. */
-interface ClaimWithEtag {
-  readonly claim: Claim;
+function isClaimDocument(value: unknown): value is ClaimDocument {
+  return (
+    isRecord(value) &&
+    isRecord(value.spec) &&
+    isRecord(value.status) &&
+    typeof value.spec.id === "string" &&
+    typeof value.status.id === "string"
+  );
+}
+
+function claimToDocument(claim: Claim): ClaimDocument {
+  return {
+    spec: claimToSpecRecord(claim),
+    status: claimToStatusRecord(claim),
+  };
+}
+
+function claimToDocumentPreservingSplitFields(
+  claim: Claim,
+  existingDocument: ClaimDocument | undefined,
+): ClaimDocument {
+  if (existingDocument === undefined) return claimToDocument(claim);
+
+  const specWithContext: ClaimSpecRecord = {
+    ...existingDocument.spec,
+    id: claim.claimId,
+    targetRef: claim.targetRef,
+    agent: claim.agent,
+    intentSummary: claim.intentSummary,
+    createdAt: claim.createdAt,
+    ...(claim.context === undefined ? {} : { context: claim.context }),
+  };
+  const spec =
+    claim.context === undefined
+      ? (({ context: _context, ...rest }) => rest)(specWithContext)
+      : specWithContext;
+
+  return {
+    spec,
+    status: {
+      ...existingDocument.status,
+      id: claim.claimId,
+      phase: claim.status,
+      lastHeartbeatAt: claim.heartbeatAt,
+      leaseExpiresAt: claim.leaseExpiresAt,
+      attemptCount: claim.attemptCount ?? existingDocument.status.attemptCount,
+      revision: claim.revision ?? existingDocument.status.revision,
+    },
+  };
+}
+
+function decodeClaimDocument(data: Uint8Array): ClaimDocument {
+  const parsed = JSON.parse(decoder.decode(data)) as unknown;
+  if (isClaimDocument(parsed)) return parsed;
+  return claimToDocument(parsed as Claim);
+}
+
+function encodeClaimDocument(document: ClaimDocument): Uint8Array {
+  return encoder.encode(JSON.stringify(document));
+}
+
+function targetRefFromActiveIndexPath(zoneId: string, path: string): string | undefined {
+  const prefix = `${activeClaimsDir(zoneId)}/`;
+  if (!path.startsWith(prefix)) return undefined;
+  const relative = path.slice(prefix.length);
+  const slashIndex = relative.lastIndexOf("/");
+  if (slashIndex < 0) return undefined;
+  return decodeSegment(relative.slice(0, slashIndex));
+}
+
+/** A claim document bundled with its VFS ETag for CAS writes. */
+interface ClaimDocumentWithEtag {
+  readonly document: ClaimDocument;
   readonly etag: string;
 }
 
@@ -122,11 +203,219 @@ export class NexusClaimStore implements ClaimStore {
     this.activeClaimsCache = undefined;
   }
 
+  async putClaimSpec(spec: ClaimSpecRecord): Promise<ClaimView> {
+    const existing = await this.readClaimWithEtag(spec.id);
+
+    if (existing === undefined) {
+      const now = new Date();
+      const nowIso = now.toISOString();
+      const createdAt = toUtcIso(spec.createdAt);
+      const createdAtMs = new Date(createdAt).getTime();
+      const leaseDeadlineSec = spec.leaseDeadlineSec ?? DEFAULT_LEASE_DURATION_MS / 1000;
+      const document: ClaimDocument = {
+        spec: { ...spec, generation: 1, createdAt },
+        status: {
+          id: spec.id,
+          phase: "active" as ClaimStatus,
+          observedGeneration: 0,
+          lastHeartbeatAt: nowIso,
+          leaseExpiresAt: new Date(createdAtMs + leaseDeadlineSec * 1000).toISOString(),
+          conditions: [],
+          lastTransitionAt: nowIso,
+          attemptCount: 0,
+          revision: 1,
+        },
+      };
+      const flatClaim = claimViewToClaim(document);
+      validateClaimContext(flatClaim);
+
+      try {
+        await this.writeActiveIndexExclusive(flatClaim);
+      } catch (err) {
+        if (err instanceof NexusConflictError) {
+          const activeOnTarget = await this.findActiveOnTarget(spec.targetRef, new Date());
+          const existingId = activeOnTarget?.claimId ?? "(unknown)";
+          throw new StateConflictError({
+            resource: "Claim",
+            reason: "target already has an active claim",
+            message: `Target '${spec.targetRef}' already has an active claim '${existingId}'`,
+          });
+        }
+        throw err;
+      }
+
+      try {
+        await this.writeClaimDocumentConditional(spec.id, document, {
+          ifNoneMatch: "*",
+        });
+      } catch (err) {
+        await safeCleanup(
+          this.deleteActiveIndexUnlessCurrentClaimOwns(flatClaim),
+          "rollback active index after split spec write failure",
+          { silent: true },
+        );
+        if (err instanceof NexusConflictError) {
+          throw new StateConflictError({
+            resource: "Claim",
+            reason: "already exists",
+            message: `Claim with id '${spec.id}' already exists`,
+          });
+        }
+        throw err;
+      }
+
+      this.claimCache.set(flatClaim.claimId, flatClaim);
+      this.invalidateActiveClaimsCache();
+      this.publishWatch(flatClaim, "ADDED");
+      return document;
+    }
+
+    const existingDocument = existing.document;
+    const updatedDocument: ClaimDocument = {
+      spec: {
+        ...spec,
+        createdAt: existingDocument.spec.createdAt,
+        generation: existingDocument.spec.generation + 1,
+      },
+      status: existingDocument.status,
+    };
+    const existingClaim = claimViewToClaim(existingDocument);
+    const updatedClaim = claimViewToClaim(updatedDocument);
+    validateClaimContext(updatedClaim);
+
+    const now = new Date();
+    const existingIsActive =
+      existingClaim.status === "active" &&
+      new Date(existingClaim.leaseExpiresAt).getTime() >= now.getTime();
+    const activeTargetChanged =
+      existingIsActive && existingClaim.targetRef !== updatedClaim.targetRef;
+
+    if (activeTargetChanged) {
+      const activeOnNewTarget = await this.findActiveOnTarget(updatedClaim.targetRef, now);
+      if (activeOnNewTarget !== undefined && activeOnNewTarget.claimId !== updatedClaim.claimId) {
+        throw new StateConflictError({
+          resource: "Claim",
+          reason: "target already has an active claim",
+          message: `Target '${updatedClaim.targetRef}' already has an active claim '${activeOnNewTarget.claimId}'`,
+        });
+      }
+      await this.assertLockOwned(existingClaim.targetRef, existingClaim.claimId);
+      await this.writeActiveIndexExclusive(updatedClaim);
+    }
+
+    try {
+      await this.writeClaimDocumentCas(spec.id, updatedDocument, existing.etag);
+    } catch (err) {
+      if (activeTargetChanged) {
+        await safeCleanup(
+          this.deleteActiveIndexUnlessCurrentClaimOwns(updatedClaim),
+          "rollback moved active index",
+          {
+            silent: true,
+          },
+        );
+      }
+      throw err;
+    }
+
+    if (activeTargetChanged) {
+      await this.deleteActiveIndex(existingClaim);
+    }
+
+    this.claimCache.set(updatedClaim.claimId, updatedClaim);
+    this.invalidateActiveClaimsCache();
+    this.publishWatch(updatedClaim, "MODIFIED");
+    return updatedDocument;
+  }
+
+  async getClaimView(claimId: string): Promise<ClaimView | undefined> {
+    const result = await this.readClaimWithEtag(claimId);
+    return result?.document;
+  }
+
+  async patchClaimStatus(claimId: string, patch: ClaimStatusPatch): Promise<ClaimView> {
+    const existing = await this.readClaimWithEtag(claimId);
+    if (existing === undefined) {
+      throw new NotFoundError({
+        resource: "Claim",
+        identifier: claimId,
+        message: `Claim '${claimId}' not found`,
+      });
+    }
+
+    const updatedDocument: ClaimDocument = {
+      spec: existing.document.spec,
+      status: {
+        ...existing.document.status,
+        phase: patch.phase ?? existing.document.status.phase,
+        observedGeneration: patch.observedGeneration ?? existing.document.status.observedGeneration,
+        agentSessionId: patch.agentSessionId ?? existing.document.status.agentSessionId,
+        lastHeartbeatAt:
+          patch.lastHeartbeatAt !== undefined
+            ? toUtcIso(patch.lastHeartbeatAt)
+            : existing.document.status.lastHeartbeatAt,
+        leaseExpiresAt:
+          patch.leaseExpiresAt !== undefined
+            ? toUtcIso(patch.leaseExpiresAt)
+            : existing.document.status.leaseExpiresAt,
+        currentContributionCid:
+          patch.currentContributionCid ?? existing.document.status.currentContributionCid,
+        conditions: patch.conditions ?? existing.document.status.conditions,
+        lastTransitionAt:
+          patch.lastTransitionAt !== undefined
+            ? toUtcIso(patch.lastTransitionAt)
+            : existing.document.status.lastTransitionAt,
+        revision: existing.document.status.revision + 1,
+      },
+    };
+
+    const existingClaim = claimViewToClaim(existing.document);
+    const updatedClaim = claimViewToClaim(updatedDocument);
+    const now = new Date();
+    const existingActiveUnexpired =
+      existingClaim.status === "active" &&
+      new Date(existingClaim.leaseExpiresAt).getTime() >= now.getTime();
+    const updatedActiveUnexpired =
+      updatedClaim.status === "active" &&
+      new Date(updatedClaim.leaseExpiresAt).getTime() >= now.getTime();
+    const needsActiveAcquire = updatedActiveUnexpired && !existingActiveUnexpired;
+    const needsActiveDelete = !updatedActiveUnexpired && existingClaim.status === "active";
+
+    if (needsActiveAcquire) {
+      await this.writeActiveIndexExclusive(updatedClaim);
+    }
+
+    try {
+      await this.writeClaimDocumentCas(claimId, updatedDocument, existing.etag);
+    } catch (err) {
+      if (needsActiveAcquire) {
+        await safeCleanup(
+          this.deleteActiveIndexUnlessCurrentClaimOwns(updatedClaim),
+          "rollback status active index",
+          {
+            silent: true,
+          },
+        );
+      }
+      throw err;
+    }
+
+    if (needsActiveDelete) {
+      await this.deleteActiveIndex(updatedClaim);
+    }
+
+    this.claimCache.set(updatedClaim.claimId, updatedClaim);
+    this.invalidateActiveClaimsCache();
+    this.publishWatch(updatedClaim, "MODIFIED");
+    return updatedDocument;
+  }
+
   async createClaim(claim: Claim): Promise<Claim> {
     validateClaimContext(claim);
 
-    // Check for duplicate claimId via conditional write (ifNoneMatch="*")
-    // This is race-safe: the write will fail if the file already exists.
+    // Acquire target ownership before exposing the claim file. If the
+    // subsequent conditional claim write fails, rollback is limited to
+    // active-index state this operation still appears to own.
     const createdClaim: Claim = {
       ...claim,
       createdAt: toUtcIso(claim.createdAt),
@@ -136,33 +425,9 @@ export class NexusClaimStore implements ClaimStore {
     };
 
     try {
-      await this.writeClaimConditional(createdClaim, { ifNoneMatch: "*" });
-    } catch (err) {
-      if (err instanceof NexusConflictError) {
-        throw new StateConflictError({
-          resource: "Claim",
-          reason: "already exists",
-          message: `Claim with id '${claim.claimId}' already exists`,
-        });
-      }
-      throw err;
-    }
-
-    // Acquire target lock + write active index. The lock uses ifNoneMatch="*"
-    // to atomically enforce one-active-per-target. If it fails, roll back.
-    try {
       await this.writeActiveIndexExclusive(createdClaim);
     } catch (err) {
-      // Roll back the claim file — the lock is the gate.
-      await safeCleanup(
-        withSemaphore(this.semaphore, () =>
-          this.client.delete(claimPath(this.zoneId, claim.claimId)),
-        ),
-        "rollback claim file after index failure",
-        { silent: true },
-      );
       if (err instanceof NexusConflictError) {
-        // Another claim already active on this target — find it for error message
         const now = new Date();
         const activeOnTarget = await this.findActiveOnTarget(claim.targetRef, now);
         const existingId = activeOnTarget?.claimId ?? "(unknown)";
@@ -170,6 +435,24 @@ export class NexusClaimStore implements ClaimStore {
           resource: "Claim",
           reason: "target already has an active claim",
           message: `Target '${claim.targetRef}' already has an active claim '${existingId}'`,
+        });
+      }
+      throw err;
+    }
+
+    try {
+      await this.writeClaimConditional(createdClaim, { ifNoneMatch: "*" });
+    } catch (err) {
+      await safeCleanup(
+        this.deleteActiveIndexUnlessCurrentClaimOwns(createdClaim),
+        "rollback active index after claim write failure",
+        { silent: true },
+      );
+      if (err instanceof NexusConflictError) {
+        throw new StateConflictError({
+          resource: "Claim",
+          reason: "already exists",
+          message: `Claim with id '${claim.claimId}' already exists`,
         });
       }
       throw err;
@@ -199,8 +482,8 @@ export class NexusClaimStore implements ClaimStore {
     if (resolution.action === "renew" && activeOnTarget !== undefined) {
       // Re-read with ETag for CAS write
       const withEtag = await this.readClaimWithEtag(activeOnTarget.claimId);
-      const existing = withEtag?.claim ?? activeOnTarget;
-      const etag = withEtag?.etag;
+      const existing =
+        withEtag !== undefined ? claimViewToClaim(withEtag.document) : activeOnTarget;
       const durationMs = computeLeaseDuration(claim);
       const renewed: Claim = {
         ...existing,
@@ -209,8 +492,8 @@ export class NexusClaimStore implements ClaimStore {
         intentSummary: claim.intentSummary,
         revision: (existing.revision ?? 0) + 1,
       };
-      if (etag !== undefined) {
-        await this.writeClaimCas(renewed, etag);
+      if (withEtag !== undefined) {
+        await this.writeClaimCas(renewed, withEtag.etag, withEtag.document);
       } else {
         await this.writeClaim(renewed);
       }
@@ -234,8 +517,26 @@ export class NexusClaimStore implements ClaimStore {
     };
 
     try {
+      await this.writeActiveIndexExclusive(createdClaim);
+    } catch (err) {
+      if (err instanceof NexusConflictError) {
+        throw new StateConflictError({
+          resource: "Claim",
+          reason: "target already has an active claim",
+          message: `Target '${claim.targetRef}' already has an active claim`,
+        });
+      }
+      throw err;
+    }
+
+    try {
       await this.writeClaimConditional(createdClaim, { ifNoneMatch: "*" });
     } catch (err) {
+      await safeCleanup(
+        this.deleteActiveIndexUnlessCurrentClaimOwns(createdClaim),
+        "rollback active index after claimOrRenew write failure",
+        { silent: true },
+      );
       if (err instanceof NexusConflictError) {
         throw new StateConflictError({
           resource: "Claim",
@@ -243,20 +544,6 @@ export class NexusClaimStore implements ClaimStore {
           message: `Claim with id '${claim.claimId}' already exists`,
         });
       }
-      throw err;
-    }
-
-    // Write active index — roll back claim on failure
-    try {
-      await this.writeActiveIndexExclusive(createdClaim);
-    } catch (err) {
-      await safeCleanup(
-        withSemaphore(this.semaphore, () =>
-          this.client.delete(claimPath(this.zoneId, claim.claimId)),
-        ),
-        "rollback claim file after claimOrRenew index failure",
-        { silent: true },
-      );
       throw err;
     }
 
@@ -272,8 +559,10 @@ export class NexusClaimStore implements ClaimStore {
 
   async heartbeat(claimId: string, leaseDurationMs?: number): Promise<Claim> {
     const result = await this.readClaimWithEtag(claimId);
-    validateHeartbeat(result?.claim, claimId);
-    const { claim: validClaim, etag } = result as ClaimWithEtag;
+    const claim = result !== undefined ? claimViewToClaim(result.document) : undefined;
+    validateHeartbeat(claim, claimId);
+    const validClaim = claim as Claim;
+    const etag = result?.etag as string;
 
     // Lock-ownership fence: if the target lock no longer points to
     // this claim, a takeover has already superseded us. Renewing the
@@ -290,7 +579,7 @@ export class NexusClaimStore implements ClaimStore {
       revision: (validClaim.revision ?? 0) + 1,
     };
 
-    await this.writeClaimCas(updated, etag);
+    await this.writeClaimCas(updated, etag, result?.document);
     this.claimCache.set(updated.claimId, updated);
     this.invalidateActiveClaimsCache();
     // Heartbeats advance heartbeatAt/leaseExpiresAt and watchers depend
@@ -337,7 +626,8 @@ export class NexusClaimStore implements ClaimStore {
     // List all claim files (not just active index — need to catch lease-expired)
     const allClaimsWithEtags = await this.listAllClaimsWithEtags();
 
-    for (const { claim, etag } of allClaimsWithEtags) {
+    for (const { document, etag } of allClaimsWithEtags) {
+      const claim = claimViewToClaim(document);
       if (claim.status !== "active") continue;
 
       let reason: typeof ExpiryReason.LeaseExpired | typeof ExpiryReason.Stalled | undefined;
@@ -357,7 +647,7 @@ export class NexusClaimStore implements ClaimStore {
           status: "expired" as ClaimStatus,
           revision: (claim.revision ?? 0) + 1,
         };
-        await this.writeClaimCas(expired, etag);
+        await this.writeClaimCas(expired, etag, document);
         await this.deleteActiveIndex(expired);
         this.claimCache.set(expired.claimId, expired);
         this.publishWatch(expired, "MODIFIED");
@@ -377,7 +667,7 @@ export class NexusClaimStore implements ClaimStore {
 
     if (targetRef !== undefined) {
       const dir = activeClaimTargetDir(this.zoneId, targetRef);
-      return this.readActiveClaimsFromDir(dir, now);
+      return this.readActiveClaimsFromDir(dir, now, targetRef);
     }
 
     // Check TTL-based cache for all-active-claims query
@@ -391,17 +681,32 @@ export class NexusClaimStore implements ClaimStore {
     });
 
     // Parallel reads for all non-directory entries
-    const claimIds = entries
+    const indexedClaims = entries
       .filter((entry) => !entry.isDirectory)
-      .map((entry) => decodeSegment(entry.name));
+      .map((entry) => ({
+        claimId: decodeSegment(entry.name),
+        targetRef: targetRefFromActiveIndexPath(this.zoneId, entry.path),
+      }));
 
-    const results = await Promise.all(claimIds.map((claimId) => this.readClaim(claimId)));
+    const results = await Promise.all(
+      indexedClaims.map(async ({ claimId, targetRef: indexedTargetRef }) => {
+        const result = await this.readClaimWithEtag(claimId);
+        const claim = result !== undefined ? claimViewToClaim(result.document) : undefined;
+        return { claim, indexedTargetRef };
+      }),
+    );
 
     const claims: Claim[] = [];
-    for (const claim of results) {
+    const seen = new Set<string>();
+    for (const { claim, indexedTargetRef } of results) {
       if (claim !== undefined && claim.status === "active") {
-        if (new Date(claim.leaseExpiresAt).getTime() >= now.getTime()) {
+        if (
+          indexedTargetRef === claim.targetRef &&
+          new Date(claim.leaseExpiresAt).getTime() >= now.getTime() &&
+          !seen.has(claim.claimId)
+        ) {
           claims.push(claim);
+          seen.add(claim.claimId);
         }
       }
     }
@@ -504,8 +809,10 @@ export class NexusClaimStore implements ClaimStore {
 
   private async transitionClaim(claimId: string, newStatus: ClaimStatus): Promise<Claim> {
     const result = await this.readClaimWithEtag(claimId);
-    validateTransition(result?.claim, claimId, newStatus);
-    const { claim: validClaim, etag } = result as ClaimWithEtag;
+    const claim = result !== undefined ? claimViewToClaim(result.document) : undefined;
+    validateTransition(claim, claimId, newStatus);
+    const validClaim = claim as Claim;
+    const etag = result?.etag as string;
 
     // Belt-and-suspenders: re-check the lease immediately before the
     // CAS write. Between the first validate and writeClaimCas, the
@@ -531,7 +838,7 @@ export class NexusClaimStore implements ClaimStore {
       status: newStatus,
       revision: (validClaim.revision ?? 0) + 1,
     };
-    await this.writeClaimCas(updated, etag);
+    await this.writeClaimCas(updated, etag, result?.document);
     if (newStatus !== "active") {
       await this.deleteActiveIndex(updated);
     }
@@ -548,14 +855,15 @@ export class NexusClaimStore implements ClaimStore {
     const cached = this.claimCache.get(claimId);
     if (cached !== undefined) return cached;
     const result = await this.readClaimWithEtag(claimId);
+    const claim = result !== undefined ? claimViewToClaim(result.document) : undefined;
     if (result !== undefined) {
-      this.claimCache.set(claimId, result.claim);
+      this.claimCache.set(claimId, claimViewToClaim(result.document));
     }
-    return result?.claim;
+    return claim;
   }
 
   /** Read a claim and its VFS ETag atomically (needed for CAS writes via ifMatch). */
-  private async readClaimWithEtag(claimId: string): Promise<ClaimWithEtag | undefined> {
+  private async readClaimWithEtag(claimId: string): Promise<ClaimDocumentWithEtag | undefined> {
     const p = claimPath(this.zoneId, claimId);
     const result = await withRetry(
       () => withSemaphore(this.semaphore, () => this.client.readWithMeta(p)),
@@ -563,26 +871,29 @@ export class NexusClaimStore implements ClaimStore {
       this.config,
     );
     if (result === undefined) return undefined;
-    return { claim: decodeClaim(result.content), etag: result.etag };
+    return { document: decodeClaimDocument(result.content), etag: result.etag };
   }
 
   /** Write claim with ifMatch for CAS safety on mutations. */
-  private async writeClaimCas(claim: Claim, expectedEtag: string): Promise<void> {
-    const p = claimPath(this.zoneId, claim.claimId);
-    await withRetry(
-      () =>
-        withSemaphore(this.semaphore, () =>
-          this.client.write(p, encodeClaim(claim), { ifMatch: expectedEtag }),
-        ),
-      "writeClaimCas",
-      this.config,
+  private async writeClaimCas(
+    claim: Claim,
+    expectedEtag: string,
+    existingDocument?: ClaimDocument,
+  ): Promise<void> {
+    await this.writeClaimDocumentCas(
+      claim.claimId,
+      claimToDocumentPreservingSplitFields(claim, existingDocument),
+      expectedEtag,
     );
   }
 
   private async writeClaim(claim: Claim): Promise<void> {
     const p = claimPath(this.zoneId, claim.claimId);
     await withRetry(
-      () => withSemaphore(this.semaphore, () => this.client.write(p, encodeClaim(claim))),
+      () =>
+        withSemaphore(this.semaphore, () =>
+          this.client.write(p, encodeClaimDocument(claimToDocument(claim))),
+        ),
       "writeClaim",
       this.config,
     );
@@ -592,13 +903,64 @@ export class NexusClaimStore implements ClaimStore {
   private async writeClaimConditional(
     claim: Claim,
     opts: { ifNoneMatch?: string; ifMatch?: string },
-  ): Promise<void> {
+  ): Promise<string> {
     const path = claimPath(this.zoneId, claim.claimId);
-    await withRetry(
-      () => withSemaphore(this.semaphore, () => this.client.write(path, encodeClaim(claim), opts)),
+    const result = await withRetry(
+      () =>
+        withSemaphore(this.semaphore, () =>
+          this.client.write(path, encodeClaimDocument(claimToDocument(claim)), opts),
+        ),
       "writeClaimConditional",
       this.config,
     );
+    return result.etag;
+  }
+
+  private async writeClaimDocumentConditional(
+    claimId: string,
+    document: ClaimDocument,
+    opts: { readonly ifNoneMatch: "*" },
+  ): Promise<string> {
+    const result = await withRetry(
+      () =>
+        withSemaphore(this.semaphore, () =>
+          this.client.write(claimPath(this.zoneId, claimId), encodeClaimDocument(document), opts),
+        ),
+      "writeClaimDocumentConditional",
+      this.config,
+    );
+    return result.etag;
+  }
+
+  private async writeClaimDocumentCas(
+    claimId: string,
+    document: ClaimDocument,
+    etag: string,
+  ): Promise<void> {
+    await withRetry(
+      () =>
+        withSemaphore(this.semaphore, () =>
+          this.client.write(claimPath(this.zoneId, claimId), encodeClaimDocument(document), {
+            ifMatch: etag,
+          }),
+        ),
+      "writeClaimDocumentCas",
+      this.config,
+    );
+  }
+
+  private async deleteActiveIndexUnlessCurrentClaimOwns(claim: Claim): Promise<void> {
+    const current = await this.readClaimWithEtag(claim.claimId);
+    const currentClaim = current !== undefined ? claimViewToClaim(current.document) : undefined;
+    if (
+      currentClaim !== undefined &&
+      currentClaim.status === "active" &&
+      currentClaim.targetRef === claim.targetRef &&
+      new Date(currentClaim.leaseExpiresAt).getTime() >= Date.now()
+    ) {
+      return;
+    }
+    await this.deleteActiveIndex(claim);
   }
 
   /**
@@ -635,13 +997,18 @@ export class NexusClaimStore implements ClaimStore {
       const isEmptyTombstone = holderId.length === 0;
 
       let holderStale = isEmptyTombstone;
-      let holderResult: ClaimWithEtag | undefined;
+      let holderTargetMismatch = false;
+      let holderResult: ClaimDocumentWithEtag | undefined;
       if (!holderStale) {
         holderResult = await this.readClaimWithEtag(holderId);
-        const holderClaim = holderResult?.claim;
+        const holderClaim =
+          holderResult !== undefined ? claimViewToClaim(holderResult.document) : undefined;
+        holderTargetMismatch =
+          holderClaim !== undefined && holderClaim.targetRef !== claim.targetRef;
         holderStale =
           holderClaim === undefined ||
           holderClaim.status !== "active" ||
+          holderTargetMismatch ||
           new Date(holderClaim.leaseExpiresAt).getTime() < Date.now();
       }
 
@@ -658,14 +1025,16 @@ export class NexusClaimStore implements ClaimStore {
       // holder record has moved under us (another party already
       // expired it, or the record was deleted), fall through: the
       // holder is already non-active and our lock takeover is safe.
-      if (holderResult !== undefined && holderResult.claim.status === "active") {
+      const holderClaim =
+        holderResult !== undefined ? claimViewToClaim(holderResult.document) : undefined;
+      if (holderResult !== undefined && holderClaim?.status === "active" && !holderTargetMismatch) {
         const expiredHolder: Claim = {
-          ...holderResult.claim,
+          ...holderClaim,
           status: "expired" as ClaimStatus,
-          revision: (holderResult.claim.revision ?? 0) + 1,
+          revision: (holderClaim.revision ?? 0) + 1,
         };
         try {
-          await this.writeClaimCas(expiredHolder, holderResult.etag);
+          await this.writeClaimCas(expiredHolder, holderResult.etag, holderResult.document);
           this.claimCache.set(expiredHolder.claimId, expiredHolder);
         } catch (expireErr) {
           // CAS-expire conflict: the holder record changed under us.
@@ -681,10 +1050,15 @@ export class NexusClaimStore implements ClaimStore {
           if (!isConflict) throw expireErr;
 
           const refreshed = await this.readClaimWithEtag(holderId);
+          const refreshedClaim =
+            refreshed !== undefined ? claimViewToClaim(refreshed.document) : undefined;
+          const refreshedTargetMismatch =
+            refreshedClaim !== undefined && refreshedClaim.targetRef !== claim.targetRef;
           const refreshedIsStale =
             refreshed === undefined ||
-            refreshed.claim.status !== "active" ||
-            new Date(refreshed.claim.leaseExpiresAt).getTime() < Date.now();
+            refreshedClaim?.status !== "active" ||
+            refreshedTargetMismatch ||
+            new Date(refreshedClaim.leaseExpiresAt).getTime() < Date.now();
           if (!refreshedIsStale) {
             // The holder heartbeated (or was renewed) and is live
             // again — abort the takeover. Re-throw the ORIGINAL
@@ -695,8 +1069,8 @@ export class NexusClaimStore implements ClaimStore {
           // Still stale on the refresh — safe to proceed. Populate
           // the cache from the refresh so a subsequent same-process
           // reader sees the latest state.
-          if (refreshed !== undefined) {
-            this.claimCache.set(refreshed.claim.claimId, refreshed.claim);
+          if (refreshed !== undefined && refreshedClaim !== undefined) {
+            this.claimCache.set(refreshedClaim.claimId, refreshedClaim);
           }
         }
       }
@@ -780,22 +1154,35 @@ export class NexusClaimStore implements ClaimStore {
 
   private async findActiveOnTarget(targetRef: string, now: Date): Promise<Claim | undefined> {
     const dir = activeClaimTargetDir(this.zoneId, targetRef);
-    const claims = await this.readActiveClaimsFromDir(dir, now);
+    const claims = await this.readActiveClaimsFromDir(dir, now, targetRef);
     return claims.length > 0 ? claims[0] : undefined;
   }
 
-  private async readActiveClaimsFromDir(dir: string, now: Date): Promise<Claim[]> {
+  private async readActiveClaimsFromDir(
+    dir: string,
+    now: Date,
+    targetRef: string,
+  ): Promise<Claim[]> {
     const entries = await listAllPages(this.client, this.semaphore, this.config, dir);
 
     const nonDirEntries = entries.filter((e) => !e.isDirectory);
     const claimIds = nonDirEntries.map((entry) => decodeSegment(entry.name));
-    const fetched = await batchParallel(claimIds, (claimId) => this.readClaim(claimId));
+    const fetched = await batchParallel(claimIds, async (claimId) => {
+      const result = await this.readClaimWithEtag(claimId);
+      return result !== undefined ? claimViewToClaim(result.document) : undefined;
+    });
 
     const claims: Claim[] = [];
+    const seen = new Set<string>();
     for (const claim of fetched) {
       if (claim !== undefined && claim.status === "active") {
-        if (new Date(claim.leaseExpiresAt).getTime() >= now.getTime()) {
+        if (
+          claim.targetRef === targetRef &&
+          new Date(claim.leaseExpiresAt).getTime() >= now.getTime() &&
+          !seen.has(claim.claimId)
+        ) {
           claims.push(claim);
+          seen.add(claim.claimId);
         }
       }
     }
@@ -804,10 +1191,10 @@ export class NexusClaimStore implements ClaimStore {
 
   private async listAllClaims(): Promise<Claim[]> {
     const results = await this.listAllClaimsWithEtags();
-    return results.map((r) => r.claim);
+    return results.map((r) => claimViewToClaim(r.document));
   }
 
-  private async listAllClaimsWithEtags(): Promise<ClaimWithEtag[]> {
+  private async listAllClaimsWithEtags(): Promise<ClaimDocumentWithEtag[]> {
     const dir = claimsDir(this.zoneId);
     const entries = await listAllPages(this.client, this.semaphore, this.config, dir);
 
@@ -815,6 +1202,6 @@ export class NexusClaimStore implements ClaimStore {
     const claimIds = nonDirEntries.map((entry) => decodeSegment(entry.name.replace(/\.json$/, "")));
     const fetched = await batchParallel(claimIds, (claimId) => this.readClaimWithEtag(claimId));
 
-    return fetched.filter((result): result is ClaimWithEtag => result !== undefined);
+    return fetched.filter((result): result is ClaimDocumentWithEtag => result !== undefined);
   }
 }

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -44,6 +44,8 @@ export interface ServerDeps {
   readonly frontierForSession?: ((sessionId: string) => FrontierCalculator) | undefined;
   /** Optional gossip service. Routes return 501 when not configured. */
   readonly gossip?: GossipService | undefined;
+  /** Optional token required for controller-owned status writes. */
+  readonly controllerToken?: string | undefined;
   /** HMAC secret for gossip route verification (required when gossip is configured). */
   readonly gossipHmacSecret?: string | undefined;
   /** Optional outcome store. Routes return 501 when not configured. */

--- a/src/server/routes/claims.ts
+++ b/src/server/routes/claims.ts
@@ -7,34 +7,132 @@
  */
 
 import { zValidator } from "@hono/zod-validator";
-import type { Hono as HonoType } from "hono";
+import type { Hono as HonoType, MiddlewareHandler } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import { DEFAULT_LEASE_MS } from "../../core/constants.js";
 import { claimToEntity } from "../../core/entity.js";
-import type { AgentIdentity, Claim, JsonValue } from "../../core/models.js";
+import type { AgentIdentity, Claim, ClaimSpecRecord, JsonValue } from "../../core/models.js";
 import { listClaimsOperation, releaseOperation } from "../../core/operations/index.js";
+import type { ClaimStatusPatch } from "../../core/store.js";
 import type { ServerEnv } from "../deps.js";
 import { toHttpResult, toOperationDeps } from "../operation-adapter.js";
+
+const agentIdentitySchema = z.object({
+  agentId: z.string().min(1),
+  agentName: z.string().optional(),
+  provider: z.string().optional(),
+  model: z.string().optional(),
+  platform: z.string().optional(),
+  version: z.string().optional(),
+  toolchain: z.string().optional(),
+  runtime: z.string().optional(),
+  role: z.string().optional(),
+});
 
 const createBodySchema = z.object({
   claimId: z.string().min(1).optional(),
   targetRef: z.string().min(1),
-  agent: z.object({
-    agentId: z.string().min(1),
-    agentName: z.string().optional(),
-    provider: z.string().optional(),
-    model: z.string().optional(),
-    platform: z.string().optional(),
-    version: z.string().optional(),
-    toolchain: z.string().optional(),
-    runtime: z.string().optional(),
-    role: z.string().optional(),
-  }),
+  agent: agentIdentitySchema,
   intentSummary: z.string().min(1),
   leaseDurationMs: z.number().int().positive().optional(),
   context: z.record(z.string(), z.unknown()).optional(),
 });
+
+const statusOwnedFields = [
+  "status",
+  "phase",
+  "observedGeneration",
+  "agentSessionId",
+  "lastHeartbeatAt",
+  "heartbeatAt",
+  "leaseExpiresAt",
+  "currentContributionCid",
+  "conditions",
+  "lastTransitionAt",
+  "attemptCount",
+  "revision",
+] as const;
+
+const specOwnedFields = [
+  "roleName",
+  "platform",
+  "blueprint",
+  "assignee",
+  "leaseDeadlineSec",
+  "priority",
+  "maxIterations",
+  "targetRef",
+  "agent",
+  "intentSummary",
+  "context",
+  "generation",
+  "createdAt",
+  "revision",
+] as const;
+
+function rejectFields(
+  body: Readonly<Record<string, unknown>>,
+  ctx: z.RefinementCtx,
+  fields: readonly string[],
+  owner: string,
+): void {
+  for (const field of fields) {
+    if (Object.hasOwn(body, field)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [field],
+        message: `${field} is owned by ${owner}`,
+      });
+    }
+  }
+}
+
+const specBodySchema = z
+  .object({
+    targetRef: z.string().min(1),
+    agent: agentIdentitySchema,
+    intentSummary: z.string().min(1),
+    roleName: z.string().optional(),
+    platform: z.string().optional(),
+    blueprint: z.string().optional(),
+    assignee: agentIdentitySchema.optional(),
+    leaseDeadlineSec: z.number().int().positive().optional(),
+    priority: z.number().int().optional(),
+    maxIterations: z.number().int().positive().optional(),
+    context: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough()
+  .superRefine((body, ctx) => {
+    rejectFields(body, ctx, statusOwnedFields, "claim status");
+  });
+
+const conditionSchema = z
+  .object({
+    type: z.string().min(1),
+    status: z.enum(["True", "False", "Unknown"]),
+    observedGeneration: z.number().int().nonnegative(),
+    lastTransitionTime: z.string().datetime(),
+    reason: z.string(),
+    message: z.string(),
+  })
+  .passthrough();
+
+const statusBodySchema = z
+  .object({
+    phase: z.enum(["active", "released", "expired", "completed"]).optional(),
+    observedGeneration: z.number().int().nonnegative().optional(),
+    agentSessionId: z.string().min(1).optional(),
+    lastHeartbeatAt: z.string().datetime().optional(),
+    leaseExpiresAt: z.string().datetime().optional(),
+    currentContributionCid: z.string().min(1).optional(),
+    conditions: z.array(conditionSchema).optional(),
+    lastTransitionAt: z.string().datetime().optional(),
+  })
+  .passthrough()
+  .superRefine((body, ctx) => {
+    rejectFields(body, ctx, specOwnedFields, "claim spec");
+  });
 
 const patchBodySchema = z.object({
   action: z.enum(["heartbeat", "release", "complete"]),
@@ -46,6 +144,25 @@ const listQuerySchema = z.object({
   agentId: z.string().optional(),
   targetRef: z.string().optional(),
 });
+
+const requireControllerToken: MiddlewareHandler<ServerEnv> = async (c, next) => {
+  const deps = c.get("deps");
+  const token = c.req.header("X-Grove-Controller-Token");
+
+  if (!deps.controllerToken || token !== deps.controllerToken) {
+    return c.json(
+      {
+        error: {
+          code: "FORBIDDEN",
+          message: "Controller token required",
+        },
+      },
+      403,
+    );
+  }
+
+  await next();
+};
 
 const claims: HonoType<ServerEnv> = new Hono<ServerEnv>();
 
@@ -106,6 +223,77 @@ claims.post("/", zValidator("json", createBodySchema), async (c) => {
 
   return c.json(result, 201);
 });
+
+/** PUT /api/claims/:id — Create or update the user-owned claim spec. */
+claims.put("/:id", zValidator("json", specBodySchema), async (c) => {
+  const deps = c.get("deps");
+  const claimId = c.req.param("id");
+  const body = c.req.valid("json");
+  const existing = await deps.claimStore.getClaimView(claimId);
+  const spec: ClaimSpecRecord = {
+    id: claimId,
+    roleName: body.roleName,
+    platform: body.platform,
+    blueprint: body.blueprint,
+    assignee: body.assignee as AgentIdentity | undefined,
+    leaseDeadlineSec: body.leaseDeadlineSec,
+    priority: body.priority,
+    maxIterations: body.maxIterations,
+    generation: 0,
+    targetRef: body.targetRef,
+    agent: body.agent as AgentIdentity,
+    intentSummary: body.intentSummary,
+    context: body.context as Readonly<Record<string, JsonValue>> | undefined,
+    createdAt: existing?.spec.createdAt ?? new Date().toISOString(),
+  };
+
+  const view = await deps.claimStore.putClaimSpec(spec);
+  return c.json(view, existing === undefined ? 201 : 200);
+});
+
+/** GET /api/claims/:id — Return the merged split claim view. */
+claims.get("/:id", async (c) => {
+  const claimId = c.req.param("id");
+  const view = await c.get("deps").claimStore.getClaimView(claimId);
+
+  if (view === undefined) {
+    return c.json(
+      {
+        error: {
+          code: "NOT_FOUND",
+          message: `Claim '${claimId}' not found`,
+        },
+      },
+      404,
+    );
+  }
+
+  return c.json(view);
+});
+
+/** PATCH /api/claims/:id/status — Patch controller-owned claim status. */
+claims.patch(
+  "/:id/status",
+  requireControllerToken,
+  zValidator("json", statusBodySchema),
+  async (c) => {
+    const deps = c.get("deps");
+    const body = c.req.valid("json");
+    const patch: ClaimStatusPatch = {
+      phase: body.phase,
+      observedGeneration: body.observedGeneration,
+      agentSessionId: body.agentSessionId,
+      lastHeartbeatAt: body.lastHeartbeatAt,
+      leaseExpiresAt: body.leaseExpiresAt,
+      currentContributionCid: body.currentContributionCid,
+      conditions: body.conditions as ClaimStatusPatch["conditions"],
+      lastTransitionAt: body.lastTransitionAt,
+    };
+
+    const view = await deps.claimStore.patchClaimStatus(c.req.param("id"), patch);
+    return c.json(view);
+  },
+);
 
 /** PATCH /api/claims/:id — Heartbeat, release, or complete a claim. */
 claims.patch("/:id", zValidator("json", patchBodySchema), async (c) => {

--- a/src/server/routes/claims.ts
+++ b/src/server/routes/claims.ts
@@ -11,7 +11,7 @@ import type { Hono as HonoType, MiddlewareHandler } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import { DEFAULT_LEASE_MS } from "../../core/constants.js";
-import { claimToEntity } from "../../core/entity.js";
+import { claimToEntity, claimViewToEntity } from "../../core/entity.js";
 import type { AgentIdentity, Claim, ClaimSpecRecord, JsonValue } from "../../core/models.js";
 import { listClaimsOperation, releaseOperation } from "../../core/operations/index.js";
 import type { ClaimStatusPatch } from "../../core/store.js";
@@ -248,6 +248,27 @@ claims.put("/:id", zValidator("json", specBodySchema), async (c) => {
   };
 
   const view = await deps.claimStore.putClaimSpec(spec);
+  const namespace = c.get("namespace");
+  const entity = claimViewToEntity(view, () => Date.now(), namespace);
+  try {
+    deps.watchHub.recordWrite({
+      kind: "Claim",
+      namespace,
+      op: existing === undefined ? "ADDED" : "MODIFIED",
+      entity,
+    });
+    deps.watchSubscriber?.markSeen({
+      kind: "Claim",
+      entityId: view.spec.id,
+      generation: entity.metadata.generation,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[grove] Warning: watch fan-out threw after PUT /api/claims/${claimId}: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+  }
   return c.json(view, existing === undefined ? 201 : 200);
 });
 
@@ -291,6 +312,22 @@ claims.patch(
     };
 
     const view = await deps.claimStore.patchClaimStatus(c.req.param("id"), patch);
+    const namespace = c.get("namespace");
+    const entity = claimViewToEntity(view, () => Date.now(), namespace);
+    try {
+      deps.watchHub.recordWrite({ kind: "Claim", namespace, op: "MODIFIED", entity });
+      deps.watchSubscriber?.markSeen({
+        kind: "Claim",
+        entityId: view.spec.id,
+        generation: entity.metadata.generation,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `[grove] Warning: watch fan-out threw after PATCH /api/claims/${view.spec.id}/status: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+    }
     return c.json(view);
   },
 );

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -350,6 +350,7 @@ const deps: ServerDeps = {
   cas: serverCas,
   frontier: serverFrontier,
   gossip: gossipService,
+  controllerToken: process.env.GROVE_CONTROLLER_TOKEN,
   gossipHmacSecret: gossipHmacSecret,
   topology: runtime.contract?.topology,
   contract: runtime.contract,

--- a/src/server/test-helpers.test.ts
+++ b/src/server/test-helpers.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { ClaimStatus } from "../core/models.js";
+import { InMemoryClaimStore } from "./test-helpers.js";
+
+describe("InMemoryClaimStore split claim methods", () => {
+  test("putClaimSpec creates default status from spec lease deadline", async () => {
+    const store = new InMemoryClaimStore();
+
+    const view = await store.putClaimSpec({
+      id: "split-create",
+      targetRef: "target-split",
+      agent: { agentId: "agent-split" },
+      intentSummary: "create split claim",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      leaseDeadlineSec: 120,
+      generation: 99,
+    });
+
+    expect(view.spec.generation).toBe(1);
+    expect(view.status.phase).toBe(ClaimStatus.Active);
+    expect(view.status.observedGeneration).toBe(0);
+    expect(view.status.leaseExpiresAt).toBe("2026-01-01T00:02:00.000Z");
+    expect(view.status.conditions).toEqual([]);
+    expect(view.status.attemptCount).toBe(0);
+    expect(view.status.revision).toBe(1);
+  });
+
+  test("putClaimSpec update preserves original createdAt and current status", async () => {
+    const store = new InMemoryClaimStore();
+
+    const created = await store.putClaimSpec({
+      id: "split-update",
+      targetRef: "target-split",
+      agent: { agentId: "agent-split" },
+      intentSummary: "first intent",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      generation: 1,
+    });
+    const patched = await store.patchClaimStatus("split-update", {
+      phase: ClaimStatus.Completed,
+      observedGeneration: created.spec.generation,
+      lastHeartbeatAt: "2026-01-01T00:05:00.000Z",
+      leaseExpiresAt: "2026-01-01T00:10:00.000Z",
+      lastTransitionAt: "2026-01-01T00:05:00.000Z",
+    });
+
+    const updated = await store.putClaimSpec({
+      ...created.spec,
+      intentSummary: "second intent",
+      createdAt: "2026-02-01T00:00:00.000Z",
+      generation: 99,
+    });
+
+    expect(updated.spec.createdAt).toBe(created.spec.createdAt);
+    expect(updated.spec.generation).toBe(created.spec.generation + 1);
+    expect(updated.spec.intentSummary).toBe("second intent");
+    expect(updated.status).toEqual(patched.status);
+  });
+
+  test("patchClaimStatus merges split-only fields while preserving spec", async () => {
+    const store = new InMemoryClaimStore();
+    const created = await store.putClaimSpec({
+      id: "split-status",
+      targetRef: "target-split",
+      agent: { agentId: "agent-split" },
+      intentSummary: "status patch",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      generation: 1,
+    });
+
+    const patched = await store.patchClaimStatus("split-status", {
+      phase: ClaimStatus.Active,
+      observedGeneration: 7,
+      agentSessionId: "session-1",
+      lastHeartbeatAt: "2026-01-01T00:03:00.000Z",
+      leaseExpiresAt: "2026-01-01T00:08:00.000Z",
+      currentContributionCid:
+        "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      conditions: [
+        {
+          type: "Ready",
+          status: "True",
+          observedGeneration: 7,
+          lastTransitionTime: "2026-01-01T00:03:00.000Z",
+          reason: "Heartbeat",
+          message: "claim heartbeat observed",
+        },
+      ],
+      lastTransitionAt: "2026-01-01T00:03:00.000Z",
+    });
+    const current = await store.getClaimView("split-status");
+
+    expect(patched.spec).toEqual(created.spec);
+    expect(patched.status.revision).toBe(2);
+    expect(patched.status.observedGeneration).toBe(7);
+    expect(patched.status.agentSessionId).toBe("session-1");
+    expect(patched.status.currentContributionCid).toBe(
+      "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    expect(patched.status.conditions).toHaveLength(1);
+    expect(patched.status.lastTransitionAt).toBe("2026-01-01T00:03:00.000Z");
+    expect(current?.spec).toEqual(created.spec);
+    expect(current?.status).toEqual(patched.status);
+  });
+});

--- a/src/server/test-helpers.ts
+++ b/src/server/test-helpers.ts
@@ -13,14 +13,25 @@ import { NotFoundError, StateConflictError } from "../core/errors.js";
 import type { EventBus } from "../core/event-bus.js";
 import { DefaultFrontierCalculator } from "../core/frontier.js";
 import { LocalEventBus } from "../core/local-event-bus.js";
-import type { AgentIdentity, Artifact, Claim, ContributionInput } from "../core/models.js";
+import type {
+  AgentIdentity,
+  Artifact,
+  Claim,
+  ClaimSpecRecord,
+  ClaimStatusRecord,
+  ClaimView,
+  ContributionInput,
+} from "../core/models.js";
+import { claimToSpecRecord, claimToStatusRecord, claimViewToClaim } from "../core/models.js";
 import type {
   ActiveClaimFilter,
   ClaimQuery,
+  ClaimStatusPatch,
   ClaimStore,
   ExpiredClaim,
   ExpireStaleOptions,
 } from "../core/store.js";
+import { ExpiryReason } from "../core/store.js";
 import { InMemoryContributionStore } from "../core/testing.js";
 import { WatchHub, type WatchHubOptions } from "../core/watch-hub.js";
 import { NexusWatchSubscriber } from "../nexus/nexus-watch-subscriber.js";
@@ -100,38 +111,150 @@ export class InMemoryContentStore implements ContentStore {
 // ---------------------------------------------------------------------------
 
 export class InMemoryClaimStore implements ClaimStore {
-  private readonly claims = new Map<string, Claim>();
+  private readonly specs = new Map<string, ClaimSpecRecord>();
+  private readonly statuses = new Map<string, ClaimStatusRecord>();
+
+  private toClaim(view: ClaimView): Claim {
+    return claimViewToClaim(view);
+  }
+
+  private viewFor(claimId: string): ClaimView | undefined {
+    const spec = this.specs.get(claimId);
+    const status = this.statuses.get(claimId);
+    if (spec === undefined || status === undefined) return undefined;
+    return { spec, status };
+  }
+
+  private allViews(): ClaimView[] {
+    const views: ClaimView[] = [];
+    for (const claimId of this.specs.keys()) {
+      const view = this.viewFor(claimId);
+      if (view !== undefined) views.push(view);
+    }
+    return views;
+  }
+
+  private putView(view: ClaimView): void {
+    this.specs.set(view.spec.id, view.spec);
+    this.statuses.set(view.status.id, view.status);
+  }
+
+  async putClaimSpec(spec: ClaimSpecRecord): Promise<ClaimView> {
+    const existing = this.viewFor(spec.id);
+    if (existing !== undefined) {
+      const updated: ClaimView = {
+        spec: {
+          ...spec,
+          createdAt: existing.spec.createdAt,
+          generation: existing.spec.generation + 1,
+        },
+        status: existing.status,
+      };
+      this.putView(updated);
+      return updated;
+    }
+
+    const now = new Date().toISOString();
+    const createdAtMs = Date.parse(spec.createdAt);
+    const leaseBaseMs = Number.isFinite(createdAtMs) ? createdAtMs : Date.now();
+    const leaseDurationSec = spec.leaseDeadlineSec ?? 300;
+    const view: ClaimView = {
+      spec: { ...spec, generation: 1 },
+      status: {
+        id: spec.id,
+        phase: "active",
+        observedGeneration: 0,
+        lastHeartbeatAt: now,
+        leaseExpiresAt: new Date(leaseBaseMs + leaseDurationSec * 1000).toISOString(),
+        conditions: [],
+        lastTransitionAt: now,
+        attemptCount: 0,
+        revision: 1,
+      },
+    };
+    this.putView(view);
+    return view;
+  }
+
+  async getClaimView(claimId: string): Promise<ClaimView | undefined> {
+    return this.viewFor(claimId);
+  }
+
+  async patchClaimStatus(claimId: string, patch: ClaimStatusPatch): Promise<ClaimView> {
+    const view = this.viewFor(claimId);
+    if (view === undefined) {
+      throw new NotFoundError({
+        resource: "Claim",
+        identifier: claimId,
+        message: `Claim ${claimId} does not exist`,
+      });
+    }
+
+    const updated: ClaimView = {
+      spec: view.spec,
+      status: {
+        ...view.status,
+        phase: patch.phase ?? view.status.phase,
+        observedGeneration: patch.observedGeneration ?? view.status.observedGeneration,
+        agentSessionId: patch.agentSessionId ?? view.status.agentSessionId,
+        lastHeartbeatAt: patch.lastHeartbeatAt ?? view.status.lastHeartbeatAt,
+        leaseExpiresAt: patch.leaseExpiresAt ?? view.status.leaseExpiresAt,
+        currentContributionCid: patch.currentContributionCid ?? view.status.currentContributionCid,
+        conditions: patch.conditions ?? view.status.conditions,
+        lastTransitionAt: patch.lastTransitionAt ?? view.status.lastTransitionAt,
+        revision: view.status.revision + 1,
+      },
+    };
+    this.putView(updated);
+    return updated;
+  }
 
   async createClaim(claim: Claim): Promise<Claim> {
-    if (this.claims.has(claim.claimId)) {
+    if (this.specs.has(claim.claimId)) {
       throw new StateConflictError({
         resource: "Claim",
         reason: "already exists",
         message: `Claim ${claim.claimId} already exists`,
       });
     }
-    this.claims.set(claim.claimId, claim);
-    return claim;
+    const claimWithRevision: Claim = { ...claim, revision: 1 };
+    const view: ClaimView = {
+      spec: { ...claimToSpecRecord(claimWithRevision), generation: 1 },
+      status: {
+        ...claimToStatusRecord(claimWithRevision),
+        observedGeneration: 0,
+        revision: 1,
+      },
+    };
+    this.putView(view);
+    return this.toClaim(view);
   }
 
   async claimOrRenew(claim: Claim): Promise<Claim> {
     // Check if same agent already has an active claim on this target
-    for (const existing of this.claims.values()) {
+    for (const existingView of this.allViews()) {
+      const existing = this.toClaim(existingView);
       if (existing.targetRef === claim.targetRef && existing.status === "active") {
         if (existing.agent.agentId === claim.agent.agentId) {
           // Renew: update lease and bump revision (matches the conformance
           // contract — SQLite + Nexus stores both increment revision on
           // every renewal, and watch fan-out depends on it to distinguish
           // create from renew).
-          const renewed: Claim = {
-            ...existing,
-            heartbeatAt: claim.heartbeatAt,
-            leaseExpiresAt: claim.leaseExpiresAt,
-            intentSummary: claim.intentSummary,
-            revision: (existing.revision ?? 1) + 1,
+          const renewedView: ClaimView = {
+            spec: {
+              ...existingView.spec,
+              intentSummary: claim.intentSummary,
+              generation: existingView.spec.generation + 1,
+            },
+            status: {
+              ...existingView.status,
+              lastHeartbeatAt: claim.heartbeatAt,
+              leaseExpiresAt: claim.leaseExpiresAt,
+              revision: existingView.status.revision + 1,
+            },
           };
-          this.claims.set(existing.claimId, renewed);
-          return renewed;
+          this.putView(renewedView);
+          return this.toClaim(renewedView);
         }
         throw new StateConflictError({
           resource: "Claim",
@@ -141,23 +264,36 @@ export class InMemoryClaimStore implements ClaimStore {
       }
     }
     const created: Claim = { ...claim, revision: 1 };
-    this.claims.set(claim.claimId, created);
-    return created;
+    this.putView({
+      spec: { ...claimToSpecRecord(created), generation: 1 },
+      status: {
+        ...claimToStatusRecord(created),
+        observedGeneration: 0,
+        revision: 1,
+      },
+    });
+    const view = this.viewFor(claim.claimId);
+    if (view === undefined) {
+      throw new Error(`Failed to create claim ${claim.claimId}`);
+    }
+    return this.toClaim(view);
   }
 
   async getClaim(claimId: string): Promise<Claim | undefined> {
-    return this.claims.get(claimId);
+    const view = this.viewFor(claimId);
+    return view === undefined ? undefined : this.toClaim(view);
   }
 
   async heartbeat(claimId: string, leaseDurationMs?: number): Promise<Claim> {
-    const claim = this.claims.get(claimId);
-    if (!claim) {
+    const view = this.viewFor(claimId);
+    if (view === undefined) {
       throw new NotFoundError({
         resource: "Claim",
         identifier: claimId,
         message: `Claim ${claimId} does not exist`,
       });
     }
+    const claim = this.toClaim(view);
     if (claim.status !== "active") {
       throw new StateConflictError({
         resource: "Claim",
@@ -166,25 +302,29 @@ export class InMemoryClaimStore implements ClaimStore {
       });
     }
     const now = new Date();
-    const updated: Claim = {
-      ...claim,
-      heartbeatAt: now.toISOString(),
-      leaseExpiresAt: new Date(now.getTime() + (leaseDurationMs ?? 300_000)).toISOString(),
-      revision: (claim.revision ?? 1) + 1,
+    const updated: ClaimView = {
+      spec: view.spec,
+      status: {
+        ...view.status,
+        lastHeartbeatAt: now.toISOString(),
+        leaseExpiresAt: new Date(now.getTime() + (leaseDurationMs ?? 300_000)).toISOString(),
+        revision: view.status.revision + 1,
+      },
     };
-    this.claims.set(claimId, updated);
-    return updated;
+    this.putView(updated);
+    return this.toClaim(updated);
   }
 
   async release(claimId: string): Promise<Claim> {
-    const claim = this.claims.get(claimId);
-    if (!claim) {
+    const view = this.viewFor(claimId);
+    if (view === undefined) {
       throw new NotFoundError({
         resource: "Claim",
         identifier: claimId,
         message: `Claim ${claimId} does not exist`,
       });
     }
+    const claim = this.toClaim(view);
     if (claim.status !== "active") {
       throw new StateConflictError({
         resource: "Claim",
@@ -192,20 +332,30 @@ export class InMemoryClaimStore implements ClaimStore {
         message: `Claim ${claimId} is not active`,
       });
     }
-    const updated: Claim = { ...claim, status: "released" };
-    this.claims.set(claimId, updated);
-    return updated;
+    const now = new Date().toISOString();
+    const updated: ClaimView = {
+      spec: view.spec,
+      status: {
+        ...view.status,
+        phase: "released",
+        lastTransitionAt: now,
+        revision: view.status.revision + 1,
+      },
+    };
+    this.putView(updated);
+    return this.toClaim(updated);
   }
 
   async complete(claimId: string): Promise<Claim> {
-    const claim = this.claims.get(claimId);
-    if (!claim) {
+    const view = this.viewFor(claimId);
+    if (view === undefined) {
       throw new NotFoundError({
         resource: "Claim",
         identifier: claimId,
         message: `Claim ${claimId} does not exist`,
       });
     }
+    const claim = this.toClaim(view);
     if (claim.status !== "active") {
       throw new StateConflictError({
         resource: "Claim",
@@ -213,32 +363,71 @@ export class InMemoryClaimStore implements ClaimStore {
         message: `Claim ${claimId} is not active`,
       });
     }
-    const updated: Claim = { ...claim, status: "completed" };
-    this.claims.set(claimId, updated);
-    return updated;
+    const now = new Date().toISOString();
+    const updated: ClaimView = {
+      spec: view.spec,
+      status: {
+        ...view.status,
+        phase: "completed",
+        lastTransitionAt: now,
+        revision: view.status.revision + 1,
+      },
+    };
+    this.putView(updated);
+    return this.toClaim(updated);
   }
 
-  async expireStale(_options?: ExpireStaleOptions): Promise<readonly ExpiredClaim[]> {
+  async expireStale(options?: ExpireStaleOptions): Promise<readonly ExpiredClaim[]> {
     const now = Date.now();
     const expired: ExpiredClaim[] = [];
-    for (const claim of this.claims.values()) {
+    for (const view of this.allViews()) {
+      const claim = this.toClaim(view);
       if (claim.status === "active" && Date.parse(claim.leaseExpiresAt) < now) {
-        const updated: Claim = { ...claim, status: "expired" };
-        this.claims.set(claim.claimId, updated);
-        expired.push({ claim: updated, reason: "lease_expired" });
+        const updated: ClaimView = {
+          spec: view.spec,
+          status: {
+            ...view.status,
+            phase: "expired",
+            lastTransitionAt: new Date().toISOString(),
+            revision: view.status.revision + 1,
+          },
+        };
+        this.putView(updated);
+        expired.push({ claim: this.toClaim(updated), reason: ExpiryReason.LeaseExpired });
+      }
+    }
+    if (options?.stallThresholdMs !== undefined) {
+      const stallCutoff = now - options.stallThresholdMs;
+      for (const view of this.allViews()) {
+        const claim = this.toClaim(view);
+        if (claim.status === "active" && Date.parse(claim.heartbeatAt) < stallCutoff) {
+          const updated: ClaimView = {
+            spec: view.spec,
+            status: {
+              ...view.status,
+              phase: "expired",
+              lastTransitionAt: new Date().toISOString(),
+              revision: view.status.revision + 1,
+            },
+          };
+          this.putView(updated);
+          expired.push({ claim: this.toClaim(updated), reason: ExpiryReason.Stalled });
+        }
       }
     }
     return expired;
   }
 
   async activeClaims(targetRef?: string): Promise<readonly Claim[]> {
-    const active = [...this.claims.values()].filter((c) => c.status === "active");
+    const active = this.allViews()
+      .map((view) => this.toClaim(view))
+      .filter((c) => c.status === "active");
     if (targetRef) return active.filter((c) => c.targetRef === targetRef);
     return active;
   }
 
   async listClaims(query?: ClaimQuery): Promise<readonly Claim[]> {
-    let results = [...this.claims.values()];
+    let results = this.allViews().map((view) => this.toClaim(view));
     if (query?.status) {
       const statuses = Array.isArray(query.status) ? query.status : [query.status];
       results = results.filter((c) => statuses.includes(c.status));
@@ -257,18 +446,28 @@ export class InMemoryClaimStore implements ClaimStore {
   }
 
   async countActiveClaims(filter?: ActiveClaimFilter): Promise<number> {
-    let active = [...this.claims.values()].filter((c) => c.status === "active");
+    let active = this.allViews()
+      .map((view) => this.toClaim(view))
+      .filter((c) => c.status === "active");
     if (filter?.agentId) active = active.filter((c) => c.agent.agentId === filter.agentId);
     if (filter?.targetRef) active = active.filter((c) => c.targetRef === filter.targetRef);
     return active.length;
   }
 
-  async detectStalled(_stallTimeoutMs: number): Promise<readonly Claim[]> {
-    return [];
+  async detectStalled(stallTimeoutMs: number): Promise<readonly Claim[]> {
+    const now = Date.now();
+    return this.allViews()
+      .map((view) => this.toClaim(view))
+      .filter(
+        (c) =>
+          c.status === "active" &&
+          Date.parse(c.leaseExpiresAt) >= now &&
+          Date.parse(c.heartbeatAt) < now - stallTimeoutMs,
+      );
   }
 
   async listEntities(query?: ClaimQuery): Promise<readonly ClaimEntity[]> {
-    let results = [...this.claims.values()];
+    let results = this.allViews().map((view) => this.toClaim(view));
     if (query?.agentId) results = results.filter((c) => c.agent.agentId === query.agentId);
     if (query?.targetRef) results = results.filter((c) => c.targetRef === query.targetRef);
     // Filter on effective (lease-aware) phase after projection.

--- a/src/tui/provider-shared.test.ts
+++ b/src/tui/provider-shared.test.ts
@@ -71,6 +71,13 @@ function makeMockContributionStore(contributions: Contribution[] = []): Contribu
 function makeMockClaimStore(): ClaimStore {
   return {
     storeIdentity: "mock-claims",
+    putClaimSpec: async () => {
+      throw new Error("putClaimSpec not implemented by test mock");
+    },
+    getClaimView: async () => undefined,
+    patchClaimStatus: async () => {
+      throw new Error("patchClaimStatus not implemented by test mock");
+    },
     createClaim: async (claim) => claim,
     claimOrRenew: async (claim) => claim,
     getClaim: async () => undefined,

--- a/src/tui/spawn-manager.test.ts
+++ b/src/tui/spawn-manager.test.ts
@@ -544,6 +544,71 @@ describe("SpawnManager — per-role skill injection", () => {
     );
   });
 
+  test("spawn writes Codex home MCP config when opt-in flag is set", async () => {
+    const { execSync } = await import("node:child_process");
+    const { mkdirSync, mkdtempSync, readFileSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const previousCodexHome = process.env.CODEX_HOME;
+    const previousCodexWriteMcpConfig = process.env.GROVE_CODEX_WRITE_MCP_CONFIG;
+    const previousNexusUrl = process.env.GROVE_NEXUS_URL;
+    const previousNexusApiKey = process.env.NEXUS_API_KEY;
+
+    try {
+      const projectRoot = mkdtempSync(join(tmpdir(), "grove-codex-home-e2e-"));
+      execSync("git init -q", { cwd: projectRoot });
+      execSync("git config user.email test@grove.test", { cwd: projectRoot });
+      execSync("git config user.name Grove-Test", { cwd: projectRoot });
+      execSync("git commit --allow-empty -q -m init", { cwd: projectRoot });
+
+      const groveDir = join(projectRoot, ".grove");
+      mkdirSync(groveDir, { recursive: true });
+
+      const codexHome = mkdtempSync(join(tmpdir(), "grove-codex-home-"));
+      writeFileSync(join(codexHome, "config.toml"), 'model = "gpt-5.4-mini"\n', "utf-8");
+      process.env.CODEX_HOME = codexHome;
+      process.env.GROVE_CODEX_WRITE_MCP_CONFIG = "1";
+      process.env.GROVE_NEXUS_URL = "http://localhost:4515";
+      process.env.NEXUS_API_KEY = "grv_test_key";
+
+      const provider = makeMockProvider();
+      const tmux = makeMockTmux();
+      manager = new SpawnManager(
+        provider,
+        tmux,
+        () => {
+          /* ignore */
+        },
+        [{ kind: "local" as const, path: projectRoot }],
+        undefined,
+        groveDir,
+      );
+      manager.setIsolationPolicy("strict");
+
+      await manager.spawn("coder", "bash");
+
+      const config = readFileSync(join(codexHome, "config.toml"), "utf-8");
+      expect(config).toContain('model = "gpt-5.4-mini"');
+      expect(config).toContain("# BEGIN GROVE GENERATED MCP");
+      expect(config).toContain("[mcp_servers.grove]");
+      expect(config).toContain('NEXUS_API_KEY = "grv_test_key"');
+      expect(config).toContain('GROVE_NEXUS_URL = "http://localhost:4515"');
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+      if (previousCodexWriteMcpConfig === undefined) {
+        delete process.env.GROVE_CODEX_WRITE_MCP_CONFIG;
+      } else {
+        process.env.GROVE_CODEX_WRITE_MCP_CONFIG = previousCodexWriteMcpConfig;
+      }
+      if (previousNexusUrl === undefined) delete process.env.GROVE_NEXUS_URL;
+      else process.env.GROVE_NEXUS_URL = previousNexusUrl;
+      if (previousNexusApiKey === undefined) delete process.env.NEXUS_API_KEY;
+      else process.env.NEXUS_API_KEY = previousNexusApiKey;
+    }
+  });
+
   test("two roles in the same session each get their own skill-injected workspace", async () => {
     const { execSync } = await import("node:child_process");
     const { existsSync, mkdirSync, mkdtempSync } = await import("node:fs");

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -9,7 +9,7 @@
 
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { appendFile, chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 
 import { watchTurnError } from "../acp/watch-turn.js";
@@ -38,6 +38,58 @@ import { debugLog } from "./debug-log.js";
 import type { NexusWsBridge } from "./nexus-ws-bridge.js";
 import type { TuiDataProvider } from "./provider.js";
 import type { PersistedSpawnRecord, SessionStore } from "./session-store.js";
+
+const CODEX_GENERATED_MCP_START = "# BEGIN GROVE GENERATED MCP";
+const CODEX_GENERATED_MCP_END = "# END GROVE GENERATED MCP";
+const SAFE_TOML_BARE_KEY = /^[A-Za-z0-9_-]+$/;
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function tomlStringArray(values: readonly string[]): string {
+  return `[${values.map(tomlString).join(", ")}]`;
+}
+
+function tomlKeySegment(segment: string): string {
+  return SAFE_TOML_BARE_KEY.test(segment) ? segment : tomlString(segment);
+}
+
+function stripGeneratedCodexMcpBlock(contents: string): string {
+  const start = contents.indexOf(CODEX_GENERATED_MCP_START);
+  if (start === -1) return contents.trimEnd();
+  const end = contents.indexOf(CODEX_GENERATED_MCP_END, start);
+  if (end === -1) return contents.slice(0, start).trimEnd();
+  return `${contents.slice(0, start)}${contents.slice(end + CODEX_GENERATED_MCP_END.length)}`.trimEnd();
+}
+
+function buildCodexMcpConfigBlock(server: {
+  readonly name: string;
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly env: Readonly<Record<string, string>>;
+}): string {
+  const serverKey = `mcp_servers.${tomlKeySegment(server.name)}`;
+  const lines = [
+    CODEX_GENERATED_MCP_START,
+    `[${serverKey}]`,
+    `command = ${tomlString(server.command)}`,
+    `args = ${tomlStringArray(server.args)}`,
+    "",
+    `[${serverKey}.env]`,
+  ];
+  for (const [name, value] of Object.entries(server.env)) {
+    lines.push(`${tomlKeySegment(name)} = ${tomlString(value)}`);
+  }
+  lines.push(CODEX_GENERATED_MCP_END, "");
+  return lines.join("\n");
+}
+
+function isNotFoundError(err: unknown): boolean {
+  return (
+    err instanceof Error && "code" in err && (err as { readonly code?: unknown }).code === "ENOENT"
+  );
+}
 
 /** PR context injected as env vars when spawning agents. */
 export interface PrContext {
@@ -617,7 +669,6 @@ export class SpawnManager {
           });
         }
         // Protect config files from agent mutation (#7 Workspace Mutation Constraints)
-        const { chmod } = await import("node:fs/promises");
         for (const protectedFile of [
           ".mcp.json",
           ".acpxrc.json",
@@ -1446,6 +1497,9 @@ export class SpawnManager {
       args: ["run", mcpServePath],
       env: { ...mcpEnv },
     };
+    if (process.env.GROVE_CODEX_WRITE_MCP_CONFIG === "1") {
+      await this.writeCodexMcpHomeConfig(this.groveMcpServer);
+    }
 
     const mcpConfig = {
       mcpServers: {
@@ -1485,6 +1539,40 @@ export class SpawnManager {
       "utf-8",
     );
     debugLog("mcpConfig", `wrote .acpxrc.json for acpx mcpServers forwarding`);
+  }
+
+  private async writeCodexMcpHomeConfig(server: {
+    readonly name: string;
+    readonly command: string;
+    readonly args: readonly string[];
+    readonly env: Readonly<Record<string, string>>;
+  }): Promise<void> {
+    const codexHome = process.env.CODEX_HOME?.trim();
+    if (!codexHome) {
+      debugLog("mcpConfig", "GROVE_CODEX_WRITE_MCP_CONFIG set but CODEX_HOME is empty");
+      return;
+    }
+
+    await mkdir(codexHome, { recursive: true });
+    const configPath = join(codexHome, "config.toml");
+    let existing = "";
+    try {
+      existing = await readFile(configPath, "utf-8");
+    } catch (err) {
+      if (!isNotFoundError(err)) throw err;
+    }
+
+    const stripped = stripGeneratedCodexMcpBlock(existing);
+    const block = buildCodexMcpConfigBlock(server);
+    const next = `${stripped}${stripped.length > 0 ? "\n\n" : ""}${block}`;
+    await writeFile(configPath, next, "utf-8");
+    await chmod(configPath, 0o600).catch(() => {
+      /* best-effort */
+    });
+    debugLog(
+      "mcpConfig",
+      `wrote CODEX_HOME config.toml MCP block: path=${configPath} hasNexusUrl=${!!server.env.GROVE_NEXUS_URL} hasApiKey=${!!server.env.NEXUS_API_KEY}`,
+    );
   }
 
   private async hideBootstrapFilesFromGit(workspacePath: string): Promise<void> {

--- a/tests/nexus/unit/nexus-claim-store.test.ts
+++ b/tests/nexus/unit/nexus-claim-store.test.ts
@@ -9,6 +9,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { runClaimStoreTests } from "../../../src/core/claim-store.conformance.js";
+import { StateConflictError } from "../../../src/core/errors.js";
 import { makeAgent, makeClaim } from "../../../src/core/test-helpers.js";
 import type { ReadResult, WriteOptions, WriteResult } from "../../../src/nexus/client.js";
 import { MockNexusClient } from "../../../src/nexus/mock-client.js";
@@ -197,6 +198,47 @@ describe("NexusClaimStore adapter-specific", () => {
     expect(patched.spec.generation).toBe(created.spec.generation);
     expect(patched.status.phase).toBe("completed");
     expect(patched.status.revision).toBe(created.status.revision + 1);
+  });
+
+  test("patchClaimStatus maps active target conflicts to StateConflictError", async () => {
+    const now = Date.now();
+    const oldCreatedAt = new Date(now).toISOString();
+    const oldReleasedAt = new Date(now + 1_000).toISOString();
+    const newCreatedAt = new Date(now + 2_000).toISOString();
+    const oldReactivatedAt = new Date(now + 3_000).toISOString();
+    const activeLeaseExpiresAt = new Date(now + 600_000).toISOString();
+
+    await store.putClaimSpec({
+      id: "nexus-activation-old",
+      targetRef: "target-nexus-activation",
+      agent: makeAgent({ agentId: "agent-nexus-activation-old" }),
+      intentSummary: "old activation candidate",
+      createdAt: oldCreatedAt,
+      generation: 1,
+    });
+    await store.patchClaimStatus("nexus-activation-old", {
+      phase: "released",
+      lastHeartbeatAt: oldReleasedAt,
+      lastTransitionAt: oldReleasedAt,
+    });
+
+    await store.putClaimSpec({
+      id: "nexus-activation-new",
+      targetRef: "target-nexus-activation",
+      agent: makeAgent({ agentId: "agent-nexus-activation-new" }),
+      intentSummary: "new active holder",
+      createdAt: newCreatedAt,
+      generation: 1,
+    });
+
+    await expect(
+      store.patchClaimStatus("nexus-activation-old", {
+        phase: "active",
+        lastHeartbeatAt: oldReactivatedAt,
+        leaseExpiresAt: activeLeaseExpiresAt,
+        lastTransitionAt: oldReactivatedAt,
+      }),
+    ).rejects.toThrow(StateConflictError);
   });
 
   test("legacy heartbeat and release preserve split-only status fields", async () => {

--- a/tests/nexus/unit/nexus-claim-store.test.ts
+++ b/tests/nexus/unit/nexus-claim-store.test.ts
@@ -9,9 +9,28 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { runClaimStoreTests } from "../../../src/core/claim-store.conformance.js";
-import { makeClaim } from "../../../src/core/test-helpers.js";
+import { makeAgent, makeClaim } from "../../../src/core/test-helpers.js";
+import type { ReadResult, WriteOptions, WriteResult } from "../../../src/nexus/client.js";
 import { MockNexusClient } from "../../../src/nexus/mock-client.js";
 import { NexusClaimStore } from "../../../src/nexus/nexus-claim-store.js";
+import { activeClaimIndexPath, claimPath, targetLockPath } from "../../../src/nexus/vfs-paths.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function encodeJson(value: unknown): Uint8Array {
+  return encoder.encode(JSON.stringify(value));
+}
+
+function decodeJson(data: Uint8Array): Record<string, unknown> {
+  return JSON.parse(decoder.decode(data)) as Record<string, unknown>;
+}
+
+async function readJson(client: MockNexusClient, path: string): Promise<Record<string, unknown>> {
+  const data = await client.read(path);
+  if (data === undefined) throw new Error(`Missing test fixture file: ${path}`);
+  return decodeJson(data);
+}
 
 // ---------------------------------------------------------------------------
 // Conformance tests
@@ -154,6 +173,368 @@ describe("NexusClaimStore adapter-specific", () => {
 
     const released = await store.release("rev-track");
     expect(released.revision).toBe(3);
+  });
+
+  test("patchClaimStatus preserves spec fields in Nexus compatibility storage", async () => {
+    const created = await store.putClaimSpec({
+      id: "nexus-split",
+      roleName: "coder",
+      platform: "codex",
+      targetRef: "target-nexus-split",
+      agent: { agentId: "agent-nexus", role: "coder", platform: "codex" },
+      intentSummary: "nexus split",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      generation: 1,
+    });
+
+    const patched = await store.patchClaimStatus("nexus-split", {
+      phase: "completed",
+      observedGeneration: created.spec.generation,
+      lastHeartbeatAt: "2026-01-01T00:05:00.000Z",
+    });
+
+    expect(patched.spec.intentSummary).toBe("nexus split");
+    expect(patched.spec.generation).toBe(created.spec.generation);
+    expect(patched.status.phase).toBe("completed");
+    expect(patched.status.revision).toBe(created.status.revision + 1);
+  });
+
+  test("legacy heartbeat and release preserve split-only status fields", async () => {
+    const created = await store.putClaimSpec({
+      id: "split-status-preserve",
+      targetRef: "target-split-status-preserve",
+      agent: makeAgent({ agentId: "agent-split-status-preserve" }),
+      intentSummary: "preserve split-only status fields",
+      createdAt: new Date().toISOString(),
+      generation: 1,
+    });
+    await store.patchClaimStatus("split-status-preserve", {
+      observedGeneration: created.spec.generation,
+      agentSessionId: "session-preserved",
+      currentContributionCid:
+        "blake3:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      conditions: [
+        {
+          type: "Accepted",
+          status: "True",
+          observedGeneration: created.spec.generation,
+          lastTransitionTime: "2026-01-01T00:01:00.000Z",
+          reason: "controller",
+          message: "accepted",
+        },
+      ],
+      lastTransitionAt: "2026-01-01T00:01:00.000Z",
+    });
+
+    await store.heartbeat("split-status-preserve");
+    const afterHeartbeat = await store.getClaimView("split-status-preserve");
+    expect(afterHeartbeat?.status.agentSessionId).toBe("session-preserved");
+    expect(afterHeartbeat?.status.currentContributionCid).toBe(
+      "blake3:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
+    expect(afterHeartbeat?.status.conditions[0]?.type).toBe("Accepted");
+    expect(afterHeartbeat?.status.lastTransitionAt).toBe("2026-01-01T00:01:00.000Z");
+    expect(afterHeartbeat?.status.observedGeneration).toBe(created.spec.generation);
+
+    await store.release("split-status-preserve");
+    const afterRelease = await store.getClaimView("split-status-preserve");
+    expect(afterRelease?.status.agentSessionId).toBe("session-preserved");
+    expect(afterRelease?.status.currentContributionCid).toBe(
+      "blake3:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
+    expect(afterRelease?.status.conditions[0]?.type).toBe("Accepted");
+    expect(afterRelease?.status.lastTransitionAt).toBe("2026-01-01T00:01:00.000Z");
+    expect(afterRelease?.status.observedGeneration).toBe(created.spec.generation);
+  });
+
+  test("moved active claim leaves old target reusable and absent from old active scan", async () => {
+    await store.putClaimSpec({
+      id: "moved-active",
+      targetRef: "target-before-move",
+      agent: makeAgent({ agentId: "agent-moved-active" }),
+      intentSummary: "before move",
+      createdAt: new Date().toISOString(),
+      generation: 1,
+    });
+    await store.getClaim("moved-active");
+
+    const path = claimPath("test-zone", "moved-active");
+    const document = await readJson(client, path);
+    const spec = document.spec as Record<string, unknown>;
+    await client.write(
+      path,
+      encodeJson({ ...document, spec: { ...spec, targetRef: "target-after-move" } }),
+    );
+
+    const oldTargetClaims = await store.activeClaims("target-before-move");
+    expect(oldTargetClaims.map((claim) => claim.claimId)).not.toContain("moved-active");
+
+    const replacement = await store.putClaimSpec({
+      id: "old-target-replacement",
+      targetRef: "target-before-move",
+      agent: makeAgent({ agentId: "agent-old-target-replacement" }),
+      intentSummary: "replacement",
+      createdAt: new Date().toISOString(),
+      generation: 1,
+    });
+    expect(replacement.spec.id).toBe("old-target-replacement");
+  });
+
+  test("putClaimSpec active move releases the old target and reports only the new target", async () => {
+    const created = await store.putClaimSpec({
+      id: "normal-active-move",
+      targetRef: "target-normal-move-old",
+      agent: makeAgent({ agentId: "agent-normal-active-move" }),
+      intentSummary: "before normal move",
+      createdAt: new Date().toISOString(),
+      generation: 1,
+    });
+
+    const moved = await store.putClaimSpec({
+      ...created.spec,
+      targetRef: "target-normal-move-new",
+      intentSummary: "after normal move",
+    });
+
+    const oldTargetClaims = await store.activeClaims("target-normal-move-old");
+    const newTargetClaims = await store.activeClaims("target-normal-move-new");
+    expect(oldTargetClaims.map((claim) => claim.claimId)).not.toContain("normal-active-move");
+    expect(newTargetClaims.map((claim) => claim.claimId)).toContain("normal-active-move");
+
+    const oldReplacement = await store.putClaimSpec({
+      id: "normal-move-old-replacement",
+      targetRef: "target-normal-move-old",
+      agent: makeAgent({ agentId: "agent-normal-move-old-replacement" }),
+      intentSummary: "old target replacement",
+      createdAt: new Date().toISOString(),
+      generation: 1,
+    });
+    expect(moved.spec.targetRef).toBe("target-normal-move-new");
+    expect(oldReplacement.spec.id).toBe("normal-move-old-replacement");
+  });
+
+  test("claimOrRenew active conflict check bypasses stale flat cache entries", async () => {
+    const cached = await store.createClaim(
+      makeClaim({
+        claimId: "cached-active",
+        targetRef: "target-cache-bypass",
+        agent: makeAgent({ agentId: "agent-cached-active" }),
+      }),
+    );
+    await store.getClaim(cached.claimId);
+
+    const path = claimPath("test-zone", "cached-active");
+    const document = await readJson(client, path);
+    const status = document.status as Record<string, unknown>;
+    await client.write(path, encodeJson({ ...document, status: { ...status, phase: "released" } }));
+
+    const created = await store.claimOrRenew(
+      makeClaim({
+        claimId: "fresh-after-cache",
+        targetRef: "target-cache-bypass",
+        agent: makeAgent({ agentId: "agent-fresh-after-cache" }),
+      }),
+    );
+
+    expect(created.claimId).toBe("fresh-after-cache");
+  });
+
+  test("rollback after active-index conflict does not delete a claim file with a newer etag", async () => {
+    class ConcurrentRollbackClient extends MockNexusClient {
+      async write(path: string, content: Uint8Array, opts?: WriteOptions): Promise<WriteResult> {
+        try {
+          return await super.write(path, content, opts);
+        } catch (err) {
+          if (
+            path === targetLockPath("rollback-zone", "rollback-target") &&
+            opts?.ifNoneMatch === "*"
+          ) {
+            await super.write(
+              claimPath("rollback-zone", "rollback-race"),
+              encodeJson({
+                spec: {
+                  id: "rollback-race",
+                  targetRef: "rollback-target",
+                  agent: makeAgent({ agentId: "agent-concurrent" }),
+                  intentSummary: "concurrent survivor",
+                  createdAt: "2026-01-01T00:00:00.000Z",
+                  generation: 2,
+                },
+                status: {
+                  id: "rollback-race",
+                  phase: "active",
+                  observedGeneration: 1,
+                  lastHeartbeatAt: "2026-01-01T00:00:00.000Z",
+                  leaseExpiresAt: "2026-01-01T00:10:00.000Z",
+                  conditions: [],
+                  lastTransitionAt: "2026-01-01T00:00:00.000Z",
+                  attemptCount: 0,
+                  revision: 2,
+                },
+              }),
+            );
+          }
+          throw err;
+        }
+      }
+    }
+
+    const rollbackClient = new ConcurrentRollbackClient();
+    const rollbackStore = new NexusClaimStore({
+      client: rollbackClient,
+      zoneId: "rollback-zone",
+      retryMaxAttempts: 1,
+    });
+    try {
+      await rollbackStore.createClaim(
+        makeClaim({
+          claimId: "rollback-holder",
+          targetRef: "rollback-target",
+          agent: makeAgent({ agentId: "agent-rollback-holder" }),
+        }),
+      );
+
+      await expect(
+        rollbackStore.createClaim(
+          makeClaim({
+            claimId: "rollback-race",
+            targetRef: "rollback-target",
+            agent: makeAgent({ agentId: "agent-rollback-race" }),
+          }),
+        ),
+      ).rejects.toThrow(/active claim/);
+
+      const survivor = await rollbackStore.getClaimView("rollback-race");
+      expect(survivor?.spec.intentSummary).toBe("concurrent survivor");
+      expect(survivor?.spec.generation).toBe(2);
+    } finally {
+      rollbackStore.close();
+      await rollbackClient.close();
+    }
+  });
+
+  test("rollback ownership read failure preserves acquired active target state", async () => {
+    class FailingRollbackReadClient extends MockNexusClient {
+      private raceNextMoveCas = true;
+      private failNextOwnershipRead = false;
+
+      async write(path: string, content: Uint8Array, opts?: WriteOptions): Promise<WriteResult> {
+        if (
+          path === claimPath("rollback-read-fail-zone", "rollback-read-fail") &&
+          opts?.ifMatch !== undefined &&
+          this.raceNextMoveCas
+        ) {
+          this.raceNextMoveCas = false;
+          this.failNextOwnershipRead = true;
+          await super.write(path, content);
+        }
+        return super.write(path, content, opts);
+      }
+
+      async readWithMeta(path: string): Promise<ReadResult | undefined> {
+        if (
+          path === claimPath("rollback-read-fail-zone", "rollback-read-fail") &&
+          this.failNextOwnershipRead
+        ) {
+          this.failNextOwnershipRead = false;
+          throw new Error("forced ownership read failure");
+        }
+        return super.readWithMeta(path);
+      }
+    }
+
+    const rollbackClient = new FailingRollbackReadClient();
+    const rollbackStore = new NexusClaimStore({
+      client: rollbackClient,
+      zoneId: "rollback-read-fail-zone",
+      retryMaxAttempts: 1,
+    });
+    try {
+      const created = await rollbackStore.putClaimSpec({
+        id: "rollback-read-fail",
+        targetRef: "rollback-read-fail-old",
+        agent: makeAgent({ agentId: "agent-rollback-read-fail" }),
+        intentSummary: "before rollback read failure",
+        createdAt: new Date().toISOString(),
+        generation: 1,
+      });
+
+      await expect(
+        rollbackStore.putClaimSpec({
+          ...created.spec,
+          targetRef: "rollback-read-fail-new",
+          intentSummary: "winning move before read failure",
+        }),
+      ).rejects.toThrow();
+
+      const lock = await rollbackClient.read(
+        targetLockPath("rollback-read-fail-zone", "rollback-read-fail-new"),
+      );
+      expect(lock === undefined ? undefined : decoder.decode(lock)).toBe("rollback-read-fail");
+      await expect(
+        rollbackClient.exists(
+          activeClaimIndexPath(
+            "rollback-read-fail-zone",
+            "rollback-read-fail-new",
+            "rollback-read-fail",
+          ),
+        ),
+      ).resolves.toBe(true);
+    } finally {
+      rollbackStore.close();
+      await rollbackClient.close();
+    }
+  });
+
+  test("CAS-failed active move rollback preserves the winning same-claim activation", async () => {
+    class ConcurrentMoveWinnerClient extends MockNexusClient {
+      private raceNextMoveCas = true;
+
+      async write(path: string, content: Uint8Array, opts?: WriteOptions): Promise<WriteResult> {
+        if (
+          path === claimPath("move-race-zone", "move-race") &&
+          opts?.ifMatch !== undefined &&
+          this.raceNextMoveCas
+        ) {
+          this.raceNextMoveCas = false;
+          await super.write(path, content);
+        }
+        return super.write(path, content, opts);
+      }
+    }
+
+    const moveClient = new ConcurrentMoveWinnerClient();
+    const moveStore = new NexusClaimStore({
+      client: moveClient,
+      zoneId: "move-race-zone",
+      retryMaxAttempts: 1,
+    });
+    try {
+      const created = await moveStore.putClaimSpec({
+        id: "move-race",
+        targetRef: "move-race-old",
+        agent: makeAgent({ agentId: "agent-move-race" }),
+        intentSummary: "before race",
+        createdAt: new Date().toISOString(),
+        generation: 1,
+      });
+
+      await expect(
+        moveStore.putClaimSpec({
+          ...created.spec,
+          targetRef: "move-race-new",
+          intentSummary: "winning move",
+        }),
+      ).rejects.toThrow();
+
+      const moved = await moveStore.getClaimView("move-race");
+      const newTargetClaims = await moveStore.activeClaims("move-race-new");
+      expect(moved?.spec.targetRef).toBe("move-race-new");
+      expect(newTargetClaims.map((claim) => claim.claimId)).toContain("move-race");
+    } finally {
+      moveStore.close();
+      await moveClient.close();
+    }
   });
 
   // -----------------------------------------------------------------------

--- a/tests/server/claims.test.ts
+++ b/tests/server/claims.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { TestContext } from "./helpers.js";
-import { claimBody, createTestContext, TEST_AUTH_HEADERS } from "./helpers.js";
+import {
+  claimBody,
+  createTestContext,
+  TEST_AUTH_HEADERS,
+  TEST_CONTROLLER_HEADERS,
+} from "./helpers.js";
 
 describe("POST /api/claims", () => {
   let ctx: TestContext;
@@ -137,6 +142,208 @@ describe("POST /api/claims", () => {
     });
 
     expect(res.status).toBe(400);
+  });
+});
+
+describe("split claim routes", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    ctx = await createTestContext();
+  });
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  test("PUT /api/claims/:id writes spec only and returns merged view", async () => {
+    const res = await ctx.app.request("/api/claims/split-put", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(claimBody()),
+    });
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.spec.id).toBe("split-put");
+    expect(data.status.phase).toBe("active");
+    expect(data.status.observedGeneration).toBe(0);
+  });
+
+  test("PUT /api/claims/:id rejects status-owned fields", async () => {
+    const res = await ctx.app.request("/api/claims/split-put-reject", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(claimBody({ phase: "completed" })),
+    });
+
+    expect(res.status).toBe(400);
+
+    const attemptCountRes = await ctx.app.request("/api/claims/split-put-reject-attempt", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(claimBody({ attemptCount: 2 })),
+    });
+
+    expect(attemptCountRes.status).toBe(400);
+  });
+
+  test("GET /api/claims/:id returns merged view", async () => {
+    const putRes = await ctx.app.request("/api/claims/split-get", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(claimBody({ targetRef: "split-target" })),
+    });
+    expect(putRes.status).toBe(201);
+
+    const res = await ctx.app.request("/api/claims/split-get", {
+      headers: TEST_AUTH_HEADERS,
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.spec.id).toBe("split-get");
+    expect(data.spec.targetRef).toBe("split-target");
+    expect(data.status.phase).toBe("active");
+  });
+
+  test("PATCH /api/claims/:id/status requires controller token before body validation", async () => {
+    const putRes = await ctx.app.request("/api/claims/split-status-auth", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(claimBody()),
+    });
+    expect(putRes.status).toBe(201);
+
+    const res = await ctx.app.request("/api/claims/split-status-auth/status", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify({ phase: "completed" }),
+    });
+
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data).toEqual({
+      error: { code: "FORBIDDEN", message: "Controller token required" },
+    });
+
+    const mismatchedRes = await ctx.app.request("/api/claims/split-status-auth/status", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...TEST_AUTH_HEADERS,
+        "X-Grove-Controller-Token": "wrong-token",
+      },
+      body: JSON.stringify({ phase: "completed" }),
+    });
+
+    expect(mismatchedRes.status).toBe(403);
+    expect(await mismatchedRes.json()).toEqual({
+      error: { code: "FORBIDDEN", message: "Controller token required" },
+    });
+
+    const missingInvalidRes = await ctx.app.request("/api/claims/split-status-auth/status", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify({ targetRef: "different" }),
+    });
+
+    expect(missingInvalidRes.status).toBe(403);
+    expect(await missingInvalidRes.json()).toEqual({
+      error: { code: "FORBIDDEN", message: "Controller token required" },
+    });
+
+    const mismatchedInvalidRes = await ctx.app.request("/api/claims/split-status-auth/status", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...TEST_AUTH_HEADERS,
+        "X-Grove-Controller-Token": "wrong-token",
+      },
+      body: JSON.stringify({ targetRef: "different" }),
+    });
+
+    expect(mismatchedInvalidRes.status).toBe(403);
+    expect(await mismatchedInvalidRes.json()).toEqual({
+      error: { code: "FORBIDDEN", message: "Controller token required" },
+    });
+  });
+
+  test("PATCH /api/claims/:id/status writes status only with controller token", async () => {
+    const putRes = await ctx.app.request("/api/claims/split-status-patch", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(
+        claimBody({
+          targetRef: "split-preserve-target",
+          intentSummary: "Preserve this spec",
+          priority: 3,
+        }),
+      ),
+    });
+    expect(putRes.status).toBe(201);
+    const created = await putRes.json();
+
+    const res = await ctx.app.request("/api/claims/split-status-patch/status", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...TEST_AUTH_HEADERS,
+        ...TEST_CONTROLLER_HEADERS,
+      },
+      body: JSON.stringify({
+        phase: "completed",
+        observedGeneration: created.spec.generation,
+        agentSessionId: "session-1",
+        currentContributionCid: "b3:work",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status.phase).toBe("completed");
+    expect(data.status.observedGeneration).toBe(created.spec.generation);
+    expect(data.status.agentSessionId).toBe("session-1");
+    expect(data.status.currentContributionCid).toBe("b3:work");
+    expect(data.spec.targetRef).toBe("split-preserve-target");
+    expect(data.spec.intentSummary).toBe("Preserve this spec");
+    expect(data.spec.priority).toBe(3);
+    expect(data.spec.generation).toBe(created.spec.generation);
+  });
+
+  test("PATCH /api/claims/:id/status rejects spec-owned fields", async () => {
+    const putRes = await ctx.app.request("/api/claims/split-status-reject", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(claimBody()),
+    });
+    expect(putRes.status).toBe(201);
+
+    const res = await ctx.app.request("/api/claims/split-status-reject/status", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...TEST_AUTH_HEADERS,
+        ...TEST_CONTROLLER_HEADERS,
+      },
+      body: JSON.stringify({ phase: "completed", targetRef: "different-target" }),
+    });
+
+    expect(res.status).toBe(400);
+
+    const createdAtRes = await ctx.app.request("/api/claims/split-status-reject/status", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...TEST_AUTH_HEADERS,
+        ...TEST_CONTROLLER_HEADERS,
+      },
+      body: JSON.stringify({
+        phase: "completed",
+        createdAt: "2026-05-06T12:00:00.000Z",
+      }),
+    });
+
+    expect(createdAtRes.status).toBe(400);
   });
 });
 

--- a/tests/server/claims.test.ts
+++ b/tests/server/claims.test.ts
@@ -5,6 +5,7 @@ import {
   createTestContext,
   TEST_AUTH_HEADERS,
   TEST_CONTROLLER_HEADERS,
+  TEST_NAMESPACE,
 } from "./helpers.js";
 
 describe("POST /api/claims", () => {
@@ -308,6 +309,55 @@ describe("split claim routes", () => {
     expect(data.spec.intentSummary).toBe("Preserve this spec");
     expect(data.spec.priority).toBe(3);
     expect(data.spec.generation).toBe(created.spec.generation);
+  });
+
+  test("split writes emit claim watch events", async () => {
+    const ac = new AbortController();
+    const events = ctx.deps.watchHub
+      .subscribe(TEST_NAMESPACE, "Claim", 0n, ac.signal)
+      [Symbol.asyncIterator]();
+
+    const putRes = await ctx.app.request("/api/claims/split-watch", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(
+        claimBody({
+          targetRef: "split-watch-target",
+          intentSummary: "Watch split claim",
+        }),
+      ),
+    });
+    expect(putRes.status).toBe(201);
+
+    const added = await events.next();
+    expect(added.done).toBe(false);
+    expect(added.value?.op).toBe("ADDED");
+    expect(added.value?.entity.id).toBe("split-watch");
+    expect(added.value?.entity.spec.intentSummary).toBe("Watch split claim");
+
+    const patchRes = await ctx.app.request("/api/claims/split-watch/status", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...TEST_AUTH_HEADERS,
+        ...TEST_CONTROLLER_HEADERS,
+      },
+      body: JSON.stringify({
+        phase: "completed",
+        agentSessionId: "session-watch",
+        lastTransitionAt: "2026-01-01T00:05:00.000Z",
+      }),
+    });
+    expect(patchRes.status).toBe(200);
+
+    const modified = await events.next();
+    expect(modified.done).toBe(false);
+    expect(modified.value?.op).toBe("MODIFIED");
+    expect(modified.value?.entity.id).toBe("split-watch");
+    expect(modified.value?.entity.status.phase).toBe("completed");
+    expect(modified.value?.entity.status.agentSessionId).toBe("session-watch");
+
+    ac.abort();
   });
 
   test("PATCH /api/claims/:id/status rejects spec-owned fields", async () => {

--- a/tests/server/helpers.ts
+++ b/tests/server/helpers.ts
@@ -36,6 +36,10 @@ export interface TestContext {
 export const TEST_KEY = `grv_${"c".repeat(64)}`;
 export const TEST_NAMESPACE = "test-project/main";
 export const TEST_AUTH_HEADERS = { Authorization: `Bearer ${TEST_KEY}` };
+export const TEST_CONTROLLER_TOKEN = "controller-token-test";
+export const TEST_CONTROLLER_HEADERS = {
+  "X-Grove-Controller-Token": TEST_CONTROLLER_TOKEN,
+} as const;
 const TEST_REGISTRY: KeyRegistry = new Map([[TEST_KEY, TEST_NAMESPACE]]);
 
 /** Create a fully wired test context with real stores in a temp directory. */
@@ -54,6 +58,7 @@ export async function createTestContext(): Promise<TestContext> {
     outcomeStore: stores.outcomeStore,
     cas,
     frontier,
+    controllerToken: TEST_CONTROLLER_TOKEN,
     watchHub: new WatchHub(),
   };
 


### PR DESCRIPTION
## Summary

Closes #270.

This PR implements the claim spec/status split and subresource write model for Grove claims, while preserving the existing merged claim shape at the API boundary.

- Adds split claim storage contracts and SQLite migration/backfill support for `claim_spec` and `claim_status`.
- Adds merged claim reads plus spec-only `PUT /api/claims/:id` and controller-gated status-only `PATCH /api/claims/:id/status` routes.
- Keeps reconciliation/status ownership separated from user-authored desired state.
- Adds focused compatibility coverage for split conversions, migrations, server routes, and reconciler behavior.
- Adds opt-in Codex `CODEX_HOME/config.toml` MCP config writing for the real TUI Codex/Claude handoff smoke path, avoiding secret-bearing MCP overrides in Codex argv.

## Validation

- `bun run typecheck`
- `bunx biome check src/core/acp-runtime.ts src/core/acp-runtime.test.ts src/tui/spawn-manager.ts src/tui/spawn-manager.test.ts`
- `bun --config=/dev/null test src/core/acp-runtime.test.ts src/tui/spawn-manager.test.ts tests/server/claims.test.ts src/local/sqlite-store.migration.test.ts src/core/entity.test.ts src/core/reconciler.test.ts` (`141 pass`, `0 fail`)
- Pre-push hook: `typecheck` and `build`
- Real TUI/tmux Codex -> Claude review loop smoke: captured `Handoffs  3 total, 0 pending`, Codex work submission, Claude review approval, and `[DONE] TUI real smoke approved` in `/Users/tafeng/.codex/tmp/grove-tui-codex-claude-utHh7N/handoffs-pane.txt`

## Notes

A full `bun test` run was attempted, but the process stayed CPU-bound without new output for several minutes after a long stream of passing tests, so it was stopped rather than used as the final verification signal. The focused issue/test-surface run above completed cleanly.
