### PR TITLE
C4: TUI pages navigation stack with breadcrumbs (#303)

### DIFF
--- a/docs/superpowers/plans/2026-05-09-tui-pages-nav-stack.md
+++ b/docs/superpowers/plans/2026-05-09-tui-pages-nav-stack.md
@@ -12,6 +12,50 @@
 
 ---
 
+## Codebase Conventions (read before any test or component work)
+
+This codebase **does not use `@testing-library/react`**. The plan code samples below show conceptual test shape; **translate them into the project's actual conventions** before committing:
+
+1. **React tests use `react-test-renderer` + `bun:test`.**
+   Reference: `src/tui/components/entity-view.test.tsx`. Pattern:
+
+   ```tsx
+   import TestRenderer, { act } from "react-test-renderer";
+   (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+   let renderer!: TestRenderer.ReactTestRenderer;
+   await act(async () => {
+     renderer = TestRenderer.create(<MyComponent ... /> as React.ReactElement);
+   });
+
+   const flat = JSON.stringify(renderer.toJSON());
+   expect(flat).toContain("expected text");
+   renderer.unmount();
+   ```
+
+   Inspect rendered text with `JSON.stringify(renderer.toJSON())`. Drive component state changes via `act(async () => { /* mutate store, etc. */ })`.
+
+2. **Keyboard handling uses `useKeyboard` from `@opentui/react`.**
+   Reference: `src/tui/screens/running-view.tsx:889+`. The PagesRouter MUST register its esc handler via `useKeyboard` — **not** an `onKeyDown` JSX prop (OpenTUI does not surface DOM events).
+
+   Pattern:
+   ```tsx
+   import { useKeyboard } from "@opentui/react";
+   useKeyboard(useCallback((key) => {
+     if (key.name === "escape") handleEscape();
+     else if (dialogOpen && key.name === "y") confirmPop();
+     else if (dialogOpen && key.name === "n") cancelDialog();
+   }, [/* deps */]));
+   ```
+
+   To test keyboard logic, **factor the handler into a pure function** (e.g., `routerKeyReducer(state, key) → action`) and unit-test that function directly. The component test then only verifies that the handler is registered with `useKeyboard` and that the produced output (rendered JSON) reflects the resulting state.
+
+3. **Existing render/imperative-state pattern for screens** — see `screen-manager.test.ts` for `act`-driven state advance, `running-view.c2.test.tsx` for keyboard injection via store/state mutation.
+
+When the implementation steps below show `fireEvent.keyDown(...)` or `<element onKeyDown={...} />`, treat that as **pseudocode for the intent**, not literal code to write. Implement the behavior using `useKeyboard` + a pure key-reducer, and test the reducer directly.
+
+---
+
 ## File Structure
 
 | File | Purpose |

--- a/docs/superpowers/plans/2026-05-09-tui-pages-nav-stack.md
+++ b/docs/superpowers/plans/2026-05-09-tui-pages-nav-stack.md
@@ -1,0 +1,1633 @@
+# TUI Pages Navigation Stack Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the fixed wizard state machine in `src/tui/screens/screen-manager.tsx` with a k9s-style pages navigation stack that supports `push` / `pop` / `replace`, fires push/popped/top events, derives breadcrumbs from depth, and pops with a confirm dialog when the top page is dirty.
+
+**Architecture:** Pure `PagesStore` class in `src/tui/data/`, thin `useScreenStack` React hook over `useSyncExternalStore`, `<PagesRouter>` component that maps `top.kind` → screen component and owns the esc handler + confirm dialog. `screen-manager.tsx` becomes a backward-compat shim. Inside running-view, goto aliases push `panel` pages instead of mutating `expandedPanel` directly; an effect syncs `expandedPanel` from the top page.
+
+**Tech Stack:** TypeScript (strict), Bun test runner, React (Ink/OpenTUI), Biome lint.
+
+**Spec:** `docs/superpowers/specs/2026-05-09-tui-pages-nav-stack-design.md`
+
+---
+
+## File Structure
+
+| File | Purpose |
+| --- | --- |
+| `src/tui/data/pages-store.ts` | `PagesStore` class — push/pop/replace/top, listeners, dirty-check registry |
+| `src/tui/data/pages-store.test.ts` | Unit tests for the store |
+| `src/tui/hooks/use-screen-stack.ts` | React hook: subscribes to a `PagesStore` via `useSyncExternalStore` |
+| `src/tui/hooks/use-screen-stack.test.tsx` | Hook tests with @testing-library/react |
+| `src/tui/components/confirm-pop-dialog.tsx` | Modal overlay shown when a dirty page tries to pop |
+| `src/tui/components/confirm-pop-dialog.test.tsx` | Dialog test |
+| `src/tui/components/pages-router.tsx` | Maps `top.kind` → component, owns esc + dialog |
+| `src/tui/components/pages-router.test.tsx` | Router tests |
+| `src/tui/components/breadcrumb-bar.tsx` *(modify)* | Add `stack` prop; render depth chain |
+| `src/tui/components/breadcrumb-bar.test.tsx` *(create)* | Tests for new prop + width breakpoints |
+| `src/tui/screens/screen-manager.tsx` *(modify)* | Becomes shim: build initial stack from props, delegate to `<PagesRouter>` |
+| `src/tui/screens/goal-input.tsx` *(modify)* | Stop rendering own breadcrumb; register dirty-check |
+| `src/tui/screens/agent-detect.tsx` *(modify)* | Stop rendering own breadcrumb |
+| `src/tui/screens/spawn-progress.tsx` *(modify)* | Stop rendering own breadcrumb |
+| `src/tui/screens/running-view.tsx` *(modify)* | `gotoDispatch` pushes panel pages; effect syncs `expandedPanel`; prompt-mode dirty-check |
+| `tests/tui/pages-nav-acceptance.test.tsx` *(create)* | End-to-end: `:a` → `:s` → esc returns to agents |
+
+---
+
+## Task 1: PagesStore data class
+
+**Files:**
+- Create: `src/tui/data/pages-store.ts`
+- Create: `src/tui/data/pages-store.test.ts`
+
+**Reference patterns:**
+- Listener-error swallowing pattern: see `src/tui/data/acp-session-store.ts:280-290` (`for…catch` log + continue)
+- Pure-data store (no React) shape: see `src/tui/data/aliases.ts`
+
+- [ ] **Step 1.1: Write the failing test scaffold**
+
+Create `src/tui/data/pages-store.test.ts`:
+
+```ts
+import { describe, expect, mock, test } from "bun:test";
+import { PagesStore, type Page, type StackEvent } from "./pages-store.js";
+
+describe("PagesStore basics", () => {
+  test("starts empty; depth=0; top=undefined", () => {
+    const s = new PagesStore();
+    expect(s.depth()).toBe(0);
+    expect(s.top()).toBeUndefined();
+    expect(s.snapshot()).toEqual([]);
+  });
+
+  test("push appends page and bumps depth", () => {
+    const s = new PagesStore();
+    s.push({ kind: "preset-select" });
+    expect(s.depth()).toBe(1);
+    expect(s.top()).toEqual({ kind: "preset-select" });
+  });
+
+  test("snapshot returns a frozen, copy-stable array", () => {
+    const s = new PagesStore();
+    s.push({ kind: "running" });
+    const snap1 = s.snapshot();
+    s.push({ kind: "panel", params: { panel: "agents" } });
+    expect(snap1).toEqual([{ kind: "running" }]); // unchanged
+    expect(Object.isFrozen(snap1)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run test, watch it fail**
+
+Run: `bun test src/tui/data/pages-store.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 1.3: Implement minimal store skeleton**
+
+Create `src/tui/data/pages-store.ts`:
+
+```ts
+/**
+ * PagesStore — k9s-style navigation stack (issue #303).
+ *
+ * Pure data class: no React, no IO. Owns an ordered stack of pages,
+ * exposes push/pop/replace/top, fires three event channels (pushed,
+ * popped, top), and lets pages register dirty-check callbacks consulted
+ * by the router before pop.
+ *
+ * Listener exceptions are caught and logged; they never kill the store.
+ */
+
+import { debugLog } from "../debug-log.js";
+
+export type PageKind =
+  | "preset-select"
+  | "goal-input"
+  | "agent-detect"
+  | "launch-preview"
+  | "spawning"
+  | "running"
+  | "complete"
+  | "advanced"
+  | "panel"
+  | "entity-detail";
+
+export interface Page {
+  readonly kind: PageKind;
+  readonly params?: Readonly<Record<string, string>>;
+}
+
+export type StackEvent =
+  | { type: "pushed"; page: Page; depth: number }
+  | { type: "popped"; page: Page; depth: number }
+  | { type: "top"; page: Page; depth: number };
+
+export type DirtyCheck = () => boolean;
+
+type EventType = StackEvent["type"];
+type Listener = (e: StackEvent) => void;
+
+export class PagesStore {
+  private stack: Page[] = [];
+  private subs: Record<EventType, Set<Listener>> = {
+    pushed: new Set(),
+    popped: new Set(),
+    top: new Set(),
+  };
+  private dirtyChecks = new Map<PageKind, DirtyCheck>();
+  private snapshotCache: readonly Page[] | null = null;
+
+  push(page: Page): void {
+    const cur = this.top();
+    if (cur && samePage(cur, page)) return; // no-op for duplicate-top
+    this.stack.push(page);
+    this.snapshotCache = null;
+    this.fire("pushed", page);
+    this.fire("top", page);
+  }
+
+  pop(): Page | undefined {
+    if (this.stack.length <= 1) return undefined; // bottom guard
+    const popped = this.stack.pop()!;
+    this.snapshotCache = null;
+    this.fire("popped", popped);
+    const next = this.top();
+    if (next) this.fire("top", next);
+    return popped;
+  }
+
+  replace(page: Page): void {
+    const cur = this.top();
+    if (cur && samePage(cur, page)) return;
+    if (this.stack.length === 0) {
+      this.push(page);
+      return;
+    }
+    this.stack[this.stack.length - 1] = page;
+    this.snapshotCache = null;
+    this.fire("pushed", page);
+    this.fire("top", page);
+  }
+
+  top(): Page | undefined {
+    return this.stack[this.stack.length - 1];
+  }
+
+  depth(): number {
+    return this.stack.length;
+  }
+
+  snapshot(): readonly Page[] {
+    if (this.snapshotCache !== null) return this.snapshotCache;
+    this.snapshotCache = Object.freeze([...this.stack]);
+    return this.snapshotCache;
+  }
+
+  subscribe(type: EventType, fn: Listener): () => void {
+    this.subs[type].add(fn);
+    return () => {
+      this.subs[type].delete(fn);
+    };
+  }
+
+  registerDirtyCheck(kind: PageKind, fn: DirtyCheck): () => void {
+    this.dirtyChecks.set(kind, fn);
+    return () => {
+      if (this.dirtyChecks.get(kind) === fn) this.dirtyChecks.delete(kind);
+    };
+  }
+
+  hasDirtyTop(): boolean {
+    const t = this.top();
+    if (!t) return false;
+    const check = this.dirtyChecks.get(t.kind);
+    if (!check) return false;
+    try {
+      return check();
+    } catch (err) {
+      debugLog("PagesStore dirty-check threw, treating as dirty", err);
+      return true;
+    }
+  }
+
+  private fire(type: EventType, page: Page): void {
+    const event: StackEvent = { type, page, depth: this.stack.length };
+    for (const fn of this.subs[type]) {
+      try {
+        fn(event);
+      } catch (err) {
+        debugLog(`PagesStore listener (${type}) threw`, err);
+      }
+    }
+  }
+}
+
+function samePage(a: Page, b: Page): boolean {
+  if (a.kind !== b.kind) return false;
+  const aP = a.params ?? {};
+  const bP = b.params ?? {};
+  const aKeys = Object.keys(aP);
+  const bKeys = Object.keys(bP);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) if (aP[k] !== bP[k]) return false;
+  return true;
+}
+```
+
+- [ ] **Step 1.4: Re-run, expect first 3 tests pass**
+
+Run: `bun test src/tui/data/pages-store.test.ts`
+Expected: 3 passed.
+
+- [ ] **Step 1.5: Add pop/replace/dup tests**
+
+Append to `pages-store.test.ts`:
+
+```ts
+describe("PagesStore mutations", () => {
+  test("pop at depth=1 is a no-op", () => {
+    const s = new PagesStore();
+    s.push({ kind: "running" });
+    expect(s.pop()).toBeUndefined();
+    expect(s.depth()).toBe(1);
+  });
+
+  test("pop at depth>1 returns popped page and exposes new top", () => {
+    const s = new PagesStore();
+    s.push({ kind: "running" });
+    s.push({ kind: "panel", params: { panel: "agents" } });
+    const out = s.pop();
+    expect(out).toEqual({ kind: "panel", params: { panel: "agents" } });
+    expect(s.top()).toEqual({ kind: "running" });
+  });
+
+  test("duplicate-top push is a no-op", () => {
+    const s = new PagesStore();
+    s.push({ kind: "panel", params: { panel: "agents" } });
+    s.push({ kind: "panel", params: { panel: "agents" } });
+    expect(s.depth()).toBe(1);
+  });
+
+  test("replace swaps top, does not change depth", () => {
+    const s = new PagesStore();
+    s.push({ kind: "preset-select" });
+    s.replace({ kind: "goal-input" });
+    expect(s.depth()).toBe(1);
+    expect(s.top()).toEqual({ kind: "goal-input" });
+  });
+
+  test("replace on empty pushes", () => {
+    const s = new PagesStore();
+    s.replace({ kind: "running" });
+    expect(s.depth()).toBe(1);
+    expect(s.top()).toEqual({ kind: "running" });
+  });
+});
+```
+
+- [ ] **Step 1.6: Run, expect all pass**
+
+Run: `bun test src/tui/data/pages-store.test.ts`
+Expected: 8 passed.
+
+- [ ] **Step 1.7: Add listener tests**
+
+Append:
+
+```ts
+describe("PagesStore listeners", () => {
+  test("pushed + top fire on push, popped + top on pop", () => {
+    const s = new PagesStore();
+    const events: StackEvent[] = [];
+    s.subscribe("pushed", (e) => events.push(e));
+    s.subscribe("popped", (e) => events.push(e));
+    s.subscribe("top", (e) => events.push(e));
+
+    s.push({ kind: "running" });
+    s.push({ kind: "panel", params: { panel: "agents" } });
+    s.pop();
+
+    expect(events.map((e) => e.type)).toEqual([
+      "pushed", "top",
+      "pushed", "top",
+      "popped", "top",
+    ]);
+    expect(events[5]?.page).toEqual({ kind: "running" });
+    expect(events[5]?.depth).toBe(1);
+  });
+
+  test("listener throw is caught; subsequent listeners still fire", () => {
+    const s = new PagesStore();
+    const seen: string[] = [];
+    s.subscribe("top", () => {
+      throw new Error("boom");
+    });
+    s.subscribe("top", () => seen.push("ok"));
+    s.push({ kind: "running" });
+    expect(seen).toEqual(["ok"]);
+  });
+
+  test("unsubscribe stops further calls", () => {
+    const s = new PagesStore();
+    const fn = mock(() => {});
+    const off = s.subscribe("top", fn);
+    s.push({ kind: "running" });
+    off();
+    s.push({ kind: "panel", params: { panel: "agents" } });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PagesStore dirty checks", () => {
+  test("hasDirtyTop is false when no check registered", () => {
+    const s = new PagesStore();
+    s.push({ kind: "goal-input" });
+    expect(s.hasDirtyTop()).toBe(false);
+  });
+
+  test("hasDirtyTop reflects registered check", () => {
+    const s = new PagesStore();
+    s.push({ kind: "goal-input" });
+    let dirty = false;
+    s.registerDirtyCheck("goal-input", () => dirty);
+    expect(s.hasDirtyTop()).toBe(false);
+    dirty = true;
+    expect(s.hasDirtyTop()).toBe(true);
+  });
+
+  test("dirty check throw → treated as dirty", () => {
+    const s = new PagesStore();
+    s.push({ kind: "goal-input" });
+    s.registerDirtyCheck("goal-input", () => {
+      throw new Error("oops");
+    });
+    expect(s.hasDirtyTop()).toBe(true);
+  });
+
+  test("registerDirtyCheck unsubscribe removes the check", () => {
+    const s = new PagesStore();
+    s.push({ kind: "goal-input" });
+    const off = s.registerDirtyCheck("goal-input", () => true);
+    expect(s.hasDirtyTop()).toBe(true);
+    off();
+    expect(s.hasDirtyTop()).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 1.8: Run, expect all pass**
+
+Run: `bun test src/tui/data/pages-store.test.ts`
+Expected: 15 passed.
+
+- [ ] **Step 1.9: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint src/tui/data/pages-store.ts src/tui/data/pages-store.test.ts`
+Expected: 0 errors.
+
+- [ ] **Step 1.10: Commit**
+
+```bash
+git add src/tui/data/pages-store.ts src/tui/data/pages-store.test.ts
+git commit -m "feat(tui): add PagesStore for navigation stack (#303)"
+```
+
+---
+
+## Task 2: useScreenStack hook
+
+**Files:**
+- Create: `src/tui/hooks/use-screen-stack.ts`
+- Create: `src/tui/hooks/use-screen-stack.test.tsx`
+
+**Reference patterns:**
+- React hook over external store: see `src/tui/hooks/use-entities.ts` (uses `useSyncExternalStore`).
+- Existing context shape: see `src/tui/hooks/entity-store-context.tsx`.
+
+- [ ] **Step 2.1: Write failing hook tests**
+
+Create `src/tui/hooks/use-screen-stack.test.tsx`:
+
+```tsx
+import { describe, expect, test } from "bun:test";
+import { render } from "@testing-library/react";
+import React from "react";
+import { PagesStore } from "../data/pages-store.js";
+import { useScreenStack } from "./use-screen-stack.js";
+
+function Probe({ store, onRender }: { store: PagesStore; onRender: (top: ReturnType<typeof useScreenStack>) => void }) {
+  const value = useScreenStack(store);
+  onRender(value);
+  return null;
+}
+
+describe("useScreenStack", () => {
+  test("returns initial top + depth, re-renders on push/pop", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+    const renders: Array<{ top: unknown; depth: number }> = [];
+    render(
+      <Probe
+        store={store}
+        onRender={(v) => renders.push({ top: v.top, depth: v.depth })}
+      />,
+    );
+    expect(renders.at(-1)).toEqual({ top: { kind: "running" }, depth: 1 });
+
+    store.push({ kind: "panel", params: { panel: "agents" } });
+    expect(renders.at(-1)?.depth).toBe(2);
+
+    store.pop();
+    expect(renders.at(-1)).toEqual({ top: { kind: "running" }, depth: 1 });
+  });
+
+  test("exposes push/pop/replace bound to the same store", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+    let api: ReturnType<typeof useScreenStack> | null = null;
+    render(<Probe store={store} onRender={(v) => (api = v)} />);
+    api?.push({ kind: "panel", params: { panel: "dag" } });
+    expect(store.top()).toEqual({ kind: "panel", params: { panel: "dag" } });
+  });
+
+  test("unsubscribes on unmount", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+    const renders: number[] = [];
+    const { unmount } = render(
+      <Probe store={store} onRender={(v) => renders.push(v.depth)} />,
+    );
+    const before = renders.length;
+    unmount();
+    store.push({ kind: "panel", params: { panel: "agents" } });
+    expect(renders.length).toBe(before);
+  });
+});
+```
+
+- [ ] **Step 2.2: Run, expect failure**
+
+Run: `bun test src/tui/hooks/use-screen-stack.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 2.3: Implement the hook**
+
+Create `src/tui/hooks/use-screen-stack.ts`:
+
+```ts
+/**
+ * useScreenStack — React subscription to a PagesStore (#303).
+ *
+ * Subscribes to the `top` event channel and re-renders whenever
+ * top changes. Returns the current top, depth, snapshot, and bound
+ * push/pop/replace actions.
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+import type { Page, PagesStore } from "../data/pages-store.js";
+
+export interface ScreenStackValue {
+  readonly top: Page | undefined;
+  readonly depth: number;
+  readonly snapshot: readonly Page[];
+  readonly push: (page: Page) => void;
+  readonly pop: () => Page | undefined;
+  readonly replace: (page: Page) => void;
+}
+
+export function useScreenStack(store: PagesStore): ScreenStackValue {
+  const subscribe = useCallback(
+    (cb: () => void) => store.subscribe("top", cb),
+    [store],
+  );
+  const getSnapshot = useCallback(() => store.snapshot(), [store]);
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  return {
+    top: snapshot[snapshot.length - 1],
+    depth: snapshot.length,
+    snapshot,
+    push: useCallback((p) => store.push(p), [store]),
+    pop: useCallback(() => store.pop(), [store]),
+    replace: useCallback((p) => store.replace(p), [store]),
+  };
+}
+```
+
+- [ ] **Step 2.4: Run, expect pass**
+
+Run: `bun test src/tui/hooks/use-screen-stack.test.tsx`
+Expected: 3 passed.
+
+- [ ] **Step 2.5: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint src/tui/hooks/use-screen-stack.ts src/tui/hooks/use-screen-stack.test.tsx`
+Expected: 0 errors.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/tui/hooks/use-screen-stack.ts src/tui/hooks/use-screen-stack.test.tsx
+git commit -m "feat(tui): add useScreenStack hook (#303)"
+```
+
+---
+
+## Task 3: ConfirmPopDialog component
+
+**Files:**
+- Create: `src/tui/components/confirm-pop-dialog.tsx`
+- Create: `src/tui/components/confirm-pop-dialog.test.tsx`
+
+**Reference patterns:**
+- Modal overlay shape and theming: see `src/tui/components/help-overlay.tsx`.
+
+- [ ] **Step 3.1: Write failing component tests**
+
+Create `src/tui/components/confirm-pop-dialog.test.tsx`:
+
+```tsx
+import { describe, expect, mock, test } from "bun:test";
+import { render } from "@testing-library/react";
+import React from "react";
+import { ConfirmPopDialog } from "./confirm-pop-dialog.js";
+
+describe("ConfirmPopDialog", () => {
+  test("returns null when not visible", () => {
+    const { container } = render(
+      <ConfirmPopDialog visible={false} onConfirm={() => {}} onCancel={() => {}} />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  test("renders prompt text when visible", () => {
+    const { container } = render(
+      <ConfirmPopDialog visible onConfirm={() => {}} onCancel={() => {}} />,
+    );
+    expect(container.textContent).toContain("Discard unsaved changes?");
+  });
+});
+```
+
+- [ ] **Step 3.2: Run, expect failure**
+
+Run: `bun test src/tui/components/confirm-pop-dialog.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3.3: Implement minimal component**
+
+Create `src/tui/components/confirm-pop-dialog.tsx`:
+
+```tsx
+/**
+ * <ConfirmPopDialog> — modal shown when a dirty page tries to pop (#303).
+ *
+ * Presentational only. The router decides when to show it and routes
+ * keystrokes (y/n/enter/esc) to onConfirm / onCancel. Mounting it does
+ * not subscribe to keys; the router intercepts.
+ */
+
+import React from "react";
+import { theme } from "../theme.js";
+
+export interface ConfirmPopDialogProps {
+  readonly visible: boolean;
+  readonly onConfirm: () => void;
+  readonly onCancel: () => void;
+}
+
+export const ConfirmPopDialog: React.NamedExoticComponent<ConfirmPopDialogProps> =
+  React.memo(function ConfirmPopDialog({ visible }: ConfirmPopDialogProps) {
+    if (!visible) return null;
+    return (
+      <box
+        flexDirection="column"
+        paddingX={2}
+        paddingY={1}
+        borderStyle="single"
+        borderColor={theme.focus}
+      >
+        <text bold color={theme.focus}>
+          Discard unsaved changes?
+        </text>
+        <text color={theme.secondary}>
+          [y] discard and go back   [n] stay
+        </text>
+      </box>
+    );
+  });
+```
+
+- [ ] **Step 3.4: Run tests, expect pass**
+
+Run: `bun test src/tui/components/confirm-pop-dialog.test.tsx`
+Expected: 2 passed.
+
+- [ ] **Step 3.5: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint src/tui/components/confirm-pop-dialog.tsx src/tui/components/confirm-pop-dialog.test.tsx`
+Expected: 0 errors.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add src/tui/components/confirm-pop-dialog.tsx src/tui/components/confirm-pop-dialog.test.tsx
+git commit -m "feat(tui): add ConfirmPopDialog overlay (#303)"
+```
+
+---
+
+## Task 4: BreadcrumbBar refactor — accept stack prop
+
+**Files:**
+- Modify: `src/tui/components/breadcrumb-bar.tsx`
+- Create: `src/tui/components/breadcrumb-bar.test.tsx`
+
+The existing `screen` prop must continue to work — three call sites (agent-detect, goal-input, spawn-progress) still pass it. We add an optional `stack` prop; when present, it takes precedence and renders a depth chain. We delete the old `screen` prop usages in Task 6 once the router renders the breadcrumb centrally.
+
+- [ ] **Step 4.1: Write failing tests for stack mode**
+
+Create `src/tui/components/breadcrumb-bar.test.tsx`:
+
+```tsx
+import { describe, expect, test } from "bun:test";
+import { render } from "@testing-library/react";
+import React from "react";
+import type { Page } from "../data/pages-store.js";
+import { BreadcrumbBar } from "./breadcrumb-bar.js";
+
+describe("BreadcrumbBar with stack prop", () => {
+  test("renders single-page stack as the page label", () => {
+    const stack: readonly Page[] = [{ kind: "preset-select" }];
+    const { container } = render(<BreadcrumbBar stack={stack} width={120} />);
+    expect(container.textContent).toContain("Preset Select");
+  });
+
+  test("renders depth chain joined by chevron", () => {
+    const stack: readonly Page[] = [
+      { kind: "running" },
+      { kind: "panel", params: { panel: "agents" } },
+      { kind: "panel", params: { panel: "sessions" } },
+    ];
+    const { container } = render(<BreadcrumbBar stack={stack} width={120} />);
+    expect(container.textContent).toContain("Running");
+    expect(container.textContent).toContain("Agents");
+    expect(container.textContent).toContain("Sessions");
+    expect(container.textContent).toContain("›"); // chevron
+  });
+
+  test("collapses to current page label only when width<70", () => {
+    const stack: readonly Page[] = [
+      { kind: "running" },
+      { kind: "panel", params: { panel: "agents" } },
+    ];
+    const { container } = render(<BreadcrumbBar stack={stack} width={50} />);
+    expect(container.textContent).toContain("Agents");
+    expect(container.textContent).not.toContain("Running");
+  });
+});
+
+describe("BreadcrumbBar with legacy screen prop", () => {
+  test("still renders Screen label when stack absent", () => {
+    const { container } = render(<BreadcrumbBar screen="goal-input" width={120} />);
+    expect(container.textContent).toContain("Goal");
+  });
+});
+```
+
+- [ ] **Step 4.2: Run, expect stack tests fail (legacy passes)**
+
+Run: `bun test src/tui/components/breadcrumb-bar.test.tsx`
+Expected: 3 stack tests FAIL, 1 legacy passes.
+
+- [ ] **Step 4.3: Add stack support to component**
+
+Modify `src/tui/components/breadcrumb-bar.tsx` — replace the entire file content:
+
+```tsx
+/**
+ * Responsive breadcrumb bar (#303).
+ *
+ * Two prop modes:
+ *   - `stack`  — render depth chain from a PagesStore snapshot (preferred)
+ *   - `screen` — legacy single-screen label (kept for shim screens that
+ *                still self-render their own breadcrumb)
+ *
+ * Width breakpoints (apply to both modes):
+ *   >= 100 cols: Full chain with "Grove" prefix
+ *   70-99 cols:  Truncated chain (no "Grove" prefix)
+ *   < 70 cols:   Current page label only
+ *   < 40 cols:   Minimal — current page label, no hint
+ */
+
+import React from "react";
+import type { Page, PageKind } from "../data/pages-store.js";
+import type { Screen } from "../screens/screen-manager.js";
+import { theme } from "../theme.js";
+
+const PAGE_LABELS: Record<PageKind, string> = {
+  "preset-select": "Preset Select",
+  "goal-input": "Goal",
+  "agent-detect": "Launch Preview",
+  "launch-preview": "Launch Preview",
+  spawning: "Spawning",
+  running: "Running",
+  complete: "Complete",
+  advanced: "Advanced",
+  panel: "Panel",
+  "entity-detail": "Detail",
+};
+
+const PANEL_LABELS: Record<string, string> = {
+  agents: "Agents",
+  sessions: "Sessions",
+  dag: "DAG",
+  tasks: "Tasks",
+  reviews: "Reviews",
+  feed: "Feed",
+};
+
+const SCREEN_LABELS: Record<Screen, string> = {
+  "preset-select": "Preset Select",
+  "agent-detect": "Launch Preview",
+  "launch-preview": "Launch Preview",
+  "goal-input": "Goal",
+  spawning: "Spawning",
+  running: "Running",
+  advanced: "Advanced",
+  complete: "Complete",
+};
+
+function pageLabel(p: Page): string {
+  if (p.kind === "panel") {
+    const panel = p.params?.panel ?? "";
+    return PANEL_LABELS[panel] ?? "Panel";
+  }
+  return PAGE_LABELS[p.kind];
+}
+
+export interface BreadcrumbBarProps {
+  readonly stack?: readonly Page[] | undefined;
+  readonly screen?: Screen | undefined;
+  readonly presetName?: string | undefined;
+  readonly sessionId?: string | undefined;
+  readonly width: number;
+}
+
+export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> =
+  React.memo(function BreadcrumbBar({
+    stack,
+    screen,
+    presetName,
+    sessionId,
+    width,
+  }: BreadcrumbBarProps): React.ReactNode {
+    const labels = stack && stack.length > 0
+      ? stack.map(pageLabel)
+      : screen
+        ? [SCREEN_LABELS[screen] ?? screen]
+        : [];
+
+    if (labels.length === 0) return null;
+    const current = labels[labels.length - 1] ?? "";
+    const shortSession = sessionId?.slice(0, 8);
+
+    if (width < 40) {
+      return (
+        <box paddingX={1}>
+          <text color={theme.focus} bold>
+            {current}
+          </text>
+        </box>
+      );
+    }
+
+    if (width < 70) {
+      return (
+        <box paddingX={1} flexDirection="row">
+          <text color={theme.focus} bold>
+            {current}
+          </text>
+        </box>
+      );
+    }
+
+    const parts: React.ReactNode[] = [];
+    if (width >= 100) {
+      parts.push(
+        <text key="grove" color={theme.text} bold>
+          Grove
+        </text>,
+        <text key="grove-sep" color={theme.secondary}>
+          {" › "}
+        </text>,
+      );
+    }
+    if (presetName) {
+      parts.push(
+        <text key="preset" color={theme.secondary}>
+          {presetName}
+        </text>,
+        <text key="preset-sep" color={theme.secondary}>
+          {" › "}
+        </text>,
+      );
+    }
+    labels.forEach((label, i) => {
+      const isLast = i === labels.length - 1;
+      parts.push(
+        <text
+          key={`label-${i}`}
+          color={isLast ? theme.focus : theme.secondary}
+          bold={isLast}
+        >
+          {label}
+        </text>,
+      );
+      if (!isLast) {
+        parts.push(
+          <text key={`sep-${i}`} color={theme.secondary}>
+            {" › "}
+          </text>,
+        );
+      }
+    });
+    if (shortSession) {
+      parts.push(
+        <text key="sess-sep" color={theme.secondary}>
+          {" › "}
+        </text>,
+        <text key="sess" color={theme.secondary}>
+          {shortSession}
+        </text>,
+      );
+    }
+
+    return (
+      <box paddingX={1} flexDirection="row">
+        {parts}
+      </box>
+    );
+  });
+```
+
+- [ ] **Step 4.4: Run tests, expect pass**
+
+Run: `bun test src/tui/components/breadcrumb-bar.test.tsx`
+Expected: 4 passed.
+
+- [ ] **Step 4.5: Typecheck — expect failure b/c PagesStore not yet imported elsewhere is fine**
+
+Run: `bun run typecheck`
+Expected: 0 errors. (Existing screen-prop call sites still compile.)
+
+- [ ] **Step 4.6: Lint**
+
+Run: `bun run lint src/tui/components/breadcrumb-bar.tsx src/tui/components/breadcrumb-bar.test.tsx`
+Expected: 0 errors.
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add src/tui/components/breadcrumb-bar.tsx src/tui/components/breadcrumb-bar.test.tsx
+git commit -m "feat(tui): BreadcrumbBar accepts stack prop (#303)"
+```
+
+---
+
+## Task 5: PagesStore React context
+
+**Files:**
+- Modify: `src/tui/hooks/use-screen-stack.ts` (add provider/context)
+
+A `<PagesStoreProvider>` lets nested screens (`goal-input`, `running-view`, etc.) reach the store without prop-drilling. Add to the same module to keep the surface in one place.
+
+- [ ] **Step 5.1: Write failing test**
+
+Append to `src/tui/hooks/use-screen-stack.test.tsx`:
+
+```tsx
+import { PagesStoreProvider, usePagesStoreFromContext } from "./use-screen-stack.js";
+
+function ContextProbe({ onValue }: { onValue: (s: unknown) => void }) {
+  const s = usePagesStoreFromContext();
+  onValue(s);
+  return null;
+}
+
+describe("PagesStoreProvider", () => {
+  test("exposes the same store instance to descendants", () => {
+    const store = new PagesStore();
+    let captured: unknown = null;
+    render(
+      <PagesStoreProvider store={store}>
+        <ContextProbe onValue={(s) => (captured = s)} />
+      </PagesStoreProvider>,
+    );
+    expect(captured).toBe(store);
+  });
+
+  test("usePagesStoreFromContext throws when no provider", () => {
+    let err: unknown = null;
+    try {
+      render(<ContextProbe onValue={() => {}} />);
+    } catch (e) {
+      err = e;
+    }
+    expect(String(err)).toContain("PagesStoreProvider");
+  });
+});
+```
+
+- [ ] **Step 5.2: Run, expect fail**
+
+Run: `bun test src/tui/hooks/use-screen-stack.test.tsx`
+Expected: FAIL — `PagesStoreProvider` not exported.
+
+- [ ] **Step 5.3: Add provider + context hook**
+
+Append to `src/tui/hooks/use-screen-stack.ts`:
+
+```ts
+import { createContext, useContext } from "react";
+
+const PagesStoreContext = createContext<PagesStore | null>(null);
+
+export interface PagesStoreProviderProps {
+  readonly store: PagesStore;
+  readonly children: React.ReactNode;
+}
+
+export function PagesStoreProvider({
+  store,
+  children,
+}: PagesStoreProviderProps): React.ReactElement {
+  return (
+    <PagesStoreContext.Provider value={store}>
+      {children}
+    </PagesStoreContext.Provider>
+  );
+}
+
+export function usePagesStoreFromContext(): PagesStore {
+  const s = useContext(PagesStoreContext);
+  if (!s) {
+    throw new Error("usePagesStoreFromContext: no <PagesStoreProvider> in tree");
+  }
+  return s;
+}
+```
+
+Then rename `use-screen-stack.ts` to `use-screen-stack.tsx` (JSX in file).
+
+- [ ] **Step 5.4: Run, expect all hook tests pass**
+
+Run: `bun test src/tui/hooks/use-screen-stack.test.tsx`
+Expected: 5 passed.
+
+- [ ] **Step 5.5: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint src/tui/hooks/use-screen-stack.tsx`
+Expected: 0 errors.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add src/tui/hooks/use-screen-stack.ts src/tui/hooks/use-screen-stack.tsx src/tui/hooks/use-screen-stack.test.tsx
+git commit -m "feat(tui): add PagesStoreProvider context (#303)"
+```
+
+---
+
+## Task 6: PagesRouter
+
+**Files:**
+- Create: `src/tui/components/pages-router.tsx`
+- Create: `src/tui/components/pages-router.test.tsx`
+
+The router is the integration point. It owns:
+- Component map keyed by `PageKind`
+- Esc handler: dirty? show dialog. Depth=1? quit-confirm. Else pop.
+- The single rendered `<BreadcrumbBar stack={...} />`
+
+For Task 6 we test only the swap + esc-handler logic. We mount stub component placeholders since the real screens have heavy deps; full integration lands in Task 8.
+
+- [ ] **Step 6.1: Write failing tests**
+
+Create `src/tui/components/pages-router.test.tsx`:
+
+```tsx
+import { describe, expect, mock, test } from "bun:test";
+import { fireEvent, render } from "@testing-library/react";
+import React from "react";
+import { PagesStore } from "../data/pages-store.js";
+import { PagesRouter, type PagesRouterComponentMap } from "./pages-router.js";
+
+function makeStubs(): PagesRouterComponentMap {
+  const stub = (name: string) =>
+    function Stub() {
+      return <text>{name}</text>;
+    };
+  return {
+    "preset-select": stub("preset"),
+    "goal-input": stub("goal"),
+    "agent-detect": stub("detect"),
+    "launch-preview": stub("preview"),
+    spawning: stub("spawning"),
+    running: stub("running"),
+    complete: stub("complete"),
+    advanced: stub("advanced"),
+    panel: stub("panel"),
+    "entity-detail": stub("detail"),
+  };
+}
+
+describe("PagesRouter", () => {
+  test("renders component for current top kind", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+    const { container } = render(
+      <PagesRouter store={store} components={makeStubs()} onQuit={() => {}} />,
+    );
+    expect(container.textContent).toContain("running");
+  });
+
+  test("re-renders on push", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+    const { container } = render(
+      <PagesRouter store={store} components={makeStubs()} onQuit={() => {}} />,
+    );
+    store.push({ kind: "panel", params: { panel: "agents" } });
+    expect(container.textContent).toContain("panel");
+  });
+
+  test("esc on non-dirty top calls pop()", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+    store.push({ kind: "panel", params: { panel: "agents" } });
+    const { container } = render(
+      <PagesRouter store={store} components={makeStubs()} onQuit={() => {}} />,
+    );
+    fireEvent.keyDown(container, { key: "Escape" });
+    expect(store.top()).toEqual({ kind: "running" });
+  });
+
+  test("esc at depth=1 calls onQuit", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+    const onQuit = mock(() => {});
+    const { container } = render(
+      <PagesRouter store={store} components={makeStubs()} onQuit={onQuit} />,
+    );
+    fireEvent.keyDown(container, { key: "Escape" });
+    expect(onQuit).toHaveBeenCalledTimes(1);
+  });
+
+  test("esc on dirty top opens dialog; n cancels; y pops", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+    store.push({ kind: "goal-input" });
+    store.registerDirtyCheck("goal-input", () => true);
+
+    const { container } = render(
+      <PagesRouter store={store} components={makeStubs()} onQuit={() => {}} />,
+    );
+    fireEvent.keyDown(container, { key: "Escape" });
+    expect(container.textContent).toContain("Discard unsaved changes?");
+
+    fireEvent.keyDown(container, { key: "n" });
+    expect(store.top()).toEqual({ kind: "goal-input" });
+    expect(container.textContent).not.toContain("Discard unsaved changes?");
+
+    fireEvent.keyDown(container, { key: "Escape" });
+    fireEvent.keyDown(container, { key: "y" });
+    expect(store.top()).toEqual({ kind: "running" });
+  });
+});
+```
+
+- [ ] **Step 6.2: Run, expect fail**
+
+Run: `bun test src/tui/components/pages-router.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 6.3: Implement router**
+
+Create `src/tui/components/pages-router.tsx`:
+
+```tsx
+/**
+ * <PagesRouter> — renders the current top page and owns navigation
+ * keyboard handling (#303).
+ *
+ * Subscribes to the supplied PagesStore via useScreenStack. Maps top
+ * page kind to a React component supplied by the caller. Handles esc:
+ *   - dirty top → opens ConfirmPopDialog (y discards + pops, n cancels)
+ *   - depth=1   → onQuit()
+ *   - otherwise → pop()
+ *
+ * Listens for keys on a wrapping <box tabIndex={-1}> so unit tests can
+ * dispatch keydown events deterministically. Production runtime relies
+ * on OpenTUI's global keyboard hook surface — see useKeyboard usage in
+ * running-view.tsx — which we wire in once router lands in screen-manager.
+ */
+
+import React, { useCallback, useState } from "react";
+import { useScreenStack } from "../hooks/use-screen-stack.js";
+import type { Page, PageKind, PagesStore } from "../data/pages-store.js";
+import { ConfirmPopDialog } from "./confirm-pop-dialog.js";
+
+export type PagesRouterComponentMap = Record<
+  PageKind,
+  React.ComponentType<{ page: Page }>
+>;
+
+export interface PagesRouterProps {
+  readonly store: PagesStore;
+  readonly components: PagesRouterComponentMap;
+  readonly onQuit: () => void;
+}
+
+export const PagesRouter: React.NamedExoticComponent<PagesRouterProps> =
+  React.memo(function PagesRouter({
+    store,
+    components,
+    onQuit,
+  }: PagesRouterProps) {
+    const { top, depth } = useScreenStack(store);
+    const [dialogOpen, setDialogOpen] = useState(false);
+
+    const handleEscape = useCallback(() => {
+      if (dialogOpen) return; // dialog handles its own keys
+      if (store.hasDirtyTop()) {
+        setDialogOpen(true);
+        return;
+      }
+      if (depth <= 1) {
+        onQuit();
+        return;
+      }
+      store.pop();
+    }, [store, depth, dialogOpen, onQuit]);
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        if (dialogOpen) {
+          if (e.key === "y") {
+            setDialogOpen(false);
+            store.pop();
+          } else if (e.key === "n" || e.key === "Escape") {
+            setDialogOpen(false);
+          }
+          return;
+        }
+        if (e.key === "Escape") handleEscape();
+      },
+      [dialogOpen, store, handleEscape],
+    );
+
+    if (!top) return null;
+    const Component = components[top.kind];
+    return (
+      <box
+        flexDirection="column"
+        onKeyDown={handleKeyDown}
+        tabIndex={-1}
+      >
+        <Component page={top} />
+        <ConfirmPopDialog
+          visible={dialogOpen}
+          onConfirm={() => {
+            setDialogOpen(false);
+            store.pop();
+          }}
+          onCancel={() => setDialogOpen(false)}
+        />
+      </box>
+    );
+  });
+```
+
+- [ ] **Step 6.4: Run, expect pass**
+
+Run: `bun test src/tui/components/pages-router.test.tsx`
+Expected: 5 passed.
+
+- [ ] **Step 6.5: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint src/tui/components/pages-router.tsx src/tui/components/pages-router.test.tsx`
+Expected: 0 errors.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add src/tui/components/pages-router.tsx src/tui/components/pages-router.test.tsx
+git commit -m "feat(tui): add PagesRouter with esc-pop + confirm dialog (#303)"
+```
+
+---
+
+## Task 7: screen-manager shim — delegate to PagesRouter
+
+**Files:**
+- Modify: `src/tui/screens/screen-manager.tsx`
+- Modify: `src/tui/screens/goal-input.tsx` (remove self-rendered breadcrumb; register dirty-check)
+- Modify: `src/tui/screens/agent-detect.tsx` (remove self-rendered breadcrumb)
+- Modify: `src/tui/screens/spawn-progress.tsx` (remove self-rendered breadcrumb)
+- Modify: `src/tui/screens/screen-manager.test.ts`
+
+Wizard transitions become `pages.push` (forward navigation) or `pages.replace` (collapsing one phase into another, e.g. spawning → running). The `ScreenState` interface stays — it's still the durable data slot for preset name, goal text, role mapping etc.
+
+- [ ] **Step 7.1: Read existing screen-manager transitions**
+
+Re-read `src/tui/screens/screen-manager.tsx`:
+- Lines 41-49 — `Screen` type definition (KEEP this export — `BreadcrumbBar` still references it for the legacy `screen` prop path).
+- Lines 51-72 — `ScreenState` (KEEP — durable data slot).
+- Lines 109-135 — initial state + topology resolution.
+- Lines 380-720 — every state transition. Each `setState(s => ({ ...s, screen: "X", ... }))` becomes `pages.push({ kind: "X" })` or `pages.replace({ kind: "X" })` — the data fields (`selectedPreset`, `goal`, `roleMapping`, `sessionId`, `sessionWarning`, `sessionStartedAt`, `spawnStates`, `completeSnapshot`) keep flowing through `setState`.
+
+Mapping:
+| Transition | New action |
+| --- | --- |
+| Initial mount, presets present | Initial stack: `[preset-select]` |
+| Initial mount, startOnRunning | Initial stack: `[running]` |
+| preset selected → goal-input | `push({ kind: "goal-input" })` |
+| goal entered → launch-preview | `push({ kind: "launch-preview" })` |
+| launch-preview → spawning | `push({ kind: "spawning" })` |
+| spawning → running | `replace({ kind: "running" })` (collapses wizard) |
+| running → complete | `replace({ kind: "complete" })` |
+| running → advanced | `push({ kind: "advanced" })` |
+| advanced → running | `pop()` |
+| complete → fresh start | New stack: `[preset-select]` (replace + pop loop or expose `resetTo`) |
+
+For "complete → fresh start", add a `resetTo(page: Page): void` method to `PagesStore` that empties the stack and pushes the given page. Update tests in Task 1 — actually fold this into Task 7 since we discovered the need late.
+
+- [ ] **Step 7.2: Add `resetTo` to PagesStore**
+
+Modify `src/tui/data/pages-store.ts`, append before the closing `}`:
+
+```ts
+  /** Empty the stack and push `page`. Fires popped+top for any prior pages. */
+  resetTo(page: Page): void {
+    while (this.stack.length > 0) {
+      const popped = this.stack.pop()!;
+      this.fire("popped", popped);
+    }
+    this.snapshotCache = null;
+    this.push(page);
+  }
+```
+
+Append test in `src/tui/data/pages-store.test.ts`:
+
+```ts
+test("resetTo empties stack and pushes the given page", () => {
+  const s = new PagesStore();
+  s.push({ kind: "preset-select" });
+  s.push({ kind: "goal-input" });
+  s.resetTo({ kind: "running" });
+  expect(s.depth()).toBe(1);
+  expect(s.top()).toEqual({ kind: "running" });
+});
+```
+
+Run: `bun test src/tui/data/pages-store.test.ts` — expect 16 passed.
+
+- [ ] **Step 7.3: Define component map and rewrite screen-manager**
+
+Modify `src/tui/screens/screen-manager.tsx`. Strategy:
+
+1. Inside `ScreenManager`, instantiate a `PagesStore` once via `useState`.
+2. Build initial stack from `initialState.screen` / `startOnRunning` / `presets`.
+3. Replace every `setState({ screen: ... })` call with the matching `pages.push`/`pages.replace`/`pages.resetTo` action — keep the rest of `ScreenState` setters (preset, goal, sessionId, etc.) unchanged.
+4. Wrap the rendered tree in `<PagesStoreProvider store={pages}>` and replace the per-screen `switch` with `<PagesRouter store={pages} components={COMPONENTS} onQuit={onQuit} />`.
+
+Skeleton:
+
+```tsx
+import { PagesStore, type Page } from "../data/pages-store.js";
+import { PagesStoreProvider } from "../hooks/use-screen-stack.js";
+import { PagesRouter, type PagesRouterComponentMap } from "../components/pages-router.js";
+
+// at top of ScreenManager body:
+const [pages] = useState(() => {
+  const store = new PagesStore();
+  const initialPage: Page = startOnRunning
+    ? { kind: "running" }
+    : initialState?.screen
+      ? { kind: initialState.screen as Page["kind"] }
+      : presets && presets.length > 0
+        ? { kind: "preset-select" }
+        : { kind: "goal-input" };
+  store.push(initialPage);
+  return store;
+});
+
+// component map: maps each PageKind → existing screen component, ignoring `page` prop
+const COMPONENTS: PagesRouterComponentMap = useMemo(() => ({
+  "preset-select": () => <PresetSelect ... />,
+  "goal-input":    () => <GoalInput ... />,
+  "agent-detect":  () => <AgentDetect ... />,
+  "launch-preview":() => <AgentDetect ... />,
+  spawning:        () => <SpawnProgress ... />,
+  running:         () => <RunningView ... />,
+  complete:        () => <CompleteView ... />,
+  advanced:        () => <App {...appProps} />,
+  panel:           () => <RunningView ... />,           // running view reads top via context
+  "entity-detail": () => <RunningView ... />,           // placeholder until C5 lands
+}), [/* deps from existing screen rendering */]);
+
+return (
+  <PagesStoreProvider store={pages}>
+    <BreadcrumbBar stack={pages.snapshot()} width={...} />
+    <PagesRouter store={pages} components={COMPONENTS} onQuit={onQuit} />
+  </PagesStoreProvider>
+);
+```
+
+Where the existing code does `setState({ screen: "goal-input", ... })`, replace `screen` updates with `pages.push({ kind: "goal-input" })` and keep the rest of the `ScreenState` mutation. After the rewrite, every `state.screen` read site uses `pages.top()?.kind` instead.
+
+- [ ] **Step 7.4: Remove self-rendered breadcrumbs from goal-input, agent-detect, spawn-progress**
+
+For each of `src/tui/screens/goal-input.tsx`, `agent-detect.tsx`, `spawn-progress.tsx`:
+
+Find the line `import { BreadcrumbBar } from "../components/breadcrumb-bar.js";` and remove it.
+Find `<BreadcrumbBar screen=... />` JSX and remove it.
+
+(The router renders one centralized breadcrumb in Step 7.3.)
+
+- [ ] **Step 7.5: Update screen-manager test**
+
+In `src/tui/screens/screen-manager.test.ts`, every assertion that reads `state.screen` or sets `initialState: { screen: "..." }` must keep working — `ScreenState.screen` is still a recognized hint. Where the test asserts a transition produced `screen: "goal-input"`, change to:
+
+```ts
+const harness = mountScreenManager({ ... });
+// previously: expect(harness.state().screen).toBe("goal-input");
+expect(harness.pages().top()?.kind).toBe("goal-input");
+```
+
+Expose `pages()` from your test harness (the harness already wraps `useState`-driven state — add a passthrough).
+
+- [ ] **Step 7.6: Run all tests**
+
+Run: `bun test src/tui/screens/screen-manager.test.ts`
+Expected: all existing test cases pass.
+
+Run: `bun test src/tui/`
+Expected: 0 regressions.
+
+- [ ] **Step 7.7: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint src/tui/`
+Expected: 0 errors.
+
+- [ ] **Step 7.8: Commit**
+
+```bash
+git add src/tui/data/pages-store.ts src/tui/data/pages-store.test.ts \
+        src/tui/screens/screen-manager.tsx src/tui/screens/screen-manager.test.ts \
+        src/tui/screens/goal-input.tsx src/tui/screens/agent-detect.tsx \
+        src/tui/screens/spawn-progress.tsx
+git commit -m "refactor(tui): screen-manager delegates to PagesRouter (#303)"
+```
+
+---
+
+## Task 8: running-view goto integration
+
+**Files:**
+- Modify: `src/tui/screens/running-view.tsx`
+
+`gotoDispatch` currently mutates `expandedPanel`. Rewrite so each goto pushes a `panel` page; an effect listens to top changes and updates `expandedPanel` from `top.params.panel`. This preserves all the downstream `expandedPanel` consumers without rewriting them.
+
+- [ ] **Step 8.1: Add hook + effect at top of RunningView**
+
+In `src/tui/screens/running-view.tsx`, add the import:
+
+```ts
+import { usePagesStoreFromContext } from "../hooks/use-screen-stack.js";
+import { useScreenStack } from "../hooks/use-screen-stack.js";
+import type { Page } from "../data/pages-store.js";
+```
+
+Inside the component body, after the `expandedPanel` state declaration around line 188:
+
+```ts
+const pagesStore = usePagesStoreFromContext();
+const { top } = useScreenStack(pagesStore);
+
+useEffect(() => {
+  if (top?.kind !== "panel") return;
+  const panel = top.params?.panel;
+  const map: Record<string, RunningPanel> = {
+    agents: RunningPanel.Agents,
+    sessions: RunningPanel.Sessions,
+    dag: RunningPanel.Dag,
+    tasks: RunningPanel.Tasks,
+    reviews: RunningPanel.Reviews,
+    feed: RunningPanel.Feed,
+  };
+  const target = panel ? map[panel] : undefined;
+  if (target !== undefined) {
+    const next = expandPanelTransition(expandedPanel, zoomLevel, target);
+    setExpandedPanel(next.expandedPanel);
+    setZoomLevel(next.zoomLevel);
+  }
+}, [top, expandedPanel, zoomLevel]);
+```
+
+- [ ] **Step 8.2: Rewrite gotoDispatch to push panel pages**
+
+Replace the existing `gotoDispatch` (around line 631) with:
+
+```ts
+const gotoDispatch = useMemo<Record<string, () => void>>(
+  () => ({
+    agents:   () => pagesStore.push({ kind: "panel", params: { panel: "agents" } }),
+    dag:      () => pagesStore.push({ kind: "panel", params: { panel: "dag" } }),
+    sessions: () => pagesStore.push({ kind: "panel", params: { panel: "sessions" } }),
+    tasks:    () => pagesStore.push({ kind: "panel", params: { panel: "tasks" } }),
+    reviews:  () => pagesStore.push({ kind: "panel", params: { panel: "reviews" } }),
+    quit:     () => onQuit(),
+  }),
+  [pagesStore, onQuit],
+);
+```
+
+- [ ] **Step 8.3: Run existing running-view tests**
+
+Run: `bun test src/tui/screens/running-view.c2.test.tsx`
+Expected: pass — the c2 test asserts the prompt routing works; with the rewrite it should still work because it tests via the alias-resolved label.
+
+If a test previously asserted `expandedPanel === RunningPanel.Agents` after `:a`, it now asserts via the store.
+
+- [ ] **Step 8.4: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint src/tui/screens/running-view.tsx`
+Expected: 0 errors.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add src/tui/screens/running-view.tsx
+git commit -m "refactor(tui): running-view goto pushes panel pages (#303)"
+```
+
+---
+
+## Task 9: Dirty-check registrations
+
+**Files:**
+- Modify: `src/tui/screens/goal-input.tsx`
+- Modify: `src/tui/screens/running-view.tsx`
+
+- [ ] **Step 9.1: Register goal-input dirty check**
+
+In `src/tui/screens/goal-input.tsx`, add inside the component body (after the existing state for goal text, e.g. `const [goalText, ...]`):
+
+```ts
+import { useEffect } from "react";
+import { usePagesStoreFromContext } from "../hooks/use-screen-stack.js";
+
+const pages = usePagesStoreFromContext();
+useEffect(() => {
+  return pages.registerDirtyCheck("goal-input", () => goalText.trim().length > 0);
+}, [pages, goalText]);
+```
+
+(The dependency array includes `goalText` so the closure always sees the latest text — registerDirtyCheck unsubscribes the prior one.)
+
+- [ ] **Step 9.2: Register prompt-mode dirty check in running-view**
+
+In `src/tui/screens/running-view.tsx`, locate the `promptMode` / `promptText` state (search for `setPromptMode(true)` — it's around the `enterPromptMode` action defined inside `keyboardActions`, near line 691 in the pre-refactor file). Below those state declarations, add:
+
+```ts
+useEffect(() => {
+  if (!promptMode) return;
+  return pagesStore.registerDirtyCheck("running", () => promptText.trim().length > 0);
+}, [pagesStore, promptMode, promptText]);
+```
+
+- [ ] **Step 9.3: Run all TUI tests**
+
+Run: `bun test src/tui/`
+Expected: pass.
+
+- [ ] **Step 9.4: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint src/tui/`
+Expected: 0 errors.
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add src/tui/screens/goal-input.tsx src/tui/screens/running-view.tsx
+git commit -m "feat(tui): register dirty checks for goal-input + prompt-mode (#303)"
+```
+
+---
+
+## Task 10: Acceptance test — `:a` → `:s` → esc → agents
+
+**Files:**
+- Create: `tests/tui/pages-nav-acceptance.test.tsx`
+
+This is the literal acceptance criterion from issue #303.
+
+- [ ] **Step 10.1: Write acceptance test**
+
+Create `tests/tui/pages-nav-acceptance.test.tsx`:
+
+```tsx
+import { describe, expect, test } from "bun:test";
+import { fireEvent, render } from "@testing-library/react";
+import React from "react";
+import { PagesStore } from "../../src/tui/data/pages-store.js";
+import { PagesRouter, type PagesRouterComponentMap } from "../../src/tui/components/pages-router.js";
+
+function stubMap(): PagesRouterComponentMap {
+  const stub = (label: string) =>
+    function Stub() {
+      return <text>{label}</text>;
+    };
+  return {
+    "preset-select": stub("preset"),
+    "goal-input": stub("goal"),
+    "agent-detect": stub("detect"),
+    "launch-preview": stub("preview"),
+    spawning: stub("spawning"),
+    running: stub("running-feed"),
+    complete: stub("complete"),
+    advanced: stub("advanced"),
+    panel: function Panel({ page }) {
+      return <text>{`panel:${page.params?.panel ?? ""}`}</text>;
+    },
+    "entity-detail": stub("detail"),
+  };
+}
+
+describe("issue #303 acceptance — :a → :s → esc returns to agents", () => {
+  test("two pushes + one pop leaves user on agents", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+
+    const { container } = render(
+      <PagesRouter store={store} components={stubMap()} onQuit={() => {}} />,
+    );
+
+    // simulate :a alias resolving to push panel:agents
+    store.push({ kind: "panel", params: { panel: "agents" } });
+    expect(container.textContent).toContain("panel:agents");
+
+    // simulate :s alias resolving to push panel:sessions
+    store.push({ kind: "panel", params: { panel: "sessions" } });
+    expect(container.textContent).toContain("panel:sessions");
+
+    // esc pops
+    fireEvent.keyDown(container, { key: "Escape" });
+    expect(container.textContent).toContain("panel:agents");
+    expect(store.depth()).toBe(2);
+    expect(store.top()).toEqual({ kind: "panel", params: { panel: "agents" } });
+  });
+});
+```
+
+- [ ] **Step 10.2: Run, expect pass**
+
+Run: `bun test tests/tui/pages-nav-acceptance.test.tsx`
+Expected: 1 passed.
+
+- [ ] **Step 10.3: Run full test suite**
+
+Run: `bun test`
+Expected: 0 regressions.
+
+- [ ] **Step 10.4: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: 0 errors.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add tests/tui/pages-nav-acceptance.test.tsx
+git commit -m "test(tui): add #303 acceptance test for pages stack"
+```
+
+---
+
+## Acceptance verification (issue #303)
+
+- [ ] `esc` pops to previous view — verified in Task 6 (`pages-router.test.tsx`) and Task 10 (acceptance).
+- [ ] Breadcrumbs reflect current depth — verified in Task 4 (`breadcrumb-bar.test.tsx`).
+- [ ] `:a` → `:s` → `esc` returns to agents, not initial route — verified in Task 10.
+
+## Out of scope (per spec)
+
+- Hint-bar refresh on stack-top change → issue #309.
+- Real `<EntityDetailView>` content → issue #311.
+- `confirmAndMutate` / 428 enforcement → issue #304.
+- Persistent stack across restarts.

--- a/docs/superpowers/specs/2026-05-09-tui-pages-nav-stack-design.md
+++ b/docs/superpowers/specs/2026-05-09-tui-pages-nav-stack-design.md
@@ -1,0 +1,200 @@
+# TUI Pages Navigation Stack — Design
+
+**Date:** 2026-05-09
+**Issue:** [#303](https://github.com/windoliver/grove/issues/303) (Epic [#284](https://github.com/windoliver/grove/issues/284))
+**Status:** Design ready for implementation
+**Reference:** k9s `internal/ui/pages.go`
+
+## Problem
+
+The TUI navigation model is a fixed forward-only state machine in `screen-manager.tsx` (preset-select → goal-input → launch-preview → running → complete). Inside `running-view.tsx`, the goto aliases `:a` `:s` `:d` `:t` `:r` mutate `expandedPanel` directly with no history — `:a` then `:s` then `esc` collapses the panel instead of returning to agents.
+
+The roadmap calls for a k9s-style pages stack with push/pop/top + listeners, breadcrumb derivation, and esc-pop with confirm-on-dirty so users can drill into views, navigate freely, and back out predictably.
+
+## Goals
+
+- Replace the wizard state machine with a uniform navigation stack covering wizard screens, panel zooms, and future entity-detail views.
+- Provide `push` / `pop` / `replace` / `top` with three event channels (`stackPushed`, `stackPopped`, `stackTop`).
+- Derive breadcrumbs from stack depth.
+- Esc pops; pages can register an `isDirty` check that triggers a confirm dialog before pop.
+- Acceptance from issue: `:a` → `:s` → esc returns to agents.
+
+## Non-goals
+
+- Hint-bar refresh on stack change (deferred to #309).
+- Live DAG view (#311).
+- `confirmAndMutate` / 428 enforcement (#304).
+- Persistent stack across process restarts.
+
+## Architecture
+
+A pure data class `PagesStore` owns the stack. React subscribes via a thin hook. `PagesRouter` consumes the top page and renders the matching screen component.
+
+### Module layout
+
+| File | Purpose |
+| --- | --- |
+| `src/tui/data/pages-store.ts` | `PagesStore` class — push/pop/replace/top, listeners, dirty-check registry |
+| `src/tui/data/pages-store.test.ts` | Unit tests for the store |
+| `src/tui/hooks/use-pages-store.ts` | React hook (`useSyncExternalStore`-style) |
+| `src/tui/hooks/use-pages-store.test.ts` | Hook tests |
+| `src/tui/components/pages-router.tsx` | Maps `top.kind` → component, owns esc handler + confirm dialog |
+| `src/tui/components/pages-router.test.tsx` | Router tests |
+| `src/tui/components/confirm-pop-dialog.tsx` | Modal overlay shown when dirty page tries to pop |
+
+### Modified files
+
+| File | Change |
+| --- | --- |
+| `src/tui/screens/screen-manager.tsx` | Becomes a shim: builds initial stack from `initialState`/`startOnRunning`/`presets`, delegates to `<PagesRouter>`. Wizard transitions rewritten to use `pages.push` / `pages.replace`. `ScreenState` interface preserved as durable data slot. |
+| `src/tui/components/breadcrumb-bar.tsx` | Adds `stack: readonly Page[]` prop. Renders depth-1 chevron chain. Old `screen` prop removed. |
+| `src/tui/screens/agent-detect.tsx`, `goal-input.tsx`, `spawn-progress.tsx` | Stop rendering their own `<BreadcrumbBar>`. The router renders one breadcrumb at the top of the screen, sourced from the stack. Removes 3 redundant `screen=...` call sites. |
+| `src/tui/screens/running-view.tsx` | `gotoDispatch` calls `pages.push({ kind: "panel", params: { panel: "..." } })` instead of mutating `expandedPanel`. `expandedPanel` becomes a selector over top page when `top.kind === "panel"`. |
+| `src/tui/screens/goal-input.tsx` | Registers dirty-check returning `text.trim().length > 0`. |
+| `src/tui/screens/running-view.tsx` (prompt-mode) | Registers dirty-check while prompt-mode active and prompt text non-empty. |
+
+## Types and API
+
+```ts
+export type PageKind =
+  | "preset-select" | "goal-input" | "agent-detect"
+  | "launch-preview" | "spawning" | "running"
+  | "complete" | "advanced"
+  | "panel"          // zoom inside running (params.panel = "agents"|"sessions"|"dag"|"tasks"|"reviews")
+  | "entity-detail"; // future drill-in target
+
+export interface Page {
+  readonly kind: PageKind;
+  readonly params?: Readonly<Record<string, string>>;
+}
+
+export type StackEvent =
+  | { type: "pushed"; page: Page; depth: number }
+  | { type: "popped"; page: Page; depth: number }
+  | { type: "top";    page: Page; depth: number };
+
+export type DirtyCheck = () => boolean;
+
+export class PagesStore {
+  push(page: Page): void;
+  pop(): Page | undefined;
+  replace(page: Page): void;
+  top(): Page | undefined;
+  depth(): number;
+  snapshot(): readonly Page[];
+  subscribe(type: StackEvent["type"], fn: (e: StackEvent) => void): () => void;
+  registerDirtyCheck(kind: PageKind, fn: DirtyCheck): () => void;
+  hasDirtyTop(): boolean;
+}
+```
+
+### Invariants
+
+- Stack always has ≥1 entry. `pop()` on depth=1 is a no-op and returns `undefined`.
+- Duplicate-top push (same kind + same params) is a no-op — guards rapid `:a:a:a`.
+- `replace()` swaps top in place (no event for `popped`; emits `pushed` + `top`).
+- Page state lives outside the stack: in central store, refs, or `ScreenState`. The stack stores only routes (kind + params).
+- Listener exceptions are caught and logged via `debugLog`, never kill the store (mirrors `acp-session-store.ts:284`).
+- Dirty-check exceptions are treated as dirty (safe default).
+
+## Data flow
+
+### Goto from running view (`:a` then `:s`)
+
+1. User types `:a`; existing prompt resolves alias; `gotoDispatch.agents` called.
+2. `gotoDispatch.agents` → `pages.push({ kind: "panel", params: { panel: "agents" } })`.
+3. Store appends to `stack`, fires `pushed` then `top`.
+4. `<PagesRouter>` re-renders, mounts `<PanelZoomView panel="agents">`. `<BreadcrumbBar>` re-renders.
+5. Subsequent `:s` pushes `panel:sessions`. Stack: `[running, panel:agents, panel:sessions]`.
+6. Esc → `hasDirtyTop()` is false → `pop()` → top is `panel:agents` → user back on agents (acceptance criterion).
+
+### Wizard navigation
+
+- Wizard forward steps use `push`. Stack inside wizard: `[preset-select, goal-input, launch-preview]`. Esc pops back through prior steps.
+- Successful spawn → transition to running calls `pages.replace({ kind: "running" })`, collapsing all wizard frames so post-launch esc never re-enters the wizard.
+
+### Esc handling (router)
+
+```
+onKey(esc):
+  if confirm-dialog open:           dialog handles key
+  else if hasDirtyTop():            open confirm dialog
+  else if depth() === 1:            existing quit-confirm flow
+  else:                             pages.pop()
+```
+
+### Replace vs push
+
+- `push` — drilling deeper (panel zoom, entity-detail, wizard forward).
+- `replace` — collapsing one phase into another (wizard → running, running → complete) so esc doesn't backtrack into a defunct phase.
+
+## Component map (router)
+
+```ts
+const COMPONENTS: Record<PageKind, React.FC<{page: Page}>> = {
+  "preset-select":  PresetSelect,
+  "goal-input":     GoalInput,
+  "agent-detect":   AgentDetect,
+  "launch-preview": AgentDetect,   // alias of above per current code
+  "spawning":       SpawnProgress,
+  "running":        RunningView,
+  "complete":       CompleteView,
+  "advanced":       App,
+  "panel":          PanelZoomView,    // thin wrapper around RunningView with expanded panel
+  "entity-detail":  EntityDetailView, // stub; populated by later Epic C work
+};
+```
+
+## Error handling
+
+| Condition | Behavior |
+| --- | --- |
+| `pop()` at depth=1 | No-op, returns `undefined`; router routes to quit-confirm. |
+| `push` of identical top | No-op. |
+| Listener throws | Caught, logged, store continues. |
+| Dirty-check throws | Treated as dirty; confirm dialog shown. |
+| Confirm dialog open + key input | Routed to dialog only (modal). |
+
+## Testing
+
+**`pages-store.test.ts`:**
+- push/pop/replace invariants: depth, top, snapshot immutability.
+- `pop()` at depth=1 returns undefined, stack unchanged.
+- Duplicate-top push is no-op.
+- Listeners fire in order with correct payload + depth.
+- Listener throw caught, store keeps working.
+- Unsubscribe removes listener.
+- `registerDirtyCheck` + `hasDirtyTop` lookup by current top kind.
+- Dirty-check throws → `hasDirtyTop` returns true.
+
+**`use-pages-store.test.ts`:**
+- Subscribes on mount, unsubscribes on unmount.
+- Top change triggers re-render.
+- Multiple subscribers on same store see same snapshot.
+
+**`pages-router.test.tsx`:**
+- `top.kind` change swaps mounted component.
+- Esc on non-dirty top calls `pop()`.
+- Esc on dirty top renders confirm dialog; cancel keeps stack; confirm pops.
+- Esc at depth=1 routes to quit-confirm (existing path).
+
+**Integration (extend existing tests):**
+- `:a` → `:s` → esc lands back on agents (acceptance criterion verbatim).
+- Breadcrumb depth chain renders correctly at each width breakpoint.
+- Wizard forward push: preset-select → goal-input typing → esc with dirty → confirm shown → cancel keeps text.
+- Post-launch `replace` collapses wizard frames.
+
+**Performance:** push/pop O(1); listener fanout O(subscribers). No regression in `entity-view.perf.test.tsx`.
+
+## Acceptance (from issue #303)
+
+- [x] `esc` pops to previous view — covered by router esc handler + integration test.
+- [x] Breadcrumbs reflect current depth — `BreadcrumbBar` consumes stack snapshot.
+- [x] `:a` → `:s` → `esc` returns to agents — covered by integration test.
+
+## Out of scope
+
+- `<HintBar>` auto-refresh on stack-top change — handled in #309.
+- `<EntityDetailView>` real implementation — handled in #311 (DAG view) and future Epic C work.
+- `confirmAndMutate` server-side 428 enforcement — handled in #304.
+- Persistent stack across restarts — not requested.

--- a/src/core/acp-runtime.test.ts
+++ b/src/core/acp-runtime.test.ts
@@ -74,6 +74,8 @@ describe("buildAcpLaunchArgs", () => {
     expect(buildAcpLaunchArgs(codexLaunch, { command: "codex --full-auto" })).toEqual([
       "codex-acp.js",
       "-c",
+      'model="gpt-5.4"',
+      "-c",
       'sandbox_mode="danger-full-access"',
       "-c",
       'approval_policy="never"',
@@ -84,10 +86,19 @@ describe("buildAcpLaunchArgs", () => {
     expect(buildAcpLaunchArgs(codexLaunch, {}, { GROVE_ALLOW_ALL_PERMISSIONS: "1" })).toEqual([
       "codex-acp.js",
       "-c",
+      'model="gpt-5.4"',
+      "-c",
       'sandbox_mode="danger-full-access"',
       "-c",
       'approval_policy="never"',
     ]);
+  });
+
+  test("pins DEFAULT_CODEX_MODEL when neither opts.model nor GROVE_CODEX_MODEL is set", () => {
+    // User config can have a model codex-acp's bundled CLI doesn't support
+    // yet (e.g. gpt-5.5). Grove must override via -c model so spawned
+    // agents don't fail the very first prompt with invalid_request_error.
+    expect(buildAcpLaunchArgs(codexLaunch, {})).toEqual(["codex-acp.js", "-c", 'model="gpt-5.4"']);
   });
 
   test("passes only non-secret Grove MCP env through codex config args", () => {
@@ -118,6 +129,8 @@ describe("buildAcpLaunchArgs", () => {
       ),
     ).toEqual([
       "codex-acp.js",
+      "-c",
+      'model="gpt-5.4"',
       "-c",
       'mcp_servers.grove.command="/Users/example/.bun/bin/bun"',
       "-c",

--- a/src/core/acp-runtime.test.ts
+++ b/src/core/acp-runtime.test.ts
@@ -273,7 +273,11 @@ describe("prepareIsolatedCodexHome", () => {
       ]);
 
       const config = readFileSync(join(isolated, "config.toml"), "utf-8");
-      expect(config).toContain('model = "gpt-5.4-mini"');
+      // User's `model` is intentionally NOT copied into the isolated config —
+      // grove pins the model via `-c model=...` in buildAcpLaunchArgs to avoid
+      // user configs lagging codex-acp's bundled CLI (e.g. user sets gpt-5.5
+      // but the CLI rejects it). See SAFE_CODEX_TOP_LEVEL_KEYS / DEFAULT_CODEX_MODEL.
+      expect(config).not.toContain('model = "gpt-5.4-mini"');
       expect(config).not.toContain("bad-mcp");
       expect(config).toContain("[mcp_servers.grove]");
       expect(config).toContain('command = "/bin/bun"');

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -99,14 +99,27 @@ function resolveAgentFromConfig(config: AgentConfig): string {
  * grove-spawned workspaces are ephemeral and explicitly approved by the
  * `GROVE_ALLOW_ALL_PERMISSIONS=1` / sandbox config the launcher passes.
  */
+// Model-selection keys (`model`, `model_provider`) are deliberately excluded:
+// users routinely bump `model` to a value codex-acp's bundled CLI hasn't
+// caught up to yet (e.g. "gpt-5.5"), and copying it into the isolated config
+// makes every grove-spawned codex agent fail at first prompt with
+// `invalid_request_error: The '<model>' model requires a newer version of
+// Codex`. Grove instead pins `DEFAULT_CODEX_MODEL` via `-c model=...` in
+// `buildAcpLaunchArgs` so agents always run a model the launched codex CLI
+// actually supports. Set GROVE_CODEX_MODEL to override.
 const SAFE_CODEX_TOP_LEVEL_KEYS = new Set([
-  "model",
-  "model_provider",
   "personality",
   "model_reasoning_effort",
   "model_reasoning_summaries",
   "approvals_reviewer",
 ]);
+
+/**
+ * Default model passed to codex when no role-level `model` and no
+ * `GROVE_CODEX_MODEL` override is set. Pinned to a value that codex-acp
+ * 0.11.1 (and the bundled CLI) accepts; bump as the supported floor moves.
+ */
+export const DEFAULT_CODEX_MODEL = "gpt-5.4";
 
 /**
  * Match a top-level TOML scalar assignment: `key = ...` outside any table.
@@ -363,10 +376,8 @@ export function buildAcpLaunchArgs(
   const args = [...launch.args];
   if (launch.agent !== "codex") return args;
 
-  const model = (opts.model ?? env.GROVE_CODEX_MODEL)?.trim();
-  if (model) {
-    args.push("-c", `model=${JSON.stringify(model)}`);
-  }
+  const model = (opts.model ?? env.GROVE_CODEX_MODEL)?.trim() || DEFAULT_CODEX_MODEL;
+  args.push("-c", `model=${JSON.stringify(model)}`);
 
   const allowAll =
     env.GROVE_ALLOW_ALL_PERMISSIONS === "1" ||

--- a/src/tui/components/breadcrumb-bar.test.tsx
+++ b/src/tui/components/breadcrumb-bar.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for BreadcrumbBar stack-mode rendering.
+ *
+ * Covers the new `stack` prop path added in #303:
+ *   1. Single-page stack renders just that label
+ *   2. Multi-page stack joins labels with ›
+ *   3. Narrow width (<70) shows only the current (last) label
+ *   4. Wide width (>=100) prepends "Grove"
+ *   5. Legacy screen prop still works when stack is absent
+ */
+
+import { describe, expect, test } from "bun:test";
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import type { Page } from "../data/pages-store.js";
+import { BreadcrumbBar } from "./breadcrumb-bar.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function render(props: Parameters<typeof BreadcrumbBar>[0]): TestRenderer.ReactTestRenderer {
+  let renderer!: TestRenderer.ReactTestRenderer;
+  act(() => {
+    renderer = TestRenderer.create(React.createElement(BreadcrumbBar, props));
+  });
+  if (!renderer) throw new Error("renderer not initialized");
+  return renderer;
+}
+
+describe("BreadcrumbBar – stack mode", () => {
+  test("single-page stack renders just that label", () => {
+    const stack: readonly Page[] = [{ kind: "preset-select" }];
+    const flat = JSON.stringify(render({ stack, width: 120 }).toJSON());
+    expect(flat).toContain("Preset Select");
+  });
+
+  test("depth chain: labels and › separator all present", () => {
+    const stack: readonly Page[] = [
+      { kind: "running" },
+      { kind: "panel", params: { panel: "agents" } },
+      { kind: "panel", params: { panel: "sessions" } },
+    ];
+    const flat = JSON.stringify(render({ stack, width: 120 }).toJSON());
+    expect(flat).toContain("Running");
+    expect(flat).toContain("Agents");
+    expect(flat).toContain("Sessions");
+    expect(flat).toContain("›");
+  });
+
+  test("width<70 shows only the current (last) label", () => {
+    const stack: readonly Page[] = [
+      { kind: "running" },
+      { kind: "panel", params: { panel: "agents" } },
+      { kind: "panel", params: { panel: "sessions" } },
+    ];
+    const flat = JSON.stringify(render({ stack, width: 50 }).toJSON());
+    expect(flat).toContain("Sessions");
+    expect(flat).not.toContain("Running");
+  });
+
+  test("width>=100 prepends Grove", () => {
+    const stack: readonly Page[] = [{ kind: "running" }];
+    const flat = JSON.stringify(render({ stack, width: 120 }).toJSON());
+    expect(flat).toContain("Grove");
+  });
+
+  test("legacy screen prop still works when stack is absent", () => {
+    const flat = JSON.stringify(render({ screen: "goal-input", width: 120 }).toJSON());
+    expect(flat).toContain("Goal");
+  });
+});

