### PR TITLE
[codex] fix review-loop handoff completion

### DIFF
--- a/docs/superpowers/specs/2026-05-08-session-skill-overrides-design.md
+++ b/docs/superpowers/specs/2026-05-08-session-skill-overrides-design.md
@@ -1,0 +1,387 @@
+# Session-Level Skill Overrides Design
+
+- **Issue**: [#327](https://github.com/windoliver/grove/issues/327)
+- **Parent**: [#202](https://github.com/windoliver/grove/issues/202)
+- **Date**: 2026-05-08
+- **Status**: Approved for full issue scope
+
+## Goal
+
+Allow a single session launch to add, remove, replace, or clear topology
+`role.skills` without editing `GROVE.md` or preset YAML, across both the CLI
+and the TUI.
+
+## Non-goals
+
+- Do not add mid-session or hot-reload skill changes after agents start.
+- Do not introduce a new persisted `skillOverrides` field on `Session` or in
+  the frozen contract snapshot.
+- Do not move skill existence validation out of bootstrap/injection into the
+  CLI, TUI, or HTTP server.
+- Do not redesign `grove skill install`, the skill catalog layout, or the
+  workspace skill injector.
+- Do not add a new standalone server API field for overrides when an edited
+  topology already expresses the effective session state.
+
+## Current State
+
+Topology roles already carry `skills?: readonly string[]` in
+[src/core/topology.ts](/Users/tafeng/.codex/worktrees/991b/grove/src/core/topology.ts:327).
+That value is treated as bootstrap input:
+
+- Headless sessions call `bootstrapWorkspace({ skills: role.skills, ... })` in
+  [src/core/session-orchestrator.ts](/Users/tafeng/.codex/worktrees/991b/grove/src/core/session-orchestrator.ts:616).
+- TUI spawns pass `context.skills = role.skills` and inject them in
+  [src/tui/spawn-manager.ts](/Users/tafeng/.codex/worktrees/991b/grove/src/tui/spawn-manager.ts:669).
+
+Session creation already persists a fully resolved topology snapshot:
+
+- CLI resolves `--roles > --preset > GROVE.md` in
+  [src/cli/commands/session.ts](/Users/tafeng/.codex/worktrees/991b/grove/src/cli/commands/session.ts:124).
+- HTTP `POST /api/sessions` accepts an inline topology and stores it in the
+  session record in
+  [src/server/routes/sessions.ts](/Users/tafeng/.codex/worktrees/991b/grove/src/server/routes/sessions.ts:78).
+- The TUI already applies session-local topology edits for edge deadlines by
+  cloning the topology before `createSession()` in
+  [src/tui/screens/screen-manager.tsx](/Users/tafeng/.codex/worktrees/991b/grove/src/tui/screens/screen-manager.tsx:624).
+
+The gap is narrow: there is no session-scoped way to mutate `role.skills`
+before the topology snapshot is stored and later consumed by bootstrap.
+
+## Chosen Approach
+
+Treat session skill overrides as a topology rewrite step that runs after base
+topology resolution and before session creation/spawn. The resulting effective
+skill lists are written directly into `role.skills` on the session topology.
+
+This is preferred over storing a separate `skillOverrides` object because:
+
+- the effective topology is already the immutable session snapshot used by CLI,
+  TUI, server, and runtime code paths;
+- bootstrap already consumes `role.skills` and does not need new precedence
+  logic;
+- persisted sessions remain directly inspectable because the stored topology is
+  the exact topology that launched.
+
+The implementation therefore has two layers:
+
+1. Parse or edit override intent at the surface layer:
+   - CLI parses repeated `--skills` flags.
+   - TUI edits effective skill lists directly in launch preview.
+2. Apply those edits through one shared core helper that returns a cloned
+   `AgentTopology` with updated `role.skills`.
+
+## Override Model
+
+### Targets
+
+Overrides target either:
+
+- a specific role name, for example `coder`
+- all roles, using the blanket selector `*`
+
+Unknown role names are rejected before session creation.
+
+### Operations
+
+Three operations are supported:
+
+- `=` replace the target list
+- `+=` append unique skills to the target list
+- `-=` remove listed skills from the target list
+
+Examples:
+
+- `coder=grove,review`
+- `coder+=lint`
+- `reviewer-=grove`
+- `*=grove`
+- `*=`
+
+Replace with an empty right-hand side clears the target list. Add/remove with
+an empty list are treated as no-ops.
+
+### Ordering and Precedence
+
+Session skill override precedence is:
+
+1. Resolve base topology exactly as today:
+   - CLI `--roles` inline topology
+   - CLI `--preset`
+   - `GROVE.md` default topology
+2. Apply blanket `*` clauses in input order.
+3. Apply per-role clauses in input order.
+
+Within a target group, later clauses win because they are applied after earlier
+clauses. Blanket overrides never clobber a role-specific override because the
+per-role group is always evaluated after the blanket group.
+
+Examples:
+
+- `--skills '*=grove' --skills 'coder+=review'`
+  - every role gets `["grove"]`
+  - `coder` becomes `["grove", "review"]`
+- `--skills 'coder=grove' --skills '*=review'`
+  - `coder` still ends as `["grove"]`
+  - every other role ends as `["review"]`
+
+### Deduplication and Order
+
+Effective skill lists are deduped while preserving left-to-right order.
+
+Rules:
+
+- replace keeps the provided order and removes duplicates
+- add appends only skills not already present
+- remove preserves the order of remaining skills
+- missing initial `role.skills` is treated as `[]`
+
+This keeps stored topologies stable, readable, and deterministic in tests.
+
+## CLI Design
+
+`grove session start` gains a repeatable `--skills` flag:
+
+```bash
+grove session start \
+  --goal "..." \
+  --preset review-loop \
+  --skills '*=grove' \
+  --skills 'coder+=review' \
+  --skills 'reviewer-=grove'
+```
+
+Design choices:
+
+- one clause per `--skills` flag
+- no semicolon mini-language inside a single flag
+- the existing issue example `--skills coder=grove,review` remains valid
+
+This keeps shell quoting manageable and error reporting precise.
+
+### CLI Parsing
+
+Add a small parser in the CLI layer that turns raw flag values into a shared
+core DTO such as:
+
+```ts
+export type SkillOverrideOp = "replace" | "add" | "remove";
+
+export interface SessionSkillOverrideClause {
+  readonly target: "*" | string;
+  readonly op: SkillOverrideOp;
+  readonly skills: readonly string[];
+}
+```
+
+Parser responsibilities:
+
+- recognize `=`, `+=`, and `-=`
+- trim surrounding whitespace
+- split skills on commas
+- reject empty role selectors
+- reject malformed clauses such as `coder`, `coder+foo`, `=grove`, or `*=,`
+
+Application responsibilities belong in shared core code, not in the parser.
+
+### CLI Flow
+
+`sessionStart()` in
+[src/cli/commands/session.ts](/Users/tafeng/.codex/worktrees/991b/grove/src/cli/commands/session.ts:71)
+changes only at the topology handoff point:
+
+1. Parse `values.skills` into `SessionSkillOverrideClause[]`.
+2. Resolve the base topology using existing logic.
+3. Apply the shared override helper to produce an edited topology.
+4. Store and launch the session with that edited topology.
+
+No `Session`, `SessionStore`, or HTTP schema changes are required for the CLI
+path because the effective topology is already what gets stored.
+
+## TUI Design
+
+The launch preview screen in
+[src/tui/screens/agent-detect.tsx](/Users/tafeng/.codex/worktrees/991b/grove/src/tui/screens/agent-detect.tsx:1)
+already edits two session-local role properties:
+
+- prompt text
+- edge reply deadlines
+
+Session-scoped skill overrides fit the same pattern.
+
+### TUI Editing Model
+
+The TUI edits effective per-role skill lists directly rather than exposing raw
+clause syntax. Operators should see the final list each role will launch with.
+
+Capabilities:
+
+- edit the selected role's skills
+- clear the selected role's skills
+- apply the selected role's current skills to all roles
+
+The last action gives the TUI a blanket-override equivalent without forcing the
+operator to learn CLI syntax.
+
+### TUI Data Flow
+
+Extend the existing `AgentDetect.onContinue(...)` handoff with a role-skills
+payload, for example:
+
+```ts
+readonly roleSkills: ReadonlyMap<string, readonly string[]>;
+```
+
+Then extend the cloned per-launch topology path in
+[src/tui/screens/screen-manager.tsx](/Users/tafeng/.codex/worktrees/991b/grove/src/tui/screens/screen-manager.tsx:624):
+
+1. clone the current topology
+2. apply edited edge deadlines
+3. apply edited role skills
+4. persist that edited topology via `provider.createSession(...)`
+5. pass the same edited topology into `spawnManager`
+
+Role prompts stay on their existing spawn-only path through `rolePromptsRef`.
+This issue only changes what is persisted into `role.skills`.
+
+This keeps remote and local TUI modes aligned because both already round-trip
+the topology through `createSessionHttp()` in
+[src/tui/provider-shared.ts](/Users/tafeng/.codex/worktrees/991b/grove/src/tui/provider-shared.ts:329).
+
+## Shared Core Helper
+
+Add a new core module, for example:
+
+```text
+src/core/session-skill-overrides.ts
+```
+
+Recommended surface:
+
+```ts
+export type SkillOverrideOp = "replace" | "add" | "remove";
+
+export interface SessionSkillOverrideClause {
+  readonly target: "*" | string;
+  readonly op: SkillOverrideOp;
+  readonly skills: readonly string[];
+}
+
+export function applySessionSkillOverrides(
+  topology: AgentTopology,
+  clauses: readonly SessionSkillOverrideClause[],
+): AgentTopology;
+```
+
+Behavior:
+
+- returns a cloned topology
+- never mutates the input topology or nested `roles`
+- validates that per-role targets exist
+- normalizes resulting `role.skills`
+- preserves all non-skill topology fields unchanged
+
+This module owns the precedence and list-manipulation rules so CLI and TUI
+cannot drift.
+
+## Session and Server Implications
+
+No new persistent session fields are needed. The existing `topology` and
+`config.topology` snapshot remain the single source of truth.
+
+No new `POST /api/sessions` request field is required either:
+
+- CLI performs the override locally, then stores the edited topology.
+- TUI already sends an inline edited topology when it has session-local changes.
+
+The existing server behavior that inline topology overrides preset topology in
+[tests/server/goals-sessions.test.ts](/Users/tafeng/.codex/worktrees/991b/grove/tests/server/goals-sessions.test.ts:590)
+already matches this design.
+
+## Error Handling
+
+### Early validation
+
+Reject before session creation when:
+
+- the `--skills` clause syntax is malformed
+- a per-role target does not exist in the resolved topology
+- no topology is available at all under the existing resolution rules
+
+These failures should surface as the same `VALIDATION_ERROR` style currently
+used for bad CLI/session inputs.
+
+### Deferred validation
+
+Do not add CLI/TUI/server-side catalog existence checks. Unknown or missing
+skill directories still fail in bootstrap through the existing injector path.
+
+This is intentional because:
+
+- the authoritative catalog may differ between environments
+- remote TUI mode should not duplicate server/bootstrap validation logic
+- the existing bootstrap failure path already stops an invalid session launch
+
+### No-op behavior
+
+- removing a skill that is not present is a no-op
+- adding a skill already present is a no-op after dedupe
+- `*=` or `coder=` clears the target list
+- `coder+=` or `coder-=` is treated as invalid syntax rather than an ambiguous
+  no-op
+
+## Testing
+
+### Core unit tests
+
+Add `src/core/session-skill-overrides.test.ts` covering:
+
+- replace, add, remove against roles with and without initial skills
+- blanket then per-role precedence
+- input immutability
+- dedupe and ordering behavior
+- clear behavior with empty replace
+- unknown role rejection
+
+### CLI tests
+
+Extend `src/cli/commands/session.test.ts` and/or CLI integration tests to cover:
+
+- valid repeated `--skills` parsing
+- malformed clause errors
+- `session start` storing the expected overridden topology
+- precedence with preset-derived roles
+
+### TUI tests
+
+Extend TUI tests around launch preview and screen manager flow to cover:
+
+- launch preview initializes from `role.skills`
+- edited per-role skills are reflected in the cloned session topology
+- apply-to-all behavior updates every role
+- the topology sent to `createSession()` and `spawnManager` contains the final
+  skill lists
+
+### Bootstrap regression coverage
+
+Existing skill injection tests remain the end-to-end proof that final
+`role.skills` still bootstrap correctly. Add a small extension where helpful to
+show that an overridden topology launches with the edited skill set rather than
+the preset default.
+
+## Documentation
+
+Update user-facing CLI help text in
+[src/cli/commands/session.ts](/Users/tafeng/.codex/worktrees/991b/grove/src/cli/commands/session.ts:64)
+to describe `--skills`.
+
+Add at least one short usage example to the relevant session-start docs or help
+surface so the blanket vs per-role model is discoverable.
+
+## Open Questions
+
+None remaining for this issue scope. The design deliberately chooses:
+
+- effective-topology persistence over separate override metadata
+- repeated `--skills` flags over a semicolon mini-language
+- TUI direct editing over exposing raw clause syntax

--- a/src/cli/commands/session-start-topology.test.ts
+++ b/src/cli/commands/session-start-topology.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AgentTopology } from "../../core/topology.js";
+import {
+  parseSessionSkillOverrideClauses,
+  resolveSessionStartTopology,
+} from "./session-start-topology.js";
+
+const PRESET_TOPOLOGY: AgentTopology = {
+  structure: "graph",
+  roles: [{ name: "planner", skills: ["grove"] }, { name: "builder" }],
+};
+
+const CONTRACT_TOPOLOGY: AgentTopology = {
+  structure: "flat",
+  roles: [{ name: "solo" }],
+};
+
+describe("parseSessionSkillOverrideClauses", () => {
+  test("parses repeated replace, add, and remove clauses", () => {
+    expect(
+      parseSessionSkillOverrideClauses(["*=grove", "planner+=review,lint", "builder-=grove"]),
+    ).toEqual([
+      { target: "*", op: "replace", skills: ["grove"] },
+      { target: "planner", op: "add", skills: ["review", "lint"] },
+      { target: "builder", op: "remove", skills: ["grove"] },
+    ]);
+  });
+
+  test("supports empty replace clauses to clear skills", () => {
+    expect(parseSessionSkillOverrideClauses(["planner="])).toEqual([
+      { target: "planner", op: "replace", skills: [] },
+    ]);
+  });
+
+  test("throws on malformed clauses", () => {
+    expect(() => parseSessionSkillOverrideClauses(["planner"])).toThrow("Invalid --skills clause");
+    expect(() => parseSessionSkillOverrideClauses(["planner+="])).toThrow(
+      "Invalid --skills clause",
+    );
+    expect(() => parseSessionSkillOverrideClauses(["=grove"])).toThrow("Invalid --skills clause");
+    expect(() => parseSessionSkillOverrideClauses(["planner= , "])).toThrow(
+      "Invalid --skills clause",
+    );
+  });
+});
+
+describe("resolveSessionStartTopology", () => {
+  test("applies skill overrides after preset resolution", () => {
+    const result = resolveSessionStartTopology(
+      {
+        presetName: "review-loop",
+        skillArgs: ["*=grove", "builder+=review"],
+      },
+      (name: string) => (name === "review-loop" ? PRESET_TOPOLOGY : undefined),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+
+    expect(result.source).toBe("preset");
+    expect(result.topology.roles[0]?.skills).toEqual(["grove"]);
+    expect(result.topology.roles[1]?.skills).toEqual(["grove", "review"]);
+  });
+
+  test("builds inline flat topology from --roles before applying overrides", () => {
+    const result = resolveSessionStartTopology({
+      rolesArg: "planner,builder",
+      skillArgs: ["builder=review"],
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+
+    expect(result.source).toBe("inline");
+    expect(result.topology.structure).toBe("flat");
+    expect(result.topology.roles.map((role) => role.name)).toEqual(["planner", "builder"]);
+    expect(result.topology.roles[0]?.skills).toBeUndefined();
+    expect(result.topology.roles[1]?.skills).toEqual(["review"]);
+  });
+
+  test("returns failed topology resolution unchanged", () => {
+    const result = resolveSessionStartTopology({
+      presetName: "missing-preset",
+      skillArgs: ["*=grove"],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Preset 'missing-preset' requested but no preset registry available",
+    });
+  });
+
+  test("returns an unknown preset error when lookup misses", () => {
+    const result = resolveSessionStartTopology(
+      {
+        presetName: "missing-preset",
+        skillArgs: [],
+      },
+      () => undefined,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Unknown preset 'missing-preset'",
+    });
+  });
+
+  test("falls back to the contract topology when no inline or preset is provided", () => {
+    const result = resolveSessionStartTopology({
+      contractDefault: CONTRACT_TOPOLOGY,
+      skillArgs: [],
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+
+    expect(result.source).toBe("contract");
+    expect(result.topology).toBe(CONTRACT_TOPOLOGY);
+  });
+
+  test("returns a descriptive error when no topology source is available", () => {
+    const result = resolveSessionStartTopology({
+      skillArgs: [],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        "No topology available: provide --preset, an inline topology, or define one in GROVE.md",
+    });
+  });
+
+  test("returns the original successful resolution when there are no overrides", () => {
+    const result = resolveSessionStartTopology(
+      {
+        presetName: "review-loop",
+        skillArgs: [],
+      },
+      (name: string) => (name === "review-loop" ? PRESET_TOPOLOGY : undefined),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+
+    expect(result.source).toBe("preset");
+    expect(result.topology).toBe(PRESET_TOPOLOGY);
+  });
+
+  test("rejects empty --roles input after trimming", () => {
+    expect(() =>
+      resolveSessionStartTopology({
+        rolesArg: " , ",
+        skillArgs: [],
+      }),
+    ).toThrow("--roles must be a comma-separated list of role names");
+  });
+});

--- a/src/cli/commands/session-start-topology.ts
+++ b/src/cli/commands/session-start-topology.ts
@@ -1,0 +1,120 @@
+import {
+  applySessionSkillOverrides,
+  type SessionSkillOverrideClause,
+} from "../../core/session-skill-overrides.js";
+import type { AgentTopology } from "../../core/topology.js";
+import {
+  type PresetLookup,
+  resolveTopology,
+  type TopologyResolutionResult,
+} from "../../core/topology-resolver.js";
+
+interface SessionStartTopologyInput {
+  readonly rolesArg?: string | undefined;
+  readonly presetName?: string | undefined;
+  readonly contractDefault?: AgentTopology | undefined;
+  readonly skillArgs: readonly string[];
+}
+
+function parseClause(raw: string): SessionSkillOverrideClause {
+  const clause = raw.trim();
+  const operators = [
+    { token: "+=", op: "add" },
+    { token: "-=", op: "remove" },
+    { token: "=", op: "replace" },
+  ] as const;
+
+  for (const { token, op } of operators) {
+    const tokenIndex = clause.indexOf(token);
+    if (tokenIndex === -1) {
+      continue;
+    }
+
+    const target = clause.slice(0, tokenIndex).trim();
+    const rhs = clause.slice(tokenIndex + token.length).trim();
+
+    if (target.length === 0) {
+      throw new Error(`Invalid --skills clause: ${raw}`);
+    }
+
+    if ((op === "add" || op === "remove") && rhs.length === 0) {
+      throw new Error(`Invalid --skills clause: ${raw}`);
+    }
+
+    const skills =
+      rhs.length === 0
+        ? []
+        : rhs
+            .split(",")
+            .map((skill) => skill.trim())
+            .filter((skill) => skill.length > 0);
+
+    if (rhs.length > 0 && skills.length === 0) {
+      throw new Error(`Invalid --skills clause: ${raw}`);
+    }
+
+    return { target, op, skills };
+  }
+
+  throw new Error(`Invalid --skills clause: ${raw}`);
+}
+
+export function parseSessionSkillOverrideClauses(
+  rawValues: readonly string[],
+): readonly SessionSkillOverrideClause[] {
+  return rawValues.map((rawValue) => parseClause(rawValue));
+}
+
+function buildInlineTopologyFromRolesArg(rolesArg?: string | undefined): AgentTopology | undefined {
+  if (rolesArg === undefined) {
+    return undefined;
+  }
+
+  const roleNames = rolesArg
+    .split(",")
+    .map((roleName) => roleName.trim())
+    .filter((roleName) => roleName.length > 0);
+
+  if (roleNames.length === 0) {
+    throw new Error("--roles must be a comma-separated list of role names");
+  }
+
+  return {
+    structure: "flat",
+    roles: roleNames.map((name) => ({
+      name,
+      description: `Agent role: ${name}`,
+      platform: "claude-code" as const,
+    })),
+  };
+}
+
+export function resolveSessionStartTopology(
+  input: SessionStartTopologyInput,
+  lookupPreset?: PresetLookup,
+): TopologyResolutionResult {
+  const inlineTopology = buildInlineTopologyFromRolesArg(input.rolesArg);
+  const resolution = resolveTopology(
+    {
+      inlineTopology,
+      presetName: input.presetName,
+      contractDefault: input.contractDefault,
+    },
+    lookupPreset,
+  );
+
+  if (!resolution.ok) {
+    return resolution;
+  }
+
+  const clauses = parseSessionSkillOverrideClauses(input.skillArgs);
+  if (clauses.length === 0) {
+    return resolution;
+  }
+
+  return {
+    ok: true,
+    topology: applySessionSkillOverrides(resolution.topology, clauses),
+    source: resolution.source,
+  };
+}

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -28,6 +28,7 @@ import {
 import { MockRuntime } from "../../core/mock-runtime.js";
 import { lookupPresetTopology } from "../../core/presets.js";
 import { SessionOrchestrator } from "../../core/session-orchestrator.js";
+import type { AgentTopology } from "../../core/topology.js";
 import type { TopologyResolutionResult } from "../../core/topology-resolver.js";
 import { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
 import { outputJson, outputJsonError } from "../format.js";

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -28,8 +28,7 @@ import {
 import { MockRuntime } from "../../core/mock-runtime.js";
 import { lookupPresetTopology } from "../../core/presets.js";
 import { SessionOrchestrator } from "../../core/session-orchestrator.js";
-import type { AgentTopology } from "../../core/topology.js";
-import { resolveTopology } from "../../core/topology-resolver.js";
+import type { TopologyResolutionResult } from "../../core/topology-resolver.js";
 import { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
 import { outputJson, outputJsonError } from "../format.js";
 import { buildRepos } from "../utils/build-repos.js";
@@ -61,7 +60,7 @@ export async function executeSession(args: readonly string[]): Promise<void> {
       console.log(`grove session <subcommand>
 
 Subcommands:
-  start --goal <goal> [--preset <name>] [--roles a,b,c]   Start a new session
+  start --goal <goal> [--preset <name>] [--roles a,b,c] [--skills <clause>]...   Start a new session
   list                                                     List all sessions
   status                                                   Show current session status
   stop [--reason <r>]                                      Stop the current session
@@ -82,6 +81,7 @@ async function sessionStart(args: readonly string[]): Promise<void> {
       goal: { type: "string" },
       preset: { type: "string" },
       roles: { type: "string" },
+      skills: { type: "string", multiple: true },
       runtime: { type: "string", default: "mock" },
       repo: { type: "string", multiple: true },
     },
@@ -128,42 +128,27 @@ async function sessionStart(args: readonly string[]): Promise<void> {
     contract = parseGroveContract(readFileSync(contractPath, "utf-8"));
   }
 
-  // Build inline topology from --roles if provided
-  const rolesArg = values.roles as string | undefined;
-  let inlineTopology: AgentTopology | undefined;
-  if (rolesArg) {
-    const roleNames = rolesArg
-      .split(",")
-      .map((r) => r.trim())
-      .filter(Boolean);
-    if (roleNames.length === 0) {
-      outputJsonError({
-        code: "VALIDATION_ERROR",
-        message: "--roles must be a comma-separated list of role names",
-      });
-      process.exitCode = 1;
-      return;
-    }
-    inlineTopology = {
-      structure: "flat",
-      roles: roleNames.map((name) => ({
-        name,
-        description: `Agent role: ${name}`,
-        platform: "claude-code" as const,
-      })),
-    };
-  }
-
-  // Resolve topology: inline (--roles) > preset (--preset) > GROVE.md default
   const presetName = values.preset as string | undefined;
-  const resolution = resolveTopology(
-    {
-      inlineTopology,
-      presetName,
-      contractDefault: contract?.topology,
-    },
-    lookupPresetTopology,
-  );
+  let resolution: TopologyResolutionResult;
+  try {
+    const { resolveSessionStartTopology } = await import("./session-start-topology.js");
+    resolution = resolveSessionStartTopology(
+      {
+        rolesArg: values.roles as string | undefined,
+        presetName,
+        contractDefault: contract?.topology,
+        skillArgs: (values.skills as readonly string[] | undefined) ?? [],
+      },
+      lookupPresetTopology,
+    );
+  } catch (err) {
+    outputJsonError({
+      code: "VALIDATION_ERROR",
+      message: err instanceof Error ? err.message : String(err),
+    });
+    process.exitCode = 1;
+    return;
+  }
 
   if (!resolution.ok) {
     outputJsonError({ code: "VALIDATION_ERROR", message: resolution.error });

--- a/src/core/acp-runtime.test.ts
+++ b/src/core/acp-runtime.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AcpLaunch } from "./acp-launch.js";
-import { AcpRuntime, buildAcpLaunchArgs, buildAcpLaunchEnv } from "./acp-runtime.js";
+import {
+  AcpRuntime,
+  buildAcpLaunchArgs,
+  buildAcpLaunchEnv,
+  prepareIsolatedCodexHome,
+} from "./acp-runtime.js";
 import { DENY_ALL_RESOLVER } from "./permission-resolver.js";
 
 describe("AcpRuntime construction", () => {
@@ -216,5 +224,52 @@ describe("buildAcpLaunchArgs", () => {
         { GROVE_ALLOW_ALL_PERMISSIONS: "1" },
       ),
     ).toEqual(["claude-agent-acp.js"]);
+  });
+});
+
+describe("prepareIsolatedCodexHome", () => {
+  test("writes Grove MCP into the isolated Codex config with private env off argv", async () => {
+    const userHome = mkdtempSync(join(tmpdir(), "grove-user-codex-"));
+    let isolated = "";
+    try {
+      writeFileSync(
+        join(userHome, "config.toml"),
+        ['model = "gpt-5.4-mini"', "", "[mcp_servers.untrusted]", 'command = "bad-mcp"', ""].join(
+          "\n",
+        ),
+        "utf-8",
+      );
+      writeFileSync(join(userHome, "auth.json"), '{"token":"ok"}', "utf-8");
+
+      isolated = await prepareIsolatedCodexHome({ CODEX_HOME: userHome }, [
+        {
+          name: "grove",
+          command: "/bin/bun",
+          args: ["run", "/tmp/grove/dist/mcp/serve.js"],
+          env: {
+            GROVE_DIR: "/tmp/project/.grove",
+            GROVE_NEXUS_URL: "http://localhost:59588",
+            NEXUS_API_KEY: "secret-key",
+            GROVE_SESSION_ID: "session-1",
+          },
+        },
+      ]);
+
+      const config = readFileSync(join(isolated, "config.toml"), "utf-8");
+      expect(config).toContain('model = "gpt-5.4-mini"');
+      expect(config).not.toContain("bad-mcp");
+      expect(config).toContain("[mcp_servers.grove]");
+      expect(config).toContain('command = "/bin/bun"');
+      expect(config).toContain('args = ["run", "/tmp/grove/dist/mcp/serve.js"]');
+      expect(config).toContain("[mcp_servers.grove.env]");
+      expect(config).toContain('GROVE_DIR = "/tmp/project/.grove"');
+      expect(config).toContain('GROVE_NEXUS_URL = "http://localhost:59588"');
+      expect(config).toContain('NEXUS_API_KEY = "secret-key"');
+      expect(config).toContain('GROVE_SESSION_ID = "session-1"');
+      expect(existsSync(join(isolated, "auth.json"))).toBe(true);
+    } finally {
+      if (isolated) rmSync(isolated, { recursive: true, force: true });
+      rmSync(userHome, { recursive: true, force: true });
+    }
   });
 });

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -113,6 +113,34 @@ const SAFE_CODEX_TOP_LEVEL_KEYS = new Set([
  * We bail at the first `[` line to switch to "inside-section" mode.
  */
 const TOML_TOP_LEVEL_KEY_LINE = /^([A-Za-z0-9_-]+)\s*=/;
+const CODEX_GENERATED_MCP_START = "# BEGIN GROVE GENERATED MCP";
+const CODEX_GENERATED_MCP_END = "# END GROVE GENERATED MCP";
+
+type McpServerConfig = NonNullable<AgentConfig["mcpServers"]>[number];
+
+function buildCodexMcpConfigBlock(server: McpServerConfig, env: NodeJS.ProcessEnv): string {
+  const name = server.name.trim();
+  const command = server.command.trim();
+  if (!name || !command) return "";
+
+  const serverKey = `mcp_servers.${tomlKeySegment(name)}`;
+  const lines = [
+    CODEX_GENERATED_MCP_START,
+    `[${serverKey}]`,
+    `command = ${tomlString(command)}`,
+    `args = ${tomlStringArray(server.args ?? [])}`,
+    "",
+    `[${serverKey}.env]`,
+  ];
+  const envEntries = Object.entries(mergedCodexMcpServerEnv(server, env)).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  for (const [envName, envValue] of envEntries) {
+    lines.push(`${tomlKeySegment(envName)} = ${tomlString(envValue)}`);
+  }
+  lines.push(CODEX_GENERATED_MCP_END);
+  return lines.join("\n");
+}
 
 /**
  * Prepare an ephemeral CODEX_HOME for grove-spawned codex children. Copies the
@@ -122,7 +150,10 @@ const TOML_TOP_LEVEL_KEY_LINE = /^([A-Za-z0-9_-]+)\s*=/;
  * on bootstrap), `projects.*` trust (grove uses its own permission gating),
  * `notify` hooks (would invoke desktop apps for grove turns), plugins.
  */
-async function prepareIsolatedCodexHome(env: NodeJS.ProcessEnv): Promise<string> {
+export async function prepareIsolatedCodexHome(
+  env: NodeJS.ProcessEnv,
+  mcpServers: AgentConfig["mcpServers"] = [],
+): Promise<string> {
   const userHome = env.CODEX_HOME ?? join(env.HOME ?? "/tmp", ".codex");
   const isolated = mkdtempSync(join(tmpdir(), "grove-codex-"));
   // Copy auth.json if present so login persists.
@@ -181,7 +212,14 @@ async function prepareIsolatedCodexHome(env: NodeJS.ProcessEnv): Promise<string>
     // flag in `buildAcpLaunchArgs` overrides this when a model is configured.
     safeLines.push('model = "gpt-5"');
   }
-  writeFileSync(join(isolated, "config.toml"), `${safeLines.join("\n")}\n`, "utf-8");
+  const mcpBlocks = (mcpServers ?? [])
+    .map((server) => buildCodexMcpConfigBlock(server, env))
+    .filter((block) => block.length > 0);
+  const configSections = [...safeLines, ...mcpBlocks.map((block) => `\n${block}`)];
+  writeFileSync(join(isolated, "config.toml"), `${configSections.join("\n")}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
   // Ensure plugins dir exists empty (some codex plugins bundle MCP servers).
   mkdirSync(join(isolated, "plugins"), { recursive: true });
   return isolated;
@@ -205,8 +243,9 @@ async function launchSubprocess(
   // which closes the entire ACP stdio connection and breaks downstream sends.
   // Isolate codex from the user MCP config by pointing CODEX_HOME at an
   // ephemeral directory that contains only the user's auth (so login still
-  // works) and a minimal config.toml. Grove's per-spawn MCP servers are
-  // appended via `-c` flags in buildAcpLaunchArgs and remain in effect.
+  // works), safe scalar settings, and the current Grove MCP server block.
+  // The MCP block is written to config.toml so codex loads tools at startup
+  // even when the ACP adapter does not surface session/new mcpServers.
   const childEnv = buildAcpLaunchEnv(agent, env, opts.mcpServers);
   let isolatedHomeForCleanup: string | undefined;
   if (agent === "codex" && env.GROVE_CODEX_NO_ISOLATION !== "1") {
@@ -216,7 +255,7 @@ async function launchSubprocess(
     // and run user-level notify hooks against grove turns). Operators that
     // explicitly accept the risk can opt out with GROVE_CODEX_NO_ISOLATION=1.
     try {
-      const isolatedHome = await prepareIsolatedCodexHome(env);
+      const isolatedHome = await prepareIsolatedCodexHome(childEnv, opts.mcpServers);
       childEnv.CODEX_HOME = isolatedHome;
       isolatedHomeForCleanup = isolatedHome;
     } catch (err) {
@@ -570,6 +609,7 @@ export class AcpRuntime implements AgentRuntime {
         const env = { ...inheritedEnv, ...(s.env ?? {}) };
         return {
           name: s.name,
+          type: "stdio" as const,
           command: s.command,
           args: [...(s.args ?? [])],
           env: Object.entries(env).map(([name, value]) => ({ name, value })),

--- a/src/core/session-skill-overrides.test.ts
+++ b/src/core/session-skill-overrides.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import type { AgentTopology } from "./topology.js";
 import {
   applySessionSkillOverrides,
   normalizeSkillList,
   type SessionSkillOverrideClause,
 } from "./session-skill-overrides.js";
+import type { AgentTopology } from "./topology.js";
 
 const BASE_TOPOLOGY: AgentTopology = {
   structure: "graph",

--- a/src/core/session-skill-overrides.test.ts
+++ b/src/core/session-skill-overrides.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentTopology } from "./topology.js";
+import {
+  applySessionSkillOverrides,
+  normalizeSkillList,
+  type SessionSkillOverrideClause,
+} from "./session-skill-overrides.js";
+
+const BASE_TOPOLOGY: AgentTopology = {
+  structure: "graph",
+  roles: [
+    { name: "planner", skills: ["grove"] },
+    { name: "builder", skills: ["review"] },
+  ],
+};
+
+describe("normalizeSkillList", () => {
+  test("trims values, drops empties, and preserves first occurrence order", () => {
+    expect(normalizeSkillList([" grove ", "review", "", "grove", "lint "])).toEqual([
+      "grove",
+      "review",
+      "lint",
+    ]);
+  });
+});
+
+describe("applySessionSkillOverrides", () => {
+  test("supports replace, add, and remove without mutating the input topology", () => {
+    const clauses: readonly SessionSkillOverrideClause[] = [
+      { target: "planner", op: "replace", skills: ["grove", "review", "grove"] },
+      { target: "builder", op: "add", skills: ["lint", "review"] },
+      { target: "builder", op: "remove", skills: ["review"] },
+    ];
+
+    const next = applySessionSkillOverrides(BASE_TOPOLOGY, clauses);
+
+    expect(next.roles[0]?.skills).toEqual(["grove", "review"]);
+    expect(next.roles[1]?.skills).toEqual(["lint"]);
+    expect(BASE_TOPOLOGY.roles[0]?.skills).toEqual(["grove"]);
+    expect(BASE_TOPOLOGY.roles[1]?.skills).toEqual(["review"]);
+  });
+
+  test("applies blanket clauses before role-specific clauses", () => {
+    const clauses: readonly SessionSkillOverrideClause[] = [
+      { target: "*", op: "replace", skills: ["grove"] },
+      { target: "builder", op: "add", skills: ["review"] },
+    ];
+
+    const next = applySessionSkillOverrides(BASE_TOPOLOGY, clauses);
+
+    expect(next.roles[0]?.skills).toEqual(["grove"]);
+    expect(next.roles[1]?.skills).toEqual(["grove", "review"]);
+  });
+
+  test("clears a touched role with replace plus empty and writes an explicit empty array", () => {
+    const clauses: readonly SessionSkillOverrideClause[] = [
+      { target: "planner", op: "replace", skills: [] },
+    ];
+
+    const next = applySessionSkillOverrides(BASE_TOPOLOGY, clauses);
+
+    expect(next.roles[0]?.skills).toEqual([]);
+    expect(next.roles[1]?.skills).toEqual(["review"]);
+  });
+
+  test("throws on unknown role names", () => {
+    const clauses: readonly SessionSkillOverrideClause[] = [
+      { target: "unknown", op: "add", skills: ["grove"] },
+    ];
+
+    expect(() => applySessionSkillOverrides(BASE_TOPOLOGY, clauses)).toThrow(
+      "Unknown role in skill override",
+    );
+  });
+});

--- a/src/core/session-skill-overrides.ts
+++ b/src/core/session-skill-overrides.ts
@@ -1,0 +1,81 @@
+import type { AgentTopology } from "./topology.js";
+
+export type SkillOverrideOp = "replace" | "add" | "remove";
+
+export interface SessionSkillOverrideClause {
+  readonly target: "*" | string;
+  readonly op: SkillOverrideOp;
+  readonly skills: readonly string[];
+}
+
+export function normalizeSkillList(skills: readonly string[]): readonly string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  for (const rawSkill of skills) {
+    const skill = rawSkill.trim();
+    if (skill.length === 0 || seen.has(skill)) {
+      continue;
+    }
+    seen.add(skill);
+    normalized.push(skill);
+  }
+
+  return normalized;
+}
+
+function applyClause(
+  existing: readonly string[],
+  clause: SessionSkillOverrideClause,
+): readonly string[] {
+  const clauseSkills = normalizeSkillList(clause.skills);
+
+  switch (clause.op) {
+    case "replace":
+      return clauseSkills;
+    case "add":
+      return normalizeSkillList([...existing, ...clauseSkills]);
+    case "remove": {
+      const blocked = new Set(clauseSkills);
+      return existing.filter((skill) => !blocked.has(skill));
+    }
+  }
+}
+
+export function applySessionSkillOverrides(
+  topology: AgentTopology,
+  clauses: readonly SessionSkillOverrideClause[],
+): AgentTopology {
+  const roleNames = new Set(topology.roles.map((role) => role.name));
+
+  for (const clause of clauses) {
+    if (clause.target !== "*" && !roleNames.has(clause.target)) {
+      throw new Error(`Unknown role in skill override: ${clause.target}`);
+    }
+  }
+
+  const blanketClauses = clauses.filter((clause) => clause.target === "*");
+  const roleClauses = clauses.filter((clause) => clause.target !== "*");
+
+  return {
+    ...topology,
+    roles: topology.roles.map((role) => {
+      const matchingRoleClauses = roleClauses.filter((clause) => clause.target === role.name);
+      const applicableClauses = [...blanketClauses, ...matchingRoleClauses];
+
+      if (applicableClauses.length === 0) {
+        return { ...role };
+      }
+
+      let nextSkills = normalizeSkillList(role.skills ?? []);
+      for (const clause of applicableClauses) {
+        nextSkills = applyClause(nextSkills, clause);
+      }
+
+      return {
+        ...role,
+        skills: [...nextSkills],
+      };
+    }),
+  };
+}

--- a/src/tui/app-reducer.ts
+++ b/src/tui/app-reducer.ts
@@ -1,0 +1,154 @@
+import { nextZoom } from "./hooks/use-keyboard-handler.js";
+import type { ZoomLevel } from "./panels/panel-manager.js";
+
+/** State managed by the keyboard-driven reducer. */
+export interface TuiKeyboardState {
+  readonly vfsNavigateTrigger: number;
+  readonly artifactIndex: number;
+  readonly showArtifactDiff: boolean;
+  readonly paletteIndex: number;
+  readonly paletteQuery: string;
+  readonly searchQuery: string;
+  readonly searchBuffer: string;
+  readonly messageBuffer: string;
+  readonly messageRecipients: string;
+  readonly goalBuffer: string;
+  readonly compareMode: boolean;
+  readonly compareCids: readonly string[];
+  readonly zoomLevel: ZoomLevel;
+  readonly terminalScrollOffset: number;
+  readonly layoutMode: "grid" | "tab";
+}
+
+/** Actions for the TUI keyboard state reducer. */
+export type TuiAction =
+  | { readonly type: "VFS_NAVIGATE" }
+  | { readonly type: "ARTIFACT_PREV" }
+  | { readonly type: "ARTIFACT_NEXT" }
+  | { readonly type: "ARTIFACT_DIFF_TOGGLE" }
+  | { readonly type: "PALETTE_UP" }
+  | { readonly type: "PALETTE_DOWN"; readonly maxIndex: number }
+  | { readonly type: "PALETTE_RESET" }
+  | { readonly type: "PALETTE_CHAR"; readonly char: string }
+  | { readonly type: "PALETTE_BACKSPACE" }
+  | { readonly type: "SEARCH_START"; readonly currentQuery: string }
+  | { readonly type: "SEARCH_CHAR"; readonly char: string }
+  | { readonly type: "SEARCH_BACKSPACE" }
+  | { readonly type: "SEARCH_SUBMIT" }
+  | { readonly type: "MESSAGE_CHAR"; readonly char: string }
+  | { readonly type: "MESSAGE_BACKSPACE" }
+  | { readonly type: "MESSAGE_CLEAR" }
+  | { readonly type: "BROADCAST_MODE" }
+  | { readonly type: "DIRECT_MESSAGE_MODE" }
+  | { readonly type: "GOAL_INPUT_MODE" }
+  | { readonly type: "GOAL_CHAR"; readonly char: string }
+  | { readonly type: "GOAL_BACKSPACE" }
+  | { readonly type: "GOAL_SUBMIT" }
+  | { readonly type: "COMPARE_TOGGLE" }
+  | { readonly type: "COMPARE_SELECT"; readonly cid: string }
+  | { readonly type: "COMPARE_ADOPT" }
+  | { readonly type: "ZOOM_CYCLE" }
+  | { readonly type: "ZOOM_RESET" }
+  | { readonly type: "TERMINAL_SCROLL_UP" }
+  | { readonly type: "TERMINAL_SCROLL_DOWN" }
+  | { readonly type: "TERMINAL_SCROLL_BOTTOM" }
+  | { readonly type: "LAYOUT_TOGGLE" };
+
+export const INITIAL_KEYBOARD_STATE: TuiKeyboardState = {
+  vfsNavigateTrigger: 0,
+  artifactIndex: 0,
+  showArtifactDiff: false,
+  paletteIndex: 0,
+  paletteQuery: "",
+  searchQuery: "",
+  searchBuffer: "",
+  messageBuffer: "",
+  messageRecipients: "",
+  goalBuffer: "",
+  compareMode: false,
+  compareCids: [],
+  zoomLevel: "normal",
+  terminalScrollOffset: 0,
+  layoutMode: "tab",
+};
+
+/** Pure reducer for TUI keyboard state - testable and serializable. */
+export function tuiReducer(state: TuiKeyboardState, action: TuiAction): TuiKeyboardState {
+  switch (action.type) {
+    case "VFS_NAVIGATE":
+      return { ...state, vfsNavigateTrigger: state.vfsNavigateTrigger + 1 };
+    case "ARTIFACT_PREV":
+      return { ...state, artifactIndex: Math.max(0, state.artifactIndex - 1) };
+    case "ARTIFACT_NEXT":
+      return { ...state, artifactIndex: state.artifactIndex + 1 };
+    case "ARTIFACT_DIFF_TOGGLE":
+      return { ...state, showArtifactDiff: !state.showArtifactDiff };
+    case "PALETTE_UP":
+      return { ...state, paletteIndex: Math.max(0, state.paletteIndex - 1) };
+    case "PALETTE_DOWN":
+      return { ...state, paletteIndex: Math.min(state.paletteIndex + 1, action.maxIndex) };
+    case "PALETTE_RESET":
+      return { ...state, paletteIndex: 0, paletteQuery: "" };
+    case "PALETTE_CHAR":
+      return { ...state, paletteQuery: state.paletteQuery + action.char, paletteIndex: 0 };
+    case "PALETTE_BACKSPACE":
+      return { ...state, paletteQuery: state.paletteQuery.slice(0, -1), paletteIndex: 0 };
+    case "SEARCH_START":
+      return { ...state, searchBuffer: action.currentQuery };
+    case "SEARCH_CHAR":
+      return { ...state, searchBuffer: state.searchBuffer + action.char };
+    case "SEARCH_BACKSPACE":
+      return { ...state, searchBuffer: state.searchBuffer.slice(0, -1) };
+    case "SEARCH_SUBMIT":
+      return { ...state, searchQuery: state.searchBuffer };
+    case "MESSAGE_CHAR":
+      return { ...state, messageBuffer: state.messageBuffer + action.char };
+    case "MESSAGE_BACKSPACE":
+      return { ...state, messageBuffer: state.messageBuffer.slice(0, -1) };
+    case "MESSAGE_CLEAR":
+      return { ...state, messageBuffer: "", messageRecipients: "" };
+    case "BROADCAST_MODE":
+      return { ...state, messageBuffer: "", messageRecipients: "@all" };
+    case "DIRECT_MESSAGE_MODE":
+      return { ...state, messageBuffer: "@", messageRecipients: "@direct" };
+    case "GOAL_INPUT_MODE":
+      return { ...state, goalBuffer: "" };
+    case "GOAL_CHAR":
+      return { ...state, goalBuffer: state.goalBuffer + action.char };
+    case "GOAL_BACKSPACE":
+      return { ...state, goalBuffer: state.goalBuffer.slice(0, -1) };
+    case "GOAL_SUBMIT":
+      return { ...state, goalBuffer: "" };
+    case "COMPARE_TOGGLE":
+      return {
+        ...state,
+        compareMode: !state.compareMode,
+        compareCids: state.compareMode ? state.compareCids : [],
+      };
+    case "COMPARE_SELECT": {
+      const prev = state.compareCids;
+      if (prev.includes(action.cid)) {
+        return { ...state, compareCids: prev.filter((c) => c !== action.cid) };
+      }
+      if (prev.length >= 2) {
+        const second = prev[1] ?? prev[0] ?? action.cid;
+        return { ...state, compareCids: [second, action.cid] };
+      }
+      return { ...state, compareCids: [...prev, action.cid] };
+    }
+    case "COMPARE_ADOPT":
+      return { ...state, compareMode: false, compareCids: [] };
+    case "ZOOM_CYCLE":
+      return { ...state, zoomLevel: nextZoom(state.zoomLevel) };
+    case "ZOOM_RESET":
+      return state.zoomLevel === "normal" ? state : { ...state, zoomLevel: "normal" };
+    case "TERMINAL_SCROLL_UP":
+      return { ...state, terminalScrollOffset: state.terminalScrollOffset + 5 };
+    case "TERMINAL_SCROLL_DOWN":
+      return { ...state, terminalScrollOffset: Math.max(0, state.terminalScrollOffset - 5) };
+    case "TERMINAL_SCROLL_BOTTOM":
+      return state.terminalScrollOffset === 0 ? state : { ...state, terminalScrollOffset: 0 };
+    case "LAYOUT_TOGGLE":
+      return { ...state, layoutMode: state.layoutMode === "tab" ? "grid" : "tab" };
+  }
+}

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -17,6 +17,7 @@ import type { Claim, Contribution } from "../core/models.js";
 import { safeCleanup } from "../shared/safe-cleanup.js";
 import { checkSpawn, checkSpawnDepth } from "./agents/spawn-validator.js";
 import { agentIdFromSession } from "./agents/tmux-manager.js";
+import { INITIAL_KEYBOARD_STATE, tuiReducer } from "./app-reducer.js";
 import { buildPaletteItems, CommandPalette, fuzzyMatch } from "./components/command-palette.js";
 import { HelpOverlay } from "./components/help-overlay.js";
 import { InputBar } from "./components/input-bar.js";
@@ -24,6 +25,10 @@ import { StatusBar } from "./components/status-bar.js";
 import { PanelBar } from "./components/tab-bar.js";
 import { TooltipOverlay, useFirstLaunchTooltips } from "./components/tooltip-overlay.js";
 import type { GroveUserConfig } from "./config-loader.js";
+
+export type { TuiAction, TuiKeyboardState } from "./app-reducer.js";
+export { tuiReducer } from "./app-reducer.js";
+
 import { useProviderScoped } from "./hooks/informer-context.js";
 import { useRelistTrigger } from "./hooks/refresh-context.js";
 import { useEventDrivenData } from "./hooks/use-event-driven-data.js";
@@ -78,163 +83,6 @@ function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M tok`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K tok`;
   return `${n} tok`;
-}
-
-// ---------------------------------------------------------------------------
-// TUI keyboard state — consolidated into a reducer for testability
-// and future session persistence support.
-// ---------------------------------------------------------------------------
-
-/** State managed by the keyboard-driven reducer. */
-export interface TuiKeyboardState {
-  readonly vfsNavigateTrigger: number;
-  readonly artifactIndex: number;
-  readonly showArtifactDiff: boolean;
-  readonly paletteIndex: number;
-  readonly paletteQuery: string;
-  readonly searchQuery: string;
-  readonly searchBuffer: string;
-  readonly messageBuffer: string;
-  readonly messageRecipients: string;
-  readonly goalBuffer: string;
-  readonly compareMode: boolean;
-  readonly compareCids: readonly string[];
-  readonly zoomLevel: ZoomLevel;
-  readonly terminalScrollOffset: number;
-  readonly layoutMode: "grid" | "tab";
-}
-
-/** Actions for the TUI keyboard state reducer. */
-export type TuiAction =
-  | { readonly type: "VFS_NAVIGATE" }
-  | { readonly type: "ARTIFACT_PREV" }
-  | { readonly type: "ARTIFACT_NEXT" }
-  | { readonly type: "ARTIFACT_DIFF_TOGGLE" }
-  | { readonly type: "PALETTE_UP" }
-  | { readonly type: "PALETTE_DOWN"; readonly maxIndex: number }
-  | { readonly type: "PALETTE_RESET" }
-  | { readonly type: "PALETTE_CHAR"; readonly char: string }
-  | { readonly type: "PALETTE_BACKSPACE" }
-  | { readonly type: "SEARCH_START"; readonly currentQuery: string }
-  | { readonly type: "SEARCH_CHAR"; readonly char: string }
-  | { readonly type: "SEARCH_BACKSPACE" }
-  | { readonly type: "SEARCH_SUBMIT" }
-  | { readonly type: "MESSAGE_CHAR"; readonly char: string }
-  | { readonly type: "MESSAGE_BACKSPACE" }
-  | { readonly type: "MESSAGE_CLEAR" }
-  | { readonly type: "BROADCAST_MODE" }
-  | { readonly type: "DIRECT_MESSAGE_MODE" }
-  | { readonly type: "GOAL_INPUT_MODE" }
-  | { readonly type: "GOAL_CHAR"; readonly char: string }
-  | { readonly type: "GOAL_BACKSPACE" }
-  | { readonly type: "GOAL_SUBMIT" }
-  | { readonly type: "COMPARE_TOGGLE" }
-  | { readonly type: "COMPARE_SELECT"; readonly cid: string }
-  | { readonly type: "COMPARE_ADOPT" }
-  | { readonly type: "ZOOM_CYCLE" }
-  | { readonly type: "ZOOM_RESET" }
-  | { readonly type: "TERMINAL_SCROLL_UP" }
-  | { readonly type: "TERMINAL_SCROLL_DOWN" }
-  | { readonly type: "TERMINAL_SCROLL_BOTTOM" }
-  | { readonly type: "LAYOUT_TOGGLE" };
-
-const INITIAL_KEYBOARD_STATE: TuiKeyboardState = {
-  vfsNavigateTrigger: 0,
-  artifactIndex: 0,
-  showArtifactDiff: false,
-  paletteIndex: 0,
-  paletteQuery: "",
-  searchQuery: "",
-  searchBuffer: "",
-  messageBuffer: "",
-  messageRecipients: "",
-  goalBuffer: "",
-  compareMode: false,
-  compareCids: [],
-  zoomLevel: "normal",
-  terminalScrollOffset: 0,
-  layoutMode: "tab",
-};
-
-/** Pure reducer for TUI keyboard state — testable and serializable. */
-export function tuiReducer(state: TuiKeyboardState, action: TuiAction): TuiKeyboardState {
-  switch (action.type) {
-    case "VFS_NAVIGATE":
-      return { ...state, vfsNavigateTrigger: state.vfsNavigateTrigger + 1 };
-    case "ARTIFACT_PREV":
-      return { ...state, artifactIndex: Math.max(0, state.artifactIndex - 1) };
-    case "ARTIFACT_NEXT":
-      return { ...state, artifactIndex: state.artifactIndex + 1 };
-    case "ARTIFACT_DIFF_TOGGLE":
-      return { ...state, showArtifactDiff: !state.showArtifactDiff };
-    case "PALETTE_UP":
-      return { ...state, paletteIndex: Math.max(0, state.paletteIndex - 1) };
-    case "PALETTE_DOWN":
-      return { ...state, paletteIndex: Math.min(state.paletteIndex + 1, action.maxIndex) };
-    case "PALETTE_RESET":
-      return { ...state, paletteIndex: 0, paletteQuery: "" };
-    case "PALETTE_CHAR":
-      return { ...state, paletteQuery: state.paletteQuery + action.char, paletteIndex: 0 };
-    case "PALETTE_BACKSPACE":
-      return { ...state, paletteQuery: state.paletteQuery.slice(0, -1), paletteIndex: 0 };
-    case "SEARCH_START":
-      return { ...state, searchBuffer: action.currentQuery };
-    case "SEARCH_CHAR":
-      return { ...state, searchBuffer: state.searchBuffer + action.char };
-    case "SEARCH_BACKSPACE":
-      return { ...state, searchBuffer: state.searchBuffer.slice(0, -1) };
-    case "SEARCH_SUBMIT":
-      return { ...state, searchQuery: state.searchBuffer };
-    case "MESSAGE_CHAR":
-      return { ...state, messageBuffer: state.messageBuffer + action.char };
-    case "MESSAGE_BACKSPACE":
-      return { ...state, messageBuffer: state.messageBuffer.slice(0, -1) };
-    case "MESSAGE_CLEAR":
-      return { ...state, messageBuffer: "", messageRecipients: "" };
-    case "BROADCAST_MODE":
-      return { ...state, messageBuffer: "", messageRecipients: "@all" };
-    case "DIRECT_MESSAGE_MODE":
-      return { ...state, messageBuffer: "@", messageRecipients: "@direct" };
-    case "GOAL_INPUT_MODE":
-      return { ...state, goalBuffer: "" };
-    case "GOAL_CHAR":
-      return { ...state, goalBuffer: state.goalBuffer + action.char };
-    case "GOAL_BACKSPACE":
-      return { ...state, goalBuffer: state.goalBuffer.slice(0, -1) };
-    case "GOAL_SUBMIT":
-      return { ...state, goalBuffer: "" };
-    case "COMPARE_TOGGLE":
-      return {
-        ...state,
-        compareMode: !state.compareMode,
-        compareCids: state.compareMode ? state.compareCids : [],
-      };
-    case "COMPARE_SELECT": {
-      const prev = state.compareCids;
-      if (prev.includes(action.cid)) {
-        return { ...state, compareCids: prev.filter((c) => c !== action.cid) };
-      }
-      if (prev.length >= 2) {
-        const second = prev[1] ?? prev[0] ?? action.cid;
-        return { ...state, compareCids: [second, action.cid] };
-      }
-      return { ...state, compareCids: [...prev, action.cid] };
-    }
-    case "COMPARE_ADOPT":
-      return { ...state, compareMode: false, compareCids: [] };
-    case "ZOOM_CYCLE":
-      return { ...state, zoomLevel: nextZoom(state.zoomLevel) };
-    case "ZOOM_RESET":
-      return state.zoomLevel === "normal" ? state : { ...state, zoomLevel: "normal" };
-    case "TERMINAL_SCROLL_UP":
-      return { ...state, terminalScrollOffset: state.terminalScrollOffset + 5 };
-    case "TERMINAL_SCROLL_DOWN":
-      return { ...state, terminalScrollOffset: Math.max(0, state.terminalScrollOffset - 5) };
-    case "TERMINAL_SCROLL_BOTTOM":
-      return state.terminalScrollOffset === 0 ? state : { ...state, terminalScrollOffset: 0 };
-    case "LAYOUT_TOGGLE":
-      return { ...state, layoutMode: state.layoutMode === "tab" ? "grid" : "tab" };
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tui/hooks/use-done-detection.ts
+++ b/src/tui/hooks/use-done-detection.ts
@@ -1,8 +1,10 @@
 /**
- * Detects session completion by watching for done signals from all topology roles.
+ * Detects session completion by watching for explicit done signals.
  *
  * Polls contributions for [DONE] prefix or context.done flag.
- * Calls onDone when all roles have signaled completion.
+ * Calls onDone on the first done signal. `grove_done` is an explicit session
+ * terminator in the TUI workflow; waiting for every role to also signal done
+ * leaves review-loop sessions alive after reviewer approval.
  *
  * Extracted from ScreenManager to reduce component complexity.
  */
@@ -33,7 +35,7 @@ function isDoneContribution(c: { summary: string; context?: unknown }): boolean 
  * @param topology - Agent topology with role definitions
  * @param screen - Current screen state (only active on "running" or "advanced")
  * @param eventBus - Event bus for real-time done detection; without it the hook is inert
- * @param onDone - Callback when all roles have signaled done
+ * @param onDone - Callback when the session has been explicitly signaled done
  */
 export function useDoneDetection(
   topology: AgentTopology | undefined,
@@ -41,20 +43,19 @@ export function useDoneDetection(
   eventBus: EventBus | undefined,
   onDone: () => void,
 ): void {
-  const doneRolesRef = useRef<Set<string>>(new Set());
+  const doneSignaledRef = useRef(false);
 
-  const checkDone = useCallback(
-    (role: string) => {
-      if (!topology) return;
-      doneRolesRef.current.add(role);
-      const roleNames = new Set(topology.roles.map((r) => r.name));
-      const allDone = [...roleNames].every((r) => doneRolesRef.current.has(r));
-      if (allDone && roleNames.size > 0) {
-        onDone();
-      }
-    },
-    [topology, onDone],
-  );
+  const signalDone = useCallback(() => {
+    if (!topology || doneSignaledRef.current) return;
+    doneSignaledRef.current = true;
+    onDone();
+  }, [topology, onDone]);
+
+  useEffect(() => {
+    if (screen !== "running" && screen !== "advanced") {
+      doneSignaledRef.current = false;
+    }
+  }, [screen]);
 
   // Event-driven mode: subscribe to EventBus for real-time done detection
   useEffect(() => {
@@ -70,11 +71,11 @@ export function useDoneDetection(
             payload.summary &&
             isDoneContribution(payload as { summary: string; context?: unknown })
           ) {
-            checkDone(event.sourceRole);
+            signalDone();
           }
         }
         if (event.type === "stop") {
-          checkDone(role.name);
+          signalDone();
         }
       };
       handlers.push({ role: role.name, handler });
@@ -86,5 +87,5 @@ export function useDoneDetection(
         eventBus.unsubscribe(role, handler);
       }
     };
-  }, [screen, topology, eventBus, checkDone]);
+  }, [screen, topology, eventBus, signalDone]);
 }

--- a/src/tui/hooks/use-keyboard-handler.test.ts
+++ b/src/tui/hooks/use-keyboard-handler.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
+import { INITIAL_KEYBOARD_STATE, tuiReducer } from "../app-reducer.js";
 import { PANEL_REGISTRY } from "../panels/panel-registry.js";
 import { buildKeyActionMap } from "./use-keybinding-overrides.js";
 import type { KeyboardActions } from "./use-keyboard-handler.js";
@@ -627,33 +628,15 @@ describe("panel registry completeness — every panel has a keybinding in routeK
 });
 
 // ---------------------------------------------------------------------------
-// TUI reducer tests (imported async because app.tsx has async deps)
+// TUI reducer tests
 // ---------------------------------------------------------------------------
 
 describe("tuiReducer", () => {
-  // biome-ignore lint/suspicious/noExplicitAny: dynamic import in test
-  let tuiReducer: any;
-
-  // Load the module once before tests
-  test("loads tuiReducer", async () => {
-    const mod = await import("../app.js");
-    tuiReducer = mod.tuiReducer;
+  test("loads tuiReducer", () => {
     expect(typeof tuiReducer).toBe("function");
   });
 
-  const initial = {
-    vfsNavigateTrigger: 0,
-    artifactIndex: 0,
-    showArtifactDiff: false,
-    paletteIndex: 0,
-    searchQuery: "",
-    searchBuffer: "",
-    messageBuffer: "",
-    messageRecipients: "",
-    compareMode: false,
-    compareCids: [] as readonly string[],
-    zoomLevel: "normal" as const,
-  };
+  const initial = INITIAL_KEYBOARD_STATE;
 
   test("ZOOM_CYCLE cycles through levels", () => {
     let state = tuiReducer(initial, { type: "ZOOM_CYCLE" });

--- a/src/tui/screens/agent-detect.launch.test.ts
+++ b/src/tui/screens/agent-detect.launch.test.ts
@@ -69,6 +69,59 @@ async function flushAsync(ms: number = 0): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function mountLaunchPreview(
+  onContinue: (
+    detected: Map<string, boolean>,
+    roleMapping: Map<string, string>,
+    rolePrompts: Map<string, string>,
+    edgeTimeouts: Map<string, number>,
+    roleSkills: Map<string, readonly string[]>,
+  ) => void,
+  topology: AgentTopology = TEST_TOPOLOGY,
+): Promise<void> {
+  let renderer: TestRenderer.ReactTestRenderer | undefined;
+  await act(async () => {
+    renderer = TestRenderer.create(
+      React.createElement(AgentDetect, {
+        topology,
+        onContinue,
+        onBack: () => undefined,
+      }),
+    );
+    await flushAsync();
+  });
+
+  if (!renderer) {
+    throw new Error("AgentDetect did not mount");
+  }
+  mountedRenderers.push(renderer);
+
+  const handler = keyboardHandler;
+  if (!handler) {
+    throw new Error("No keyboard handler registered");
+  }
+}
+
+async function pressCurrentKey(key: KeyboardKey): Promise<void> {
+  const handler = keyboardHandler;
+  if (!handler) {
+    throw new Error("No keyboard handler registered");
+  }
+  await act(async () => {
+    handler(key);
+    await flushAsync();
+  });
+}
+
+async function typeCurrentText(value: string): Promise<void> {
+  for (const char of value) {
+    await pressCurrentKey({
+      name: char === " " ? "space" : char,
+      sequence: char,
+    });
+  }
+}
+
 describe("AgentDetect launch preview", () => {
   test("launch submits initialized role skills for all roles", async () => {
     let capturedRoleSkills: Map<string, readonly string[]> | undefined;
@@ -82,36 +135,55 @@ describe("AgentDetect launch preview", () => {
       capturedRoleSkills = roleSkills;
     };
 
-    let renderer: TestRenderer.ReactTestRenderer | undefined;
-    await act(async () => {
-      renderer = TestRenderer.create(
-        React.createElement(AgentDetect, {
-          topology: TEST_TOPOLOGY,
-          onContinue,
-          onBack: () => undefined,
-        }),
-      );
-      await flushAsync();
-    });
+    await mountLaunchPreview(onContinue);
 
-    if (!renderer) {
-      throw new Error("AgentDetect did not mount");
-    }
-    mountedRenderers.push(renderer);
-
-    const handler = keyboardHandler;
-    if (!handler) {
-      throw new Error("No keyboard handler registered");
-    }
-
-    await act(async () => {
-      handler({ name: "return" });
-      await flushAsync();
-    });
+    await pressCurrentKey({ name: "return" });
 
     expect(capturedRoleSkills).toEqual(
       new Map<string, readonly string[]>([
         ["planner", ["grove"]],
+        ["builder", []],
+      ]),
+    );
+  });
+
+  test("skill editing and copy-to-all are reflected on launch", async () => {
+    let capturedRoleSkills: Map<string, readonly string[]> | undefined;
+    await mountLaunchPreview(
+      (_detected, _roleMapping, _rolePrompts, _edgeTimeouts, roleSkills): void => {
+        capturedRoleSkills = roleSkills;
+      },
+    );
+
+    await pressCurrentKey({ name: "j" });
+    await pressCurrentKey({ name: "s" });
+    await typeCurrentText("review, lint");
+    await pressCurrentKey({ name: "return" });
+    await pressCurrentKey({ name: "a" });
+    await pressCurrentKey({ name: "return" });
+
+    expect(capturedRoleSkills).toEqual(
+      new Map<string, readonly string[]>([
+        ["planner", ["review", "lint"]],
+        ["builder", ["review", "lint"]],
+      ]),
+    );
+  });
+
+  test("clear removes the selected role skills before launch", async () => {
+    let capturedRoleSkills: Map<string, readonly string[]> | undefined;
+    await mountLaunchPreview(
+      (_detected, _roleMapping, _rolePrompts, _edgeTimeouts, roleSkills): void => {
+        capturedRoleSkills = roleSkills;
+      },
+    );
+
+    await pressCurrentKey({ name: "x" });
+    await pressCurrentKey({ name: "return" });
+
+    expect(capturedRoleSkills).toEqual(
+      new Map<string, readonly string[]>([
+        ["planner", []],
         ["builder", []],
       ]),
     );

--- a/src/tui/screens/agent-detect.launch.test.ts
+++ b/src/tui/screens/agent-detect.launch.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import type { AgentTopology } from "../../core/topology.js";
+
+type KeyboardKey = {
+  readonly name?: string | undefined;
+  readonly sequence?: string | undefined;
+};
+
+type KeyboardHandler = (key: KeyboardKey) => void;
+
+let keyboardHandler: KeyboardHandler | undefined;
+const mountedRenderers: TestRenderer.ReactTestRenderer[] = [];
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+mock.module("@opentui/react", () => ({
+  useKeyboard: (handler: KeyboardHandler): void => {
+    keyboardHandler = handler;
+  },
+  useRenderer: (): { destroy: () => void } => ({
+    destroy: () => undefined,
+  }),
+  useTerminalDimensions: (): { width: number; height: number } => ({
+    width: 120,
+    height: 40,
+  }),
+  useTimeline: (): { add: () => unknown; play: () => unknown } => ({
+    add: () => ({ add: () => ({ play: () => undefined }), play: () => undefined }),
+    play: () => undefined,
+  }),
+}));
+
+mock.module("./agent-cli-detect.js", () => ({
+  detectCli: () => true,
+}));
+
+mock.module("../layout/graph-layout.js", () => ({
+  layoutGraph: () => ({ nodes: [], edges: [] }),
+}));
+
+mock.module("../layout/edge-render.js", () => ({
+  renderGraph: () => ({ lines: [] }),
+}));
+
+const { AgentDetect } = await import("./agent-detect.js");
+
+const TEST_TOPOLOGY: AgentTopology = {
+  structure: "flat",
+  roles: [{ name: "planner", skills: ["grove"] }, { name: "builder" }],
+  spawning: { dynamic: false },
+};
+
+beforeEach(() => {
+  keyboardHandler = undefined;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const renderer of mountedRenderers.splice(0)) {
+      renderer.unmount();
+    }
+    await flushAsync();
+  });
+});
+
+async function flushAsync(ms: number = 0): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("AgentDetect launch preview", () => {
+  test("launch submits initialized role skills for all roles", async () => {
+    let capturedRoleSkills: Map<string, readonly string[]> | undefined;
+    const onContinue = (
+      _detected: Map<string, boolean>,
+      _roleMapping: Map<string, string>,
+      _rolePrompts: Map<string, string>,
+      _edgeTimeouts: Map<string, number>,
+      roleSkills: Map<string, readonly string[]>,
+    ): void => {
+      capturedRoleSkills = roleSkills;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        React.createElement(AgentDetect, {
+          topology: TEST_TOPOLOGY,
+          onContinue,
+          onBack: () => undefined,
+        }),
+      );
+      await flushAsync();
+    });
+
+    if (!renderer) {
+      throw new Error("AgentDetect did not mount");
+    }
+    mountedRenderers.push(renderer);
+
+    const handler = keyboardHandler;
+    if (!handler) {
+      throw new Error("No keyboard handler registered");
+    }
+
+    await act(async () => {
+      handler({ name: "return" });
+      await flushAsync();
+    });
+
+    expect(capturedRoleSkills).toEqual(
+      new Map<string, readonly string[]>([
+        ["planner", ["grove"]],
+        ["builder", []],
+      ]),
+    );
+  });
+});

--- a/src/tui/screens/agent-detect.launch.test.ts
+++ b/src/tui/screens/agent-detect.launch.test.ts
@@ -10,6 +10,10 @@ type KeyboardKey = {
 
 type KeyboardHandler = (key: KeyboardKey) => void;
 
+interface KeyboardHandlerGlobal {
+  __groveTestKeyboardHandler?: KeyboardHandler | undefined;
+}
+
 let keyboardHandler: KeyboardHandler | undefined;
 const mountedRenderers: TestRenderer.ReactTestRenderer[] = [];
 
@@ -18,6 +22,7 @@ const mountedRenderers: TestRenderer.ReactTestRenderer[] = [];
 mock.module("@opentui/react", () => ({
   useKeyboard: (handler: KeyboardHandler): void => {
     keyboardHandler = handler;
+    (globalThis as KeyboardHandlerGlobal).__groveTestKeyboardHandler = handler;
   },
   useRenderer: (): { destroy: () => void } => ({
     destroy: () => undefined,
@@ -44,7 +49,8 @@ mock.module("../layout/edge-render.js", () => ({
   renderGraph: () => ({ lines: [] }),
 }));
 
-const { AgentDetect } = await import("./agent-detect.js");
+const agentDetectModulePath = "./agent-detect.js?agent-detect-launch";
+const { AgentDetect } = (await import(agentDetectModulePath)) as typeof import("./agent-detect.js");
 
 const TEST_TOPOLOGY: AgentTopology = {
   structure: "flat",
@@ -54,6 +60,7 @@ const TEST_TOPOLOGY: AgentTopology = {
 
 beforeEach(() => {
   keyboardHandler = undefined;
+  (globalThis as KeyboardHandlerGlobal).__groveTestKeyboardHandler = undefined;
 });
 
 afterEach(async () => {
@@ -96,14 +103,16 @@ async function mountLaunchPreview(
   }
   mountedRenderers.push(renderer);
 
-  const handler = keyboardHandler;
+  const handler =
+    keyboardHandler ?? (globalThis as KeyboardHandlerGlobal).__groveTestKeyboardHandler;
   if (!handler) {
     throw new Error("No keyboard handler registered");
   }
 }
 
 async function pressCurrentKey(key: KeyboardKey): Promise<void> {
-  const handler = keyboardHandler;
+  const handler =
+    keyboardHandler ?? (globalThis as KeyboardHandlerGlobal).__groveTestKeyboardHandler;
   if (!handler) {
     throw new Error("No keyboard handler registered");
   }

--- a/src/tui/screens/agent-detect.tsx
+++ b/src/tui/screens/agent-detect.tsx
@@ -20,6 +20,12 @@ import { renderGraph } from "../layout/edge-render.js";
 import { layoutGraph } from "../layout/graph-layout.js";
 import { PLATFORM_COLORS, theme } from "../theme.js";
 import { detectCli } from "./agent-cli-detect.js";
+import {
+  applyRoleSkillsToAll,
+  formatRoleSkillsInput,
+  parseRoleSkillsInput,
+  setRoleSkills,
+} from "./role-skills.js";
 
 /** Known CLI tools and their platform identifiers. */
 const AGENT_CLIS: readonly { cli: string; platform: string; label: string }[] = [
@@ -38,6 +44,7 @@ export interface AgentDetectProps {
     roleMapping: Map<string, string>,
     rolePrompts: Map<string, string>,
     edgeTimeouts: Map<string, number>,
+    roleSkills: Map<string, readonly string[]>,
   ) => void;
   readonly onBack: () => void;
 }
@@ -55,6 +62,8 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
     const [cursor, setCursor] = useState(0);
     const [editing, setEditing] = useState(false);
     const [editBuffer, setEditBuffer] = useState("");
+    const [editingSkills, setEditingSkills] = useState(false);
+    const [skillBuffer, setSkillBuffer] = useState("");
 
     // Role prompts — initialized from topology, editable by user
     const [rolePrompts, setRolePrompts] = useState<Map<string, string>>(() => {
@@ -68,6 +77,17 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
     });
 
     const roles = topology?.roles ?? [];
+    const roleNames = useMemo(() => roles.map((role) => role.name), [roles]);
+
+    const [roleSkills, setRoleSkillsState] = useState<Map<string, readonly string[]>>(() => {
+      const map = new Map<string, readonly string[]>();
+      if (topology) {
+        for (const role of topology.roles) {
+          map.set(role.name, [...(role.skills ?? [])]);
+        }
+      }
+      return map;
+    });
 
     // Edge reply timeouts — initialized from topology, editable by user via [t] key
     const [edgeTimeouts, setEdgeTimeouts] = useState<Map<string, number>>(() => {
@@ -203,6 +223,27 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
             return;
           }
 
+          if (editingSkills) {
+            if (key.name === "escape" || key.name === "return" || key.name === "enter") {
+              const roleName = roles[cursor]?.name;
+              if (roleName) {
+                setRoleSkillsState((current) =>
+                  setRoleSkills(current, roleName, parseRoleSkillsInput(skillBuffer)),
+                );
+              }
+              setEditingSkills(false);
+              return;
+            }
+            if (key.name === "backspace") {
+              setSkillBuffer((current) => current.slice(0, -1));
+              return;
+            }
+            if ((key.sequence ?? "").length === 1) {
+              setSkillBuffer((current) => current + (key.sequence ?? ""));
+            }
+            return;
+          }
+
           if (editing) {
             if (key.name === "escape") {
               // Save on exit
@@ -228,6 +269,28 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
           }
           if (key.name === "k" || key.name === "up") {
             setCursor((c) => Math.max(c - 1, 0));
+            return;
+          }
+          if (key.name === "s") {
+            const roleName = roles[cursor]?.name;
+            if (roleName) {
+              setSkillBuffer(formatRoleSkillsInput(roleSkills.get(roleName) ?? []));
+              setEditingSkills(true);
+            }
+            return;
+          }
+          if (key.name === "x") {
+            const roleName = roles[cursor]?.name;
+            if (roleName) {
+              setRoleSkillsState((current) => setRoleSkills(current, roleName, []));
+            }
+            return;
+          }
+          if (key.name === "a") {
+            const roleName = roles[cursor]?.name;
+            if (roleName) {
+              setRoleSkillsState((current) => applyRoleSkillsToAll(roleNames, current, roleName));
+            }
             return;
           }
           // c: cycle CLI for the selected role
@@ -271,7 +334,7 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
           // Enter: launch agents (only Enter, not Tab/Space/Right which caused accidental spawns)
           if (key.name === "return" || key.name === "enter") {
             if (!scanning) {
-              onContinue(detected, roleMapping, rolePrompts, edgeTimeouts);
+              onContinue(detected, roleMapping, rolePrompts, edgeTimeouts, roleSkills);
             }
             return;
           }
@@ -286,14 +349,18 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
           roleMapping,
           rolePrompts,
           edgeTimeouts,
+          roleSkills,
           onContinue,
           onBack,
           editing,
           editBuffer,
+          editingSkills,
+          skillBuffer,
           editingTimeout,
           timeoutBuffer,
           cursor,
           roles,
+          roleNames,
           availableClis,
         ],
       ),
@@ -484,16 +551,58 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
           </box>
         ) : null}
 
+        {/* Role skills — editable */}
+        {roles.length > 0 ? (
+          <box
+            flexDirection="column"
+            marginX={2}
+            marginTop={1}
+            borderStyle="round"
+            borderColor={theme.border}
+            paddingX={1}
+          >
+            <text color={theme.text} bold>
+              Role Skills (s:edit, x:clear, a:copy to all)
+            </text>
+            {roles.map((role, i) => {
+              const selected = i === cursor;
+              const skills = roleSkills.get(role.name) ?? [];
+              const isEditingSelected = editingSkills && selected;
+              return (
+                <box
+                  key={role.name}
+                  flexDirection="row"
+                  backgroundColor={selected ? theme.selectedBg : undefined}
+                  paddingX={1}
+                >
+                  <text color={selected ? theme.focus : theme.text}>{selected ? "> " : "  "}</text>
+                  <text color={theme.text}>{role.name.padEnd(12)}</text>
+                  <text color={theme.secondary}> </text>
+                  <text color={isEditingSelected ? theme.focus : theme.secondary}>
+                    {isEditingSelected
+                      ? `${skillBuffer}_`
+                      : skills.length > 0
+                        ? formatRoleSkillsInput(skills)
+                        : "(none)"}
+                  </text>
+                </box>
+              );
+            })}
+          </box>
+        ) : null}
+
         {/* Hints */}
         <box paddingX={2} marginTop={1}>
           <text color={theme.secondary}>
             {editingTimeout
               ? "Type timeout in seconds (min 10, 0 or empty = no deadline)  Enter/Esc:save"
-              : editing
-                ? "Edit prompt (vim keys)  Esc:save & close"
-                : scanning
-                  ? "Scanning..."
-                  : "c:change CLI  e:edit prompt  t:set deadline  j/k:navigate  Enter:launch  Esc:back"}
+              : editingSkills
+                ? "Edit skills as comma-separated names  Enter/Esc:save"
+                : editing
+                  ? "Edit prompt (vim keys)  Esc:save & close"
+                  : scanning
+                    ? "Scanning..."
+                    : "c:change CLI  e:edit prompt  s:edit skills  x:clear skills  a:copy skills  t:set deadline  j/k:navigate  Enter:launch  Esc:back"}
           </text>
         </box>
       </box>

--- a/src/tui/screens/role-skills.test.ts
+++ b/src/tui/screens/role-skills.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applyRoleSkillsToAll,
+  formatRoleSkillsInput,
+  parseRoleSkillsInput,
+  setRoleSkills,
+} from "./role-skills.js";
+
+describe("role skill helpers", () => {
+  test("parseRoleSkillsInput normalizes comma-separated skill names", () => {
+    expect(parseRoleSkillsInput(" grove, review , ,grove,lint ")).toEqual([
+      "grove",
+      "review",
+      "lint",
+    ]);
+  });
+
+  test("parseRoleSkillsInput returns an empty list for blank input", () => {
+    expect(parseRoleSkillsInput("   ")).toEqual([]);
+  });
+
+  test("formatRoleSkillsInput joins skills for editing", () => {
+    expect(formatRoleSkillsInput(["grove", "review"])).toBe("grove, review");
+  });
+
+  test("setRoleSkills replaces one role without mutating the original map", () => {
+    const original = new Map<string, readonly string[]>([
+      ["planner", ["grove"]],
+      ["builder", ["review"]],
+    ]);
+
+    const updated = setRoleSkills(original, "builder", ["lint"]);
+
+    expect([...original.entries()]).toEqual([
+      ["planner", ["grove"]],
+      ["builder", ["review"]],
+    ]);
+    expect([...updated.entries()]).toEqual([
+      ["planner", ["grove"]],
+      ["builder", ["lint"]],
+    ]);
+    expect(updated).not.toBe(original);
+    expect(updated.get("builder")).not.toBe(original.get("builder"));
+  });
+
+  test("applyRoleSkillsToAll copies the selected role skills to every role", () => {
+    const current = new Map<string, readonly string[]>([
+      ["planner", ["grove", "review"]],
+      ["builder", []],
+      ["qa", ["lint"]],
+    ]);
+
+    const updated = applyRoleSkillsToAll(["planner", "builder", "qa"], current, "planner");
+
+    expect([...updated.entries()]).toEqual([
+      ["planner", ["grove", "review"]],
+      ["builder", ["grove", "review"]],
+      ["qa", ["grove", "review"]],
+    ]);
+    expect(updated.get("planner")).not.toBe(current.get("planner"));
+  });
+});

--- a/src/tui/screens/role-skills.ts
+++ b/src/tui/screens/role-skills.ts
@@ -1,0 +1,38 @@
+import { normalizeSkillList } from "../../core/session-skill-overrides.js";
+
+export function parseRoleSkillsInput(input: string): readonly string[] {
+  if (input.trim().length === 0) {
+    return [];
+  }
+
+  return normalizeSkillList(input.split(","));
+}
+
+export function formatRoleSkillsInput(skills: readonly string[]): string {
+  return skills.join(", ");
+}
+
+export function setRoleSkills(
+  current: ReadonlyMap<string, readonly string[]>,
+  roleName: string,
+  skills: readonly string[],
+): Map<string, readonly string[]> {
+  const next = new Map(current);
+  next.set(roleName, [...skills]);
+  return next;
+}
+
+export function applyRoleSkillsToAll(
+  roleNames: readonly string[],
+  current: ReadonlyMap<string, readonly string[]>,
+  sourceRole: string,
+): Map<string, readonly string[]> {
+  const sourceSkills = [...(current.get(sourceRole) ?? [])];
+  const next = new Map(current);
+
+  for (const roleName of roleNames) {
+    next.set(roleName, [...sourceSkills]);
+  }
+
+  return next;
+}

--- a/src/tui/screens/screen-manager.test.ts
+++ b/src/tui/screens/screen-manager.test.ts
@@ -10,6 +10,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
+import { LocalEventBus } from "../../core/local-event-bus.js";
 import type { Contribution } from "../../core/models.js";
 import { ContributionKind, ContributionMode } from "../../core/models.js";
 import { lookupPresetTopology } from "../../core/presets.js";
@@ -86,6 +87,7 @@ interface TestSpawnManager {
   readonly reconcileCalls: string[];
   readonly saveTraceCalls: string[];
   readonly stopLogPollingCalls: string[];
+  readonly stopCurrentSessionCalls: string[];
   reconcile(): Promise<void>;
   ensureLogBuffer(roleName: string): void;
   getLogBuffers(): Map<string, unknown>;
@@ -94,6 +96,7 @@ interface TestSpawnManager {
   setSessionId(sessionId: string): void;
   loadTraces(sessionId: string): Promise<void>;
   saveTraces(): Promise<void>;
+  stopCurrentSession(): Promise<void>;
   setSessionGoal(goal: string): void;
   setTopology(topology: AgentTopology): void;
   spawn(
@@ -360,6 +363,7 @@ function makeSpawnManager(): TestSpawnManager {
     reconcileCalls: [],
     saveTraceCalls: [],
     stopLogPollingCalls: [],
+    stopCurrentSessionCalls: [],
     reconcile: async () => {
       manager.reconcileCalls.push("reconcile");
     },
@@ -378,6 +382,9 @@ function makeSpawnManager(): TestSpawnManager {
     loadTraces: async () => undefined,
     saveTraces: async () => {
       manager.saveTraceCalls.push("save");
+    },
+    stopCurrentSession: async () => {
+      manager.stopCurrentSessionCalls.push("stop-current");
     },
     setSessionGoal: (goal: string) => {
       manager.sessionGoals.push(goal);
@@ -699,7 +706,7 @@ describe("ScreenManager transition flow", () => {
     const providerBundle = makeProvider({
       contributions: [makeContribution("c1"), makeContribution("c2")],
     });
-    renderScreenManager({
+    const { spawnManager } = renderScreenManager({
       provider: providerBundle.provider,
       topology: TEST_TOPOLOGY,
       initialState: {
@@ -720,6 +727,99 @@ describe("ScreenManager transition flow", () => {
     expect(requireCompleteView().reason).toBe("All roles signaled done");
     expect(requireCompleteView().contributionCount).toBe(2);
     expect(providerBundle.calls.archiveSession).toEqual(["session-done"]);
+    expect(spawnManager.stopCurrentSessionCalls).toEqual(["stop-current"]);
+  });
+
+  test("running -> complete when reviewer signals grove_done", async () => {
+    const eventBus = new LocalEventBus();
+    const doneContribution: Contribution = {
+      ...makeContribution("done-reviewer"),
+      kind: ContributionKind.Discussion,
+      summary: "[DONE] Approved",
+      context: { done: true, reason: "Approved", ephemeral: true },
+      agent: { agentId: "reviewer-1", role: "reviewer" },
+    };
+    const providerBundle = makeProvider({
+      contributions: [doneContribution],
+    });
+    const reviewTopology: AgentTopology = {
+      structure: "graph",
+      roles: [
+        { name: "coder", description: "Writes code", command: "codex" },
+        { name: "reviewer", description: "Reviews code", command: "claude" },
+      ],
+      spawning: { dynamic: false },
+    };
+
+    renderScreenManager({
+      appProps: { ...makeAppProps(providerBundle.provider, reviewTopology), eventBus },
+      provider: providerBundle.provider,
+      initialState: {
+        screen: "running",
+        goal: "Complete the review loop",
+        sessionId: "session-review-done",
+        sessionStartedAt: "2026-03-29T00:00:00.000Z",
+      },
+    });
+
+    await act(async () => {
+      await eventBus.publishLocal({
+        type: "contribution",
+        sourceRole: "reviewer",
+        targetRole: "reviewer",
+        payload: {
+          summary: doneContribution.summary,
+          context: doneContribution.context,
+        },
+        timestamp: "2026-03-29T00:00:01.000Z",
+      });
+      await flushAsync();
+      await flushAsync();
+    });
+
+    expect(captured.screen).toBe("complete");
+    expect(requireCompleteView().reason).toBe("Session signaled done");
+    expect(requireCompleteView().contributionCount).toBe(1);
+    expect(providerBundle.calls.archiveSession).toEqual(["session-review-done"]);
+    eventBus.close();
+  });
+
+  test("running -> complete when contribution feed observes reviewer grove_done", async () => {
+    const doneContribution: Contribution = {
+      ...makeContribution("done-reviewer-feed"),
+      kind: ContributionKind.Discussion,
+      summary: "[DONE] Approved",
+      context: { done: true, reason: "Approved", ephemeral: true },
+      agent: { agentId: "reviewer-1", role: "reviewer" },
+    };
+    const providerBundle = makeProvider({
+      contributions: [doneContribution],
+    });
+
+    const { spawnManager } = renderScreenManager({
+      provider: providerBundle.provider,
+      topology: TEST_TOPOLOGY,
+      initialState: {
+        screen: "running",
+        goal: "Complete from feed",
+        sessionId: "session-feed-done",
+        sessionStartedAt: "2026-03-29T00:00:00.000Z",
+      },
+    });
+
+    await act(async () => {
+      const onNewContribution = requireRunningView().onNewContribution;
+      if (!onNewContribution) throw new Error("RunningView did not receive onNewContribution");
+      onNewContribution(doneContribution);
+      await flushAsync();
+      await flushAsync();
+    });
+
+    expect(captured.screen).toBe("complete");
+    expect(requireCompleteView().reason).toBe("Session signaled done");
+    expect(requireCompleteView().contributionCount).toBe(1);
+    expect(providerBundle.calls.archiveSession).toEqual(["session-feed-done"]);
+    expect(spawnManager.stopCurrentSessionCalls).toEqual(["stop-current"]);
   });
 
   test("complete -> preset-select starts a fresh session when no preset state is reusable", () => {

--- a/src/tui/screens/screen-manager.test.ts
+++ b/src/tui/screens/screen-manager.test.ts
@@ -12,6 +12,7 @@ import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import type { Contribution } from "../../core/models.js";
 import { ContributionKind, ContributionMode } from "../../core/models.js";
+import { lookupPresetTopology } from "../../core/presets.js";
 import type { AgentTopology } from "../../core/topology.js";
 import type { AppProps } from "../app.js";
 import type {
@@ -735,6 +736,70 @@ describe("ScreenManager transition flow", () => {
     });
 
     expect(captured.screen).toBe("preset-select");
+  });
+
+  test("complete -> new session restores preset topology after session skill edits", async () => {
+    const presetTopology = lookupPresetTopology("review-loop");
+    if (!presetTopology) {
+      throw new Error("Expected review-loop preset topology");
+    }
+
+    renderScreenManager({
+      presets: PRESETS,
+      initialState: {
+        screen: "goal-input",
+        selectedPreset: "review-loop",
+      },
+    });
+
+    await submitGoal("First run");
+
+    await act(async () => {
+      requireLaunchPreview().onContinue(
+        new Map([["claude", true]]),
+        new Map([
+          ["coder", "claude"],
+          ["reviewer", "claude"],
+        ]),
+        new Map(),
+        new Map(),
+        new Map<string, readonly string[]>([
+          ["coder", ["grove", "review"]],
+          ["reviewer", []],
+        ]),
+      );
+      await flushAsync();
+      await flushAsync();
+    });
+
+    await act(async () => {
+      requireSpawnProgress().onAllResolved();
+      await flushAsync();
+    });
+
+    await act(async () => {
+      requireRunningView().onComplete("First run complete");
+      await flushAsync();
+      await flushAsync();
+    });
+
+    act(() => {
+      requireCompleteView().onNewSession();
+    });
+
+    await submitGoal("Second run");
+
+    const nextLaunchPreview = requireLaunchPreview();
+    expect(nextLaunchPreview.topology?.roles).toEqual([
+      expect.objectContaining({
+        name: presetTopology.roles[0]?.name,
+        skills: presetTopology.roles[0]?.skills,
+      }),
+      expect.objectContaining({
+        name: presetTopology.roles[1]?.name,
+        skills: presetTopology.roles[1]?.skills,
+      }),
+    ]);
   });
 });
 

--- a/src/tui/screens/screen-manager.test.ts
+++ b/src/tui/screens/screen-manager.test.ts
@@ -127,6 +127,10 @@ mock.module("@opentui/react", () => ({
   }),
 }));
 
+mock.module("../app.js", () => ({
+  App: (): null => null,
+}));
+
 mock.module("../hooks/use-permission-detection.js", () => ({
   usePermissionDetection: (): readonly unknown[] => [],
 }));
@@ -586,6 +590,10 @@ describe("ScreenManager transition flow", () => {
           ["builder", "Build carefully"],
         ]),
         new Map([["planner:builder", 120]]),
+        new Map([
+          ["planner", []],
+          ["builder", []],
+        ]),
       );
       await flushAsync();
       await flushAsync();
@@ -599,6 +607,68 @@ describe("ScreenManager transition flow", () => {
     ]);
     expect(spawnManager.sessionGoals).toEqual(["Launch agents"]);
     expect(spawnManager.spawnCalls.map((call) => call.roleId)).toEqual(["planner", "builder"]);
+  });
+
+  test("launch-preview -> spawning stores edited role skills in the session topology snapshot", async () => {
+    const topologyWithSkills: AgentTopology = {
+      ...TEST_TOPOLOGY,
+      roles: [
+        {
+          name: "planner",
+          description: "Plans the work",
+          command: "codex",
+          platform: "codex",
+          edges: [{ target: "builder", edgeType: "delegates" }],
+          skills: ["grove"],
+        },
+        {
+          name: "builder",
+          description: "Builds the work",
+          command: "claude",
+          platform: "claude-code",
+          skills: ["review"],
+        },
+      ],
+    };
+    const providerBundle = makeProvider();
+    const { spawnManager } = renderScreenManager({
+      provider: providerBundle.provider,
+      topology: topologyWithSkills,
+    });
+    await submitGoal("Launch with skill overrides");
+
+    await act(async () => {
+      requireLaunchPreview().onContinue(
+        new Map([
+          ["codex", true],
+          ["claude", true],
+        ]),
+        new Map([
+          ["planner", "codex"],
+          ["builder", "claude"],
+        ]),
+        new Map(),
+        new Map(),
+        new Map<string, readonly string[]>([
+          ["planner", ["grove", "review"]],
+          ["builder", []],
+        ]),
+      );
+      await flushAsync();
+      await flushAsync();
+    });
+
+    const createdSession = providerBundle.calls.createSession[0];
+    if (!createdSession?.topology) {
+      throw new Error("Expected createSession to receive a topology");
+    }
+
+    expect(createdSession.topology.roles).toEqual([
+      expect.objectContaining({ name: "planner", skills: ["grove", "review"] }),
+      expect.objectContaining({ name: "builder", skills: [] }),
+    ]);
+    expect(spawnManager.spawnCalls[0]?.context?.skills).toEqual(["grove", "review"]);
+    expect(spawnManager.spawnCalls[1]?.context?.skills).toBeUndefined();
   });
 
   test("spawning -> running when spawn progress resolves", async () => {
@@ -705,7 +775,7 @@ describe("ScreenManager navigation and edge cases", () => {
     await submitGoal("Run without topology");
 
     await act(async () => {
-      requireLaunchPreview().onContinue(new Map(), new Map(), new Map(), new Map());
+      requireLaunchPreview().onContinue(new Map(), new Map(), new Map(), new Map(), new Map());
       await flushAsync();
       await flushAsync();
     });

--- a/src/tui/screens/screen-manager.test.ts
+++ b/src/tui/screens/screen-manager.test.ts
@@ -46,6 +46,10 @@ type KeyboardKey = {
 };
 type KeyboardHandler = (key: KeyboardKey) => void;
 
+interface KeyboardHandlerGlobal {
+  __groveTestKeyboardHandler?: KeyboardHandler | undefined;
+}
+
 interface CapturedScreens {
   screen?: "preset-select" | "launch-preview" | "spawning" | "running" | "complete";
   presetSelect?: PresetSelectProps;
@@ -118,6 +122,7 @@ let rendererDestroy = mock(() => undefined);
 mock.module("@opentui/react", () => ({
   useKeyboard: (handler: KeyboardHandler): void => {
     keyboardHandler = handler;
+    (globalThis as KeyboardHandlerGlobal).__groveTestKeyboardHandler = handler;
   },
   useRenderer: (): { destroy: () => void } => ({
     destroy: rendererDestroy,

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -309,6 +309,9 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
           /* best-effort */
         });
         spawnManager.stopLogPolling();
+        await spawnManager.stopCurrentSession().catch(() => {
+          /* best-effort */
+        });
 
         let contributionCount = 0;
         try {
@@ -334,7 +337,9 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
       [provider, spawnManager],
     );
     const handleDone = useCallback(() => {
-      void snapshotAndComplete("All roles signaled done");
+      if (doneSignaledRef.current) return;
+      doneSignaledRef.current = true;
+      void snapshotAndComplete("Session signaled done");
     }, [snapshotAndComplete]);
     useDoneDetection(topology, state.screen, appProps.eventBus, handleDone);
 
@@ -857,7 +862,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
                   typeof c.context === "object" &&
                   (c.context as Record<string, unknown>).done === true);
               if (isDone) {
-                doneSignaledRef.current = true;
+                handleDone();
                 return;
               }
               // Routing is handled by the SSE push bridge — don't re-deliver here.

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -13,6 +13,10 @@
 import { useKeyboard, useRenderer } from "@opentui/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { lookupPresetTopology } from "../../core/presets.js";
+import {
+  applySessionSkillOverrides,
+  type SessionSkillOverrideClause,
+} from "../../core/session-skill-overrides.js";
 import type { AgentTopology } from "../../core/topology.js";
 import { topologicalSortRoles } from "../../core/topology.js";
 import type { AppProps } from "../app.js";
@@ -415,6 +419,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
      */
     const spawnAgents = useCallback(
       async (goal: string, roleMapping: Map<string, string>) => {
+        const resolvedTopology = sessionTopologyRef.current ?? topology;
         debugLog(
           "spawnAgents",
           `goal="${goal}" roles=[${[...roleMapping.entries()].map(([k, v]) => `${k}→${v}`).join(",")}]`,
@@ -439,7 +444,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         // edited topology to createSession.
         if (isSessionProvider(provider)) {
           try {
-            const sessionTopology = sessionTopologyRef.current ?? topology;
+            const sessionTopology = resolvedTopology;
             const sessionConfig =
               contract && sessionTopology ? { ...contract, topology: sessionTopology } : contract;
             const session = await provider.createSession({
@@ -511,8 +516,8 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         }
 
         // Transition to spawning screen with per-agent tracking
-        if (topology && topology.roles.length > 0) {
-          const initialStates: AgentSpawnState[] = topology.roles.map((role) => ({
+        if (resolvedTopology && resolvedTopology.roles.length > 0) {
+          const initialStates: AgentSpawnState[] = resolvedTopology.roles.map((role) => ({
             role: role.name,
             command: roleMapping.get(role.name) ?? role.command ?? "codex",
             status: "waiting" as const,
@@ -528,12 +533,12 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
           spawnManager.setSessionGoal(goal);
           // Give SpawnManager the topology so it can resolve edge-type-aware
           // base branches (delegates/feeds/escalates → branch off source).
-          spawnManager.setTopology(topology);
+          spawnManager.setTopology(resolvedTopology);
           // Ensure log buffers exist for all topology roles BEFORE seekToEnd.
           // startLogPolling(seekToEnd=true) iterates logBuffers to record file
           // offsets; if buffers don't exist yet, the loop has nothing to iterate
           // and no positions are recorded — leaving pollLogFile() reading from 0.
-          for (const role of topology.roles) {
+          for (const role of resolvedTopology.roles) {
             spawnManager.ensureLogBuffer(role.name);
           }
           // New session — record current end-of-file for ALL existing role log
@@ -546,7 +551,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
           // dependent roles try to base their worktrees on them (delegates/feeds/escalates).
           // Sequential spawning is required because provisionWorkspace happens inside spawn().
           void (async () => {
-            const orderedRoles = topologicalSortRoles(topology);
+            const orderedRoles = topologicalSortRoles(resolvedTopology);
             for (const role of orderedRoles) {
               const userOverrideCmd = roleMapping.get(role.name);
               const command = userOverrideCmd ?? role.command ?? "codex";
@@ -561,7 +566,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
               // resolveAgent(). Let resolveAgent fall back to command parsing instead.
               if (!userOverrideCmd && role.platform) context.platform = role.platform;
               if (role.model) context.model = role.model;
-              if (topology) context.topology = topology;
+              context.topology = resolvedTopology;
 
               // Mark as spawning
               setState((s) => ({
@@ -608,6 +613,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         roleMappingFromPreview: Map<string, string>,
         rolePrompts: Map<string, string>,
         edgeTimeouts: Map<string, number>,
+        roleSkills: Map<string, readonly string[]>,
       ) => {
         // Guard: prevent duplicate spawn when user presses Escape → Enter twice.
         // hasSpawnedRef is set to true here and only reset in handleNewSession.
@@ -631,7 +637,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         // spawnAgents picks it up bypassing React's async state update. Also
         // call setTopology so the UI reflects the current session's config.
         if (topology) {
-          const sessionTopology = structuredClone(topology);
+          let sessionTopology = structuredClone(topology);
           for (const role of sessionTopology.roles) {
             if (role.edges) {
               for (const edge of role.edges) {
@@ -645,6 +651,14 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
               }
             }
           }
+          const skillClauses: SessionSkillOverrideClause[] = [...roleSkills.entries()].map(
+            ([target, skills]) => ({
+              target,
+              op: "replace",
+              skills: [...skills],
+            }),
+          );
+          sessionTopology = applySessionSkillOverrides(sessionTopology, skillClauses);
           sessionTopologyRef.current = sessionTopology;
           setTopology(sessionTopology);
         }

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -116,6 +116,16 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
       return presetName ? lookupPresetTopology(presetName) : undefined;
     });
 
+    const resolveBaselineTopology = useCallback(
+      (presetName?: string): AgentTopology | undefined => {
+        if (presetName) {
+          return lookupPresetTopology(presetName) ?? initialTopology;
+        }
+        return initialTopology;
+      },
+      [initialTopology],
+    );
+
     // Capture the resume session ID for setSessionScope — written in the useState
     // initializer (runs synchronously before effects) and read in the mount effect below.
     const resumeScopeIdRef = useRef<string | undefined>(undefined);
@@ -376,18 +386,21 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
     }, [provider, renderer, state.sessionId, spawnManager]);
 
     // Screen 1 -> Screen 2: preset selected → resolve topology and go to goal input
-    const handlePresetSelect = useCallback((presetName: string) => {
-      // Resolve topology from preset, falling back to GROVE.md default
-      const presetTopology = lookupPresetTopology(presetName);
-      if (presetTopology) {
-        setTopology(presetTopology);
-      }
-      setState((s) => ({
-        ...s,
-        screen: "goal-input",
-        selectedPreset: presetName,
-      }));
-    }, []);
+    const handlePresetSelect = useCallback(
+      (presetName: string) => {
+        // Resolve topology from preset, falling back to GROVE.md default
+        const presetTopology = resolveBaselineTopology(presetName);
+        if (presetTopology) {
+          setTopology(presetTopology);
+        }
+        setState((s) => ({
+          ...s,
+          screen: "goal-input",
+          selectedPreset: presetName,
+        }));
+      },
+      [resolveBaselineTopology],
+    );
 
     // Screen 2 -> Screen 3: goal entered → go to launch preview (auto-detect)
     const rolePromptsRef = useRef<Map<string, string>>(new Map());
@@ -707,26 +720,26 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
     const handleNewSession = useCallback(() => {
       doneSignaledRef.current = false;
       hasSpawnedRef.current = false; // Reset spawn guard for new session
-      setState((s) => {
-        // If we have preset + role mapping from a prior run, skip to goal input
-        if (s.selectedPreset && s.roleMapping) {
-          // Destructure to omit session-specific fields, preserve preset/detection state
-          const {
-            goal: _g,
-            sessionId: _s,
-            sessionStartedAt: _st,
-            spawnStates: _sp,
-            completeSnapshot: _c,
-            ...preserved
-          } = s;
-          return { ...preserved, screen: "goal-input" as const };
-        }
-        // No prior preset state — fall back to preset selection
-        return {
-          screen: presets && presets.length > 0 ? ("preset-select" as const) : ("running" as const),
-        };
+      sessionTopologyRef.current = undefined;
+
+      if (state.selectedPreset && state.roleMapping) {
+        setTopology(resolveBaselineTopology(state.selectedPreset));
+        const {
+          goal: _g,
+          sessionId: _s,
+          sessionStartedAt: _st,
+          spawnStates: _sp,
+          completeSnapshot: _c,
+          ...preserved
+        } = state;
+        setState({ ...preserved, screen: "goal-input" as const });
+        return;
+      }
+
+      setState({
+        screen: presets && presets.length > 0 ? ("preset-select" as const) : ("running" as const),
       });
-    }, [presets]);
+    }, [presets, resolveBaselineTopology, state]);
 
     // Compute duration string
     const getDuration = useCallback(() => {

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -28,7 +28,7 @@ import { provisionWorkspace } from "../core/workspace-provisioner.js";
 import { startInterval } from "../local/use-interval.js";
 import { safeCleanup } from "../shared/safe-cleanup.js";
 import type { SpawnOptions, TmuxManager } from "./agents/tmux-manager.js";
-import { agentIdFromSession } from "./agents/tmux-manager.js";
+import { agentIdFromSession, tmuxSessionName } from "./agents/tmux-manager.js";
 // ---------------------------------------------------------------------------
 import type { AcpSessionStore } from "./data/acp-session-store.js";
 import { AgentLogBuffer } from "./data/agent-log-buffer.js";
@@ -960,6 +960,43 @@ export class SpawnManager {
           "clean workspace during kill",
           { silent: true },
         );
+      }
+    }
+  }
+
+  /**
+   * Stop all currently spawned agents for the active TUI session without
+   * deleting their workspaces. Completion needs this lighter-weight teardown:
+   * operators still need to inspect artifacts, but the bridge/runtime must stop
+   * accepting post-done handoffs that would otherwise keep agents ping-ponging.
+   */
+  async stopCurrentSession(): Promise<void> {
+    this.stopLogPolling();
+
+    const runtimeEntries = [...this.agentSessions.entries()];
+    for (const [spawnId, session] of runtimeEntries) {
+      try {
+        await this.agentRuntime?.close(session);
+      } catch {
+        /* best-effort */
+      }
+
+      const tracked = this.spawnRecords.get(spawnId);
+      const roleKey = tracked?.role ?? session.role ?? spawnId;
+      this.wsBridge?.unregisterSession(roleKey, session.id);
+      this.unregisterAcpSession(session.id);
+      this.agentSessions.delete(spawnId);
+      this.routableSessions.delete(spawnId);
+    }
+
+    if (!this.agentRuntime && this.tmux) {
+      for (const spawnId of this.spawnRecords.keys()) {
+        try {
+          await this.tmux.kill(tmuxSessionName(spawnId));
+        } catch {
+          /* best-effort */
+        }
+        this.routableSessions.delete(spawnId);
       }
     }
   }

--- a/tests/server/goals-sessions.test.ts
+++ b/tests/server/goals-sessions.test.ts
@@ -611,6 +611,32 @@ describe("POST /api/sessions — topology and preset", () => {
     expect(data.topology.roles[0].name).toBe("custom-worker");
   });
 
+  test("inline topology preserves explicit role skills on the stored session topology", async () => {
+    const inlineTopology = {
+      structure: "flat" as const,
+      roles: [
+        {
+          name: "custom-worker",
+          description: "Custom worker",
+          skills: ["grove", "review"],
+        },
+      ],
+    };
+
+    const res = await ctx.app.request("/api/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...GS_TEST_AUTH_HEADERS },
+      body: JSON.stringify({
+        preset: "review-loop",
+        topology: inlineTopology,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.topology.roles[0].skills).toEqual(["grove", "review"]);
+  });
+
   test("creates session with goal + preset", async () => {
     const res = await ctx.app.request("/api/sessions", {
       method: "POST",


### PR DESCRIPTION
## Summary
- make Codex ACP discover Grove MCP tools by writing Grove MCP config into the isolated Codex home and forwarding stdio MCP metadata
- complete TUI sessions on the first explicit `grove_done` signal from the review loop and stop current agents/bridge while preserving workspaces
- add regression coverage for Codex MCP config and reviewer DONE completion paths

Fixes #327.

## Validation
- `bun run typecheck`
- `bun run check` (exits 0; existing warnings remain)
- `bun run build`
- `bun test src/core/acp-runtime.test.ts src/core/acp-runtime.spawn.test.ts src/tui/screens/screen-manager.test.ts` (`39 pass`, `0 fail`; command exits non-zero because narrowed coverage does not meet repo-wide thresholds)
- tmux TUI e2e: Codex coder -> Claude reviewer reached Complete with `Reason: Session signaled done`, 4 stable contributions, injected Grove skills present, and no project-specific agent children remaining