### PR TITLE
[codex] Add AgentTask task controller reconcile loop

### DIFF
--- a/docs/superpowers/plans/2026-05-14-task-controller-reconcile-loop.md
+++ b/docs/superpowers/plans/2026-05-14-task-controller-reconcile-loop.md
@@ -1,0 +1,1696 @@
+# Task Controller Reconcile Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the full issue #299 vertical slice: an `AgentTask` controller that watches tasks, binds/spawns ready work, retries failures, and reattaches live sessions after restart.
+
+**Architecture:** Add a core `TaskController` modeled after `ClaimReconciliationController`, with a keyed retry queue and an injectable `TaskBinder`. Extend the watch/informer pipeline to support `AgentTask`, wire SQLite and HTTP task writes into `WatchHub`, and start the controller from `grove-server` with a shared `AgentRuntime`.
+
+**Tech Stack:** Bun 1.3.x, TypeScript strict mode, `bun:test`, Hono routes, SQLite local store, Grove `AgentRuntime`, Grove `KeyedWorkQueue`, Grove watch/informer primitives.
+
+---
+
+## File Structure
+
+- Create `src/core/task-controller.ts`: controller types, default binder, status transition logic, condition helpers, worker loop.
+- Create `src/core/task-controller.test.ts`: fake store/runtime/binder tests for transitions, retries, restart reattach, and failure injection.
+- Modify `src/core/watch-events.ts`: add `AgentTask` to watch kind/entity unions.
+- Modify `src/core/informer.ts`: map `AgentTask` entities and include the kind in remote/local factory support.
+- Modify `src/core/index.ts`: export task controller types/classes.
+- Modify `src/local/watch-hub-recorder.ts`: add `agentTask()` fan-out.
+- Modify `src/local/runtime.ts`: wire `SqliteAgentTaskStore.onAgentTaskWrite` when a local watch hub is present.
+- Modify `src/local/sqlite-store.ts`: add task write callback support for spec and status writes.
+- Modify `src/local/sqlite-agent-task-store.test.ts`: verify callback operations and entities.
+- Modify `src/server/routes/watch.ts`: list/watch/notify support for `AgentTask`.
+- Modify `src/server/routes/agent-tasks.ts`: emit task watch events after spec/status writes.
+- Modify `tests/server/agent-tasks.test.ts`: verify task route fan-out.
+- Modify `src/server/serve.ts`: create shared runtime, start/stop task controller by default, reuse runtime for `SessionService`.
+
+## Task 1: Core Controller Transitions
+
+**Files:**
+- Create: `src/core/task-controller.ts`
+- Create: `src/core/task-controller.test.ts`
+- Modify: `src/core/index.ts`
+
+- [ ] **Step 1: Write failing transition tests**
+
+Create `src/core/task-controller.test.ts` with this starting fixture and transition tests:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentConfig, AgentSession } from "./agent-runtime.js";
+import {
+  AgentTaskPhase,
+  type AgentTaskEntity,
+  type AgentTaskStatusRecord,
+  type AgentTaskView,
+  agentTaskViewToEntity,
+} from "./agent-task.js";
+import type { Condition } from "./entity.js";
+import type { AgentTaskStatusPatch } from "./store.js";
+import {
+  DefaultTaskBinder,
+  type TaskBinder,
+  type TaskControllerStore,
+  TaskController,
+  type TaskControllerRuntime,
+} from "./task-controller.js";
+
+const FIXED_NOW_MS = Date.parse("2026-05-14T12:00:00.000Z");
+const FIXED_NOW_ISO = "2026-05-14T12:00:00.000Z";
+
+interface RecordedPatch {
+  readonly taskId: string;
+  readonly patch: AgentTaskStatusPatch;
+}
+
+class FakeTaskStore implements TaskControllerStore {
+  readonly views = new Map<string, AgentTaskView>();
+  readonly patches: RecordedPatch[] = [];
+
+  seed(view: AgentTaskView): void {
+    this.views.set(view.spec.id, view);
+  }
+
+  getAgentTask = async (taskId: string): Promise<AgentTaskView | undefined> => {
+    return this.views.get(taskId);
+  };
+
+  patchAgentTaskStatus = async (
+    taskId: string,
+    patch: AgentTaskStatusPatch,
+  ): Promise<AgentTaskView> => {
+    const current = this.views.get(taskId);
+    if (current === undefined) throw new Error(`missing task ${taskId}`);
+    this.patches.push({ taskId, patch });
+    const status: AgentTaskStatusRecord = {
+      ...current.status,
+      phase: patch.phase ?? current.status.phase,
+      sessionId: patch.sessionId ?? current.status.sessionId,
+      contributions: patch.contributions ?? current.status.contributions,
+      conditions: patch.conditions ?? current.status.conditions,
+      observedGeneration: patch.observedGeneration ?? current.status.observedGeneration,
+      lastTransitionAt: patch.lastTransitionAt ?? current.status.lastTransitionAt,
+      revision: current.status.revision + 1,
+    };
+    const updated: AgentTaskView = { spec: current.spec, status };
+    this.views.set(taskId, updated);
+    return updated;
+  };
+
+  listAgentTaskEntities = async (): Promise<readonly AgentTaskEntity[]> => {
+    return [...this.views.values()].map((view) => agentTaskViewToEntity(view));
+  };
+}
+
+class FakeRuntime implements TaskControllerRuntime {
+  readonly spawnCalls: Array<{ readonly role: string; readonly config: AgentConfig }> = [];
+  readonly sessions = new Map<string, AgentSession>();
+  private nextId = 1;
+
+  spawn = async (role: string, config: AgentConfig): Promise<AgentSession> => {
+    this.spawnCalls.push({ role, config });
+    const session: AgentSession = {
+      id: `session-${this.nextId}`,
+      role,
+      status: "running",
+      platform: config.platform,
+      model: config.model,
+    };
+    this.nextId += 1;
+    this.sessions.set(session.id, session);
+    return session;
+  };
+
+  listSessions = async (): Promise<readonly AgentSession[]> => [...this.sessions.values()];
+
+  close = async (session: AgentSession): Promise<void> => {
+    this.sessions.delete(session.id);
+  };
+}
+
+class FakeBinder implements TaskBinder {
+  readonly calls: AgentTaskView[] = [];
+  session: AgentSession = { id: "bound-session", role: "worker", status: "running" };
+
+  bind = async ({ task }: { readonly task: AgentTaskView }): Promise<{ readonly session: AgentSession }> => {
+    this.calls.push(task);
+    return { session: this.session };
+  };
+}
+
+function taskView(overrides: {
+  readonly id?: string;
+  readonly phase?: AgentTaskPhase;
+  readonly generation?: number;
+  readonly observedGeneration?: number;
+  readonly dependsOn?: readonly string[];
+  readonly sessionId?: string;
+  readonly conditions?: readonly Condition[];
+} = {}): AgentTaskView {
+  const id = overrides.id ?? "task-1";
+  const generation = overrides.generation ?? 1;
+  return {
+    spec: {
+      id,
+      worktree: "/tmp/grove-task",
+      runtime: "codex",
+      role: "worker",
+      prompt: "Implement the task",
+      dependsOn: overrides.dependsOn ?? [],
+      generation,
+      createdAt: "2026-05-14T11:00:00.000Z",
+    },
+    status: {
+      id,
+      phase: overrides.phase ?? AgentTaskPhase.Pending,
+      ...(overrides.sessionId === undefined ? {} : { sessionId: overrides.sessionId }),
+      contributions: [],
+      conditions: overrides.conditions ?? [],
+      observedGeneration: overrides.observedGeneration ?? 0,
+      lastTransitionAt: "2026-05-14T11:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function controllerFor(
+  store: FakeTaskStore,
+  overrides: {
+    readonly runtime?: FakeRuntime;
+    readonly binder?: TaskBinder;
+  } = {},
+): TaskController {
+  return new TaskController({
+    taskStore: store,
+    runtime: overrides.runtime ?? new FakeRuntime(),
+    binder: overrides.binder,
+    now: () => FIXED_NOW_MS,
+  });
+}
+
+function onlyPatch(store: FakeTaskStore): RecordedPatch {
+  expect(store.patches).toHaveLength(1);
+  const patch = store.patches[0];
+  if (patch === undefined) throw new Error("expected one patch");
+  return patch;
+}
+
+function condition(conditions: readonly Condition[] | undefined, type: string): Condition | undefined {
+  return conditions?.find((candidate) => candidate.type === type);
+}
+
+describe("TaskController transitions", () => {
+  test("missing tasks are successful no-ops", async () => {
+    const store = new FakeTaskStore();
+    const controller = controllerFor(store);
+
+    await expect(controller.reconcileTask("missing")).resolves.toBeUndefined();
+    expect(store.patches).toEqual([]);
+  });
+
+  test("terminal tasks catch up observed generation without reopening", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({
+      phase: AgentTaskPhase.Failed,
+      generation: 4,
+      observedGeneration: 2,
+    }));
+    const controller = controllerFor(store);
+
+    const transition = await controller.reconcileTask("task-1");
+
+    expect(transition).toEqual({
+      taskId: "task-1",
+      fromPhase: AgentTaskPhase.Failed,
+      toPhase: AgentTaskPhase.Failed,
+      reason: "terminal-observed-generation",
+      observedGeneration: 4,
+    });
+    expect(onlyPatch(store).patch.phase).toBeUndefined();
+    expect(onlyPatch(store).patch.observedGeneration).toBe(4);
+  });
+
+  test("pending tasks with missing dependencies stay blocked", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ dependsOn: ["task-a", "task-b"] }));
+    const controller = controllerFor(store);
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Pending);
+    expect(patch.observedGeneration).toBe(1);
+    expect(condition(patch.conditions, "Blocked")).toEqual({
+      type: "Blocked",
+      status: "True",
+      observedGeneration: 1,
+      lastTransitionTime: FIXED_NOW_ISO,
+      reason: "depends-on",
+      message: "Waiting for task-a, task-b",
+    });
+  });
+
+  test("pending tasks with satisfied dependencies move to PendingBind", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ id: "task-a", phase: AgentTaskPhase.Succeeded, observedGeneration: 1 }));
+    store.seed(taskView({ dependsOn: ["task-a"] }));
+    const controller = controllerFor(store);
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.PendingBind);
+    expect(condition(patch.conditions, "Scheduled")?.reason).toBe("ready-to-bind");
+  });
+
+  test("PendingBind tasks bind, spawn, and become Running", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const binder = new FakeBinder();
+    const controller = controllerFor(store, { binder });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(binder.calls.map((task) => task.spec.id)).toEqual(["task-1"]);
+    expect(patch.phase).toBe(AgentTaskPhase.Running);
+    expect(patch.sessionId).toBe("bound-session");
+    expect(condition(patch.conditions, "Bound")?.reason).toBe("session-bound");
+    expect(condition(patch.conditions, "Running")?.reason).toBe("session-running");
+  });
+
+  test("running tasks reattach when the session is live", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({
+      phase: AgentTaskPhase.Running,
+      observedGeneration: 1,
+      sessionId: "session-live",
+    }));
+    const runtime = new FakeRuntime();
+    runtime.sessions.set("session-live", {
+      id: "session-live",
+      role: "worker",
+      status: "idle",
+    });
+    const controller = controllerFor(store, { runtime });
+
+    await controller.reconcileTask("task-1");
+
+    expect(store.patches).toEqual([]);
+  });
+
+  test("running tasks fail when the session is missing", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({
+      phase: AgentTaskPhase.Running,
+      observedGeneration: 1,
+      sessionId: "session-missing",
+    }));
+    const controller = controllerFor(store, { runtime: new FakeRuntime() });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Failed);
+    expect(condition(patch.conditions, "Failed")?.reason).toBe("session-lost");
+  });
+});
+
+describe("DefaultTaskBinder", () => {
+  test("maps AgentTask spec to AgentRuntime spawn config with task correlation env", async () => {
+    const runtime = new FakeRuntime();
+    const binder = new DefaultTaskBinder(runtime);
+    const view = taskView({ generation: 3 });
+
+    const result = await binder.bind({ task: view });
+
+    expect(result.session.id).toBe("session-1");
+    expect(runtime.spawnCalls[0]).toEqual({
+      role: "worker",
+      config: {
+        role: "worker",
+        command: "codex",
+        cwd: "/tmp/grove-task",
+        goal: "Implement the task",
+        prompt: "Implement the task",
+        platform: "codex",
+        env: {
+          GROVE_AGENT_TASK_ID: "task-1",
+          GROVE_AGENT_TASK_GENERATION: "3",
+          GROVE_AGENT_TASK_RUNTIME: "codex",
+        },
+      },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+bun test src/core/task-controller.test.ts
+```
+
+Expected: FAIL with module resolution errors for `./task-controller.js` or missing exported symbols such as `TaskController`.
+
+- [ ] **Step 3: Implement minimal controller and binder**
+
+Create `src/core/task-controller.ts` with these exported shapes and behavior:
+
+```ts
+import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
+import {
+  AgentTaskConditionType,
+  AgentTaskPhase,
+  type AgentTaskEntity,
+  type AgentTaskView,
+} from "./agent-task.js";
+import type { Condition } from "./entity.js";
+import type { AgentTaskStatusPatch, AgentTaskStore } from "./store.js";
+import { KeyedWorkQueue, QueueClosedError, type WorkItemResult } from "./workqueue.js";
+
+export type TaskControllerStore = Pick<
+  AgentTaskStore,
+  "getAgentTask" | "listAgentTaskEntities" | "patchAgentTaskStatus"
+>;
+
+export type TaskControllerRuntime = Pick<AgentRuntime, "spawn" | "listSessions" | "close">;
+
+export interface TaskBindRequest {
+  readonly task: AgentTaskView;
+}
+
+export interface TaskBindResult {
+  readonly session: AgentSession;
+}
+
+export interface TaskBinder {
+  bind(request: TaskBindRequest): Promise<TaskBindResult>;
+}
+
+export interface AgentTaskStatusTransition {
+  readonly taskId: string;
+  readonly fromPhase: AgentTaskPhase;
+  readonly toPhase: AgentTaskPhase;
+  readonly reason: string;
+  readonly observedGeneration: number;
+}
+
+export interface TaskControllerOptions {
+  readonly taskStore: TaskControllerStore;
+  readonly runtime: TaskControllerRuntime;
+  readonly binder?: TaskBinder | undefined;
+  readonly queue?: KeyedWorkQueue | undefined;
+  readonly resyncIntervalMs?: number | undefined;
+  readonly workerCount?: number | undefined;
+  readonly now?: (() => number) | undefined;
+  readonly onError?: ((error: unknown, taskId: string) => void) | undefined;
+  readonly onTransition?: ((transition: AgentTaskStatusTransition) => void) | undefined;
+}
+
+const DEFAULT_RESYNC_INTERVAL_MS = 30_000;
+const DEFAULT_WORKER_COUNT = 1;
+const MAX_RESYNC_INTERVAL_MS = 2_147_483_647;
+const MAX_WORKER_COUNT = 1_000;
+
+export class DefaultTaskBinder implements TaskBinder {
+  private readonly runtime: TaskControllerRuntime;
+
+  constructor(runtime: TaskControllerRuntime) {
+    this.runtime = runtime;
+  }
+
+  async bind(request: TaskBindRequest): Promise<TaskBindResult> {
+    const task = request.task;
+    const modelValue = task.spec.budget?.model;
+    const config: AgentConfig = {
+      role: task.spec.role,
+      command: task.spec.runtime,
+      cwd: task.spec.worktree,
+      goal: task.spec.prompt,
+      prompt: task.spec.prompt,
+      platform: runtimeToPlatform(task.spec.runtime),
+      ...(typeof modelValue === "string" ? { model: modelValue } : {}),
+      env: {
+        GROVE_AGENT_TASK_ID: task.spec.id,
+        GROVE_AGENT_TASK_GENERATION: String(task.spec.generation),
+        GROVE_AGENT_TASK_RUNTIME: task.spec.runtime,
+      },
+    };
+    const session = await this.runtime.spawn(task.spec.role, config);
+    return { session };
+  }
+}
+
+export class TaskController {
+  private readonly taskStore: TaskControllerStore;
+  private readonly runtime: TaskControllerRuntime;
+  private readonly binder: TaskBinder;
+  private readonly queue: KeyedWorkQueue;
+  private readonly now: () => number;
+  private readonly resyncIntervalMs: number;
+  private readonly workerCount: number;
+  private readonly onError: ((error: unknown, taskId: string) => void) | undefined;
+  private readonly onTransition: ((transition: AgentTaskStatusTransition) => void) | undefined;
+  private running = false;
+  private stopRequested = false;
+  private workers: Promise<void>[] = [];
+  private resyncTimer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(options: TaskControllerOptions) {
+    this.taskStore = options.taskStore;
+    this.runtime = options.runtime;
+    this.binder = options.binder ?? new DefaultTaskBinder(options.runtime);
+    this.now = options.now ?? Date.now;
+    this.queue = options.queue ?? new KeyedWorkQueue({ now: this.now });
+    this.resyncIntervalMs = options.resyncIntervalMs ?? DEFAULT_RESYNC_INTERVAL_MS;
+    this.workerCount = options.workerCount ?? DEFAULT_WORKER_COUNT;
+    validateResyncIntervalMs(this.resyncIntervalMs);
+    validateWorkerCount(this.workerCount);
+    this.onError = options.onError;
+    this.onTransition = options.onTransition;
+  }
+
+  enqueue(taskId: string): void {
+    this.queue.enqueue(taskId);
+  }
+
+  enqueueFromEntity(entity: AgentTaskEntity): void {
+    this.enqueue(entity.id);
+  }
+
+  async resync(): Promise<number> {
+    const entities = await this.taskStore.listAgentTaskEntities();
+    for (const entity of entities) this.enqueue(entity.id);
+    return entities.length;
+  }
+
+  async reconcileTask(taskId: string): Promise<AgentTaskStatusTransition | undefined> {
+    const task = await this.taskStore.getAgentTask(taskId);
+    if (task === undefined) return undefined;
+    const transition = await this.computeAndApply(task);
+    if (transition !== undefined) this.onTransition?.(transition);
+    return transition;
+  }
+
+  start(): void {
+    if (this.running) return;
+    if (this.stopRequested) throw new QueueClosedError();
+    this.running = true;
+    for (let i = 0; i < this.workerCount; i += 1) this.workers.push(this.workerLoop());
+    this.resyncTimer = setInterval(() => {
+      void this.resync().catch((error: unknown) => this.reportError(error, "__resync__"));
+    }, this.resyncIntervalMs);
+    this.resyncTimer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running && this.stopRequested) return;
+    this.stopRequested = true;
+    if (this.resyncTimer !== undefined) {
+      clearInterval(this.resyncTimer);
+      this.resyncTimer = undefined;
+    }
+    this.queue.close();
+    const workers = this.workers;
+    this.workers = [];
+    await Promise.all(workers);
+    this.running = false;
+  }
+
+  private async workerLoop(): Promise<void> {
+    while (!this.stopRequested) {
+      let item: WorkItemResult;
+      try {
+        item = await this.queue.take();
+      } catch (error) {
+        if (this.stopRequested) return;
+        throw error;
+      }
+      try {
+        await this.reconcileTask(item.key);
+        this.queue.acknowledge(item.key);
+      } catch (error) {
+        if (!this.stopRequested) this.queue.retry(item.key);
+        this.reportError(error, item.key);
+      }
+    }
+  }
+
+  private async computeAndApply(
+    task: AgentTaskView,
+  ): Promise<AgentTaskStatusTransition | undefined> {
+    if (isTerminal(task.status.phase)) return this.catchUpTerminal(task);
+    if (task.status.phase === AgentTaskPhase.Running) return this.reconcileRunning(task);
+    if (task.status.phase === AgentTaskPhase.PendingBind) return this.bindPendingTask(task);
+    return this.reconcilePending(task);
+  }
+
+  private async reconcilePending(
+    task: AgentTaskView,
+  ): Promise<AgentTaskStatusTransition | undefined> {
+    const blockedOn = await this.blockingDependencies(task);
+    const nowIso = this.nowIso();
+    if (blockedOn.length > 0) {
+      const patch: AgentTaskStatusPatch = {
+        phase: AgentTaskPhase.Pending,
+        observedGeneration: task.spec.generation,
+        conditions: upsertCondition(task.status.conditions, {
+          type: AgentTaskConditionType.Blocked,
+          status: "True",
+          observedGeneration: task.spec.generation,
+          lastTransitionTime: nowIso,
+          reason: "depends-on",
+          message: `Waiting for ${blockedOn.join(", ")}`,
+        }, nowIso),
+      };
+      await this.taskStore.patchAgentTaskStatus(task.spec.id, patch);
+      return transition(task, AgentTaskPhase.Pending, "depends-on");
+    }
+    const patch: AgentTaskStatusPatch = {
+      phase: AgentTaskPhase.PendingBind,
+      observedGeneration: task.spec.generation,
+      conditions: upsertCondition(task.status.conditions, {
+        type: AgentTaskConditionType.Scheduled,
+        status: "True",
+        observedGeneration: task.spec.generation,
+        lastTransitionTime: nowIso,
+        reason: "ready-to-bind",
+        message: "",
+      }, nowIso),
+      lastTransitionAt: nowIso,
+    };
+    await this.taskStore.patchAgentTaskStatus(task.spec.id, patch);
+    return transition(task, AgentTaskPhase.PendingBind, "ready-to-bind");
+  }
+
+  private async bindPendingTask(
+    task: AgentTaskView,
+  ): Promise<AgentTaskStatusTransition | undefined> {
+    if (task.status.sessionId !== undefined) return this.reconcileRunning(task);
+    const { session } = await this.binder.bind({ task });
+    const nowIso = this.nowIso();
+    let conditions = upsertCondition(task.status.conditions, {
+      type: AgentTaskConditionType.Bound,
+      status: "True",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "session-bound",
+      message: `Started ${session.id}`,
+    }, nowIso);
+    conditions = upsertCondition(conditions, {
+      type: AgentTaskConditionType.Running,
+      status: "True",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "session-running",
+      message: "",
+    }, nowIso);
+    await this.taskStore.patchAgentTaskStatus(task.spec.id, {
+      phase: AgentTaskPhase.Running,
+      sessionId: session.id,
+      observedGeneration: task.spec.generation,
+      conditions,
+      lastTransitionAt: nowIso,
+    });
+    return transition(task, AgentTaskPhase.Running, "session-bound");
+  }
+
+  private async reconcileRunning(
+    task: AgentTaskView,
+  ): Promise<AgentTaskStatusTransition | undefined> {
+    if (task.status.sessionId === undefined) return this.failLostSession(task);
+    const sessions = await this.runtime.listSessions();
+    const session = sessions.find((candidate) => candidate.id === task.status.sessionId);
+    if (session !== undefined && (session.status === "running" || session.status === "idle")) {
+      return undefined;
+    }
+    return this.failLostSession(task);
+  }
+
+  private async failLostSession(task: AgentTaskView): Promise<AgentTaskStatusTransition> {
+    const nowIso = this.nowIso();
+    let conditions = upsertCondition(task.status.conditions, {
+      type: AgentTaskConditionType.Running,
+      status: "False",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "session-lost",
+      message: "",
+    }, nowIso);
+    conditions = upsertCondition(conditions, {
+      type: AgentTaskConditionType.Failed,
+      status: "True",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "session-lost",
+      message: "",
+    }, nowIso);
+    await this.taskStore.patchAgentTaskStatus(task.spec.id, {
+      phase: AgentTaskPhase.Failed,
+      observedGeneration: task.spec.generation,
+      conditions,
+      lastTransitionAt: nowIso,
+    });
+    return transition(task, AgentTaskPhase.Failed, "session-lost");
+  }
+
+  private async catchUpTerminal(
+    task: AgentTaskView,
+  ): Promise<AgentTaskStatusTransition | undefined> {
+    if (task.status.observedGeneration >= task.spec.generation) return undefined;
+    await this.taskStore.patchAgentTaskStatus(task.spec.id, {
+      observedGeneration: task.spec.generation,
+    });
+    return transition(task, task.status.phase, "terminal-observed-generation");
+  }
+
+  private async blockingDependencies(task: AgentTaskView): Promise<readonly string[]> {
+    const blocked: string[] = [];
+    for (const dependencyId of task.spec.dependsOn) {
+      const dependency = await this.taskStore.getAgentTask(dependencyId);
+      if (dependency?.status.phase !== AgentTaskPhase.Succeeded) blocked.push(dependencyId);
+    }
+    return blocked;
+  }
+
+  private nowIso(): string {
+    return new Date(this.now()).toISOString();
+  }
+
+  private reportError(error: unknown, taskId: string): void {
+    try {
+      this.onError?.(error, taskId);
+    } catch {
+      return;
+    }
+  }
+}
+
+function validateResyncIntervalMs(value: number): void {
+  if (!Number.isFinite(value) || value < 1 || value > MAX_RESYNC_INTERVAL_MS) {
+    throw new RangeError(
+      `resyncIntervalMs must be a finite positive number no greater than ${MAX_RESYNC_INTERVAL_MS}`,
+    );
+  }
+}
+
+function validateWorkerCount(value: number): void {
+  if (!Number.isInteger(value) || value < 1 || value > MAX_WORKER_COUNT) {
+    throw new RangeError(`workerCount must be an integer between 1 and ${MAX_WORKER_COUNT}`);
+  }
+}
+
+function runtimeToPlatform(runtime: string): AgentConfig["platform"] {
+  if (runtime === "claude" || runtime === "claude-code") return "claude-code";
+  if (runtime === "gemini") return "gemini";
+  if (runtime === "codex") return "codex";
+  return undefined;
+}
+
+function isTerminal(phase: AgentTaskPhase): boolean {
+  return phase === AgentTaskPhase.Succeeded || phase === AgentTaskPhase.Failed;
+}
+
+function transition(
+  task: AgentTaskView,
+  toPhase: AgentTaskPhase,
+  reason: string,
+): AgentTaskStatusTransition {
+  return {
+    taskId: task.spec.id,
+    fromPhase: task.status.phase,
+    toPhase,
+    reason,
+    observedGeneration: task.spec.generation,
+  };
+}
+
+function upsertCondition(
+  existing: readonly Condition[],
+  next: Condition,
+  nowIso: string,
+): readonly Condition[] {
+  const current = existing.find((condition) => condition.type === next.type);
+  const stableNext =
+    current !== undefined &&
+    current.status === next.status &&
+    current.reason === next.reason &&
+    current.message === next.message
+      ? { ...next, lastTransitionTime: current.lastTransitionTime }
+      : { ...next, lastTransitionTime: nowIso };
+  const rest = existing.filter((condition) => condition.type !== next.type);
+  return [...rest, stableNext];
+}
+```
+
+- [ ] **Step 4: Export task controller**
+
+Modify `src/core/index.ts` near the claim-controller exports:
+
+```ts
+export type {
+  AgentTaskStatusTransition,
+  TaskBindRequest,
+  TaskBindResult,
+  TaskBinder,
+  TaskControllerOptions,
+  TaskControllerRuntime,
+  TaskControllerStore,
+} from "./task-controller.js";
+export { DefaultTaskBinder, TaskController } from "./task-controller.js";
+```
+
+- [ ] **Step 5: Run tests to verify GREEN**
+
+Run:
+
+```bash
+bun test src/core/task-controller.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/task-controller.ts src/core/task-controller.test.ts src/core/index.ts
+git commit -m "feat: add agent task controller transitions"
+```
+
+## Task 2: Queue Lifecycle And Failure Injection
+
+**Files:**
+- Modify: `src/core/task-controller.test.ts`
+- Modify: `src/core/task-controller.ts`
+
+- [ ] **Step 1: Add failing worker/retry tests**
+
+Append these tests to `src/core/task-controller.test.ts`:
+
+```ts
+import { KeyedWorkQueue } from "./workqueue.js";
+
+describe("TaskController worker lifecycle", () => {
+  test("rejects invalid lifecycle options", () => {
+    const invalidOptions: ReadonlyArray<{
+      readonly resyncIntervalMs?: number;
+      readonly workerCount?: number;
+    }> = [
+      { resyncIntervalMs: 0 },
+      { resyncIntervalMs: Number.NaN },
+      { workerCount: 0 },
+      { workerCount: 1.5 },
+    ];
+
+    for (const options of invalidOptions) {
+      const store = new FakeTaskStore();
+      expect(
+        () =>
+          new TaskController({
+            taskStore: store,
+            runtime: new FakeRuntime(),
+            now: () => FIXED_NOW_MS,
+            ...options,
+          }),
+      ).toThrow(RangeError);
+    }
+  });
+
+  test("resync enqueues every AgentTask entity id", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ id: "task-a" }));
+    store.seed(taskView({ id: "task-b" }));
+    const queue = new KeyedWorkQueue({ now: () => FIXED_NOW_MS });
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      queue,
+      now: () => FIXED_NOW_MS,
+    });
+
+    const count = await controller.resync();
+
+    expect(count).toBe(2);
+    await expect(queue.take()).resolves.toEqual({ key: "task-a", attempt: 0 });
+    await expect(queue.take()).resolves.toEqual({ key: "task-b", attempt: 0 });
+  });
+
+  test("failed worker reconcile retries and re-reads fresh task state", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    let fail = true;
+    const binder: TaskBinder = {
+      bind: async () => {
+        if (fail) throw new Error("spawn unavailable");
+        return { session: { id: "session-retry", role: "worker", status: "running" } };
+      },
+    };
+    const errors: Array<{ readonly taskId: string; readonly message: string }> = [];
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      binder,
+      queue: new KeyedWorkQueue({ baseDelayMs: 1, maxDelayMs: 1 }),
+      now: () => FIXED_NOW_MS,
+      onError: (error, taskId) => {
+        errors.push({ taskId, message: error instanceof Error ? error.message : String(error) });
+      },
+    });
+
+    controller.enqueue("task-1");
+    controller.start();
+    await waitFor(() => errors.length === 1);
+    fail = false;
+    await waitFor(() => store.patches.some((patch) => patch.patch.sessionId === "session-retry"));
+    await controller.stop();
+
+    expect(errors).toEqual([{ taskId: "task-1", message: "spawn unavailable" }]);
+  });
+
+  test("stop cancels workers and rejects new work", async () => {
+    const store = new FakeTaskStore();
+    const controller = controllerFor(store);
+
+    controller.start();
+    await controller.stop();
+
+    expect(() => controller.enqueue("task-1")).toThrow("Work queue is closed");
+    expect(() => controller.start()).toThrow("Work queue is closed");
+  });
+});
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > 500) throw new Error("condition was not met in time");
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+bun test src/core/task-controller.test.ts
+```
+
+Expected: FAIL if the initial implementation lacks retry, validation, or lifecycle behavior.
+
+- [ ] **Step 3: Fill lifecycle gaps**
+
+Update `src/core/task-controller.ts` so:
+
+```ts
+start(): void {
+  if (this.running) return;
+  if (this.stopRequested) throw new QueueClosedError();
+  this.running = true;
+  this.stopRequested = false;
+  for (let i = 0; i < this.workerCount; i += 1) {
+    this.workers.push(this.workerLoop());
+  }
+  this.resyncTimer = setInterval(() => {
+    void this.resync().catch((error: unknown) => this.reportError(error, "__resync__"));
+  }, this.resyncIntervalMs);
+  this.resyncTimer.unref?.();
+}
+```
+
+Also confirm `workerLoop()` catches reconcile errors, calls `queue.retry(item.key)`, and calls `reportError(error, item.key)`.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+bun test src/core/task-controller.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add failure-injection convergence tests**
+
+Append this focused table test:
+
+```ts
+describe("TaskController failure injection", () => {
+  test("converges when each bind step fails once", async () => {
+    const cases = ["bind", "patch-running"] as const;
+
+    for (const failurePoint of cases) {
+      const store = new FakeTaskStore();
+      store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+      let failed = false;
+      const binder: TaskBinder = {
+        bind: async () => {
+          if (failurePoint === "bind" && !failed) {
+            failed = true;
+            throw new Error("injected bind failure");
+          }
+          return { session: { id: `session-${failurePoint}`, role: "worker", status: "running" } };
+        },
+      };
+      const originalPatch = store.patchAgentTaskStatus;
+      store.patchAgentTaskStatus = async (taskId, patch) => {
+        if (failurePoint === "patch-running" && patch.phase === AgentTaskPhase.Running && !failed) {
+          failed = true;
+          throw new Error("injected patch failure");
+        }
+        return originalPatch(taskId, patch);
+      };
+      const controller = controllerFor(store, { binder });
+
+      await expect(controller.reconcileTask("task-1")).rejects.toThrow("injected");
+      await expect(controller.reconcileTask("task-1")).resolves.toBeDefined();
+
+      expect(store.views.get("task-1")?.status.phase).toBe(AgentTaskPhase.Running);
+    }
+  });
+});
+```
+
+- [ ] **Step 6: Run tests to verify GREEN**
+
+Run:
+
+```bash
+bun test src/core/task-controller.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/task-controller.ts src/core/task-controller.test.ts
+git commit -m "test: cover task controller retry convergence"
+```
+
+## Task 3: Watch And Informer AgentTask Support
+
+**Files:**
+- Modify: `src/core/watch-events.ts`
+- Modify: `src/core/informer.ts`
+- Modify: `src/core/informer.test.ts`
+- Modify: `src/server/routes/watch.ts`
+- Modify: `tests/server/routes.test.ts` or create focused assertions in `tests/server/agent-tasks.test.ts`
+
+- [ ] **Step 1: Write failing informer/watch tests**
+
+Append a focused test to `src/core/informer.test.ts` near factory kind support tests:
+
+```ts
+test("InformerFactory supports AgentTask in local and remote modes", () => {
+  const localFactory = new InformerFactory({
+    mode: "local",
+    hub: new WatchHub(),
+    namespace: "default",
+    listFn: () => [],
+  });
+  expect(localFactory.supportsKind("AgentTask")).toBe(true);
+  expect(localFactory.informerFor("AgentTask")).toBeDefined();
+
+  const remoteFactory = new InformerFactory({
+    mode: "remote",
+    baseUrl: "http://localhost:4515",
+    authHeader: "Bearer test",
+  });
+  expect(remoteFactory.supportsKind("AgentTask")).toBe(true);
+  expect(remoteFactory.informerFor("AgentTask")).toBeDefined();
+});
+```
+
+Add a server route test in `tests/server/agent-tasks.test.ts`:
+
+```ts
+test("GET /api/list supports AgentTask snapshots", async () => {
+  await ctx.agentTaskStore.putAgentTaskSpec({
+    id: "task-watch-list",
+    ...SPEC_BODY,
+    generation: 0,
+    createdAt: "2026-05-14T12:00:00.000Z",
+  });
+
+  const res = await ctx.app.request("/api/list?kind=AgentTask", {
+    headers: TEST_AUTH_HEADERS,
+  });
+
+  expect(res.status).toBe(200);
+  const data = await res.json();
+  expect(data.items[0].kind).toBe("AgentTask");
+  expect(data.items[0].id).toBe("task-watch-list");
+});
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+bun test src/core/informer.test.ts tests/server/agent-tasks.test.ts
+```
+
+Expected: FAIL because `AgentTask` is not assignable to `WatchKind` or the server watch route returns validation/config errors.
+
+- [ ] **Step 3: Extend watch event types**
+
+Modify `src/core/watch-events.ts`:
+
+```ts
+import type { AgentTaskEntity } from "./agent-task.js";
+import type { AgentSessionEntity, ClaimEntity, ContributionEntity } from "./entity.js";
+
+export type WatchKind = "Contribution" | "Claim" | "AgentSession" | "AgentTask";
+
+export type WatchEntity = ContributionEntity | ClaimEntity | AgentSessionEntity | AgentTaskEntity;
+```
+
+- [ ] **Step 4: Extend informer kind mapping and supported sets**
+
+Modify the import and mapping in `src/core/informer.ts`:
+
+```ts
+import type { AgentTaskEntity } from "./agent-task.js";
+import type { AgentSessionEntity, ClaimEntity, ContributionEntity } from "./entity.js";
+
+export type EntityForKind<K extends WatchKind> = K extends "Contribution"
+  ? ContributionEntity
+  : K extends "Claim"
+    ? ClaimEntity
+    : K extends "AgentSession"
+      ? AgentSessionEntity
+      : K extends "AgentTask"
+        ? AgentTaskEntity
+        : never;
+```
+
+Update kind lists:
+
+```ts
+const REMOTE_KINDS: readonly WatchKind[] = ["Contribution", "Claim", "AgentTask"];
+const LOCAL_KINDS: readonly WatchKind[] = [
+  "Contribution",
+  "Claim",
+  "AgentSession",
+  "AgentTask",
+];
+```
+
+- [ ] **Step 5: Extend server watch routes**
+
+Modify `src/server/routes/watch.ts` imports:
+
+```ts
+import { agentTaskViewToEntity } from "../../core/agent-task.js";
+import { claimToEntity, contributionToEntity } from "../../core/entity.js";
+```
+
+Update kind constants:
+
+```ts
+const KIND_VALUES = ["Contribution", "Claim", "AgentSession", "AgentTask"] as const;
+const SUPPORTED_KINDS: ReadonlySet<(typeof KIND_VALUES)[number]> = new Set([
+  "Contribution",
+  "Claim",
+  "AgentTask",
+]);
+```
+
+Update `hydrateEntity`:
+
+```ts
+if (kind === "AgentTask") {
+  const view = await deps.agentTaskStore?.getAgentTask(entityId);
+  if (view !== undefined) {
+    return agentTaskViewToEntity(view, namespace) as MaybeVersioned;
+  }
+  return undefined;
+}
+```
+
+Update `listForKind`:
+
+```ts
+case "AgentTask":
+  if (deps.agentTaskStore === undefined) {
+    throw new Error("AgentTask store is not configured");
+  }
+  return deps.agentTaskStore.listAgentTaskEntities();
+```
+
+Before calling `listForKind`, add an explicit configured-store guard so missing task stores return `501`:
+
+```ts
+if (kind === "AgentTask" && deps.agentTaskStore === undefined) {
+  return c.json(
+    {
+      error: {
+        code: "NOT_CONFIGURED",
+        message: "AgentTask store is not configured",
+      },
+    },
+    501,
+  );
+}
+```
+
+Update `makeWatchEntityFetcher` at the bottom of `src/server/serve.ts` so cross-process watch hydration can fetch task entities:
+
+```ts
+function makeWatchEntityFetcher(stores: {
+  contributionStore: import("../core/store.js").ContributionStore;
+  claimStore: import("../core/store.js").ClaimStore;
+  agentTaskStore?: import("../core/store.js").AgentTaskStore | undefined;
+}): (kind: WatchKind, namespace: string, id: string) => Promise<WatchEntity> {
+  return async (kind, namespace, id) => {
+    if (kind === "Contribution") {
+      const c = await stores.contributionStore.get(id);
+      if (!c) throw new Error(`Contribution ${id} not found`);
+      return contributionToEntity(c, namespace);
+    }
+    if (kind === "Claim") {
+      const c = await stores.claimStore.getClaim(id);
+      if (!c) throw new Error(`Claim ${id} not found`);
+      return claimToEntity(c, () => Date.now(), namespace);
+    }
+    if (kind === "AgentTask") {
+      const view = await stores.agentTaskStore?.getAgentTask(id);
+      if (!view) throw new Error(`AgentTask ${id} not found`);
+      return agentTaskViewToEntity(view, namespace);
+    }
+    throw new Error(`Unsupported kind for watch fetcher: ${kind}`);
+  };
+}
+```
+
+Update the call site:
+
+```ts
+fetchEntity: makeWatchEntityFetcher({
+  contributionStore: serverContributionStore,
+  claimStore: serverClaimStore,
+  agentTaskStore: runtime.agentTaskStore,
+}),
+```
+
+- [ ] **Step 6: Run tests to verify GREEN**
+
+Run:
+
+```bash
+bun test src/core/informer.test.ts tests/server/agent-tasks.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/watch-events.ts src/core/informer.ts src/core/informer.test.ts src/server/routes/watch.ts tests/server/agent-tasks.test.ts
+git commit -m "feat: add AgentTask watch informer support"
+```
+
+## Task 4: Store And Local Watch Fan-Out
+
+**Files:**
+- Modify: `src/local/sqlite-store.ts`
+- Modify: `src/local/sqlite-agent-task-store.test.ts`
+- Modify: `src/local/watch-hub-recorder.ts`
+- Modify: `src/local/runtime.ts`
+
+- [ ] **Step 1: Write failing SQLite callback tests**
+
+Append to `src/local/sqlite-agent-task-store.test.ts`:
+
+```ts
+test("emits AgentTask write callbacks for spec create, spec update, and status patch", async () => {
+  const seen: Array<{ readonly op: "ADDED" | "MODIFIED"; readonly id: string }> = [];
+  stores.agentTaskStore.onAgentTaskWrite = (op, view) => {
+    seen.push({ op, id: view.spec.id });
+  };
+
+  await stores.agentTaskStore.putAgentTaskSpec({
+    id: "task-callback",
+    worktree: "/tmp/worktree",
+    runtime: "codex",
+    role: "worker",
+    prompt: "Implement callback",
+    dependsOn: [],
+    generation: 0,
+    createdAt: "2026-05-14T12:00:00.000Z",
+  });
+  await stores.agentTaskStore.putAgentTaskSpec({
+    id: "task-callback",
+    worktree: "/tmp/worktree",
+    runtime: "codex",
+    role: "worker",
+    prompt: "Implement callback update",
+    dependsOn: [],
+    generation: 0,
+    createdAt: "2026-05-14T12:00:00.000Z",
+  });
+  await stores.agentTaskStore.patchAgentTaskStatus("task-callback", {
+    phase: AgentTaskPhase.PendingBind,
+  });
+
+  expect(seen).toEqual([
+    { op: "ADDED", id: "task-callback" },
+    { op: "MODIFIED", id: "task-callback" },
+    { op: "MODIFIED", id: "task-callback" },
+  ]);
+});
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+bun test src/local/sqlite-agent-task-store.test.ts
+```
+
+Expected: FAIL because `onAgentTaskWrite` does not exist.
+
+- [ ] **Step 3: Add SQLite callback support**
+
+Modify `SqliteAgentTaskStore` in `src/local/sqlite-store.ts`:
+
+```ts
+export class SqliteAgentTaskStore implements AgentTaskStore {
+  readonly storeIdentity: string;
+  onAgentTaskWrite: ((op: "ADDED" | "MODIFIED", view: AgentTaskView) => void) | undefined;
+```
+
+In `putAgentTaskSpec`, track operation and fire after reading the view:
+
+```ts
+let op: "ADDED" | "MODIFIED" = "MODIFIED";
+const tx = this.db.transaction(() => {
+  const existing = this.readAgentTask(spec.id);
+  if (existing === null) {
+    op = "ADDED";
+    // existing insert body
+    return;
+  }
+  op = "MODIFIED";
+  // existing update body
+});
+tx.immediate();
+
+const view = this.readAgentTask(spec.id);
+if (view === null) throw new Error(`Failed to read back agent task '${spec.id}'`);
+this.fireAgentTaskWrite(op, view);
+return view;
+```
+
+In `patchAgentTaskStatus`, fire after transaction returns:
+
+```ts
+const view = tx.immediate();
+this.fireAgentTaskWrite("MODIFIED", view);
+return view;
+```
+
+Add private helper:
+
+```ts
+private fireAgentTaskWrite(op: "ADDED" | "MODIFIED", view: AgentTaskView): void {
+  try {
+    this.onAgentTaskWrite?.(op, view);
+  } catch {
+    return;
+  }
+}
+```
+
+- [ ] **Step 4: Extend WatchHubRecorder**
+
+Modify `src/local/watch-hub-recorder.ts`:
+
+```ts
+import { agentTaskViewToEntity, type AgentTaskView } from "../core/agent-task.js";
+
+export interface WatchHubRecorder {
+  contribution(op: WatchOp, c: Contribution): void;
+  claim(op: WatchOp, c: Claim): void;
+  agentSession(op: WatchOp, s: AgentSession): void;
+  agentTask(op: WatchOp, view: AgentTaskView): void;
+}
+```
+
+Update `safeRecord` kind union and entity union to include `AgentTask`, then add:
+
+```ts
+agentTask(op, view) {
+  safeRecord("AgentTask", op, agentTaskViewToEntity(view, namespace));
+},
+```
+
+- [ ] **Step 5: Wire local runtime**
+
+Modify `src/local/runtime.ts` inside the `if (options.watchHub)` block:
+
+```ts
+stores.agentTaskStore.onAgentTaskWrite = (op, view) => recorder.agentTask(op, view);
+```
+
+- [ ] **Step 6: Run tests to verify GREEN**
+
+Run:
+
+```bash
+bun test src/local/sqlite-agent-task-store.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/local/sqlite-store.ts src/local/sqlite-agent-task-store.test.ts src/local/watch-hub-recorder.ts src/local/runtime.ts
+git commit -m "feat: publish AgentTask local watch events"
+```
+
+## Task 5: HTTP AgentTask Watch Fan-Out
+
+**Files:**
+- Modify: `src/server/routes/agent-tasks.ts`
+- Modify: `tests/server/agent-tasks.test.ts`
+
+- [ ] **Step 1: Write failing route fan-out tests**
+
+Append to `tests/server/agent-tasks.test.ts`:
+
+```ts
+test("PUT /api/agent-tasks/:id emits AgentTask watch writes", async () => {
+  const events: Array<{ readonly op: string; readonly id: string }> = [];
+  const original = ctx.deps.watchHub.recordWrite.bind(ctx.deps.watchHub);
+  ctx.deps.watchHub.recordWrite = (event) => {
+    if (event.kind === "AgentTask") events.push({ op: event.op, id: event.entity.id });
+    return original(event);
+  };
+
+  await ctx.app.request("/api/agent-tasks/task-watch-route", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+    body: JSON.stringify(SPEC_BODY),
+  });
+  await ctx.app.request("/api/agent-tasks/task-watch-route", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+    body: JSON.stringify({ ...SPEC_BODY, prompt: "Updated route task" }),
+  });
+
+  expect(events).toEqual([
+    { op: "ADDED", id: "task-watch-route" },
+    { op: "MODIFIED", id: "task-watch-route" },
+  ]);
+});
+
+test("PATCH /api/agent-tasks/:id/status emits AgentTask watch writes", async () => {
+  const events: Array<{ readonly op: string; readonly id: string }> = [];
+  const original = ctx.deps.watchHub.recordWrite.bind(ctx.deps.watchHub);
+  ctx.deps.watchHub.recordWrite = (event) => {
+    if (event.kind === "AgentTask") events.push({ op: event.op, id: event.entity.id });
+    return original(event);
+  };
+  await ctx.app.request("/api/agent-tasks/task-watch-status", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+    body: JSON.stringify(SPEC_BODY),
+  });
+
+  const res = await ctx.app.request("/api/agent-tasks/task-watch-status/status", {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      ...TEST_AUTH_HEADERS,
+      ...TEST_CONTROLLER_HEADERS,
+    },
+    body: JSON.stringify({ phase: AgentTaskPhase.PendingBind }),
+  });
+
+  expect(res.status).toBe(200);
+  expect(events.at(-1)).toEqual({ op: "MODIFIED", id: "task-watch-status" });
+});
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+bun test tests/server/agent-tasks.test.ts
+```
+
+Expected: FAIL because no `AgentTask` watch events are emitted by the route.
+
+- [ ] **Step 3: Emit watch events from routes**
+
+Modify imports in `src/server/routes/agent-tasks.ts`:
+
+```ts
+import { AgentTaskPhase, agentTaskViewToEntity } from "../../core/agent-task.js";
+```
+
+In `PUT`, after `const view = await store.putAgentTaskSpec(spec);`:
+
+```ts
+const namespace = c.get("namespace");
+c.get("deps").watchHub.recordWrite({
+  kind: "AgentTask",
+  namespace,
+  op: existing === undefined ? "ADDED" : "MODIFIED",
+  entity: agentTaskViewToEntity(view, namespace),
+});
+return c.json(view, existing === undefined ? 201 : 200);
+```
+
+In `PATCH /:id/status`, after status patch:
+
+```ts
+const view = await store.patchAgentTaskStatus(c.req.param("id"), patch);
+const namespace = c.get("namespace");
+c.get("deps").watchHub.recordWrite({
+  kind: "AgentTask",
+  namespace,
+  op: "MODIFIED",
+  entity: agentTaskViewToEntity(view, namespace),
+});
+return c.json(view);
+```
+
+- [ ] **Step 4: Run test to verify GREEN**
+
+Run:
+
+```bash
+bun test tests/server/agent-tasks.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/routes/agent-tasks.ts tests/server/agent-tasks.test.ts
+git commit -m "feat: emit AgentTask watch events from HTTP routes"
+```
+
+## Task 6: Server Startup Controller Wiring
+
+**Files:**
+- Modify: `src/server/serve.ts`
+- Create: `src/server/task-controller-wiring.test.ts` if route-level testing cannot cover the helper
+
+- [ ] **Step 1: Extract shared runtime helper and write failing test**
+
+If direct testing of `serve.ts` is too expensive, create a small helper in `src/server/task-controller-wiring.ts`:
+
+```ts
+import type { AgentRuntime } from "../core/agent-runtime.js";
+import { selectRuntime } from "../core/select-runtime.js";
+import { TmuxRuntime } from "../core/tmux-runtime.js";
+
+export async function createServerAgentRuntime(): Promise<AgentRuntime> {
+  const picked = selectRuntime();
+  if (await picked.isAvailable()) return picked;
+  return new TmuxRuntime();
+}
+
+export function taskControllerEnabled(env: Readonly<Record<string, string | undefined>>): boolean {
+  return env.GROVE_TASK_CONTROLLER !== "0";
+}
+```
+
+Create `src/server/task-controller-wiring.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { taskControllerEnabled } from "./task-controller-wiring.js";
+
+describe("task controller server wiring", () => {
+  test("enables task controller by default and supports env opt-out", () => {
+    expect(taskControllerEnabled({})).toBe(true);
+    expect(taskControllerEnabled({ GROVE_TASK_CONTROLLER: "1" })).toBe(true);
+    expect(taskControllerEnabled({ GROVE_TASK_CONTROLLER: "0" })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+bun test src/server/task-controller-wiring.test.ts
+```
+
+Expected: FAIL because `task-controller-wiring.js` does not exist.
+
+- [ ] **Step 3: Implement helper and use it from serve**
+
+Add `src/server/task-controller-wiring.ts` as shown in Step 1.
+
+Modify `src/server/serve.ts` imports:
+
+```ts
+import { TaskController } from "../core/task-controller.js";
+import { createServerAgentRuntime, taskControllerEnabled } from "./task-controller-wiring.js";
+```
+
+Create one shared runtime before the `SessionService` block:
+
+```ts
+let sharedAgentRuntime: import("../core/agent-runtime.js").AgentRuntime | undefined;
+const getSharedAgentRuntime = async (): Promise<import("../core/agent-runtime.js").AgentRuntime> => {
+  sharedAgentRuntime ??= await createServerAgentRuntime();
+  return sharedAgentRuntime;
+};
+```
+
+Start the task controller after `deps` and before server start:
+
+```ts
+let taskController: TaskController | undefined;
+if (taskControllerEnabled(process.env) && runtime.agentTaskStore !== undefined) {
+  taskController = new TaskController({
+    taskStore: runtime.agentTaskStore,
+    runtime: await getSharedAgentRuntime(),
+    onError(error, taskId) {
+      const detail = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`[task-controller] ${taskId}: ${detail}\n`);
+    },
+  });
+  await taskController.resync();
+  taskController.start();
+  console.log("task-controller enabled");
+}
+```
+
+Update `SessionService` runtime selection:
+
+```ts
+const agentRuntime = await getSharedAgentRuntime();
+```
+
+Add task controller shutdown in `shutdown()` before `sessionService.destroy()`:
+
+```ts
+await taskController?.stop();
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+bun test src/server/task-controller-wiring.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/serve.ts src/server/task-controller-wiring.ts src/server/task-controller-wiring.test.ts
+git commit -m "feat: start task controller in grove server"
+```
+
+## Task 7: Final Verification And Issue Sweep
+
+**Files:**
+- Modify: files changed by Tasks 1-6 when type, lint, or test verification identifies a concrete defect.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+bun test src/core/task-controller.test.ts src/core/informer.test.ts src/local/sqlite-agent-task-store.test.ts tests/server/agent-tasks.test.ts src/server/task-controller-wiring.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run lint/check**
+
+Run:
+
+```bash
+bun run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full test suite if focused checks pass**
+
+Run:
+
+```bash
+bun test --timeout 60000
+```
+
+Expected: PASS. If this is too slow for the local environment, record the timeout or failing test names in the final handoff.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+git diff --check
+```
+
+Expected: only intentional files changed and no whitespace errors.
+
+- [ ] **Step 6: Commit final fixes**
+
+```bash
+git add src/core src/local src/server tests docs/superpowers/plans/2026-05-14-task-controller-reconcile-loop.md
+git commit -m "test: verify task controller integration"
+```
+
+## Self-Review Notes
+
+- Spec coverage: Tasks 1-2 cover controller loop, binder, retry, and failure convergence. Tasks 3-5 cover watch/informer and write fan-out. Task 6 covers default server startup and shared runtime. Task 7 covers verification.
+- Placeholder scan: no deferred implementation markers are used in the task steps.
+- Type consistency: the plan consistently uses `TaskController`, `DefaultTaskBinder`, `TaskControllerStore`, `TaskControllerRuntime`, `AgentTaskStatusTransition`, and `AgentTaskStatusPatch`.

--- a/docs/superpowers/specs/2026-05-14-task-controller-reconcile-loop-design.md
+++ b/docs/superpowers/specs/2026-05-14-task-controller-reconcile-loop-design.md
@@ -1,0 +1,332 @@
+# Task Controller Reconcile Loop Design
+
+## Summary
+
+Issue #299 adds a Kubernetes-style `AgentTask` controller that owns task status convergence. The controller watches `AgentTask` records, enqueues task keys, runs an idempotent `syncHandler(taskId)`, and performs one durable step per reconcile: catch up observed generation, block on dependencies, bind/spawn ready tasks, reattach live sessions after restart, or mark missing/crashed sessions failed.
+
+This PR should be a full vertical slice for #299. It includes controller logic, local watch/informer support for `AgentTask`, server watch fan-out for task writes, runtime binding through `AgentRuntime`, and failure-injected convergence tests. It intentionally does not implement the configurable scheduler plugin framework from #300; the bind decision is kept behind a narrow interface so #300 can replace it without rewriting the controller.
+
+## Goals
+
+- Add a `TaskController` with a rate-limited keyed work queue and exponential retry on reconcile errors.
+- Support `AgentTask` informers by extending the watch protocol, local watch client types, and server list/watch routes.
+- Keep `syncHandler(taskId)` level-triggered and idempotent: read current world state, compute one next step, persist status, return.
+- Spawn ready tasks via `AgentRuntime` and record `status.sessionId` durably.
+- Treat restart reattachment as normal reconciliation by comparing `status.sessionId` with `AgentRuntime.listSessions()`.
+- Recover automatically after controller crashes or process restarts without manual repair.
+- Add unit tests that inject failures at every meaningful reconcile step and verify repeated reconcile converges.
+- Preserve the spec/status split from #297: controller writes status only and never mutates task spec.
+
+## Non-Goals
+
+- Do not implement #300's Filter/Score/Permit/Bind plugin framework in this PR.
+- Do not add trigger adapters from #379.
+- Do not add one-shot termination, output schema validation, or retry policy semantics from #359.
+- Do not add plan/shard/merge orchestration from #358.
+- Do not change TUI task creation flows beyond what is needed for the new watch kind to be observable.
+- Do not add cross-process leader election. This controller is safe and idempotent, but active-active deployment coordination belongs in a later scheduler/controller-manager issue.
+
+## Current State
+
+`AgentTask` already has split spec/status records in `src/core/agent-task.ts` and `AgentTaskStore` exposes:
+
+- `putAgentTaskSpec`
+- `getAgentTask`
+- `listAgentTasks`
+- `patchAgentTaskStatus`
+- `listAgentTaskEntities`
+
+The HTTP API has `PUT /api/agent-tasks/:id` for spec writes and `PATCH /api/agent-tasks/:id/status` for controller-owned status writes guarded by `X-Grove-Controller-Token`.
+
+The codebase also already has reusable controller infrastructure:
+
+- `KeyedWorkQueue` in `src/core/workqueue.ts`
+- `ClaimReconciliationController` in `src/core/claim-controller.ts`
+- `Informer` and `InformerFactory` in `src/core/informer.ts`
+
+The watch protocol currently supports `Contribution`, `Claim`, and `AgentSession`. `AgentTask` can be projected as an entity through `agentTaskViewToEntity`, but the watch API and informer type mapping do not yet include it.
+
+## Architecture
+
+Add `src/core/task-controller.ts` as the core controller module. It should follow the shape of `ClaimReconciliationController`:
+
+- constructor-injected stores, runtime, queue, clock, callbacks, and options
+- `enqueue(taskId)`
+- `enqueueFromEntity(entity)`
+- `resync()`
+- `syncHandler(taskId)` or `reconcileTask(taskId)` public test hook
+- `start()`
+- `stop()`
+
+The controller depends on a narrow store/runtime surface:
+
+```ts
+export type TaskControllerStore = Pick<
+  AgentTaskStore,
+  "getAgentTask" | "listAgentTaskEntities" | "patchAgentTaskStatus"
+>;
+
+export type TaskControllerRuntime = Pick<
+  AgentRuntime,
+  "spawn" | "listSessions" | "close"
+>;
+```
+
+Add an injectable binder boundary:
+
+```ts
+export interface TaskBindRequest {
+  readonly task: AgentTaskView;
+}
+
+export interface TaskBindResult {
+  readonly session: AgentSession;
+}
+
+export interface TaskBinder {
+  bind(request: TaskBindRequest): Promise<TaskBindResult>;
+}
+```
+
+The default binder maps `AgentTaskSpecRecord` into `AgentRuntime.spawn()`:
+
+- `role` from `task.spec.role`
+- `cwd` from `task.spec.worktree`
+- `command` and `platform` from `task.spec.runtime` using the same runtime/platform conventions already used by Grove agent spawning
+- `prompt` and `goal` from `task.spec.prompt`
+- `model` from `task.spec.budget.model` only if the value is a string
+- `maxTurns` and richer budget policy are recorded on the task but not enforced in this PR
+
+#300 can later replace this simple binder with scheduler Filter/Score/Permit/Bind plugins.
+
+## Reconcile State Machine
+
+Each reconcile reads the latest task and current sessions before deciding. Stale informer payloads are never trusted for status writes.
+
+### Missing Task
+
+If `getAgentTask(taskId)` returns `undefined`, reconciliation succeeds with no patch. This handles delete races and stale queue items.
+
+### Terminal Tasks
+
+For `Succeeded` and `Failed`, the controller does not regress phase. If `status.observedGeneration < spec.generation`, it may patch only `observedGeneration` and a condition explaining that the terminal task observed a later spec generation without reopening.
+
+### Dependency Blocking
+
+If `spec.dependsOn` contains task IDs whose current phase is not terminal success, the controller keeps the task in `Pending`, sets `observedGeneration` to the current spec generation, and upserts a `Blocked` condition:
+
+- `type: "Blocked"`
+- `status: "True"`
+- `reason: "depends-on"`
+- `message: "Waiting for task-a, task-b"`
+
+When all dependencies are satisfied, the controller clears or flips the `Blocked` condition to `False` as part of the next transition.
+
+The first implementation can resolve dependencies through the same `TaskControllerStore.getAgentTask` method. It should treat missing dependencies as blocked, not failed, because trigger adapters may create tasks out of order.
+
+### Pending Bind
+
+For ready tasks in `Pending`, the controller should perform one durable pre-bind step:
+
+- phase: `PendingBind`
+- observedGeneration: current spec generation
+- condition `Scheduled=True`, reason `ready-to-bind`
+- `lastTransitionAt`: now
+
+This phase is the crash recovery marker. If the controller dies after deciding a task is ready but before spawn, the restarted controller sees `PendingBind` and continues with bind.
+
+### Binding And Spawn
+
+For `PendingBind` tasks without `status.sessionId`, the controller calls the binder. On success it patches:
+
+- phase: `Running`
+- sessionId: returned session ID
+- observedGeneration: current spec generation
+- condition `Bound=True`, reason `session-bound`
+- condition `Running=True`, reason `session-running`
+- `lastTransitionAt`: now
+
+If binder/spawn throws, the worker retries the task through `KeyedWorkQueue.retry()`. It should not patch `Failed` for transient spawn errors in the first failed attempt. The queue retry backoff handles transient runtime availability problems.
+
+### Running Reattach
+
+For `Running` tasks with `status.sessionId`, the controller compares the ID with `runtime.listSessions()`.
+
+Live session states:
+
+- `running`
+- `idle`
+
+For live sessions, reconciliation succeeds. If conditions are stale or `observedGeneration` lags, the controller patches only status metadata and conditions. This is the primary restart behavior: after `kill -9`, a new controller lists live ACP sessions, sees that `status.sessionId` is still present, and reattaches by doing nothing destructive.
+
+Missing or dead session states:
+
+- missing from `listSessions()`
+- `stopped`
+- `crashed`
+
+For missing/dead sessions, the controller patches:
+
+- phase: `Failed`
+- condition `Running=False`, reason `session-lost`
+- condition `Failed=True`, reason `session-lost`
+- `lastTransitionAt`: now
+
+This closes the gap where a task claims to be running but the runtime no longer has the process.
+
+### Contributions And Success
+
+This PR should not invent one-shot completion semantics. The controller preserves `status.contributions` and does not mark `Succeeded` based solely on runtime idleness. Completion will be driven later by explicit task completion paths from one-shot execution (#359), trigger adapters (#379), or MCP/tool events.
+
+The controller may keep a `completeTask(taskId, contributions)` helper out of scope unless an existing route/tool already writes task success.
+
+## Conditions
+
+Use the condition types already declared in `AgentTaskConditionType`:
+
+- `Blocked`
+- `Scheduled`
+- `Bound`
+- `Running`
+- `Failed`
+
+Condition writes must preserve unknown condition types. Controller-owned condition updates should upsert by `type`, update `lastTransitionTime` only when status/reason/message changes, and keep previous timestamps when the condition is unchanged.
+
+Reason strings should be stable:
+
+- `depends-on`
+- `ready-to-bind`
+- `session-bound`
+- `session-running`
+- `session-lost`
+- `observed-generation-current`
+- `terminal-observed-generation`
+
+## Watch And Informer Support
+
+Extend `WatchKind` and `WatchEntity` to include `AgentTask`.
+
+Update `EntityForKind<K>` in `src/core/informer.ts` so `Informer<"AgentTask">` returns `AgentTaskEntity`.
+
+Update server watch routes:
+
+- include `AgentTask` in `KIND_VALUES`
+- include `AgentTask` in `SUPPORTED_KINDS`
+- make `listForKind` call `deps.agentTaskStore.listAgentTaskEntities()`
+- return `501` when `agentTaskStore` is absent
+- support `POST /api/watch/notify` hydration for `AgentTask` if cross-process task writes need fan-out
+
+Update `agent-tasks` HTTP routes so spec and status writes call `watchHub.recordWrite()` with `AgentTask` entities after successful store writes.
+
+Update local runtime watch recorder so SQLite task writes can fan out to a local watch hub. Add an `onAgentTaskWrite` callback to `SqliteAgentTaskStore`, mirroring contribution and claim write hooks.
+
+The controller can be wired directly to an informer when available:
+
+- event handler enqueues the task ID for all add/modify/delete events
+- sync handler triggers `resync()` after relist completion
+
+When no informer is available, periodic `resync()` still gives convergence.
+
+## Server And Runtime Wiring
+
+Server startup should enable the controller by default when `agentTaskStore` is configured. Operators can disable it with `GROVE_TASK_CONTROLLER=0` for diagnostics or deployments that only want the HTTP task API.
+
+`server/serve.ts` should create one shared `AgentRuntime` with `selectRuntime()` and the existing `TmuxRuntime` fallback. That runtime is reused by both `TaskController` and `SessionService` when both are enabled, so the process has one authoritative `listSessions()` view.
+
+In local in-process mode, the controller uses the store directly instead of calling HTTP status routes. The controller token remains required for external HTTP status writes.
+
+The controller exposes a clean `stop()` path and is included in server shutdown cleanup.
+
+Recommended options:
+
+```ts
+export interface TaskControllerOptions {
+  readonly taskStore: TaskControllerStore;
+  readonly runtime: TaskControllerRuntime;
+  readonly binder?: TaskBinder | undefined;
+  readonly queue?: KeyedWorkQueue | undefined;
+  readonly resyncIntervalMs?: number | undefined;
+  readonly workerCount?: number | undefined;
+  readonly now?: (() => number) | undefined;
+  readonly onError?: ((error: unknown, taskId: string) => void) | undefined;
+  readonly onTransition?: ((transition: AgentTaskStatusTransition) => void) | undefined;
+}
+```
+
+Defaults should match the claim controller unless a task-specific value is needed:
+
+- `resyncIntervalMs`: 30 seconds
+- `workerCount`: 1
+- queue defaults from `KeyedWorkQueue`
+
+## Crash Recovery
+
+The important invariant is "persist before external ambiguity where possible, and reconcile after ambiguity."
+
+Crash windows:
+
+1. Before `Pending -> PendingBind` patch: restart sees `Pending` and repeats readiness checks.
+2. After `PendingBind` patch but before spawn: restart sees `PendingBind` without `sessionId` and spawns.
+3. After spawn but before `Running/sessionId` patch: this is the one non-atomic external side effect. The default binder includes `GROVE_AGENT_TASK_ID`, `GROVE_AGENT_TASK_GENERATION`, and `GROVE_AGENT_TASK_RUNTIME` in `AgentConfig.env` so runtimes and diagnostics can correlate the child process to the task. If a runtime cannot rediscover that metadata after a process restart, the controller may spawn a duplicate in this narrow window. Full exactly-once spawn is deferred to #300/#305 reservation and CAS work.
+4. After `Running/sessionId` patch: restart lists sessions and reattaches if live.
+5. While reconciling running task: restart repeats the same session comparison and converges.
+
+The acceptance criterion "kill -9 controller mid-sync -> restart reattaches all live sessions" is satisfied for tasks that reached the durable `Running/sessionId` state before the kill, and for runtimes whose `listSessions()` can rediscover task-associated sessions. The tests cover durable reattach and injected failures around each store/runtime call.
+
+## Testing
+
+Add `src/core/task-controller.test.ts` with fake store, fake runtime, fake binder, fake queue/clock helpers. Follow the style of `claim-controller.test.ts`.
+
+Core cases:
+
+- rejects invalid `resyncIntervalMs` and `workerCount`
+- missing task is a no-op
+- terminal tasks do not regress
+- stale observed generation is patched without spec mutation
+- dependencies block pending tasks
+- satisfied dependencies move `Pending -> PendingBind`
+- `PendingBind` binds/spawns and patches `Running` with `sessionId`
+- running task with live session is a no-op or metadata catch-up
+- running task with missing session becomes `Failed`
+- running task with crashed/stopped session becomes `Failed`
+- `resync()` enqueues all task entity IDs
+- worker retry re-reads fresh state after a failed reconcile
+- throwing `onError` does not prevent retry
+- `stop()` cancels queue workers
+
+Failure-injection convergence:
+
+- Build a fake store/runtime that can throw once at each named step:
+  - read task
+  - read dependencies
+  - patch `PendingBind`
+  - spawn/bind
+  - patch `Running`
+  - list sessions
+  - patch `Failed`
+- For each injection point, call reconcile or run the worker until the injected error is observed, then clear the failure and re-enqueue. Assert final task status converges.
+
+Watch/informer tests:
+
+- `AgentTask` appears in watch list responses when store is configured.
+- spec writes emit `ADDED`/`MODIFIED` AgentTask watch events.
+- status writes emit `MODIFIED` AgentTask watch events.
+- `InformerFactory.informerFor("AgentTask")` caches and lists task entities.
+
+Integration-style local test:
+
+- create a task, run controller to `Running`, create a second controller with the same store/runtime, call `resync()`, and verify it reattaches by leaving the live `sessionId` untouched.
+
+## Risks
+
+- The spawn call cannot be made fully atomic with the status patch. This PR reduces the risk with `PendingBind`, durable `sessionId`, and reattach checks, but exactly-once spawn needs later reservation/CAS work.
+- Adding `AgentTask` to watch increases the typed surface area for `WatchKind`; all exhaustive switch statements must be updated.
+- Direct in-process controller writes bypass the HTTP controller-token check by design. The security boundary remains at HTTP routes; in-process code already has direct store authority.
+- Completion semantics are intentionally conservative. A running session becoming idle does not automatically mean the task succeeded.
+
+## Implementation Decisions
+
+- The controller starts by default in `grove-server`; `GROVE_TASK_CONTROLLER=0` disables it.
+- The server uses one shared `AgentRuntime` for task control and WebSocket `SessionService`.
+- The default binder stamps task correlation into `AgentConfig.env`; exact-once recovery for spawn-before-status-patch crashes remains deferred to reservation/CAS work.
+- `PendingBind` remains a real API phase and the TUI may render it with the existing AgentTask phase chip vocabulary.

--- a/src/core/agent-task.test.ts
+++ b/src/core/agent-task.test.ts
@@ -71,7 +71,20 @@ describe("AgentTask entity projection", () => {
     expect(entity.observedGeneration).toBe(1);
     expect(entity.metadata.generation).toBe(2);
     expect(entity.metadata.creationTimestamp).toBe("2026-05-13T11:00:00.000Z");
-    expect(entity.resourceVersion).toBe("5");
+    expect(entity.resourceVersion).toBe("7:2:5");
+  });
+
+  test("resourceVersion changes when spec generation or status revision changes", () => {
+    const base = agentTaskViewToEntity(taskView());
+    const specUpdated = agentTaskViewToEntity(
+      taskView({ spec: { ...taskView().spec, generation: 3 } }),
+    );
+    const statusUpdated = agentTaskViewToEntity(
+      taskView({ status: { ...taskView().status, revision: 6 } }),
+    );
+
+    expect(specUpdated.resourceVersion).not.toBe(base.resourceVersion);
+    expect(statusUpdated.resourceVersion).not.toBe(base.resourceVersion);
   });
 
   test("detects stale specs when status has not observed current generation", () => {

--- a/src/core/agent-task.ts
+++ b/src/core/agent-task.ts
@@ -78,6 +78,9 @@ export interface AgentTaskStatus {
 export type AgentTaskEntity = Entity<"AgentTask", AgentTaskSpec, AgentTaskStatus>;
 
 export function agentTaskViewToEntity(view: AgentTaskView, namespace = "default"): AgentTaskEntity {
+  // WatchClient parses the leading numeric prefix for snapshot dedup ordering.
+  const resourceVersionPrefix = view.spec.generation + view.status.revision;
+  const resourceVersion = `${resourceVersionPrefix}:${view.spec.generation}:${view.status.revision}`;
   return {
     kind: "AgentTask",
     namespace,
@@ -100,7 +103,7 @@ export function agentTaskViewToEntity(view: AgentTaskView, namespace = "default"
     },
     conditions: view.status.conditions,
     observedGeneration: view.status.observedGeneration,
-    resourceVersion: String(view.status.revision),
+    resourceVersion,
     metadata: {
       generation: view.spec.generation,
       creationTimestamp: view.spec.createdAt,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -327,6 +327,16 @@ export type {
 export { ExpiryReason } from "./store.js";
 export { type SpawnOptions, type SpawnResult, spawnCommand, spawnOrThrow } from "./subprocess.js";
 export { SubprocessRuntime } from "./subprocess-runtime.js";
+export type {
+  AgentTaskStatusTransition,
+  TaskBinder,
+  TaskBindRequest,
+  TaskBindResult,
+  TaskControllerOptions,
+  TaskControllerRuntime,
+  TaskControllerStore,
+} from "./task-controller.js";
+export { DefaultTaskBinder, TaskController } from "./task-controller.js";
 export { toUtcIso } from "./time.js";
 export { TmuxRuntime } from "./tmux-runtime.js";
 export { resolveTopology } from "./topology-resolver.js";

--- a/src/core/informer.test.ts
+++ b/src/core/informer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { AgentTaskPhase, type AgentTaskView, agentTaskViewToEntity } from "./agent-task.js";
 import { Informer, InformerFactory } from "./informer.js";
 import type { WatchClientEvent } from "./watch-client.js";
 import { WatchClient } from "./watch-client.js";
@@ -92,6 +93,38 @@ const E_B: WatchEntity = {
   id: "cid-b",
   resourceVersion: "1",
 } as unknown as WatchEntity;
+
+const AGENT_TASK_VIEW: AgentTaskView = {
+  spec: {
+    id: "task-a",
+    worktree: "/tmp/worktree",
+    runtime: "codex",
+    role: "worker",
+    prompt: "Implement task",
+    dependsOn: [],
+    generation: 1,
+    createdAt: "2026-05-14T12:00:00.000Z",
+  },
+  status: {
+    id: "task-a",
+    phase: AgentTaskPhase.Pending,
+    contributions: [],
+    conditions: [],
+    observedGeneration: 0,
+    lastTransitionAt: "2026-05-14T12:00:00.000Z",
+    revision: 1,
+  },
+};
+
+const AGENT_TASK_ENTITY = agentTaskViewToEntity(AGENT_TASK_VIEW);
+const AGENT_TASK_SPEC_UPDATED_ENTITY = agentTaskViewToEntity({
+  spec: {
+    ...AGENT_TASK_VIEW.spec,
+    prompt: "Implement updated task",
+    generation: 2,
+  },
+  status: AGENT_TASK_VIEW.status,
+});
 
 function sse(event: string, data: unknown, id?: string): string {
   const idLine = id ? `id: ${id}\n` : "";
@@ -456,6 +489,57 @@ describe("Informer Replace reconciliation on relist", () => {
     expect(
       (informer.getById("cid-a") as { resourceVersion: string } | undefined)?.resourceVersion,
     ).toBe("2");
+  });
+
+  test("AgentTask spec-only update on relist → MODIFIED handler fired", async () => {
+    const events: Array<{ op: string; id: string; rv: string; generation: number }> = [];
+    const ac = new AbortController();
+    let step = 0;
+    const fetchImpl: typeof fetch = (async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/list")) {
+        step += 1;
+        const items = step === 1 ? [AGENT_TASK_ENTITY] : [AGENT_TASK_SPEC_UPDATED_ENTITY];
+        return new Response(
+          JSON.stringify({ items, listResourceVersion: step === 1 ? "5" : "10" }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (step === 1) {
+        return new Response(sse("ERROR", { code: 410 }, "5"), {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      ac.abort();
+      return new Response("", { headers: { "Content-Type": "text/event-stream" } });
+    }) as typeof fetch;
+
+    const informer = new Informer(
+      new WatchClient({
+        baseUrl: "http://t",
+        kind: "AgentTask",
+        authHeader: "Bearer x",
+        fetch: fetchImpl,
+        backoff: { minMs: 0, maxMs: 0, jitter: 0 },
+      }),
+      "AgentTask",
+    );
+    informer.addEventHandler((op, entity) => {
+      events.push({
+        op,
+        id: entity.id,
+        rv: entity.resourceVersion,
+        generation: entity.metadata.generation,
+      });
+    });
+    await informer.run(ac.signal);
+
+    const modifiedTask = events.find(
+      (e) => e.op === "MODIFIED" && e.id === "task-a" && e.generation === 2,
+    );
+    expect(modifiedTask).toBeDefined();
+    expect(modifiedTask?.rv).toBe(AGENT_TASK_SPEC_UPDATED_ENTITY.resourceVersion);
+    expect(informer.getById("task-a")?.metadata.generation).toBe(2);
   });
 
   test("unchanged item on relist → no handler called for it", async () => {

--- a/src/core/informer.test.ts
+++ b/src/core/informer.test.ts
@@ -685,6 +685,25 @@ describe("InformerFactory memoization", () => {
     expect(informer).toBeDefined();
   });
 
+  test("InformerFactory supports AgentTask in local and remote modes", () => {
+    const localFactory = new InformerFactory({
+      mode: "local",
+      hub: new WatchHub(),
+      namespace: "default",
+      listFn: () => [],
+    });
+    expect(localFactory.supportsKind("AgentTask")).toBe(true);
+    expect(localFactory.informerFor("AgentTask")).toBeDefined();
+
+    const remoteFactory = new InformerFactory({
+      mode: "remote",
+      baseUrl: "http://localhost:4515",
+      authHeader: "Bearer test",
+    });
+    expect(remoteFactory.supportsKind("AgentTask")).toBe(true);
+    expect(remoteFactory.informerFor("AgentTask")).toBeDefined();
+  });
+
   test("separate factories for separate namespaces use distinct instances", () => {
     // Each namespace gets its own factory (and its own authHeader that encodes
     // the namespace server-side). Two factories for different namespaces must
@@ -733,7 +752,9 @@ describe("Informer run() safety", () => {
     await expect(informer.run(ac.signal)).rejects.toThrow(/already running/);
     // Clean up
     ac.abort();
-    await firstRun.catch(() => {});
+    await firstRun.catch(() => {
+      /* abort rejects the blocked fake fetch */
+    });
   });
 
   test("abort unblocks run() even if a handler promise is still pending", async () => {

--- a/src/core/informer.ts
+++ b/src/core/informer.ts
@@ -9,6 +9,7 @@
  * gate first render on a fully-populated cache (no empty-flash).
  */
 
+import type { AgentTaskEntity } from "./agent-task.js";
 import type { AgentSessionEntity, ClaimEntity, ContributionEntity } from "./entity.js";
 import { LocalWatchClient } from "./local-watch-client.js";
 import { WatchClient, type WatchClientOp, type WatchClientOptions } from "./watch-client.js";
@@ -22,7 +23,9 @@ export type EntityForKind<K extends WatchKind> = K extends "Contribution"
     ? ClaimEntity
     : K extends "AgentSession"
       ? AgentSessionEntity
-      : never;
+      : K extends "AgentTask"
+        ? AgentTaskEntity
+        : never;
 
 export type InformerOp = "ADDED" | "MODIFIED" | "DELETED";
 
@@ -466,17 +469,18 @@ interface RunningInformer {
  *
  * Remote: AgentSession is excluded because the grove-server `/api/list`
  * route currently returns 501 NOT_CONFIGURED for it (handler exists, list
- * source not wired). Re-add once server support lands.
+ * source not wired). AgentTask is backed by the server task store when
+ * configured.
  *
- * Local: AgentSession is supported — the in-process `WatchHub` plus
- * `agentRuntime.listSessions()` snapshot covers it without any server
- * route. PR2 (#388) wires this in via `LocalRuntime` + `tui/main.ts`.
+ * Local: AgentSession and AgentTask are supported — the in-process
+ * `WatchHub` plus caller-provided list snapshots cover them without any
+ * server route.
  *
  * Asking for an unsupported kind throws — louder than handing back an
  * informer that would silently never sync.
  */
-const REMOTE_KINDS: readonly WatchKind[] = ["Contribution", "Claim"];
-const LOCAL_KINDS: readonly WatchKind[] = ["Contribution", "Claim", "AgentSession"];
+const REMOTE_KINDS: readonly WatchKind[] = ["Contribution", "Claim", "AgentTask"];
+const LOCAL_KINDS: readonly WatchKind[] = ["Contribution", "Claim", "AgentSession", "AgentTask"];
 
 const REMOTE_SUPPORTED = new Set<WatchKind>(REMOTE_KINDS);
 const LOCAL_SUPPORTED = new Set<WatchKind>(LOCAL_KINDS);

--- a/src/core/task-controller.test.ts
+++ b/src/core/task-controller.test.ts
@@ -28,6 +28,7 @@ interface RecordedPatch {
 class FakeTaskStore implements TaskControllerStore {
   readonly views = new Map<string, AgentTaskView>();
   readonly patches: RecordedPatch[] = [];
+  patchError: Error | undefined;
 
   seed(view: AgentTaskView): void {
     this.views.set(view.spec.id, view);
@@ -41,6 +42,7 @@ class FakeTaskStore implements TaskControllerStore {
     taskId: string,
     patch: AgentTaskStatusPatch,
   ): Promise<AgentTaskView> => {
+    if (this.patchError !== undefined) throw this.patchError;
     const current = this.views.get(taskId);
     if (current === undefined) throw new Error(`missing task ${taskId}`);
     this.patches.push({ taskId, patch });
@@ -66,6 +68,7 @@ class FakeTaskStore implements TaskControllerStore {
 
 class FakeRuntime implements TaskControllerRuntime {
   readonly spawnCalls: Array<{ readonly role: string; readonly config: AgentConfig }> = [];
+  readonly closeCalls: AgentSession[] = [];
   readonly sessions = new Map<string, AgentSession>();
   private nextId = 1;
 
@@ -86,6 +89,7 @@ class FakeRuntime implements TaskControllerRuntime {
   listSessions = async (): Promise<readonly AgentSession[]> => [...this.sessions.values()];
 
   close = async (session: AgentSession): Promise<void> => {
+    this.closeCalls.push(session);
     this.sessions.delete(session.id);
   };
 }
@@ -170,6 +174,18 @@ function condition(
   return conditions?.find((candidate) => candidate.type === type);
 }
 
+function makeCondition(type: string, overrides: Partial<Condition> = {}): Condition {
+  return {
+    type,
+    status: "True",
+    observedGeneration: 1,
+    lastTransitionTime: FIXED_NOW_ISO,
+    reason: "seeded",
+    message: "",
+    ...overrides,
+  };
+}
+
 describe("TaskController transitions", () => {
   test("missing tasks are successful no-ops", async () => {
     const store = new FakeTaskStore();
@@ -225,6 +241,28 @@ describe("TaskController transitions", () => {
     });
   });
 
+  test("pending tasks that are already blocked do not patch unchanged status", async () => {
+    const store = new FakeTaskStore();
+    store.seed(
+      taskView({
+        observedGeneration: 1,
+        dependsOn: ["task-a", "task-b"],
+        conditions: [
+          makeCondition("Blocked", {
+            reason: "depends-on",
+            message: "Waiting for task-a, task-b",
+          }),
+        ],
+      }),
+    );
+    const controller = controllerFor(store);
+
+    const transition = await controller.reconcileTask("task-1");
+
+    expect(transition).toBeUndefined();
+    expect(store.patches).toEqual([]);
+  });
+
   test("pending tasks with satisfied dependencies move to PendingBind", async () => {
     const store = new FakeTaskStore();
     store.seed(taskView({ id: "task-a", phase: AgentTaskPhase.Succeeded, observedGeneration: 1 }));
@@ -235,6 +273,43 @@ describe("TaskController transitions", () => {
 
     const patch = onlyPatch(store).patch;
     expect(patch.phase).toBe(AgentTaskPhase.PendingBind);
+    expect(condition(patch.conditions, "Scheduled")).toEqual({
+      type: "Scheduled",
+      status: "True",
+      observedGeneration: 1,
+      lastTransitionTime: FIXED_NOW_ISO,
+      reason: "ready-to-bind",
+      message: "",
+    });
+  });
+
+  test("pending tasks clear stale Blocked condition when dependencies become satisfied", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ id: "task-a", phase: AgentTaskPhase.Succeeded, observedGeneration: 1 }));
+    store.seed(
+      taskView({
+        dependsOn: ["task-a"],
+        conditions: [
+          makeCondition("Blocked", {
+            reason: "depends-on",
+            message: "Waiting for task-a",
+          }),
+        ],
+      }),
+    );
+    const controller = controllerFor(store);
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(condition(patch.conditions, "Blocked")).toEqual({
+      type: "Blocked",
+      status: "False",
+      observedGeneration: 1,
+      lastTransitionTime: FIXED_NOW_ISO,
+      reason: "ready-to-bind",
+      message: "",
+    });
     expect(condition(patch.conditions, "Scheduled")).toEqual({
       type: "Scheduled",
       status: "True",
@@ -273,6 +348,20 @@ describe("TaskController transitions", () => {
       reason: "session-running",
       message: "",
     });
+  });
+
+  test("PendingBind tasks close spawned sessions when Running patch fails", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    store.patchError = new Error("patch failed");
+    const runtime = new FakeRuntime();
+    const controller = controllerFor(store, { runtime });
+
+    await expect(controller.reconcileTask("task-1")).rejects.toThrow("patch failed");
+
+    expect(runtime.spawnCalls).toHaveLength(1);
+    expect(runtime.closeCalls.map((session) => session.id)).toEqual(["session-1"]);
+    expect(runtime.sessions.has("session-1")).toBe(false);
   });
 
   test("running tasks reattach when the session is live", async () => {
@@ -320,6 +409,36 @@ describe("TaskController transitions", () => {
       reason: "session-lost",
       message: "",
     });
+  });
+
+  test("running tasks clear stale Running condition when the session is missing", async () => {
+    const store = new FakeTaskStore();
+    store.seed(
+      taskView({
+        phase: AgentTaskPhase.Running,
+        observedGeneration: 1,
+        sessionId: "session-missing",
+        conditions: [
+          makeCondition("Running", {
+            reason: "session-running",
+          }),
+        ],
+      }),
+    );
+    const controller = controllerFor(store, { runtime: new FakeRuntime() });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(condition(patch.conditions, "Running")).toEqual({
+      type: "Running",
+      status: "False",
+      observedGeneration: 1,
+      lastTransitionTime: FIXED_NOW_ISO,
+      reason: "session-lost",
+      message: "",
+    });
+    expect(condition(patch.conditions, "Failed")?.reason).toBe("session-lost");
   });
 });
 

--- a/src/core/task-controller.test.ts
+++ b/src/core/task-controller.test.ts
@@ -512,8 +512,7 @@ describe("TaskController worker lifecycle", () => {
     const count = await controller.resync();
 
     expect(count).toBe(2);
-    await expect(queue.take()).resolves.toEqual({ key: "task-a", attempt: 0 });
-    await expect(queue.take()).resolves.toEqual({ key: "task-b", attempt: 0 });
+    expect(queue.pendingKeys()).toEqual(["task-a", "task-b"]);
   });
 
   test("failed worker reconcile retries and re-reads fresh task state", async () => {

--- a/src/core/task-controller.test.ts
+++ b/src/core/task-controller.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentConfig, AgentSession } from "./agent-runtime.js";
+import {
+  type AgentTaskEntity,
+  AgentTaskPhase,
+  type AgentTaskStatusRecord,
+  type AgentTaskView,
+  agentTaskViewToEntity,
+} from "./agent-task.js";
+import type { Condition } from "./entity.js";
+import type { AgentTaskStatusPatch } from "./store.js";
+import {
+  DefaultTaskBinder,
+  type TaskBinder,
+  TaskController,
+  type TaskControllerRuntime,
+  type TaskControllerStore,
+} from "./task-controller.js";
+
+const FIXED_NOW_MS = Date.parse("2026-05-14T12:00:00.000Z");
+const FIXED_NOW_ISO = "2026-05-14T12:00:00.000Z";
+
+interface RecordedPatch {
+  readonly taskId: string;
+  readonly patch: AgentTaskStatusPatch;
+}
+
+class FakeTaskStore implements TaskControllerStore {
+  readonly views = new Map<string, AgentTaskView>();
+  readonly patches: RecordedPatch[] = [];
+
+  seed(view: AgentTaskView): void {
+    this.views.set(view.spec.id, view);
+  }
+
+  getAgentTask = async (taskId: string): Promise<AgentTaskView | undefined> => {
+    return this.views.get(taskId);
+  };
+
+  patchAgentTaskStatus = async (
+    taskId: string,
+    patch: AgentTaskStatusPatch,
+  ): Promise<AgentTaskView> => {
+    const current = this.views.get(taskId);
+    if (current === undefined) throw new Error(`missing task ${taskId}`);
+    this.patches.push({ taskId, patch });
+    const status: AgentTaskStatusRecord = {
+      ...current.status,
+      phase: patch.phase ?? current.status.phase,
+      sessionId: patch.sessionId ?? current.status.sessionId,
+      contributions: patch.contributions ?? current.status.contributions,
+      conditions: patch.conditions ?? current.status.conditions,
+      observedGeneration: patch.observedGeneration ?? current.status.observedGeneration,
+      lastTransitionAt: patch.lastTransitionAt ?? current.status.lastTransitionAt,
+      revision: current.status.revision + 1,
+    };
+    const updated: AgentTaskView = { spec: current.spec, status };
+    this.views.set(taskId, updated);
+    return updated;
+  };
+
+  listAgentTaskEntities = async (): Promise<readonly AgentTaskEntity[]> => {
+    return [...this.views.values()].map((view) => agentTaskViewToEntity(view));
+  };
+}
+
+class FakeRuntime implements TaskControllerRuntime {
+  readonly spawnCalls: Array<{ readonly role: string; readonly config: AgentConfig }> = [];
+  readonly sessions = new Map<string, AgentSession>();
+  private nextId = 1;
+
+  spawn = async (role: string, config: AgentConfig): Promise<AgentSession> => {
+    this.spawnCalls.push({ role, config });
+    const session: AgentSession = {
+      id: `session-${this.nextId}`,
+      role,
+      status: "running",
+      platform: config.platform,
+      model: config.model,
+    };
+    this.nextId += 1;
+    this.sessions.set(session.id, session);
+    return session;
+  };
+
+  listSessions = async (): Promise<readonly AgentSession[]> => [...this.sessions.values()];
+
+  close = async (session: AgentSession): Promise<void> => {
+    this.sessions.delete(session.id);
+  };
+}
+
+class FakeBinder implements TaskBinder {
+  readonly calls: AgentTaskView[] = [];
+  session: AgentSession = { id: "bound-session", role: "worker", status: "running" };
+
+  bind = async ({
+    task,
+  }: {
+    readonly task: AgentTaskView;
+  }): Promise<{ readonly session: AgentSession }> => {
+    this.calls.push(task);
+    return { session: this.session };
+  };
+}
+
+function taskView(
+  overrides: {
+    readonly id?: string;
+    readonly phase?: AgentTaskPhase;
+    readonly generation?: number;
+    readonly observedGeneration?: number;
+    readonly dependsOn?: readonly string[];
+    readonly sessionId?: string;
+    readonly conditions?: readonly Condition[];
+  } = {},
+): AgentTaskView {
+  const id = overrides.id ?? "task-1";
+  const generation = overrides.generation ?? 1;
+  return {
+    spec: {
+      id,
+      worktree: "/tmp/grove-task",
+      runtime: "codex",
+      role: "worker",
+      prompt: "Implement the task",
+      dependsOn: overrides.dependsOn ?? [],
+      generation,
+      createdAt: "2026-05-14T11:00:00.000Z",
+    },
+    status: {
+      id,
+      phase: overrides.phase ?? AgentTaskPhase.Pending,
+      ...(overrides.sessionId === undefined ? {} : { sessionId: overrides.sessionId }),
+      contributions: [],
+      conditions: overrides.conditions ?? [],
+      observedGeneration: overrides.observedGeneration ?? 0,
+      lastTransitionAt: "2026-05-14T11:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function controllerFor(
+  store: FakeTaskStore,
+  overrides: {
+    readonly runtime?: FakeRuntime;
+    readonly binder?: TaskBinder;
+  } = {},
+): TaskController {
+  return new TaskController({
+    taskStore: store,
+    runtime: overrides.runtime ?? new FakeRuntime(),
+    binder: overrides.binder,
+    now: () => FIXED_NOW_MS,
+  });
+}
+
+function onlyPatch(store: FakeTaskStore): RecordedPatch {
+  expect(store.patches).toHaveLength(1);
+  const patch = store.patches[0];
+  if (patch === undefined) throw new Error("expected one patch");
+  return patch;
+}
+
+function condition(
+  conditions: readonly Condition[] | undefined,
+  type: string,
+): Condition | undefined {
+  return conditions?.find((candidate) => candidate.type === type);
+}
+
+describe("TaskController transitions", () => {
+  test("missing tasks are successful no-ops", async () => {
+    const store = new FakeTaskStore();
+    const controller = controllerFor(store);
+
+    await expect(controller.reconcileTask("missing")).resolves.toBeUndefined();
+
+    expect(store.patches).toEqual([]);
+  });
+
+  test("terminal tasks catch up observed generation without reopening", async () => {
+    const store = new FakeTaskStore();
+    store.seed(
+      taskView({
+        phase: AgentTaskPhase.Failed,
+        generation: 4,
+        observedGeneration: 2,
+      }),
+    );
+    const controller = controllerFor(store);
+
+    const transition = await controller.reconcileTask("task-1");
+
+    expect(transition).toEqual({
+      taskId: "task-1",
+      fromPhase: AgentTaskPhase.Failed,
+      toPhase: AgentTaskPhase.Failed,
+      reason: "terminal-observed-generation",
+      observedGeneration: 4,
+    });
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBeUndefined();
+    expect(patch.observedGeneration).toBe(4);
+  });
+
+  test("pending tasks with missing dependencies stay blocked", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ dependsOn: ["task-a", "task-b"] }));
+    const controller = controllerFor(store);
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Pending);
+    expect(patch.observedGeneration).toBe(1);
+    expect(condition(patch.conditions, "Blocked")).toEqual({
+      type: "Blocked",
+      status: "True",
+      observedGeneration: 1,
+      lastTransitionTime: FIXED_NOW_ISO,
+      reason: "depends-on",
+      message: "Waiting for task-a, task-b",
+    });
+  });
+
+  test("pending tasks with satisfied dependencies move to PendingBind", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ id: "task-a", phase: AgentTaskPhase.Succeeded, observedGeneration: 1 }));
+    store.seed(taskView({ dependsOn: ["task-a"] }));
+    const controller = controllerFor(store);
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.PendingBind);
+    expect(condition(patch.conditions, "Scheduled")).toEqual({
+      type: "Scheduled",
+      status: "True",
+      observedGeneration: 1,
+      lastTransitionTime: FIXED_NOW_ISO,
+      reason: "ready-to-bind",
+      message: "",
+    });
+  });
+
+  test("PendingBind tasks bind and become Running", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const binder = new FakeBinder();
+    const controller = controllerFor(store, { binder });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(binder.calls.map((task) => task.spec.id)).toEqual(["task-1"]);
+    expect(patch.phase).toBe(AgentTaskPhase.Running);
+    expect(patch.sessionId).toBe("bound-session");
+    expect(condition(patch.conditions, "Bound")).toEqual({
+      type: "Bound",
+      status: "True",
+      observedGeneration: 1,
+      lastTransitionTime: FIXED_NOW_ISO,
+      reason: "session-bound",
+      message: "",
+    });
+    expect(condition(patch.conditions, "Running")).toEqual({
+      type: "Running",
+      status: "True",
+      observedGeneration: 1,
+      lastTransitionTime: FIXED_NOW_ISO,
+      reason: "session-running",
+      message: "",
+    });
+  });
+
+  test("running tasks reattach when the session is live", async () => {
+    const store = new FakeTaskStore();
+    store.seed(
+      taskView({
+        phase: AgentTaskPhase.Running,
+        observedGeneration: 1,
+        sessionId: "session-live",
+      }),
+    );
+    const runtime = new FakeRuntime();
+    runtime.sessions.set("session-live", {
+      id: "session-live",
+      role: "worker",
+      status: "idle",
+    });
+    const controller = controllerFor(store, { runtime });
+
+    await controller.reconcileTask("task-1");
+
+    expect(store.patches).toEqual([]);
+  });
+
+  test("running tasks fail when the session is missing", async () => {
+    const store = new FakeTaskStore();
+    store.seed(
+      taskView({
+        phase: AgentTaskPhase.Running,
+        observedGeneration: 1,
+        sessionId: "session-missing",
+      }),
+    );
+    const controller = controllerFor(store, { runtime: new FakeRuntime() });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Failed);
+    expect(condition(patch.conditions, "Failed")).toEqual({
+      type: "Failed",
+      status: "True",
+      observedGeneration: 1,
+      lastTransitionTime: FIXED_NOW_ISO,
+      reason: "session-lost",
+      message: "",
+    });
+  });
+});
+
+describe("DefaultTaskBinder", () => {
+  test("maps AgentTask spec to AgentRuntime spawn config with task correlation env", async () => {
+    const runtime = new FakeRuntime();
+    const binder = new DefaultTaskBinder(runtime);
+    const view = taskView({ generation: 3 });
+
+    const result = await binder.bind({ task: view });
+
+    expect(result.session.id).toBe("session-1");
+    expect(runtime.spawnCalls[0]).toEqual({
+      role: "worker",
+      config: {
+        role: "worker",
+        command: "codex",
+        cwd: "/tmp/grove-task",
+        goal: "Implement the task",
+        prompt: "Implement the task",
+        platform: "codex",
+        env: {
+          GROVE_AGENT_TASK_ID: "task-1",
+          GROVE_AGENT_TASK_GENERATION: "3",
+          GROVE_AGENT_TASK_RUNTIME: "codex",
+        },
+      },
+    });
+  });
+});

--- a/src/core/task-controller.test.ts
+++ b/src/core/task-controller.test.ts
@@ -372,6 +372,16 @@ describe("TaskController transitions", () => {
         phase: AgentTaskPhase.Running,
         observedGeneration: 1,
         sessionId: "session-live",
+        conditions: [
+          {
+            type: "Running",
+            status: "True",
+            observedGeneration: 1,
+            lastTransitionTime: "2026-05-14T10:00:00.000Z",
+            reason: "session-running",
+            message: "",
+          },
+        ],
       }),
     );
     const runtime = new FakeRuntime();
@@ -385,6 +395,57 @@ describe("TaskController transitions", () => {
     await controller.reconcileTask("task-1");
 
     expect(store.patches).toEqual([]);
+  });
+
+  test("running tasks with live sessions catch up stale observed generation", async () => {
+    const store = new FakeTaskStore();
+    store.seed(
+      taskView({
+        phase: AgentTaskPhase.Running,
+        generation: 3,
+        observedGeneration: 1,
+        sessionId: "session-live",
+        conditions: [
+          {
+            type: "Running",
+            status: "True",
+            observedGeneration: 1,
+            lastTransitionTime: "2026-05-14T10:00:00.000Z",
+            reason: "session-running",
+            message: "",
+          },
+        ],
+      }),
+    );
+    const runtime = new FakeRuntime();
+    runtime.sessions.set("session-live", {
+      id: "session-live",
+      role: "worker",
+      status: "idle",
+      platform: "codex",
+    });
+    const controller = controllerFor(store, { runtime });
+
+    const transition = await controller.reconcileTask("task-1");
+
+    expect(transition).toEqual({
+      taskId: "task-1",
+      fromPhase: AgentTaskPhase.Running,
+      toPhase: AgentTaskPhase.Running,
+      reason: "session-running",
+      observedGeneration: 3,
+    });
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBeUndefined();
+    expect(patch.observedGeneration).toBe(3);
+    expect(condition(patch.conditions, "Running")).toEqual({
+      type: "Running",
+      status: "True",
+      observedGeneration: 3,
+      lastTransitionTime: "2026-05-14T10:00:00.000Z",
+      reason: "session-running",
+      message: "",
+    });
   });
 
   test("running tasks fail when the session is missing", async () => {

--- a/src/core/task-controller.test.ts
+++ b/src/core/task-controller.test.ts
@@ -564,11 +564,57 @@ describe("TaskController worker lifecycle", () => {
     expect(errors).toEqual([{ taskId: "task-1", message: "spawn unavailable" }]);
   });
 
+  test("start is idempotent while running", async () => {
+    const store = new FakeTaskStore();
+    store.seed(
+      taskView({ id: "task-1", phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }),
+    );
+    store.seed(
+      taskView({ id: "task-2", phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }),
+    );
+    let releaseBind: (() => void) | undefined;
+    let blockNextBind = true;
+    const bindCalls: string[] = [];
+    const binder: TaskBinder = {
+      bind: async ({ task }) => {
+        bindCalls.push(task.spec.id);
+        if (blockNextBind) {
+          blockNextBind = false;
+          await new Promise<void>((resolve) => {
+            releaseBind = resolve;
+          });
+        }
+        return { session: { id: `session-${task.spec.id}`, role: "worker", status: "running" } };
+      },
+    };
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      binder,
+      queue: new KeyedWorkQueue({ baseDelayMs: 1, maxDelayMs: 1 }),
+      now: () => FIXED_NOW_MS,
+      workerCount: 1,
+    });
+
+    controller.enqueue("task-1");
+    controller.enqueue("task-2");
+    controller.start();
+    controller.start();
+    await waitFor(() => bindCalls.length === 1);
+    await sleep(10);
+
+    expect(bindCalls).toEqual(["task-1"]);
+    releaseBind?.();
+    await waitFor(() => store.patches.some((patch) => patch.taskId === "task-1"));
+    await controller.stop();
+  });
+
   test("stop cancels workers and rejects new work", async () => {
     const store = new FakeTaskStore();
     const controller = controllerFor(store);
 
     controller.start();
+    await controller.stop();
     await controller.stop();
 
     expect(() => controller.enqueue("task-1")).toThrow("Work queue is closed");
@@ -609,7 +655,48 @@ describe("TaskController failure injection", () => {
       expect(store.views.get("task-1")?.status.phase).toBe(AgentTaskPhase.Running);
     }
   });
+
+  test("worker retry closes failed patch session and converges without duplicate live sessions", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const runtime = new FakeRuntime();
+    let failed = false;
+    const errors: Array<{ readonly taskId: string; readonly message: string }> = [];
+    const originalPatch = store.patchAgentTaskStatus;
+    store.patchAgentTaskStatus = async (taskId, patch) => {
+      if (patch.phase === AgentTaskPhase.Running && !failed) {
+        failed = true;
+        throw new Error("injected patch failure");
+      }
+      return originalPatch(taskId, patch);
+    };
+    const controller = new TaskController({
+      taskStore: store,
+      runtime,
+      queue: new KeyedWorkQueue({ baseDelayMs: 1, maxDelayMs: 1 }),
+      now: () => FIXED_NOW_MS,
+      onError: (error, taskId) => {
+        errors.push({ taskId, message: error instanceof Error ? error.message : String(error) });
+      },
+    });
+
+    controller.enqueue("task-1");
+    controller.start();
+    await waitFor(() => errors.length === 1);
+    await waitFor(() => store.views.get("task-1")?.status.sessionId === "session-2");
+    await controller.stop();
+
+    expect(errors).toEqual([{ taskId: "task-1", message: "injected patch failure" }]);
+    expect(runtime.spawnCalls).toHaveLength(2);
+    expect(runtime.closeCalls.map((session) => session.id)).toEqual(["session-1"]);
+    expect([...runtime.sessions.keys()]).toEqual(["session-2"]);
+    expect(store.views.get("task-1")?.status.phase).toBe(AgentTaskPhase.Running);
+  });
 });
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 async function waitFor(predicate: () => boolean): Promise<void> {
   const started = Date.now();

--- a/src/core/task-controller.test.ts
+++ b/src/core/task-controller.test.ts
@@ -16,6 +16,7 @@ import {
   type TaskControllerRuntime,
   type TaskControllerStore,
 } from "./task-controller.js";
+import { KeyedWorkQueue } from "./workqueue.js";
 
 const FIXED_NOW_MS = Date.parse("2026-05-14T12:00:00.000Z");
 const FIXED_NOW_ISO = "2026-05-14T12:00:00.000Z";
@@ -469,3 +470,135 @@ describe("DefaultTaskBinder", () => {
     });
   });
 });
+
+describe("TaskController worker lifecycle", () => {
+  test("rejects invalid lifecycle options", () => {
+    const invalidOptions: ReadonlyArray<{
+      readonly resyncIntervalMs?: number;
+      readonly workerCount?: number;
+    }> = [
+      { resyncIntervalMs: 0 },
+      { resyncIntervalMs: Number.NaN },
+      { workerCount: 0 },
+      { workerCount: 1.5 },
+    ];
+
+    for (const options of invalidOptions) {
+      const store = new FakeTaskStore();
+      expect(
+        () =>
+          new TaskController({
+            taskStore: store,
+            runtime: new FakeRuntime(),
+            now: () => FIXED_NOW_MS,
+            ...options,
+          }),
+      ).toThrow(RangeError);
+    }
+  });
+
+  test("resync enqueues every AgentTask entity id", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ id: "task-a" }));
+    store.seed(taskView({ id: "task-b" }));
+    const queue = new KeyedWorkQueue({ now: () => FIXED_NOW_MS });
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      queue,
+      now: () => FIXED_NOW_MS,
+    });
+
+    const count = await controller.resync();
+
+    expect(count).toBe(2);
+    await expect(queue.take()).resolves.toEqual({ key: "task-a", attempt: 0 });
+    await expect(queue.take()).resolves.toEqual({ key: "task-b", attempt: 0 });
+  });
+
+  test("failed worker reconcile retries and re-reads fresh task state", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    let fail = true;
+    const binder: TaskBinder = {
+      bind: async () => {
+        if (fail) throw new Error("spawn unavailable");
+        return { session: { id: "session-retry", role: "worker", status: "running" } };
+      },
+    };
+    const errors: Array<{ readonly taskId: string; readonly message: string }> = [];
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      binder,
+      queue: new KeyedWorkQueue({ baseDelayMs: 1, maxDelayMs: 1 }),
+      now: () => FIXED_NOW_MS,
+      onError: (error, taskId) => {
+        errors.push({ taskId, message: error instanceof Error ? error.message : String(error) });
+      },
+    });
+
+    controller.enqueue("task-1");
+    controller.start();
+    await waitFor(() => errors.length === 1);
+    fail = false;
+    await waitFor(() => store.patches.some((patch) => patch.patch.sessionId === "session-retry"));
+    await controller.stop();
+
+    expect(errors).toEqual([{ taskId: "task-1", message: "spawn unavailable" }]);
+  });
+
+  test("stop cancels workers and rejects new work", async () => {
+    const store = new FakeTaskStore();
+    const controller = controllerFor(store);
+
+    controller.start();
+    await controller.stop();
+
+    expect(() => controller.enqueue("task-1")).toThrow("Work queue is closed");
+    expect(() => controller.start()).toThrow("Work queue is closed");
+  });
+});
+
+describe("TaskController failure injection", () => {
+  test("converges when each bind step fails once", async () => {
+    const cases = ["bind", "patch-running"] as const;
+
+    for (const failurePoint of cases) {
+      const store = new FakeTaskStore();
+      store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+      let failed = false;
+      const binder: TaskBinder = {
+        bind: async () => {
+          if (failurePoint === "bind" && !failed) {
+            failed = true;
+            throw new Error("injected bind failure");
+          }
+          return { session: { id: `session-${failurePoint}`, role: "worker", status: "running" } };
+        },
+      };
+      const originalPatch = store.patchAgentTaskStatus;
+      store.patchAgentTaskStatus = async (taskId, patch) => {
+        if (failurePoint === "patch-running" && patch.phase === AgentTaskPhase.Running && !failed) {
+          failed = true;
+          throw new Error("injected patch failure");
+        }
+        return originalPatch(taskId, patch);
+      };
+      const controller = controllerFor(store, { binder });
+
+      await expect(controller.reconcileTask("task-1")).rejects.toThrow("injected");
+      await expect(controller.reconcileTask("task-1")).resolves.toBeDefined();
+
+      expect(store.views.get("task-1")?.status.phase).toBe(AgentTaskPhase.Running);
+    }
+  });
+});
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > 500) throw new Error("condition was not met in time");
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}

--- a/src/core/task-controller.test.ts
+++ b/src/core/task-controller.test.ts
@@ -520,8 +520,10 @@ describe("TaskController worker lifecycle", () => {
     const store = new FakeTaskStore();
     store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
     let fail = true;
+    const bindCalls: Array<{ readonly prompt: string; readonly generation: number }> = [];
     const binder: TaskBinder = {
-      bind: async () => {
+      bind: async ({ task }) => {
+        bindCalls.push({ prompt: task.spec.prompt, generation: task.spec.generation });
         if (fail) throw new Error("spawn unavailable");
         return { session: { id: "session-retry", role: "worker", status: "running" } };
       },
@@ -541,10 +543,24 @@ describe("TaskController worker lifecycle", () => {
     controller.enqueue("task-1");
     controller.start();
     await waitFor(() => errors.length === 1);
+    const current = store.views.get("task-1");
+    if (current === undefined) throw new Error("expected seeded task");
+    store.views.set("task-1", {
+      spec: {
+        ...current.spec,
+        prompt: "Implement the updated task",
+        generation: 2,
+      },
+      status: current.status,
+    });
     fail = false;
     await waitFor(() => store.patches.some((patch) => patch.patch.sessionId === "session-retry"));
     await controller.stop();
 
+    expect(bindCalls).toEqual([
+      { prompt: "Implement the task", generation: 1 },
+      { prompt: "Implement the updated task", generation: 2 },
+    ]);
     expect(errors).toEqual([{ taskId: "task-1", message: "spawn unavailable" }]);
   });
 

--- a/src/core/task-controller.ts
+++ b/src/core/task-controller.ts
@@ -317,7 +317,7 @@ export class TaskController {
     const sessions = await this.runtime.listSessions();
     const session = sessions.find((candidate) => candidate.id === task.status.sessionId);
     if (session !== undefined && (session.status === "running" || session.status === "idle")) {
-      return undefined;
+      return runningLiveCatchUp(task, this.nowIso());
     }
 
     return failLostSession(task, this.nowIso());
@@ -361,6 +361,27 @@ function terminalObservedGenerationCatchUp(task: AgentTaskView): ReconciliationR
     patch: { observedGeneration: task.spec.generation },
     transition: transition(task, task.status.phase, "terminal-observed-generation"),
   };
+}
+
+function runningLiveCatchUp(task: AgentTaskView, nowIso: string): ReconciliationResult | undefined {
+  const patch: AgentTaskStatusPatch = {
+    observedGeneration: task.spec.generation,
+    conditions: upsertCondition(task.status.conditions, {
+      type: AgentTaskConditionType.Running,
+      status: "True",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "session-running",
+      message: "",
+    }),
+  };
+
+  return statusPatchIsNoOp(task, patch)
+    ? undefined
+    : {
+        patch,
+        transition: transition(task, AgentTaskPhase.Running, "session-running"),
+      };
 }
 
 function failLostSession(task: AgentTaskView, nowIso: string): ReconciliationResult {

--- a/src/core/task-controller.ts
+++ b/src/core/task-controller.ts
@@ -51,6 +51,7 @@ export interface TaskControllerOptions {
 interface ReconciliationResult {
   readonly patch: AgentTaskStatusPatch;
   readonly transition: AgentTaskStatusTransition;
+  readonly sessionToCloseOnPatchFailure?: AgentSession | undefined;
 }
 
 const DEFAULT_RESYNC_INTERVAL_MS = 30_000;
@@ -139,7 +140,14 @@ export class TaskController {
     const result = await this.computeReconciliation(task);
     if (result === undefined) return undefined;
 
-    await this.taskStore.patchAgentTaskStatus(taskId, result.patch);
+    try {
+      await this.taskStore.patchAgentTaskStatus(taskId, result.patch);
+    } catch (error) {
+      if (result.sessionToCloseOnPatchFailure !== undefined) {
+        await this.closeAfterPatchFailure(result.sessionToCloseOnPatchFailure);
+      }
+      throw error;
+    }
     this.onTransition?.(result.transition);
     return result.transition;
   }
@@ -216,40 +224,44 @@ export class TaskController {
     return undefined;
   }
 
-  private async reconcilePending(task: AgentTaskView): Promise<ReconciliationResult> {
+  private async reconcilePending(task: AgentTaskView): Promise<ReconciliationResult | undefined> {
     const blockedOn = await this.blockingDependencies(task);
     const nowIso = this.nowIso();
 
     if (blockedOn.length > 0) {
-      return {
-        patch: {
-          phase: AgentTaskPhase.Pending,
+      const patch: AgentTaskStatusPatch = {
+        phase: AgentTaskPhase.Pending,
+        observedGeneration: task.spec.generation,
+        conditions: upsertCondition(task.status.conditions, {
+          type: AgentTaskConditionType.Blocked,
+          status: "True",
           observedGeneration: task.spec.generation,
-          conditions: upsertCondition(task.status.conditions, {
-            type: AgentTaskConditionType.Blocked,
-            status: "True",
-            observedGeneration: task.spec.generation,
-            lastTransitionTime: nowIso,
-            reason: "depends-on",
-            message: `Waiting for ${blockedOn.join(", ")}`,
-          }),
-        },
-        transition: transition(task, AgentTaskPhase.Pending, "depends-on"),
+          lastTransitionTime: nowIso,
+          reason: "depends-on",
+          message: `Waiting for ${blockedOn.join(", ")}`,
+        }),
       };
+      return statusPatchIsNoOp(task, patch)
+        ? undefined
+        : {
+            patch,
+            transition: transition(task, AgentTaskPhase.Pending, "depends-on"),
+          };
     }
 
+    const conditions = upsertCondition(clearBlockedCondition(task, nowIso), {
+      type: AgentTaskConditionType.Scheduled,
+      status: "True",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "ready-to-bind",
+      message: "",
+    });
     return {
       patch: {
         phase: AgentTaskPhase.PendingBind,
         observedGeneration: task.spec.generation,
-        conditions: upsertCondition(task.status.conditions, {
-          type: AgentTaskConditionType.Scheduled,
-          status: "True",
-          observedGeneration: task.spec.generation,
-          lastTransitionTime: nowIso,
-          reason: "ready-to-bind",
-          message: "",
-        }),
+        conditions,
         lastTransitionAt: nowIso,
       },
       transition: transition(task, AgentTaskPhase.PendingBind, "ready-to-bind"),
@@ -293,6 +305,7 @@ export class TaskController {
         lastTransitionAt: nowIso,
       },
       transition: transition(task, AgentTaskPhase.Running, "session-bound"),
+      sessionToCloseOnPatchFailure: session,
     };
   }
 
@@ -332,6 +345,14 @@ export class TaskController {
       return;
     }
   }
+
+  private async closeAfterPatchFailure(session: AgentSession): Promise<void> {
+    try {
+      await this.runtime.close(session);
+    } catch {
+      return;
+    }
+  }
 }
 
 function terminalObservedGenerationCatchUp(task: AgentTaskView): ReconciliationResult | undefined {
@@ -343,22 +364,77 @@ function terminalObservedGenerationCatchUp(task: AgentTaskView): ReconciliationR
 }
 
 function failLostSession(task: AgentTaskView, nowIso: string): ReconciliationResult {
+  const conditions = upsertCondition(
+    upsertCondition(task.status.conditions, {
+      type: AgentTaskConditionType.Running,
+      status: "False",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "session-lost",
+      message: "",
+    }),
+    {
+      type: AgentTaskConditionType.Failed,
+      status: "True",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "session-lost",
+      message: "",
+    },
+  );
+
   return {
     patch: {
       phase: AgentTaskPhase.Failed,
       observedGeneration: task.spec.generation,
-      conditions: upsertCondition(task.status.conditions, {
-        type: AgentTaskConditionType.Failed,
-        status: "True",
-        observedGeneration: task.spec.generation,
-        lastTransitionTime: nowIso,
-        reason: "session-lost",
-        message: "",
-      }),
+      conditions,
       lastTransitionAt: nowIso,
     },
     transition: transition(task, AgentTaskPhase.Failed, "session-lost"),
   };
+}
+
+function clearBlockedCondition(task: AgentTaskView, nowIso: string): readonly Condition[] {
+  const blocked = task.status.conditions.find(
+    (condition) => condition.type === AgentTaskConditionType.Blocked && condition.status === "True",
+  );
+  if (blocked === undefined) return task.status.conditions;
+
+  return upsertCondition(task.status.conditions, {
+    type: AgentTaskConditionType.Blocked,
+    status: "False",
+    observedGeneration: task.spec.generation,
+    lastTransitionTime: nowIso,
+    reason: "ready-to-bind",
+    message: "",
+  });
+}
+
+function statusPatchIsNoOp(task: AgentTaskView, patch: AgentTaskStatusPatch): boolean {
+  return (
+    (patch.phase === undefined || patch.phase === task.status.phase) &&
+    (patch.sessionId === undefined || patch.sessionId === task.status.sessionId) &&
+    (patch.contributions === undefined ||
+      stringArraysEqual(patch.contributions, task.status.contributions)) &&
+    (patch.conditions === undefined || conditionsEqual(patch.conditions, task.status.conditions)) &&
+    (patch.observedGeneration === undefined ||
+      patch.observedGeneration === task.status.observedGeneration) &&
+    (patch.lastTransitionAt === undefined ||
+      patch.lastTransitionAt === task.status.lastTransitionAt)
+  );
+}
+
+function stringArraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}
+
+function conditionsEqual(left: readonly Condition[], right: readonly Condition[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((condition, index) => {
+    const other = right[index];
+    return other !== undefined && conditionEqual(condition, other);
+  });
 }
 
 function validateResyncIntervalMs(value: number): void {

--- a/src/core/task-controller.ts
+++ b/src/core/task-controller.ts
@@ -1,0 +1,440 @@
+import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
+import {
+  AgentTaskConditionType,
+  type AgentTaskEntity,
+  AgentTaskPhase,
+  type AgentTaskView,
+} from "./agent-task.js";
+import type { Condition } from "./entity.js";
+import type { AgentTaskStatusPatch, AgentTaskStore } from "./store.js";
+import { KeyedWorkQueue, QueueClosedError, type WorkItemResult } from "./workqueue.js";
+
+export type TaskControllerStore = Pick<
+  AgentTaskStore,
+  "getAgentTask" | "patchAgentTaskStatus" | "listAgentTaskEntities"
+>;
+
+export type TaskControllerRuntime = Pick<AgentRuntime, "spawn" | "listSessions" | "close">;
+
+export interface TaskBindRequest {
+  readonly task: AgentTaskView;
+}
+
+export interface TaskBindResult {
+  readonly session: AgentSession;
+}
+
+export interface TaskBinder {
+  bind(request: TaskBindRequest): Promise<TaskBindResult>;
+}
+
+export interface AgentTaskStatusTransition {
+  readonly taskId: string;
+  readonly fromPhase: AgentTaskPhase;
+  readonly toPhase: AgentTaskPhase;
+  readonly reason: string;
+  readonly observedGeneration: number;
+}
+
+export interface TaskControllerOptions {
+  readonly taskStore: TaskControllerStore;
+  readonly runtime: TaskControllerRuntime;
+  readonly binder?: TaskBinder | undefined;
+  readonly queue?: KeyedWorkQueue | undefined;
+  readonly resyncIntervalMs?: number | undefined;
+  readonly workerCount?: number | undefined;
+  readonly now?: (() => number) | undefined;
+  readonly onError?: ((error: unknown, taskId: string) => void) | undefined;
+  readonly onTransition?: ((transition: AgentTaskStatusTransition) => void) | undefined;
+}
+
+interface ReconciliationResult {
+  readonly patch: AgentTaskStatusPatch;
+  readonly transition: AgentTaskStatusTransition;
+}
+
+const DEFAULT_RESYNC_INTERVAL_MS = 30_000;
+const DEFAULT_WORKER_COUNT = 1;
+const MAX_RESYNC_INTERVAL_MS = 2_147_483_647;
+const MAX_WORKER_COUNT = 1_000;
+
+export class DefaultTaskBinder implements TaskBinder {
+  private readonly runtime: TaskControllerRuntime;
+
+  constructor(runtime: TaskControllerRuntime) {
+    this.runtime = runtime;
+  }
+
+  async bind(request: TaskBindRequest): Promise<TaskBindResult> {
+    const task = request.task;
+    const model = task.spec.budget?.model;
+    const config: AgentConfig = {
+      role: task.spec.role,
+      command: task.spec.runtime,
+      cwd: task.spec.worktree,
+      goal: task.spec.prompt,
+      prompt: task.spec.prompt,
+      platform: runtimeToPlatform(task.spec.runtime),
+      ...(typeof model === "string" ? { model } : {}),
+      env: {
+        GROVE_AGENT_TASK_ID: task.spec.id,
+        GROVE_AGENT_TASK_GENERATION: String(task.spec.generation),
+        GROVE_AGENT_TASK_RUNTIME: task.spec.runtime,
+      },
+    };
+    const session = await this.runtime.spawn(task.spec.role, config);
+    return { session };
+  }
+}
+
+export class TaskController {
+  private readonly taskStore: TaskControllerStore;
+  private readonly runtime: TaskControllerRuntime;
+  private readonly binder: TaskBinder;
+  private readonly queue: KeyedWorkQueue;
+  private readonly now: () => number;
+  private readonly resyncIntervalMs: number;
+  private readonly workerCount: number;
+  private readonly onError: ((error: unknown, taskId: string) => void) | undefined;
+  private readonly onTransition: ((transition: AgentTaskStatusTransition) => void) | undefined;
+  private running = false;
+  private stopRequested = false;
+  private workers: Promise<void>[] = [];
+  private resyncTimer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(options: TaskControllerOptions) {
+    this.taskStore = options.taskStore;
+    this.runtime = options.runtime;
+    this.binder = options.binder ?? new DefaultTaskBinder(options.runtime);
+    this.now = options.now ?? Date.now;
+    this.queue = options.queue ?? new KeyedWorkQueue({ now: this.now });
+    this.resyncIntervalMs = options.resyncIntervalMs ?? DEFAULT_RESYNC_INTERVAL_MS;
+    this.workerCount = options.workerCount ?? DEFAULT_WORKER_COUNT;
+    validateResyncIntervalMs(this.resyncIntervalMs);
+    validateWorkerCount(this.workerCount);
+    this.onError = options.onError;
+    this.onTransition = options.onTransition;
+  }
+
+  enqueue(taskId: string): void {
+    this.queue.enqueue(taskId);
+  }
+
+  enqueueFromEntity(entity: AgentTaskEntity): void {
+    this.enqueue(entity.id);
+  }
+
+  async resync(): Promise<number> {
+    const entities = await this.taskStore.listAgentTaskEntities();
+    for (const entity of entities) {
+      this.enqueue(entity.id);
+    }
+    return entities.length;
+  }
+
+  async reconcileTask(taskId: string): Promise<AgentTaskStatusTransition | undefined> {
+    const task = await this.taskStore.getAgentTask(taskId);
+    if (task === undefined) return undefined;
+
+    const result = await this.computeReconciliation(task);
+    if (result === undefined) return undefined;
+
+    await this.taskStore.patchAgentTaskStatus(taskId, result.patch);
+    this.onTransition?.(result.transition);
+    return result.transition;
+  }
+
+  start(): void {
+    if (this.running) return;
+    if (this.stopRequested) throw new QueueClosedError();
+    this.running = true;
+    this.stopRequested = false;
+    for (let i = 0; i < this.workerCount; i += 1) {
+      this.workers.push(this.workerLoop());
+    }
+    this.resyncTimer = setInterval(() => {
+      void this.resync().catch((error: unknown) => {
+        this.reportError(error, "__resync__");
+      });
+    }, this.resyncIntervalMs);
+    this.resyncTimer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running && this.stopRequested) return;
+    this.stopRequested = true;
+    if (this.resyncTimer !== undefined) {
+      clearInterval(this.resyncTimer);
+      this.resyncTimer = undefined;
+    }
+    this.queue.close();
+    const workers = this.workers;
+    this.workers = [];
+    await Promise.all(workers);
+    this.running = false;
+  }
+
+  private async workerLoop(): Promise<void> {
+    while (!this.stopRequested) {
+      let item: WorkItemResult;
+      try {
+        item = await this.queue.take();
+      } catch (error) {
+        if (this.stopRequested) return;
+        throw error;
+      }
+
+      try {
+        await this.reconcileTask(item.key);
+        this.queue.acknowledge(item.key);
+      } catch (error) {
+        if (!this.stopRequested) this.queue.retry(item.key);
+        this.reportError(error, item.key);
+      }
+    }
+  }
+
+  private async computeReconciliation(
+    task: AgentTaskView,
+  ): Promise<ReconciliationResult | undefined> {
+    if (isTerminal(task.status.phase)) {
+      return terminalObservedGenerationCatchUp(task);
+    }
+
+    if (task.status.phase === AgentTaskPhase.Pending) {
+      return this.reconcilePending(task);
+    }
+
+    if (task.status.phase === AgentTaskPhase.PendingBind) {
+      return this.reconcilePendingBind(task);
+    }
+
+    if (task.status.phase === AgentTaskPhase.Running) {
+      return this.reconcileRunning(task);
+    }
+
+    return undefined;
+  }
+
+  private async reconcilePending(task: AgentTaskView): Promise<ReconciliationResult> {
+    const blockedOn = await this.blockingDependencies(task);
+    const nowIso = this.nowIso();
+
+    if (blockedOn.length > 0) {
+      return {
+        patch: {
+          phase: AgentTaskPhase.Pending,
+          observedGeneration: task.spec.generation,
+          conditions: upsertCondition(task.status.conditions, {
+            type: AgentTaskConditionType.Blocked,
+            status: "True",
+            observedGeneration: task.spec.generation,
+            lastTransitionTime: nowIso,
+            reason: "depends-on",
+            message: `Waiting for ${blockedOn.join(", ")}`,
+          }),
+        },
+        transition: transition(task, AgentTaskPhase.Pending, "depends-on"),
+      };
+    }
+
+    return {
+      patch: {
+        phase: AgentTaskPhase.PendingBind,
+        observedGeneration: task.spec.generation,
+        conditions: upsertCondition(task.status.conditions, {
+          type: AgentTaskConditionType.Scheduled,
+          status: "True",
+          observedGeneration: task.spec.generation,
+          lastTransitionTime: nowIso,
+          reason: "ready-to-bind",
+          message: "",
+        }),
+        lastTransitionAt: nowIso,
+      },
+      transition: transition(task, AgentTaskPhase.PendingBind, "ready-to-bind"),
+    };
+  }
+
+  private async reconcilePendingBind(
+    task: AgentTaskView,
+  ): Promise<ReconciliationResult | undefined> {
+    if (task.status.sessionId !== undefined) {
+      return this.reconcileRunning(task);
+    }
+
+    const { session } = await this.binder.bind({ task });
+    const nowIso = this.nowIso();
+    const conditions = upsertCondition(
+      upsertCondition(task.status.conditions, {
+        type: AgentTaskConditionType.Bound,
+        status: "True",
+        observedGeneration: task.spec.generation,
+        lastTransitionTime: nowIso,
+        reason: "session-bound",
+        message: "",
+      }),
+      {
+        type: AgentTaskConditionType.Running,
+        status: "True",
+        observedGeneration: task.spec.generation,
+        lastTransitionTime: nowIso,
+        reason: "session-running",
+        message: "",
+      },
+    );
+
+    return {
+      patch: {
+        phase: AgentTaskPhase.Running,
+        sessionId: session.id,
+        observedGeneration: task.spec.generation,
+        conditions,
+        lastTransitionAt: nowIso,
+      },
+      transition: transition(task, AgentTaskPhase.Running, "session-bound"),
+    };
+  }
+
+  private async reconcileRunning(task: AgentTaskView): Promise<ReconciliationResult | undefined> {
+    if (task.status.sessionId === undefined) {
+      return failLostSession(task, this.nowIso());
+    }
+
+    const sessions = await this.runtime.listSessions();
+    const session = sessions.find((candidate) => candidate.id === task.status.sessionId);
+    if (session !== undefined && (session.status === "running" || session.status === "idle")) {
+      return undefined;
+    }
+
+    return failLostSession(task, this.nowIso());
+  }
+
+  private async blockingDependencies(task: AgentTaskView): Promise<readonly string[]> {
+    const blocked: string[] = [];
+    for (const dependencyId of task.spec.dependsOn) {
+      const dependency = await this.taskStore.getAgentTask(dependencyId);
+      if (dependency?.status.phase !== AgentTaskPhase.Succeeded) {
+        blocked.push(dependencyId);
+      }
+    }
+    return blocked;
+  }
+
+  private nowIso(): string {
+    return new Date(this.now()).toISOString();
+  }
+
+  private reportError(error: unknown, taskId: string): void {
+    try {
+      this.onError?.(error, taskId);
+    } catch {
+      return;
+    }
+  }
+}
+
+function terminalObservedGenerationCatchUp(task: AgentTaskView): ReconciliationResult | undefined {
+  if (task.status.observedGeneration >= task.spec.generation) return undefined;
+  return {
+    patch: { observedGeneration: task.spec.generation },
+    transition: transition(task, task.status.phase, "terminal-observed-generation"),
+  };
+}
+
+function failLostSession(task: AgentTaskView, nowIso: string): ReconciliationResult {
+  return {
+    patch: {
+      phase: AgentTaskPhase.Failed,
+      observedGeneration: task.spec.generation,
+      conditions: upsertCondition(task.status.conditions, {
+        type: AgentTaskConditionType.Failed,
+        status: "True",
+        observedGeneration: task.spec.generation,
+        lastTransitionTime: nowIso,
+        reason: "session-lost",
+        message: "",
+      }),
+      lastTransitionAt: nowIso,
+    },
+    transition: transition(task, AgentTaskPhase.Failed, "session-lost"),
+  };
+}
+
+function validateResyncIntervalMs(value: number): void {
+  if (!Number.isFinite(value) || value < 1 || value > MAX_RESYNC_INTERVAL_MS) {
+    throw new RangeError(
+      `resyncIntervalMs must be a finite positive number no greater than ${MAX_RESYNC_INTERVAL_MS}`,
+    );
+  }
+}
+
+function validateWorkerCount(value: number): void {
+  if (!Number.isInteger(value) || value < 1 || value > MAX_WORKER_COUNT) {
+    throw new RangeError(`workerCount must be an integer between 1 and ${MAX_WORKER_COUNT}`);
+  }
+}
+
+function runtimeToPlatform(runtime: string): AgentConfig["platform"] {
+  if (runtime === "claude" || runtime === "claude-code") return "claude-code";
+  if (runtime === "codex") return "codex";
+  if (runtime === "gemini") return "gemini";
+  return undefined;
+}
+
+function isTerminal(phase: AgentTaskPhase): boolean {
+  return phase === AgentTaskPhase.Failed || phase === AgentTaskPhase.Succeeded;
+}
+
+function transition(
+  task: AgentTaskView,
+  toPhase: AgentTaskPhase,
+  reason: string,
+): AgentTaskStatusTransition {
+  return {
+    taskId: task.spec.id,
+    fromPhase: task.status.phase,
+    toPhase,
+    reason,
+    observedGeneration: task.spec.generation,
+  };
+}
+
+function upsertCondition(
+  conditions: readonly Condition[],
+  desired: Condition,
+): readonly Condition[] {
+  const index = conditions.findIndex((condition) => condition.type === desired.type);
+  if (index === -1) {
+    return [...conditions, desired];
+  }
+
+  const existing = conditions[index];
+  if (existing === undefined) return conditions;
+  const next: Condition =
+    existing.status === desired.status &&
+    existing.reason === desired.reason &&
+    existing.message === desired.message
+      ? {
+          ...desired,
+          lastTransitionTime: existing.lastTransitionTime,
+        }
+      : desired;
+
+  if (conditionEqual(existing, next)) return conditions;
+
+  return conditions.map((condition, conditionIndex) =>
+    conditionIndex === index ? next : condition,
+  );
+}
+
+function conditionEqual(left: Condition, right: Condition): boolean {
+  return (
+    left.type === right.type &&
+    left.status === right.status &&
+    left.observedGeneration === right.observedGeneration &&
+    left.lastTransitionTime === right.lastTransitionTime &&
+    left.reason === right.reason &&
+    left.message === right.message
+  );
+}

--- a/src/core/watch-events.ts
+++ b/src/core/watch-events.ts
@@ -6,13 +6,14 @@
  * revision) — see docs/superpowers/specs/2026-04-27-a5-watch-protocol-design.md.
  */
 
+import type { AgentTaskEntity } from "./agent-task.js";
 import type { AgentSessionEntity, ClaimEntity, ContributionEntity } from "./entity.js";
 
-export type WatchKind = "Contribution" | "Claim" | "AgentSession";
+export type WatchKind = "Contribution" | "Claim" | "AgentSession" | "AgentTask";
 
 export type WatchOp = "ADDED" | "MODIFIED" | "DELETED";
 
-export type WatchEntity = ContributionEntity | ClaimEntity | AgentSessionEntity;
+export type WatchEntity = ContributionEntity | ClaimEntity | AgentSessionEntity | AgentTaskEntity;
 
 /** A watch-stream event emitted by the hub to subscribers. */
 export interface WatchEvent {

--- a/src/local/runtime.ts
+++ b/src/local/runtime.ts
@@ -48,10 +48,11 @@ export interface LocalRuntimeOptions {
   /** Whether to parse the GROVE.md contract. Default: `true`. */
   readonly parseContract?: boolean;
   /**
-   * Optional process-local `WatchHub` to which contribution + claim writes
+   * Optional process-local `WatchHub` to which contribution, claim, and task writes
    * are republished as `EntityWriteEvent`s. When provided, the runtime
    * wires `SqliteContributionStore.onContributionWrite` and
-   * `SqliteClaimStore.onClaimWrite` to the recorder shipped in #388 PR2.
+   * `SqliteClaimStore.onClaimWrite` / `SqliteAgentTaskStore.onAgentTaskWrite`
+   * to the recorder shipped in #388 PR2.
    * When omitted, no hub plumbing is created — existing CLI / server
    * callers that supply their own `OperationDeps.onEntityWrite` path are
    * unaffected.
@@ -145,7 +146,8 @@ export function createLocalRuntime(options: LocalRuntimeOptions): LocalRuntime {
   stores.contributionStore.onWrite = onContributionWrite;
 
   // Wire local-mode WatchHub republish (#388 PR2). The recorder projects
-  // domain types via `contributionToEntity` / `claimToEntity` and calls
+  // domain types via `contributionToEntity` / `claimToEntity` /
+  // `agentTaskViewToEntity` and calls
   // `WatchHub.recordWrite`. AgentSession is wired by the TUI main entry
   // (it owns the AgentRuntime), not here.
   if (options.watchHub) {
@@ -158,6 +160,7 @@ export function createLocalRuntime(options: LocalRuntimeOptions): LocalRuntime {
     });
     stores.contributionStore.onContributionWrite = (op, c) => recorder.contribution(op, c);
     stores.claimStore.onClaimWrite = (op, c) => recorder.claim(op, c);
+    stores.agentTaskStore.onAgentTaskWrite = (op, view) => recorder.agentTask(op, view);
   }
 
   let workspace: LocalWorkspaceManager | undefined;

--- a/src/local/sqlite-agent-task-store.test.ts
+++ b/src/local/sqlite-agent-task-store.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { AgentTaskView } from "../core/agent-task.js";
 import { AgentTaskPhase } from "../core/agent-task.js";
 import type { Condition } from "../core/entity.js";
 import { createSqliteStores } from "./sqlite-store.js";
@@ -110,5 +111,48 @@ describe("SqliteAgentTaskStore", () => {
     expect(patched.status.phase).toBe(AgentTaskPhase.Succeeded);
     expect(patched.status.contributions).toEqual(["b3:done"]);
     expect(patched.status.conditions).toEqual([condition]);
+  });
+
+  test("write callback sees spec creates, spec updates, and status patches", async () => {
+    const stores = createSqliteStores(join(tempDir, "test.db"));
+    closeStores = stores.close;
+    const events: Array<{
+      readonly op: "ADDED" | "MODIFIED";
+      readonly view: AgentTaskView;
+    }> = [];
+    stores.agentTaskStore.onAgentTaskWrite = (op, view) => {
+      events.push({ op, view });
+    };
+
+    const created = await stores.agentTaskStore.putAgentTaskSpec({
+      id: "task-callback",
+      worktree: "/tmp/worktree",
+      runtime: "codex",
+      role: "worker",
+      prompt: "Initial",
+      dependsOn: [],
+      generation: 0,
+      createdAt: "2026-05-13T11:00:00.000Z",
+    });
+
+    await stores.agentTaskStore.putAgentTaskSpec({
+      ...created.spec,
+      prompt: "Changed",
+    });
+
+    await stores.agentTaskStore.patchAgentTaskStatus("task-callback", {
+      phase: AgentTaskPhase.PendingBind,
+      observedGeneration: created.spec.generation + 1,
+    });
+
+    expect(events.map((event) => event.op)).toEqual(["ADDED", "MODIFIED", "MODIFIED"]);
+    expect(events.map((event) => event.view.spec.id)).toEqual([
+      "task-callback",
+      "task-callback",
+      "task-callback",
+    ]);
+    expect(events[0]?.view.spec.prompt).toBe("Initial");
+    expect(events[1]?.view.spec.prompt).toBe("Changed");
+    expect(events[2]?.view.status.phase).toBe(AgentTaskPhase.PendingBind);
   });
 });

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -1867,6 +1867,9 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
   private readonly db: Database;
   private readonly stmtGetTask: Statement;
 
+  /** Optional callback invoked after a successful AgentTask spec/status write. */
+  onAgentTaskWrite?: (op: "ADDED" | "MODIFIED", view: AgentTaskView) => void;
+
   constructor(db: Database) {
     this.db = db;
     this.storeIdentity = db.filename;
@@ -1879,9 +1882,11 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
   }
 
   putAgentTaskSpec = async (spec: AgentTaskSpecRecord): Promise<AgentTaskView> => {
+    let op: "ADDED" | "MODIFIED" = "MODIFIED";
     const tx = this.db.transaction(() => {
       const existing = this.readAgentTask(spec.id);
       if (existing === null) {
+        op = "ADDED";
         const nowIso = new Date().toISOString();
         this.insertTaskSpecRow({ ...spec, generation: 1 });
         this.insertTaskStatusRow({
@@ -1930,6 +1935,7 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
 
     const view = this.readAgentTask(spec.id);
     if (view === null) throw new Error(`Failed to read back agent task '${spec.id}'`);
+    this.emitAgentTaskWrite(op, view);
     return view;
   };
 
@@ -2012,7 +2018,9 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
       return view;
     });
 
-    return tx.immediate();
+    const view = tx.immediate();
+    this.emitAgentTaskWrite("MODIFIED", view);
+    return view;
   };
 
   async listAgentTaskEntities(query?: AgentTaskQuery): Promise<readonly AgentTaskEntity[]> {
@@ -2077,6 +2085,14 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
     const row = this.stmtGetTask.get(taskId) as AgentTaskViewRow | null;
     if (row === null) return null;
     return rowToAgentTaskView(row);
+  }
+
+  private emitAgentTaskWrite(op: "ADDED" | "MODIFIED", view: AgentTaskView): void {
+    try {
+      this.onAgentTaskWrite?.(op, view);
+    } catch {
+      // Local watch fan-out must not make the underlying SQLite write fail.
+    }
   }
 }
 

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -2090,8 +2090,9 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
   private emitAgentTaskWrite(op: "ADDED" | "MODIFIED", view: AgentTaskView): void {
     try {
       this.onAgentTaskWrite?.(op, view);
-    } catch {
-      // Local watch fan-out must not make the underlying SQLite write fail.
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[sqlite-agent-task-store] onAgentTaskWrite failed: ${detail}\n`);
     }
   }
 }