--- a/src/tui/components/breadcrumb-bar.tsx
+++ b/src/tui/components/breadcrumb-bar.tsx
@@ -9,14 +9,152 @@
  */
 
 import React from "react";
+import type { Page, PageKind } from "../data/pages-store.js";
 import type { Screen } from "../screens/screen-manager.js";
 import { theme } from "../theme.js";
 
 export interface BreadcrumbBarProps {
-  readonly screen: Screen;
+  readonly stack?: readonly Page[] | undefined;
+  readonly screen?: Screen | undefined;
   readonly presetName?: string | undefined;
   readonly sessionId?: string | undefined;
   readonly width: number;
+}
+
+// ---------------------------------------------------------------------------
+// Stack-mode helpers
+// ---------------------------------------------------------------------------
+
+const PAGE_LABELS: Record<PageKind, string> = {
+  "preset-select": "Preset Select",
+  "goal-input": "Goal",
+  "agent-detect": "Launch Preview",
+  "launch-preview": "Launch Preview",
+  spawning: "Spawning",
+  running: "Running",
+  complete: "Complete",
+  advanced: "Advanced",
+  panel: "Panel",
+  "entity-detail": "Detail",
+};
+
+const PANEL_LABELS: Record<string, string> = {
+  agents: "Agents",
+  sessions: "Sessions",
+  dag: "DAG",
+  tasks: "Tasks",
+  reviews: "Reviews",
+  feed: "Feed",
+};
+
+function pageLabel(p: Page): string {
+  if (p.kind === "panel") {
+    const panel = p.params?.panel ?? "";
+    return PANEL_LABELS[panel] ?? "Panel";
+  }
+  return PAGE_LABELS[p.kind];
+}
+
+function renderStackChain(
+  stack: readonly Page[],
+  presetName: string | undefined,
+  sessionId: string | undefined,
+  width: number,
+): React.ReactNode {
+  const currentPage = stack[stack.length - 1];
+  const currentLabel = currentPage ? pageLabel(currentPage) : "";
+
+  // Narrow modes: only show the current label
+  if (width < 70) {
+    return (
+      <box paddingX={1}>
+        <text color={theme.focus} bold>
+          {currentLabel}
+        </text>
+      </box>
+    );
+  }
+
+  const shortSession = sessionId?.slice(0, 8);
+  const parts: React.ReactNode[] = [];
+
+  // >= 100: prepend "Grove ›"
+  if (width >= 100) {
+    parts.push(
+      <text key="grove" color={theme.text} bold>
+        Grove
+      </text>,
+    );
+    parts.push(
+      <text key="sep-grove" color={theme.secondary}>
+        {" "}
+        {"›"}{" "}
+      </text>,
+    );
+  }
+
+  // Optional presetName at front
+  if (presetName) {
+    parts.push(
+      <text key="preset" color={theme.secondary}>
+        {presetName}
+      </text>,
+    );
+    parts.push(
+      <text key="sep-preset" color={theme.secondary}>
+        {" "}
+        {"›"}{" "}
+      </text>,
+    );
+  }
+
+  // Full stack chain: prior pages as secondary, current page as focus/bold
+  for (let i = 0; i < stack.length; i++) {
+    const page = stack[i];
+    if (!page) continue;
+    const label = pageLabel(page);
+    const isCurrent = i === stack.length - 1;
+    if (i > 0) {
+      parts.push(
+        <text key={`sep-${i}`} color={theme.secondary}>
+          {" "}
+          {"›"}{" "}
+        </text>,
+      );
+    }
+    parts.push(
+      isCurrent ? (
+        <text key={`page-${i}`} color={theme.focus} bold>
+          {label}
+        </text>
+      ) : (
+        <text key={`page-${i}`} color={theme.secondary}>
+          {label}
+        </text>
+      ),
+    );
+  }
+
+  // Optional shortSession at end
+  if (shortSession) {
+    parts.push(
+      <text key="sep-sess" color={theme.secondary}>
+        {" "}
+        {"›"}{" "}
+      </text>,
+    );
+    parts.push(
+      <text key="sess" color={theme.secondary}>
+        {shortSession}
+      </text>,
+    );
+  }
+
+  return (
+    <box paddingX={1} flexDirection="row">
+      {parts}
+    </box>
+  );
 }
 
 const SCREEN_LABELS: Record<Screen, string> = {
@@ -32,12 +170,19 @@ const SCREEN_LABELS: Record<Screen, string> = {
 
 export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> = React.memo(
   function BreadcrumbBar({
+    stack,
     screen,
     presetName,
     sessionId,
     width,
   }: BreadcrumbBarProps): React.ReactNode {
-    const label = SCREEN_LABELS[screen] ?? screen;
+    // Stack mode: when stack is provided and non-empty, use new rendering path
+    if (stack && stack.length > 0) {
+      return renderStackChain(stack, presetName, sessionId, width);
+    }
+
+    // Legacy mode: screen-based rendering (unchanged)
+    const label = SCREEN_LABELS[screen ?? "preset-select"] ?? (screen as string);
     const shortSession = sessionId?.slice(0, 8);
 
     // Minimal: < 40 cols
@@ -58,7 +203,7 @@ export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> = Rea
           <text color={theme.focus} bold>
             {label}
           </text>
-          {screen !== "preset-select" ? (
+          {screen !== "preset-select" && screen !== undefined ? (
             <text color={theme.secondary}> [Esc]</text>
           ) : (
             <text color={theme.secondary}> [q]uit</text>
@@ -104,7 +249,9 @@ export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> = Rea
       return (
         <box paddingX={1} flexDirection="row">
           {parts}
-          {screen !== "preset-select" ? <text color={theme.secondary}> [Esc]</text> : null}
+          {screen !== "preset-select" && screen !== undefined ? (
+            <text color={theme.secondary}> [Esc]</text>
+          ) : null}
         </box>
       );
     }
@@ -159,7 +306,7 @@ export const BreadcrumbBar: React.NamedExoticComponent<BreadcrumbBarProps> = Rea
         {parts}
         {screen === "running" || screen === "advanced" ? (
           <text color={theme.secondary}> [Tab]</text>
-        ) : screen !== "preset-select" ? (
+        ) : screen !== "preset-select" && screen !== undefined ? (
           <text color={theme.secondary}> [Esc]</text>
         ) : null}
       </box>

--- a/src/tui/components/confirm-pop-dialog.test.tsx
+++ b/src/tui/components/confirm-pop-dialog.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tests for ConfirmPopDialog: visibility, content rendering.
+ */
+
+import { describe, expect, test } from "bun:test";
+import TestRenderer, { act } from "react-test-renderer";
+import { ConfirmPopDialog } from "./confirm-pop-dialog.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ConfirmPopDialog", () => {
+  test("renders null when visible=false", () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(
+        <ConfirmPopDialog
+          visible={false}
+          onConfirm={() => {
+            // noop for test
+          }}
+          onCancel={() => {
+            // noop for test
+          }}
+        />,
+      );
+    });
+
+    expect(renderer.toJSON()).toBe(null);
+    renderer.unmount();
+  });
+
+  test("renders title when visible=true", () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(
+        <ConfirmPopDialog
+          visible={true}
+          onConfirm={() => {
+            // noop for test
+          }}
+          onCancel={() => {
+            // noop for test
+          }}
+        />,
+      );
+    });
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("Discard unsaved changes?");
+
+    renderer.unmount();
+  });
+
+  test("renders hint markers when visible=true", () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(
+        <ConfirmPopDialog
+          visible={true}
+          onConfirm={() => {
+            // noop for test
+          }}
+          onCancel={() => {
+            // noop for test
+          }}
+        />,
+      );
+    });
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("[y]");
+    expect(flat).toContain("[n]");
+
+    renderer.unmount();
+  });
+});

