### PR TITLE
[codex] Fix review-loop completion routing

### DIFF
--- a/GROVE.md
+++ b/GROVE.md
@@ -71,8 +71,9 @@ agent_topology:
     - name: reviewer
       description: "Reviews code and provides feedback"
       prompt: |
-        You are a code reviewer. Your workflow:
-        1. You will receive a notification with the coder's Workspace path
+        You are a code reviewer. Wait for a coder contribution to arrive — do not act on the session goal yourself.
+        Your workflow:
+        1. Wait for a push notification with the coder's CID and Workspace path
         2. Read the actual source files at that path (e.g., cat /path/to/coder-workspace/app.js)
         3. Review for bugs, correctness, security, edge cases, code quality
         4. Submit your review:
@@ -83,6 +84,7 @@ agent_topology:
       max_instances: 1
       mode: broadcast
       platform: claude-code
+      ends_session: true
       skills: ["grove"]
   spawning:
     dynamic: true

--- a/src/cli/grove-md-builder.ts
+++ b/src/cli/grove-md-builder.ts
@@ -229,6 +229,7 @@ function renderTopology(topology: AgentTopology | undefined, version: 2 | 3): st
     if (role.mode) lines.push(`      mode: ${role.mode}`);
     if (role.platform) lines.push(`      platform: ${role.platform}`);
     if (role.command) lines.push(`      command: "${role.command}"`);
+    if (role.endsSession !== undefined) lines.push(`      ends_session: ${role.endsSession}`);
     if (role.skills && role.skills.length > 0) {
       lines.push(`      skills: [${role.skills.map((s) => `"${s}"`).join(", ")}]`);
     }

--- a/src/cli/presets/review-loop.ts
+++ b/src/cli/presets/review-loop.ts
@@ -39,6 +39,7 @@ export const reviewLoopPreset: PresetConfig = {
         maxInstances: 1,
         mode: "broadcast",
         platform: "claude-code",
+        endsSession: true,
         skills: ["grove"],
         prompt:
           "You are a code reviewer. Wait for a coder contribution to arrive — do not act on the session goal yourself.\n" +

--- a/src/core/acp-runtime.test.ts
+++ b/src/core/acp-runtime.test.ts
@@ -90,24 +90,24 @@ describe("buildAcpLaunchArgs", () => {
     ]);
   });
 
