### PR TITLE
[codex] Fix ACP TUI handoff flow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@xterm/headless": "6.0.0",
         "@zed-industries/codex-acp": "^0.14.0",
         "blake3": "^1.0.2",
+        "chokidar": "5.0.0",
         "hono": "^4.12.6",
         "proper-lockfile": "^4.1.2",
         "react": "^19.0.0",
@@ -390,7 +391,7 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
-    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
@@ -642,7 +643,7 @@
 
     "readable-web-to-node-stream": ["readable-web-to-node-stream@3.0.4", "", { "dependencies": { "readable-stream": "^4.7.0" } }, "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw=="],
 
-    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -806,6 +807,8 @@
 
     "react-reconciler/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
+    "tsup/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
     "@grove/ask-user/@biomejs/biome/@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA=="],
 
     "@grove/ask-user/@biomejs/biome/@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-I+cOG3sd/7HdFtvDSnF9QQPrWguUH7zrkIMMykM3PtfWU9soTcS2yRb9Myq6MHmzbeCT08D1UmY+BaiMl5CcoQ=="],
@@ -821,5 +824,7 @@
     "@grove/ask-user/@biomejs/biome/@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-hOUHBMlFCvDhu3WCq6vaBoG0dp0LkWxSEnEEsxxXvOa9TfT6ZBnbh72A/xBM7CBYB7WgwqboetzFEVDnMxelyw=="],
 
     "@grove/ask-user/@biomejs/biome/@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.7", "", { "os": "win32", "cpu": "x64" }, "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ=="],