--- a/src/local/watch-hub-recorder.ts
+++ b/src/local/watch-hub-recorder.ts
@@ -1,6 +1,6 @@
 /**
  * WatchHubRecorder — typed adapter that bridges domain writes (Contribution,
- * Claim, AgentSession) to `WatchHub.recordWrite` (#388 PR2).
+ * Claim, AgentSession, AgentTask) to `WatchHub.recordWrite` (#388 PR2).
  *
  * Local mode publishes to a process-local `WatchHub`; the existing remote
  * path goes through `OperationDeps.onEntityWrite` → server-side hub. This
@@ -12,6 +12,7 @@
  */
 
 import type { AgentSession } from "../core/agent-runtime.js";
+import { type AgentTaskView, agentTaskViewToEntity } from "../core/agent-task.js";
 import { agentSessionToEntity, claimToEntity, contributionToEntity } from "../core/entity.js";
 import type { Claim, Contribution } from "../core/models.js";
 import type { WatchOp } from "../core/watch-events.js";
@@ -21,6 +22,7 @@ export interface WatchHubRecorder {
   contribution(op: WatchOp, c: Contribution): void;
   claim(op: WatchOp, c: Claim): void;
   agentSession(op: WatchOp, s: AgentSession): void;
+  agentTask(op: WatchOp, view: AgentTaskView): void;
 }
 
 export interface CreateWatchHubRecorderOptions {
@@ -38,12 +40,13 @@ export function createWatchHubRecorder(opts: CreateWatchHubRecorderOptions): Wat
   const now = opts.now ?? (() => Date.now());
 
   const safeRecord = (
-    kind: "Contribution" | "Claim" | "AgentSession",
+    kind: "Contribution" | "Claim" | "AgentSession" | "AgentTask",
     op: WatchOp,
     entity:
       | ReturnType<typeof contributionToEntity>
       | ReturnType<typeof claimToEntity>
-      | ReturnType<typeof agentSessionToEntity>,
+      | ReturnType<typeof agentSessionToEntity>
+      | ReturnType<typeof agentTaskViewToEntity>,
   ): void => {
     try {
       hub.recordWrite({ kind, namespace, op, entity });
@@ -62,6 +65,9 @@ export function createWatchHubRecorder(opts: CreateWatchHubRecorderOptions): Wat
     },
     agentSession(op, s) {
       safeRecord("AgentSession", op, agentSessionToEntity(s, undefined, namespace));
+    },
+    agentTask(op, view) {
+      safeRecord("AgentTask", op, agentTaskViewToEntity(view, namespace));
     },
   };
 }