-  test("passes process-local MCP config to codex-acp without secret env values", () => {
-    expect(
-      buildAcpLaunchArgs(codexLaunch, {
-        mcpServers: [
-          {
-            name: "grove",
-            command: "/Users/example/.bun/bin/bun",
-            args: ["run", "/tmp/grove/dist/mcp/serve.js"],
-            env: {
-              GROVE_DIR: "/tmp/grove/.grove",
-              GROVE_NEXUS_URL: "http://localhost:10120",
-              NEXUS_API_KEY: "example-secret",
-              GROVE_SESSION_ID: "session-1",
-            },
+  test("passes process-local MCP config to codex-acp without embedding secret env values", () => {
+    const args = buildAcpLaunchArgs(codexLaunch, {
+      mcpServers: [
+        {
+          name: "grove",
+          command: "/Users/example/.bun/bin/bun",
+          args: ["run", "/tmp/grove/dist/mcp/serve.js"],
+          env: {
+            GROVE_DIR: "/tmp/grove/.grove",
+            GROVE_NEXUS_URL: "http://localhost:10120",
+            NEXUS_API_KEY: "example-secret",
+            GROVE_SESSION_ID: "session-1",
           },
-        ],
-      }),
-    ).toEqual([
+        },
+      ],
+    });
+
+    expect(args).toEqual([
       "codex-acp.js",
       "-c",
       'mcp_servers.grove.command="/Users/example/.bun/bin/bun"',
@@ -119,7 +119,27 @@ describe("buildAcpLaunchArgs", () => {
       'mcp_servers.grove.env.GROVE_NEXUS_URL="http://localhost:10120"',
       "-c",
       'mcp_servers.grove.env.GROVE_SESSION_ID="session-1"',
+      "-c",
+      'mcp_servers.grove.env_vars=["NEXUS_API_KEY"]',
     ]);
+    expect(args.join("\n")).not.toContain("example-secret");
+  });
+
+  test("deduplicates sensitive MCP env var names across config entries", () => {
+    const args = buildAcpLaunchArgs(codexLaunch, {
+      mcpServers: [
+        {
+          name: "grove",
+          command: "/Users/example/.bun/bin/bun",
+          env: {
+            FIRST_TOKEN: "sk-test",
+            SECOND_SECRET: "example-secret",
+          },
+        },
+      ],
+    });
+
+    expect(args).toContain('mcp_servers.grove.env_vars=["FIRST_TOKEN", "SECOND_SECRET"]');
   });
 
   test("does not pass codex config flags to non-codex adapters", () => {

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -244,9 +244,16 @@ function appendCodexMcpServerOverrides(
     args.push("-c", `${serverKey}.command=${tomlString(command)}`);
     args.push("-c", `${serverKey}.args=${tomlStringArray(server.args ?? [])}`);
 
+    const envVars = new Set<string>();
     for (const [envName, envValue] of Object.entries(server.env ?? {})) {
-      if (!shouldPassMcpEnvViaCodexConfig(envName, envValue)) continue;
+      if (!shouldPassMcpEnvViaCodexConfig(envName, envValue)) {
+        if (envName.length > 0) envVars.add(envName);
+        continue;
+      }
       args.push("-c", `${serverKey}.env.${tomlKeySegment(envName)}=${tomlString(envValue)}`);
+    }
+    if (envVars.size > 0) {
+      args.push("-c", `${serverKey}.env_vars=${tomlStringArray([...envVars])}`);
     }
   }
 }

--- a/src/core/presets.ts
+++ b/src/core/presets.ts
@@ -61,6 +61,7 @@ export function getPresetTopologyRegistry(): Readonly<Record<string, CorePresetC
             maxInstances: 1,
             mode: "broadcast",
             platform: "claude-code",
+            endsSession: true,
             prompt:
               "You are a code reviewer. Wait for a coder contribution to arrive — do not act on the session goal yourself.\n" +
               "Your workflow:\n" +

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -397,9 +397,9 @@ export class SessionOrchestrator {
           }
         }
 
-        // Detect [DONE] signal. A single role being done is not enough to end
-        // a multi-agent session; the runner stops only after all spawned roles
-        // have signaled done.
+        // Detect [DONE] signal. Topologies can designate terminal roles that
+        // are sufficient to end the session; otherwise all spawned roles must
+        // signal completion.
         if (
           c.summary.startsWith("[DONE]") ||
           (c.context && (c.context as Record<string, unknown>).done === true)
@@ -423,6 +423,11 @@ export class SessionOrchestrator {
 
   private doneRequiredRoleNames(): readonly string[] {
     const spawnedRoleNames = new Set(this.agents.map((agent) => agent.role));
+    const explicitEndingRoles = this.config.topology.roles
+      .filter((role) => spawnedRoleNames.has(role.name) && role.endsSession === true)
+      .map((role) => role.name);
+    if (explicitEndingRoles.length > 0) return explicitEndingRoles;
+
     const terminalRoles = this.config.topology.roles
       .filter((role) => spawnedRoleNames.has(role.name) && (role.edges?.length ?? 0) === 0)
       .map((role) => role.name);

--- a/src/core/topology.test.ts
+++ b/src/core/topology.test.ts
@@ -59,6 +59,7 @@ describe("AgentTopologySchema", () => {
           description: "writes code",
           max_instances: 3,
           command: "claude --role coder",
+          ends_session: true,
           edges: [{ target: "reviewer", edge_type: "delegates" }],
         },
         { name: "reviewer" },
@@ -221,6 +222,7 @@ describe("wireToTopology", () => {
         {
           name: "coder",
           max_instances: 3,
+          ends_session: true,
           edges: [{ target: "reviewer", edge_type: "delegates" as const }],
           command: "claude --role coder",
         },
@@ -246,6 +248,7 @@ describe("wireToTopology", () => {
     const coder = topology.roles[0]!;
     expect(coder.name).toBe("coder");
     expect(coder.maxInstances).toBe(3);
+    expect(coder.endsSession).toBe(true);
     expect(coder.edges).toHaveLength(1);
     expect(coder.edges?.[0]?.edgeType).toBe("delegates");
     expect(coder.command).toBe("claude --role coder");

--- a/src/core/topology.ts
+++ b/src/core/topology.ts
@@ -60,6 +60,8 @@ const TopologyRoleWithEdgesSchema = z
     mode: RoleModeEnum.optional(),
     edges: z.array(RoleEdgeSchema).max(50).optional(),
     command: z.string().max(512).optional(),
+    /** When true, this role's grove_done signal completes the session. */
+    ends_session: z.boolean().optional(),
     // Profile fields — runtime agent configuration (boardroom)
     platform: z.enum(["claude-code", "codex", "gemini", "custom"]).optional(),
     model: z.string().max(128).optional(),
@@ -98,6 +100,7 @@ interface WireAgentTopology {
         }[]
       | undefined;
     readonly command?: string | undefined;
+    readonly ends_session?: boolean | undefined;
     readonly platform?: "claude-code" | "codex" | "gemini" | "custom" | undefined;
     readonly model?: string | undefined;
     readonly color?: string | undefined;
@@ -333,6 +336,8 @@ export interface AgentRole {
   readonly edges?: readonly RoleEdge[] | undefined;
   /** Shell command to run when spawning this role (defaults to $SHELL). */
   readonly command?: string | undefined;
+  /** True when this role's grove_done signal is sufficient to complete the session. */
+  readonly endsSession?: boolean | undefined;
   /** Agent platform identifier (boardroom). */
   readonly platform?: AgentPlatformType | undefined;
   /** Model identifier, e.g. "claude-opus-4-6" (boardroom). */
@@ -395,6 +400,7 @@ export function wireToTopology(wire: z.infer<typeof AgentTopologySchema>): Agent
           ),
         }),
         ...(role.command !== undefined && { command: role.command }),
+        ...(role.ends_session !== undefined && { endsSession: role.ends_session }),
         ...(role.platform !== undefined && { platform: role.platform as AgentPlatformType }),
         ...(role.model !== undefined && { model: role.model }),
         ...(role.color !== undefined && { color: role.color }),

--- a/src/mcp/serve-http.ts
+++ b/src/mcp/serve-http.ts
@@ -620,7 +620,12 @@ async function buildScopedDeps(sessionId: string | undefined): Promise<ScopedDep
       const apiKey = process.env.NEXUS_API_KEY;
       const ipcClient =
         nexusUrl && apiKey
-          ? new NexusIpcClient({ nexusUrl, apiKey, sessionId: process.env.GROVE_SESSION_ID })
+          ? new NexusIpcClient({
+              nexusUrl,
+              apiKey,
+              sessionId,
+              zoneId,
+            })
           : undefined;
       eventBus = new NexusEventBus(ipcClient);
     } else {

--- a/src/mcp/serve.ts
+++ b/src/mcp/serve.ts
@@ -404,7 +404,12 @@ try {
       const apiKey = process.env.NEXUS_API_KEY;
       const ipcClient =
         nexusUrl && apiKey
-          ? new NexusIpcClient({ nexusUrl, apiKey, sessionId: process.env.GROVE_SESSION_ID })
+          ? new NexusIpcClient({
+              nexusUrl,
+              apiKey,
+              sessionId: process.env.GROVE_SESSION_ID,
+              zoneId,
+            })
           : undefined;
       eventBus = new NexusEventBus(ipcClient);
       process.stderr.write(`grove-mcp: IPC via Nexus EventBus at ${nexusUrl}\n`);

--- a/src/mcp/tools/done.ts
+++ b/src/mcp/tools/done.ts
@@ -3,14 +3,13 @@
  *
  * grove_done — Signal that this agent has finished its work for the session.
  *
- * When an agent calls grove_done, it creates a contribution with kind=work
+ * When an agent calls grove_done, it creates a contribution with kind=discussion
  * and context.done=true. Other agents see this via grove_log and know the
- * signaling agent is finished. The TUI watches for done signals from all
- * roles to transition to the Complete screen.
+ * signaling agent is finished. Topologies may mark one or more roles as
+ * session-ending; otherwise Grove falls back to requiring every role.
  *
  * This is the explicit stop condition for review loops where there's no
- * numeric threshold — the reviewer calls grove_done when satisfied, the
- * coder calls grove_done when it has no more work.
+ * numeric threshold — the reviewer calls grove_done when satisfied.
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -37,10 +36,11 @@ export function registerDoneTools(server: McpServer, deps: McpDeps): void {
     {
       description:
         "Signal that you have finished your work for this session. " +
-        "Call this when you have no more work to do — e.g., the reviewer " +
-        "has approved the code, or the coder has addressed all feedback. " +
+        "Call this only when your role is responsible for ending the session — " +
+        "for example, when the reviewer has approved the code. " +
         "Other agents will see your done signal via grove_log and can " +
-        "finish their own work. When all agents signal done, the session ends.",
+        "finish their own work. The session ends after the topology's required " +
+        "done roles have signaled completion.",
       inputSchema: doneInputSchema,
     },
     async (args) => {

--- a/src/nexus/client.ts
+++ b/src/nexus/client.ts
@@ -33,6 +33,12 @@ export interface WriteResult {
   readonly version?: number | undefined;
 }
 
+/** A single file entry in an atomic batch write. */
+export interface WriteBatchEntry {
+  readonly path: string;
+  readonly content: Uint8Array;
+}
+
 // ---------------------------------------------------------------------------
 // File metadata
 // ---------------------------------------------------------------------------
@@ -136,6 +142,9 @@ export interface NexusClient {
 
   /** Write a file. Supports conditional writes via ETags. */
   write(path: string, content: Uint8Array, opts?: WriteOptions): Promise<WriteResult>;
+
+  /** Write multiple files atomically. */
+  writeBatch(files: readonly WriteBatchEntry[]): Promise<readonly WriteResult[]>;
 
   /** Check if a file or directory exists. */
   exists(path: string): Promise<boolean>;

--- a/src/nexus/ipc-handoff-integration.test.ts
+++ b/src/nexus/ipc-handoff-integration.test.ts
@@ -359,4 +359,32 @@ describe("IPC handoff integration", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test("NexusIpcClient writes session IPC messages under the encoded zone", async () => {
+    const { NexusIpcClient: RealIpcClient } = await import("./nexus-ipc-client.js");
+    const originalFetch = globalThis.fetch;
+    const bodies: unknown[] = [];
+    globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      bodies.push(JSON.parse(init?.body as string));
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    try {
+      const client = new RealIpcClient({
+        nexusUrl: "http://localhost:9999",
+        apiKey: "test",
+        sessionId: "sess-123",
+        zoneId: "project-123/worktree-a",
+      });
+
+      const result = await client.send("coder", "reviewer", { kind: "work" });
+      expect(result.ok).toBe(true);
+      const body = bodies[0] as { path: string };
+      expect(body.path).toMatch(
+        /^\/zones\/project-123%2Fworktree-a\/sessions\/sess-123\/ipc\/reviewer\/inbox\/.+\.json$/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/src/nexus/list-pages.test.ts
+++ b/src/nexus/list-pages.test.ts
@@ -33,6 +33,7 @@ function stubClient(
     read: async () => undefined,
     readWithMeta: async () => undefined,
     write: async () => ({ bytesWritten: 0, etag: "e" }),
+    writeBatch: async () => [],
     exists: async () => false,
     stat: async () => undefined,
     delete: async () => false,

--- a/src/nexus/mock-client.ts
+++ b/src/nexus/mock-client.ts
@@ -15,6 +15,7 @@ import type {
   ReadResult,
   SearchOptions,
   SearchResult,
+  WriteBatchEntry,
   WriteOptions,
   WriteResult,
 } from "./client.js";
@@ -112,13 +113,17 @@ export class MockNexusClient implements NexusClient {
   // Directory helpers
   // -----------------------------------------------------------------------
 
-  private ensureParentDirs(path: string): void {
+  private addParentDirs(directories: Set<string>, path: string): void {
     const parts = path.split("/").filter(Boolean);
     let current = "";
     for (let i = 0; i < parts.length - 1; i++) {
       current += `/${parts[i]}`;
-      this.directories.add(current);
+      directories.add(current);
     }
+  }
+
+  private ensureParentDirs(path: string): void {
+    this.addParentDirs(this.directories, path);
   }
 
   private normalizeDirPath(path: string): string {
@@ -186,6 +191,41 @@ export class MockNexusClient implements NexusClient {
     });
 
     return { bytesWritten: content.byteLength, etag };
+  }
+
+  async writeBatch(files: readonly WriteBatchEntry[]): Promise<readonly WriteResult[]> {
+    this.maybeThrow();
+
+    const nextFiles = new Map(this.files);
+    const nextDirectories = new Set(this.directories);
+    const results: WriteResult[] = [];
+    const now = new Date().toISOString();
+    let nextEtagCounter = this.etagCounter;
+
+    for (const file of files) {
+      this.addParentDirs(nextDirectories, file.path);
+      const existing = nextFiles.get(file.path);
+      const etag = `etag-${++nextEtagCounter}`;
+      nextFiles.set(file.path, {
+        content: new Uint8Array(file.content),
+        etag,
+        createdAt: existing?.createdAt ?? now,
+        modifiedAt: now,
+      });
+      results.push({ bytesWritten: file.content.byteLength, etag });
+    }
+
+    this.files.clear();
+    for (const [path, file] of nextFiles) {
+      this.files.set(path, file);
+    }
+    this.directories.clear();
+    for (const directory of nextDirectories) {
+      this.directories.add(directory);
+    }
+    this.etagCounter = nextEtagCounter;
+
+    return results;
   }
 
   async exists(path: string): Promise<boolean> {

--- a/src/nexus/nexus-contribution-store.ts
+++ b/src/nexus/nexus-contribution-store.ts
@@ -425,12 +425,19 @@ export class NexusContributionStore implements ContributionStore {
           "put:commitContentHashRepairConflictLookup",
         );
         if (latest !== undefined) {
-          return this.resolveExistingContentHash(
+          const resolved = await this.resolveExistingContentHash(
             contribution,
             contentHashPath,
             latest,
             Date.now() + CONTENT_HASH_REPAIR_WAIT_MS,
           );
+          if (resolved.cid !== contribution.cid) {
+            await this.deleteContributionRecord(
+              contribution,
+              "put:cleanupLosingContributionRecord",
+            );
+          }
+          return resolved;
         }
       }
       throw err;
@@ -464,6 +471,23 @@ export class NexusContributionStore implements ContributionStore {
   private async writeContributionRecord(contribution: Contribution): Promise<void> {
     const files = this.contributionRecordFiles(contribution);
     await withSemaphore(this.semaphore, () => this.client.writeBatch(files));
+  }
+
+  private async deleteContributionRecord(
+    contribution: Contribution,
+    context: string,
+  ): Promise<void> {
+    await withRetry(
+      async () => {
+        await batchParallel(this.contributionRecordFiles(contribution), (file) =>
+          withSemaphore(this.semaphore, () => this.client.delete(file.path)),
+        );
+      },
+      context,
+      this.config,
+    );
+    this.cache.delete(contribution.cid);
+    this.invalidateListCache();
   }
 
   private contributionRecordFiles(contribution: Contribution): readonly WriteBatchEntry[] {

--- a/src/nexus/nexus-contribution-store.ts
+++ b/src/nexus/nexus-contribution-store.ts
@@ -33,7 +33,7 @@ import type {
 import { toUtcIso } from "../core/time.js";
 import { debugLog } from "../tui/debug-log.js";
 import { batchParallel } from "./batch.js";
-import type { NexusClient, ReadResult, WriteResult } from "./client.js";
+import type { NexusClient, ReadResult, WriteBatchEntry, WriteResult } from "./client.js";
 import type { NexusConfig, ResolvedNexusConfig } from "./config.js";
 import { resolveConfig } from "./config.js";
 import { NexusConflictError } from "./errors.js";
@@ -403,8 +403,8 @@ export class NexusContributionStore implements ContributionStore {
     repairClaim: WriteResult,
   ): Promise<ContributionPutResult> {
     await withRetry(
-      () => this.writeContributionManifest(contribution),
-      "put:writeContributionManifest",
+      () => this.writeContributionRecord(contribution),
+      "put:writeContributionRecord",
       this.config,
     );
     try {
@@ -435,11 +435,6 @@ export class NexusContributionStore implements ContributionStore {
       }
       throw err;
     }
-    await withRetry(
-      () => this.writeContributionIndexes(contribution),
-      "put:writeContributionIndexes",
-      this.config,
-    );
     this.cache.set(contribution.cid, contribution);
     this.invalidateListCache();
     this.publishContributionAdded(contribution);
@@ -467,48 +462,46 @@ export class NexusContributionStore implements ContributionStore {
   }
 
   private async writeContributionRecord(contribution: Contribution): Promise<void> {
-    await this.writeContributionManifest(contribution);
-    await this.writeContributionIndexes(contribution);
+    const files = this.contributionRecordFiles(contribution);
+    await withSemaphore(this.semaphore, () => this.client.writeBatch(files));
   }
 
-  private async writeContributionManifest(contribution: Contribution): Promise<void> {
+  private contributionRecordFiles(contribution: Contribution): readonly WriteBatchEntry[] {
+    const files: WriteBatchEntry[] = [];
     const manifestPath = contributionPath(this.zoneId, contribution.cid, this.sessionId);
     const manifest = toManifest(contribution);
-    await withSemaphore(this.semaphore, () => this.client.write(manifestPath, encode(manifest)));
-  }
+    files.push({ path: manifestPath, content: encode(manifest) });
 
-  private async writeContributionIndexes(contribution: Contribution): Promise<void> {
     for (const rel of contribution.relations) {
       const relPath = relationIndexPath(this.zoneId, rel.targetCid, contribution.cid);
       const relData = encode({
         relationType: rel.relationType,
         ...(rel.metadata !== undefined ? { metadata: rel.metadata } : {}),
       });
-      await withSemaphore(this.semaphore, () => this.client.write(relPath, relData));
+      files.push({ path: relPath, content: relData });
     }
 
     for (const tag of contribution.tags) {
       const tp = tagIndexPath(this.zoneId, tag, contribution.cid);
-      await withSemaphore(this.semaphore, () => this.client.write(tp, new Uint8Array(0)));
+      files.push({ path: tp, content: new Uint8Array(0) });
     }
 
     const ftsPath = ftsIndexPath(this.zoneId, contribution.cid, this.sessionId);
-    await withSemaphore(this.semaphore, () =>
-      this.client.write(
-        ftsPath,
-        encode({
-          cid: contribution.cid,
-          summary: contribution.summary,
-          description: contribution.description ?? "",
-          kind: contribution.kind,
-          mode: contribution.mode,
-          agentId: contribution.agent.agentId,
-          agentName: contribution.agent.agentName ?? null,
-          createdAt: toUtcIso(contribution.createdAt),
-          tags: contribution.tags,
-        }),
-      ),
-    );
+    files.push({
+      path: ftsPath,
+      content: encode({
+        cid: contribution.cid,
+        summary: contribution.summary,
+        description: contribution.description ?? "",
+        kind: contribution.kind,
+        mode: contribution.mode,
+        agentId: contribution.agent.agentId,
+        agentName: contribution.agent.agentName ?? null,
+        createdAt: toUtcIso(contribution.createdAt),
+        tags: contribution.tags,
+      }),
+    });
+    return files;
   }
 
   private publishContributionAdded(contribution: Contribution): void {

--- a/src/nexus/nexus-http-client.test.ts
+++ b/src/nexus/nexus-http-client.test.ts
@@ -54,4 +54,43 @@ describe("NexusHttpClient", () => {
       client.write("/path/file", new TextEncoder().encode("data"), { ifNoneMatch: "*" }),
     ).rejects.toThrow(NexusConflictError);
   });
+
+  test("writeBatch posts wrapped bytes to the REST batch endpoint", async () => {
+    const bodies: unknown[] = [];
+    const urls: string[] = [];
+    setMockFetch(async (input, init) => {
+      urls.push(String(input));
+      bodies.push(parseRequestBody(init));
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              path: "/path/file",
+              content_id: "etag-1",
+              version: 2,
+              size: 4,
+              modified_at: "2026-05-11T00:00:00Z",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+
+    const client = new NexusHttpClient({ url: "http://nexus.local" });
+    const results = await client.writeBatch([{ path: "/path/file", content: new Uint8Array([1]) }]);
+
+    expect(urls).toEqual(["http://nexus.local/api/v2/files/batch/write"]);
+    expect(bodies).toEqual([
+      {
+        files: [
+          {
+            path: "/path/file",
+            content_base64: Buffer.from("AQ==").toString("base64"),
+          },
+        ],
+      },
+    ]);
+    expect(results).toEqual([{ bytesWritten: 4, etag: "etag-1", version: 2 }]);
+  });
 });

--- a/src/nexus/nexus-http-client.ts
+++ b/src/nexus/nexus-http-client.ts
@@ -27,6 +27,7 @@ import type {
   ReadResult,
   SearchOptions,
   SearchResult,
+  WriteBatchEntry,
   WriteOptions,
   WriteResult,
 } from "./client.js";
@@ -60,6 +61,10 @@ function toBase64(data: Uint8Array): string {
   return Buffer.from(data).toString("base64");
 }
 
+function utf8ToBase64(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64");
+}
+
 function fromBase64(b64: string): Uint8Array {
   return new Uint8Array(Buffer.from(b64, "base64"));
 }
@@ -76,6 +81,20 @@ const WriteResponseSchema = z
     modified_at: z.string().nullable().optional(),
   })
   .passthrough();
+
+const BatchWriteResponseSchema = z.object({
+  results: z.array(
+    z
+      .object({
+        path: z.string(),
+        content_id: z.string().nullable().optional(),
+        version: z.number().nullable().optional(),
+        size: z.number().nullable().optional(),
+        modified_at: z.string().nullable().optional(),
+      })
+      .passthrough(),
+  ),
+});
 
 const ReadResponseSchema = z
   .object({
@@ -298,6 +317,28 @@ export class NexusHttpClient implements NexusClient {
       etag: result.content_id ?? "",
       version: result.version ?? undefined,
     };
+  }
+
+  async writeBatch(files: readonly WriteBatchEntry[]): Promise<readonly WriteResult[]> {
+    const result = await this.request(
+      "POST",
+      "/api/v2/files/batch/write",
+      BatchWriteResponseSchema,
+      {
+        body: {
+          files: files.map((file) => ({
+            path: file.path,
+            content_base64: utf8ToBase64(toBase64(file.content)),
+          })),
+        },
+      },
+    );
+
+    return result.results.map((item, index) => ({
+      bytesWritten: item.size ?? files[index]?.content.byteLength ?? 0,
+      etag: item.content_id ?? "",
+      version: item.version ?? undefined,
+    }));
   }
 
   async exists(path: string): Promise<boolean> {

--- a/src/nexus/nexus-ipc-client.ts
+++ b/src/nexus/nexus-ipc-client.ts
@@ -12,6 +12,7 @@
  */
 
 import { debugLog } from "../tui/debug-log.js";
+import { encodeSegment } from "./vfs-paths.js";
 
 /** Result of an IPC send operation. */
 export interface IpcSendResult {
@@ -32,6 +33,7 @@ export interface NexusIpcClientOptions {
   readonly nexusUrl: string;
   readonly apiKey: string;
   readonly sessionId?: string | undefined;
+  readonly zoneId?: string | undefined;
 }
 
 /** How long to cache a transient IPC failure before retrying (ms). */
@@ -41,6 +43,7 @@ export class NexusIpcClient {
   private readonly nexusUrl: string;
   private readonly apiKey: string;
   private readonly sessionId: string | undefined;
+  private readonly zoneId: string | undefined;
   /**
    * Endpoint availability state:
    * - undefined: unknown (first call)
@@ -55,6 +58,13 @@ export class NexusIpcClient {
     this.nexusUrl = opts.nexusUrl;
     this.apiKey = opts.apiKey;
     this.sessionId = opts.sessionId;
+    this.zoneId = opts.zoneId;
+  }
+
+  private inboxPath(recipient: string, messageId: string): string {
+    const zonePrefix = this.zoneId ? `/zones/${encodeSegment(this.zoneId)}` : "";
+    const sessionPrefix = this.sessionId ? `/sessions/${encodeSegment(this.sessionId)}` : "";
+    return `${zonePrefix}${sessionPrefix}/ipc/${encodeSegment(recipient)}/inbox/${encodeSegment(messageId)}.json`;
   }
 
   /**
@@ -108,9 +118,7 @@ export class NexusIpcClient {
           Authorization: `Bearer ${this.apiKey}`,
         },
         body: JSON.stringify({
-          path: this.sessionId
-            ? `/sessions/${this.sessionId}/ipc/${recipient}/inbox/${messageId}.json`
-            : `/ipc/${recipient}/inbox/${messageId}.json`,
+          path: this.inboxPath(recipient, messageId),
           content,
           encoding: "base64",
         }),

--- a/src/server/session-service.test.ts
+++ b/src/server/session-service.test.ts
@@ -249,6 +249,59 @@ describe("SessionService", () => {
     bus.close();
   });
 
+  test("stop event from explicit session-ending reviewer completes session", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    const service = new SessionService({
+      contract: makeContract({
+        topology: {
+          structure: "graph",
+          roles: [
+            {
+              name: "coder",
+              description: "Write code",
+              command: "echo coder",
+              edges: [{ target: "reviewer", edgeType: "delegates" }],
+            },
+            {
+              name: "reviewer",
+              description: "Review code",
+              command: "echo reviewer",
+              endsSession: true,
+            },
+          ],
+        },
+      }),
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback" as const,
+    });
+
+    const events: SessionEvent[] = [];
+    service.onEvent((e) => events.push(e));
+
+    await service.startSession("Test");
+
+    void bus.publish({
+      type: "stop",
+      sourceRole: "reviewer",
+      targetRole: "reviewer",
+      payload: { reason: "approved" },
+      timestamp: new Date().toISOString(),
+    });
+
+    const completeEvents = events.filter((e) => e.type === "session_complete");
+    expect(completeEvents).toHaveLength(1);
+    expect((completeEvents[0] as { reason: string }).reason).toBe("Required agents done");
+    expect(service.getState().status).toBe("complete");
+    expect(service.getState().stopStatus).toBe(LoopStopStatus.Achieved);
+
+    service.destroy();
+    bus.close();
+  });
+
   test("stopSession closes agents and emits session_complete", async () => {
     const runtime = new MockRuntime();
     const bus = new LocalEventBus();

--- a/src/server/session-service.ts
+++ b/src/server/session-service.ts
@@ -243,15 +243,16 @@ export class SessionService {
       this.emit({ type: "agent_done", role: event.sourceRole, reason });
       this.doneRoles.add(event.sourceRole);
 
-      // Check if all roles are done
-      const allDone = this.topology.roles.every((r) => this.doneRoles.has(r.name));
-      if (allDone && this.sessionStatus === "running") {
+      const requiredDoneRoles = this.doneRequiredRoleNames();
+      const requiredDone =
+        requiredDoneRoles.length > 0 && requiredDoneRoles.every((r) => this.doneRoles.has(r));
+      if (requiredDone && this.sessionStatus === "running") {
         this.sessionStatus = "complete";
-        this.stopReason = "All agents done";
+        this.stopReason = "Required agents done";
         this.stopStatus = LoopStopStatus.Achieved;
         this.emit({
           type: "session_complete",
-          reason: "All agents done",
+          reason: "Required agents done",
           stopStatus: LoopStopStatus.Achieved,
         });
       }
@@ -267,6 +268,15 @@ export class SessionService {
         /* ignore listener errors */
       }
     }
+  }
+
+  private doneRequiredRoleNames(): readonly string[] {
+    const explicitEndingRoles = this.topology.roles
+      .filter((role) => role.endsSession === true)
+      .map((role) => role.name);
+    return explicitEndingRoles.length > 0
+      ? explicitEndingRoles
+      : this.topology.roles.map((role) => role.name);
   }
 }
 

--- a/src/tui/hooks/use-done-detection.ts
+++ b/src/tui/hooks/use-done-detection.ts
@@ -1,8 +1,8 @@
 /**
- * Detects session completion by watching for done signals from all topology roles.
+ * Detects session completion by watching for done signals from required topology roles.
  *
  * Polls contributions for [DONE] prefix or context.done flag.
- * Calls onDone when all roles have signaled completion.
+ * Calls onDone when all required roles have signaled completion.
  *
  * Extracted from ScreenManager to reduce component complexity.
  */
@@ -22,6 +22,15 @@ function isDoneContribution(c: { summary: string; context?: unknown }): boolean 
   );
 }
 
+function requiredDoneRoles(topology: AgentTopology): readonly string[] {
+  const explicit = topology.roles.filter((role) => role.endsSession).map((role) => role.name);
+  return explicit.length > 0 ? explicit : topology.roles.map((role) => role.name);
+}
+
+function doneRoleFromEvent(event: GroveEvent, subscribedRole: string): string {
+  return event.sourceRole && event.sourceRole !== "system" ? event.sourceRole : subscribedRole;
+}
+
 /**
  * Watch for session completion via contribution done signals.
  *
@@ -33,7 +42,7 @@ function isDoneContribution(c: { summary: string; context?: unknown }): boolean 
  * @param topology - Agent topology with role definitions
  * @param screen - Current screen state (only active on "running" or "advanced")
  * @param eventBus - Event bus for real-time done detection; without it the hook is inert
- * @param onDone - Callback when all roles have signaled done
+ * @param onDone - Callback when all required roles have signaled done
  */
 export function useDoneDetection(
   topology: AgentTopology | undefined,
@@ -47,9 +56,9 @@ export function useDoneDetection(
     (role: string) => {
       if (!topology) return;
       doneRolesRef.current.add(role);
-      const roleNames = new Set(topology.roles.map((r) => r.name));
-      const allDone = [...roleNames].every((r) => doneRolesRef.current.has(r));
-      if (allDone && roleNames.size > 0) {
+      const roleNames = requiredDoneRoles(topology);
+      const allDone = roleNames.every((r) => doneRolesRef.current.has(r));
+      if (allDone && roleNames.length > 0) {
         onDone();
       }
     },
@@ -70,11 +79,11 @@ export function useDoneDetection(
             payload.summary &&
             isDoneContribution(payload as { summary: string; context?: unknown })
           ) {
-            checkDone(role.name);
+            checkDone(doneRoleFromEvent(event, role.name));
           }
         }
         if (event.type === "stop") {
-          checkDone(role.name);
+          checkDone(doneRoleFromEvent(event, role.name));
         }
       };
       handlers.push({ role: role.name, handler });

--- a/src/tui/nexus-provider.ts
+++ b/src/tui/nexus-provider.ts
@@ -134,6 +134,10 @@ export class NexusDataProvider
     this.nexusSessionStore = new NexusSessionStore(this.client, this.zoneId);
   }
 
+  getNexusZoneId(): string {
+    return this.zoneId;
+  }
+
   private get authHeaders(): Record<string, string> | undefined {
     return this.serverApiKey ? { Authorization: `Bearer ${this.serverApiKey}` } : undefined;
   }

--- a/src/tui/nexus-ws-bridge.test.ts
+++ b/src/tui/nexus-ws-bridge.test.ts
@@ -354,6 +354,59 @@ describe("NexusWsBridge", () => {
     bus.close();
   });
 
+  test("handleEvent ignores Nexus EventRecord writes outside the configured zone", async () => {
+    const runtime = makeMockRuntime();
+    const readPaths: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/v2/events/stream") {
+        return new Response("", {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      if (url.pathname === "/api/v2/files/read") {
+        readPaths.push(url.searchParams.get("path") ?? "");
+        return new Response(
+          JSON.stringify({
+            content: JSON.stringify({
+              sender: "coder",
+              payload: { cid: "blake3:foreign", kind: "work", summary: "foreign work" },
+            }),
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const bridge = new TestableNexusWsBridge(
+      makeBridgeOpts({
+        runtime,
+        getSessionId: () => "sess-123",
+        zoneId: "zone-a",
+      }),
+    );
+    bridge.registerSession("reviewer", makeSession("reviewer"));
+
+    bridge.testHandleEvent(
+      "reviewer",
+      "event",
+      JSON.stringify({
+        event_id: "nexus-event-id",
+        type: "write",
+        path: "/zones/zone-b/sessions/sess-123/ipc/reviewer/inbox/msg-foreign.json",
+        agent_id: "coder",
+      }),
+    );
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(readPaths).toEqual([]);
+    expect(runtime.send).not.toHaveBeenCalled();
+    bridge.close();
+  });
+
   test("handleEvent does NOT publish for non-contribution IPC (no cid+kind)", async () => {
     const runtime = makeMockRuntime();
     const bus = new LocalEventBus();

--- a/src/tui/nexus-ws-bridge.test.ts
+++ b/src/tui/nexus-ws-bridge.test.ts
@@ -200,7 +200,114 @@ describe("NexusWsBridge", () => {
       message_id: "msg-1",
       cid: "blake3:abc",
       kind: "work",
+      summary: "test contribution",
     });
+
+    bridge.close();
+    bus.close();
+  });
+
+  test("handleEvent includes done summary and context in EventBus contribution payload", async () => {
+    const runtime = makeMockRuntime();
+    const bus = new LocalEventBus();
+    const received: GroveEvent[] = [];
+    bus.subscribe("coder", (e) => received.push(e));
+
+    const bridge = new TestableNexusWsBridge(makeBridgeOpts({ runtime, eventBus: bus }));
+    const session = makeSession("coder");
+    bridge.registerSession("coder", session);
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          content: JSON.stringify({
+            sender: "reviewer",
+            payload: {
+              cid: "blake3:done",
+              kind: "discussion",
+              summary: "[DONE] Approved",
+              context: { done: true },
+            },
+          }),
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+
+    bridge.testHandleEvent(
+      "coder",
+      "message_delivered",
+      JSON.stringify({
+        event: "message_delivered",
+        message_id: "msg-done",
+        sender: "reviewer",
+        recipient: "coder",
+        type: "event",
+        path: "/inbox/msg-done",
+      }),
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]!.sourceRole).toBe("reviewer");
+    expect(received[0]!.targetRole).toBe("coder");
+    expect(received[0]!.payload).toMatchObject({
+      message_id: "msg-done",
+      cid: "blake3:done",
+      kind: "discussion",
+      summary: "[DONE] Approved",
+      context: { done: true },
+    });
+
+    bridge.close();
+    bus.close();
+  });
+
+  test("handleEvent skips runtime delivery when done handling unregisters the session", async () => {
+    const runtime = makeMockRuntime();
+    const bus = new LocalEventBus();
+    const bridge = new TestableNexusWsBridge(makeBridgeOpts({ runtime, eventBus: bus }));
+    const session = makeSession("coder");
+    const received: GroveEvent[] = [];
+    bus.subscribe("coder", (e) => {
+      received.push(e);
+      bridge.unregisterSession("coder", session.id);
+    });
+    bridge.registerSession("coder", session);
+
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          content: JSON.stringify({
+            sender: "reviewer",
+            payload: {
+              cid: "blake3:done",
+              kind: "discussion",
+              summary: "[DONE] Approved",
+              context: { done: true },
+            },
+          }),
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+
+    bridge.testHandleEvent(
+      "coder",
+      "message_delivered",
+      JSON.stringify({
+        event: "message_delivered",
+        message_id: "msg-done",
+        sender: "reviewer",
+        recipient: "coder",
+        type: "event",
+        path: "/inbox/msg-done",
+      }),
+    );
+
+    await waitFor(() => received.length === 1);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(runtime.send).not.toHaveBeenCalled();
 
     bridge.close();
     bus.close();
@@ -701,6 +808,66 @@ describe("NexusWsBridge", () => {
       session_id: string;
     };
     expect(decoded.session_id).toBe("sess-123");
+    bridge.close();
+  });
+
+  test("send() scopes the inbox path under an encoded zone when provided", async () => {
+    const fetchCalls: { body: unknown }[] = [];
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      fetchCalls.push({
+        body: JSON.parse(init?.body as string),
+      });
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const bridge = new NexusWsBridge(
+      makeBridgeOpts({
+        getSessionId: () => "sess-123",
+        zoneId: "project-123/worktree-a",
+      }),
+    );
+    const ok = await bridge.send("coder", "reviewer", { summary: "test" });
+
+    expect(ok).toBe(true);
+    const body = fetchCalls[0]!.body as { path: string };
+    expect(body.path).toMatch(
+      /^\/zones\/project-123%2Fworktree-a\/sessions\/sess-123\/ipc\/reviewer\/inbox\/.+\.json$/,
+    );
+    bridge.close();
+  });
+
+  test("drainRoleInbox lists the encoded zone-scoped inbox when provided", async () => {
+    const runtime = makeMockRuntime();
+    const listPaths: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/v2/events/stream") {
+        return new Response("", {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      if (url.pathname === "/api/v2/files/list") {
+        listPaths.push(url.searchParams.get("path") ?? "");
+        return new Response(JSON.stringify({ items: [], has_more: false }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const bridge = new TestableNexusWsBridge(
+      makeBridgeOpts({
+        runtime,
+        getSessionId: () => "sess-123",
+        zoneId: "project-123/worktree-a",
+      }),
+    );
+    bridge.registerSession("reviewer", makeSession("reviewer"));
+
+    await bridge.testDrainRoleInbox("reviewer");
+
+    expect(listPaths).toContain(
+      "/zones/project-123%2Fworktree-a/sessions/sess-123/ipc/reviewer/inbox",
+    );
     bridge.close();
   });
 

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -125,19 +125,37 @@ const INBOX_DRAIN_TIMEOUT_MS = 5000;
 const INBOX_DRAIN_LIMIT = 100;
 
 /** URL builder for the per-role inbox subscription on the new events SSE. */
-function inboxStreamUrl(nexusUrl: string, role: string, sessionId?: string | undefined): string {
+function inboxStreamUrl(
+  nexusUrl: string,
+  role: string,
+  sessionId?: string | undefined,
+  zoneId?: string | undefined,
+): string {
   // path_pattern is matched (SQL LIKE) against the stored zone-prefixed path.
   // `*/sessions/{sessionId}/ipc/{role}/inbox/*` scopes delivery to the
   // active Grove session. The legacy `/ipc/{role}/inbox/*` path remains as a
   // fallback for callers without a session.
-  const pattern = sessionId
-    ? `*/sessions/${sessionId}/ipc/${role}/inbox/*`
-    : `*/ipc/${role}/inbox/*`;
+  const encodedRole = encodeSegment(role);
+  const sessionPrefix = sessionId ? `/sessions/${encodeSegment(sessionId)}` : "";
+  const pattern = zoneId
+    ? `/zones/${encodeSegment(zoneId)}${sessionPrefix}/ipc/${encodedRole}/inbox/*`
+    : sessionId
+      ? `*/sessions/${encodeSegment(sessionId)}/ipc/${encodedRole}/inbox/*`
+      : `*/ipc/${encodedRole}/inbox/*`;
   const params = new URLSearchParams({
     path_pattern: pattern,
     event_types: "write",
   });
   return `${nexusUrl}/api/v2/events/stream?${params.toString()}`;
+}
+
+function pathMatchesZone(path: string, zoneId: string): boolean {
+  const encoded = encodeSegment(zoneId);
+  const plural = path.match(/^\/zones\/([^/]+)(?:\/|$)/);
+  if (plural) return plural[1] === encoded;
+  const singular = path.match(/^\/zone\/([^/]+)(?:\/|$)/);
+  if (singular) return singular[1] === encoded || singular[1] === zoneId;
+  return false;
 }
 
 /**
@@ -425,13 +443,16 @@ export class NexusWsBridge {
         const onAbort = () => ac.abort();
         deadline.addEventListener("abort", onAbort, { once: true });
         try {
-          const resp = await fetch(inboxStreamUrl(this.opts.nexusUrl, role.name), {
-            headers: {
-              Authorization: `Bearer ${this.opts.apiKey}`,
-              Accept: "text/event-stream",
+          const resp = await fetch(
+            inboxStreamUrl(this.opts.nexusUrl, role.name, undefined, this.opts.zoneId),
+            {
+              headers: {
+                Authorization: `Bearer ${this.opts.apiKey}`,
+                Accept: "text/event-stream",
+              },
+              signal: ac.signal,
             },
-            signal: ac.signal,
-          });
+          );
           if (!resp.ok) return { role: role.name, reason: `HTTP ${resp.status}` };
           // 2xx is necessary but not sufficient — a misconfigured proxy can
           // serve a success status without an actual event stream. Verify
@@ -806,7 +827,12 @@ export class NexusWsBridge {
       // and prevent onRoleUnhealthy from ever firing.
       const openMs = 15000;
       const openTimer = setTimeout(() => ac.abort(), openMs);
-      const url = inboxStreamUrl(this.opts.nexusUrl, role, this.currentSessionId());
+      const url = inboxStreamUrl(
+        this.opts.nexusUrl,
+        role,
+        this.currentSessionId(),
+        this.opts.zoneId,
+      );
 
       let resp: Response;
       try {
@@ -951,6 +977,7 @@ export class NexusWsBridge {
       // an EventRecord describing a file write — translate it to the
       // SseEvent shape the rest of the pipeline already speaks.
       let event: SseEvent;
+      let checkedZonePath = false;
       if (eventType === "message_delivered") {
         event = JSON.parse(raw) as SseEvent;
       } else if (eventType === "event") {
@@ -960,6 +987,10 @@ export class NexusWsBridge {
         // role's inbox prefix; this is belt-and-suspenders against future
         // pattern drift or shared streams.
         if (rec.type !== "write") return;
+        if (this.opts.zoneId) {
+          if (!pathMatchesZone(rec.path, this.opts.zoneId)) return;
+          checkedZonePath = true;
+        }
         const relPath = stripZonePrefix(rec.path);
         const messageId = messageIdFromInboxPath(relPath) ?? rec.event_id;
         event = {
@@ -971,6 +1002,10 @@ export class NexusWsBridge {
           path: relPath,
         };
       } else {
+        return;
+      }
+
+      if (this.opts.zoneId && !checkedZonePath && !pathMatchesZone(event.path, this.opts.zoneId)) {
         return;
       }
 

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -30,6 +30,7 @@ import { getProcessInstanceId } from "../core/process-instance.js";
 import type { AgentTopology } from "../core/topology.js";
 import { startInterval } from "../local/use-interval.js";
 import type { NexusIpcClient } from "../nexus/nexus-ipc-client.js";
+import { encodeSegment } from "../nexus/vfs-paths.js";
 import { debugLog } from "./debug-log.js";
 
 export interface NexusWsBridgeOptions {
@@ -47,6 +48,8 @@ export interface NexusWsBridgeOptions {
   ipcClient?: NexusIpcClient | undefined;
   /** Returns the active Grove session ID for session-scoped IPC paths. */
   getSessionId?: (() => string | undefined) | undefined;
+  /** Encoded into IPC VFS paths so the bridge reads the same namespace agents write. */
+  zoneId?: string | undefined;
   /**
    * Forwards inner payloads whose `type` is "acp.message" or "acp.result"
    * to a typed consumer (AcpMessageSink). Called only when the event's
@@ -155,15 +158,22 @@ function inboxFilePath(
   recipient: string,
   messageId: string,
   sessionId?: string | undefined,
+  zoneId?: string | undefined,
 ): string {
-  return sessionId
-    ? `/sessions/${sessionId}/ipc/${recipient}/inbox/${messageId}.json`
-    : `/ipc/${recipient}/inbox/${messageId}.json`;
+  const zonePrefix = zoneId ? `/zones/${encodeSegment(zoneId)}` : "";
+  const sessionPrefix = sessionId ? `/sessions/${encodeSegment(sessionId)}` : "";
+  return `${zonePrefix}${sessionPrefix}/ipc/${encodeSegment(recipient)}/inbox/${encodeSegment(messageId)}.json`;
 }
 
 /** Build the inbox directory path for a recipient role. */
-function inboxDirPath(recipient: string, sessionId?: string | undefined): string {
-  return sessionId ? `/sessions/${sessionId}/ipc/${recipient}/inbox` : `/ipc/${recipient}/inbox`;
+function inboxDirPath(
+  recipient: string,
+  sessionId?: string | undefined,
+  zoneId?: string | undefined,
+): string {
+  const zonePrefix = zoneId ? `/zones/${encodeSegment(zoneId)}` : "";
+  const sessionPrefix = sessionId ? `/sessions/${encodeSegment(sessionId)}` : "";
+  return `${zonePrefix}${sessionPrefix}/ipc/${encodeSegment(recipient)}/inbox`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -202,16 +212,23 @@ function messageIdFromInboxPath(path: string): string | undefined {
   return file.endsWith(".json") ? file.slice(0, -".json".length) : file;
 }
 
+function sessionIdFromInboxPath(path: string): string | undefined {
+  const clean = stripZonePrefix(path);
+  const match = clean.match(/(?:^|\/)sessions\/([^/]+)\//);
+  return match?.[1];
+}
+
 function inboxPathFromListItem(
   role: string,
   item: Record<string, unknown>,
   sessionId?: string | undefined,
+  zoneId?: string | undefined,
 ): string | undefined {
   const path = stringField(item, "path");
   if (path) return stripZonePrefix(path);
   const name = stringField(item, "name");
   if (!name) return undefined;
-  return `${inboxDirPath(role, sessionId)}/${name}`;
+  return `${inboxDirPath(role, sessionId, zoneId)}/${name}`;
 }
 
 function modifiedMsFromListItem(item: Record<string, unknown>): number | undefined {
@@ -529,7 +546,7 @@ export class NexusWsBridge {
           Authorization: `Bearer ${this.opts.apiKey}`,
         },
         body: JSON.stringify({
-          path: inboxFilePath(recipient, messageId, sessionId),
+          path: inboxFilePath(recipient, messageId, sessionId, this.opts.zoneId),
           content,
           encoding: "base64",
         }),
@@ -573,7 +590,7 @@ export class NexusWsBridge {
         for (const item of page.items) {
           const isDirectory = booleanField(item, "is_directory", "isDirectory");
           if (isDirectory === true) continue;
-          const path = inboxPathFromListItem(role, item, sessionId);
+          const path = inboxPathFromListItem(role, item, sessionId, this.opts.zoneId);
           if (!path || !path.endsWith(".json")) continue;
           const modifiedMs = modifiedMsFromListItem(item);
           if (modifiedMs !== undefined && modifiedMs < this.bridgeStartedAtMs) continue;
@@ -599,7 +616,7 @@ export class NexusWsBridge {
     cursor?: string,
   ): Promise<InboxListPage> {
     const params = new URLSearchParams({
-      path: inboxDirPath(role, sessionId),
+      path: inboxDirPath(role, sessionId, this.opts.zoneId),
       limit: String(INBOX_DRAIN_LIMIT),
     });
     if (cursor) params.set("cursor", cursor);
@@ -1661,7 +1678,7 @@ export class NexusWsBridge {
 
       const activeSessionId = this.currentSessionId();
       if (activeSessionId) {
-        const pathSessionId = path.match(/^\/sessions\/([^/]+)\//)?.[1];
+        const pathSessionId = sessionIdFromInboxPath(path);
         const msgSessionId = msg.session_id ?? pathSessionId;
         if (msgSessionId !== activeSessionId) {
           debugLog(
@@ -1703,7 +1720,13 @@ export class NexusWsBridge {
           type: "contribution",
           sourceRole: msgSender,
           targetRole: _targetRole,
-          payload: { message_id: effectiveIpcMessageId, cid, kind },
+          payload: {
+            message_id: effectiveIpcMessageId,
+            cid,
+            kind,
+            ...(typeof payload.summary === "string" ? { summary: payload.summary } : {}),
+            ...(payload.context !== undefined ? { context: payload.context } : {}),
+          },
           timestamp: new Date().toISOString(),
         };
         void this.opts.eventBus.publish(groveEvent);

--- a/src/tui/screens/screen-manager.test.ts
+++ b/src/tui/screens/screen-manager.test.ts
@@ -675,6 +675,49 @@ describe("ScreenManager transition flow", () => {
     expect(providerBundle.calls.archiveSession).toEqual(["session-done"]);
   });
 
+  test("running -> complete does not wait for agent teardown to settle", async () => {
+    const providerBundle = makeProvider({
+      contributions: [makeContribution("c1")],
+    });
+    const spawnManager = makeSpawnManager();
+    let releaseStop: (() => void) | undefined;
+    spawnManager.stopAllAgents = async (reason: string) => {
+      spawnManager.stopAllAgentsCalls.push(reason);
+      await new Promise<void>((resolve) => {
+        releaseStop = resolve;
+      });
+    };
+    renderScreenManager({
+      provider: providerBundle.provider,
+      spawnManager,
+      topology: TEST_TOPOLOGY,
+      initialState: {
+        screen: "running",
+        goal: "Complete without waiting",
+        sessionId: "session-teardown-hangs",
+        sessionStartedAt: "2026-03-29T00:00:00.000Z",
+      },
+    });
+
+    try {
+      await act(async () => {
+        requireRunningView().onComplete("All roles signaled done");
+        await flushAsync();
+        await flushAsync();
+      });
+
+      expect(captured.screen).toBe("complete");
+      expect(requireCompleteView().contributionCount).toBe(1);
+      expect(spawnManager.stopAllAgentsCalls).toEqual(["All roles signaled done"]);
+      expect(providerBundle.calls.archiveSession).toEqual(["session-teardown-hangs"]);
+    } finally {
+      releaseStop?.();
+      await act(async () => {
+        await flushAsync();
+      });
+    }
+  });
+
   test("running -> complete when the terminal reviewer role signals done", async () => {
     const eventBus = new LocalEventBus();
     const providerBundle = makeProvider({

--- a/src/tui/screens/screen-manager.test.ts
+++ b/src/tui/screens/screen-manager.test.ts
@@ -10,6 +10,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
+import { LocalEventBus } from "../../core/local-event-bus.js";
 import type { Contribution } from "../../core/models.js";
 import { ContributionKind, ContributionMode } from "../../core/models.js";
 import type { AgentTopology } from "../../core/topology.js";
@@ -85,11 +86,13 @@ interface TestSpawnManager {
   readonly reconcileCalls: string[];
   readonly saveTraceCalls: string[];
   readonly stopLogPollingCalls: string[];
+  readonly stopAllAgentsCalls: string[];
   reconcile(): Promise<void>;
   ensureLogBuffer(roleName: string): void;
   getLogBuffers(): Map<string, unknown>;
   startLogPolling(intervalMs?: number, seekToEnd?: boolean): void;
   stopLogPolling(): void;
+  stopAllAgents(reason: string): Promise<void>;
   setSessionId(sessionId: string): void;
   loadTraces(sessionId: string): Promise<void>;
   saveTraces(): Promise<void>;
@@ -198,6 +201,26 @@ const TEST_TOPOLOGY: AgentTopology = {
       description: "Builds the work",
       command: "claude",
       platform: "claude-code",
+    },
+  ],
+  spawning: { dynamic: false },
+};
+
+const REVIEWER_TERMINAL_TOPOLOGY: AgentTopology = {
+  structure: "graph",
+  roles: [
+    {
+      name: "coder",
+      description: "Writes code",
+      command: "codex",
+      platform: "codex",
+    },
+    {
+      name: "reviewer",
+      description: "Reviews code",
+      command: "claude",
+      platform: "claude-code",
+      endsSession: true,
     },
   ],
   spawning: { dynamic: false },
@@ -351,6 +374,7 @@ function makeSpawnManager(): TestSpawnManager {
     reconcileCalls: [],
     saveTraceCalls: [],
     stopLogPollingCalls: [],
+    stopAllAgentsCalls: [],
     reconcile: async () => {
       manager.reconcileCalls.push("reconcile");
     },
@@ -362,6 +386,9 @@ function makeSpawnManager(): TestSpawnManager {
     startLogPolling: () => undefined,
     stopLogPolling: () => {
       manager.stopLogPollingCalls.push("stop");
+    },
+    stopAllAgents: async (reason: string) => {
+      manager.stopAllAgentsCalls.push(reason);
     },
     setSessionId: (sessionId: string) => {
       manager.sessionIds.push(sessionId);
@@ -624,7 +651,7 @@ describe("ScreenManager transition flow", () => {
     const providerBundle = makeProvider({
       contributions: [makeContribution("c1"), makeContribution("c2")],
     });
-    renderScreenManager({
+    const { spawnManager } = renderScreenManager({
       provider: providerBundle.provider,
       topology: TEST_TOPOLOGY,
       initialState: {
@@ -644,7 +671,100 @@ describe("ScreenManager transition flow", () => {
     expect(captured.screen).toBe("complete");
     expect(requireCompleteView().reason).toBe("All roles signaled done");
     expect(requireCompleteView().contributionCount).toBe(2);
+    expect(spawnManager.stopAllAgentsCalls).toEqual(["All roles signaled done"]);
     expect(providerBundle.calls.archiveSession).toEqual(["session-done"]);
+  });
+
+  test("running -> complete when the terminal reviewer role signals done", async () => {
+    const eventBus = new LocalEventBus();
+    const providerBundle = makeProvider({
+      contributions: [makeContribution("review-done")],
+    });
+    const { spawnManager } = renderScreenManager({
+      provider: providerBundle.provider,
+      topology: REVIEWER_TERMINAL_TOPOLOGY,
+      appProps: {
+        provider: providerBundle.provider,
+        intervalMs: 10,
+        topology: REVIEWER_TERMINAL_TOPOLOGY,
+        eventBus,
+      },
+      initialState: {
+        screen: "running",
+        goal: "Complete after review",
+        sessionId: "session-review-done",
+        sessionStartedAt: "2026-03-29T00:00:00.000Z",
+      },
+    });
+
+    await act(async () => {
+      await eventBus.publish({
+        type: "contribution",
+        sourceRole: "reviewer",
+        targetRole: "reviewer",
+        payload: {
+          summary: "[DONE] Approved",
+          context: { done: true },
+        },
+        timestamp: "2026-03-29T00:00:01.000Z",
+      });
+      await flushAsync();
+      await flushAsync();
+    });
+
+    expect(captured.screen).toBe("complete");
+    expect(requireCompleteView().reason).toBe("Required roles signaled done");
+    expect(requireCompleteView().contributionCount).toBe(1);
+    expect(spawnManager.stopAllAgentsCalls).toEqual(["Required roles signaled done"]);
+    expect(providerBundle.calls.archiveSession).toEqual(["session-review-done"]);
+
+    eventBus.close();
+  });
+
+  test("running -> complete when the terminal reviewer done event is routed to another role", async () => {
+    const eventBus = new LocalEventBus();
+    const providerBundle = makeProvider({
+      contributions: [makeContribution("review-done")],
+    });
+    const { spawnManager } = renderScreenManager({
+      provider: providerBundle.provider,
+      topology: REVIEWER_TERMINAL_TOPOLOGY,
+      appProps: {
+        provider: providerBundle.provider,
+        intervalMs: 10,
+        topology: REVIEWER_TERMINAL_TOPOLOGY,
+        eventBus,
+      },
+      initialState: {
+        screen: "running",
+        goal: "Complete after review",
+        sessionId: "session-review-done",
+        sessionStartedAt: "2026-03-29T00:00:00.000Z",
+      },
+    });
+
+    await act(async () => {
+      await eventBus.publish({
+        type: "contribution",
+        sourceRole: "reviewer",
+        targetRole: "coder",
+        payload: {
+          summary: "[DONE] Approved",
+          context: { done: true },
+        },
+        timestamp: "2026-03-29T00:00:01.000Z",
+      });
+      await flushAsync();
+      await flushAsync();
+    });
+
+    expect(captured.screen).toBe("complete");
+    expect(requireCompleteView().reason).toBe("Required roles signaled done");
+    expect(requireCompleteView().contributionCount).toBe(1);
+    expect(spawnManager.stopAllAgentsCalls).toEqual(["Required roles signaled done"]);
+    expect(providerBundle.calls.archiveSession).toEqual(["session-review-done"]);
+
+    eventBus.close();
   });
 
   test("complete -> preset-select starts a fresh session when no preset state is reusable", () => {

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -284,17 +284,28 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
     const sessionStartRef = useRef<number>(Date.now());
     // Track if grove_done was signaled — stops IPC routing to prevent ping-pong
     const doneSignaledRef = useRef(false);
+    const completionInFlightRef = useRef(false);
 
     // ---------------------------------------------------------------------------
     // Done detection — extracted to custom hook (supports event-driven + polling)
     // ---------------------------------------------------------------------------
     const snapshotAndComplete = useCallback(
       async (reason: string) => {
+        if (completionInFlightRef.current) return;
+        completionInFlightRef.current = true;
+        doneSignaledRef.current = true;
+
+        // Stop live agents before archiving the row. Otherwise already-running
+        // Codex/Claude turns can keep reacting to IPC and publish duplicate
+        // contributions after the TUI has moved to "complete".
+        await spawnManager.stopAllAgents(reason).catch(() => {
+          /* best-effort */
+        });
+
         // Save trace history before completing
         await spawnManager.saveTraces().catch(() => {
           /* best-effort */
         });
-        spawnManager.stopLogPolling();
 
         let contributionCount = 0;
         try {
@@ -320,7 +331,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
       [provider, spawnManager],
     );
     const handleDone = useCallback(() => {
-      void snapshotAndComplete("All roles signaled done");
+      void snapshotAndComplete("Required roles signaled done");
     }, [snapshotAndComplete]);
     useDoneDetection(topology, state.screen, appProps.eventBus, handleDone);
 
@@ -692,6 +703,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
     // Screen 5 -> Screen 3 (reuse preset) or Screen 1 (no preset state)
     const handleNewSession = useCallback(() => {
       doneSignaledRef.current = false;
+      completionInFlightRef.current = false;
       hasSpawnedRef.current = false; // Reset spawn guard for new session
       setState((s) => {
         // If we have preset + role mapping from a prior run, skip to goal input

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -295,10 +295,11 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
         completionInFlightRef.current = true;
         doneSignaledRef.current = true;
 
-        // Stop live agents before archiving the row. Otherwise already-running
-        // Codex/Claude turns can keep reacting to IPC and publish duplicate
-        // contributions after the TUI has moved to "complete".
-        await spawnManager.stopAllAgents(reason).catch(() => {
+        // stopAllAgents synchronously unregisters IPC routes and marks runtime
+        // sessions closed before awaiting process teardown. Do not await the
+        // teardown here: a stuck adapter close must not keep the session row
+        // active after grove_done has already completed the session.
+        void spawnManager.stopAllAgents(reason).catch(() => {
           /* best-effort */
         });
 

--- a/src/tui/spawn-manager.test.ts
+++ b/src/tui/spawn-manager.test.ts
@@ -192,11 +192,16 @@ function makeMockTmux(shouldFail = false): TmuxManager & {
   };
 }
 
-function makeMockRuntime(): AgentRuntime & { readonly configs: AgentConfig[] } {
+function makeMockRuntime(): AgentRuntime & {
+  readonly configs: AgentConfig[];
+  readonly closedSessions: string[];
+} {
   const configs: AgentConfig[] = [];
+  const closedSessions: string[] = [];
   return {
     sendsInitialPromptOnSpawn: true,
     configs,
+    closedSessions,
     async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
       configs.push(config);
       return { id: `session-${role}`, role, status: "running", agent: "mock" };
@@ -204,8 +209,8 @@ function makeMockRuntime(): AgentRuntime & { readonly configs: AgentConfig[] } {
     async send(): Promise<AcpxTurn> {
       throw new Error("mock runtime send should not be called by SpawnManager.spawn");
     },
-    async close(): Promise<void> {
-      // No-op for test mock.
+    async close(session: AgentSession): Promise<void> {
+      closedSessions.push(session.id);
     },
     onIdle(): void {
       // No-op for test mock.
@@ -396,6 +401,54 @@ describe("SpawnManager", () => {
 
     expect(manager.getSpawnRecord(result1.spawnId)).toBeUndefined();
     expect(manager.getSpawnRecord(result2.spawnId)).toBeUndefined();
+  });
+
+  test("stopAllAgents closes active runtime sessions and unregisters bridge routes", async () => {
+    const provider = makeMockProvider();
+    const runtime = makeMockRuntime();
+    manager = new SpawnManager(
+      provider,
+      undefined,
+      () => {
+        /* noop */
+      },
+      [{ kind: "local" as const, path: "/tmp" }],
+      undefined,
+      "/tmp/no-grove",
+      runtime,
+    );
+
+    const unregistered: { role: string; sessionId: string | undefined }[] = [];
+    const stubBridge = {
+      getProvisionedRoleNames() {
+        return [];
+      },
+      registerSession() {
+        /* spawn() calls this when the bridge is attached */
+      },
+      unregisterSession(role: string, expectedSessionId?: string) {
+        unregistered.push({ role, sessionId: expectedSessionId });
+      },
+      close() {
+        /* destroy() calls this on teardown */
+      },
+    } as unknown as Parameters<typeof manager.setWsBridge>[0];
+    manager.setWsBridge(stubBridge);
+
+    const coder = await manager.spawn("coder", "codex");
+    const reviewer = await manager.spawn("reviewer", "claude");
+
+    await manager.stopAllAgents("Session complete");
+
+    expect(runtime.closedSessions.sort()).toEqual(["session-coder", "session-reviewer"]);
+    expect(unregistered).toEqual([
+      { role: "coder", sessionId: "session-coder" },
+      { role: "reviewer", sessionId: "session-reviewer" },
+    ]);
+    expect(manager.getSpawnRecord(coder.spawnId)).toBeUndefined();
+    expect(manager.getSpawnRecord(reviewer.spawnId)).toBeUndefined();
+    expect(manager.getActiveRoles()).toEqual([]);
+    expect(provider.cleanedWorkspaces.size).toBe(0);
   });
 
   test("spawn without workspace support falls back to git worktree", async () => {

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -864,6 +864,59 @@ export class SpawnManager {
     }
   }
 
+  /**
+   * Stop every active agent for the current session without deleting their
+   * workspaces. Used by normal session completion: artifacts must remain
+   * inspectable, but live runtime sessions and IPC routes must be quiesced so
+   * agents cannot keep reacting and submit duplicate late contributions.
+   */
+  async stopAllAgents(reason: string): Promise<void> {
+    debugLog(
+      "spawn",
+      `stopAllAgents reason=${reason} sessions=${this.agentSessions.size} records=${this.spawnRecords.size}`,
+    );
+    this.stopLogPolling();
+
+    const spawnIds = new Set<string>([...this.spawnRecords.keys(), ...this.agentSessions.keys()]);
+    const stopTasks: Promise<void>[] = [];
+
+    for (const spawnId of spawnIds) {
+      const tracked = this.spawnRecords.get(spawnId);
+      const session = this.agentSessions.get(spawnId);
+      const roleKey = tracked?.role ?? session?.role ?? spawnId.replace(/-[a-z0-9]+$/i, "");
+
+      // Cut IPC delivery before closing the runtime. This closes the window
+      // where a newly written inbox message could push another turn into a
+      // session that is already logically complete.
+      this.wsBridge?.unregisterSession(roleKey, session?.id);
+      this.unregisterAcpSession(session?.id ?? spawnId);
+
+      this.spawnRecords.delete(spawnId);
+      this.agentSessions.delete(spawnId);
+      this.routableSessions.delete(spawnId);
+      this.sessionStore?.remove(spawnId);
+
+      if (session && this.agentRuntime) {
+        stopTasks.push(
+          this.agentRuntime.close(session).catch((err) => {
+            const detail = err instanceof Error ? err.message : String(err);
+            this.onError(`Failed to close agent session ${session.id}: ${detail}`);
+          }),
+        );
+      } else if (this.tmux) {
+        const sessionName = `grove-${spawnId}`;
+        stopTasks.push(
+          this.tmux.kill(sessionName).catch((err) => {
+            const detail = err instanceof Error ? err.message : String(err);
+            this.onError(`Failed to kill tmux session ${sessionName}: ${detail}`);
+          }),
+        );
+      }
+    }
+
+    await Promise.all(stopTasks);
+  }
+
   /** Get the spawn record for an agentId (for testing). */
   getSpawnRecord(agentId: string): SpawnRecord | undefined {
     return this.spawnRecords.get(agentId);

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -402,10 +402,15 @@ export const TuiApp: React.NamedExoticComponent<TuiAppProps> = React.memo(functi
           // every store-touching path short-circuits).
           const maybeProvider = appProps.provider as {
             getHandoffStore?: () => import("../core/handoff.js").HandoffStore | undefined;
+            getNexusZoneId?: () => string;
           };
           const handoffStore =
             typeof maybeProvider.getHandoffStore === "function"
               ? maybeProvider.getHandoffStore()
+              : undefined;
+          const zoneId =
+            typeof maybeProvider.getNexusZoneId === "function"
+              ? maybeProvider.getNexusZoneId()
               : undefined;
           const bridge = new NexusWsBridge({
             topology: topo,
@@ -413,6 +418,7 @@ export const TuiApp: React.NamedExoticComponent<TuiAppProps> = React.memo(functi
             nexusUrl,
             apiKey,
             getSessionId: () => manager.getSessionId(),
+            zoneId,
             eventBus: appProps.eventBus,
             handoffStore,
             onAcpEvent: (ev) => acpSink.handleGroveEvent(ev),

--- a/tests/nexus/unit/nexus-cas.test.ts
+++ b/tests/nexus/unit/nexus-cas.test.ts
@@ -20,6 +20,7 @@ import type {
   ReadResult,
   SearchOptions,
   SearchResult,
+  WriteBatchEntry,
   WriteOptions,
   WriteResult,
 } from "../../../src/nexus/client.js";
@@ -48,6 +49,14 @@ class EncodedStorageSizeClient implements NexusClient {
     const etag = `etag-${String(++this.nextVersion)}`;
     this.files.set(path, { raw: new Uint8Array(content), stored, etag });
     return { bytesWritten: stored.byteLength, etag, version: this.nextVersion };
+  }
+
+  async writeBatch(files: readonly WriteBatchEntry[]): Promise<readonly WriteResult[]> {
+    const results: WriteResult[] = [];
+    for (const file of files) {
+      results.push(await this.write(file.path, file.content));
+    }
+    return results;
   }
 
   async exists(path: string): Promise<boolean> {

--- a/tests/nexus/unit/nexus-contribution-store.test.ts
+++ b/tests/nexus/unit/nexus-contribution-store.test.ts
@@ -10,10 +10,11 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { computeContributionContentHash } from "../../../src/core/content-dedup.js";
 import { toManifest } from "../../../src/core/manifest.js";
-import { RelationType } from "../../../src/core/models.js";
+import { type Contribution, RelationType } from "../../../src/core/models.js";
 import { runContributionStoreTests } from "../../../src/core/store.conformance.js";
 import { makeContribution } from "../../../src/core/test-helpers.js";
 import type { WriteOptions, WriteResult } from "../../../src/nexus/client.js";
+import { NexusConflictError } from "../../../src/nexus/errors.js";
 import { MockNexusClient } from "../../../src/nexus/mock-client.js";
 import { NexusContributionStore } from "../../../src/nexus/nexus-contribution-store.js";
 import {
@@ -56,6 +57,43 @@ class RecordingBatchClient extends MockNexusClient {
       results.push(await super.write(file.path, file.content, file.opts));
     }
     return results;
+  }
+}
+
+class ContentHashCommitConflictClient extends MockNexusClient {
+  private conflicted = false;
+  private readonly encoder = new TextEncoder();
+
+  constructor(
+    private readonly zoneId: string,
+    private readonly contentHashPath: string,
+    private readonly winner: Contribution,
+  ) {
+    super();
+  }
+
+  override async write(
+    path: string,
+    content: Uint8Array,
+    opts?: WriteOptions,
+  ): Promise<WriteResult> {
+    if (path === this.contentHashPath && opts?.ifMatch !== undefined && !this.conflicted) {
+      this.conflicted = true;
+      await super.write(
+        contributionPath(this.zoneId, this.winner.cid),
+        this.encoder.encode(JSON.stringify(toManifest(this.winner))),
+      );
+      await super.write(
+        ftsIndexPath(this.zoneId, this.winner.cid),
+        this.encoder.encode(JSON.stringify({ cid: this.winner.cid })),
+      );
+      await super.write(this.contentHashPath, this.encoder.encode(this.winner.cid));
+      throw new NexusConflictError({
+        message: `simulated content-hash commit race for ${path}`,
+        expectedEtag: opts.ifMatch,
+      });
+    }
+    return super.write(path, content, opts);
   }
 }
 
@@ -380,6 +418,42 @@ describe("NexusContributionStore adapter-specific", () => {
 
     batchStore.close();
     await batchClient.close();
+  });
+
+  test("put removes loser record files when content-hash commit races", async () => {
+    const winner = makeContribution({
+      summary: "same logical payload",
+      tags: ["race"],
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    const loser = makeContribution({
+      summary: "same logical payload",
+      tags: ["race"],
+      createdAt: "2026-01-02T00:00:00Z",
+    });
+    const contentHash = computeContributionContentHash(loser);
+    expect(computeContributionContentHash(winner)).toBe(contentHash);
+    expect(winner.cid).not.toBe(loser.cid);
+
+    const raceClient = new ContentHashCommitConflictClient(
+      "race-zone",
+      contributionContentHashIndexPath("race-zone", contentHash),
+      winner,
+    );
+    const raceStore = new NexusContributionStore({
+      client: raceClient,
+      zoneId: "race-zone",
+      retryMaxAttempts: 1,
+    });
+
+    const result = await raceStore.put(loser);
+
+    expect(result.cid).toBe(winner.cid);
+    expect(await raceStore.get(loser.cid)).toBeUndefined();
+    expect((await raceStore.list()).map((entry) => entry.cid)).toEqual([winner.cid]);
+
+    raceStore.close();
+    await raceClient.close();
   });
 
   test("getByContentHash ignores committed incomplete manifest records", async () => {

--- a/tests/nexus/unit/nexus-contribution-store.test.ts
+++ b/tests/nexus/unit/nexus-contribution-store.test.ts
@@ -10,14 +10,54 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { computeContributionContentHash } from "../../../src/core/content-dedup.js";
 import { toManifest } from "../../../src/core/manifest.js";
+import { RelationType } from "../../../src/core/models.js";
 import { runContributionStoreTests } from "../../../src/core/store.conformance.js";
 import { makeContribution } from "../../../src/core/test-helpers.js";
+import type { WriteOptions, WriteResult } from "../../../src/nexus/client.js";
 import { MockNexusClient } from "../../../src/nexus/mock-client.js";
 import { NexusContributionStore } from "../../../src/nexus/nexus-contribution-store.js";
 import {
   contributionContentHashIndexPath,
   contributionPath,
+  ftsIndexPath,
+  relationIndexPath,
+  tagIndexPath,
 } from "../../../src/nexus/vfs-paths.js";
+
+interface RecordedBatchFile {
+  readonly path: string;
+  readonly content: Uint8Array;
+  readonly opts?: WriteOptions | undefined;
+}
+
+class RecordingBatchClient extends MockNexusClient {
+  readonly writeCalls: string[] = [];
+  readonly writeBatchCalls: RecordedBatchFile[][] = [];
+
+  override async write(
+    path: string,
+    content: Uint8Array,
+    opts?: WriteOptions,
+  ): Promise<WriteResult> {
+    this.writeCalls.push(path);
+    return super.write(path, content, opts);
+  }
+
+  async writeBatch(files: readonly RecordedBatchFile[]): Promise<readonly WriteResult[]> {
+    this.writeBatchCalls.push(
+      files.map((file) => ({
+        path: file.path,
+        content: new Uint8Array(file.content),
+        ...(file.opts !== undefined ? { opts: file.opts } : {}),
+      })),
+    );
+    const results: WriteResult[] = [];
+    for (const file of files) {
+      results.push(await super.write(file.path, file.content, file.opts));
+    }
+    return results;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Conformance tests
@@ -302,6 +342,44 @@ describe("NexusContributionStore adapter-specific", () => {
     expect(result.contribution?.cid).toBe(c.cid);
     expect((await store.list()).map((entry) => entry.cid)).toContain(c.cid);
     expect((await store.search("finish")).map((entry) => entry.cid)).toContain(c.cid);
+  });
+
+  test("put writes manifest and secondary indexes in one batch", async () => {
+    const batchClient = new RecordingBatchClient();
+    const batchStore = new NexusContributionStore({
+      client: batchClient,
+      zoneId: "batch-zone",
+      retryMaxAttempts: 1,
+    });
+    const targetCid = `blake3:${"a".repeat(64)}`;
+    const c = makeContribution({
+      summary: "batch contribution record",
+      description: "batch indexed text",
+      relations: [{ targetCid, relationType: RelationType.DerivesFrom }],
+      tags: ["alpha", "beta"],
+    });
+    const expectedRecordPaths = [
+      contributionPath("batch-zone", c.cid),
+      relationIndexPath("batch-zone", targetCid, c.cid),
+      tagIndexPath("batch-zone", "alpha", c.cid),
+      tagIndexPath("batch-zone", "beta", c.cid),
+      ftsIndexPath("batch-zone", c.cid),
+    ].sort();
+
+    await batchStore.put(c);
+
+    const firstBatch = batchClient.writeBatchCalls.at(0);
+    if (firstBatch === undefined) {
+      throw new Error("expected contribution record to be written with writeBatch");
+    }
+    expect(batchClient.writeBatchCalls).toHaveLength(1);
+    expect(firstBatch.map((file) => file.path).sort()).toEqual(expectedRecordPaths);
+    for (const path of expectedRecordPaths) {
+      expect(batchClient.writeCalls).not.toContain(path);
+    }
+
+    batchStore.close();
+    await batchClient.close();
   });
 
   test("getByContentHash ignores committed incomplete manifest records", async () => {

--- a/tests/presets/preset-integration.test.ts
+++ b/tests/presets/preset-integration.test.ts
@@ -1089,6 +1089,7 @@ function topologyToWire(t: AgentTopology): Record<string, unknown> {
         })),
       }),
       ...(role.command !== undefined && { command: role.command }),
+      ...(role.endsSession !== undefined && { ends_session: role.endsSession }),
       ...(role.platform !== undefined && { platform: role.platform }),
       ...(role.model !== undefined && { model: role.model }),
       ...(role.color !== undefined && { color: role.color }),


### PR DESCRIPTION
## Summary

Fixes the review-loop completion path so reviewer-only `grove_done` ends the session, stops live agent runtimes, and prevents late duplicate contributions after completion.

## What changed

- Added topology-level `endsSession` / `ends_session` support and wired the review-loop reviewer role as the session-ending role.
- Updated TUI done detection to require only explicit session-ending roles when present.
- Stopped all active Codex/Claude sessions and unregistered IPC routes before archiving completed sessions.
- Scoped Nexus IPC inbox writes and drains by encoded zone plus active session so Codex work reaches the reviewer in the correct namespace.
- Forwarded Codex MCP sensitive env vars by name instead of embedding secret values.
- Added regression coverage for done detection, runtime shutdown, zone-scoped IPC, and Codex MCP config.

## Root Cause

The TUI waited for every topology role to signal done even though the review-loop instructions say only the reviewer should call `grove_done`. After completion, runtime sessions and Nexus bridge routes were still live, so queued IPC could still trigger agents and produce duplicate late contributions. A separate namespace mismatch also let contributions write under a zone-scoped path while the bridge drained an unzoned inbox path.

## Validation

- `bun test` targeted regression group: 115 pass, 0 fail
- broader regression group: 241 pass, 0 fail
- `bun run typecheck`
- `bun run check` (existing warnings only)
- `bun run build`
- live tmux Codex -> Claude review-loop run: coder created `hello.txt` exactly `hi`, reviewer approved and called `grove_done`, TUI completed with `Required roles signaled done`, and post-completion watch stayed at 3 contributions with no late duplicates.