+
+    "tsup/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "grove-mcp-http": "./dist/mcp/serve-http.js"
   },
   "scripts": {
-    "build": "bun run --cwd packages/ask-user build && tsup",
+    "build": "bun run --bun --cwd packages/ask-user build && bun run --bun tsup",
     "typecheck": "bun run --cwd packages/ask-user typecheck && tsc --noEmit",
     "lint": "biome check .",
     "format": "biome format --write .",
@@ -69,6 +69,7 @@
     "@xterm/headless": "6.0.0",
     "@zed-industries/codex-acp": "^0.14.0",
     "blake3": "^1.0.2",
+    "chokidar": "5.0.0",
     "hono": "^4.12.6",
     "proper-lockfile": "^4.1.2",
     "react": "^19.0.0",

--- a/packages/ask-user/package.json
+++ b/packages/ask-user/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "bun run --bun tsup",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "test:coverage": "bun test --coverage",

--- a/src/cli/commands/outcome.test.ts
+++ b/src/cli/commands/outcome.test.ts
@@ -17,6 +17,7 @@ let stdout: string[];
 let stderr: string[];
 
 beforeEach(() => {
+  process.exitCode = 0;
   db = new Database(":memory:");
   db.run("PRAGMA busy_timeout = 5000");
   outcomeStore = new SqliteOutcomeStore(db);
@@ -32,6 +33,7 @@ beforeEach(() => {
 afterEach(() => {
   outcomeStore.close();
   db.close();
+  process.exitCode = 0;
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/acp-launch.test.ts
+++ b/src/core/acp-launch.test.ts
@@ -27,7 +27,8 @@ describe("resolveAcpLaunch", () => {
   test("codex resolves to the pinned @zed-industries/codex-acp binary", () => {
     const launch = resolveAcpLaunch("codex");
     expect(launch.agent).toBe("codex");
-    expect(launch.args[0]).toMatch(/codex-acp/);
+    expect(launch.command).toMatch(/codex-acp/);
+    expect(launch.args).toEqual([]);
     expect(launch.packageName).toBe("@zed-industries/codex-acp");
   });
 

--- a/src/core/acp-launch.ts
+++ b/src/core/acp-launch.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -74,18 +74,42 @@ function resolveBuiltIn(agent: "codex" | "claude"): AcpLaunch {
   if (!relBin) {
     throw new Error(`[acp-launch] ${spec.packageName} has no usable bin entry`);
   }
-  const binPath = pathResolve(root, relBin);
+  const nativeCodexBin = agent === "codex" ? resolveNativeCodexBin(root) : undefined;
+  const binPath = nativeCodexBin ?? pathResolve(root, relBin);
   if (!existsSync(binPath)) {
     throw new Error(`[acp-launch] bin not found at ${binPath}. Reinstall: ${spec.installHint}`);
   }
   const result: AcpLaunch = {
     agent,
-    command: process.execPath,
-    args: [binPath],
+    command: nativeCodexBin ?? process.execPath,
+    args: nativeCodexBin ? [] : [binPath],
     packageName: spec.packageName,
     ...(manifest.version !== undefined ? { packageVersion: manifest.version } : {}),
   };
   return result;
+}
+
+function nativeCodexPackageName(): string | undefined {
+  if (process.arch !== "arm64" && process.arch !== "x64") return undefined;
+  switch (process.platform) {
+    case "darwin":
+      return `codex-acp-darwin-${process.arch}`;
+    case "linux":
+      return `codex-acp-linux-${process.arch}`;
+    case "win32":
+      return `codex-acp-win32-${process.arch}`;
+    default:
+      return undefined;
+  }
+}
+
+function resolveNativeCodexBin(codexPackageRoot: string): string | undefined {
+  const nativePackage = nativeCodexPackageName();
+  if (!nativePackage) return undefined;
+  const binaryName = process.platform === "win32" ? "codex-acp.exe" : "codex-acp";
+  const realRoot = realpathSync(codexPackageRoot);
+  const candidate = join(dirname(realRoot), nativePackage, "bin", binaryName);
+  return existsSync(candidate) ? candidate : undefined;
 }
 
 export function resolveAcpLaunch(agent: string): AcpLaunch {

--- a/src/core/acp-runtime.spawn.test.ts
+++ b/src/core/acp-runtime.spawn.test.ts
@@ -3,6 +3,7 @@ import {
   type Agent,
   AgentSideConnection,
   ndJsonStream,
+  RequestError,
   type RequestPermissionRequest,
 } from "@agentclientprotocol/sdk";
 import { AcpRuntime, type AcpRuntimeEvent, type LaunchOverride } from "./acp-runtime.js";
@@ -14,6 +15,7 @@ interface AgentStubHandlers {
     sessionId: string;
     agentSide: AgentSideConnection;
   }) => Promise<{ stopReason: "end_turn" | "cancelled" | "error" | "max_tokens" }>;
+  onDispose?: () => Promise<void> | void;
   capture?: (ref: { agentSide: AgentSideConnection | null }) => void;
 }
 
@@ -59,7 +61,9 @@ function makeInProcessAgent(handlers: AgentStubHandlers = {}): {
 
     return {
       clientStream,
-      dispose: async () => undefined,
+      dispose: async () => {
+        await handlers.onDispose?.();
+      },
     };
   };
   return { launchOverride, ref };
@@ -264,6 +268,64 @@ describe("AcpRuntime.send", () => {
 
     const result = await turn.result;
     expect(result.stopReason).toBe("cancelled");
+  });
+
+  test("close is bounded when an adapter ignores cancel", async () => {
+    const promptStarted = deferred();
+    let disposed = false;
+    const { launchOverride } = makeInProcessAgent({
+      async onPrompt() {
+        promptStarted.resolve();
+        await new Promise(() => undefined);
+        return { stopReason: "cancelled" };
+      },
+      onDispose() {
+        disposed = true;
+      },
+    });
+    const rt = new AcpRuntime({ launchOverride });
+
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: process.cwd(),
+    });
+
+    const turn = await rt.send(session, "slow task");
+    await promptStarted.promise;
+    const start = Date.now();
+    await rt.close(session);
+
+    expect(Date.now() - start).toBeLessThan(3_000);
+    expect(disposed).toBe(true);
+    expect(await rt.listSessions()).toEqual([]);
+
+    void turn.result;
+  });
+
+  test("surfaces ACP RequestError data messages on prompt failure", async () => {
+    const { launchOverride } = makeInProcessAgent({
+      async onPrompt() {
+        throw new RequestError(-32603, "Internal error", {
+          message: "Your access token could not be refreshed. Please log out and sign in again.",
+        });
+      },
+    });
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: process.cwd(),
+    });
+
+    const turn = await rt.send(session, "hello");
+    const result = await turn.result;
+
+    expect(result.stopReason).toBe("error");
+    expect(result.error?.message).toBe(
+      "Your access token could not be refreshed. Please log out and sign in again.",
+    );
+    await rt.close(session);
   });
 
   test("emits direct ACP messages and results to the event sink", async () => {

--- a/src/core/acp-runtime.test.ts
+++ b/src/core/acp-runtime.test.ts
@@ -313,6 +313,8 @@ describe("prepareIsolatedCodexHome", () => {
       expect(config).toContain('GROVE_SESSION_ID = "session-1"');
       expect(config).not.toContain("secret-key");
       expect(existsSync(join(isolated, "auth.json"))).toBe(true);
+      writeFileSync(join(userHome, "auth.json"), '{"token":"rotated"}', "utf-8");
+      expect(readFileSync(join(isolated, "auth.json"), "utf-8")).toBe('{"token":"rotated"}');
     } finally {
       if (isolated) rmSync(isolated, { recursive: true, force: true });
       rmSync(userHome, { recursive: true, force: true });

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -1,5 +1,13 @@
 import { type ChildProcessByStdio, spawn as nodeSpawn } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Readable, Writable } from "node:stream";
@@ -8,6 +16,7 @@ import {
   type Client,
   ClientSideConnection,
   ndJsonStream,
+  RequestError,
   type RequestPermissionRequest,
   type Stream,
 } from "@agentclientprotocol/sdk";
@@ -73,6 +82,10 @@ interface AcpSessionEntry {
   closed: boolean;
 }
 
+const CLOSE_SEND_DRAIN_TIMEOUT_MS = 2_000;
+const CHILD_TERM_TIMEOUT_MS = 2_000;
+const CHILD_KILL_TIMEOUT_MS = 500;
+
 function resolveAgentFromConfig(config: AgentConfig): string {
   if (config.platform === "claude-code") return "claude";
   if (config.platform === "codex") return "codex";
@@ -83,6 +96,59 @@ function resolveAgentFromConfig(config: AgentConfig): string {
     if (base === "claude" || base === "codex" || base === "gemini") return base;
   }
   return "codex";
+}
+
+function recordValue(value: unknown, key: string): unknown {
+  if (typeof value !== "object" || value === null || !Object.hasOwn(value, key)) {
+    return undefined;
+  }
+  return (value as Record<string, unknown>)[key];
+}
+
+function stringRecordValue(value: unknown, key: string): string | undefined {
+  const found = recordValue(value, key);
+  return typeof found === "string" && found.trim().length > 0 ? found : undefined;
+}
+
+function acpErrorMessage(err: unknown): string {
+  if (err instanceof RequestError) {
+    const dataMessage =
+      stringRecordValue(err.data, "message") ?? stringRecordValue(err.data, "details");
+    if (dataMessage) return dataMessage;
+  }
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+async function settleWithTimeout(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+async function waitForChildExit(
+  child: ChildProcessByStdio<Writable, Readable, Readable>,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return true;
+  return await new Promise<boolean>((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
 }
 
 /**
@@ -161,8 +227,9 @@ function buildCodexMcpConfigBlock(server: McpServerConfig, env: NodeJS.ProcessEn
 }
 
 /**
- * Prepare an ephemeral CODEX_HOME for grove-spawned codex children. Copies the
- * user's auth.json (so login persists), then writes a minimal config.toml
+ * Prepare an ephemeral CODEX_HOME for grove-spawned codex children. Links the
+ * user's auth.json (so login persists without stale refresh-token copies),
+ * then writes a minimal config.toml
  * containing ONLY allow-listed top-level scalars. Drops everything else —
  * `mcp_servers` (DNS-blocked enterprise endpoints crash codex's rmcp transport
  * on bootstrap), `projects.*` trust (grove uses its own permission gating),
@@ -174,13 +241,21 @@ export async function prepareIsolatedCodexHome(
 ): Promise<string> {
   const userHome = env.CODEX_HOME ?? join(env.HOME ?? "/tmp", ".codex");
   const isolated = mkdtempSync(join(tmpdir(), "grove-codex-"));
-  // Copy auth.json if present so login persists.
+  // Link auth.json if present so login persists. Codex OAuth refresh tokens
+  // rotate; copying auth.json into a throwaway CODEX_HOME can leave the child
+  // with a refresh token that has already been superseded by the real global
+  // Codex home. A symlink keeps isolation for config/plugins while letting the
+  // adapter read the current auth material.
   const userAuth = join(userHome, "auth.json");
   if (existsSync(userAuth)) {
     try {
-      copyFileSync(userAuth, join(isolated, "auth.json"));
+      symlinkSync(userAuth, join(isolated, "auth.json"));
     } catch {
-      /* best-effort */
+      try {
+        copyFileSync(userAuth, join(isolated, "auth.json"));
+      } catch {
+        /* best-effort */
+      }
     }
   }
 
@@ -381,15 +456,16 @@ async function launchSubprocess(
     // Wait briefly for the child to exit so we don't `rm -rf` the isolated
     // home out from under codex while it's still flushing session state.
     // Bounded so a stuck child doesn't block teardown indefinitely.
+    let exited = await waitForChildExit(child, CHILD_TERM_TIMEOUT_MS);
+    if (!exited) {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* ignore */
+      }
+      exited = await waitForChildExit(child, CHILD_KILL_TIMEOUT_MS);
+    }
     if (isolatedHomeForCleanup) {
-      const exited = await new Promise<boolean>((resolve) => {
-        if (child.exitCode !== null || child.signalCode !== null) return resolve(true);
-        const timer = setTimeout(() => resolve(false), 2000);
-        child.once("exit", () => {
-          clearTimeout(timer);
-          resolve(true);
-        });
-      });
       try {
         rmSync(isolatedHomeForCleanup, { recursive: true, force: true });
       } catch (err) {
@@ -659,7 +735,7 @@ export class AcpRuntime implements AgentRuntime {
       } catch {
         /* ignore */
       }
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = acpErrorMessage(err);
       throw new Error(`[acp-runtime] ACP handshake failed for agent ${agent}: ${msg}`);
     }
 
@@ -708,6 +784,7 @@ export class AcpRuntime implements AgentRuntime {
           current.session = {
             ...current.session,
             status: "crashed",
+            statusMessage: msg,
           };
           this.fireSessionWrite("MODIFIED", current.session);
           for (const cb of current.idleCallbacks) {
@@ -784,12 +861,13 @@ export class AcpRuntime implements AgentRuntime {
         });
         finishTurn({ turnId, stopReason: ok.stopReason });
       } catch (err) {
+        const message = acpErrorMessage(err);
         finishTurn({
           turnId,
           stopReason: "error",
           error: {
             code: "prompt_rejected",
-            message: err instanceof Error ? err.message : String(err),
+            message,
           },
         });
       } finally {
@@ -829,7 +907,7 @@ export class AcpRuntime implements AgentRuntime {
     }
     // Drain any pending sends so we don't leak prompt() promises past dispose.
     try {
-      await entry.sendChainTail;
+      await settleWithTimeout(entry.sendChainTail, CLOSE_SEND_DRAIN_TIMEOUT_MS);
     } catch {
       /* ignore */
     }

--- a/src/core/agent-runtime.ts
+++ b/src/core/agent-runtime.ts
@@ -56,6 +56,8 @@ export interface AgentSession {
   readonly role: string;
   readonly pid?: number | undefined;
   readonly status: "running" | "idle" | "stopped" | "crashed";
+  /** Optional human-readable reason for the current status. */
+  readonly statusMessage?: string | undefined;
   /** Agent platform used for this session (e.g. "claude-code", "codex"). */
   readonly platform?: AgentPlatformType | undefined;
   /** Model identifier used for this session. */

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -8,7 +8,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { useKeyboard, useRenderer } from "@opentui/react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
@@ -25,6 +25,7 @@ import { StatusBar } from "./components/status-bar.js";
 import { PanelBar } from "./components/tab-bar.js";
 import { TooltipOverlay, useFirstLaunchTooltips } from "./components/tooltip-overlay.js";
 import type { GroveUserConfig } from "./config-loader.js";
+import { createTuiConfigWatcher } from "./config-watcher.js";
 import { DagStateStore } from "./data/dag-state-store.js";
 import { DagStateProvider } from "./hooks/dag-state-context.js";
 
@@ -34,7 +35,11 @@ export { tuiReducer } from "./app-reducer.js";
 import { useProviderScoped } from "./hooks/informer-context.js";
 import { useRelistTrigger } from "./hooks/refresh-context.js";
 import { useEventDrivenData } from "./hooks/use-event-driven-data.js";
-import { buildKeyActionMap, useKeybindingOverrides } from "./hooks/use-keybinding-overrides.js";
+import {
+  buildKeyActionMap,
+  type KeybindingOverrides,
+  useKeybindingOverrides,
+} from "./hooks/use-keybinding-overrides.js";
 import type { KeyboardActions } from "./hooks/use-keyboard-handler.js";
 import { nextZoom, routeKey } from "./hooks/use-keyboard-handler.js";
 import { useNavigation } from "./hooks/use-navigation.js";
@@ -51,7 +56,7 @@ import {
   type TuiDataProvider,
 } from "./provider.js";
 import { useSpawnManager } from "./spawn-manager-context.js";
-import { theme } from "./theme.js";
+import { replaceTheme, theme } from "./theme.js";
 
 /** Props for the root App component. */
 export interface AppProps {
@@ -113,10 +118,12 @@ export function App({
   const { showTooltips, dismissAll: dismissTooltips } = useFirstLaunchTooltips();
   const { savedState, saveState } = useTuiStatePersistence("global", groveDir);
   const fileOverrides = useKeybindingOverrides();
-  // Merge config.json keymap (lower priority) with file-based overrides (higher priority).
+  const [hotkeyOverrides, setHotkeyOverrides] = useState<KeybindingOverrides>({});
+  const [, setThemeRevision] = useState(0);
+  // Merge config.json keymap (lower priority), hotkeys.yaml, then file-based overrides.
   const keybindingOverrides = useMemo(
-    () => ({ ...userConfig?.keymap, ...fileOverrides }),
-    [userConfig?.keymap, fileOverrides],
+    () => ({ ...userConfig?.keymap, ...hotkeyOverrides, ...fileOverrides }),
+    [userConfig?.keymap, hotkeyOverrides, fileOverrides],
   );
   const keyActionMap = useMemo(() => buildKeyActionMap(keybindingOverrides), [keybindingOverrides]);
   const [ks, dispatch] = useReducer(tuiReducer, INITIAL_KEYBOARD_STATE);
@@ -186,6 +193,43 @@ export function App({
     setLastError(message);
     errorTimerRef.current = setTimeout(() => setLastError(undefined), 5_000);
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const projectRoot = groveDir !== undefined ? dirname(groveDir) : undefined;
+    const watcher = createTuiConfigWatcher({ projectRoot });
+    const unsubscribe = watcher.subscribe((event) => {
+      if (cancelled) return;
+      if (event.type === "ConfigError") {
+        showError(event.message);
+        return;
+      }
+      if (event.changed === "hotkeys") {
+        setHotkeyOverrides(event.config.hotkeys);
+      }
+      if (event.changed === "theme") {
+        replaceTheme({ ...userConfig?.theme, ...event.config.theme });
+        setThemeRevision((revision) => revision + 1);
+      }
+    });
+    void watcher
+      .start()
+      .then(() => {
+        if (cancelled) return;
+        const config = watcher.current();
+        setHotkeyOverrides(config.hotkeys);
+        replaceTheme({ ...userConfig?.theme, ...config.theme });
+        setThemeRevision((revision) => revision + 1);
+      })
+      .catch((err) => {
+        if (!cancelled) showError(err instanceof Error ? err.message : "config watcher failed");
+      });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+      void watcher.stop();
+    };
+  }, [groveDir, showError, userConfig?.theme]);
 
   // SpawnManager singleton — provided by tui-app.tsx via SpawnManagerContext.
   const spawnManager = useSpawnManager();

--- a/src/tui/config-watcher.test.ts
+++ b/src/tui/config-watcher.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTuiConfigWatcher } from "./config-watcher.js";
+
+const cleanupDirs: string[] = [];
+
+async function makeFixture(): Promise<{
+  readonly root: string;
+  readonly homeDir: string;
+  readonly projectRoot: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "grove-config-watch-"));
+  cleanupDirs.push(root);
+  const homeDir = join(root, "home");
+  const projectRoot = join(root, "project");
+  await mkdir(join(homeDir, ".grove"), { recursive: true });
+  await mkdir(join(projectRoot, ".grove"), { recursive: true });
+  return { root, homeDir, projectRoot };
+}
+
+function waitFor<T>(fn: () => T | undefined, timeoutMs = 500): Promise<T> {
+  const started = Date.now();
+  return new Promise<T>((resolve, reject) => {
+    const tick = (): void => {
+      const result = fn();
+      if (result !== undefined) {
+        resolve(result);
+        return;
+      }
+      if (Date.now() - started >= timeoutMs) {
+        reject(new Error(`timed out after ${timeoutMs}ms`));
+        return;
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+function settleWatcher(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+afterEach(async () => {
+  const dirs = cleanupDirs.splice(0);
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("createTuiConfigWatcher", () => {
+  test("broadcasts ConfigChanged when aliases.yaml changes within 500ms", async () => {
+    const { homeDir, projectRoot } = await makeFixture();
+    const aliasPath = join(homeDir, ".grove", "aliases.yaml");
+    await writeFile(aliasPath, "ops: agents\n", "utf8");
+
+    const watcher = createTuiConfigWatcher({ homeDir, projectRoot, debounceMs: 20 });
+    const events: string[] = [];
+    const unsubscribe = watcher.subscribe((event) => {
+      if (event.type === "ConfigChanged" && event.changed === "aliases") {
+        events.push(event.config.aliases.get("new")?.value ?? "");
+      }
+    });
+
+    await watcher.start();
+    await settleWatcher();
+    await writeFile(aliasPath, "ops: agents\nnew: dag\n", "utf8");
+
+    await waitFor(() => (events.includes("dag") ? true : undefined));
+    expect(watcher.current().aliases.get("new")?.value).toBe("dag");
+
+    unsubscribe();
+    await watcher.stop();
+  });
+
+  test("invalid aliases.yaml emits ConfigError and keeps the last good aliases", async () => {
+    const { homeDir, projectRoot } = await makeFixture();
+    const aliasPath = join(homeDir, ".grove", "aliases.yaml");
+    await writeFile(aliasPath, "ops: agents\n", "utf8");
+
+    const watcher = createTuiConfigWatcher({ homeDir, projectRoot, debounceMs: 20 });
+    const errors: string[] = [];
+    watcher.subscribe((event) => {
+      if (event.type === "ConfigError" && event.changed === "aliases") {
+        errors.push(event.message);
+      }
+    });
+
+    await watcher.start();
+    await settleWatcher();
+    expect(watcher.current().aliases.get("ops")?.value).toBe("agents");
+
+    await writeFile(aliasPath, "not: : valid:: yaml: [", "utf8");
+
+    await waitFor(() => errors[0]);
+    expect(errors[0]).toContain("aliases.yaml");
+    expect(watcher.current().aliases.get("ops")?.value).toBe("agents");
+
+    await watcher.stop();
+  });
+
+  test("invalid aliases.yaml at startup emits ConfigError and keeps defaults", async () => {
+    const { homeDir, projectRoot } = await makeFixture();
+    const aliasPath = join(homeDir, ".grove", "aliases.yaml");
+    await writeFile(aliasPath, "not: : valid:: yaml: [", "utf8");
+
+    const watcher = createTuiConfigWatcher({ homeDir, projectRoot, debounceMs: 20 });
+    const errors: string[] = [];
+    watcher.subscribe((event) => {
+      if (event.type === "ConfigError" && event.changed === "aliases") {
+        errors.push(event.message);
+      }
+    });
+
+    await watcher.start();
+
+    expect(errors[0]).toContain("aliases.yaml");
+    expect(watcher.current().aliases.get("a")?.value).toBe("agents");
+
+    await watcher.stop();
+  });
+
+  test("broadcasts hotkeys.yaml changes as remappable key overrides", async () => {
+    const { homeDir, projectRoot } = await makeFixture();
+    const hotkeysPath = join(homeDir, ".grove", "hotkeys.yaml");
+    await writeFile(hotkeysPath, "refresh: F5\n", "utf8");
+
+    const watcher = createTuiConfigWatcher({ homeDir, projectRoot, debounceMs: 20 });
+    const values: string[] = [];
+    watcher.subscribe((event) => {
+      if (event.type === "ConfigChanged" && event.changed === "hotkeys") {
+        values.push(event.config.hotkeys.quit ?? "");
+      }
+    });
+
+    await watcher.start();
+    await settleWatcher();
+    await writeFile(hotkeysPath, "refresh: F5\nquit: Q\n", "utf8");
+
+    await waitFor(() => (values.includes("Q") ? true : undefined));
+    expect(watcher.current().hotkeys.quit).toBe("Q");
+
+    await watcher.stop();
+  });
+
+  test("broadcasts theme.yaml changes as theme token overrides", async () => {
+    const { homeDir, projectRoot } = await makeFixture();
+    const themePath = join(homeDir, ".grove", "theme.yaml");
+    await writeFile(themePath, "focus: '#00ffff'\n", "utf8");
+
+    const watcher = createTuiConfigWatcher({ homeDir, projectRoot, debounceMs: 20 });
+    const values: string[] = [];
+    watcher.subscribe((event) => {
+      if (event.type === "ConfigChanged" && event.changed === "theme") {
+        values.push(event.config.theme.error ?? "");
+      }
+    });
+
+    await watcher.start();
+    await settleWatcher();
+    await writeFile(themePath, "focus: '#00ffff'\nerror: red\n", "utf8");
+
+    await waitFor(() => (values.includes("red") ? true : undefined));
+    expect(watcher.current().theme.error).toBe("red");
+
+    await watcher.stop();
+  });
+});

--- a/src/tui/config-watcher.ts
+++ b/src/tui/config-watcher.ts
@@ -1,0 +1,341 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { type FSWatcher, watch } from "chokidar";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import { type AliasMap, DEFAULT_ALIASES } from "./data/aliases.js";
+import { loadAliases } from "./data/aliases-loader.js";
+import {
+  type KeybindingOverrides,
+  REMAPPABLE_ACTIONS,
+  type RemappableAction,
+} from "./hooks/use-keybinding-overrides.js";
+import type { ThemeColorTokens } from "./theme.js";
+
+export type ConfigFileKind = "aliases" | "hotkeys" | "theme";
+
+export interface TuiConfigSnapshot {
+  readonly aliases: AliasMap;
+  readonly hotkeys: KeybindingOverrides;
+  readonly theme: Partial<ThemeColorTokens>;
+}
+
+export type TuiConfigEvent =
+  | {
+      readonly type: "ConfigChanged";
+      readonly changed: ConfigFileKind;
+      readonly config: TuiConfigSnapshot;
+    }
+  | {
+      readonly type: "ConfigError";
+      readonly changed: ConfigFileKind;
+      readonly message: string;
+    };
+
+export type TuiConfigSubscriber = (event: TuiConfigEvent) => void;
+
+export interface TuiConfigWatcherOptions {
+  readonly homeDir?: string | undefined;
+  readonly projectRoot?: string | undefined;
+  readonly debounceMs?: number | undefined;
+}
+
+export interface TuiConfigWatcher {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  current(): TuiConfigSnapshot;
+  subscribe(subscriber: TuiConfigSubscriber): () => void;
+}
+
+interface FileLoadResult<T> {
+  readonly value: T;
+  readonly errors: readonly string[];
+}
+
+const EMPTY_SNAPSHOT: TuiConfigSnapshot = {
+  aliases: DEFAULT_ALIASES,
+  hotkeys: {},
+  theme: {},
+};
+
+const HOTKEY_SCHEMA = z.record(z.string(), z.string().min(1));
+const REMAPPABLE_ACTION_SET: ReadonlySet<string> = new Set(REMAPPABLE_ACTIONS);
+
+const THEME_KEYS = [
+  "focus",
+  "inactive",
+  "border",
+  "running",
+  "waiting",
+  "idle",
+  "error",
+  "stale",
+  "work",
+  "review",
+  "discussion",
+  "adoption",
+  "reproduction",
+  "text",
+  "secondary",
+  "disabled",
+  "panelBg",
+  "headerBg",
+  "selectedBg",
+  "success",
+  "warning",
+  "info",
+  "compare",
+  "statusRunning",
+  "statusDone",
+  "statusFailed",
+  "statusBlocked",
+  "statusAwaitingReview",
+  "statusIdle",
+  "highlightMatch",
+] as const satisfies readonly (keyof ThemeColorTokens)[];
+const THEME_KEY_SET: ReadonlySet<string> = new Set(THEME_KEYS);
+const THEME_SCHEMA = z.record(z.string(), z.string().min(1));
+
+function isRemappableAction(action: string): action is RemappableAction {
+  return REMAPPABLE_ACTION_SET.has(action);
+}
+
+function isThemeKey(key: string): key is keyof ThemeColorTokens {
+  return THEME_KEY_SET.has(key);
+}
+
+async function readYamlRecord(
+  filePath: string,
+  schema: z.ZodType<Readonly<Record<string, string>>>,
+): Promise<FileLoadResult<Readonly<Record<string, string>>>> {
+  let text: string;
+  try {
+    text = await readFile(filePath, "utf8");
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === "ENOENT") return { value: {}, errors: [] };
+    return { value: {}, errors: [`${filePath}: ${e.message}`] };
+  }
+
+  let raw: unknown;
+  try {
+    raw = parseYaml(text);
+  } catch (err) {
+    return { value: {}, errors: [`${filePath}: parse error - ${(err as Error).message}`] };
+  }
+  if (raw === null || raw === undefined) return { value: {}, errors: [] };
+
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    return { value: {}, errors: [`${filePath}: schema error - ${parsed.error.message}`] };
+  }
+
+  return { value: parsed.data, errors: [] };
+}
+
+export async function loadHotkeysFile(
+  filePath: string,
+): Promise<FileLoadResult<KeybindingOverrides>> {
+  const loaded = await readYamlRecord(filePath, HOTKEY_SCHEMA);
+  if (loaded.errors.length > 0) return { value: {}, errors: loaded.errors };
+
+  const hotkeys: Partial<Record<RemappableAction, string>> = {};
+  const errors: string[] = [];
+  for (const [action, key] of Object.entries(loaded.value)) {
+    if (!isRemappableAction(action)) {
+      errors.push(`${filePath}: unknown hotkey action "${action}"`);
+      continue;
+    }
+    hotkeys[action] = key;
+  }
+
+  return errors.length > 0 ? { value: {}, errors } : { value: hotkeys, errors: [] };
+}
+
+export async function loadThemeFile(
+  filePath: string,
+): Promise<FileLoadResult<Partial<ThemeColorTokens>>> {
+  const loaded = await readYamlRecord(filePath, THEME_SCHEMA);
+  if (loaded.errors.length > 0) return { value: {}, errors: loaded.errors };
+
+  const theme: Partial<ThemeColorTokens> = {};
+  const errors: string[] = [];
+  for (const [key, value] of Object.entries(loaded.value)) {
+    if (!isThemeKey(key)) {
+      errors.push(`${filePath}: unknown theme token "${key}"`);
+      continue;
+    }
+    theme[key] = value;
+  }
+
+  return errors.length > 0 ? { value: {}, errors } : { value: theme, errors: [] };
+}
+
+class DefaultTuiConfigWatcher implements TuiConfigWatcher {
+  private readonly homeDir: string;
+  private readonly projectRoot: string | undefined;
+  private readonly debounceMs: number;
+  private readonly subscribers = new Set<TuiConfigSubscriber>();
+  private readonly timers = new Map<ConfigFileKind, ReturnType<typeof setTimeout>>();
+  private watcher: FSWatcher | undefined;
+  private snapshot: TuiConfigSnapshot = EMPTY_SNAPSHOT;
+
+  constructor(options: TuiConfigWatcherOptions = {}) {
+    this.homeDir = options.homeDir ?? homedir();
+    this.projectRoot = options.projectRoot;
+    this.debounceMs = options.debounceMs ?? 75;
+  }
+
+  async start(): Promise<void> {
+    if (this.watcher !== undefined) return;
+
+    await Promise.all([this.reloadAliases(true), this.reloadHotkeys(true), this.reloadTheme(true)]);
+
+    this.watcher = watch([...this.watchedPaths()], {
+      ignoreInitial: true,
+      persistent: true,
+      ignorePermissionErrors: true,
+      awaitWriteFinish: { stabilityThreshold: 50, pollInterval: 10 },
+    });
+    this.watcher.on("all", (_event, filePath) => {
+      const kind = this.kindForPath(String(filePath));
+      if (kind !== undefined) this.scheduleReload(kind);
+    });
+    this.watcher.on("error", (err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emit({ type: "ConfigError", changed: "aliases", message });
+    });
+
+    await new Promise<void>((resolveReady) => {
+      const current = this.watcher;
+      if (current === undefined) {
+        resolveReady();
+        return;
+      }
+      current.on("ready", () => resolveReady());
+    });
+  }
+
+  async stop(): Promise<void> {
+    for (const timer of this.timers.values()) clearTimeout(timer);
+    this.timers.clear();
+    const current = this.watcher;
+    this.watcher = undefined;
+    if (current !== undefined) await current.close();
+  }
+
+  current(): TuiConfigSnapshot {
+    return this.snapshot;
+  }
+
+  subscribe(subscriber: TuiConfigSubscriber): () => void {
+    this.subscribers.add(subscriber);
+    return () => {
+      this.subscribers.delete(subscriber);
+    };
+  }
+
+  private userGroveDir(): string {
+    return join(this.homeDir, ".grove");
+  }
+
+  private aliasesPaths(): readonly string[] {
+    const paths = [join(this.userGroveDir(), "aliases.yaml")];
+    if (this.projectRoot !== undefined)
+      paths.push(join(this.projectRoot, ".grove", "aliases.yaml"));
+    return paths;
+  }
+
+  private hotkeysPath(): string {
+    return join(this.userGroveDir(), "hotkeys.yaml");
+  }
+
+  private themePath(): string {
+    return join(this.userGroveDir(), "theme.yaml");
+  }
+
+  private watchedPaths(): readonly string[] {
+    return [...this.aliasesPaths(), this.hotkeysPath(), this.themePath()];
+  }
+
+  private kindForPath(filePath: string): ConfigFileKind | undefined {
+    const normalized = resolve(filePath);
+    if (this.aliasesPaths().some((path) => resolve(path) === normalized)) return "aliases";
+    if (resolve(this.hotkeysPath()) === normalized) return "hotkeys";
+    if (resolve(this.themePath()) === normalized) return "theme";
+    return undefined;
+  }
+
+  private scheduleReload(kind: ConfigFileKind): void {
+    const existing = this.timers.get(kind);
+    if (existing !== undefined) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      this.timers.delete(kind);
+      void this.reloadKind(kind, true);
+    }, this.debounceMs);
+    this.timers.set(kind, timer);
+  }
+
+  private async reloadKind(kind: ConfigFileKind, emitChange: boolean): Promise<void> {
+    switch (kind) {
+      case "aliases":
+        await this.reloadAliases(emitChange);
+        return;
+      case "hotkeys":
+        await this.reloadHotkeys(emitChange);
+        return;
+      case "theme":
+        await this.reloadTheme(emitChange);
+        return;
+    }
+  }
+
+  private async reloadAliases(emitChange: boolean): Promise<void> {
+    const result = await loadAliases(this.projectRoot ?? this.homeDir, {
+      homeOverride: this.homeDir,
+    });
+    if (result.errors.length > 0) {
+      if (emitChange) this.emitError("aliases", result.errors[0] ?? "aliases.yaml failed to load");
+      return;
+    }
+    this.snapshot = { ...this.snapshot, aliases: result.aliases };
+    if (emitChange) this.emitChanged("aliases");
+  }
+
+  private async reloadHotkeys(emitChange: boolean): Promise<void> {
+    const result = await loadHotkeysFile(this.hotkeysPath());
+    if (result.errors.length > 0) {
+      if (emitChange) this.emitError("hotkeys", result.errors[0] ?? "hotkeys.yaml failed to load");
+      return;
+    }
+    this.snapshot = { ...this.snapshot, hotkeys: result.value };
+    if (emitChange) this.emitChanged("hotkeys");
+  }
+
+  private async reloadTheme(emitChange: boolean): Promise<void> {
+    const result = await loadThemeFile(this.themePath());
+    if (result.errors.length > 0) {
+      if (emitChange) this.emitError("theme", result.errors[0] ?? "theme.yaml failed to load");
+      return;
+    }
+    this.snapshot = { ...this.snapshot, theme: result.value };
+    if (emitChange) this.emitChanged("theme");
+  }
+
+  private emitChanged(changed: ConfigFileKind): void {
+    this.emit({ type: "ConfigChanged", changed, config: this.snapshot });
+  }
+
+  private emitError(changed: ConfigFileKind, message: string): void {
+    this.emit({ type: "ConfigError", changed, message });
+  }
+
+  private emit(event: TuiConfigEvent): void {
+    for (const subscriber of this.subscribers) subscriber(event);
+  }
+}
+
+export function createTuiConfigWatcher(options: TuiConfigWatcherOptions = {}): TuiConfigWatcher {
+  return new DefaultTuiConfigWatcher(options);
+}

--- a/src/tui/screens/empty-feed-hint.ts
+++ b/src/tui/screens/empty-feed-hint.ts
@@ -1,0 +1,13 @@
+/** Empty contribution-feed hint based on live agent state. */
+export function emptyFeedHint(
+  activeRoles?: readonly string[] | undefined,
+  agentFailures?: ReadonlyMap<string, string> | undefined,
+): string {
+  if ((agentFailures?.size ?? 0) > 0) {
+    return "Agent startup failed; check agent status";
+  }
+  if (activeRoles && activeRoles.length === 0) {
+    return "No active agents";
+  }
+  return "Agents are working on your goal";
+}

--- a/src/tui/screens/running-view.c2.test.tsx
+++ b/src/tui/screens/running-view.c2.test.tsx
@@ -17,6 +17,7 @@ import { join } from "node:path";
 import { DEFAULT_ALIASES, resolveAlias } from "../data/aliases.js";
 import { loadAliases } from "../data/aliases-loader.js";
 import { PagesStore } from "../data/pages-store.js";
+import { emptyFeedHint } from "./empty-feed-hint.js";
 import { expandPanel as expandPanelTransition, RunningPanel } from "./running-keyboard.js";
 
 async function makeTmp(): Promise<string> {
@@ -63,6 +64,15 @@ describe("C2 acceptance — issue #302", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  test("empty feed does not say agents are working after startup failure", () => {
+    expect(emptyFeedHint([], new Map([["coder", "Internal error"]]))).toBe(
+      "Agent startup failed; check agent status",
+    );
+    expect(emptyFeedHint(["reviewer"], new Map([["coder", "Internal error"]]))).toBe(
+      "Agent startup failed; check agent status",
+    );
   });
 });
 

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -30,9 +30,9 @@ import { EmptyState } from "../components/empty-state.js";
 import { FlashBar } from "../components/flash-bar.js";
 import { ProgressBar } from "../components/progress-bar.js";
 import { Prompt } from "../components/prompt.js";
+import { createTuiConfigWatcher } from "../config-watcher.js";
 import type { AgentLogBuffer } from "../data/agent-log-buffer.js";
 import { type AliasMap, DEFAULT_ALIASES, matchAliases, resolveAlias } from "../data/aliases.js";
-import { loadAliases } from "../data/aliases-loader.js";
 import { debugLog } from "../debug-log.js";
 import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useAgentMonitor } from "../hooks/use-agent-monitor.js";
@@ -51,6 +51,7 @@ import { HandoffsView } from "../views/handoffs-view.js";
 import { TerminalView } from "../views/terminal.js";
 import { TracePane } from "../views/trace-pane.js";
 import { VfsBrowserView } from "../views/vfs-browser.js";
+import { emptyFeedHint } from "./empty-feed-hint.js";
 import {
   type CmdModeState,
   appendChar as cmdAppend,
@@ -124,6 +125,8 @@ export interface RunningViewProps {
   readonly activeRoles?: readonly string[] | undefined;
   /** Per-agent log buffers for the Trace panel. Keyed by role name. */
   readonly logBuffers?: ReadonlyMap<string, AgentLogBuffer> | undefined;
+  /** Per-role runtime failures, such as ACP bootstrap/auth failures. */
+  readonly agentFailures?: ReadonlyMap<string, string> | undefined;
   readonly onToggleAdvanced: () => void;
   readonly onComplete: (reason: string) => void;
   readonly onQuit: () => void;
@@ -193,6 +196,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     onSendToAgent,
     activeRoles,
     logBuffers,
+    agentFailures,
     onToggleAdvanced,
     onComplete: _onComplete,
     onQuit,
@@ -263,19 +267,31 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     useEffect(() => {
       if (!groveDir) return;
       let cancelled = false;
-      // `groveDir` prop is the resolved `.grove/` directory (per resolveGroveDir);
-      // loadAliases expects the project root and joins `.grove/aliases.yaml` itself.
+      // `groveDir` prop is the resolved `.grove/` directory (per resolveGroveDir).
       const projectRoot = dirname(groveDir);
-      void loadAliases(projectRoot).then((r) => {
+      const watcher = createTuiConfigWatcher({ projectRoot });
+      const unsubscribe = watcher.subscribe((event) => {
         if (cancelled) return;
-        setAliases(r.aliases);
-        if (r.errors.length > 0) {
-          const first = r.errors[0];
-          if (first) flash(first);
+        if (event.type === "ConfigChanged" && event.changed === "aliases") {
+          setAliases(event.config.aliases);
+          return;
+        }
+        if (event.type === "ConfigError") {
+          flash(event.message);
         }
       });
+      void watcher
+        .start()
+        .then(() => {
+          if (!cancelled) setAliases(watcher.current().aliases);
+        })
+        .catch((err) => {
+          if (!cancelled) flash(err instanceof Error ? err.message : "config watcher failed");
+        });
       return () => {
         cancelled = true;
+        unsubscribe();
+        void watcher.stop();
       };
     }, [groveDir, flash]);
 
@@ -1160,6 +1176,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             traceScrollOffset,
             sessionStartedAt,
             handoffs,
+            activeRoles,
+            agentFailures,
             filterText: cmdState.mode === "filter" ? cmdState.text : filterQuery,
             dagKeysEnabled:
               expandedPanel === RunningPanel.Dag &&
@@ -1205,6 +1223,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
                 frontier,
                 autoFollow,
                 newSinceFreeze,
+                activeRoles,
+                agentFailures,
               )}
             </box>
             {/* Right: expanded panel */}
@@ -1237,6 +1257,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
                 traceScrollOffset,
                 sessionStartedAt,
                 handoffs,
+                activeRoles,
+                agentFailures,
                 filterText: cmdState.mode === "filter" ? cmdState.text : filterQuery,
                 dagKeysEnabled:
                   expandedPanel === RunningPanel.Dag &&
@@ -1287,7 +1309,14 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
         />
 
         {/* Agent status with live output */}
-        {renderAgentSection(topology, dashboard, monitor, sessionStartedAt, feed.length)}
+        {renderAgentSection(
+          topology,
+          dashboard,
+          monitor,
+          agentFailures,
+          sessionStartedAt,
+          feed.length,
+        )}
 
         {/* Main feed area */}
         {renderFeedSection(
@@ -1298,6 +1327,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           frontier,
           autoFollow,
           newSinceFreeze,
+          activeRoles,
+          agentFailures,
         )}
 
         {/* Bottom chrome: permissions, IPC, quit confirm, progress, prompt */}
@@ -1343,6 +1374,7 @@ function renderAgentSection(
   topology: AgentTopology | undefined,
   dashboard: DashboardData | undefined,
   monitor: ReturnType<typeof useAgentMonitor>,
+  agentFailures: ReadonlyMap<string, string> | undefined,
   sessionStartedAt?: string,
   sessionContribCount?: number,
 ): React.ReactNode {
@@ -1372,6 +1404,7 @@ function renderAgentSection(
         const activeClaim = dashboard?.activeClaims.find(
           (c) => c.agent.role === role.name || c.agent.agentId.startsWith(role.name),
         );
+        const failure = agentFailures?.get(role.name);
         const platformColor = PLATFORM_COLORS[role.platform ?? "claude-code"] ?? theme.text;
         const output = monitor.agentOutputs.get(role.name);
         // Skip raw ACP JSON-RPC envelopes bleeding through from acpx stdout.
@@ -1390,7 +1423,7 @@ function renderAgentSection(
           return "";
         })();
 
-        const status = activeClaim ? "running" : "idle";
+        const status = failure ? "error" : activeClaim ? "running" : "idle";
         const badge = agentStatusIcon(status, activeClaim ? monitor.spinnerFrame : undefined);
 
         return (
@@ -1400,7 +1433,11 @@ function renderAgentSection(
               {role.name}
             </text>
             <text color={theme.secondary}> [{idx + 1}] </text>
-            {lastLine ? <text color={theme.secondary}>{lastLine.slice(0, 80)}</text> : null}
+            {failure ? (
+              <text color={theme.error}>{failure.slice(0, 96)}</text>
+            ) : lastLine ? (
+              <text color={theme.secondary}>{lastLine.slice(0, 80)}</text>
+            ) : null}
           </box>
         );
       })}
@@ -1417,6 +1454,8 @@ function renderFeedSection(
   frontier: DashboardData["frontierSummary"] | undefined,
   autoFollow: boolean,
   newSinceFreeze: number,
+  activeRoles?: readonly string[] | undefined,
+  agentFailures?: ReadonlyMap<string, string> | undefined,
 ): React.ReactNode {
   return (
     <box flexDirection="column" flexGrow={1}>
@@ -1466,7 +1505,10 @@ function renderFeedSection(
           Contribution Feed
         </text>
         {feed.length === 0 ? (
-          <EmptyState title="Waiting for contributions..." hint="Agents are working on your goal" />
+          <EmptyState
+            title="Waiting for contributions..."
+            hint={emptyFeedHint(activeRoles, agentFailures)}
+          />
         ) : (
           (() => {
             // Explicit windowing: keep cursor visible within a viewport-sized window
@@ -1569,6 +1611,8 @@ interface PanelRenderContext {
   readonly traceScrollOffset?: number;
   readonly sessionStartedAt?: string | undefined;
   readonly handoffs?: readonly import("../../core/handoff.js").Handoff[] | undefined;
+  readonly activeRoles?: readonly string[] | undefined;
+  readonly agentFailures?: ReadonlyMap<string, string> | undefined;
   /** C2 (#302): in-view filter query. Applied to current expanded panel only. */
   readonly filterText?: string | undefined;
   /** #311: true when DAG-local keyboard shortcuts may fire (DAG focused and
@@ -1588,6 +1632,8 @@ function renderExpandedPanel(panel: RunningPanel, ctx: PanelRenderContext): Reac
         undefined,
         ctx.autoFollow,
         ctx.newSinceFreeze,
+        ctx.activeRoles,
+        ctx.agentFailures,
       );
 
     case RunningPanel.Agents:

--- a/src/tui/screens/screen-manager.test.ts
+++ b/src/tui/screens/screen-manager.test.ts
@@ -87,6 +87,7 @@ interface TestSpawnManager {
   readonly sessionIds: string[];
   readonly sessionGoals: string[];
   readonly topologies: AgentTopology[];
+  readonly agentFailures: Map<string, string>;
   readonly ensuredBuffers: string[];
   readonly reconcileCalls: string[];
   readonly saveTraceCalls: string[];
@@ -96,6 +97,8 @@ interface TestSpawnManager {
   reconcile(): Promise<void>;
   ensureLogBuffer(roleName: string): void;
   getLogBuffers(): Map<string, unknown>;
+  getAgentFailures(): ReadonlyMap<string, string>;
+  subscribeAgentFailures(listener: () => void): () => void;
   startLogPolling(intervalMs?: number, seekToEnd?: boolean): void;
   stopLogPolling(): void;
   stopActiveSession(): Promise<void>;
@@ -386,6 +389,7 @@ function makeSpawnManager(): TestSpawnManager {
     sessionIds: [],
     sessionGoals: [],
     topologies: [],
+    agentFailures: new Map(),
     ensuredBuffers: [],
     reconcileCalls: [],
     saveTraceCalls: [],
@@ -400,6 +404,8 @@ function makeSpawnManager(): TestSpawnManager {
       logBuffers.set(roleName, {});
     },
     getLogBuffers: () => logBuffers,
+    getAgentFailures: () => manager.agentFailures,
+    subscribeAgentFailures: () => () => undefined,
     startLogPolling: () => undefined,
     stopLogPolling: () => {
       manager.stopLogPollingCalls.push("stop");
@@ -731,6 +737,27 @@ describe("ScreenManager transition flow", () => {
     });
 
     expect(captured.screen).toBe("running");
+  });
+
+  test("running view receives agent bootstrap failures from the spawn manager", async () => {
+    const spawnManager = makeSpawnManager();
+    spawnManager.agentFailures.set("planner", "unexpected status 401 Unauthorized");
+
+    renderScreenManager({
+      topology: TEST_TOPOLOGY,
+      spawnManager,
+      initialState: {
+        screen: "running",
+        goal: "Observe failures",
+        sessionId: "session-failed",
+        sessionStartedAt: "2026-03-29T00:00:00.000Z",
+      },
+    });
+    await act(async () => {
+      await flushAsync();
+    });
+
+    expect(requireRunningView().agentFailures?.get("planner")).toContain("401 Unauthorized");
   });
 
   test("running -> complete when the running screen completes", async () => {

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -260,10 +260,18 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
     // Always bump reconcileVersion after reconcile to force RunningView re-render
     // with updated activeRoles from SpawnManager.
     const [reconcileVersion, setReconcileVersion] = useState(0);
+    const [agentFailureVersion, setAgentFailureVersion] = useState(0);
     const lastReconciledScreenRef = useRef<string>("");
     // Spawn guard: prevents duplicate spawn when user presses Escape → Enter twice on agent-detect screen.
     // Reset when user navigates back past goal-input (handleGoalBack) or starts a new session.
     const hasSpawnedRef = useRef<boolean>(false);
+    useEffect(() => {
+      if (!spawnManager) return undefined;
+      return spawnManager.subscribeAgentFailures(() => {
+        setAgentFailureVersion((v) => v + 1);
+      });
+    }, [spawnManager]);
+
     useEffect(() => {
       if (
         state.screen === "running" &&
@@ -923,6 +931,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
             eventBus={appProps.eventBus}
             groveDir={appProps.groveDir}
             logBuffers={reconcileVersion >= 0 ? spawnManager.getLogBuffers() : undefined}
+            agentFailures={agentFailureVersion >= 0 ? spawnManager.getAgentFailures() : undefined}
             onNewContribution={(c) => {
               debugLog(
                 "contribution",
@@ -1021,6 +1030,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
       appProps,
       spawnManager,
       reconcileVersion,
+      agentFailureVersion,
       observeDoneContribution,
       getDuration,
       wrapWithPermissions,

--- a/src/tui/spawn-manager.test.ts
+++ b/src/tui/spawn-manager.test.ts
@@ -253,14 +253,26 @@ function restoreEnv(name: string, value: string | undefined): void {
   }
 }
 
-function makeMockRuntime(): AgentRuntime & { readonly configs: AgentConfig[] } {
+function makeMockRuntime(): AgentRuntime & {
+  readonly configs: AgentConfig[];
+  setSessionStatus(sessionId: string, status: AgentSession["status"], message?: string): void;
+} {
   const configs: AgentConfig[] = [];
+  const sessions = new Map<string, AgentSession>();
+  const idleCallbacks = new Map<string, Array<() => void>>();
   return {
     sendsInitialPromptOnSpawn: true,
     configs,
     async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
       configs.push(config);
-      return { id: `session-${role}`, role, status: "running", agent: "mock" };
+      const session: AgentSession = {
+        id: `session-${role}`,
+        role,
+        status: "running",
+        agent: "mock",
+      };
+      sessions.set(session.id, session);
+      return session;
     },
     async send(): Promise<AcpxTurn> {
       throw new Error("mock runtime send should not be called by SpawnManager.spawn");
@@ -268,11 +280,13 @@ function makeMockRuntime(): AgentRuntime & { readonly configs: AgentConfig[] } {
     async close(): Promise<void> {
       // No-op for test mock.
     },
-    onIdle(): void {
-      // No-op for test mock.
+    onIdle(session: AgentSession, callback: () => void): void {
+      const callbacks = idleCallbacks.get(session.id) ?? [];
+      callbacks.push(callback);
+      idleCallbacks.set(session.id, callbacks);
     },
     async listSessions(): Promise<readonly AgentSession[]> {
-      return [];
+      return [...sessions.values()];
     },
     async listSessionEntities(): Promise<
       readonly import("../core/entity.js").AgentSessionEntity[]
@@ -281,6 +295,16 @@ function makeMockRuntime(): AgentRuntime & { readonly configs: AgentConfig[] } {
     },
     async isAvailable(): Promise<boolean> {
       return true;
+    },
+    setSessionStatus(sessionId: string, status: AgentSession["status"], message?: string): void {
+      const current = sessions.get(sessionId);
+      if (!current) throw new Error(`unknown session ${sessionId}`);
+      const next =
+        message === undefined
+          ? { ...current, status }
+          : { ...current, status, statusMessage: message };
+      sessions.set(sessionId, next);
+      for (const callback of idleCallbacks.get(sessionId) ?? []) callback();
     },
   };
 }
@@ -354,6 +378,39 @@ describe("SpawnManager", () => {
 
     releaseClose?.();
     await stopPromise;
+  });
+
+  test("runtime crash marks role failed and removes it from active roles", async () => {
+    const provider = makeMockProvider();
+    const runtime = makeMockRuntime();
+    manager = new SpawnManager(
+      provider,
+      undefined,
+      () => {
+        // No-op for test mock.
+      },
+      [{ kind: "local" as const, path: "/tmp" }],
+      undefined,
+      "/tmp/no-grove",
+      runtime,
+    );
+
+    await manager.spawn("coder", "codex");
+    expect(manager.getActiveRoles()).toEqual(["coder"]);
+
+    let failureNotifications = 0;
+    const unsubscribe = manager.subscribeAgentFailures(() => {
+      failureNotifications++;
+    });
+
+    runtime.setSessionStatus("session-coder", "crashed", "unexpected status 401 Unauthorized");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(manager.getActiveRoles()).toEqual([]);
+    expect(manager.getAgentFailures().get("coder")).toContain("401 Unauthorized");
+    expect(failureNotifications).toBe(1);
+
+    unsubscribe();
   });
 
   test("spawn creates workspace and tmux session (no auto-claims)", async () => {

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -167,6 +167,8 @@ export class SpawnManager {
   private readonly agentRuntime: AgentRuntime | undefined;
   private readonly spawnRecords = new Map<string, SpawnRecord>();
   private readonly agentSessions = new Map<string, AgentSession>();
+  private readonly agentFailures = new Map<string, string>();
+  private readonly agentFailureListeners = new Set<() => void>();
   private readonly logBuffers = new Map<string, AgentLogBuffer>();
   private readonly onError: (message: string) => void;
   private readonly sessionStore: SessionStore | undefined;
@@ -241,6 +243,48 @@ export class SpawnManager {
       this.acpSessionStore?.register(event.sessionId);
       this.acpSessionStore?.ingest(event);
     });
+  }
+
+  private notifyAgentFailures(): void {
+    for (const listener of this.agentFailureListeners) listener();
+  }
+
+  private recordAgentFailure(role: string, message: string): void {
+    this.agentFailures.set(role, message);
+    this.ensureLogBuffer(role).pushRawLines([`[error] ${message}`]);
+    this.onError(`${role}: ${message}`);
+    this.notifyAgentFailures();
+  }
+
+  private monitorRuntimeSession(spawnId: string, roleId: string, session: AgentSession): void {
+    if (!this.agentRuntime) return;
+    this.agentRuntime.onIdle(session, () => {
+      void this.refreshRuntimeSessionStatus(spawnId, roleId, session.id);
+    });
+  }
+
+  private async refreshRuntimeSessionStatus(
+    spawnId: string,
+    roleId: string,
+    sessionId: string,
+  ): Promise<void> {
+    if (!this.agentRuntime) return;
+    try {
+      const latest = (await this.agentRuntime.listSessions()).find((s) => s.id === sessionId);
+      if (!latest) return;
+      this.agentSessions.set(spawnId, latest);
+      if (latest.status !== "crashed") return;
+
+      this.routableSessions.delete(spawnId);
+      this.wsBridge?.unregisterSession(roleId, latest.id);
+      this.unregisterAcpSession(latest.id);
+      this.recordAgentFailure(roleId, latest.statusMessage ?? "agent session crashed");
+    } catch (err) {
+      debugLog(
+        "spawn",
+        `runtime status refresh failed for role=${roleId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   /**
@@ -621,6 +665,7 @@ export class SpawnManager {
     context?: Record<string, unknown>,
   ): Promise<SpawnResult> {
     debugLog("spawn", `role=${roleId} command=${command}`);
+    if (this.agentFailures.delete(roleId)) this.notifyAgentFailures();
     // Fail closed on delivery state:
     //   disabled → refuse ONLY when the current topology actually
     //              needs cross-role IPC (multi-role). A single-role
@@ -889,6 +934,7 @@ export class SpawnManager {
         const session = await this.agentRuntime.spawn(roleId, agentConfig);
         this.agentSessions.set(spawnId, session);
         this.routableSessions.add(spawnId);
+        this.monitorRuntimeSession(spawnId, roleId, session);
       } else if (this.tmux) {
         // Fallback: tmux (for TUI testing)
         const options: SpawnOptions = {
@@ -1042,6 +1088,7 @@ export class SpawnManager {
       // id matches the killed session's id.
       const roleKey = tracked.role ?? agentSession?.role ?? killedAgentId;
       this.wsBridge?.unregisterSession(roleKey, agentSession?.id);
+      if (this.agentFailures.delete(roleKey)) this.notifyAgentFailures();
       // AcpSessionStore is keyed by the runtime's agentSession.id (e.g.
       // `grove-coder-0-abc123`), which may differ from `killedAgentId`
       // (the spawn-manager's agentId key). Prefer the captured
@@ -1065,6 +1112,10 @@ export class SpawnManager {
   async stopActiveSession(): Promise<void> {
     this.stopLogPolling();
     this.routableSessions.clear();
+    if (this.agentFailures.size > 0) {
+      this.agentFailures.clear();
+      this.notifyAgentFailures();
+    }
 
     const spawnIds = new Set<string>([...this.spawnRecords.keys(), ...this.agentSessions.keys()]);
     const sessions: AgentSession[] = [];
@@ -1328,7 +1379,8 @@ export class SpawnManager {
   /** Get list of active agent roles (for UI display). */
   getActiveRoles(): string[] {
     const roles: string[] = [];
-    for (const spawnId of this.agentSessions.keys()) {
+    for (const [spawnId, session] of this.agentSessions) {
+      if (session.status === "crashed" || session.status === "stopped") continue;
       const role = spawnId.replace(/-[a-z0-9]+$/i, "");
       if (!roles.includes(role)) roles.push(role);
     }
@@ -1351,6 +1403,17 @@ export class SpawnManager {
 
   getLogBuffers(): ReadonlyMap<string, AgentLogBuffer> {
     return this.logBuffers;
+  }
+
+  getAgentFailures(): ReadonlyMap<string, string> {
+    return this.agentFailures;
+  }
+
+  subscribeAgentFailures(listener: () => void): () => void {
+    this.agentFailureListeners.add(listener);
+    return () => {
+      this.agentFailureListeners.delete(listener);
+    };
   }
 
   /** Set the session ID for log buffer naming and persistence. */
@@ -1595,6 +1658,8 @@ export class SpawnManager {
     }
     this.logBuffers.clear();
     this.spawnRecords.clear();
+    this.agentFailures.clear();
+    this.agentFailureListeners.clear();
     for (const unsubscribe of this.acpProjections.values()) {
       unsubscribe();
     }

--- a/src/tui/theme.test.ts
+++ b/src/tui/theme.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { AGENT_COLORS, theme } from "./theme.js";
+import { AGENT_COLORS, replaceTheme, theme } from "./theme.js";
 
 describe("theme", () => {
   test("has all focus/chrome tokens", () => {
@@ -74,6 +74,22 @@ describe("theme", () => {
         expect(isValid).toBe(true);
       }
     }
+  });
+
+  test("replaceTheme resets removed override keys", () => {
+    const initialFocus = theme.focus;
+    const initialError = theme.error;
+
+    replaceTheme({ focus: "red", error: "green" });
+    expect(theme.focus).toBe("red");
+    expect(theme.error).toBe("green");
+
+    replaceTheme({ error: "yellow" });
+    expect(theme.focus).toBe(initialFocus);
+    expect(theme.error).toBe("yellow");
+
+    replaceTheme({});
+    expect(theme.error).toBe(initialError);
   });
 });
 

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -262,6 +262,39 @@ const _themeStore: {
  */
 export const theme: Readonly<typeof _themeStore> = _themeStore;
 
+const DEFAULT_THEME_COLOR_TOKENS: ThemeColorTokens = {
+  focus: _themeStore.focus,
+  inactive: _themeStore.inactive,
+  border: _themeStore.border,
+  running: _themeStore.running,
+  waiting: _themeStore.waiting,
+  idle: _themeStore.idle,
+  error: _themeStore.error,
+  stale: _themeStore.stale,
+  work: _themeStore.work,
+  review: _themeStore.review,
+  discussion: _themeStore.discussion,
+  adoption: _themeStore.adoption,
+  reproduction: _themeStore.reproduction,
+  text: _themeStore.text,
+  secondary: _themeStore.secondary,
+  disabled: _themeStore.disabled,
+  panelBg: _themeStore.panelBg,
+  headerBg: _themeStore.headerBg,
+  selectedBg: _themeStore.selectedBg,
+  success: _themeStore.success,
+  warning: _themeStore.warning,
+  info: _themeStore.info,
+  compare: _themeStore.compare,
+  statusRunning: _themeStore.statusRunning,
+  statusDone: _themeStore.statusDone,
+  statusFailed: _themeStore.statusFailed,
+  statusBlocked: _themeStore.statusBlocked,
+  statusAwaitingReview: _themeStore.statusAwaitingReview,
+  statusIdle: _themeStore.statusIdle,
+  highlightMatch: _themeStore.highlightMatch,
+};
+
 /**
  * Apply user theme overrides from config.
  *
@@ -275,6 +308,19 @@ export function configureTheme(overrides: Partial<ThemeColorTokens>): void {
       (_themeStore as Record<string, unknown>)[key] = resolveColor(value);
     }
   }
+}
+
+/**
+ * Replace all overridable color tokens with defaults plus the provided overrides.
+ *
+ * This is used by hot reload so removing a key from theme.yaml restores the
+ * lower-priority color instead of leaving the previous override behind.
+ */
+export function replaceTheme(overrides: Partial<ThemeColorTokens>): void {
+  for (const [key, value] of Object.entries(DEFAULT_THEME_COLOR_TOKENS)) {
+    (_themeStore as Record<string, unknown>)[key] = value;
+  }
+  configureTheme(overrides);
 }
 
 /** Return the current theme (same as the exported `theme` constant). */


### PR DESCRIPTION
## Summary

- Add TUI config watching so GROVE.md changes to aliases, hotkeys, and theme are reloaded live.
- Refresh the running/session screens so empty feeds, hotkey/theme updates, and session state changes render correctly.
- Harden ACP launch/runtime behavior for Codex and Claude handoffs, including native Codex ACP resolution, clearer handshake errors, safer teardown, and symlinked Codex auth to avoid stale rotated refresh tokens.

Closes #289.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run check` (existing warnings only)
- `git diff --check`
- `bun --config=/tmp/bunfig-no-coverage.toml test --timeout 60000 --reporter=dots` — 7479 pass, 7 skip, 0 fail
- Live tmux TUI validation with `coder -> codex` and `reviewer -> claude`: session completed, reviewer verified README contents, and the coder workspace commit was present on disk.
- Pre-push hook reran typecheck and build successfully.