--- a/src/server/agent-task-store-wiring.test.ts
+++ b/src/server/agent-task-store-wiring.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentTaskPhase } from "../core/agent-task.js";
+import { WatchHub } from "../core/watch-hub.js";
+import { createSqliteStores } from "../local/sqlite-store.js";
+import { wireAgentTaskStoreWrites } from "./agent-task-store-wiring.js";
+
+const TEST_NAMESPACE = "test-project/main";
+
+describe("wireAgentTaskStoreWrites", () => {
+  let tempDir: string;
+  let stores: ReturnType<typeof createSqliteStores>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "grove-task-wiring-test-"));
+    stores = createSqliteStores(join(tempDir, "test.db"));
+  });
+
+  afterEach(async () => {
+    stores.close();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("publishes and enqueues after AgentTask spec and status writes", async () => {
+    const watchHub = new WatchHub();
+    const enqueued: string[] = [];
+
+    wireAgentTaskStoreWrites({
+      store: stores.agentTaskStore,
+      namespace: TEST_NAMESPACE,
+      watchHub,
+      enqueueTaskId: (taskId) => enqueued.push(taskId),
+    });
+
+    await stores.agentTaskStore.putAgentTaskSpec({
+      id: "task-wire",
+      worktree: "/tmp/worktree",
+      runtime: "codex",
+      role: "worker",
+      prompt: "Implement issue 299",
+      dependsOn: [],
+      generation: 0,
+      createdAt: "2026-05-14T12:00:00.000Z",
+    });
+
+    expect(watchHub.currentRv(TEST_NAMESPACE, "AgentTask")).toBe(1n);
+    expect(enqueued).toEqual(["task-wire"]);
+
+    await stores.agentTaskStore.patchAgentTaskStatus("task-wire", {
+      phase: AgentTaskPhase.Running,
+      observedGeneration: 1,
+      sessionId: "session-1",
+    });
+
+    expect(watchHub.currentRv(TEST_NAMESPACE, "AgentTask")).toBe(2n);
+    expect(enqueued).toEqual(["task-wire", "task-wire"]);
+  });
+
+  test("preserves an existing AgentTask write callback", async () => {
+    const watchHub = new WatchHub();
+    const priorCalls: string[] = [];
+    stores.agentTaskStore.onAgentTaskWrite = (op, view) => {
+      priorCalls.push(`${op}:${view.spec.id}`);
+    };
+
+    wireAgentTaskStoreWrites({
+      store: stores.agentTaskStore,
+      namespace: TEST_NAMESPACE,
+      watchHub,
+    });
+
+    await stores.agentTaskStore.putAgentTaskSpec({
+      id: "task-prior",
+      worktree: "/tmp/worktree",
+      runtime: "codex",
+      role: "worker",
+      prompt: "Keep existing callback",
+      dependsOn: [],
+      generation: 0,
+      createdAt: "2026-05-14T12:00:00.000Z",
+    });
+
+    expect(priorCalls).toEqual(["ADDED:task-prior"]);
+    expect(watchHub.currentRv(TEST_NAMESPACE, "AgentTask")).toBe(1n);
+  });
+});