--- a/src/tui/components/confirm-pop-dialog.tsx
+++ b/src/tui/components/confirm-pop-dialog.tsx
@@ -1,0 +1,35 @@
+/**
+ * ConfirmPopDialog: modal overlay for "Discard unsaved changes?" confirmation.
+ *
+ * Presentational component — does not handle keyboard input. The router (Task 6)
+ * will route keystrokes to onConfirm/onCancel props.
+ */
+
+import React from "react";
+import { theme } from "../theme.js";
+
+export interface ConfirmPopDialogProps {
+  readonly visible: boolean;
+  readonly onConfirm: () => void;
+  readonly onCancel: () => void;
+}
+
+export const ConfirmPopDialog: React.NamedExoticComponent<ConfirmPopDialogProps> = React.memo(
+  function ConfirmPopDialog({ visible }: ConfirmPopDialogProps) {
+    if (!visible) return null;
+    return (
+      <box
+        flexDirection="column"
+        paddingX={2}
+        paddingY={1}
+        borderStyle="single"
+        borderColor={theme.focus}
+      >
+        <text bold color={theme.focus}>
+          Discard unsaved changes?
+        </text>
+        <text color={theme.secondary}>[y] discard and go back [n] stay</text>
+      </box>
+    );
+  },
+);

--- a/src/tui/components/pages-router.test.tsx
+++ b/src/tui/components/pages-router.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * Tests for PagesRouter.
+ *
+ * Two groups:
+ *   Group 1 — pure reducer (no rendering). All 8 action-mapping cases.
+ *   Group 2 — component rendering via react-test-renderer + store mutations.
+ *
+ * Note on useKeyboard mocking:
+ *   We use mock.module("@opentui/react", ...) (same pattern as screen-manager.test.ts)
+ *   to capture the keyboard handler. This lets us drive keyboard events from tests
+ *   without a real OpenTUI renderer. The mock is set up at module scope so it applies
+ *   before the pages-router module is imported.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import type { Page, PageKind } from "../data/pages-store.js";
+import { PagesStore } from "../data/pages-store.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// Group 1 — pure reducer (no rendering, no mocks needed)
+// ---------------------------------------------------------------------------
+
+import type { RouterKeyState } from "./pages-router.js";
+// Import the pure functions directly — safe before any mock.module() calls
+import { reduceRouterKey } from "./pages-router.js";
+
+describe("reduceRouterKey", () => {
+  const clean: RouterKeyState = { dialogOpen: false, dirty: false, depth: 2 };
+  const cleanDepth1: RouterKeyState = { dialogOpen: false, dirty: false, depth: 1 };
+  const dirty: RouterKeyState = { dialogOpen: false, dirty: true, depth: 2 };
+  const withDialog: RouterKeyState = { dialogOpen: true, dirty: false, depth: 2 };
+
+  test("escape + clean + depth=2 → pop", () => {
+    expect(reduceRouterKey(clean, "escape")).toEqual({ type: "pop" });
+  });
+
+  test("escape + clean + depth=1 → quit", () => {
+    expect(reduceRouterKey(cleanDepth1, "escape")).toEqual({ type: "quit" });
+  });
+
+  test("escape + dirty → openDialog", () => {
+    expect(reduceRouterKey(dirty, "escape")).toEqual({ type: "openDialog" });
+  });
+
+  test("dialogOpen=true + y → popAndCloseDialog", () => {
+    expect(reduceRouterKey(withDialog, "y")).toEqual({ type: "popAndCloseDialog" });
+  });
+
+  test("dialogOpen=true + n → closeDialog", () => {
+    expect(reduceRouterKey(withDialog, "n")).toEqual({ type: "closeDialog" });
+  });
+
+  test("dialogOpen=true + escape → closeDialog", () => {
+    expect(reduceRouterKey(withDialog, "escape")).toEqual({ type: "closeDialog" });
+  });
+
+  test("dialogOpen=true + any other key → noop", () => {
+    expect(reduceRouterKey(withDialog, "j")).toEqual({ type: "noop" });
+    expect(reduceRouterKey(withDialog, "q")).toEqual({ type: "noop" });
+    expect(reduceRouterKey(withDialog, "return")).toEqual({ type: "noop" });
+  });
+
+  test("non-escape key with dialogOpen=false → noop", () => {
+    expect(reduceRouterKey(clean, "j")).toEqual({ type: "noop" });
+    expect(reduceRouterKey(clean, "q")).toEqual({ type: "noop" });
+    expect(reduceRouterKey(clean, "tab")).toEqual({ type: "noop" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 2 — component rendering
+// ---------------------------------------------------------------------------
+
+type KeyboardHandler = (key: { name: string }) => void;
+let capturedKeyboardHandler: KeyboardHandler | undefined;
+
+// Mock @opentui/react before importing pages-router component so the handler
+// is captured during component mount.
+mock.module("@opentui/react", () => ({
+  useKeyboard: (handler: KeyboardHandler): void => {
+    capturedKeyboardHandler = handler;
+  },
+  useRenderer: (): { destroy: () => void } => ({ destroy: () => undefined }),
+  useTerminalDimensions: (): { width: number; height: number } => ({ width: 120, height: 40 }),
+}));
+
+// Import the component AFTER mock.module so the mock is applied
+const { PagesRouter } = await import("./pages-router.js");
+
+import type { PagesRouterComponentMap } from "./pages-router.js";
+
+// Minimal stub components for each PageKind used in tests
+function makeStubComponents(): PagesRouterComponentMap {
+  const kinds: PageKind[] = [
+    "preset-select",
+    "goal-input",
+    "agent-detect",
+    "launch-preview",
+    "spawning",
+    "running",
+    "complete",
+    "advanced",
+    "panel",
+    "entity-detail",
+  ];
+  const map: Partial<PagesRouterComponentMap> = {};
+  for (const kind of kinds) {
+    const label = kind.toUpperCase().replace(/-/g, "_");
+    map[kind] = ({ page }: { page: Page }) => (
+      <text>{`STUB_${label}:${page.params?.panel ?? ""}`}</text>
+    );
+  }
+  return map as PagesRouterComponentMap;
+}
+
+const STUB_COMPONENTS = makeStubComponents();
+
+function makeStore(...pages: Page[]): PagesStore {
+  const store = new PagesStore();
+  for (const page of pages) {
+    store.push(page);
+  }
+  return store;
+}
+
+function renderRouter(
+  store: PagesStore,
+  onQuit: () => void = () => undefined,
+): TestRenderer.ReactTestRenderer {
+  let renderer!: TestRenderer.ReactTestRenderer;
+  act(() => {
+    renderer = TestRenderer.create(
+      React.createElement(PagesRouter, {
+        store,
+        components: STUB_COMPONENTS,
+        onQuit,
+        width: 120,
+      }),
+    );
+  });
+  if (!renderer) throw new Error("PagesRouter did not mount");
+  return renderer;
+}
+
+const mountedRenderers: TestRenderer.ReactTestRenderer[] = [];
+
+beforeEach(() => {
+  capturedKeyboardHandler = undefined;
+});
+
+afterEach(() => {
+  for (const r of mountedRenderers.splice(0)) {
+    r.unmount();
+  }
+});
+
+async function pressKey(name: string): Promise<void> {
+  const handler = capturedKeyboardHandler;
+  if (!handler) throw new Error("No keyboard handler registered");
+  await act(async () => {
+    handler({ name });
+  });
+}
+
+describe("PagesRouter rendering", () => {
+  test("renders the running stub when a running page is on the stack", () => {
+    const store = makeStore({ kind: "running" });
+    const renderer = renderRouter(store);
+    mountedRenderers.push(renderer);
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("STUB_RUNNING");
+  });
+
+  test("pushing a panel page swaps to the panel stub", () => {
+    const store = makeStore({ kind: "running" });
+    const renderer = renderRouter(store);
+    mountedRenderers.push(renderer);
+
+    act(() => {
+      store.push({ kind: "panel", params: { panel: "agents" } });
+    });
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("STUB_PANEL");
+    expect(flat).not.toContain("STUB_RUNNING");
+  });
+
+  test("breadcrumb shows Running for a running page (width 120)", () => {
+    const store = makeStore({ kind: "running" });
+    const renderer = renderRouter(store);
+    mountedRenderers.push(renderer);
+
+    const flat = JSON.stringify(renderer.toJSON());
+    // BreadcrumbBar renders "Running" as the current label
+    expect(flat).toContain("Running");
+  });
+
+  test("breadcrumb shows Panel page label after pushing a panel", () => {
+    const store = makeStore({ kind: "running" });
+    const renderer = renderRouter(store);
+    mountedRenderers.push(renderer);
+
+    act(() => {
+      store.push({ kind: "panel", params: { panel: "agents" } });
+    });
+
+    const flat = JSON.stringify(renderer.toJSON());
+    // BreadcrumbBar renders "Agents" for panel:agents
+    expect(flat).toContain("Agents");
+  });
+
+  // Keyboard-driven tests: use mock-captured handler
+  test("esc on non-dirty top with depth=2 calls store.pop()", async () => {
+    const store = makeStore({ kind: "running" }, { kind: "panel", params: { panel: "agents" } });
+    expect(store.depth()).toBe(2);
+    const renderer = renderRouter(store);
+    mountedRenderers.push(renderer);
+
+    await pressKey("escape");
+
+    expect(store.depth()).toBe(1);
+    expect(store.top()?.kind).toBe("running");
+  });
+
+  test("esc on dirty top opens dialog (rendered text contains 'Discard unsaved changes?')", async () => {
+    const store = makeStore({ kind: "running" }, { kind: "panel", params: { panel: "agents" } });
+    // Register a dirty check for the panel page
+    store.registerDirtyCheck("panel", () => true);
+
+    const renderer = renderRouter(store);
+    mountedRenderers.push(renderer);
+
+    await pressKey("escape");
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("Discard unsaved changes?");
+  });
+
+  test("from open dialog, n closes dialog without popping", async () => {
+    const store = makeStore({ kind: "running" }, { kind: "panel", params: { panel: "agents" } });
+    store.registerDirtyCheck("panel", () => true);
+
+    const renderer = renderRouter(store);
+    mountedRenderers.push(renderer);
+
+    // Open dialog
+    await pressKey("escape");
+    expect(JSON.stringify(renderer.toJSON())).toContain("Discard unsaved changes?");
+
+    // Close without popping
+    await pressKey("n");
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).not.toContain("Discard unsaved changes?");
+    // Stack should be unchanged
+    expect(store.depth()).toBe(2);
+  });
+
+  test("from open dialog, y pops and closes dialog", async () => {
+    const store = makeStore({ kind: "running" }, { kind: "panel", params: { panel: "agents" } });
+    store.registerDirtyCheck("panel", () => true);
+
+    const renderer = renderRouter(store);
+    mountedRenderers.push(renderer);
+
+    // Open dialog
+    await pressKey("escape");
+    expect(JSON.stringify(renderer.toJSON())).toContain("Discard unsaved changes?");
+
+    // Confirm pop
+    await pressKey("y");
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).not.toContain("Discard unsaved changes?");
+    // Stack should have been popped
+    expect(store.depth()).toBe(1);
+    expect(store.top()?.kind).toBe("running");
+  });
+
+  test("renders null when the store is empty", () => {
+    const store = new PagesStore(); // empty
+    const renderer = renderRouter(store);
+    mountedRenderers.push(renderer);
+    expect(renderer.toJSON()).toBeNull();
+  });
+});

--- a/src/tui/components/pages-router.test.tsx
+++ b/src/tui/components/pages-router.test.tsx
@@ -2,7 +2,8 @@
  * Tests for PagesRouter.
  *
  * Two groups:
- *   Group 1 — pure reducer (no rendering). All 8 action-mapping cases.
+ *   Group 1 — pure reducer (no rendering). Only the dialog-key cases now;
+ *             non-dialog states are uniformly noop.
  *   Group 2 — component rendering via react-test-renderer + store mutations.
  *
  * Note on useKeyboard mocking:
@@ -10,6 +11,9 @@
  *   to capture the keyboard handler. This lets us drive keyboard events from tests
  *   without a real OpenTUI renderer. The mock is set up at module scope so it applies
  *   before the pages-router module is imported.
+ *
+ * Esc-pop behavior was deliberately moved out of the router (see
+ * pages-router.tsx header). Tests reflect that: bare escape is a noop here.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -29,22 +33,8 @@ import type { RouterKeyState } from "./pages-router.js";
 import { reduceRouterKey } from "./pages-router.js";
 
 describe("reduceRouterKey", () => {
-  const clean: RouterKeyState = { dialogOpen: false, dirty: false, depth: 2 };
-  const cleanDepth1: RouterKeyState = { dialogOpen: false, dirty: false, depth: 1 };
-  const dirty: RouterKeyState = { dialogOpen: false, dirty: true, depth: 2 };
-  const withDialog: RouterKeyState = { dialogOpen: true, dirty: false, depth: 2 };
-
-  test("escape + clean + depth=2 → pop", () => {
-    expect(reduceRouterKey(clean, "escape")).toEqual({ type: "pop" });
-  });
-
-  test("escape + clean + depth=1 → quit", () => {
-    expect(reduceRouterKey(cleanDepth1, "escape")).toEqual({ type: "quit" });
-  });
-
-  test("escape + dirty → openDialog", () => {
-    expect(reduceRouterKey(dirty, "escape")).toEqual({ type: "openDialog" });
-  });
+  const closed: RouterKeyState = { dialogOpen: false };
+  const withDialog: RouterKeyState = { dialogOpen: true };
 
   test("dialogOpen=true + y → popAndCloseDialog", () => {
     expect(reduceRouterKey(withDialog, "y")).toEqual({ type: "popAndCloseDialog" });
@@ -64,10 +54,16 @@ describe("reduceRouterKey", () => {
     expect(reduceRouterKey(withDialog, "return")).toEqual({ type: "noop" });
   });
 
-  test("non-escape key with dialogOpen=false → noop", () => {
-    expect(reduceRouterKey(clean, "j")).toEqual({ type: "noop" });
-    expect(reduceRouterKey(clean, "q")).toEqual({ type: "noop" });
-    expect(reduceRouterKey(clean, "tab")).toEqual({ type: "noop" });
+  test("dialogOpen=false + escape → noop (router does NOT pop or quit)", () => {
+    expect(reduceRouterKey(closed, "escape")).toEqual({ type: "noop" });
+  });
+
+  test("dialogOpen=false + any non-escape key → noop", () => {
+    expect(reduceRouterKey(closed, "j")).toEqual({ type: "noop" });
+    expect(reduceRouterKey(closed, "q")).toEqual({ type: "noop" });
+    expect(reduceRouterKey(closed, "tab")).toEqual({ type: "noop" });
+    expect(reduceRouterKey(closed, "y")).toEqual({ type: "noop" });
+    expect(reduceRouterKey(closed, "n")).toEqual({ type: "noop" });
   });
 });
 
@@ -127,9 +123,14 @@ function makeStore(...pages: Page[]): PagesStore {
   return store;
 }
 
+interface RenderRouterOptions {
+  readonly presetName?: string;
+  readonly sessionId?: string;
+}
+
 function renderRouter(
   store: PagesStore,
-  onQuit: () => void = () => undefined,
+  options: RenderRouterOptions = {},
 ): TestRenderer.ReactTestRenderer {
   let renderer!: TestRenderer.ReactTestRenderer;
   act(() => {
@@ -137,8 +138,9 @@ function renderRouter(
       React.createElement(PagesRouter, {
         store,
         components: STUB_COMPONENTS,
-        onQuit,
         width: 120,
+        ...(options.presetName !== undefined ? { presetName: options.presetName } : {}),
+        ...(options.sessionId !== undefined ? { sessionId: options.sessionId } : {}),
       }),
     );
   });
@@ -214,8 +216,21 @@ describe("PagesRouter rendering", () => {
     expect(flat).toContain("Agents");
   });
 
-  // Keyboard-driven tests: use mock-captured handler
-  test("esc on non-dirty top with depth=2 calls store.pop()", async () => {
+  test("breadcrumb forwards presetName during the wizard", () => {
+    const store = makeStore({ kind: "goal-input" });
+    const renderer = renderRouter(store, { presetName: "review-loop" });
+    mountedRenderers.push(renderer);
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("review-loop");
+  });
+
+  // Keyboard-driven tests: use mock-captured handler.
+  // The router no longer pops or opens dialogs on bare escape — those
+  // responsibilities live in inner screens (running-view, etc.). The
+  // dialog-handling branch is dormant in production; Task 9 will rewire it.
+
+  test("esc when dialog is closed is a noop (no pop, stack unchanged)", async () => {
     const store = makeStore({ kind: "running" }, { kind: "panel", params: { panel: "agents" } });
     expect(store.depth()).toBe(2);
     const renderer = renderRouter(store);
@@ -223,63 +238,38 @@ describe("PagesRouter rendering", () => {
 
     await pressKey("escape");
 
-    expect(store.depth()).toBe(1);
-    expect(store.top()?.kind).toBe("running");
-  });
-
-  test("esc on dirty top opens dialog (rendered text contains 'Discard unsaved changes?')", async () => {
-    const store = makeStore({ kind: "running" }, { kind: "panel", params: { panel: "agents" } });
-    // Register a dirty check for the panel page
-    store.registerDirtyCheck("panel", () => true);
-
-    const renderer = renderRouter(store);
-    mountedRenderers.push(renderer);
-
-    await pressKey("escape");
-
-    const flat = JSON.stringify(renderer.toJSON());
-    expect(flat).toContain("Discard unsaved changes?");
-  });
-
-  test("from open dialog, n closes dialog without popping", async () => {
-    const store = makeStore({ kind: "running" }, { kind: "panel", params: { panel: "agents" } });
-    store.registerDirtyCheck("panel", () => true);
-
-    const renderer = renderRouter(store);
-    mountedRenderers.push(renderer);
-
-    // Open dialog
-    await pressKey("escape");
-    expect(JSON.stringify(renderer.toJSON())).toContain("Discard unsaved changes?");
-
-    // Close without popping
-    await pressKey("n");
-
-    const flat = JSON.stringify(renderer.toJSON());
-    expect(flat).not.toContain("Discard unsaved changes?");
-    // Stack should be unchanged
+    // Router does NOT pop on bare escape — stack should be unchanged.
     expect(store.depth()).toBe(2);
+    expect(store.top()?.kind).toBe("panel");
   });
 
-  test("from open dialog, y pops and closes dialog", async () => {
+  test("esc when dialog is closed at depth=1 does not call onQuit (no quit prop)", async () => {
+    const store = makeStore({ kind: "running" });
+    expect(store.depth()).toBe(1);
+    const renderer = renderRouter(store);
+    mountedRenderers.push(renderer);
+
+    await pressKey("escape");
+
+    // Stack stays the same — router never quits on its own.
+    expect(store.depth()).toBe(1);
+    expect(store.top()?.kind).toBe("running");
+  });
+
+  test("esc when dirty top is registered does NOT open dialog (router no longer auto-opens)", async () => {
     const store = makeStore({ kind: "running" }, { kind: "panel", params: { panel: "agents" } });
     store.registerDirtyCheck("panel", () => true);
 
     const renderer = renderRouter(store);
     mountedRenderers.push(renderer);
 
-    // Open dialog
     await pressKey("escape");
-    expect(JSON.stringify(renderer.toJSON())).toContain("Discard unsaved changes?");
-
-    // Confirm pop
-    await pressKey("y");
 
     const flat = JSON.stringify(renderer.toJSON());
+    // Dialog stays dormant; the dirty-confirm UX is rewired in a later task.
     expect(flat).not.toContain("Discard unsaved changes?");
-    // Stack should have been popped
-    expect(store.depth()).toBe(1);
-    expect(store.top()?.kind).toBe("running");
+    // Stack unchanged.
+    expect(store.depth()).toBe(2);
   });
 
   test("renders null when the store is empty", () => {

--- a/src/tui/components/pages-router.tsx
+++ b/src/tui/components/pages-router.tsx
@@ -1,0 +1,125 @@
+/**
+ * PagesRouter — integration point that maps the top page to a screen component,
+ * handles esc-pop with confirm-on-dirty, and renders the breadcrumb.
+ *
+ * Architecture:
+ *   - Pure key-reducer (reduceRouterKey) is exported so tests can exercise it
+ *     directly without mounting any components or mocking useKeyboard.
+ *   - The component composes the reducer with useKeyboard and applies actions.
+ */
+
+import { useKeyboard } from "@opentui/react";
+import React, { useCallback, useState } from "react";
+import type { Page, PageKind, PagesStore } from "../data/pages-store.js";
+import { useScreenStack } from "../hooks/use-screen-stack.js";
+import { BreadcrumbBar } from "./breadcrumb-bar.js";
+import { ConfirmPopDialog } from "./confirm-pop-dialog.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type PagesRouterComponentMap = Record<PageKind, React.ComponentType<{ page: Page }>>;
+
+export interface PagesRouterProps {
+  readonly store: PagesStore;
+  readonly components: PagesRouterComponentMap;
+  readonly onQuit: () => void;
+  readonly width: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure key reducer (exported for tests)
+// ---------------------------------------------------------------------------
+
+export type RouterAction =
+  | { type: "noop" }
+  | { type: "pop" }
+  | { type: "openDialog" }
+  | { type: "closeDialog" }
+  | { type: "popAndCloseDialog" }
+  | { type: "quit" };
+
+export interface RouterKeyState {
+  readonly dialogOpen: boolean;
+  readonly dirty: boolean; // hasDirtyTop()
+  readonly depth: number;
+}
+
+export function reduceRouterKey(state: RouterKeyState, keyName: string): RouterAction {
+  if (state.dialogOpen) {
+    if (keyName === "y") return { type: "popAndCloseDialog" };
+    if (keyName === "n" || keyName === "escape") return { type: "closeDialog" };
+    return { type: "noop" };
+  }
+  if (keyName !== "escape") return { type: "noop" };
+  if (state.dirty) return { type: "openDialog" };
+  if (state.depth <= 1) return { type: "quit" };
+  return { type: "pop" };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const PagesRouter: React.NamedExoticComponent<PagesRouterProps> = React.memo(
+  function PagesRouter({ store, components, onQuit, width }: PagesRouterProps) {
+    const { top, depth, snapshot } = useScreenStack(store);
+    const [dialogOpen, setDialogOpen] = useState(false);
+
+    const handleConfirm = useCallback(() => {
+      store.pop();
+      setDialogOpen(false);
+    }, [store]);
+
+    const handleCancel = useCallback(() => {
+      setDialogOpen(false);
+    }, []);
+
+    useKeyboard(
+      useCallback(
+        (key) => {
+          const state: RouterKeyState = {
+            dialogOpen,
+            dirty: store.hasDirtyTop(),
+            depth,
+          };
+          const action = reduceRouterKey(state, key.name);
+          switch (action.type) {
+            case "pop":
+              store.pop();
+              break;
+            case "openDialog":
+              setDialogOpen(true);
+              break;
+            case "closeDialog":
+              setDialogOpen(false);
+              break;
+            case "popAndCloseDialog":
+              store.pop();
+              setDialogOpen(false);
+              break;
+            case "quit":
+              onQuit();
+              break;
+            case "noop":
+              break;
+          }
+        },
+        [dialogOpen, store, depth, onQuit],
+      ),
+    );
+
+    if (top === undefined) return null;
+
+    const Component = components[top.kind];
+
+    return (
+      <>
+        <BreadcrumbBar stack={snapshot} width={width} />
+        <Component page={top} />
+        <ConfirmPopDialog visible={dialogOpen} onConfirm={handleConfirm} onCancel={handleCancel} />
+      </>
+    );
+  },
+);

--- a/src/tui/components/pages-router.tsx
+++ b/src/tui/components/pages-router.tsx
@@ -16,6 +16,13 @@
  *   Pop/quit responsibility lives entirely with inner screens, whose onBack
  *   callbacks are wired by screen-manager to pages.pop/replace/resetTo.
  *   The router only consumes keys when the confirm dialog is open.
+ *
+ * Dormant dirty-confirm UX:
+ *   `<ConfirmPopDialog>` and `setDialogOpen` are wired but never triggered in
+ *   production. `pages.hasDirtyTop()` and the goal-input/prompt-mode dirty
+ *   checks are registered (Task 9 / #303) but no caller fires the dialog yet.
+ *   A follow-up will rewire dirty → confirm UX through a different mechanism
+ *   that respects the multi-handler keyboard model documented above.
  */
 
 import { useKeyboard } from "@opentui/react";

--- a/src/tui/components/pages-router.tsx
+++ b/src/tui/components/pages-router.tsx
@@ -1,11 +1,21 @@
 /**
- * PagesRouter — integration point that maps the top page to a screen component,
- * handles esc-pop with confirm-on-dirty, and renders the breadcrumb.
+ * PagesRouter — integration point that maps the top page to a screen component
+ * and renders the breadcrumb. Handles the dirty-confirm dialog when open.
  *
  * Architecture:
  *   - Pure key-reducer (reduceRouterKey) is exported so tests can exercise it
  *     directly without mounting any components or mocking useKeyboard.
  *   - The component composes the reducer with useKeyboard and applies actions.
+ *
+ * Esc handling note:
+ *   In production, multiple components register `useKeyboard` handlers via
+ *   `@opentui/react` and ALL handlers fire on every keypress (no
+ *   stopPropagation). To avoid double-pop / unwanted-quit conflicts with
+ *   inner screens that already handle escape (running-view, agent-detect,
+ *   goal-input, etc.), this router does NOT pop or quit on bare escape.
+ *   Pop/quit responsibility lives entirely with inner screens, whose onBack
+ *   callbacks are wired by screen-manager to pages.pop/replace/resetTo.
+ *   The router only consumes keys when the confirm dialog is open.
  */
 
 import { useKeyboard } from "@opentui/react";
@@ -24,8 +34,9 @@ export type PagesRouterComponentMap = Record<PageKind, React.ComponentType<{ pag
 export interface PagesRouterProps {
   readonly store: PagesStore;
   readonly components: PagesRouterComponentMap;
-  readonly onQuit: () => void;
   readonly width: number;
+  readonly presetName?: string | undefined;
+  readonly sessionId?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -34,28 +45,18 @@ export interface PagesRouterProps {
 
 export type RouterAction =
   | { type: "noop" }
-  | { type: "pop" }
-  | { type: "openDialog" }
   | { type: "closeDialog" }
-  | { type: "popAndCloseDialog" }
-  | { type: "quit" };
+  | { type: "popAndCloseDialog" };
 
 export interface RouterKeyState {
   readonly dialogOpen: boolean;
-  readonly dirty: boolean; // hasDirtyTop()
-  readonly depth: number;
 }
 
 export function reduceRouterKey(state: RouterKeyState, keyName: string): RouterAction {
-  if (state.dialogOpen) {
-    if (keyName === "y") return { type: "popAndCloseDialog" };
-    if (keyName === "n" || keyName === "escape") return { type: "closeDialog" };
-    return { type: "noop" };
-  }
-  if (keyName !== "escape") return { type: "noop" };
-  if (state.dirty) return { type: "openDialog" };
-  if (state.depth <= 1) return { type: "quit" };
-  return { type: "pop" };
+  if (!state.dialogOpen) return { type: "noop" };
+  if (keyName === "y") return { type: "popAndCloseDialog" };
+  if (keyName === "n" || keyName === "escape") return { type: "closeDialog" };
+  return { type: "noop" };
 }
 
 // ---------------------------------------------------------------------------
@@ -63,8 +64,8 @@ export function reduceRouterKey(state: RouterKeyState, keyName: string): RouterA
 // ---------------------------------------------------------------------------
 
 export const PagesRouter: React.NamedExoticComponent<PagesRouterProps> = React.memo(
-  function PagesRouter({ store, components, onQuit, width }: PagesRouterProps) {
-    const { top, depth, snapshot } = useScreenStack(store);
+  function PagesRouter({ store, components, width, presetName, sessionId }: PagesRouterProps) {
+    const { top, snapshot } = useScreenStack(store);
     const [dialogOpen, setDialogOpen] = useState(false);
 
     const handleConfirm = useCallback(() => {
@@ -79,19 +80,12 @@ export const PagesRouter: React.NamedExoticComponent<PagesRouterProps> = React.m
     useKeyboard(
       useCallback(
         (key) => {
-          const state: RouterKeyState = {
-            dialogOpen,
-            dirty: store.hasDirtyTop(),
-            depth,
-          };
-          const action = reduceRouterKey(state, key.name);
+          // Fast-path: when the dialog is closed, this handler is a noop.
+          // Pop/quit lives in inner screens to avoid useKeyboard handler
+          // conflicts (see file header).
+          if (!dialogOpen) return;
+          const action = reduceRouterKey({ dialogOpen }, key.name);
           switch (action.type) {
-            case "pop":
-              store.pop();
-              break;
-            case "openDialog":
-              setDialogOpen(true);
-              break;
             case "closeDialog":
               setDialogOpen(false);
               break;
@@ -99,14 +93,11 @@ export const PagesRouter: React.NamedExoticComponent<PagesRouterProps> = React.m
               store.pop();
               setDialogOpen(false);
               break;
-            case "quit":
-              onQuit();
-              break;
             case "noop":
               break;
           }
         },
-        [dialogOpen, store, depth, onQuit],
+        [dialogOpen, store],
       ),
     );
 
@@ -116,7 +107,12 @@ export const PagesRouter: React.NamedExoticComponent<PagesRouterProps> = React.m
 
     return (
       <>
-        <BreadcrumbBar stack={snapshot} width={width} />
+        <BreadcrumbBar
+          stack={snapshot}
+          presetName={presetName}
+          sessionId={sessionId}
+          width={width}
+        />
         <Component page={top} />
         <ConfirmPopDialog visible={dialogOpen} onConfirm={handleConfirm} onCancel={handleCancel} />
       </>

--- a/src/tui/data/pages-store.test.ts
+++ b/src/tui/data/pages-store.test.ts
@@ -1,0 +1,440 @@
+import { describe, expect, test } from "bun:test";
+import { type Page, PagesStore, type StackEvent } from "./pages-store.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePage(kind: Page["kind"], params?: Record<string, string>): Page {
+  return params !== undefined ? { kind, params } : { kind };
+}
+
+// Collect all events fired during a thunk, in order.
+function capture(
+  store: PagesStore,
+  types: Array<StackEvent["type"]>,
+  thunk: () => void,
+): StackEvent[] {
+  const events: StackEvent[] = [];
+  const unsubs = types.map((t) => store.subscribe(t, (e) => events.push(e)));
+  thunk();
+  for (const u of unsubs) u();
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Initial state
+// ---------------------------------------------------------------------------
+
+describe("PagesStore — initial state", () => {
+  test("depth() is 0", () => {
+    const s = new PagesStore();
+    expect(s.depth()).toBe(0);
+  });
+
+  test("top() is undefined", () => {
+    const s = new PagesStore();
+    expect(s.top()).toBeUndefined();
+  });
+
+  test("snapshot() is []", () => {
+    const s = new PagesStore();
+    expect(s.snapshot()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. push — appends, fires pushed + top; duplicate is no-op
+// ---------------------------------------------------------------------------
+
+describe("PagesStore — push", () => {
+  test("push appends and increments depth", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    expect(s.depth()).toBe(1);
+    expect(s.top()?.kind).toBe("preset-select");
+  });
+
+  test("push fires 'pushed' then 'top' in order", () => {
+    const s = new PagesStore();
+    const events = capture(s, ["pushed", "top"], () => {
+      s.push(makePage("goal-input"));
+    });
+    expect(events).toHaveLength(2);
+    expect(events[0]?.type).toBe("pushed");
+    expect(events[1]?.type).toBe("top");
+  });
+
+  test("pushed event carries page and depth", () => {
+    const s = new PagesStore();
+    const events = capture(s, ["pushed"], () => {
+      s.push(makePage("goal-input"));
+    });
+    expect(events[0]).toEqual({ type: "pushed", page: { kind: "goal-input" }, depth: 1 });
+  });
+
+  test("top event carries page and depth", () => {
+    const s = new PagesStore();
+    const events = capture(s, ["top"], () => {
+      s.push(makePage("goal-input"));
+    });
+    expect(events[0]).toEqual({ type: "top", page: { kind: "goal-input" }, depth: 1 });
+  });
+
+  test("duplicate-top push (same kind, no params) is a no-op", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    const events = capture(s, ["pushed", "popped", "top"], () => {
+      s.push(makePage("preset-select"));
+    });
+    expect(events).toHaveLength(0);
+    expect(s.depth()).toBe(1);
+  });
+
+  test("duplicate-top push (same kind + same params) is a no-op", () => {
+    const s = new PagesStore();
+    s.push(makePage("entity-detail", { id: "42" }));
+    const events = capture(s, ["pushed", "popped", "top"], () => {
+      s.push(makePage("entity-detail", { id: "42" }));
+    });
+    expect(events).toHaveLength(0);
+    expect(s.depth()).toBe(1);
+  });
+
+  test("different params is NOT a duplicate", () => {
+    const s = new PagesStore();
+    s.push(makePage("entity-detail", { id: "1" }));
+    const events = capture(s, ["pushed", "top"], () => {
+      s.push(makePage("entity-detail", { id: "2" }));
+    });
+    expect(events).toHaveLength(2);
+    expect(s.depth()).toBe(2);
+  });
+
+  test("same kind different params key set is NOT a duplicate", () => {
+    const s = new PagesStore();
+    s.push(makePage("entity-detail", { id: "1" }));
+    const events = capture(s, ["pushed", "top"], () => {
+      s.push(makePage("entity-detail", { id: "1", extra: "yes" }));
+    });
+    expect(events).toHaveLength(2);
+    expect(s.depth()).toBe(2);
+  });
+
+  test("push with undefined params vs defined empty object — kind-only dedup", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    // Same kind, same implicit undefined params → no-op
+    const events = capture(s, ["pushed", "top"], () => {
+      s.push(makePage("preset-select"));
+    });
+    expect(events).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. pop — no-op at depth ≤ 1; otherwise pops + fires popped + top
+// ---------------------------------------------------------------------------
+
+describe("PagesStore — pop", () => {
+  test("pop on empty stack returns undefined and fires no events", () => {
+    const s = new PagesStore();
+    const events = capture(s, ["popped", "top"], () => {
+      const result = s.pop();
+      expect(result).toBeUndefined();
+    });
+    expect(events).toHaveLength(0);
+  });
+
+  test("pop on single-item stack returns undefined (depth ≤ 1 guard)", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    const events = capture(s, ["popped", "top"], () => {
+      const result = s.pop();
+      expect(result).toBeUndefined();
+    });
+    expect(events).toHaveLength(0);
+    expect(s.depth()).toBe(1);
+  });
+
+  test("pop on depth=2 pops top, fires 'popped' then 'top' for new top", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    s.push(makePage("goal-input"));
+    const events = capture(s, ["popped", "top"], () => {
+      s.pop();
+    });
+    expect(events).toHaveLength(2);
+    expect(events[0]?.type).toBe("popped");
+    expect(events[0]).toMatchObject({ type: "popped", page: { kind: "goal-input" }, depth: 1 });
+    expect(events[1]?.type).toBe("top");
+    expect(events[1]).toMatchObject({ type: "top", page: { kind: "preset-select" }, depth: 1 });
+  });
+
+  test("pop returns the popped page", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    s.push(makePage("goal-input", { foo: "bar" }));
+    const popped = s.pop();
+    expect(popped).toEqual({ kind: "goal-input", params: { foo: "bar" } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. replace — swaps top; depth unchanged; fires pushed + top
+// ---------------------------------------------------------------------------
+
+describe("PagesStore — replace", () => {
+  test("replace on non-empty stack keeps depth, fires pushed + top", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    s.push(makePage("goal-input"));
+    const events = capture(s, ["pushed", "popped", "top"], () => {
+      s.replace(makePage("agent-detect"));
+    });
+    expect(s.depth()).toBe(2);
+    expect(s.top()?.kind).toBe("agent-detect");
+    const types = events.map((e) => e.type);
+    expect(types).toEqual(["pushed", "top"]);
+  });
+
+  test("replace on empty stack acts like push", () => {
+    const s = new PagesStore();
+    const events = capture(s, ["pushed", "top"], () => {
+      s.replace(makePage("preset-select"));
+    });
+    expect(s.depth()).toBe(1);
+    expect(events.map((e) => e.type)).toEqual(["pushed", "top"]);
+  });
+
+  test("identical-top replace is a no-op", () => {
+    const s = new PagesStore();
+    s.push(makePage("goal-input", { x: "1" }));
+    const events = capture(s, ["pushed", "popped", "top"], () => {
+      s.replace(makePage("goal-input", { x: "1" }));
+    });
+    expect(events).toHaveLength(0);
+    expect(s.depth()).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. resetTo — clears stack firing popped for each, then pushes page
+// ---------------------------------------------------------------------------
+
+describe("PagesStore — resetTo", () => {
+  test("resetTo on empty stack ends with depth=1", () => {
+    const s = new PagesStore();
+    s.resetTo(makePage("preset-select"));
+    expect(s.depth()).toBe(1);
+    expect(s.top()?.kind).toBe("preset-select");
+  });
+
+  test("resetTo fires popped for each removed entry, then pushed + top", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    s.push(makePage("goal-input"));
+    s.push(makePage("agent-detect"));
+
+    const events = capture(s, ["pushed", "popped", "top"], () => {
+      s.resetTo(makePage("running"));
+    });
+
+    const types = events.map((e) => e.type);
+    // 3 pops + 1 pushed + 1 top
+    expect(types).toEqual(["popped", "popped", "popped", "pushed", "top"]);
+    expect(s.depth()).toBe(1);
+    expect(s.top()?.kind).toBe("running");
+  });
+
+  test("resetTo fires popped in reverse stack order (top first)", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    s.push(makePage("goal-input"));
+
+    const poppedPages: Page["kind"][] = [];
+    const unsub = s.subscribe("popped", (e) => poppedPages.push(e.page.kind));
+    s.resetTo(makePage("running"));
+    unsub();
+
+    expect(poppedPages[0]).toBe("goal-input");
+    expect(poppedPages[1]).toBe("preset-select");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. snapshot — copy-stable, frozen
+// ---------------------------------------------------------------------------
+
+describe("PagesStore — snapshot", () => {
+  test("snapshot returns frozen array", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    const snap = s.snapshot();
+    expect(Object.isFrozen(snap)).toBe(true);
+  });
+
+  test("snapshot taken before mutation is not affected by mutation", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    const snapBefore = s.snapshot();
+    s.push(makePage("goal-input"));
+    // snapBefore should still have only 1 entry
+    expect(snapBefore).toHaveLength(1);
+    expect(snapBefore[0]?.kind).toBe("preset-select");
+  });
+
+  test("snapshot reflects current state", () => {
+    const s = new PagesStore();
+    s.push(makePage("preset-select"));
+    s.push(makePage("goal-input"));
+    expect(s.snapshot()).toHaveLength(2);
+    expect(s.snapshot()[1]?.kind).toBe("goal-input");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Listener error handling — throw caught + logged; other listeners fire
+// ---------------------------------------------------------------------------
+
+describe("PagesStore — listener error handling", () => {
+  test("throwing listener does not prevent subsequent listeners from firing", () => {
+    const s = new PagesStore();
+    const called: string[] = [];
+
+    s.subscribe("pushed", () => {
+      throw new Error("boom");
+    });
+    s.subscribe("pushed", () => called.push("second"));
+
+    // Should not throw
+    expect(() => s.push(makePage("preset-select"))).not.toThrow();
+    expect(called).toContain("second");
+  });
+
+  test("store keeps working after a listener throws", () => {
+    const s = new PagesStore();
+    s.subscribe("pushed", () => {
+      throw new Error("listener error");
+    });
+    s.push(makePage("preset-select"));
+    s.push(makePage("goal-input"));
+    expect(s.depth()).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. subscribe — returns unsubscribe function
+// ---------------------------------------------------------------------------
+
+describe("PagesStore — subscribe / unsubscribe", () => {
+  test("subscribe returns a function", () => {
+    const s = new PagesStore();
+    // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op listener for subscribe-return test
+    const unsub = s.subscribe("pushed", () => {});
+    expect(typeof unsub).toBe("function");
+  });
+
+  test("unsubscribe stops listener from firing", () => {
+    const s = new PagesStore();
+    const calls: number[] = [];
+    const unsub = s.subscribe("pushed", () => calls.push(1));
+
+    s.push(makePage("preset-select"));
+    unsub();
+    s.push(makePage("goal-input"));
+
+    expect(calls).toHaveLength(1);
+  });
+
+  test("multiple independent subscriptions work", () => {
+    const s = new PagesStore();
+    const a: string[] = [];
+    const b: string[] = [];
+
+    s.subscribe("top", () => a.push("A"));
+    s.subscribe("top", () => b.push("B"));
+
+    s.push(makePage("preset-select"));
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9 & 10. registerDirtyCheck / hasDirtyTop
+// ---------------------------------------------------------------------------
+
+describe("PagesStore — registerDirtyCheck / hasDirtyTop", () => {
+  test("hasDirtyTop returns false when no check registered for current top kind", () => {
+    const s = new PagesStore();
+    s.push(makePage("goal-input"));
+    expect(s.hasDirtyTop()).toBe(false);
+  });
+
+  test("hasDirtyTop returns false when no top", () => {
+    const s = new PagesStore();
+    expect(s.hasDirtyTop()).toBe(false);
+  });
+
+  test("hasDirtyTop returns false when check returns false", () => {
+    const s = new PagesStore();
+    s.registerDirtyCheck("goal-input", () => false);
+    s.push(makePage("goal-input"));
+    expect(s.hasDirtyTop()).toBe(false);
+  });
+
+  test("hasDirtyTop returns true when check returns true", () => {
+    const s = new PagesStore();
+    s.registerDirtyCheck("goal-input", () => true);
+    s.push(makePage("goal-input"));
+    expect(s.hasDirtyTop()).toBe(true);
+  });
+
+  test("check consulted only for top kind — other kinds ignored", () => {
+    const s = new PagesStore();
+    s.registerDirtyCheck("goal-input", () => true);
+    s.push(makePage("preset-select")); // different kind
+    expect(s.hasDirtyTop()).toBe(false);
+  });
+
+  test("throwing dirty-check is treated as dirty (true)", () => {
+    const s = new PagesStore();
+    s.registerDirtyCheck("goal-input", () => {
+      throw new Error("dirty check error");
+    });
+    s.push(makePage("goal-input"));
+    expect(s.hasDirtyTop()).toBe(true);
+  });
+
+  test("registerDirtyCheck returns an unsubscribe function", () => {
+    const s = new PagesStore();
+    const unsub = s.registerDirtyCheck("goal-input", () => true);
+    expect(typeof unsub).toBe("function");
+  });
+
+  test("unsubscribing dirty-check removes it", () => {
+    const s = new PagesStore();
+    const unsub = s.registerDirtyCheck("goal-input", () => true);
+    s.push(makePage("goal-input"));
+    expect(s.hasDirtyTop()).toBe(true);
+    unsub();
+    expect(s.hasDirtyTop()).toBe(false);
+  });
+
+  test("multiple dirty checks for same kind — true if any returns true", () => {
+    const s = new PagesStore();
+    s.registerDirtyCheck("goal-input", () => false);
+    s.registerDirtyCheck("goal-input", () => true);
+    s.push(makePage("goal-input"));
+    expect(s.hasDirtyTop()).toBe(true);
+  });
+
+  test("multiple dirty checks — false if all return false", () => {
+    const s = new PagesStore();
+    s.registerDirtyCheck("goal-input", () => false);
+    s.registerDirtyCheck("goal-input", () => false);
+    s.push(makePage("goal-input"));
+    expect(s.hasDirtyTop()).toBe(false);
+  });
+});

--- a/src/tui/data/pages-store.ts
+++ b/src/tui/data/pages-store.ts
@@ -1,0 +1,213 @@
+/**
+ * PagesStore — k9s-style navigation stack for the TUI.
+ *
+ * Pure data class (no React). Maintains an ordered stack of Pages with
+ * push/pop/replace/resetTo semantics, event subscriptions, and dirty-check
+ * registration.
+ */
+
+import { debugLog } from "../debug-log.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type PageKind =
+  | "preset-select"
+  | "goal-input"
+  | "agent-detect"
+  | "launch-preview"
+  | "spawning"
+  | "running"
+  | "complete"
+  | "advanced"
+  | "panel"
+  | "entity-detail";
+
+export interface Page {
+  readonly kind: PageKind;
+  readonly params?: Readonly<Record<string, string>>;
+}
+
+export type StackEvent =
+  | { type: "pushed"; page: Page; depth: number }
+  | { type: "popped"; page: Page; depth: number }
+  | { type: "top"; page: Page; depth: number };
+
+export type DirtyCheck = () => boolean;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+type EventType = StackEvent["type"];
+type Listener = (e: StackEvent) => void;
+
+/**
+ * Deep-equality check for two Page values.
+ * Pages are equal when kind matches AND params are key-by-key identical.
+ */
+function pagesEqual(a: Page, b: Page): boolean {
+  if (a.kind !== b.kind) return false;
+  const ap = a.params;
+  const bp = b.params;
+  if (ap === undefined && bp === undefined) return true;
+  if (ap === undefined || bp === undefined) return false;
+  const aKeys = Object.keys(ap);
+  const bKeys = Object.keys(bp);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (ap[key] !== bp[key]) return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// PagesStore
+// ---------------------------------------------------------------------------
+
+export class PagesStore {
+  private readonly stack: Page[] = [];
+  private cachedSnapshot: readonly Page[] | null = null;
+
+  private readonly subs: Record<EventType, Set<Listener>> = {
+    pushed: new Set(),
+    popped: new Set(),
+    top: new Set(),
+  };
+
+  private readonly dirtyChecks: Map<PageKind, Set<DirtyCheck>> = new Map();
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  push(page: Page): void {
+    const current = this.top();
+    if (current !== undefined && pagesEqual(current, page)) return;
+    this.stack.push(page);
+    this.invalidateSnapshot();
+    const depth = this.stack.length;
+    this.emit({ type: "pushed", page, depth });
+    this.emit({ type: "top", page, depth });
+  }
+
+  pop(): Page | undefined {
+    if (this.stack.length <= 1) return undefined;
+    const page = this.stack.pop();
+    if (page === undefined) return undefined;
+    this.invalidateSnapshot();
+    const depth = this.stack.length;
+    this.emit({ type: "popped", page, depth });
+    const newTop = this.stack[depth - 1];
+    if (newTop !== undefined) {
+      this.emit({ type: "top", page: newTop, depth });
+    }
+    return page;
+  }
+
+  replace(page: Page): void {
+    const current = this.top();
+    if (current !== undefined && pagesEqual(current, page)) return;
+    if (this.stack.length === 0) {
+      // Act like push on empty stack
+      this.stack.push(page);
+      this.invalidateSnapshot();
+      const depth = this.stack.length;
+      this.emit({ type: "pushed", page, depth });
+      this.emit({ type: "top", page, depth });
+      return;
+    }
+    this.stack[this.stack.length - 1] = page;
+    this.invalidateSnapshot();
+    const depth = this.stack.length;
+    this.emit({ type: "pushed", page, depth });
+    this.emit({ type: "top", page, depth });
+  }
+
+  resetTo(page: Page): void {
+    // Fire popped for each entry from top to bottom
+    while (this.stack.length > 0) {
+      const removed = this.stack.pop();
+      if (removed === undefined) break;
+      this.invalidateSnapshot();
+      this.emit({ type: "popped", page: removed, depth: this.stack.length });
+    }
+    // Push the new page
+    this.stack.push(page);
+    this.invalidateSnapshot();
+    const depth = this.stack.length;
+    this.emit({ type: "pushed", page, depth });
+    this.emit({ type: "top", page, depth });
+  }
+
+  top(): Page | undefined {
+    return this.stack[this.stack.length - 1];
+  }
+
+  depth(): number {
+    return this.stack.length;
+  }
+
+  snapshot(): readonly Page[] {
+    if (this.cachedSnapshot === null) {
+      this.cachedSnapshot = Object.freeze([...this.stack]);
+    }
+    return this.cachedSnapshot;
+  }
+
+  subscribe(type: EventType, fn: Listener): () => void {
+    this.subs[type].add(fn);
+    return () => {
+      this.subs[type].delete(fn);
+    };
+  }
+
+  registerDirtyCheck(kind: PageKind, fn: DirtyCheck): () => void {
+    if (!this.dirtyChecks.has(kind)) {
+      this.dirtyChecks.set(kind, new Set());
+    }
+    this.dirtyChecks.get(kind)?.add(fn);
+    return () => {
+      this.dirtyChecks.get(kind)?.delete(fn);
+    };
+  }
+
+  hasDirtyTop(): boolean {
+    const current = this.top();
+    if (current === undefined) return false;
+    const checks = this.dirtyChecks.get(current.kind);
+    if (checks === undefined || checks.size === 0) return false;
+    for (const check of checks) {
+      try {
+        if (check()) return true;
+      } catch {
+        debugLog("PagesStore", `dirty-check for kind=${current.kind} threw; treating as dirty`);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private invalidateSnapshot(): void {
+    this.cachedSnapshot = null;
+  }
+
+  private emit(event: StackEvent): void {
+    const listeners = this.subs[event.type];
+    for (const fn of listeners) {
+      try {
+        fn(event);
+      } catch (err) {
+        debugLog(
+          "PagesStore",
+          `listener for event=${event.type} threw: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+}

--- a/src/tui/hooks/use-screen-stack.test.tsx
+++ b/src/tui/hooks/use-screen-stack.test.tsx
@@ -47,12 +47,14 @@ describe("useScreenStack", () => {
     let renderer!: TestRenderer.ReactTestRenderer;
     await act(async () => {
       renderer = TestRenderer.create(
-        (        <Probe
-          store={store}
-          onValue={(v) => {
-            captured = v;
-          }}
-        />) as React.ReactElement,
+        (
+          <Probe
+            store={store}
+            onValue={(v) => {
+              captured = v;
+            }}
+          />
+        ) as React.ReactElement,
       );
     });
 
@@ -78,12 +80,14 @@ describe("useScreenStack", () => {
     let renderer!: TestRenderer.ReactTestRenderer;
     await act(async () => {
       renderer = TestRenderer.create(
-        (        <Probe
-          store={store}
-          onValue={(v) => {
-            renders.push(v);
-          }}
-        />) as React.ReactElement,
+        (
+          <Probe
+            store={store}
+            onValue={(v) => {
+              renders.push(v);
+            }}
+          />
+        ) as React.ReactElement,
       );
     });
 
@@ -113,12 +117,14 @@ describe("useScreenStack", () => {
     let renderer!: TestRenderer.ReactTestRenderer;
     await act(async () => {
       renderer = TestRenderer.create(
-        (        <Probe
-          store={store}
-          onValue={(v) => {
-            renders.push(v);
-          }}
-        />) as React.ReactElement,
+        (
+          <Probe
+            store={store}
+            onValue={(v) => {
+              renders.push(v);
+            }}
+          />
+        ) as React.ReactElement,
       );
     });
 
@@ -147,12 +153,14 @@ describe("useScreenStack", () => {
     let renderer!: TestRenderer.ReactTestRenderer;
     await act(async () => {
       renderer = TestRenderer.create(
-        (        <Probe
-          store={store}
-          onValue={() => {
-            renderCount += 1;
-          }}
-        />) as React.ReactElement,
+        (
+          <Probe
+            store={store}
+            onValue={() => {
+              renderCount += 1;
+            }}
+          />
+        ) as React.ReactElement,
       );
     });
 
@@ -186,12 +194,14 @@ describe("useScreenStack", () => {
     let renderer!: TestRenderer.ReactTestRenderer;
     await act(async () => {
       renderer = TestRenderer.create(
-        (        <Probe
-          store={store}
-          onValue={(v) => {
-            captured = v;
-          }}
-        />) as React.ReactElement,
+        (
+          <Probe
+            store={store}
+            onValue={(v) => {
+              captured = v;
+            }}
+          />
+        ) as React.ReactElement,
       );
     });
 
@@ -238,9 +248,11 @@ describe("PagesStoreProvider and usePagesStoreFromContext", () => {
     let renderer!: TestRenderer.ReactTestRenderer;
     await act(async () => {
       renderer = TestRenderer.create(
-        (        <PagesStoreProvider store={store}>
-          <Consumer />
-        </PagesStoreProvider>) as React.ReactElement,
+        (
+          <PagesStoreProvider store={store}>
+            <Consumer />
+          </PagesStoreProvider>
+        ) as React.ReactElement,
       );
     });
 

--- a/src/tui/hooks/use-screen-stack.test.tsx
+++ b/src/tui/hooks/use-screen-stack.test.tsx
@@ -8,7 +8,11 @@ import { describe, expect, test } from "bun:test";
 import TestRenderer, { act } from "react-test-renderer";
 import { PagesStore } from "../data/pages-store.js";
 import type { ScreenStackValue } from "./use-screen-stack.js";
-import { useScreenStack } from "./use-screen-stack.js";
+import {
+  PagesStoreProvider,
+  usePagesStoreFromContext,
+  useScreenStack,
+} from "./use-screen-stack.js";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -212,5 +216,61 @@ describe("useScreenStack", () => {
     expect(store.depth()).toBe(1);
 
     renderer.unmount();
+  });
+});
+
+describe("PagesStoreProvider and usePagesStoreFromContext", () => {
+  // -------------------------------------------------------------------------
+  // 6. Provider exposes store via context hook
+  // -------------------------------------------------------------------------
+  test("PagesStoreProvider exposes store via usePagesStoreFromContext", async () => {
+    const store = new PagesStore();
+    store.push({ kind: "preset-select" });
+
+    let capturedStore: PagesStore | undefined;
+
+    function Consumer(): null {
+      capturedStore = usePagesStoreFromContext();
+      return null;
+    }
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <PagesStoreProvider store={store}>
+          <Consumer />
+        </PagesStoreProvider>,
+      );
+    });
+
+    expect(capturedStore).toBe(store);
+    renderer.unmount();
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. usePagesStoreFromContext throws when no provider in tree
+  // -------------------------------------------------------------------------
+  test("usePagesStoreFromContext throws when no provider is in tree", async () => {
+    function Consumer(): null {
+      usePagesStoreFromContext();
+      return null;
+    }
+
+    let caughtError: Error | undefined;
+
+    try {
+      await act(async () => {
+        TestRenderer.create(<Consumer />);
+      });
+    } catch (e) {
+      if (e instanceof Error) {
+        caughtError = e;
+      } else {
+        throw e;
+      }
+    }
+
+    expect(caughtError).toBeDefined();
+    expect(caughtError!.message).toContain("PagesStoreProvider");
   });
 });

--- a/src/tui/hooks/use-screen-stack.test.tsx
+++ b/src/tui/hooks/use-screen-stack.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Tests for useScreenStack hook.
+ *
+ * Uses react-test-renderer + bun:test (no @testing-library/react).
+ */
+
+import { describe, expect, test } from "bun:test";
+import TestRenderer, { act } from "react-test-renderer";
+import { PagesStore } from "../data/pages-store.js";
+import type { ScreenStackValue } from "./use-screen-stack.js";
+import { useScreenStack } from "./use-screen-stack.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// Probe component — captures the hook's return value on each render.
+// ---------------------------------------------------------------------------
+
+function Probe({
+  store,
+  onValue,
+}: {
+  store: PagesStore;
+  onValue: (v: ScreenStackValue) => void;
+}): null {
+  const value = useScreenStack(store);
+  onValue(value);
+  return null;
+}
+
+describe("useScreenStack", () => {
+  // -------------------------------------------------------------------------
+  // 1. Initial state from a pre-populated store
+  // -------------------------------------------------------------------------
+  test("returns initial top and depth from a pre-populated store", async () => {
+    const store = new PagesStore();
+    store.push({ kind: "preset-select" });
+    store.push({ kind: "goal-input" });
+
+    let captured: ScreenStackValue | undefined;
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <Probe
+          store={store}
+          onValue={(v) => {
+            captured = v;
+          }}
+        />,
+      );
+    });
+
+    expect(captured).toBeDefined();
+    expect(captured!.top?.kind).toBe("goal-input");
+    expect(captured!.depth).toBe(2);
+    expect(captured!.snapshot).toHaveLength(2);
+    expect(captured!.snapshot[0]?.kind).toBe("preset-select");
+    expect(captured!.snapshot[1]?.kind).toBe("goal-input");
+
+    renderer.unmount();
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. push on the store causes the hook to deliver new top + depth
+  // -------------------------------------------------------------------------
+  test("push on the store updates top and depth in the hook", async () => {
+    const store = new PagesStore();
+    store.push({ kind: "preset-select" });
+
+    const renders: ScreenStackValue[] = [];
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <Probe
+          store={store}
+          onValue={(v) => {
+            renders.push(v);
+          }}
+        />,
+      );
+    });
+
+    expect(renders.at(-1)!.depth).toBe(1);
+    expect(renders.at(-1)!.top?.kind).toBe("preset-select");
+
+    await act(async () => {
+      store.push({ kind: "goal-input" });
+    });
+
+    expect(renders.at(-1)!.depth).toBe(2);
+    expect(renders.at(-1)!.top?.kind).toBe("goal-input");
+
+    renderer.unmount();
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. pop on the store delivers the prior top and decremented depth
+  // -------------------------------------------------------------------------
+  test("pop on the store reverts top and depth in the hook", async () => {
+    const store = new PagesStore();
+    store.push({ kind: "preset-select" });
+    store.push({ kind: "goal-input" });
+
+    const renders: ScreenStackValue[] = [];
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <Probe
+          store={store}
+          onValue={(v) => {
+            renders.push(v);
+          }}
+        />,
+      );
+    });
+
+    expect(renders.at(-1)!.depth).toBe(2);
+    expect(renders.at(-1)!.top?.kind).toBe("goal-input");
+
+    await act(async () => {
+      store.pop();
+    });
+
+    expect(renders.at(-1)!.depth).toBe(1);
+    expect(renders.at(-1)!.top?.kind).toBe("preset-select");
+
+    renderer.unmount();
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. After unmount, store mutations no longer trigger renders
+  // -------------------------------------------------------------------------
+  test("store mutations after unmount do not trigger renders", async () => {
+    const store = new PagesStore();
+    store.push({ kind: "preset-select" });
+
+    let renderCount = 0;
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <Probe
+          store={store}
+          onValue={() => {
+            renderCount += 1;
+          }}
+        />,
+      );
+    });
+
+    const countAtUnmount = renderCount;
+
+    await act(async () => {
+      renderer.unmount();
+    });
+
+    // Mutate after unmount
+    store.push({ kind: "goal-input" });
+    store.push({ kind: "running" });
+
+    // Give React a tick to process anything (should be nothing)
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(renderCount).toBe(countAtUnmount);
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Bound action callbacks (push/pop/replace) mutate the underlying store
+  // -------------------------------------------------------------------------
+  test("push/pop/replace action callbacks mutate the underlying store", async () => {
+    const store = new PagesStore();
+    store.push({ kind: "preset-select" });
+
+    let captured: ScreenStackValue | undefined;
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <Probe
+          store={store}
+          onValue={(v) => {
+            captured = v;
+          }}
+        />,
+      );
+    });
+
+    // push via hook callback
+    await act(async () => {
+      captured!.push({ kind: "goal-input" });
+    });
+    expect(store.top()?.kind).toBe("goal-input");
+    expect(store.depth()).toBe(2);
+
+    // replace via hook callback
+    await act(async () => {
+      captured!.replace({ kind: "agent-detect" });
+    });
+    expect(store.top()?.kind).toBe("agent-detect");
+    expect(store.depth()).toBe(2);
+
+    // pop via hook callback
+    await act(async () => {
+      captured!.pop();
+    });
+    expect(store.top()?.kind).toBe("preset-select");
+    expect(store.depth()).toBe(1);
+
+    renderer.unmount();
+  });
+});

--- a/src/tui/hooks/use-screen-stack.ts
+++ b/src/tui/hooks/use-screen-stack.ts
@@ -1,0 +1,55 @@
+/**
+ * useScreenStack — reactive hook over PagesStore.
+ *
+ * Subscribes to the store's "top" event channel via useSyncExternalStore;
+ * exposes the current top page, stack depth, immutable snapshot, and
+ * stable push/pop/replace action callbacks.
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+import type { Page, PagesStore } from "../data/pages-store.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ScreenStackValue {
+  readonly top: Page | undefined;
+  readonly depth: number;
+  readonly snapshot: readonly Page[];
+  readonly push: (page: Page) => void;
+  readonly pop: () => Page | undefined;
+  readonly replace: (page: Page) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useScreenStack(store: PagesStore): ScreenStackValue {
+  // Subscribe to the "top" event so we re-render whenever the visible top
+  // page changes (push, pop, replace all emit "top").
+  const subscribe = useCallback(
+    (onChange: () => void) => store.subscribe("top", () => onChange()),
+    [store],
+  );
+
+  // getSnapshot returns the cached, version-stable array from the store.
+  // The store guarantees identity stability between mutations (same reference
+  // while nothing has changed), satisfying useSyncExternalStore requirements.
+  const getSnapshot = useCallback(() => store.snapshot(), [store]);
+
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot);
+
+  // Derive top from the snapshot instead of calling store.top() separately;
+  // this keeps the values consistent within the same render.
+  const top = snapshot[snapshot.length - 1];
+  const depth = snapshot.length;
+
+  // Stable action callbacks bound to the store instance.
+  const push = useCallback((page: Page) => store.push(page), [store]);
+  const pop = useCallback(() => store.pop(), [store]);
+  const replace = useCallback((page: Page) => store.replace(page), [store]);
+
+  return { top, depth, snapshot, push, pop, replace };
+}

--- a/src/tui/hooks/use-screen-stack.tsx
+++ b/src/tui/hooks/use-screen-stack.tsx
@@ -4,9 +4,19 @@
  * Subscribes to the store's "top" event channel via useSyncExternalStore;
  * exposes the current top page, stack depth, immutable snapshot, and
  * stable push/pop/replace action callbacks.
+ *
+ * Also provides PagesStoreProvider and usePagesStoreFromContext for
+ * accessing the store via React context (avoiding prop drilling).
  */
 
-import { useCallback, useSyncExternalStore } from "react";
+import {
+  createContext,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useSyncExternalStore,
+} from "react";
 import type { Page, PagesStore } from "../data/pages-store.js";
 
 // ---------------------------------------------------------------------------
@@ -52,4 +62,25 @@ export function useScreenStack(store: PagesStore): ScreenStackValue {
   const replace = useCallback((page: Page) => store.replace(page), [store]);
 
   return { top, depth, snapshot, push, pop, replace };
+}
+
+// ---------------------------------------------------------------------------
+// Context Provider
+// ---------------------------------------------------------------------------
+
+const PagesStoreContext = createContext<PagesStore | null>(null);
+
+export interface PagesStoreProviderProps {
+  readonly store: PagesStore;
+  readonly children: ReactNode;
+}
+
+export function PagesStoreProvider({ store, children }: PagesStoreProviderProps): ReactElement {
+  return <PagesStoreContext.Provider value={store}>{children}</PagesStoreContext.Provider>;
+}
+
+export function usePagesStoreFromContext(): PagesStore {
+  const s = useContext(PagesStoreContext);
+  if (!s) throw new Error("usePagesStoreFromContext: no <PagesStoreProvider> in tree");
+  return s;
 }

--- a/src/tui/screens/agent-detect.tsx
+++ b/src/tui/screens/agent-detect.tsx
@@ -14,7 +14,6 @@
 import { useKeyboard } from "@opentui/react";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import type { AgentTopology } from "../../core/topology.js";
-import { BreadcrumbBar } from "../components/breadcrumb-bar.js";
 import { EmptyState } from "../components/empty-state.js";
 import { renderGraph } from "../layout/edge-render.js";
 import { layoutGraph } from "../layout/graph-layout.js";
@@ -307,8 +306,6 @@ export const AgentDetect: React.NamedExoticComponent<AgentDetectProps> = React.m
         borderStyle="round"
         borderColor={theme.focus}
       >
-        <BreadcrumbBar screen="agent-detect" width={100} />
-
         <box flexDirection="column" paddingX={2} paddingTop={1}>
           <text color={theme.focus} bold>
             {scanning ? "Scanning..." : "Detection complete"}

--- a/src/tui/screens/goal-input.tsx
+++ b/src/tui/screens/goal-input.tsx
@@ -8,7 +8,6 @@
 import { useKeyboard } from "@opentui/react";
 import React, { useCallback, useState } from "react";
 import type { AgentTopology } from "../../core/topology.js";
-import { BreadcrumbBar } from "../components/breadcrumb-bar.js";
 import { PLATFORM_COLORS, theme } from "../theme.js";
 
 /** Props for the GoalInput screen. */
@@ -24,7 +23,7 @@ export interface GoalInputProps {
 
 /** Screen 2: goal text input. Single Enter → launch preview. */
 export const GoalInput: React.NamedExoticComponent<GoalInputProps> = React.memo(function GoalInput({
-  presetName,
+  presetName: _presetName,
   topology,
   roleMapping,
   onSubmit,
@@ -87,8 +86,6 @@ export const GoalInput: React.NamedExoticComponent<GoalInputProps> = React.memo(
       borderStyle="round"
       borderColor={theme.focus}
     >
-      <BreadcrumbBar screen="goal-input" presetName={presetName} width={100} />
-
       <box flexDirection="column" paddingX={2} paddingTop={1}>
         <text color={theme.text}>What should agents work on?</text>
       </box>

--- a/src/tui/screens/goal-input.tsx
+++ b/src/tui/screens/goal-input.tsx
@@ -6,8 +6,9 @@
  */
 
 import { useKeyboard } from "@opentui/react";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import type { AgentTopology } from "../../core/topology.js";
+import { usePagesStoreFromContext } from "../hooks/use-screen-stack.js";
 import { PLATFORM_COLORS, theme } from "../theme.js";
 
 /** Props for the GoalInput screen. */
@@ -31,6 +32,11 @@ export const GoalInput: React.NamedExoticComponent<GoalInputProps> = React.memo(
 }: GoalInputProps): React.ReactNode {
   const [buffer, setBuffer] = useState("");
   const [showEmpty, setShowEmpty] = useState(false);
+
+  const pages = usePagesStoreFromContext();
+  useEffect(() => {
+    return pages.registerDirtyCheck("goal-input", () => buffer.trim().length > 0);
+  }, [pages, buffer]);
 
   useKeyboard(
     useCallback(

--- a/src/tui/screens/running-view.c2.test.tsx
+++ b/src/tui/screens/running-view.c2.test.tsx
@@ -3,6 +3,11 @@
  *   1. ":a" routes to agents view
  *   2. "/foo" filters current view without tearing down state
  *   3. Invalid alias file → flash-bar error, falls back to defaults
+ *
+ * Issue #303 — running-view goto integration acceptance:
+ *   4. ":a" pushes panel page onto PagesStore
+ *   5. Sync mapping: panel page kind → RunningPanel enum
+ *   6. ":a" then ":s" then esc returns to panel:agents (stack pop semantics)
  */
 
 import { describe, expect, test } from "bun:test";
@@ -11,6 +16,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_ALIASES, resolveAlias } from "../data/aliases.js";
 import { loadAliases } from "../data/aliases-loader.js";
+import { PagesStore } from "../data/pages-store.js";
+import { expandPanel as expandPanelTransition, RunningPanel } from "./running-keyboard.js";
 
 async function makeTmp(): Promise<string> {
   return mkdtemp(join(tmpdir(), "c2-acc-"));
@@ -56,5 +63,117 @@ describe("C2 acceptance — issue #302", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #303 — running-view goto pushes panel pages onto PagesStore
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirror of running-view.tsx's gotoDispatch (post-#303). Kept in lockstep
+ * with the component so we can assert on the data path the cmd-mode
+ * submission takes — without mounting RunningView (no harness).
+ */
+function buildGotoDispatch(store: PagesStore, onQuit: () => void): Record<string, () => void> {
+  return {
+    agents: () => store.push({ kind: "panel", params: { panel: "agents" } }),
+    dag: () => store.push({ kind: "panel", params: { panel: "dag" } }),
+    sessions: () => store.push({ kind: "panel", params: { panel: "sessions" } }),
+    tasks: () => store.push({ kind: "panel", params: { panel: "tasks" } }),
+    reviews: () => store.push({ kind: "panel", params: { panel: "reviews" } }),
+    quit: onQuit,
+  };
+}
+
+/**
+ * Mirror of running-view.tsx's panel-name → RunningPanel enum map. If this
+ * test starts failing because the component table changed without the
+ * mirror being updated, that itself signals the intended desync.
+ */
+const PANEL_NAME_TO_ENUM: Readonly<Record<string, RunningPanel>> = {
+  agents: RunningPanel.Agents,
+  sessions: RunningPanel.Sessions,
+  dag: RunningPanel.Dag,
+  tasks: RunningPanel.Tasks,
+  reviews: RunningPanel.Reviews,
+  feed: RunningPanel.Feed,
+};
+
+/** No-op stand-in for the onQuit callback (none of these tests trigger quit). */
+function noop(): void {
+  // intentionally empty
+}
+
+describe("C2 acceptance — issue #303 (goto pushes panel pages)", () => {
+  test("AC4: ':a' (agents) pushes a panel page onto the store", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+    const dispatch = buildGotoDispatch(store, noop);
+
+    dispatch.agents?.();
+
+    expect(store.depth()).toBe(2);
+    expect(store.top()).toEqual({ kind: "panel", params: { panel: "agents" } });
+  });
+
+  test("AC5: panel-name on the top page maps to a valid RunningPanel enum", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+    const dispatch = buildGotoDispatch(store, noop);
+
+    // Each goto entry produces a panel name that the sync map can resolve to
+    // a known RunningPanel — this is the contract the running-view sync
+    // effect relies on to update expandedPanel/zoomLevel.
+    for (const cmd of ["agents", "dag", "sessions", "tasks", "reviews"] as const) {
+      const fresh = new PagesStore();
+      fresh.push({ kind: "running" });
+      const d = buildGotoDispatch(fresh, noop);
+      d[cmd]?.();
+      const top = fresh.top();
+      expect(top?.kind).toBe("panel");
+      const panel = top?.params?.panel ?? "";
+      expect(PANEL_NAME_TO_ENUM[panel]).toBeDefined();
+    }
+
+    // Spot-check that the mapping picks the right enum value.
+    dispatch.agents?.();
+    const top = store.top();
+    const panel = top?.params?.panel ?? "";
+    expect(PANEL_NAME_TO_ENUM[panel]).toBe(RunningPanel.Agents);
+
+    // And that the resulting expandPanelTransition output is sensible
+    // (Agents at half-zoom — same shape running-view's sync effect applies).
+    const next = expandPanelTransition(null, "normal", PANEL_NAME_TO_ENUM[panel] as RunningPanel);
+    expect(next.expandedPanel).toBe(RunningPanel.Agents);
+    expect(next.zoomLevel).toBe("half");
+  });
+
+  test("AC6: ':a' then ':s' then esc-pop returns top to panel:agents", () => {
+    const store = new PagesStore();
+    store.push({ kind: "running" });
+    const dispatch = buildGotoDispatch(store, noop);
+
+    dispatch.agents?.();
+    dispatch.sessions?.();
+    expect(store.depth()).toBe(3);
+    expect(store.top()).toEqual({ kind: "panel", params: { panel: "sessions" } });
+
+    // Esc-pop simulation (depth>1 short-circuit in running-view.tsx).
+    store.pop();
+    expect(store.depth()).toBe(2);
+    expect(store.top()).toEqual({ kind: "panel", params: { panel: "agents" } });
+
+    // Pop again returns to running root; the sync effect would clear
+    // expandedPanel here.
+    store.pop();
+    expect(store.depth()).toBe(1);
+    expect(store.top()).toEqual({ kind: "running" });
+
+    // PagesStore.pop is a no-op at depth 1 — the existing layered esc
+    // dismissal in routeRunningKey takes over from this point.
+    const popped = store.pop();
+    expect(popped).toBeUndefined();
+    expect(store.depth()).toBe(1);
   });
 });

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -39,6 +39,7 @@ import { useAgentMonitor } from "../hooks/use-agent-monitor.js";
 import { useEntities } from "../hooks/use-entities.js";
 import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
 import { InputMode } from "../hooks/use-panel-focus.js";
+import { usePagesStoreFromContext, useScreenStack } from "../hooks/use-screen-stack.js";
 import { useTuiStatePersistence } from "../hooks/use-session-persistence.js";
 import type { DashboardData, TuiDataProvider } from "../provider.js";
 import { isHandoffProvider, isVfsProvider } from "../provider.js";
@@ -281,6 +282,56 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     useEffect(() => {
       persistViewState({ expandedPanel, zoomLevel, traceSelectedAgent });
     }, [expandedPanel, zoomLevel, traceSelectedAgent, persistViewState]);
+
+    // ─── PagesStore wiring (#303): goto pushes panel pages, top→expandedPanel sync ───
+    // The store is created once at screen-manager mount and supplied via context.
+    // Each :a/:s/:d/:t/:r entry pushes a panel page; the sync effect below mirrors
+    // the visible top page back into local expandedPanel/zoomLevel state so the
+    // existing panel-render logic remains unchanged. Esc on a panel page pops
+    // the stack (handled in the useKeyboard short-circuit further below).
+    const pagesStore = usePagesStoreFromContext();
+    const { top: pagesTop } = useScreenStack(pagesStore);
+
+    // Mirror the latest zoomLevel into a ref so the sync effect can read it
+    // without listing it in the dep array (which would re-fire the mapping
+    // every time the zoom changes — defeating the lastAppliedTopRef guard).
+    const zoomLevelRef = useRef(zoomLevel);
+    useEffect(() => {
+      zoomLevelRef.current = zoomLevel;
+    }, [zoomLevel]);
+
+    // Track the last-applied top page (by identity) so the effect is idempotent
+    // even when expandedPanel/zoomLevel changes for unrelated reasons (1-9 keys,
+    // panel toggles). Without this, every state change would re-run the mapping.
+    const lastAppliedTopRef = useRef<typeof pagesTop>(undefined);
+    useEffect(() => {
+      if (lastAppliedTopRef.current === pagesTop) return;
+      lastAppliedTopRef.current = pagesTop;
+      if (!pagesTop) return;
+      if (pagesTop.kind === "panel") {
+        const panel = pagesTop.params?.panel ?? "";
+        const map: Record<string, RunningPanel> = {
+          agents: RunningPanel.Agents,
+          sessions: RunningPanel.Sessions,
+          dag: RunningPanel.Dag,
+          tasks: RunningPanel.Tasks,
+          reviews: RunningPanel.Reviews,
+          feed: RunningPanel.Feed,
+        };
+        const target = map[panel];
+        if (target !== undefined) {
+          setExpandedPanel((cur) => {
+            const next = expandPanelTransition(cur, zoomLevelRef.current, target);
+            setZoomLevel(next.zoomLevel);
+            return next.expandedPanel;
+          });
+        }
+      } else if (pagesTop.kind === "running") {
+        // Back at the bottom of the stack — clear panel zoom.
+        setExpandedPanel(null);
+        setZoomLevel("normal");
+      }
+    }, [pagesTop]);
 
     // ─── Elapsed timer ───
     const [elapsed, setElapsed] = useState("0s");
@@ -628,36 +679,20 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     );
 
     // ─── C2 goto dispatch table ───
+    // Each goto pushes a panel page onto the PagesStore (#303). The sync
+    // effect above translates the new top page back into expandedPanel /
+    // zoomLevel — keeping render output unchanged but routing navigation
+    // through the unified k9s-style stack.
     const gotoDispatch = useMemo<Record<string, () => void>>(
       () => ({
-        agents: () => {
-          const next = expandPanelTransition(expandedPanel, zoomLevel, RunningPanel.Agents);
-          setExpandedPanel(next.expandedPanel);
-          setZoomLevel(next.zoomLevel);
-        },
-        dag: () => {
-          const next = expandPanelTransition(expandedPanel, zoomLevel, RunningPanel.Dag);
-          setExpandedPanel(next.expandedPanel);
-          setZoomLevel(next.zoomLevel);
-        },
-        sessions: () => {
-          const next = expandPanelTransition(expandedPanel, zoomLevel, RunningPanel.Sessions);
-          setExpandedPanel(next.expandedPanel);
-          setZoomLevel(next.zoomLevel);
-        },
-        tasks: () => {
-          const next = expandPanelTransition(expandedPanel, zoomLevel, RunningPanel.Tasks);
-          setExpandedPanel(next.expandedPanel);
-          setZoomLevel(next.zoomLevel);
-        },
-        reviews: () => {
-          const next = expandPanelTransition(expandedPanel, zoomLevel, RunningPanel.Reviews);
-          setExpandedPanel(next.expandedPanel);
-          setZoomLevel(next.zoomLevel);
-        },
+        agents: () => pagesStore.push({ kind: "panel", params: { panel: "agents" } }),
+        dag: () => pagesStore.push({ kind: "panel", params: { panel: "dag" } }),
+        sessions: () => pagesStore.push({ kind: "panel", params: { panel: "sessions" } }),
+        tasks: () => pagesStore.push({ kind: "panel", params: { panel: "tasks" } }),
+        reviews: () => pagesStore.push({ kind: "panel", params: { panel: "reviews" } }),
         quit: () => onQuit(),
       }),
-      [expandedPanel, zoomLevel, onQuit],
+      [pagesStore, onQuit],
     );
 
     // Tab-complete suggestions for goto mode.
@@ -909,6 +944,27 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
               return;
             }
           }
+
+          // (#303) PagesStore esc-pop short-circuit. When a panel page sits
+          // above the running root (depth > 1) and no other dismissal layer
+          // is active, esc pops the stack — the sync effect then mirrors the
+          // new top back into expandedPanel/zoomLevel. Layered dismissal
+          // (cmd-mode, prompt-mode, help, VFS, filter) takes priority and is
+          // handled by the existing routeRunningKey path (which we fall
+          // through to when the guard fails).
+          if (
+            key.name === "escape" &&
+            pagesStore.depth() > 1 &&
+            !confirmQuit &&
+            cmdStateRef.current.mode === "none" &&
+            !promptMode &&
+            !showHelp &&
+            filterQueryRef.current === ""
+          ) {
+            pagesStore.pop();
+            return;
+          }
+
           // Live snapshot of cmdMode/cmdText/filterQuery from refs — needed
           // because keyboardState's useMemo only re-runs after React commits,
           // and a burst of keys arriving in a single tick would otherwise see
@@ -921,7 +977,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           };
           routeRunningKey(key, liveState, keyboardActions);
         },
-        [showVfs, keyboardState, keyboardActions],
+        [showVfs, keyboardState, keyboardActions, pagesStore, confirmQuit, promptMode, showHelp],
       ),
     );
 

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -292,6 +292,14 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     const pagesStore = usePagesStoreFromContext();
     const { top: pagesTop } = useScreenStack(pagesStore);
 
+    // ─── Dirty-check: prompt-mode (#303) ───
+    // Registers a dirty check while prompt mode is active so hasDirtyTop()
+    // returns true when the user has typed something into the prompt bar.
+    useEffect(() => {
+      if (!promptMode) return;
+      return pagesStore.registerDirtyCheck("running", () => promptText.trim().length > 0);
+    }, [pagesStore, promptMode, promptText]);
+
     // Mirror the latest zoomLevel into a ref so the sync effect can read it
     // without listing it in the dep array (which would re-fire the mapping
     // every time the zoom changes — defeating the lastAppliedTopRef guard).

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -11,15 +11,18 @@
  */
 
 import { useKeyboard, useRenderer } from "@opentui/react";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { lookupPresetTopology } from "../../core/presets.js";
 import type { AgentTopology } from "../../core/topology.js";
 import { topologicalSortRoles } from "../../core/topology.js";
 import type { AppProps } from "../app.js";
 import { App } from "../app.js";
+import { PagesRouter, type PagesRouterComponentMap } from "../components/pages-router.js";
+import { type PageKind, PagesStore } from "../data/pages-store.js";
 import { debugLog } from "../debug-log.js";
 import { isDoneContribution, useDoneDetection } from "../hooks/use-done-detection.js";
 import { usePermissionDetection } from "../hooks/use-permission-detection.js";
+import { PagesStoreProvider } from "../hooks/use-screen-stack.js";
 import type { SessionRecord } from "../provider.js";
 import { isGoalProvider, isSessionProvider } from "../provider.js";
 import { useSpawnManager } from "../spawn-manager-context.js";
@@ -162,6 +165,16 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         ...(resumeSessionStartedAt ? { sessionStartedAt: resumeSessionStartedAt } : {}),
         ...(resumeSessionId ? { sessionId: resumeSessionId } : {}),
       };
+    });
+
+    // PagesStore — k9s-style navigation stack. Created once at mount and
+    // seeded with the initial screen so the router has a top page to render.
+    // Kept in sync with state.screen below: every setState that flips screen
+    // also calls the equivalent pages.{push|pop|replace|resetTo}.
+    const [pages] = useState<PagesStore>(() => {
+      const store = new PagesStore();
+      store.push({ kind: state.screen as PageKind });
+      return store;
     });
 
     // Apply session scope on mount for resumed sessions (startOnRunning path).
@@ -320,8 +333,11 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
             completeSnapshot: { reason, contributionCount },
           };
         });
+        // Collapse wizard onto the complete page so esc on complete doesn't
+        // walk back into running/spawning history.
+        pages.replace({ kind: "complete" });
       },
-      [provider, spawnManager],
+      [provider, spawnManager, pages],
     );
     const handleDone = useCallback(() => {
       if (completionStartedRef.current) return;
@@ -356,7 +372,8 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
       setState({
         screen: "preset-select",
       });
-    }, [provider, state.sessionId, spawnManager]);
+      pages.resetTo({ kind: "preset-select" });
+    }, [provider, state.sessionId, spawnManager, pages]);
 
     const handleQuit = useCallback(() => {
       spawnManager.stopLogPolling();
@@ -383,18 +400,22 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
     }, [provider, renderer, state.sessionId, spawnManager]);
 
     // Screen 1 -> Screen 2: preset selected → resolve topology and go to goal input
-    const handlePresetSelect = useCallback((presetName: string) => {
-      // Resolve topology from preset, falling back to GROVE.md default
-      const presetTopology = lookupPresetTopology(presetName);
-      if (presetTopology) {
-        setTopology(presetTopology);
-      }
-      setState((s) => ({
-        ...s,
-        screen: "goal-input",
-        selectedPreset: presetName,
-      }));
-    }, []);
+    const handlePresetSelect = useCallback(
+      (presetName: string) => {
+        // Resolve topology from preset, falling back to GROVE.md default
+        const presetTopology = lookupPresetTopology(presetName);
+        if (presetTopology) {
+          setTopology(presetTopology);
+        }
+        setState((s) => ({
+          ...s,
+          screen: "goal-input",
+          selectedPreset: presetName,
+        }));
+        pages.push({ kind: "goal-input" });
+      },
+      [pages],
+    );
 
     // Screen 2 -> Screen 3: goal entered → go to launch preview (auto-detect)
     const rolePromptsRef = useRef<Map<string, string>>(new Map());
@@ -406,19 +427,24 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
      * would either not apply (stale closure) or mutate the shared preset.
      */
     const sessionTopologyRef = useRef<AgentTopology | undefined>(undefined);
-    const handleGoalToPreview = useCallback((goal: string) => {
-      setState((s) => ({
-        ...s,
-        screen: "launch-preview" as const,
-        goal,
-      }));
-    }, []);
+    const handleGoalToPreview = useCallback(
+      (goal: string) => {
+        setState((s) => ({
+          ...s,
+          screen: "launch-preview" as const,
+          goal,
+        }));
+        pages.push({ kind: "launch-preview" });
+      },
+      [pages],
+    );
 
     // Screen 3 -> Screen 2: back to goal input
     const handleLaunchBack = useCallback(() => {
       hasSpawnedRef.current = false; // Reset so re-entering launch preview can spawn
       setState((s) => ({ ...s, screen: "goal-input" }));
-    }, []);
+      pages.pop();
+    }, [pages]);
 
     /**
      * Spawn agents and transition to running view.
@@ -508,6 +534,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
                 error: `Failed to create Nexus session: ${msg}. Retry or fall back to local mode.`,
                 screen: "preset-select",
               }));
+              pages.resetTo({ kind: "preset-select" });
               return;
             }
             const fallbackId = crypto.randomUUID();
@@ -535,6 +562,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
             sessionStartedAt,
             spawnStates: initialStates,
           }));
+          pages.push({ kind: "spawning" });
 
           spawnManager.setSessionGoal(goal);
           // Give SpawnManager the topology so it can resolve edge-type-aware
@@ -607,9 +635,11 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         } else {
           // No topology — go straight to running
           setState((s) => ({ ...s, screen: "running", goal, sessionStartedAt }));
+          // Collapse the wizard so esc from running doesn't re-enter launch-preview.
+          pages.replace({ kind: "running" });
         }
       },
-      [provider, topology, contract, state.selectedPreset, spawnManager, appProps.groveDir],
+      [provider, topology, contract, state.selectedPreset, spawnManager, appProps.groveDir, pages],
     );
 
     // Screen 3 (launch preview) -> spawning: Ctrl+Enter confirmed launch
@@ -674,7 +704,11 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
     // Screen 3.5 -> Screen 4: all spawns resolved
     const handleSpawnComplete = useCallback(() => {
       setState((s) => ({ ...s, screen: "running" }));
-    }, []);
+      // Collapse spawning + launch-preview + goal-input + preset-select into
+      // a single running entry so esc on running doesn't walk back into
+      // wizard pages.
+      pages.resetTo({ kind: "running" });
+    }, [pages]);
 
     // Screen 2 -> back: go to preset-select if presets exist, otherwise quit
     // (topology-first launches skip preset-select, so Esc should exit, not dead-end)
@@ -682,15 +716,24 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
       hasSpawnedRef.current = false; // Reset so fresh launch is allowed after going back
       if (presets && presets.length > 0) {
         setState((s) => ({ ...s, screen: "preset-select" }));
+        // Pop goal-input off the stack so the router lands back on
+        // preset-select. resetTo guards against the case where goal-input
+        // was the only entry (topology-first init).
+        if (pages.depth() > 1) {
+          pages.pop();
+        } else {
+          pages.resetTo({ kind: "preset-select" });
+        }
       } else {
         handleQuit();
       }
-    }, [presets, handleQuit]);
+    }, [presets, handleQuit, pages]);
 
     // Screen 4 -> advanced mode (Ctrl+A, deliberate entry)
     const handleToggleAdvanced = useCallback(() => {
       setState((s) => ({ ...s, screen: "advanced" }));
-    }, []);
+      pages.push({ kind: "advanced" });
+    }, [pages]);
 
     // Screen 4 -> Screen 5: session complete
     const handleComplete = useCallback(
@@ -705,6 +748,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
       doneSignaledRef.current = false;
       completionStartedRef.current = false;
       hasSpawnedRef.current = false; // Reset spawn guard for new session
+      let nextKind: PageKind = "preset-select";
       setState((s) => {
         // If we have preset + role mapping from a prior run, skip to goal input
         if (s.selectedPreset && s.roleMapping) {
@@ -717,14 +761,17 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
             completeSnapshot: _c,
             ...preserved
           } = s;
+          nextKind = "goal-input";
           return { ...preserved, screen: "goal-input" as const };
         }
         // No prior preset state — fall back to preset selection
-        return {
-          screen: presets && presets.length > 0 ? ("preset-select" as const) : ("running" as const),
-        };
+        const fallback =
+          presets && presets.length > 0 ? ("preset-select" as const) : ("running" as const);
+        nextKind = fallback;
+        return { screen: fallback };
       });
-    }, [presets]);
+      pages.resetTo({ kind: nextKind });
+    }, [presets, pages]);
 
     // Compute duration string
     const getDuration = useCallback(() => {
@@ -766,58 +813,67 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
     // ---------------------------------------------------------------------------
 
     // Wrap screen content with global permission bar
-    const wrapWithPermissions = (content: React.ReactNode): React.ReactNode => (
-      <box flexDirection="column" width="100%" height="100%">
-        {permissionBar}
-        <box flexGrow={1}>{content}</box>
-      </box>
+    const wrapWithPermissions = useCallback(
+      (content: React.ReactNode): React.ReactNode => (
+        <box flexDirection="column" width="100%" height="100%">
+          {permissionBar}
+          <box flexGrow={1}>{content}</box>
+        </box>
+      ),
+      [permissionBar],
     );
 
-    switch (state.screen) {
-      case "preset-select":
-        return (
-          <PresetSelect
-            presets={presets ?? []}
-            sessions={sessions}
-            onSelect={handlePresetSelect}
-            onQuit={handleQuit}
-          />
-        );
+    // Advanced -> Running back handler. setState keeps state.screen in sync;
+    // pages.pop() walks back off the advanced page that was pushed on entry.
+    const handleAdvancedBack = useCallback(() => {
+      setState((s) => ({ ...s, screen: "running" }));
+      pages.pop();
+    }, [pages]);
 
-      case "agent-detect":
-      case "launch-preview":
-        return (
-          <AgentDetect
-            topology={topology}
-            goal={state.goal}
-            onContinue={handleLaunchConfirm}
-            onBack={handleLaunchBack}
-          />
-        );
-
-      case "goal-input":
-        return (
-          <GoalInput
-            presetName={state.selectedPreset ?? "default"}
-            topology={topology}
-            roleMapping={state.roleMapping}
-            onSubmit={handleGoalToPreview}
-            onBack={handleGoalBack}
-          />
-        );
-
-      case "spawning":
-        return (
-          <SpawnProgress
-            agents={state.spawnStates ?? []}
-            goal={state.goal ?? ""}
-            presetName={state.selectedPreset}
-            onAllResolved={handleSpawnComplete}
-          />
-        );
-
-      case "running":
-        return wrapWithPermissions(
+    // ---------------------------------------------------------------------------
+    // Page → component bindings for PagesRouter.
+    // ---------------------------------------------------------------------------
+    //
+    // PagesRouter calls each entry as `<Component page={top} />`. We close
+    // over the real props (handlers, topology, state) and ignore the page
+    // arg — keeping the existing wiring identical to the prior switch
+    // statement so behavior, lifecycle, and tests don't shift.
+    const components = useMemo<PagesRouterComponentMap>(() => {
+      const PresetSelectPage = (): React.ReactNode => (
+        <PresetSelect
+          presets={presets ?? []}
+          sessions={sessions}
+          onSelect={handlePresetSelect}
+          onQuit={handleQuit}
+        />
+      );
+      const GoalInputPage = (): React.ReactNode => (
+        <GoalInput
+          presetName={state.selectedPreset ?? "default"}
+          topology={topology}
+          roleMapping={state.roleMapping}
+          onSubmit={handleGoalToPreview}
+          onBack={handleGoalBack}
+        />
+      );
+      const LaunchPreviewPage = (): React.ReactNode => (
+        <AgentDetect
+          topology={topology}
+          goal={state.goal}
+          onContinue={handleLaunchConfirm}
+          onBack={handleLaunchBack}
+        />
+      );
+      const SpawningPage = (): React.ReactNode => (
+        <SpawnProgress
+          agents={state.spawnStates ?? []}
+          goal={state.goal ?? ""}
+          presetName={state.selectedPreset}
+          onAllResolved={handleSpawnComplete}
+        />
+      );
+      const RunningPage = (): React.ReactNode =>
+        wrapWithPermissions(
           <RunningView
             provider={provider}
             intervalMs={appProps.intervalMs}
@@ -860,43 +916,83 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
             onBackToMain={handleBackToMain}
           />,
         );
-
-      case "advanced":
-        return wrapWithPermissions(
+      const AdvancedPage = (): React.ReactNode =>
+        wrapWithPermissions(
           <box flexDirection="column" width="100%" height="100%">
             <box paddingX={2}>
               <text color={theme.secondary}>Ctrl+B:back to running view</text>
             </box>
             <box flexGrow={1}>
-              <AdvancedModeWrapper
-                appProps={appProps}
-                onBack={() => setState((s) => ({ ...s, screen: "running" }))}
-              />
+              <AdvancedModeWrapper appProps={appProps} onBack={handleAdvancedBack} />
             </box>
           </box>,
         );
+      const CompletePage = (): React.ReactNode => (
+        <CompleteView
+          reason={state.completeSnapshot?.reason ?? "Session ended"}
+          contributionCount={state.completeSnapshot?.contributionCount ?? 0}
+          duration={getDuration()}
+          presetName={state.selectedPreset}
+          metricResult={state.completeSnapshot?.metricResult}
+          cost={state.completeSnapshot?.cost}
+          onNewSession={handleNewSession}
+          onQuit={handleQuit}
+        />
+      );
+      // Stub kinds the router knows about but screen-manager doesn't drive yet.
+      // Returning the default running view keeps the router safe even if a page
+      // for these kinds is pushed (Task 9 / Task 10 will wire real screens).
+      const PanelPage = (): React.ReactNode => RunningPage();
+      const EntityDetailPage = (): React.ReactNode => RunningPage();
+      return {
+        "preset-select": PresetSelectPage,
+        "goal-input": GoalInputPage,
+        "agent-detect": LaunchPreviewPage,
+        "launch-preview": LaunchPreviewPage,
+        spawning: SpawningPage,
+        running: RunningPage,
+        advanced: AdvancedPage,
+        complete: CompletePage,
+        panel: PanelPage,
+        "entity-detail": EntityDetailPage,
+      };
+    }, [
+      presets,
+      sessions,
+      handlePresetSelect,
+      handleQuit,
+      state.selectedPreset,
+      state.roleMapping,
+      state.goal,
+      state.sessionId,
+      state.sessionStartedAt,
+      state.spawnStates,
+      state.completeSnapshot,
+      topology,
+      handleGoalToPreview,
+      handleGoalBack,
+      handleLaunchConfirm,
+      handleLaunchBack,
+      handleSpawnComplete,
+      handleToggleAdvanced,
+      handleComplete,
+      handleBackToMain,
+      handleAdvancedBack,
+      handleNewSession,
+      provider,
+      appProps,
+      spawnManager,
+      reconcileVersion,
+      observeDoneContribution,
+      getDuration,
+      wrapWithPermissions,
+    ]);
 
-      case "complete":
-        return (
-          <CompleteView
-            reason={state.completeSnapshot?.reason ?? "Session ended"}
-            contributionCount={state.completeSnapshot?.contributionCount ?? 0}
-            duration={getDuration()}
-            presetName={state.selectedPreset}
-            metricResult={state.completeSnapshot?.metricResult}
-            cost={state.completeSnapshot?.cost}
-            onNewSession={handleNewSession}
-            onQuit={handleQuit}
-          />
-        );
-
-      default:
-        return (
-          <box paddingX={2} paddingTop={1}>
-            <text color={theme.error}>Unknown screen state</text>
-          </box>
-        );
-    }
+    return (
+      <PagesStoreProvider store={pages}>
+        <PagesRouter store={pages} components={components} onQuit={handleQuit} width={100} />
+      </PagesStoreProvider>
+    );
   },
 );
 

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -636,7 +636,10 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
           // No topology — go straight to running
           setState((s) => ({ ...s, screen: "running", goal, sessionStartedAt }));
           // Collapse the wizard so esc from running doesn't re-enter launch-preview.
-          pages.replace({ kind: "running" });
+          // Use resetTo (not replace) for parity with the topology branch in
+          // handleSpawnComplete — both paths must collapse the entire wizard
+          // stack into a single running entry.
+          pages.resetTo({ kind: "running" });
         }
       },
       [provider, topology, contract, state.selectedPreset, spawnManager, appProps.groveDir, pages],
@@ -990,7 +993,13 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
 
     return (
       <PagesStoreProvider store={pages}>
-        <PagesRouter store={pages} components={components} onQuit={handleQuit} width={100} />
+        <PagesRouter
+          store={pages}
+          components={components}
+          width={100}
+          presetName={state.selectedPreset}
+          sessionId={state.sessionId}
+        />
       </PagesStoreProvider>
     );
   },

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -942,11 +942,12 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
           onQuit={handleQuit}
         />
       );
-      // Stub kinds the router knows about but screen-manager doesn't drive yet.
-      // Returning the default running view keeps the router safe even if a page
-      // for these kinds is pushed (Task 9 / Task 10 will wire real screens).
-      const PanelPage = (): React.ReactNode => RunningPage();
-      const EntityDetailPage = (): React.ReactNode => RunningPage();
+      // panel and entity-detail share the same RunningPage component reference
+      // (not wrapper functions) so React's reconciler sees the same type across
+      // running/panel/entity-detail stack pushes and preserves the mounted
+      // RunningView subtree. Distinct wrapper functions (PanelPage, EntityDetailPage)
+      // would cause React to unmount+remount on every :a/:s/:d/:t/:r push, losing
+      // feed cursor, autoFollow, traceSelectedAgent, and other local state.
       return {
         "preset-select": PresetSelectPage,
         "goal-input": GoalInputPage,
@@ -956,8 +957,8 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         running: RunningPage,
         advanced: AdvancedPage,
         complete: CompletePage,
-        panel: PanelPage,
-        "entity-detail": EntityDetailPage,
+        panel: RunningPage,
+        "entity-detail": RunningPage,
       };
     }, [
       presets,

--- a/src/tui/screens/spawn-progress.tsx
+++ b/src/tui/screens/spawn-progress.tsx
@@ -12,7 +12,6 @@ import { toast } from "@opentui-ui/toast/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import type { WorkspaceMode } from "../../core/workspace-provisioner.js";
 import { useInterval } from "../../local/use-interval.js";
-import { BreadcrumbBar } from "../components/breadcrumb-bar.js";
 import { BRAILLE_SPINNER, PLATFORM_COLORS, theme } from "../theme.js";
 
 /** Spawn status for a single agent role. */
@@ -134,8 +133,6 @@ export const SpawnProgress: React.NamedExoticComponent<SpawnProgressProps> = Rea
 
     return (
       <box flexDirection="column" width="100%" height="100%">
-        <BreadcrumbBar screen="spawning" presetName={presetName} width={100} />
-
         <box flexDirection="column" paddingX={2} paddingTop={1}>
           <text color={theme.text} bold>
             Starting session...

--- a/tests/tui/pages-nav-acceptance.test.tsx
+++ b/tests/tui/pages-nav-acceptance.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Issue #303 acceptance test — :a → :s → esc returns to agents.
+ *
+ * Integration test of PagesStore data plane + PagesRouter rendering.
+ * Drives the store with the same push/pop calls that gotoDispatch makes in
+ * production (running-view.tsx), then verifies that the rendered output and
+ * stack state both match the expected navigation outcome.
+ *
+ * Acceptance criterion (verbatim from #303):
+ *   Typing :a (goto agents), then :s (goto sessions), then pressing escape
+ *   returns the user to the agents view — NOT to the initial running view.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { PagesStore } from "../../src/tui/data/pages-store.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// Mock @opentui/react — required because PagesRouter calls useKeyboard.
+// Must be set up before importing PagesRouter.
+// ---------------------------------------------------------------------------
+
+mock.module("@opentui/react", () => ({
+  useKeyboard: (): void => {
+    // No-op: keyboard handler is not exercised in this data-plane test.
+    // Esc is simulated via direct store.pop() calls, mirroring the pop
+    // short-circuit that running-view fires on escape (Task 8).
+  },
+  useRenderer: (): { destroy: () => void } => ({ destroy: () => undefined }),
+  useTerminalDimensions: (): { width: number; height: number } => ({ width: 120, height: 40 }),
+}));
+
+// Import AFTER mock.module so the mock is applied at component load time.
+const { PagesRouter } = await import("../../src/tui/components/pages-router.js");
+
+import type { PagesRouterComponentMap } from "../../src/tui/components/pages-router.js";
+import type { Page } from "../../src/tui/data/pages-store.js";
+
+// ---------------------------------------------------------------------------
+// Stub component map — covers all 10 PageKind values (TS forces completeness)
+// ---------------------------------------------------------------------------
+
+function makeStubs(): PagesRouterComponentMap {
+  const stub = (label: string) =>
+    function Stub() {
+      return <text>{label}</text>;
+    };
+
+  return {
+    "preset-select": stub("preset"),
+    "goal-input": stub("goal"),
+    "agent-detect": stub("detect"),
+    "launch-preview": stub("preview"),
+    spawning: stub("spawning"),
+    running: stub("running-feed"),
+    complete: stub("complete"),
+    advanced: stub("advanced"),
+    panel: function Panel({ page }: { page: Page }) {
+      return <text>{`panel:${page.params?.panel ?? ""}`}</text>;
+    },
+    "entity-detail": stub("detail"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test
+// ---------------------------------------------------------------------------
+
+describe("issue #303 acceptance — :a → :s → esc returns to agents", () => {
+  test("two pushes + one pop leaves user on agents", async () => {
+    const store = new PagesStore();
+    // Simulate screen-manager's resetTo("running") after spawn-complete.
+    store.push({ kind: "running" });
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (<PagesRouter store={store} components={makeStubs()} width={120} />) as React.ReactElement,
+      );
+    });
+
+    // Step 1: initial render shows the running screen.
+    expect(JSON.stringify(renderer.toJSON())).toContain("running-feed");
+    expect(store.depth()).toBe(1);
+
+    // Step 2: :a → gotoDispatch pushes panel:agents.
+    await act(async () => {
+      store.push({ kind: "panel", params: { panel: "agents" } });
+    });
+    expect(JSON.stringify(renderer.toJSON())).toContain("panel:agents");
+    expect(store.depth()).toBe(2);
+
+    // Step 3: :s → gotoDispatch pushes panel:sessions.
+    await act(async () => {
+      store.push({ kind: "panel", params: { panel: "sessions" } });
+    });
+    expect(JSON.stringify(renderer.toJSON())).toContain("panel:sessions");
+    expect(store.depth()).toBe(3);
+
+    // Step 4: esc → running-view's pop short-circuit fires (Task 8).
+    // Simulate that by calling store.pop() directly — same call the screen makes.
+    await act(async () => {
+      store.pop();
+    });
+
+    // Acceptance criterion: rendered view returns to agents, NOT to running.
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("panel:agents");
+    expect(flat).not.toContain("panel:sessions");
+    expect(flat).not.toContain("running-feed");
+
+    // Stack state: depth=2, top=panel:agents.
+    expect(store.depth()).toBe(2);
+    expect(store.top()).toEqual({ kind: "panel", params: { panel: "agents" } });
+
+    renderer.unmount();
+  });
+});


### PR DESCRIPTION
## Summary

Implements [#303](https://github.com/windoliver/grove/issues/303) — k9s-style pages navigation stack for the TUI.

- **`PagesStore`** (`src/tui/data/pages-store.ts`) — pure data class with `push`/`pop`/`replace`/`resetTo`/`top`/`depth`/`snapshot`, three event channels (`pushed`/`popped`/`top`), and a dirty-check registry.
- **`useScreenStack` hook + `PagesStoreProvider`** (`src/tui/hooks/use-screen-stack.tsx`) — React subscription via `useSyncExternalStore`, plus context for nested screens.
- **`<PagesRouter>`** (`src/tui/components/pages-router.tsx`) — maps top page kind to component, renders centralized `<BreadcrumbBar>`.
- **`<BreadcrumbBar>` refactor** — accepts `stack` prop and renders the depth chain; legacy `screen` prop kept compatible.
- **`screen-manager` shim** — wizard transitions now drive `pages.push` / `pages.replace` / `pages.resetTo` while keeping `state.screen` as a parallel data slot.
- **`running-view` goto integration** — `:a`/`:s`/`:d`/`:t`/`:r` push `panel:*` pages; sync effect mirrors top → `expandedPanel`; esc-pop short-circuit at `depth>1`.
- **Dirty-check registrations** for `goal-input` and `running` (prompt-mode) — wired but currently dormant; rewire tracked as follow-up.
- **Acceptance test** at `tests/tui/pages-nav-acceptance.test.tsx` — proves `:a` → `:s` → esc returns to agents.

Spec: [`docs/superpowers/specs/2026-05-09-tui-pages-nav-stack-design.md`](./docs/superpowers/specs/2026-05-09-tui-pages-nav-stack-design.md)
Plan: [`docs/superpowers/plans/2026-05-09-tui-pages-nav-stack.md`](./docs/superpowers/plans/2026-05-09-tui-pages-nav-stack.md)

## Acceptance criteria

- [x] `esc` pops to previous view — running-view's keyboard handler at `depth>1`, plus `agent-detect`/`goal-input` `onBack` → `pages.pop`/`resetTo`.
- [x] Breadcrumbs reflect current depth — `<PagesRouter>` forwards `snapshot` to `<BreadcrumbBar>`.
- [x] `:a` → `:s` → `esc` returns to agents (not initial route) — verified by acceptance test.

## Test plan

- [x] `bun test src/tui/` → 1219 pass, 1 skip, 0 fail
- [x] `bun test tests/tui/` → 23 pass, 0 fail
- [x] `bun run typecheck` → 0 new errors (2 pre-existing in `packages/ask-user/src/strategies/llm.ts`)
- [x] `bun run lint` on changed files → 0 errors
- [ ] Manual smoke: launch TUI, run a session through preset → goal → spawn → running, exercise `:a`/`:s`/esc panel navigation, verify breadcrumb reflects depth

## Tracked follow-ups (out of scope)

- Dual source of truth between `state.screen` and `pages.top()` — invariant assert or single-source-drive
- Dormant confirm-dialog UX rewire (documented in `pages-router.tsx` header)
- Hard-coded breadcrumb `width={100}` — wire `useTerminalDimensions`
- Legacy 1-5 panel-toggle keys can desync from stack — route through `pagesStore.push`
- Real-keyboard end-to-end test for multi-handler interactions
- Wizard-back unit test (`preset-select → goal-input → esc → preset-select`)
- Trailing `[Esc]/[Tab]` hint missing in stack-mode breadcrumb