--- a/src/server/agent-task-store-wiring.ts
+++ b/src/server/agent-task-store-wiring.ts
@@ -1,0 +1,62 @@
+import { type AgentTaskView, agentTaskViewToEntity } from "../core/agent-task.js";
+import type { AgentTaskStore } from "../core/store.js";
+import type { WatchHub } from "../core/watch-hub.js";
+import type { NexusWatchSubscriber } from "../nexus/nexus-watch-subscriber.js";
+
+type AgentTaskWriteOp = "ADDED" | "MODIFIED";
+type AgentTaskWriteCallback = (op: AgentTaskWriteOp, view: AgentTaskView) => void;
+
+interface ObservableAgentTaskStore extends AgentTaskStore {
+  onAgentTaskWrite?: AgentTaskWriteCallback | undefined;
+}
+
+export interface WireAgentTaskStoreWritesOptions {
+  readonly store: AgentTaskStore;
+  readonly namespace: string;
+  readonly watchHub: WatchHub;
+  readonly watchSubscriber?: NexusWatchSubscriber | undefined;
+  readonly enqueueTaskId?: ((taskId: string) => void) | undefined;
+  readonly onError?: ((error: unknown) => void) | undefined;
+}
+
+export function hasAgentTaskWriteCallback(store: AgentTaskStore): boolean {
+  return typeof (store as ObservableAgentTaskStore).onAgentTaskWrite === "function";
+}
+
+export function wireAgentTaskStoreWrites(options: WireAgentTaskStoreWritesOptions): void {
+  const observable = options.store as ObservableAgentTaskStore;
+  const previous = observable.onAgentTaskWrite;
+
+  observable.onAgentTaskWrite = (op, view) => {
+    if (previous !== undefined) {
+      try {
+        previous(op, view);
+      } catch (error) {
+        options.onError?.(error);
+      }
+    }
+
+    const entity = agentTaskViewToEntity(view, options.namespace);
+    try {
+      options.watchHub.recordWrite({
+        kind: "AgentTask",
+        namespace: options.namespace,
+        op,
+        entity,
+      });
+      options.watchSubscriber?.markSeen({
+        kind: "AgentTask",
+        entityId: view.spec.id,
+        generation: entity.metadata.generation,
+      });
+    } catch (error) {
+      options.onError?.(error);
+    }
+
+    try {
+      options.enqueueTaskId?.(view.spec.id);
+    } catch (error) {
+      options.onError?.(error);
+    }
+  };
+}

--- a/src/server/routes/agent-tasks.ts
+++ b/src/server/routes/agent-tasks.ts
@@ -12,7 +12,7 @@ import type { Hono as HonoType, MiddlewareHandler } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import type { AgentTaskSpecRecord } from "../../core/agent-task.js";
-import { AgentTaskPhase } from "../../core/agent-task.js";
+import { AgentTaskPhase, agentTaskViewToEntity } from "../../core/agent-task.js";
 import type { JsonValue } from "../../core/models.js";
 import type { AgentTaskStatusPatch } from "../../core/store.js";
 import type { ServerEnv } from "../deps.js";
@@ -154,9 +154,10 @@ export const agentTasks: HonoType<ServerEnv> = new Hono<ServerEnv>();
 agentTasks.use("*", requireAgentTaskStore);
 
 agentTasks.put("/:id", zValidator("json", specBodySchema), async (c) => {
+  const deps = c.get("deps");
   const taskId = c.req.param("id");
   const body = c.req.valid("json");
-  const store = c.get("deps").agentTaskStore;
+  const store = deps.agentTaskStore;
   if (store === undefined) throw new Error("AgentTask store middleware did not run");
 
   const existing = await store.getAgentTask(taskId);
@@ -177,6 +178,27 @@ agentTasks.put("/:id", zValidator("json", specBodySchema), async (c) => {
   };
 
   const view = await store.putAgentTaskSpec(spec);
+  const namespace = c.get("namespace");
+  const entity = agentTaskViewToEntity(view, namespace);
+  try {
+    deps.watchHub.recordWrite({
+      kind: "AgentTask",
+      namespace,
+      op: existing === undefined ? "ADDED" : "MODIFIED",
+      entity,
+    });
+    deps.watchSubscriber?.markSeen({
+      kind: "AgentTask",
+      entityId: view.spec.id,
+      generation: entity.metadata.generation,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[grove] Warning: watch fan-out threw after PUT /api/agent-tasks/${taskId}: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+  }
   return c.json(view, existing === undefined ? 201 : 200);
 });
 
@@ -211,7 +233,8 @@ agentTasks.patch(
   requireControllerToken,
   zValidator("json", statusBodySchema),
   async (c) => {
-    const store = c.get("deps").agentTaskStore;
+    const deps = c.get("deps");
+    const store = deps.agentTaskStore;
     if (store === undefined) throw new Error("AgentTask store middleware did not run");
     const body = c.req.valid("json");
     const patch: AgentTaskStatusPatch = {
@@ -222,6 +245,24 @@ agentTasks.patch(
       observedGeneration: body.observedGeneration,
       lastTransitionAt: body.lastTransitionAt,
     };
-    return c.json(await store.patchAgentTaskStatus(c.req.param("id"), patch));
+    const taskId = c.req.param("id");
+    const view = await store.patchAgentTaskStatus(taskId, patch);
+    const namespace = c.get("namespace");
+    const entity = agentTaskViewToEntity(view, namespace);
+    try {
+      deps.watchHub.recordWrite({ kind: "AgentTask", namespace, op: "MODIFIED", entity });
+      deps.watchSubscriber?.markSeen({
+        kind: "AgentTask",
+        entityId: view.spec.id,
+        generation: entity.metadata.generation,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `[grove] Warning: watch fan-out threw after PATCH /api/agent-tasks/${taskId}/status: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+    }
+    return c.json(view);
   },
 );

--- a/src/server/routes/agent-tasks.ts
+++ b/src/server/routes/agent-tasks.ts
@@ -15,6 +15,7 @@ import type { AgentTaskSpecRecord } from "../../core/agent-task.js";
 import { AgentTaskPhase, agentTaskViewToEntity } from "../../core/agent-task.js";
 import type { JsonValue } from "../../core/models.js";
 import type { AgentTaskStatusPatch } from "../../core/store.js";
+import { hasAgentTaskWriteCallback } from "../agent-task-store-wiring.js";
 import type { ServerEnv } from "../deps.js";
 
 const phaseSchema = z.enum([
@@ -180,24 +181,26 @@ agentTasks.put("/:id", zValidator("json", specBodySchema), async (c) => {
   const view = await store.putAgentTaskSpec(spec);
   const namespace = c.get("namespace");
   const entity = agentTaskViewToEntity(view, namespace);
-  try {
-    deps.watchHub.recordWrite({
-      kind: "AgentTask",
-      namespace,
-      op: existing === undefined ? "ADDED" : "MODIFIED",
-      entity,
-    });
-    deps.watchSubscriber?.markSeen({
-      kind: "AgentTask",
-      entityId: view.spec.id,
-      generation: entity.metadata.generation,
-    });
-  } catch (err) {
-    process.stderr.write(
-      `[grove] Warning: watch fan-out threw after PUT /api/agent-tasks/${taskId}: ${
-        err instanceof Error ? err.message : String(err)
-      }\n`,
-    );
+  if (!hasAgentTaskWriteCallback(store)) {
+    try {
+      deps.watchHub.recordWrite({
+        kind: "AgentTask",
+        namespace,
+        op: existing === undefined ? "ADDED" : "MODIFIED",
+        entity,
+      });
+      deps.watchSubscriber?.markSeen({
+        kind: "AgentTask",
+        entityId: view.spec.id,
+        generation: entity.metadata.generation,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `[grove] Warning: watch fan-out threw after PUT /api/agent-tasks/${taskId}: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+    }
   }
   return c.json(view, existing === undefined ? 201 : 200);
 });
@@ -249,19 +252,21 @@ agentTasks.patch(
     const view = await store.patchAgentTaskStatus(taskId, patch);
     const namespace = c.get("namespace");
     const entity = agentTaskViewToEntity(view, namespace);
-    try {
-      deps.watchHub.recordWrite({ kind: "AgentTask", namespace, op: "MODIFIED", entity });
-      deps.watchSubscriber?.markSeen({
-        kind: "AgentTask",
-        entityId: view.spec.id,
-        generation: entity.metadata.generation,
-      });
-    } catch (err) {
-      process.stderr.write(
-        `[grove] Warning: watch fan-out threw after PATCH /api/agent-tasks/${taskId}/status: ${
-          err instanceof Error ? err.message : String(err)
-        }\n`,
-      );
+    if (!hasAgentTaskWriteCallback(store)) {
+      try {
+        deps.watchHub.recordWrite({ kind: "AgentTask", namespace, op: "MODIFIED", entity });
+        deps.watchSubscriber?.markSeen({
+          kind: "AgentTask",
+          entityId: view.spec.id,
+          generation: entity.metadata.generation,
+        });
+      } catch (err) {
+        process.stderr.write(
+          `[grove] Warning: watch fan-out threw after PATCH /api/agent-tasks/${taskId}/status: ${
+            err instanceof Error ? err.message : String(err)
+          }\n`,
+        );
+      }
     }
     return c.json(view);
   },

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -570,7 +570,6 @@ async function listForKind(
   namespace: string,
   kind: WatchKind,
 ): Promise<readonly unknown[]> {
-  void namespace;
   switch (kind) {
     case "Contribution":
       return deps.contributionStore.listEntities();
@@ -584,7 +583,9 @@ async function listForKind(
       if (deps.agentTaskStore === undefined) {
         throw new Error("AgentTask store is not configured");
       }
-      return deps.agentTaskStore.listAgentTaskEntities();
+      return (await deps.agentTaskStore.listAgentTasks()).map((view) =>
+        agentTaskViewToEntity(view, namespace),
+      );
     default: {
       const _exhaustive: never = kind;
       void _exhaustive;

--- a/src/server/routes/watch.ts
+++ b/src/server/routes/watch.ts
@@ -13,6 +13,7 @@ import { zValidator } from "@hono/zod-validator";
 import type { Hono as HonoType } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
+import { agentTaskViewToEntity } from "../../core/agent-task.js";
 import { claimToEntity, contributionToEntity } from "../../core/entity.js";
 import {
   StaleResourceVersionError,
@@ -22,7 +23,7 @@ import {
 import { BufferOverflowError, type WatchHub } from "../../core/watch-hub.js";
 import type { ServerDeps, ServerEnv } from "../deps.js";
 
-const KIND_VALUES = ["Contribution", "Claim", "AgentSession"] as const;
+const KIND_VALUES = ["Contribution", "Claim", "AgentSession", "AgentTask"] as const;
 // Subset of KIND_VALUES for which list+watch are actually backed by
 // stores and fan-out hooks. AgentSession remains in KIND_VALUES so the
 // type narrowing stays exhaustive, but watching it returns 501 until
@@ -30,6 +31,7 @@ const KIND_VALUES = ["Contribution", "Claim", "AgentSession"] as const;
 const SUPPORTED_KINDS: ReadonlySet<(typeof KIND_VALUES)[number]> = new Set([
   "Contribution",
   "Claim",
+  "AgentTask",
 ]);
 
 const listQuerySchema = z.object({
@@ -59,6 +61,17 @@ watch.get("/list", zValidator("query", listQuerySchema), async (c) => {
     );
   }
   const deps = c.get("deps");
+  if (kind === "AgentTask" && deps.agentTaskStore === undefined) {
+    return c.json(
+      {
+        error: {
+          code: "NOT_CONFIGURED",
+          message: "AgentTask store is not configured",
+        },
+      },
+      501,
+    );
+  }
   const hub: WatchHub = deps.watchHub;
 
   // Race-correctness invariant (spec §Critical path): capture RV BEFORE the
@@ -90,6 +103,18 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
       501,
     );
   }
+  const deps = c.get("deps");
+  if (kind === "AgentTask" && deps.agentTaskStore === undefined) {
+    return c.json(
+      {
+        error: {
+          code: "NOT_CONFIGURED",
+          message: "AgentTask store is not configured",
+        },
+      },
+      501,
+    );
+  }
   const lastEventId = c.req.header("last-event-id");
   // Last-Event-ID overrides resumeFrom on auto-reconnect (browser EventSource).
   // If present but malformed, fail fast with 400 — silently falling back to
@@ -107,7 +132,7 @@ watch.get("/watch", zValidator("query", watchQuerySchema), (c) => {
     );
   }
   const fromRv = BigInt(lastEventId ?? resumeFrom);
-  const hub: WatchHub = c.get("deps").watchHub;
+  const hub: WatchHub = deps.watchHub;
 
   // SSE-route per-connection byte cap. The WatchHub already bounds its
   // per-subscriber queue, but once a hub event is drained into the route's
@@ -442,6 +467,13 @@ async function hydrateEntity(
     }
     return undefined;
   }
+  if (kind === "AgentTask") {
+    const view = await deps.agentTaskStore?.getAgentTask(entityId);
+    if (view !== undefined) {
+      return agentTaskViewToEntity(view, namespace) as MaybeVersioned;
+    }
+    return undefined;
+  }
   // Unsupported kinds are rejected at the route entry; this path is
   // unreachable but kept for type exhaustiveness.
   return undefined;
@@ -468,6 +500,17 @@ watch.post("/watch/notify", zValidator("json", watchNotifySchema), async (c) => 
   }
 
   const deps = c.get("deps") as ServerDeps;
+  if (kind === "AgentTask" && deps.agentTaskStore === undefined) {
+    return c.json(
+      {
+        error: {
+          code: "NOT_CONFIGURED",
+          message: "AgentTask store is not configured",
+        },
+      },
+      501,
+    );
+  }
   const hub: WatchHub = deps.watchHub;
 
   // Session-scoped contribution writes cannot be safely fanned out to
@@ -537,6 +580,11 @@ async function listForKind(
       // AgentSession listing is not yet a Store API. Return empty until the
       // session-orchestrator integration lands (out of scope for #292).
       return [];
+    case "AgentTask":
+      if (deps.agentTaskStore === undefined) {
+        throw new Error("AgentTask store is not configured");
+      }
+      return deps.agentTaskStore.listAgentTaskEntities();
     default: {
       const _exhaustive: never = kind;
       void _exhaustive;

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -10,6 +10,7 @@
  */
 
 import { join } from "node:path";
+import { agentTaskViewToEntity } from "../core/agent-task.js";
 import { claimToEntity, contributionToEntity } from "../core/entity.js";
 import type { FrontierCalculator } from "../core/frontier.js";
 import { SessionAggregatingFrontierCalculator } from "../core/frontier.js";
@@ -372,6 +373,7 @@ const watchSubscriber = new NexusWatchSubscriber({
   fetchEntity: makeWatchEntityFetcher({
     contributionStore: serverContributionStore,
     claimStore: serverClaimStore,
+    agentTaskStore: runtime.agentTaskStore,
   }),
 });
 watchSubscriber.start();
@@ -643,6 +645,7 @@ process.on("SIGINT", () => void shutdown());
 function makeWatchEntityFetcher(stores: {
   contributionStore: import("../core/store.js").ContributionStore;
   claimStore: import("../core/store.js").ClaimStore;
+  agentTaskStore?: import("../core/store.js").AgentTaskStore | undefined;
 }): (kind: WatchKind, namespace: string, id: string) => Promise<WatchEntity> {
   return async (kind, namespace, id) => {
     if (kind === "Contribution") {
@@ -654,6 +657,11 @@ function makeWatchEntityFetcher(stores: {
       const c = await stores.claimStore.getClaim(id);
       if (!c) throw new Error(`Claim ${id} not found`);
       return claimToEntity(c, () => Date.now(), namespace);
+    }
+    if (kind === "AgentTask") {
+      const view = await stores.agentTaskStore?.getAgentTask(id);
+      if (!view) throw new Error(`AgentTask ${id} not found`);
+      return agentTaskViewToEntity(view, namespace);
     }
     throw new Error(`Unsupported kind for watch fetcher: ${kind}`);
   };

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -416,19 +416,6 @@ const getSharedAgentRuntime = async (): Promise<
 };
 
 let taskController: TaskController | undefined;
-if (taskControllerEnabled(process.env) && runtime.agentTaskStore !== undefined) {
-  taskController = new TaskController({
-    taskStore: runtime.agentTaskStore,
-    runtime: await getSharedAgentRuntime(),
-    onError(error, taskId) {
-      const detail = error instanceof Error ? error.message : String(error);
-      process.stderr.write(`[task-controller] ${taskId}: ${detail}\n`);
-    },
-  });
-  await taskController.resync();
-  taskController.start();
-  console.log("task-controller enabled");
-}
 
 // ---------------------------------------------------------------------------
 // Background sweep reconciler
@@ -500,6 +487,36 @@ const claimExpiryTimer = setInterval(async () => {
 (claimExpiryTimer as unknown as { unref?: () => void }).unref?.();
 
 // ---------------------------------------------------------------------------
+// Server bind safety checks
+// ---------------------------------------------------------------------------
+
+// Refuse to bind a non-localhost address without an explicit operator
+// opt-in. The HTTP surface has no authentication (role-sensitive mutations
+// are gated to MCP stdio, but read routes and `?sessionId=` scoping are
+// caller-asserted), so the deployment trust boundary is the localhost
+// binding. Operators who want remote access MUST set
+// `GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true` to acknowledge the risk;
+// typical production usage places the server behind an authenticated
+// reverse proxy.
+//
+// MUST run before SessionService/task-controller setup or Bun.serve() —
+// otherwise we could spawn sessions or bind the socket before deciding to exit.
+const LOCALHOST_ADDRESSES = new Set(["localhost", "127.0.0.1", "::1"]);
+if (HOST && !LOCALHOST_ADDRESSES.has(HOST)) {
+  if (process.env.GROVE_ALLOW_UNAUTHENTICATED_REMOTE !== "true") {
+    console.error(
+      "\u26a0 Refusing to bind non-localhost address without authentication.\n" +
+        "  Set GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true to opt in explicitly,\n" +
+        "  or front this process with an authenticated reverse proxy and bind to localhost.",
+    );
+    process.exit(1);
+  }
+  console.warn(
+    "\u26a0 Server bound to non-localhost address without authentication (GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true).",
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Optional SessionService + WebSocket push
 // ---------------------------------------------------------------------------
 
@@ -525,32 +542,6 @@ if (runtime.contract?.topology !== undefined) {
 // ---------------------------------------------------------------------------
 // Start server (with optional WebSocket upgrade)
 // ---------------------------------------------------------------------------
-
-// Refuse to bind a non-localhost address without an explicit operator
-// opt-in. The HTTP surface has no authentication (role-sensitive mutations
-// are gated to MCP stdio, but read routes and `?sessionId=` scoping are
-// caller-asserted), so the deployment trust boundary is the localhost
-// binding. Operators who want remote access MUST set
-// `GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true` to acknowledge the risk;
-// typical production usage places the server behind an authenticated
-// reverse proxy.
-//
-// MUST run BEFORE Bun.serve() — otherwise the socket would already be
-// bound and listening before we decided to exit.
-const LOCALHOST_ADDRESSES = new Set(["localhost", "127.0.0.1", "::1"]);
-if (HOST && !LOCALHOST_ADDRESSES.has(HOST)) {
-  if (process.env.GROVE_ALLOW_UNAUTHENTICATED_REMOTE !== "true") {
-    console.error(
-      "\u26a0 Refusing to bind non-localhost address without authentication.\n" +
-        "  Set GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true to opt in explicitly,\n" +
-        "  or front this process with an authenticated reverse proxy and bind to localhost.",
-    );
-    process.exit(1);
-  }
-  console.warn(
-    "\u26a0 Server bound to non-localhost address without authentication (GROVE_ALLOW_UNAUTHENTICATED_REMOTE=true).",
-  );
-}
 
 function startServer() {
   const hostnameOpts = HOST ? { hostname: HOST } : {};
@@ -615,6 +606,20 @@ function startServer() {
 }
 
 const server = startServer();
+
+if (taskControllerEnabled(process.env) && runtime.agentTaskStore !== undefined) {
+  taskController = new TaskController({
+    taskStore: runtime.agentTaskStore,
+    runtime: await getSharedAgentRuntime(),
+    onError(error, taskId) {
+      const detail = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`[task-controller] ${taskId}: ${detail}\n`);
+    },
+  });
+  await taskController.resync();
+  taskController.start();
+  console.log("task-controller enabled");
+}
 
 // Start gossip after server is listening
 if (gossipService) {

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -34,6 +34,7 @@ import { DefaultGossipService } from "../gossip/protocol.js";
 import { createLocalRuntime } from "../local/runtime.js";
 import { NexusWatchSubscriber } from "../nexus/nexus-watch-subscriber.js";
 import { parseGossipSeeds, parsePort } from "../shared/env.js";
+import { wireAgentTaskStoreWrites } from "./agent-task-store-wiring.js";
 import { createApp } from "./app.js";
 import type { ServerDeps } from "./deps.js";
 import { loadKeyRegistry } from "./middleware/namespace-auth.js";
@@ -221,6 +222,7 @@ if (registry.size === 0) {
 // NexusEventBus (cross-process via Nexus IPC) on both sides.
 const watchHub = new WatchHub(resolveWatchHubConfig(process.env));
 const watchEventBus = new LocalEventBus();
+let taskController: TaskController | undefined;
 
 if (nexusUrl) {
   const { NexusHttpClient } = await import("../nexus/nexus-http-client.js");
@@ -379,6 +381,20 @@ const watchSubscriber = new NexusWatchSubscriber({
 });
 watchSubscriber.start();
 
+wireAgentTaskStoreWrites({
+  store: runtime.agentTaskStore,
+  namespace: zoneId,
+  watchHub,
+  watchSubscriber,
+  enqueueTaskId: (taskId) => {
+    taskController?.enqueue(taskId);
+  },
+  onError(error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`[grove] Warning: AgentTask write fan-out failed: ${detail}\n`);
+  },
+});
+
 const deps: ServerDeps = {
   contributionStore: serverContributionStore,
   contributionStoreForSession: contributionStoreForSessionFactory,
@@ -414,8 +430,6 @@ const getSharedAgentRuntime = async (): Promise<
   sharedAgentRuntime ??= await createServerAgentRuntime();
   return sharedAgentRuntime;
 };
-
-let taskController: TaskController | undefined;
 
 // ---------------------------------------------------------------------------
 // Background sweep reconciler

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -25,7 +25,7 @@ import {
   writeClientKey,
   writeNamespace,
 } from "../core/project-key.js";
-import { TmuxRuntime } from "../core/tmux-runtime.js";
+import { TaskController } from "../core/task-controller.js";
 import type { WatchEntity, WatchKind } from "../core/watch-events.js";
 import { WatchHub } from "../core/watch-hub.js";
 import { CachedFrontierCalculator } from "../gossip/cached-frontier.js";
@@ -39,6 +39,7 @@ import type { ServerDeps } from "./deps.js";
 import { loadKeyRegistry } from "./middleware/namespace-auth.js";
 import { SessionService } from "./session-service.js";
 import { memoizeContributionStoreForSession } from "./session-store-factory.js";
+import { createServerAgentRuntime, taskControllerEnabled } from "./task-controller-wiring.js";
 import { resolveWatchHubConfig } from "./watch-hub-config.js";
 import { createWsHandler } from "./ws-handler.js";
 
@@ -406,6 +407,29 @@ const deps: ServerDeps = {
 
 const app = createApp(deps, registry);
 
+let sharedAgentRuntime: import("../core/agent-runtime.js").AgentRuntime | undefined;
+const getSharedAgentRuntime = async (): Promise<
+  import("../core/agent-runtime.js").AgentRuntime
+> => {
+  sharedAgentRuntime ??= await createServerAgentRuntime();
+  return sharedAgentRuntime;
+};
+
+let taskController: TaskController | undefined;
+if (taskControllerEnabled(process.env) && runtime.agentTaskStore !== undefined) {
+  taskController = new TaskController({
+    taskStore: runtime.agentTaskStore,
+    runtime: await getSharedAgentRuntime(),
+    onError(error, taskId) {
+      const detail = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`[task-controller] ${taskId}: ${detail}\n`);
+    },
+  });
+  await taskController.resync();
+  taskController.start();
+  console.log("task-controller enabled");
+}
+
 // ---------------------------------------------------------------------------
 // Background sweep reconciler
 // ---------------------------------------------------------------------------
@@ -483,19 +507,7 @@ let sessionService: SessionService | undefined;
 let wsHandler: ReturnType<typeof createWsHandler> | undefined;
 
 if (runtime.contract?.topology !== undefined) {
-  // Create an agent runtime via selectRuntime (honors GROVE_RUNTIME env),
-  // fall back to tmux when neither acp nor acpx is available
-  let agentRuntime: import("../core/agent-runtime.js").AgentRuntime;
-  {
-    const { selectRuntime } = await import("../core/select-runtime.js");
-    const picked = selectRuntime();
-    if (await picked.isAvailable()) {
-      agentRuntime = picked;
-    } else {
-      agentRuntime = new TmuxRuntime();
-    }
-  }
-
+  const agentRuntime = await getSharedAgentRuntime();
   const eventBus = new LocalEventBus();
 
   sessionService = new SessionService({
@@ -618,6 +630,7 @@ async function shutdown(): Promise<void> {
   if (sweepReconciler) {
     sweepReconciler.stop();
   }
+  await taskController?.stop();
   if (sessionService) {
     sessionService.destroy();
   }

--- a/src/server/task-controller-wiring.test.ts
+++ b/src/server/task-controller-wiring.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { AcpxTurn } from "../acp/types.js";
-import type { AgentRuntime } from "../core/agent-runtime.js";
+import type { AgentConfig, AgentRuntime, AgentSession } from "../core/agent-runtime.js";
+import type { AgentSessionEntity } from "../core/entity.js";
+import { createServerAgentRuntime, taskControllerEnabled } from "./task-controller-wiring.js";
 
 function emptyTurn(sessionId: string): AcpxTurn {
   return {
@@ -32,33 +34,65 @@ const selectedRuntime: AgentRuntime = {
   isAvailable: mock(async () => selectedRuntimeAvailable),
 };
 
-class FakeTmuxRuntime {
+class FakeTmuxRuntime implements AgentRuntime {
   readonly fallbackRuntime = true;
+
+  readonly sendsInitialPromptOnSpawn = true;
+
+  async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
+    return {
+      id: "fallback-session",
+      role,
+      status: "running",
+      platform: config.platform,
+      model: config.model,
+    };
+  }
+
+  async send(session: AgentSession): Promise<AcpxTurn> {
+    return emptyTurn(session.id);
+  }
+
+  async close(): Promise<void> {
+    return undefined;
+  }
+
+  onIdle(): void {
+    // no-op
+  }
+
+  async listSessions(): Promise<readonly AgentSession[]> {
+    return [];
+  }
+
+  async listSessionEntities(): Promise<readonly AgentSessionEntity[]> {
+    return [];
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
 }
-
-mock.module("../core/select-runtime.js", () => ({
-  selectRuntime: () => selectedRuntime,
-}));
-
-mock.module("../core/tmux-runtime.js", () => ({
-  TmuxRuntime: FakeTmuxRuntime,
-}));
-
-const { createServerAgentRuntime, taskControllerEnabled } = await import(
-  "./task-controller-wiring.js"
-);
 
 describe("task controller server wiring", () => {
   test("uses selected runtime when available", async () => {
     selectedRuntimeAvailable = true;
 
-    await expect(createServerAgentRuntime()).resolves.toBe(selectedRuntime);
+    await expect(
+      createServerAgentRuntime({
+        selectRuntime: () => selectedRuntime,
+        createFallbackRuntime: () => new FakeTmuxRuntime(),
+      }),
+    ).resolves.toBe(selectedRuntime);
   });
 
   test("falls back to tmux runtime when selected runtime is unavailable", async () => {
     selectedRuntimeAvailable = false;
 
-    const runtime = await createServerAgentRuntime();
+    const runtime = await createServerAgentRuntime({
+      selectRuntime: () => selectedRuntime,
+      createFallbackRuntime: () => new FakeTmuxRuntime(),
+    });
 
     expect(runtime).toBeInstanceOf(FakeTmuxRuntime);
   });

--- a/src/server/task-controller-wiring.test.ts
+++ b/src/server/task-controller-wiring.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AcpxTurn } from "../acp/types.js";
+import type { AgentRuntime } from "../core/agent-runtime.js";
+
+function emptyTurn(sessionId: string): AcpxTurn {
+  return {
+    sessionId,
+    turnId: `${sessionId}-turn`,
+    messages: (async function* () {
+      // no messages
+    })(),
+    result: Promise.resolve({ turnId: `${sessionId}-turn`, stopReason: "end_turn" }),
+    cancel: async () => undefined,
+    close: async () => undefined,
+  };
+}
+
+let selectedRuntimeAvailable = true;
+const selectedRuntime: AgentRuntime = {
+  spawn: async (role, config) => ({
+    id: "selected-session",
+    role,
+    status: "running",
+    platform: config.platform,
+    model: config.model,
+  }),
+  send: async (session) => emptyTurn(session.id),
+  close: async () => undefined,
+  onIdle: () => undefined,
+  listSessions: async () => [],
+  listSessionEntities: async () => [],
+  isAvailable: mock(async () => selectedRuntimeAvailable),
+};
+
+class FakeTmuxRuntime {
+  readonly fallbackRuntime = true;
+}
+
+mock.module("../core/select-runtime.js", () => ({
+  selectRuntime: () => selectedRuntime,
+}));
+
+mock.module("../core/tmux-runtime.js", () => ({
+  TmuxRuntime: FakeTmuxRuntime,
+}));
+
+const { createServerAgentRuntime, taskControllerEnabled } = await import(
+  "./task-controller-wiring.js"
+);
+
+describe("task controller server wiring", () => {
+  test("uses selected runtime when available", async () => {
+    selectedRuntimeAvailable = true;
+
+    await expect(createServerAgentRuntime()).resolves.toBe(selectedRuntime);
+  });
+
+  test("falls back to tmux runtime when selected runtime is unavailable", async () => {
+    selectedRuntimeAvailable = false;
+
+    const runtime = await createServerAgentRuntime();
+
+    expect(runtime).toBeInstanceOf(FakeTmuxRuntime);
+  });
+
+  test("enables task controller by default", () => {
+    expect(taskControllerEnabled({})).toBe(true);
+  });
+
+  test("enables task controller when explicitly enabled", () => {
+    expect(taskControllerEnabled({ GROVE_TASK_CONTROLLER: "1" })).toBe(true);
+  });
+
+  test("disables task controller when explicitly disabled", () => {
+    expect(taskControllerEnabled({ GROVE_TASK_CONTROLLER: "0" })).toBe(false);
+  });
+});

--- a/src/server/task-controller-wiring.ts
+++ b/src/server/task-controller-wiring.ts
@@ -2,10 +2,17 @@ import type { AgentRuntime } from "../core/agent-runtime.js";
 import { selectRuntime } from "../core/select-runtime.js";
 import { TmuxRuntime } from "../core/tmux-runtime.js";
 
-export async function createServerAgentRuntime(): Promise<AgentRuntime> {
-  const picked = selectRuntime();
+export interface ServerAgentRuntimeDeps {
+  readonly selectRuntime?: typeof selectRuntime;
+  readonly createFallbackRuntime?: () => AgentRuntime;
+}
+
+export async function createServerAgentRuntime(
+  deps: ServerAgentRuntimeDeps = {},
+): Promise<AgentRuntime> {
+  const picked = (deps.selectRuntime ?? selectRuntime)();
   if (await picked.isAvailable()) return picked;
-  return new TmuxRuntime();
+  return (deps.createFallbackRuntime ?? (() => new TmuxRuntime()))();
 }
 
 export function taskControllerEnabled(env: Readonly<Record<string, string | undefined>>): boolean {

--- a/src/server/task-controller-wiring.ts
+++ b/src/server/task-controller-wiring.ts
@@ -1,0 +1,13 @@
+import type { AgentRuntime } from "../core/agent-runtime.js";
+import { selectRuntime } from "../core/select-runtime.js";
+import { TmuxRuntime } from "../core/tmux-runtime.js";
+
+export async function createServerAgentRuntime(): Promise<AgentRuntime> {
+  const picked = selectRuntime();
+  if (await picked.isAvailable()) return picked;
+  return new TmuxRuntime();
+}
+
+export function taskControllerEnabled(env: Readonly<Record<string, string | undefined>>): boolean {
+  return env.GROVE_TASK_CONTROLLER !== "0";
+}

--- a/tests/server/agent-tasks.test.ts
+++ b/tests/server/agent-tasks.test.ts
@@ -143,4 +143,22 @@ describe("Agent task routes", () => {
     expect(data.spec.prompt).toBe("Implement issue 297");
     expect(data.spec.generation).toBe(created.spec.generation);
   });
+
+  test("GET /api/list supports AgentTask snapshots", async () => {
+    await ctx.agentTaskStore.putAgentTaskSpec({
+      id: "task-watch-list",
+      ...SPEC_BODY,
+      generation: 0,
+      createdAt: "2026-05-14T12:00:00.000Z",
+    });
+
+    const res = await ctx.app.request("/api/list?kind=AgentTask", {
+      headers: TEST_AUTH_HEADERS,
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.items[0].kind).toBe("AgentTask");
+    expect(data.items[0].id).toBe("task-watch-list");
+  });
 });

--- a/tests/server/agent-tasks.test.ts
+++ b/tests/server/agent-tasks.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { AgentTaskPhase } from "../../src/core/agent-task.js";
+import {
+  AgentTaskPhase,
+  type AgentTaskView,
+  agentTaskViewToEntity,
+} from "../../src/core/agent-task.js";
 import { Finalizer } from "../../src/core/lifecycle-metadata.js";
+import type { AgentTaskStore } from "../../src/core/store.js";
 import type { EntityWriteEvent } from "../../src/core/watch-events.js";
 import type { TestContext } from "./helpers.js";
 import {
@@ -28,6 +33,15 @@ function captureWatchWrites(ctx: TestContext): EntityWriteEvent[] {
     return original(event);
   };
   return events;
+}
+
+type AgentTaskWriteCallback = (op: "ADDED" | "MODIFIED", view: AgentTaskView) => void;
+type ObservableAgentTaskStore = AgentTaskStore & {
+  onAgentTaskWrite?: AgentTaskWriteCallback | undefined;
+};
+
+function asObservableAgentTaskStore(store: AgentTaskStore): ObservableAgentTaskStore {
+  return store as ObservableAgentTaskStore;
 }
 
 describe("Agent task routes", () => {
@@ -86,6 +100,28 @@ describe("Agent task routes", () => {
     expect(events[1]?.entity.id).toBe("task-watch-put");
     expect(events[1]?.entity.metadata.generation).toBe(2);
     expect(events[1]?.entity.spec.prompt).toBe("Updated prompt");
+  });
+
+  test("PUT /api/agent-tasks/:id does not double-publish when store write fan-out is wired", async () => {
+    const events = captureWatchWrites(ctx);
+    asObservableAgentTaskStore(ctx.agentTaskStore).onAgentTaskWrite = (op, view) => {
+      ctx.deps.watchHub.recordWrite({
+        kind: "AgentTask",
+        namespace: TEST_NAMESPACE,
+        op,
+        entity: agentTaskViewToEntity(view, TEST_NAMESPACE),
+      });
+    };
+
+    const createRes = await ctx.app.request("/api/agent-tasks/task-watch-store", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(SPEC_BODY),
+    });
+
+    expect(createRes.status).toBe(201);
+    expect(ctx.deps.watchHub.currentRv(TEST_NAMESPACE, "AgentTask")).toBe(1n);
+    expect(events.map((event) => event.op)).toEqual(["ADDED"]);
   });
 
   test("PUT /api/agent-tasks/:id rejects status-owned fields from the TUI path", async () => {

--- a/tests/server/agent-tasks.test.ts
+++ b/tests/server/agent-tasks.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { AgentTaskPhase } from "../../src/core/agent-task.js";
 import { Finalizer } from "../../src/core/lifecycle-metadata.js";
+import type { EntityWriteEvent } from "../../src/core/watch-events.js";
 import type { TestContext } from "./helpers.js";
 import {
   createTestContext,
@@ -18,6 +19,16 @@ const SPEC_BODY = {
   maxTurns: 4,
   budget: { usd: 3 },
 };
+
+function captureWatchWrites(ctx: TestContext): EntityWriteEvent[] {
+  const events: EntityWriteEvent[] = [];
+  const original = ctx.deps.watchHub.recordWrite.bind(ctx.deps.watchHub);
+  ctx.deps.watchHub.recordWrite = (event: EntityWriteEvent) => {
+    events.push(event);
+    return original(event);
+  };
+  return events;
+}
 
 describe("Agent task routes", () => {
   let ctx: TestContext;
@@ -44,6 +55,37 @@ describe("Agent task routes", () => {
     expect(data.spec.generation).toBe(1);
     expect(data.status.phase).toBe(AgentTaskPhase.Pending);
     expect(data.status.observedGeneration).toBe(0);
+  });
+
+  test("PUT /api/agent-tasks/:id emits AgentTask watch writes for create and update", async () => {
+    const events = captureWatchWrites(ctx);
+    expect(ctx.deps.watchHub.currentRv(TEST_NAMESPACE, "AgentTask")).toBe(0n);
+
+    const createRes = await ctx.app.request("/api/agent-tasks/task-watch-put", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(SPEC_BODY),
+    });
+
+    expect(createRes.status).toBe(201);
+    expect(ctx.deps.watchHub.currentRv(TEST_NAMESPACE, "AgentTask")).toBe(1n);
+
+    const updateRes = await ctx.app.request("/api/agent-tasks/task-watch-put", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify({ ...SPEC_BODY, prompt: "Updated prompt" }),
+    });
+
+    expect(updateRes.status).toBe(200);
+    expect(ctx.deps.watchHub.currentRv(TEST_NAMESPACE, "AgentTask")).toBe(2n);
+    expect(events.map((event) => event.op)).toEqual(["ADDED", "MODIFIED"]);
+    expect(events.map((event) => event.kind)).toEqual(["AgentTask", "AgentTask"]);
+    expect(events.map((event) => event.namespace)).toEqual([TEST_NAMESPACE, TEST_NAMESPACE]);
+    expect(events[0]?.entity.id).toBe("task-watch-put");
+    expect(events[0]?.entity.metadata.generation).toBe(1);
+    expect(events[1]?.entity.id).toBe("task-watch-put");
+    expect(events[1]?.entity.metadata.generation).toBe(2);
+    expect(events[1]?.entity.spec.prompt).toBe("Updated prompt");
   });
 
   test("PUT /api/agent-tasks/:id rejects status-owned fields from the TUI path", async () => {
@@ -147,6 +189,44 @@ describe("Agent task routes", () => {
     expect(data.status.conditions[0].message).toBe("Started session-1");
     expect(data.spec.prompt).toBe("Implement issue 297");
     expect(data.spec.generation).toBe(created.spec.generation);
+  });
+
+  test("PATCH /api/agent-tasks/:id/status emits AgentTask MODIFIED watch write", async () => {
+    const events = captureWatchWrites(ctx);
+
+    const putRes = await ctx.app.request("/api/agent-tasks/task-watch-status-source", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...TEST_AUTH_HEADERS },
+      body: JSON.stringify(SPEC_BODY),
+    });
+    expect(putRes.status).toBe(201);
+    const created = await putRes.json();
+    expect(ctx.deps.watchHub.currentRv(TEST_NAMESPACE, "AgentTask")).toBe(1n);
+
+    const patchRes = await ctx.app.request("/api/agent-tasks/task-watch-status-source/status", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...TEST_AUTH_HEADERS,
+        ...TEST_CONTROLLER_HEADERS,
+      },
+      body: JSON.stringify({
+        phase: AgentTaskPhase.Running,
+        observedGeneration: created.spec.generation,
+        sessionId: "session-watch",
+      }),
+    });
+
+    expect(patchRes.status).toBe(200);
+    expect(ctx.deps.watchHub.currentRv(TEST_NAMESPACE, "AgentTask")).toBe(2n);
+    expect(events.map((event) => event.op)).toEqual(["ADDED", "MODIFIED"]);
+    const statusEvent = events[1];
+    expect(statusEvent?.kind).toBe("AgentTask");
+    expect(statusEvent?.namespace).toBe(TEST_NAMESPACE);
+    expect(statusEvent?.entity.id).toBe("task-watch-status-source");
+    expect(statusEvent?.entity.metadata.generation).toBe(created.spec.generation);
+    expect(statusEvent?.entity.status.phase).toBe(AgentTaskPhase.Running);
+    expect(statusEvent?.entity.status.sessionId).toBe("session-watch");
   });
 
   test("GET /api/list supports AgentTask snapshots", async () => {

--- a/tests/server/agent-tasks.test.ts
+++ b/tests/server/agent-tasks.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { AgentTaskPhase } from "../../src/core/agent-task.js";
 import { Finalizer } from "../../src/core/lifecycle-metadata.js";
 import type { TestContext } from "./helpers.js";
-import { createTestContext, TEST_AUTH_HEADERS, TEST_CONTROLLER_HEADERS } from "./helpers.js";
+import {
+  createTestContext,
+  TEST_AUTH_HEADERS,
+  TEST_CONTROLLER_HEADERS,
+  TEST_NAMESPACE,
+} from "./helpers.js";
 
 const SPEC_BODY = {
   worktree: "/tmp/worktree",
@@ -160,5 +165,6 @@ describe("Agent task routes", () => {
     const data = await res.json();
     expect(data.items[0].kind).toBe("AgentTask");
     expect(data.items[0].id).toBe("task-watch-list");
+    expect(data.items[0].namespace).toBe(TEST_NAMESPACE);
   });
 });


### PR DESCRIPTION
## Summary

Closes #299.

Implements the D2 AgentTask task controller scope in one PR:

- Adds the core `TaskController` and `DefaultTaskBinder` for AgentTask reconciliation, binding, retries, lifecycle start/stop, resync, and status transitions.
- Adds AgentTask watch/informer support, resourceVersion behavior, local SQLite write fan-out, HTTP AgentTask list/watch fan-out, and server startup wiring.
- Wires server-side AgentTask store writes so controller-owned status patches publish watch events and enqueue task IDs immediately, without duplicate route fan-out.
- Handles live Running reattach catch-up for stale observed generation / Running condition metadata.
- Adds focused tests across core controller behavior, watch/informer projection, SQLite store callbacks, HTTP routes, server wiring, and task-store write wiring.

## Validation

- `PATH=/Users/tafeng/.bun/bin:$PATH bun --config=/dev/null test src/core/task-controller.test.ts src/core/agent-task.test.ts src/core/informer.test.ts src/local/sqlite-agent-task-store.test.ts tests/server/agent-tasks.test.ts src/server/task-controller-wiring.test.ts src/server/agent-task-store-wiring.test.ts` -> 91 pass, 0 fail
- `PATH=/Users/tafeng/.bun/bin:$PATH bun run typecheck` -> pass
- `PATH=/Users/tafeng/.bun/bin:$PATH bun run check` -> exit 0 with existing warnings outside this change
- `PATH=/Users/tafeng/.bun/bin:$PATH bun run build` -> pass
- `PATH=/Users/tafeng/.bun/bin:$PATH bun --config=/dev/null test --timeout 60000` -> summary reports 7503 pass, 7 skip, 0 fail; Bun returned code 2 after the clean summary, matching the pre-existing full-suite harness behavior observed before the final review fixes
