### PR TITLE
[codex] Add TUI registry foundation and harden handoffs

### DIFF
--- a/docs/superpowers/plans/2026-05-15-tui-registry-foundation.md
+++ b/docs/superpowers/plans/2026-05-15-tui-registry-foundation.md
@@ -1,0 +1,985 @@
+# TUI Registry Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add stable string panel IDs and a typed TUI registry foundation so built-in panels and future plugin panels can share one registry boundary.
+
+**Architecture:** Keep existing numeric `Panel` constants for current focus and rendering internals, but introduce string IDs at config/plugin boundaries. Add a pure plugin registry model that can merge built-in entries with plugin registrations, and adapt existing panel registry helpers so built-in panel definitions expose stable IDs and can be queried through injectable registries.
+
+**Tech Stack:** Bun 1.3.x, TypeScript strict mode, React/OpenTUI types, `bun:test`, Biome.
+
+---
+
+## File Structure
+
+- Create `src/tui/panels/panel-ids.ts`: built-in panel string IDs and conversion helpers between `Panel` and string IDs.
+- Create `src/tui/panels/panel-ids.test.ts`: pure tests for ID stability and conversions.
+- Create `src/tui/plugins/types.ts`: public TUI plugin/slot/context types; no loading behavior.
+- Create `src/tui/plugins/registry.ts`: pure merge/validation helpers for built-in registry entries plus plugin registrations.
+- Create `src/tui/plugins/registry.test.ts`: pure tests for duplicate handling, invalid IDs, ordering, and diagnostics.
+- Modify `src/tui/panels/panel-registry.ts`: add built-in IDs, slot metadata, string-ID preset helpers, injectable registry query helpers, and built-in-to-TUI-entry conversion.
+- Modify `src/tui/panels/panel-registry.test.ts`: add tests for stable IDs, built-in registry entries, string-ID preset filters, and injectable helper behavior.
+- Modify `src/tui/panels/panel-manager.tsx`: use stable string IDs for row keys so render identity no longer depends on numeric enum values.
+
+## Task 1: Built-In Panel ID Map
+
+**Files:**
+- Create: `src/tui/panels/panel-ids.test.ts`
+- Create: `src/tui/panels/panel-ids.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tui/panels/panel-ids.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { Panel } from "../hooks/use-panel-focus.js";
+import {
+  BUILT_IN_PANEL_IDS,
+  CORE_PANEL_IDS,
+  OPERATOR_PANEL_IDS,
+  PanelId,
+  idToPanel,
+  panelToId,
+} from "./panel-ids.js";
+
+describe("panel IDs", () => {
+  test("keeps stable string IDs for all built-in panels", () => {
+    expect(PanelId.Dag).toBe("dag");
+    expect(PanelId.Detail).toBe("detail");
+    expect(PanelId.Frontier).toBe("frontier");
+    expect(PanelId.Claims).toBe("claims");
+    expect(PanelId.AgentList).toBe("agents");
+    expect(PanelId.Terminal).toBe("terminal");
+    expect(PanelId.Artifact).toBe("artifact");
+    expect(PanelId.Vfs).toBe("vfs");
+    expect(PanelId.Activity).toBe("activity");
+    expect(PanelId.Search).toBe("search");
+    expect(PanelId.Threads).toBe("threads");
+    expect(PanelId.Outcomes).toBe("outcomes");
+    expect(PanelId.Bounties).toBe("bounties");
+    expect(PanelId.Gossip).toBe("gossip");
+    expect(PanelId.Inbox).toBe("inbox");
+    expect(PanelId.Decisions).toBe("decisions");
+    expect(PanelId.GitHub).toBe("github");
+    expect(PanelId.Plan).toBe("plan");
+  });
+
+  test("converts numeric Panel values to stable string IDs", () => {
+    expect(panelToId(Panel.Dag)).toBe(PanelId.Dag);
+    expect(panelToId(Panel.AgentList)).toBe(PanelId.AgentList);
+    expect(panelToId(Panel.GitHub)).toBe(PanelId.GitHub);
+  });
+
+  test("converts stable string IDs back to numeric Panel values", () => {
+    expect(idToPanel("dag")).toBe(Panel.Dag);
+    expect(idToPanel("agents")).toBe(Panel.AgentList);
+    expect(idToPanel("github")).toBe(Panel.GitHub);
+  });
+
+  test("returns undefined for unknown string IDs", () => {
+    expect(idToPanel("missing")).toBeUndefined();
+    expect(idToPanel("bad/id")).toBeUndefined();
+  });
+
+  test("exports ordered built-in, core, and operator ID lists", () => {
+    expect(CORE_PANEL_IDS).toEqual(["dag", "detail", "frontier", "claims"]);
+    expect(OPERATOR_PANEL_IDS[0]).toBe("agents");
+    expect(OPERATOR_PANEL_IDS[OPERATOR_PANEL_IDS.length - 1]).toBe("plan");
+    expect(BUILT_IN_PANEL_IDS).toEqual([...CORE_PANEL_IDS, ...OPERATOR_PANEL_IDS]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+bun test src/tui/panels/panel-ids.test.ts
+```
+
+Expected: FAIL because `src/tui/panels/panel-ids.ts` does not exist.
+
+- [ ] **Step 3: Add the panel ID implementation**
+
+Create `src/tui/panels/panel-ids.ts`:
+
+```ts
+import { CORE_PANELS, OPERATOR_PANELS, type Panel, Panel } from "../hooks/use-panel-focus.js";
+
+export const PanelId = {
+  Dag: "dag",
+  Detail: "detail",
+  Frontier: "frontier",
+  Claims: "claims",
+  AgentList: "agents",
+  Terminal: "terminal",
+  Artifact: "artifact",
+  Vfs: "vfs",
+  Activity: "activity",
+  Search: "search",
+  Threads: "threads",
+  Outcomes: "outcomes",
+  Bounties: "bounties",
+  Gossip: "gossip",
+  Inbox: "inbox",
+  Decisions: "decisions",
+  GitHub: "github",
+  Plan: "plan",
+} as const;
+
+export type BuiltInPanelId = (typeof PanelId)[keyof typeof PanelId];
+
+const PANEL_TO_ID: Readonly<Record<Panel, BuiltInPanelId>> = {
+  [Panel.Dag]: PanelId.Dag,
+  [Panel.Detail]: PanelId.Detail,
+  [Panel.Frontier]: PanelId.Frontier,
+  [Panel.Claims]: PanelId.Claims,
+  [Panel.AgentList]: PanelId.AgentList,
+  [Panel.Terminal]: PanelId.Terminal,
+  [Panel.Artifact]: PanelId.Artifact,
+  [Panel.Vfs]: PanelId.Vfs,
+  [Panel.Activity]: PanelId.Activity,
+  [Panel.Search]: PanelId.Search,
+  [Panel.Threads]: PanelId.Threads,
+  [Panel.Outcomes]: PanelId.Outcomes,
+  [Panel.Bounties]: PanelId.Bounties,
+  [Panel.Gossip]: PanelId.Gossip,
+  [Panel.Inbox]: PanelId.Inbox,
+  [Panel.Decisions]: PanelId.Decisions,
+  [Panel.GitHub]: PanelId.GitHub,
+  [Panel.Plan]: PanelId.Plan,
+};
+
+const ID_TO_PANEL = new Map<BuiltInPanelId, Panel>(
+  Object.entries(PANEL_TO_ID).map(([panel, id]) => [id, Number(panel) as Panel]),
+);
+
+export const CORE_PANEL_IDS: readonly BuiltInPanelId[] = CORE_PANELS.map((panel) => PANEL_TO_ID[panel]);
+export const OPERATOR_PANEL_IDS: readonly BuiltInPanelId[] = OPERATOR_PANELS.map(
+  (panel) => PANEL_TO_ID[panel],
+);
+export const BUILT_IN_PANEL_IDS: readonly BuiltInPanelId[] = [
+  ...CORE_PANEL_IDS,
+  ...OPERATOR_PANEL_IDS,
+];
+
+export function panelToId(panel: Panel): BuiltInPanelId {
+  return PANEL_TO_ID[panel];
+}
+
+export function idToPanel(id: string): Panel | undefined {
+  return ID_TO_PANEL.get(id as BuiltInPanelId);
+}
+```
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run:
+
+```bash
+bun test src/tui/panels/panel-ids.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/panels/panel-ids.ts src/tui/panels/panel-ids.test.ts
+git commit -m "feat(tui): add stable built-in panel ids"
+```
+
+## Task 2: TUI Plugin Registry Types And Merge Helper
+
+**Files:**
+- Create: `src/tui/plugins/types.ts`
+- Create: `src/tui/plugins/registry.ts`
+- Create: `src/tui/plugins/registry.test.ts`
+
+- [ ] **Step 1: Write the failing registry tests**
+
+Create `src/tui/plugins/registry.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { Panel } from "../hooks/use-panel-focus.js";
+import type { TuiPanelRegistration } from "./types.js";
+import { mergeTuiRegistrations, type TuiRegistryEntry } from "./registry.js";
+
+const NullPanel = () => null;
+
+function builtIn(id: string, order: number, panel: Panel): TuiRegistryEntry {
+  return {
+    id,
+    label: id,
+    slot: "operator-panel",
+    order,
+    source: "builtin",
+    builtInPanel: panel,
+  };
+}
+
+function plugin(id: string, order?: number): TuiPanelRegistration {
+  return {
+    id,
+    label: id,
+    slot: "operator-panel",
+    ...(order === undefined ? {} : { order }),
+    component: NullPanel,
+  };
+}
+
+describe("mergeTuiRegistrations", () => {
+  test("orders built-in and plugin entries by order then id", () => {
+    const result = mergeTuiRegistrations({
+      builtIns: [builtIn("dag", 10, Panel.Dag), builtIn("claims", 30, Panel.Claims)],
+      plugins: [plugin("eval-results", 20), plugin("audit-feed", 20)],
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.entries.map((entry) => entry.id)).toEqual([
+      "dag",
+      "audit-feed",
+      "eval-results",
+      "claims",
+    ]);
+  });
+
+  test("skips plugin entries that duplicate built-in IDs", () => {
+    const result = mergeTuiRegistrations({
+      builtIns: [builtIn("dag", 10, Panel.Dag)],
+      plugins: [plugin("dag", 20)],
+    });
+
+    expect(result.entries.map((entry) => entry.id)).toEqual(["dag"]);
+    expect(result.diagnostics).toEqual([
+      {
+        id: "dag",
+        severity: "error",
+        message: "Duplicate TUI panel id: dag",
+      },
+    ]);
+  });
+
+  test("skips plugin entries with unsafe IDs", () => {
+    const result = mergeTuiRegistrations({
+      builtIns: [builtIn("dag", 10, Panel.Dag)],
+      plugins: [plugin("bad/id", 20), plugin("UpperCase", 30)],
+    });
+
+    expect(result.entries.map((entry) => entry.id)).toEqual(["dag"]);
+    expect(result.diagnostics).toEqual([
+      {
+        id: "bad/id",
+        severity: "error",
+        message: "Invalid TUI panel id: bad/id",
+      },
+      {
+        id: "UpperCase",
+        severity: "error",
+        message: "Invalid TUI panel id: UpperCase",
+      },
+    ]);
+  });
+
+  test("uses default plugin order after built-ins when order is omitted", () => {
+    const result = mergeTuiRegistrations({
+      builtIns: [builtIn("dag", 10, Panel.Dag)],
+      plugins: [plugin("eval-results")],
+    });
+
+    expect(result.entries.map((entry) => entry.id)).toEqual(["dag", "eval-results"]);
+    expect(result.entries[1]?.order).toBe(1000);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+bun test src/tui/plugins/registry.test.ts
+```
+
+Expected: FAIL because `src/tui/plugins/types.ts` and `src/tui/plugins/registry.ts` do not exist.
+
+- [ ] **Step 3: Add public plugin types**
+
+Create `src/tui/plugins/types.ts`:
+
+```ts
+import type React from "react";
+import type { AgentTopology } from "../../core/topology.js";
+import type { TuiDataProvider } from "../provider.js";
+
+export type TuiSlot =
+  | "operator-panel"
+  | "dashboard"
+  | "detail-adjacent"
+  | "footer"
+  | "command-palette";
+
+export interface TuiPluginManifest {
+  readonly id: string;
+  readonly name: string;
+  readonly version: string;
+  readonly slots: readonly TuiSlot[];
+}
+
+export interface TuiPluginContext {
+  readonly provider: TuiDataProvider;
+  readonly topology?: AgentTopology | undefined;
+  readonly selectedSession?: string | undefined;
+  readonly selectedCid?: string | undefined;
+  readonly density: "comfortable" | "compact";
+}
+
+export interface TuiPanelRegistration {
+  readonly id: string;
+  readonly label: string;
+  readonly slot: TuiSlot;
+  readonly defaultVisible?: boolean | undefined;
+  readonly order?: number | undefined;
+  readonly component: React.ComponentType<TuiPluginContext>;
+}
+```
+
+- [ ] **Step 4: Add pure registry merge implementation**
+
+Create `src/tui/plugins/registry.ts`:
+
+```ts
+import type { Panel } from "../hooks/use-panel-focus.js";
+import type { TuiPanelRegistration, TuiSlot } from "./types.js";
+
+const DEFAULT_PLUGIN_ORDER = 1000;
+const SAFE_PANEL_ID = /^[a-z][a-z0-9.-]*$/;
+
+export interface TuiRegistryEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly slot: TuiSlot;
+  readonly order: number;
+  readonly source: "builtin" | "plugin";
+  readonly builtInPanel?: Panel | undefined;
+  readonly registration?: TuiPanelRegistration | undefined;
+}
+
+export interface TuiRegistryDiagnostic {
+  readonly id: string;
+  readonly severity: "error";
+  readonly message: string;
+}
+
+export interface MergeTuiRegistrationsInput {
+  readonly builtIns: readonly TuiRegistryEntry[];
+  readonly plugins?: readonly TuiPanelRegistration[] | undefined;
+}
+
+export interface MergeTuiRegistrationsResult {
+  readonly entries: readonly TuiRegistryEntry[];
+  readonly diagnostics: readonly TuiRegistryDiagnostic[];
+}
+
+export function isSafeTuiPanelId(id: string): boolean {
+  return SAFE_PANEL_ID.test(id);
+}
+
+export function mergeTuiRegistrations(
+  input: MergeTuiRegistrationsInput,
+): MergeTuiRegistrationsResult {
+  const entries: TuiRegistryEntry[] = [];
+  const diagnostics: TuiRegistryDiagnostic[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of input.builtIns) {
+    if (!isSafeTuiPanelId(entry.id)) {
+      throw new Error(`Built-in TUI panel has invalid id: ${entry.id}`);
+    }
+    if (seen.has(entry.id)) {
+      throw new Error(`Built-in TUI panel id is duplicated: ${entry.id}`);
+    }
+    seen.add(entry.id);
+    entries.push(entry);
+  }
+
+  for (const registration of input.plugins ?? []) {
+    if (!isSafeTuiPanelId(registration.id)) {
+      diagnostics.push({
+        id: registration.id,
+        severity: "error",
+        message: `Invalid TUI panel id: ${registration.id}`,
+      });
+      continue;
+    }
+    if (seen.has(registration.id)) {
+      diagnostics.push({
+        id: registration.id,
+        severity: "error",
+        message: `Duplicate TUI panel id: ${registration.id}`,
+      });
+      continue;
+    }
+    seen.add(registration.id);
+    entries.push({
+      id: registration.id,
+      label: registration.label,
+      slot: registration.slot,
+      order: registration.order ?? DEFAULT_PLUGIN_ORDER,
+      source: "plugin",
+      registration,
+    });
+  }
+
+  entries.sort((a, b) => {
+    const orderDelta = a.order - b.order;
+    if (orderDelta !== 0) return orderDelta;
+    const sourceDelta = sourceRank(a.source) - sourceRank(b.source);
+    if (sourceDelta !== 0) return sourceDelta;
+    return a.id.localeCompare(b.id);
+  });
+
+  return {
+    entries: Object.freeze(entries),
+    diagnostics: Object.freeze(diagnostics),
+  };
+}
+
+function sourceRank(source: "builtin" | "plugin"): number {
+  return source === "builtin" ? 0 : 1;
+}
+```
+
+- [ ] **Step 5: Run the focused test to verify it passes**
+
+Run:
+
+```bash
+bun test src/tui/plugins/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui/plugins/types.ts src/tui/plugins/registry.ts src/tui/plugins/registry.test.ts
+git commit -m "feat(tui): add plugin registry foundation"
+```
+
+## Task 3: Add Stable IDs To Built-In Panel Registry
+
+**Files:**
+- Modify: `src/tui/panels/panel-registry.ts`
+- Modify: `src/tui/panels/panel-registry.test.ts`
+
+- [ ] **Step 1: Add failing tests for built-in registry IDs**
+
+Append these tests to `src/tui/panels/panel-registry.test.ts`:
+
+```ts
+// ---------------------------------------------------------------------------
+// Stable panel IDs
+// ---------------------------------------------------------------------------
+
+describe("stable panel IDs", () => {
+  it("assigns a stable string id to every built-in panel definition", () => {
+    const registry = getRegistry();
+    const ids = registry.map((def) => def.id);
+
+    expect(ids).toEqual([
+      "dag",
+      "detail",
+      "frontier",
+      "claims",
+      "agents",
+      "terminal",
+      "artifact",
+      "vfs",
+      "activity",
+      "search",
+      "threads",
+      "outcomes",
+      "bounties",
+      "gossip",
+      "inbox",
+      "decisions",
+      "github",
+      "plan",
+    ]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("looks up a built-in panel definition by string id", () => {
+    expect(getPanelDefById("dag")?.panel).toBe(Panel.Dag);
+    expect(getPanelDefById("agents")?.panel).toBe(Panel.AgentList);
+    expect(getPanelDefById("github")?.panel).toBe(Panel.GitHub);
+  });
+
+  it("converts built-in panel definitions into TUI registry entries", () => {
+    const entries = getBuiltInTuiRegistryEntries();
+    expect(entries[0]).toEqual({
+      id: "dag",
+      label: "DAG",
+      slot: "operator-panel",
+      order: 0,
+      source: "builtin",
+      builtInPanel: Panel.Dag,
+    });
+    expect(entries.at(-1)).toEqual({
+      id: "plan",
+      label: "Plan",
+      slot: "operator-panel",
+      order: 17,
+      source: "builtin",
+      builtInPanel: Panel.Plan,
+    });
+  });
+});
+```
+
+Update the import list in the same file to include:
+
+```ts
+  getBuiltInTuiRegistryEntries,
+  getPanelDefById,
+```
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+```bash
+bun test src/tui/panels/panel-registry.test.ts
+```
+
+Expected: FAIL because `PanelDef.id`, `getPanelDefById`, and `getBuiltInTuiRegistryEntries` do not exist.
+
+- [ ] **Step 3: Modify the panel registry types and imports**
+
+In `src/tui/panels/panel-registry.ts`, add these imports:
+
+```ts
+import type { TuiRegistryEntry } from "../plugins/registry.js";
+import { panelToId, type BuiltInPanelId } from "./panel-ids.js";
+```
+
+Replace the `PanelDef` interface with this base/interface split:
+
+```ts
+interface PanelDefBase {
+  readonly panel: Panel;
+  readonly label: string;
+  readonly rowGroup: number;
+  readonly kind: "core" | "operator";
+  readonly rowPartners?: readonly Panel[];
+  readonly keybinding: string;
+}
+
+export interface PanelDef extends PanelDefBase {
+  readonly id: BuiltInPanelId;
+  readonly slot: "operator-panel";
+}
+```
+
+- [ ] **Step 4: Build `PANEL_REGISTRY` from a base registry**
+
+Rename the existing `PANEL_REGISTRY` declaration to `PANEL_REGISTRY_BASE` and change its type:
+
+```ts
+const PANEL_REGISTRY_BASE: readonly PanelDefBase[] = [
+```
+
+Keep the existing array contents unchanged. After the closing array, add:
+
+```ts
+export const PANEL_REGISTRY: readonly PanelDef[] = Object.freeze(
+  PANEL_REGISTRY_BASE.map((def) =>
+    Object.freeze({
+      ...def,
+      id: panelToId(def.panel),
+      slot: "operator-panel" as const,
+    }),
+  ),
+);
+```
+
+Remove the old `export const PANEL_REGISTRY: readonly PanelDef[] = [` declaration so there is only one exported `PANEL_REGISTRY`.
+
+- [ ] **Step 5: Add lookup and built-in entry helpers**
+
+Add these functions after `getRegistry()`:
+
+```ts
+export function getPanelDefById(id: BuiltInPanelId): PanelDef | undefined {
+  return PANEL_REGISTRY.find((def) => def.id === id);
+}
+
+export function getBuiltInTuiRegistryEntries(): readonly TuiRegistryEntry[] {
+  return PANEL_REGISTRY.map((def, order) => ({
+    id: def.id,
+    label: def.label,
+    slot: def.slot,
+    order,
+    source: "builtin",
+    builtInPanel: def.panel,
+  }));
+}
+```
+
+- [ ] **Step 6: Run the focused tests to verify they pass**
+
+Run:
+
+```bash
+bun test src/tui/panels/panel-registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tui/panels/panel-registry.ts src/tui/panels/panel-registry.test.ts
+git commit -m "feat(tui): expose built-in panel registry ids"
+```
+
+## Task 4: Add String-ID Preset Filters
+
+**Files:**
+- Modify: `src/tui/panels/panel-registry.ts`
+- Modify: `src/tui/panels/panel-registry.test.ts`
+
+- [ ] **Step 1: Add failing tests for preset panel IDs**
+
+Append these tests to `src/tui/panels/panel-registry.test.ts`:
+
+```ts
+// ---------------------------------------------------------------------------
+// getPresetPanelIds()
+// ---------------------------------------------------------------------------
+
+describe("getPresetPanelIds", () => {
+  it("returns stable string IDs for review-loop", () => {
+    expect([...(getPresetPanelIds("review-loop") ?? [])]).toEqual([
+      "dag",
+      "detail",
+      "claims",
+      "terminal",
+    ]);
+  });
+
+  it("returns stable string IDs for swarm-ops", () => {
+    expect([...(getPresetPanelIds("swarm-ops") ?? [])]).toEqual([
+      "dag",
+      "detail",
+      "claims",
+      "terminal",
+      "frontier",
+      "outcomes",
+      "bounties",
+    ]);
+  });
+
+  it("returns undefined for unknown preset", () => {
+    expect(getPresetPanelIds("unknown-preset")).toBeUndefined();
+  });
+});
+```
+
+Update the import list in the same file to include:
+
+```ts
+  getPresetPanelIds,
+```
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+```bash
+bun test src/tui/panels/panel-registry.test.ts
+```
+
+Expected: FAIL because `getPresetPanelIds` does not exist.
+
+- [ ] **Step 3: Add string-ID preset filter data**
+
+In `src/tui/panels/panel-registry.ts`, add `PanelId` to the existing panel ID import:
+
+```ts
+import { PanelId, panelToId, type BuiltInPanelId } from "./panel-ids.js";
+```
+
+After `PRESET_PANELS`, add:
+
+```ts
+export const PRESET_PANEL_IDS: Readonly<Record<string, ReadonlySet<BuiltInPanelId>>> = {
+  "review-loop": new Set([PanelId.Dag, PanelId.Detail, PanelId.Claims, PanelId.Terminal]),
+  "swarm-ops": new Set([
+    PanelId.Dag,
+    PanelId.Detail,
+    PanelId.Claims,
+    PanelId.Terminal,
+    PanelId.Frontier,
+    PanelId.Outcomes,
+    PanelId.Bounties,
+  ]),
+  "federated-swarm": new Set([
+    PanelId.Dag,
+    PanelId.Detail,
+    PanelId.Claims,
+    PanelId.Terminal,
+    PanelId.Frontier,
+    PanelId.Gossip,
+  ]),
+};
+
+export function getPresetPanelIds(
+  presetName?: string,
+): ReadonlySet<BuiltInPanelId> | undefined {
+  if (!presetName) return undefined;
+  return PRESET_PANEL_IDS[presetName];
+}
+```
+
+Keep `PRESET_PANELS` and `getPresetPanels()` unchanged for existing callers.
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run:
+
+```bash
+bun test src/tui/panels/panel-registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/panels/panel-registry.ts src/tui/panels/panel-registry.test.ts
+git commit -m "feat(tui): add preset panel id filters"
+```
+
+## Task 5: Make Registry Query Helpers Accept Injected Registries
+
+**Files:**
+- Modify: `src/tui/panels/panel-registry.ts`
+- Modify: `src/tui/panels/panel-registry.test.ts`
+
+- [ ] **Step 1: Add failing tests for injected registry helpers**
+
+Append these tests to `src/tui/panels/panel-registry.test.ts`:
+
+```ts
+// ---------------------------------------------------------------------------
+// Injectable registry helpers
+// ---------------------------------------------------------------------------
+
+describe("injectable registry helpers", () => {
+  it("groups an injected registry instead of always reading PANEL_REGISTRY", () => {
+    const registry = getRegistry().filter((def) => def.id === "claims");
+    const groups = getRowGroups(registry);
+    expect(groups.size).toBe(1);
+    expect(groups.get(2)?.map((def) => def.id)).toEqual(["claims"]);
+  });
+
+  it("computes visible panels from an injected registry", () => {
+    const registry = getRegistry().filter((def) => def.id === "dag" || def.id === "claims");
+    const visible = getVisiblePanelsForLayout(initialPanelState(), "grid", undefined, registry);
+    expect(visible.map((def) => def.id)).toEqual(["dag", "claims"]);
+  });
+
+  it("computes active panels from an injected registry", () => {
+    const registry = getRegistry().filter((def) => def.id === "dag" || def.id === "claims");
+    const active = getActivePanelsForLayout(initialPanelState(), "grid", registry);
+    expect([...active]).toEqual([Panel.Dag, Panel.Claims]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+```bash
+bun test src/tui/panels/panel-registry.test.ts
+```
+
+Expected: FAIL because `getRowGroups`, `getVisiblePanelsForLayout`, and `getActivePanelsForLayout` do not accept injected registries yet.
+
+- [ ] **Step 3: Update `getRowGroups`**
+
+Replace the `getRowGroups()` signature and first lines with:
+
+```ts
+export function getRowGroups(registry: readonly PanelDef[] = PANEL_REGISTRY): Map<number, readonly PanelDef[]> {
+  const groups = new Map<number, PanelDef[]>();
+  for (const def of registry) {
+    let group = groups.get(def.rowGroup);
+    if (group === undefined) {
+      group = [];
+      groups.set(def.rowGroup, group);
+    }
+    group.push(def);
+  }
+  return groups;
+}
+```
+
+- [ ] **Step 4: Update `getVisiblePanelsForLayout`**
+
+Replace the function signature and registry reference with:
+
+```ts
+export function getVisiblePanelsForLayout(
+  panelState: PanelFocusState,
+  mode: LayoutMode,
+  allowedPanels?: ReadonlySet<Panel>,
+  registry: readonly PanelDef[] = PANEL_REGISTRY,
+): readonly PanelDef[] {
+  if (mode === "tab") {
+    const def = registry.find((d) => d.panel === panelState.focused);
+    return def !== undefined ? [def] : [];
+  }
+
+  return registry.filter(
+    (def) =>
+      isPanelVisible(panelState, def.panel) &&
+      (allowedPanels === undefined || allowedPanels.has(def.panel)),
+  );
+}
+```
+
+- [ ] **Step 5: Update `getActivePanelsForLayout`**
+
+Replace the function signature and registry loop with:
+
+```ts
+export function getActivePanelsForLayout(
+  panelState: PanelFocusState,
+  mode: LayoutMode,
+  registry: readonly PanelDef[] = PANEL_REGISTRY,
+): ReadonlySet<Panel> {
+  if (mode === "tab") {
+    return new Set([panelState.focused]);
+  }
+
+  const active = new Set<Panel>();
+  for (const def of registry) {
+    if (isPanelVisible(panelState, def.panel)) {
+      active.add(def.panel);
+    }
+  }
+  return active;
+}
+```
+
+- [ ] **Step 6: Run the focused tests to verify they pass**
+
+Run:
+
+```bash
+bun test src/tui/panels/panel-registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tui/panels/panel-registry.ts src/tui/panels/panel-registry.test.ts
+git commit -m "feat(tui): allow injected panel registries"
+```
+
+## Task 6: Use Stable IDs In PanelManager Row Rendering
+
+**Files:**
+- Modify: `src/tui/panels/panel-manager.tsx`
+
+- [ ] **Step 1: Make render keys use string IDs**
+
+In `src/tui/panels/panel-manager.tsx`, locate the row rendering block near the end of the component and change the `PanelChrome` key from:
+
+```tsx
+<PanelChrome key={def.panel} panel={def.panel} focused={isFocused(def.panel)}>
+```
+
+to:
+
+```tsx
+<PanelChrome key={def.id} panel={def.panel} focused={isFocused(def.panel)}>
+```
+
+- [ ] **Step 2: Run targeted typecheck through the existing package command**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/panels/panel-manager.tsx
+git commit -m "refactor(tui): key panel rows by stable ids"
+```
+
+## Task 7: Full Verification
+
+**Files:**
+- Verify only; no file changes expected.
+
+- [ ] **Step 1: Run focused TUI registry tests**
+
+Run:
+
+```bash
+bun test src/tui/panels/panel-ids.test.ts src/tui/plugins/registry.test.ts src/tui/panels/panel-registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Biome check**
+
+Run:
+
+```bash
+bun run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Confirm verification did not modify files**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no output. If output appears, stop and inspect the changed files because
+verification for this task should not modify the working tree.
+
+## Self-Review
+
+- **Spec coverage:** This plan covers Track 1 from the approved design: stable string IDs, pure TUI registry types, duplicate ID diagnostics, preset filtering by string ID, built-in registry entry conversion, injectable registry query helpers, and render keys based on stable IDs.
+- **Out of scope by design:** Dynamic local plugin loading, plugin component rendering, layout config, scroll anchoring, agent identity UX, collaboration protocol models, recipes, memory, and distributions each belong to separate implementation plans after this foundation lands.
+- **Type consistency:** Built-in string IDs use `BuiltInPanelId`; public plugin IDs use `string` validated by `isSafeTuiPanelId`; existing focus/render code still uses numeric `Panel`; registry entries bridge both shapes through optional `builtInPanel`.

--- a/docs/superpowers/plans/2026-05-15-tui-registry-foundation.md
+++ b/docs/superpowers/plans/2026-05-15-tui-registry-foundation.md
@@ -10,6 +10,25 @@
 
 ---
 
+## Execution Notes
+
+This repo's `bunfig.toml` enables coverage thresholds globally. For targeted
+TDD commands in this plan, run the listed `bun test ...` file set with a
+temporary config that disables coverage:
+
+```bash
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test <test-files>
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
+```
+
+For `bun run typecheck`, `bun run check`, and full-suite commands, use the
+repository config as written.
+
 ## File Structure
 
 - Create `src/tui/panels/panel-ids.ts`: built-in panel string IDs and conversion helpers between `Panel` and string IDs.
@@ -96,7 +115,13 @@ describe("panel IDs", () => {
 Run:
 
 ```bash
-bun test src/tui/panels/panel-ids.test.ts
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test src/tui/panels/panel-ids.test.ts
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
 ```
 
 Expected: FAIL because `src/tui/panels/panel-ids.ts` does not exist.
@@ -179,7 +204,13 @@ export function idToPanel(id: string): Panel | undefined {
 Run:
 
 ```bash
-bun test src/tui/panels/panel-ids.test.ts
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test src/tui/panels/panel-ids.test.ts
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
 ```
 
 Expected: PASS.
@@ -301,7 +332,13 @@ describe("mergeTuiRegistrations", () => {
 Run:
 
 ```bash
-bun test src/tui/plugins/registry.test.ts
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test src/tui/plugins/registry.test.ts
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
 ```
 
 Expected: FAIL because `src/tui/plugins/types.ts` and `src/tui/plugins/registry.ts` do not exist.
@@ -458,7 +495,13 @@ function sourceRank(source: "builtin" | "plugin"): number {
 Run:
 
 ```bash
-bun test src/tui/plugins/registry.test.ts
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test src/tui/plugins/registry.test.ts
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
 ```
 
 Expected: PASS.
@@ -553,7 +596,13 @@ Update the import list in the same file to include:
 Run:
 
 ```bash
-bun test src/tui/panels/panel-registry.test.ts
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test src/tui/panels/panel-registry.test.ts
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
 ```
 
 Expected: FAIL because `PanelDef.id`, `getPanelDefById`, and `getBuiltInTuiRegistryEntries` do not exist.
@@ -635,7 +684,13 @@ export function getBuiltInTuiRegistryEntries(): readonly TuiRegistryEntry[] {
 Run:
 
 ```bash
-bun test src/tui/panels/panel-registry.test.ts
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test src/tui/panels/panel-registry.test.ts
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
 ```
 
 Expected: PASS.
@@ -701,7 +756,13 @@ Update the import list in the same file to include:
 Run:
 
 ```bash
-bun test src/tui/panels/panel-registry.test.ts
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test src/tui/panels/panel-registry.test.ts
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
 ```
 
 Expected: FAIL because `getPresetPanelIds` does not exist.
@@ -753,7 +814,13 @@ Keep `PRESET_PANELS` and `getPresetPanels()` unchanged for existing callers.
 Run:
 
 ```bash
-bun test src/tui/panels/panel-registry.test.ts
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test src/tui/panels/panel-registry.test.ts
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
 ```
 
 Expected: PASS.
@@ -807,7 +874,13 @@ describe("injectable registry helpers", () => {
 Run:
 
 ```bash
-bun test src/tui/panels/panel-registry.test.ts
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test src/tui/panels/panel-registry.test.ts
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
 ```
 
 Expected: FAIL because `getRowGroups`, `getVisiblePanelsForLayout`, and `getActivePanelsForLayout` do not accept injected registries yet.
@@ -884,7 +957,13 @@ export function getActivePanelsForLayout(
 Run:
 
 ```bash
-bun test src/tui/panels/panel-registry.test.ts
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test src/tui/panels/panel-registry.test.ts
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
 ```
 
 Expected: PASS.
@@ -942,7 +1021,13 @@ git commit -m "refactor(tui): key panel rows by stable ids"
 Run:
 
 ```bash
-bun test src/tui/panels/panel-ids.test.ts src/tui/plugins/registry.test.ts src/tui/panels/panel-registry.test.ts
+tmpdir=$(mktemp -d /tmp/grove-bunfig.XXXXXX)
+tmp="$tmpdir/bunfig.toml"
+printf '[test]\ncoverage = false\n' > "$tmp"
+PATH="$HOME/.bun/bin:$PATH" bun --config="$tmp" test src/tui/panels/panel-ids.test.ts src/tui/plugins/registry.test.ts src/tui/panels/panel-registry.test.ts
+rc=$?
+rm -rf "$tmpdir"
+exit $rc
 ```
 
 Expected: PASS.

--- a/docs/superpowers/specs/2026-05-15-opencode-goose-full-scope-design.md
+++ b/docs/superpowers/specs/2026-05-15-opencode-goose-full-scope-design.md
@@ -1,0 +1,549 @@
+# OpenCode And Goose Full-Scope DX Adoption - Design
+
+- **Date:** 2026-05-15
+- **Issue:** [#225](https://github.com/windoliver/grove/issues/225)
+- **Builds on:** [#212](https://github.com/windoliver/grove/issues/212), [#216](https://github.com/windoliver/grove/issues/216), [#272](https://github.com/windoliver/grove/issues/272), [#328](https://github.com/windoliver/grove/issues/328)
+- **Status:** Approved design; awaiting user review before implementation plan
+
+## Summary
+
+Grove should adopt the useful architectural lessons from OpenCode's OpenTUI
+implementation and Goose's agent organization model as one coherent program,
+not as unrelated UI tweaks. This design covers the full target architecture:
+extensible TUI panels, configurable layouts, anchored scrolling, stable
+agent-colored collaboration surfaces, an ACP-like Grove collaboration protocol,
+recipe-style reusable work templates, two-tier memory, and packaged
+distributions.
+
+The work should not ship as one monolithic change. It should be implemented in
+dependency order through seven PR-sized tracks. The early tracks make the TUI
+registry and layout system extensible; the later tracks make the collaboration
+and reusable-work concepts first-class while preserving Grove's contribution
+DAG as the source of truth.
+
+## Goals
+
+- Allow Grove presets, local tools, and future integrations to contribute TUI
+  panels and footer/dashboard content through typed slots.
+- Make operator layouts configurable through the existing layered Grove config
+  path, including built-in `default`, `dense`, and `wide` modes.
+- Keep scrollable views stable when content streams in and the user is pinned
+  above the bottom.
+- Make role and agent identity visually stable across all TUI collaboration
+  surfaces.
+- Formalize Grove's agent discovery, capability, delegation, and handoff
+  semantics around existing gossip, claims, inbox, and handoff primitives.
+- Add recipe, memory, and distribution concepts without creating a parallel
+  storage model outside the contribution graph.
+- Keep each implementation track independently testable and reviewable.
+
+## Non-Goals
+
+- A remote plugin marketplace.
+- Sandboxed execution for untrusted plugin code in the first implementation.
+- Replacing the direct ACP provider runtime. Grove's collaboration protocol is
+  above provider ACP and should not undo the direct ACP runtime work.
+- Replacing `Contribution`, `Claim`, `Handoff`, inbox messages, or gossip peer
+  state with new stores.
+- Solving full provider-native hot reload for skills or plugins.
+- Building a visual plugin authoring UI.
+
+## Current State
+
+The repository already contains several pieces this design should reuse:
+
+- `src/tui/panels/panel-registry.ts` defines data-driven built-in panel
+  metadata, preset filtering, row groups, keybindings, zoom behavior, and grid
+  versus tab layout modes.
+- `src/tui/panels/panel-manager.tsx` renders built-in panels and adapts to
+  small and medium terminal sizes.
+- `src/tui/config-loader.ts` already loads layered config from global, project,
+  and env override files and merges theme/keymap configuration.
+- `src/tui/theme.ts` already centralizes theme tokens, `AGENT_COLORS`, platform
+  colors, contribution kind icons, and `agentStatusIcon`.
+- `src/tui/components/command-palette.tsx` already has fuzzy matching and
+  command palette item composition.
+- `src/tui/views/terminal.tsx` already models `scrollOffset` as offset from
+  bottom, but anchoring is local and not shared with other scrollable panes.
+- `src/core/handoff.ts`, `src/core/operations/messaging.ts`, and gossip peer
+  capacity already provide much of the collaboration substrate.
+- `src/core/acp-runtime.ts` and related direct ACP work already handle provider
+  ACP. Grove should build coordination semantics on top of that instead of
+  replacing it.
+
+The missing piece is a stable public layer over these internals: string panel
+IDs, slot registration, layout config, shared viewport anchoring, deterministic
+agent display identity, collaboration protocol envelopes, and typed reusable
+work object contexts.
+
+## Chosen Approach
+
+Use a foundation-first full-scope approach.
+
+The full architecture is designed now, but implementation proceeds in order:
+
+1. TUI registry foundation.
+2. Local plugin loading and example panels.
+3. Layout config and built-in layout modes.
+4. Shared scroll anchoring.
+5. Agent identity UX.
+6. Grove collaboration protocol layer.
+7. Recipes, memory, and distributions.
+
+This sequence gives later tracks stable APIs to build on. The TUI plugin and
+layout tracks establish public IDs and extension boundaries. The agent UX track
+then applies stable identity consistently. The protocol and reusable-work tracks
+use existing persistence primitives after the UI has a place to expose them.
+
+## Architecture
+
+### TUI Extensibility Foundation
+
+Add `src/tui/plugins/` as the public extension boundary for TUI features. Core
+panels remain built in, but they should be represented through the same
+registry shape that plugin panels use. This lets `PanelManager` render a merged
+registry of built-in and plugin entries while keeping built-in panels typed and
+tree-shaken normally.
+
+Slots:
+
+- `operator-panel`: full panels that participate in focus, visibility,
+  keybinding, and layout.
+- `dashboard`: compact dashboard widgets rendered near existing dashboard
+  content.
+- `detail-adjacent`: context panels related to the selected contribution,
+  artifact, or session.
+- `footer`: compact status/footer content such as subagent state.
+- `command-palette`: palette actions contributed by integrations or
+  distributions.
+
+Plugins receive a constrained `TuiPluginContext`, not raw access to the whole
+application. The context includes the data provider, topology, selected
+session, selected contribution, current theme, layout density, and limited
+actions such as selecting a session or opening detail.
+
+The first implementation is trusted local code loaded by Bun from configured
+paths. A failing plugin should log a diagnostic and be skipped; it must not
+prevent the TUI from starting.
+
+### Operator Layout And Scroll Ergonomics
+
+Extend `GroveUserConfig` with a `layout` section. Config still loads from:
+
+1. `~/.config/grove/config.json`
+2. `.grove/config.json`
+3. `GROVE_CONFIG`
+
+Layout config uses string IDs so built-in and plugin panels share the same
+path. Built-in panels should get stable IDs such as `dag`, `detail`,
+`frontier`, `claims`, `agents`, `terminal`, `artifact`, `vfs`, `activity`,
+`search`, `threads`, `outcomes`, `bounties`, `gossip`, `inbox`, `decisions`,
+`github`, and `plan`.
+
+The layout system should provide three built-ins:
+
+- `default`: current behavior.
+- `dense`: fewer margins, compact rows, hide low-signal operator panels unless
+  explicitly visible.
+- `wide`: keep protocol panels and operator panels side by side when terminal
+  width allows.
+
+Scroll anchoring becomes a pure helper used by terminal, trace, session,
+artifact, and search-like views. The model stays offset-from-bottom for simple
+auto-scroll but records an anchor line key while pinned so layout recalculation
+does not jump the user's viewport.
+
+### Agent Identity And Live Collaboration UX
+
+Add deterministic display identity helpers around existing `AgentIdentity`.
+Colors should be assigned by stable input, preferably `role + agentId`, not by
+registration order. This keeps colors stable across refreshes, reconnects, and
+different panels.
+
+All collaboration surfaces should use the same helpers:
+
+- DAG and contribution rows.
+- Detail and dashboard contribution metadata.
+- Agent graph/list.
+- Inbox and handoff views.
+- Terminal/session headers.
+- Footer slot content.
+
+The footer slot should include a compact subagent status strip with role,
+agent display name, status icon, last activity, and handoff/blocked indicators.
+This gives multi-agent sessions an always-visible status surface without
+requiring the operator to keep the agents panel open.
+
+### Grove Collaboration Protocol
+
+Formalize an internal Grove collaboration protocol above the existing stores.
+It is ACP-like in purpose, but Grove-specific in persistence and routing.
+
+Core concepts:
+
+- Discovery: which agents, roles, peers, and capacities are visible.
+- Capabilities: named abilities an agent or peer can satisfy.
+- Delegation: a structured request to a role, agent, or peer.
+- Handoff: receipt, acknowledgement, processing, reply, expiry, and
+  dead-letter states.
+- Session binding: which request, claim, contribution, and handoff belong
+  together.
+
+This protocol should map onto existing primitives:
+
+- `Claim` continues to represent lease-based coordination.
+- `Handoff` continues to represent role-to-role work transfer and reply
+  lifecycle.
+- Discussion contributions with message context continue to power inbox
+  messages.
+- Gossip peer state continues to power peer discovery and remote capacity.
+- Contributions remain the durable result of delegated work.
+
+The protocol layer should first ship as typed models and helpers, then later
+gain CLI/API commands. The TUI can render protocol state as soon as the helpers
+exist.
+
+### Reusable Work Objects
+
+Recipes, memory, and distributions should be first-class but graph-compatible.
+
+Recipes are reusable task templates. Store them as `ContributionKind.Plan`
+with tag `recipe` and context type `grove.recipe.v1`. A recipe contains a
+parameter schema, default values, optional schedule hints, required
+capabilities, suggested topology role, and prompt/body template. Running a
+recipe creates normal claims, messages, or plan/work contributions according to
+the recipe definition.
+
+Memory is persistent knowledge. Store project memory as normal discussion
+contributions with tag `memory` and context type `grove.memory.v1`. User-global
+memory can live in a user Grove directory and be imported into a session view
+as read-only or copied into the project as a contribution. Memory entries
+should include scope, tags, summary, body, provenance, and updated/replaces
+relations when revised.
+
+Distributions package presets, topology, layout, plugins, recipes, memory seed
+entries, and docs into a shareable bundle. Importing a distribution writes or
+references normal Grove config and contributions. The first distribution format
+should be local-file based; publishing and remote trust policy can come later.
+
+## Public Types
+
+### TUI Plugins
+
+```ts
+export type TuiSlot =
+  | "operator-panel"
+  | "dashboard"
+  | "detail-adjacent"
+  | "footer"
+  | "command-palette";
+
+export interface TuiPluginManifest {
+  readonly id: string;
+  readonly name: string;
+  readonly version: string;
+  readonly slots: readonly TuiSlot[];
+}
+
+export interface TuiPanelRegistration {
+  readonly id: string;
+  readonly label: string;
+  readonly slot: TuiSlot;
+  readonly defaultVisible?: boolean | undefined;
+  readonly order?: number | undefined;
+  readonly component: React.ComponentType<TuiPluginContext>;
+}
+
+export interface TuiPluginContext {
+  readonly provider: import("../provider.js").TuiDataProvider;
+  readonly topology?: import("../../core/topology.js").AgentTopology | undefined;
+  readonly selectedSession?: string | undefined;
+  readonly selectedCid?: string | undefined;
+  readonly density: "comfortable" | "compact";
+}
+```
+
+### Layout Config
+
+```ts
+export interface TuiLayoutConfig {
+  readonly preset?: "default" | "dense" | "wide" | undefined;
+  readonly mode?: "grid" | "tab" | undefined;
+  readonly visiblePanels?: readonly string[] | undefined;
+  readonly rowWeights?: Readonly<Record<string, number>> | undefined;
+  readonly panelOrder?: readonly string[] | undefined;
+  readonly density?: "comfortable" | "compact" | undefined;
+}
+```
+
+### Anchored Viewports
+
+```ts
+export interface AnchoredViewportState {
+  readonly offsetFromBottom: number;
+  readonly anchorLineKey?: string | undefined;
+  readonly anchorLineOffset?: number | undefined;
+}
+
+export interface ViewportLine {
+  readonly key: string;
+}
+```
+
+### Agent Display Identity
+
+```ts
+export interface AgentDisplayIdentity {
+  readonly agentId: string;
+  readonly role?: string | undefined;
+  readonly platform?: string | undefined;
+  readonly displayName: string;
+  readonly color: string;
+}
+```
+
+### Collaboration Protocol
+
+```ts
+export interface AgentCapability {
+  readonly name: string;
+  readonly version?: string | undefined;
+  readonly inputSchema?: import("./models.js").JsonValue | undefined;
+}
+
+export interface DelegationEnvelope {
+  readonly requestId: string;
+  readonly fromAgentId: string;
+  readonly toAgentId?: string | undefined;
+  readonly toRole?: string | undefined;
+  readonly peerId?: string | undefined;
+  readonly requiredCapabilities: readonly string[];
+  readonly sourceCid?: string | undefined;
+  readonly claimId?: string | undefined;
+  readonly replyRequired: boolean;
+  readonly createdAt: string;
+}
+```
+
+### Reusable Work Contexts
+
+```ts
+export interface RecipeContextV1 {
+  readonly type: "grove.recipe.v1";
+  readonly parameters: import("./models.js").JsonValue;
+  readonly defaults?: import("./models.js").JsonValue | undefined;
+  readonly requiredCapabilities?: readonly string[] | undefined;
+  readonly suggestedRole?: string | undefined;
+  readonly template: string;
+}
+
+export interface MemoryContextV1 {
+  readonly type: "grove.memory.v1";
+  readonly scope: "project" | "global";
+  readonly tags: readonly string[];
+  readonly body: string;
+  readonly provenance?: import("./models.js").JsonValue | undefined;
+}
+
+export interface GroveDistributionManifest {
+  readonly id: string;
+  readonly name: string;
+  readonly version: string;
+  readonly presets?: readonly string[] | undefined;
+  readonly layout?: TuiLayoutConfig | undefined;
+  readonly plugins?: readonly string[] | undefined;
+  readonly recipes?: readonly string[] | undefined;
+  readonly docs?: readonly string[] | undefined;
+}
+```
+
+## Data Flow
+
+### TUI Startup
+
+1. Load Grove config with the existing config loader.
+2. Validate `layout` and `plugins` config fields.
+3. Build the built-in panel registry.
+4. Load trusted local plugin modules from configured paths and distribution
+   manifests.
+5. Merge built-in and plugin panel registrations by slot.
+6. Apply layout preset, panel order, visible panel list, row weights, and
+   terminal-size fallbacks.
+7. Render `PanelManager` against the merged registry.
+
+### Delegation
+
+1. A local agent or operator creates a delegation envelope.
+2. The protocol layer resolves target role, agent, or peer using topology,
+   live agent state, capabilities, and gossip capacity.
+3. The write path creates or updates the relevant claim/handoff/message
+   records through existing stores.
+4. Target agents receive handoff/inbox notifications through existing delivery
+   paths.
+5. Replies resolve the handoff by contribution CID and update protocol views.
+
+### Recipe Execution
+
+1. A recipe is discovered by tag/context or distribution manifest.
+2. User or agent supplies parameters.
+3. Grove validates parameters against the recipe schema.
+4. Grove materializes a plan, claim, message, or prompt using the template.
+5. Normal contribution and handoff flows handle the execution result.
+
+### Memory Retrieval
+
+1. A user or agent queries memory by scope, tags, text, or provenance.
+2. Project memory comes from current project/session contributions.
+3. Global memory comes from user-level Grove storage or imported seed entries.
+4. Returned entries include provenance and CIDs so agents can cite durable
+   graph state when possible.
+
+## Implementation Tracks
+
+### Track 1: TUI Registry Foundation
+
+- Introduce stable string IDs for built-in panels at the registry/config
+  boundary.
+- Add `TuiPluginRegistry` and slot descriptor types.
+- Adapt built-in panels into the merged registry path.
+- Keep the numeric `Panel` constants internally where useful during migration.
+- Test ordering, duplicate IDs, preset filtering, focus behavior, and visibility.
+
+### Track 2: Local Plugin Loading And Example Panels
+
+- Add trusted local plugin loading from config.
+- Add distribution-provided plugin references.
+- Add failure isolation and diagnostics for failed plugin imports.
+- Add a minimal `research-loop/eval-results` example operator panel.
+- Test missing plugin, bad plugin, duplicate plugin ID, and working example
+  render.
+
+### Track 3: Layout Config And Dense/Wide Modes
+
+- Extend `GroveUserConfig` and its Zod schema with `layout`.
+- Add built-in layout presets.
+- Apply layout config in `PanelManager` and registry query helpers.
+- Support `visiblePanels`, `panelOrder`, `rowWeights`, `density`, and `mode`.
+- Test layered config merge and layout application.
+
+### Track 4: Scroll Anchoring And Viewport Helpers
+
+- Add pure viewport anchoring helpers under `src/tui/data/` or
+  `src/tui/hooks/`.
+- Migrate terminal view first.
+- Migrate trace/session-like panes, artifact preview, and search result panes
+  where the data shape can provide stable line keys.
+- Test auto-scroll, pinned scroll, new content while pinned, truncation, and
+  terminal resize.
+
+### Track 5: Agent Identity UX
+
+- Add deterministic agent display identity helpers.
+- Replace one-off role/platform color use with shared helpers.
+- Apply colors to contribution rows, DAG/detail metadata, agent views,
+  inbox/handoff views, terminal/session headers, and footer slot.
+- Add subagent footer registration as a built-in footer slot entry.
+- Test deterministic colors and representative rendered output.
+
+### Track 6: Collaboration Protocol Layer
+
+- Add protocol models for capabilities, discovery, delegation, and session
+  binding.
+- Add helpers that map envelopes to claims, handoffs, inbox messages, and
+  gossip peers.
+- Expose protocol state to TUI panels.
+- Add server/CLI routes only after the internal helper API is stable.
+- Test mapping behavior, invalid targets, capability mismatch, reply-required
+  lifecycle, peer delegation, and dead-letter visibility.
+
+### Track 7: Recipes, Memory, And Distributions
+
+- Add typed context schemas for `grove.recipe.v1` and `grove.memory.v1`.
+- Add operations for creating, listing, validating, and running recipes.
+- Add operations for writing and retrieving project/global memory.
+- Add local distribution manifest parsing and import.
+- Add TUI/CLI discovery once storage behavior is stable.
+- Test context validation, graph compatibility, import idempotency, and
+  execution through normal Grove write paths.
+
+## Testing Strategy
+
+- Use `bun test`.
+- Keep pure helpers heavily unit-tested: registry merging, layout resolution,
+  viewport anchoring, color hashing, protocol envelope validation, context
+  schemas.
+- Use `react-test-renderer` for TUI component tests, matching existing TUI
+  tests.
+- Add integration tests only where a track crosses storage or config
+  boundaries: plugin loading, config layering, recipe import, memory retrieval,
+  and delegation mapping.
+- Add targeted regression tests for small terminal behavior and plugin failure
+  isolation.
+- Run `bun run typecheck` and `bun run check` before each PR.
+
+## Migration And Compatibility
+
+- Existing config without `layout` or `plugins` keeps current behavior.
+- Existing numeric `Panel` internals can remain until all built-in panel logic
+  has moved to string IDs.
+- Existing contribution kinds remain unchanged. Recipes and memory use tags and
+  typed contexts instead of new enum variants.
+- Existing handoff, inbox, claim, and gossip stores remain the durable backing
+  model for the collaboration protocol layer.
+- Plugins are opt-in. A plugin load failure should not make existing Grove
+  sessions unusable.
+
+## Security And Trust
+
+The first plugin system is trusted local code. Loading plugins from arbitrary
+paths is equivalent to running local code in the TUI process. The loader should
+make that trust boundary explicit in config docs and diagnostics.
+
+Remote plugin marketplaces, signature verification, permission prompts, and
+sandboxing are deferred. Distribution import should start local-only and reuse
+existing safe path validation patterns where it writes files or references
+plugin paths.
+
+Collaboration protocol envelopes should not trust model-supplied agent
+identity. Trusted identity comes from Grove session/runtime context, existing
+claim ownership, handoff source, or server-side auth context.
+
+## Risks
+
+- Dynamic plugin loading can destabilize TUI startup if failure isolation is
+  weak.
+- Converting panel IDs risks focus/keybinding regressions if numeric and string
+  IDs are mixed carelessly.
+- Layout customization can make panels unreadable if constraints are too loose.
+- Scroll anchoring needs stable line keys; some existing views may need small
+  data-shape changes before they can migrate safely.
+- The collaboration protocol can become a second source of truth if it stores
+  state outside claims, handoffs, inbox messages, gossip, and contributions.
+- Recipes and distributions can grow into a package manager if scope is not
+  kept local and graph-compatible at first.
+
+## Acceptance Criteria
+
+- A local plugin can register an operator panel and command palette item through
+  config without modifying `PanelManager`.
+- Built-in and plugin panels use stable string IDs for layout config.
+- `default`, `dense`, and `wide` layout presets work through layered config.
+- Pinned terminal output remains anchored when new output arrives.
+- Agent colors are deterministic across TUI refreshes and are shared by DAG,
+  agent, inbox/handoff, and terminal/session surfaces.
+- The subagent footer shows compact live multi-agent status without requiring
+  the agents panel to be visible.
+- Delegation envelopes can be mapped to existing claim/handoff/inbox/gossip
+  state and rendered in the TUI.
+- Recipes and memory are stored as normal contributions with typed contexts.
+- A local distribution can import or reference layout, plugins, recipes, and
+  docs without creating a parallel store.
+
+## Follow-Up Plans
+
+This design should produce separate implementation plans for each track. Track
+1 is the first implementation plan because every later TUI-facing feature
+depends on stable string IDs and a merged registry. Track 6 and Track 7 should
+not begin until the UI extension and layout paths are stable enough to expose
+their state.
+

--- a/src/core/acp-runtime.spawn.test.ts
+++ b/src/core/acp-runtime.spawn.test.ts
@@ -202,6 +202,59 @@ describe("AcpRuntime.send", () => {
     await rt.close(session);
   });
 
+  test("marks the session idle after a prompt result", async () => {
+    const promptStarted = deferred();
+    const finishPrompt = deferred<{ stopReason: "end_turn" }>();
+    const { launchOverride } = makeInProcessAgent({
+      async onPrompt() {
+        promptStarted.resolve();
+        return await finishPrompt.promise;
+      },
+    });
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: process.cwd(),
+    });
+
+    const turn = await rt.send(session, "slow task");
+    await promptStarted.promise;
+
+    expect((await rt.listSessions())[0]?.status).toBe("running");
+
+    finishPrompt.resolve({ stopReason: "end_turn" });
+    await turn.result;
+
+    expect((await rt.listSessions())[0]?.status).toBe("idle");
+    await rt.close(session);
+  });
+
+  test("marks the session crashed after a prompt error", async () => {
+    const { launchOverride } = makeInProcessAgent({
+      async onPrompt() {
+        throw new RequestError(-32603, "Internal error", {
+          message: "adapter connection closed",
+        });
+      },
+    });
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: process.cwd(),
+    });
+
+    const turn = await rt.send(session, "hello");
+    const result = await turn.result;
+    const current = (await rt.listSessions())[0];
+
+    expect(result.stopReason).toBe("error");
+    expect(current?.status).toBe("crashed");
+    expect(current?.statusMessage).toBe("adapter connection closed");
+    await rt.close(session);
+  });
+
   test("agent sessionUpdate notifications stream into the turn's messages", async () => {
     const { launchOverride } = makeInProcessAgent({
       async onPrompt({ sessionId, agentSide }) {

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -151,6 +151,15 @@ async function waitForChildExit(
   });
 }
 
+function withSessionStatus(
+  session: AgentSession,
+  status: AgentSession["status"],
+  statusMessage?: string,
+): AgentSession {
+  const { statusMessage: _oldStatusMessage, ...rest } = session;
+  return statusMessage === undefined ? { ...rest, status } : { ...rest, status, statusMessage };
+}
+
 /**
  * Top-level scalar keys we copy from the user's `~/.codex/config.toml` into the
  * isolated CODEX_HOME. Restrict to safe, well-known keys: model preferences
@@ -814,6 +823,13 @@ export class AcpRuntime implements AgentRuntime {
       resolveResult = r;
     });
     const finishTurn = (result: Result): void => {
+      const statusMessage = result.stopReason === "error" ? result.error?.message : undefined;
+      entry.session = withSessionStatus(
+        entry.session,
+        result.stopReason === "error" ? "crashed" : "idle",
+        statusMessage,
+      );
+      this.fireSessionWrite("MODIFIED", entry.session);
       resolveResult(result);
       this.emitAcpEvent({
         kind: "result",
@@ -853,6 +869,8 @@ export class AcpRuntime implements AgentRuntime {
         });
         return;
       }
+      entry.session = withSessionStatus(entry.session, "running");
+      this.fireSessionWrite("MODIFIED", entry.session);
       entry.currentTurn = turn;
       try {
         const ok = await entry.connection.prompt({

--- a/src/core/resolve-mcp-serve-path.test.ts
+++ b/src/core/resolve-mcp-serve-path.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { isAbsolute } from "node:path";
+import { resolveBundledSkillsRoot, resolveMcpServePath } from "./resolve-mcp-serve-path.js";
+
+const originalArgv1 = process.argv[1];
+
+afterEach(() => {
+  if (originalArgv1 === undefined) {
+    process.argv.splice(1, 1);
+  } else {
+    process.argv[1] = originalArgv1;
+  }
+});
+
+describe("resolveMcpServePath", () => {
+  test("returns an absolute path when the launcher argv is relative", () => {
+    process.argv[1] = "src/cli/main.ts";
+
+    expect(isAbsolute(resolveMcpServePath(process.cwd()))).toBe(true);
+  });
+
+  test("returns an absolute path when the launcher argv is absent", () => {
+    process.argv.splice(1, 1);
+
+    expect(isAbsolute(resolveMcpServePath(process.cwd()))).toBe(true);
+  });
+});
+
+describe("resolveBundledSkillsRoot", () => {
+  test("returns an absolute path when the launcher argv is relative", () => {
+    process.argv[1] = "src/cli/main.ts";
+
+    expect(isAbsolute(resolveBundledSkillsRoot(process.cwd()))).toBe(true);
+  });
+
+  test("returns an absolute path when the launcher argv is absent", () => {
+    process.argv.splice(1, 1);
+
+    expect(isAbsolute(resolveBundledSkillsRoot(process.cwd()))).toBe(true);
+  });
+});

--- a/src/core/resolve-mcp-serve-path.ts
+++ b/src/core/resolve-mcp-serve-path.ts
@@ -16,7 +16,8 @@
  */
 
 import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve as pathResolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * Resolve the MCP serve entry point from the grove installation.
@@ -24,25 +25,26 @@ import { dirname, join } from "node:path";
  * @param projectRoot — fallback if no installation path can be derived
  */
 export function resolveMcpServePath(projectRoot?: string): string {
-  const entryPoint = process.argv[1] ?? "";
-  // process.argv[1] = "<groveRoot>/dist/cli/main.js" or "<groveRoot>/src/cli/main.ts"
-  // Climb 3 levels: main.js → cli/ → dist/ or src/ → <groveRoot>
-  const groveRootFromEntry = dirname(dirname(dirname(entryPoint)));
+  const groveRoots: string[] = [];
+  if (process.argv[1]) {
+    const entryPoint = pathResolve(process.argv[1]);
+    // process.argv[1] = "<groveRoot>/dist/cli/main.js" or "<groveRoot>/src/cli/main.ts"
+    // Climb 3 levels: main.js -> cli/ -> dist/ or src/ -> <groveRoot>
+    groveRoots.push(dirname(dirname(dirname(entryPoint))));
+  }
 
-  // import.meta.url fallback — may point to a bundled chunk, but worth trying
-  const groveRootFromMeta = dirname(dirname(dirname(new URL(import.meta.url).pathname)));
+  // import.meta.url fallback may point to a bundled chunk, but worth trying.
+  groveRoots.push(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
 
   // Try dist first (built install), then src (development)
-  const candidates = [
-    join(groveRootFromEntry, "dist", "mcp", "serve.js"),
-    join(groveRootFromEntry, "src", "mcp", "serve.ts"),
-    join(groveRootFromMeta, "dist", "mcp", "serve.js"),
-    join(groveRootFromMeta, "src", "mcp", "serve.ts"),
-  ];
+  const candidates = groveRoots.flatMap((groveRoot) => [
+    join(groveRoot, "dist", "mcp", "serve.js"),
+    join(groveRoot, "src", "mcp", "serve.ts"),
+  ]);
 
   // Last resort: project root (only works when project IS the grove repo)
   if (projectRoot) {
-    candidates.push(join(projectRoot, "src", "mcp", "serve.ts"));
+    candidates.push(join(pathResolve(projectRoot), "src", "mcp", "serve.ts"));
   }
 
   for (const candidate of candidates) {
@@ -65,13 +67,16 @@ export function resolveMcpServePath(projectRoot?: string): string {
  * @param projectRoot — fallback if no installation path can be derived
  */
 export function resolveBundledSkillsRoot(projectRoot?: string): string {
-  const entryPoint = process.argv[1] ?? "";
-  // process.argv[1] = "<groveRoot>/dist/cli/main.js" or "<groveRoot>/src/cli/main.ts"
-  const groveRootFromEntry = dirname(dirname(dirname(entryPoint)));
-  const groveRootFromMeta = dirname(dirname(dirname(new URL(import.meta.url).pathname)));
+  const groveRoots: string[] = [];
+  if (process.argv[1]) {
+    const entryPoint = pathResolve(process.argv[1]);
+    // process.argv[1] = "<groveRoot>/dist/cli/main.js" or "<groveRoot>/src/cli/main.ts"
+    groveRoots.push(dirname(dirname(dirname(entryPoint))));
+  }
+  groveRoots.push(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
 
-  const candidates = [join(groveRootFromEntry, "skills"), join(groveRootFromMeta, "skills")];
-  if (projectRoot) candidates.push(join(projectRoot, "skills"));
+  const candidates = groveRoots.map((groveRoot) => join(groveRoot, "skills"));
+  if (projectRoot) candidates.push(join(pathResolve(projectRoot), "skills"));
 
   for (const c of candidates) {
     if (existsSync(c)) return c;

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -5,6 +5,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hash } from "blake3";
+import { SqliteGoalSessionStore } from "../local/sqlite-goal-session-store.js";
+import { initSqliteDb } from "../local/sqlite-store.js";
 import { MockNexusClient } from "../nexus/mock-client.js";
 import { writeSkillCatalogToNexusForTest } from "../nexus/nexus-skill-catalog.js";
 import { createStoredZip } from "../shared/zip.js";
@@ -233,6 +235,38 @@ function makeOrchestrator(
   return { orchestrator, runtime, bus };
 }
 
+class FailingSpawnRuntime extends MockRuntime {
+  private readonly failingRoles: ReadonlySet<string>;
+
+  constructor(failingRoles: ReadonlySet<string>) {
+    super();
+    this.failingRoles = failingRoles;
+  }
+
+  override async spawn(
+    role: string,
+    config: Parameters<MockRuntime["spawn"]>[1],
+  ): ReturnType<MockRuntime["spawn"]> {
+    if (this.failingRoles.has(role)) {
+      throw new Error(`boom from ${role}`);
+    }
+    return await super.spawn(role, config);
+  }
+}
+
+class CloseStatusRuntime extends MockRuntime {
+  readonly sendsInitialPromptOnSpawn = true;
+  readonly statusesAtClose: Array<string | undefined> = [];
+
+  override async close(
+    session: Parameters<MockRuntime["close"]>[0],
+  ): ReturnType<MockRuntime["close"]> {
+    const current = (await this.listSessions()).find((candidate) => candidate.id === session.id);
+    this.statusesAtClose.push(current?.status);
+    return await super.close(session);
+  }
+}
+
 function signContributionForRouting(
   contribution: ReturnType<typeof makeContribution>,
   routingToken: string,
@@ -304,11 +338,83 @@ describe("SessionOrchestrator", () => {
     const coderConfig = runtime.spawnCalls.find((call) => call.role === "coder")?.config;
     expect(coderConfig?.mcpServers).toHaveLength(1);
     expect(coderConfig?.mcpServers?.[0]?.name).toBe("grove");
-    expect(coderConfig?.mcpServers?.[0]?.command).toBe("bun");
+    expect(coderConfig?.mcpServers?.[0]?.command).toBe(process.execPath);
     expect(coderConfig?.mcpServers?.[0]?.args?.join(" ")).toContain("mcp/serve");
     expect(coderConfig?.mcpServers?.[0]?.env?.GROVE_DIR).toBe("/tmp/.grove");
     expect(coderConfig?.mcpServers?.[0]?.env?.GROVE_AGENT_ROLE).toBe("coder");
     expect(coderConfig?.mcpServers?.[0]?.env?.GROVE_SESSION_ID).toBe("session-mcp-forward");
+    bus.close();
+  });
+
+  test("start registers the local session before spawning MCP-backed agents", async () => {
+    const contract = makeContract();
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    const projectRoot = mkdtempSync(join(tmpdir(), "grove-so-session-root-"));
+    mkdirSync(join(projectRoot, ".grove"), { recursive: true });
+    const sessionId = "session-local-registration";
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract,
+      topology: contract.topology!,
+      runtime,
+      eventBus: bus,
+      projectRoot,
+      repos: [{ kind: "local", path: projectRoot }],
+      workspaceBaseDir: join(projectRoot, ".grove", "workspaces"),
+      workspaceIsolationPolicy: "allow-fallback",
+      sessionId,
+    });
+
+    try {
+      await orchestrator.start();
+
+      const db = initSqliteDb(join(projectRoot, ".grove", "grove.db"));
+      try {
+        const store = new SqliteGoalSessionStore(db);
+        const session = await store.getSession(sessionId);
+        expect(session?.id).toBe(sessionId);
+        expect(session?.goal).toBe("Build auth module");
+        expect(session?.topology?.roles.map((role) => role.name)).toEqual(["coder", "reviewer"]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      bus.close();
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("start aborts and closes spawned agents when any required role fails to spawn", async () => {
+    const runtime = new FailingSpawnRuntime(new Set(["reviewer"]));
+    const contract = makeContract();
+    const { orchestrator, bus } = makeOrchestrator(contract, { runtime });
+
+    await expect(orchestrator.start()).rejects.toThrow(
+      "Failed to spawn required role(s): reviewer",
+    );
+
+    expect(runtime.spawnCalls.map((call) => call.role)).toEqual(["coder"]);
+    expect(runtime.closeCalls).toHaveLength(1);
+    bus.close();
+  });
+
+  test("crashed agents stop the session as an error instead of waiting for timeout", async () => {
+    const runtime = new MockRuntime();
+    Object.assign(runtime, { sendsInitialPromptOnSpawn: true });
+    const contract = makeContract();
+    const { orchestrator, bus } = makeOrchestrator(contract, { runtime });
+
+    const status = await orchestrator.start();
+    const coder = status.agents.find((agent) => agent.role === "coder");
+    expect(coder).toBeDefined();
+
+    runtime.setSessionStatus(coder?.session.id ?? "", "crashed");
+    const stopped = await orchestrator.checkIdleCompletion();
+
+    expect(stopped).toBe(true);
+    expect(orchestrator.getStatus().stopStatus).toBe(LoopStopStatus.Error);
+    expect(orchestrator.getStatus().stopReason).toContain("coder");
     bus.close();
   });
 
@@ -361,6 +467,24 @@ describe("SessionOrchestrator", () => {
     expect(status.stopped).toBe(true);
     expect(status.stopStatus).toBe(LoopStopStatus.Interrupted);
     expect(runtime.closeCalls).toHaveLength(2);
+    bus.close();
+  });
+
+  test("achieved stop waits for ACP-style turns to settle before closing", async () => {
+    const runtime = new CloseStatusRuntime();
+    const contract = makeContract();
+    const { orchestrator, bus } = makeOrchestrator(contract, { runtime });
+
+    const started = await orchestrator.start();
+    setTimeout(() => {
+      for (const agent of started.agents) {
+        runtime.setSessionStatus(agent.session.id, "idle");
+      }
+    }, 20);
+
+    await orchestrator.stop("done", LoopStopStatus.Achieved);
+
+    expect(runtime.statusesAtClose).toEqual(["idle", "idle"]);
     bus.close();
   });
 

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -21,6 +21,7 @@ import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js
 import { type GroveConfig, parseGroveConfig } from "./config.js";
 import type { GroveContract } from "./contract.js";
 import type { EventBus, GroveEvent } from "./event-bus.js";
+import { DEFAULT_SESSION_FINALIZERS } from "./lifecycle-metadata.js";
 import { LoopStopStatus, type LoopStopStatus as LoopStopStatusValue } from "./loop-runner.js";
 import { type ResolvedRepo, type ResolveRepoOptions, resolveRepo } from "./repo-cache.js";
 import type { RepoRef } from "./repo-ref.js";
@@ -294,6 +295,8 @@ export class SessionOrchestrator {
     const topology = this.config.topology;
     const policy = this.config.workspaceIsolationPolicy ?? "strict";
 
+    await this.ensureLocalSessionRecord();
+
     // Resolve workspace strategies from edge types — delegates/feeds/escalates edges
     // make the target role's worktree branch off the source role's branch.
     const wsStrategies = resolveRoleWorkspaceStrategies(topology, this.sessionId);
@@ -323,9 +326,9 @@ export class SessionOrchestrator {
         const ac = new AbortController();
         const timeoutId = setTimeout(() => ac.abort(), SPAWN_TIMEOUT_MS);
         try {
-          const result = await this.spawnAgent(role, ac.signal, ws);
+          const agent = await this.spawnAgent(role, ac.signal, ws);
           clearTimeout(timeoutId);
-          return result;
+          return { role: role.name, agent };
         } catch (err) {
           clearTimeout(timeoutId);
           if (ac.signal.aborted) {
@@ -336,18 +339,36 @@ export class SessionOrchestrator {
       }),
     );
 
-    for (const result of spawnResults) {
+    const spawnedAgents: AgentSessionInfo[] = [];
+    const spawnFailures: Array<{ role: string; reason: unknown }> = [];
+    for (const [index, result] of spawnResults.entries()) {
       if (result.status === "fulfilled") {
-        this.agents.push(result.value);
+        spawnedAgents.push(result.value.agent);
       } else {
-        process.stderr.write(`[SessionOrchestrator] spawn failed: ${result.reason}\n`);
+        const role = topology.roles[index]?.name ?? `role-${index}`;
+        spawnFailures.push({ role, reason: result.reason });
+        process.stderr.write(
+          `[SessionOrchestrator] spawn failed for '${role}': ${result.reason}\n`,
+        );
       }
     }
 
-    // Require at least one agent
-    if (this.agents.length === 0) {
-      throw new Error("No agents spawned — all roles failed");
+    if (spawnFailures.length > 0) {
+      for (const agent of spawnedAgents) {
+        try {
+          await this.config.runtime.close(agent.session);
+        } catch {
+          /* best-effort cleanup before surfacing the spawn failure */
+        }
+      }
+      const roles = spawnFailures.map((failure) => failure.role).join(", ");
+      const details = spawnFailures
+        .map((failure) => `${failure.role}: ${messageFromError(failure.reason)}`)
+        .join("; ");
+      throw new Error(`Failed to spawn required role(s): ${roles}. ${details}`);
     }
+
+    this.agents.push(...spawnedAgents);
 
     this.startedAt = Date.now();
 
@@ -414,9 +435,26 @@ export class SessionOrchestrator {
 
     this.unsubscribeEventHandlers();
 
+    if (stopStatus === LoopStopStatus.Achieved && this.config.runtime.sendsInitialPromptOnSpawn) {
+      await this.waitForAgentTurnsToSettle();
+    }
+
     // Close all agent sessions
     for (const agent of this.agents) {
       await this.config.runtime.close(agent.session);
+    }
+  }
+
+  private async waitForAgentTurnsToSettle(timeoutMs = 5_000, pollMs = 100): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const sessions = await this.config.runtime.listSessions();
+      const settled = this.agents.every((agent) => {
+        const current = sessions.find((session) => session.id === agent.session.id);
+        return current === undefined || current.status !== "running";
+      });
+      if (settled) return;
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
     }
   }
 
@@ -633,10 +671,57 @@ export class SessionOrchestrator {
     if (process.env.NEXUS_API_KEY) env.NEXUS_API_KEY = process.env.NEXUS_API_KEY;
     return {
       name: "grove",
-      command: "bun",
+      command: process.execPath,
       args: ["run", resolveMcpServePath(this.config.projectRoot)],
       env,
     };
+  }
+
+  private async ensureLocalSessionRecord(): Promise<void> {
+    const groveDir = join(this.config.projectRoot, ".grove");
+    if (!existsSync(groveDir)) return;
+
+    try {
+      const { initSqliteDb } = await import("../local/sqlite-store.js");
+      const db = initSqliteDb(join(groveDir, "grove.db"));
+      try {
+        const startedAt = new Date().toISOString();
+        const worktreeStrategies = Object.fromEntries(
+          resolveRoleWorkspaceStrategies(this.config.topology, this.sessionId),
+        );
+        db.prepare(`
+          INSERT OR IGNORE INTO sessions (
+            session_id,
+            uid,
+            goal,
+            preset_name,
+            topology_json,
+            config_json,
+            worktree_strategy_json,
+            status,
+            started_at,
+            finalizers_json
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)
+        `).run(
+          this.sessionId,
+          randomUUID(),
+          this.config.goal,
+          this.config.contract.name,
+          JSON.stringify(this.config.topology),
+          JSON.stringify(this.config.contract),
+          JSON.stringify(worktreeStrategies),
+          startedAt,
+          JSON.stringify(DEFAULT_SESSION_FINALIZERS),
+        );
+      } finally {
+        db.close();
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to register local session '${this.sessionId}': ${messageFromError(error)}`,
+      );
+    }
   }
 
   private async ensureReposResolved(): Promise<void> {
@@ -786,6 +871,21 @@ export class SessionOrchestrator {
     if (this.stopped) return;
 
     const sessions = await this.config.runtime.listSessions();
+    const crashed: Array<{ role: string; message: string | undefined }> = [];
+    for (const agent of this.agents) {
+      const current = sessions.find((s) => s.id === agent.session.id);
+      if (current?.status === "crashed") {
+        crashed.push({ role: agent.role, message: current.statusMessage });
+      }
+    }
+    if (crashed.length > 0) {
+      const detail = crashed
+        .map((agent) => (agent.message ? `${agent.role} (${agent.message})` : agent.role))
+        .join(", ");
+      await this.stop(`Agent(s) crashed: ${detail}`, LoopStopStatus.Error);
+      return;
+    }
+
     const allIdle = this.agents.every((agent) => {
       const current = sessions.find((s) => s.id === agent.session.id);
       return current?.status === "idle" || current?.status === "stopped";

--- a/src/tui/panels/panel-ids.test.ts
+++ b/src/tui/panels/panel-ids.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { Panel } from "../hooks/use-panel-focus.js";
+import {
+  BUILT_IN_PANEL_IDS,
+  CORE_PANEL_IDS,
+  idToPanel,
+  OPERATOR_PANEL_IDS,
+  PanelId,
+  panelToId,
+} from "./panel-ids.js";
+
+describe("panel IDs", () => {
+  test("keeps stable string IDs for all built-in panels", () => {
+    expect(PanelId.Dag).toBe("dag");
+    expect(PanelId.Detail).toBe("detail");
+    expect(PanelId.Frontier).toBe("frontier");
+    expect(PanelId.Claims).toBe("claims");
+    expect(PanelId.AgentList).toBe("agents");
+    expect(PanelId.Terminal).toBe("terminal");
+    expect(PanelId.Artifact).toBe("artifact");
+    expect(PanelId.Vfs).toBe("vfs");
+    expect(PanelId.Activity).toBe("activity");
+    expect(PanelId.Search).toBe("search");
+    expect(PanelId.Threads).toBe("threads");
+    expect(PanelId.Outcomes).toBe("outcomes");
+    expect(PanelId.Bounties).toBe("bounties");
+    expect(PanelId.Gossip).toBe("gossip");
+    expect(PanelId.Inbox).toBe("inbox");
+    expect(PanelId.Decisions).toBe("decisions");
+    expect(PanelId.GitHub).toBe("github");
+    expect(PanelId.Plan).toBe("plan");
+  });
+
+  test("converts numeric Panel values to stable string IDs", () => {
+    expect(panelToId(Panel.Dag)).toBe(PanelId.Dag);
+    expect(panelToId(Panel.AgentList)).toBe(PanelId.AgentList);
+    expect(panelToId(Panel.GitHub)).toBe(PanelId.GitHub);
+  });
+
+  test("converts stable string IDs back to numeric Panel values", () => {
+    expect(idToPanel("dag")).toBe(Panel.Dag);
+    expect(idToPanel("agents")).toBe(Panel.AgentList);
+    expect(idToPanel("github")).toBe(Panel.GitHub);
+  });
+
+  test("returns undefined for unknown string IDs", () => {
+    expect(idToPanel("missing")).toBeUndefined();
+    expect(idToPanel("bad/id")).toBeUndefined();
+  });
+
+  test("exports ordered built-in, core, and operator ID lists", () => {
+    expect(CORE_PANEL_IDS).toEqual(["dag", "detail", "frontier", "claims"]);
+    expect(OPERATOR_PANEL_IDS[0]).toBe("agents");
+    expect(OPERATOR_PANEL_IDS[OPERATOR_PANEL_IDS.length - 1]).toBe("plan");
+    expect(BUILT_IN_PANEL_IDS).toEqual([...CORE_PANEL_IDS, ...OPERATOR_PANEL_IDS]);
+  });
+});

--- a/src/tui/panels/panel-ids.test.ts
+++ b/src/tui/panels/panel-ids.test.ts
@@ -50,8 +50,41 @@ describe("panel IDs", () => {
 
   test("exports ordered built-in, core, and operator ID lists", () => {
     expect(CORE_PANEL_IDS).toEqual(["dag", "detail", "frontier", "claims"]);
-    expect(OPERATOR_PANEL_IDS[0]).toBe("agents");
-    expect(OPERATOR_PANEL_IDS[OPERATOR_PANEL_IDS.length - 1]).toBe("plan");
-    expect(BUILT_IN_PANEL_IDS).toEqual([...CORE_PANEL_IDS, ...OPERATOR_PANEL_IDS]);
+    expect(OPERATOR_PANEL_IDS).toEqual([
+      "agents",
+      "terminal",
+      "artifact",
+      "vfs",
+      "activity",
+      "search",
+      "threads",
+      "outcomes",
+      "bounties",
+      "gossip",
+      "inbox",
+      "decisions",
+      "github",
+      "plan",
+    ]);
+    expect(BUILT_IN_PANEL_IDS).toEqual([
+      "dag",
+      "detail",
+      "frontier",
+      "claims",
+      "agents",
+      "terminal",
+      "artifact",
+      "vfs",
+      "activity",
+      "search",
+      "threads",
+      "outcomes",
+      "bounties",
+      "gossip",
+      "inbox",
+      "decisions",
+      "github",
+      "plan",
+    ]);
   });
 });

--- a/src/tui/panels/panel-ids.ts
+++ b/src/tui/panels/panel-ids.ts
@@ -1,0 +1,73 @@
+import {
+  CORE_PANELS,
+  OPERATOR_PANELS,
+  Panel,
+  type Panel as PanelValue,
+} from "../hooks/use-panel-focus.js";
+
+export const PanelId = {
+  Dag: "dag",
+  Detail: "detail",
+  Frontier: "frontier",
+  Claims: "claims",
+  AgentList: "agents",
+  Terminal: "terminal",
+  Artifact: "artifact",
+  Vfs: "vfs",
+  Activity: "activity",
+  Search: "search",
+  Threads: "threads",
+  Outcomes: "outcomes",
+  Bounties: "bounties",
+  Gossip: "gossip",
+  Inbox: "inbox",
+  Decisions: "decisions",
+  GitHub: "github",
+  Plan: "plan",
+} as const;
+
+export type BuiltInPanelId = (typeof PanelId)[keyof typeof PanelId];
+
+const PANEL_TO_ID: Readonly<Record<PanelValue, BuiltInPanelId>> = {
+  [Panel.Dag]: PanelId.Dag,
+  [Panel.Detail]: PanelId.Detail,
+  [Panel.Frontier]: PanelId.Frontier,
+  [Panel.Claims]: PanelId.Claims,
+  [Panel.AgentList]: PanelId.AgentList,
+  [Panel.Terminal]: PanelId.Terminal,
+  [Panel.Artifact]: PanelId.Artifact,
+  [Panel.Vfs]: PanelId.Vfs,
+  [Panel.Activity]: PanelId.Activity,
+  [Panel.Search]: PanelId.Search,
+  [Panel.Threads]: PanelId.Threads,
+  [Panel.Outcomes]: PanelId.Outcomes,
+  [Panel.Bounties]: PanelId.Bounties,
+  [Panel.Gossip]: PanelId.Gossip,
+  [Panel.Inbox]: PanelId.Inbox,
+  [Panel.Decisions]: PanelId.Decisions,
+  [Panel.GitHub]: PanelId.GitHub,
+  [Panel.Plan]: PanelId.Plan,
+};
+
+const ID_TO_PANEL = new Map<BuiltInPanelId, PanelValue>(
+  Object.entries(PANEL_TO_ID).map(([panel, id]) => [id, Number(panel) as PanelValue]),
+);
+
+export const CORE_PANEL_IDS: readonly BuiltInPanelId[] = CORE_PANELS.map(
+  (panel) => PANEL_TO_ID[panel],
+);
+export const OPERATOR_PANEL_IDS: readonly BuiltInPanelId[] = OPERATOR_PANELS.map(
+  (panel) => PANEL_TO_ID[panel],
+);
+export const BUILT_IN_PANEL_IDS: readonly BuiltInPanelId[] = [
+  ...CORE_PANEL_IDS,
+  ...OPERATOR_PANEL_IDS,
+];
+
+export function panelToId(panel: PanelValue): BuiltInPanelId {
+  return PANEL_TO_ID[panel];
+}
+
+export function idToPanel(id: string): PanelValue | undefined {
+  return ID_TO_PANEL.get(id as BuiltInPanelId);
+}

--- a/src/tui/panels/panel-manager.tsx
+++ b/src/tui/panels/panel-manager.tsx
@@ -524,7 +524,7 @@ export const PanelManager: React.NamedExoticComponent<PanelManagerProps> = React
               flexGrow={getRowFlex(rowGroup, focusedRowGroup, zoom, rowGroup === 0 ? 2 : 1)}
             >
               {visibleInRow.map((def) => (
-                <PanelChrome key={def.panel} panel={def.panel} focused={isFocused(def.panel)}>
+                <PanelChrome key={def.id} panel={def.panel} focused={isFocused(def.panel)}>
                   {renderPanel(def.panel)}
                 </PanelChrome>
               ))}

--- a/src/tui/panels/panel-registry.test.ts
+++ b/src/tui/panels/panel-registry.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from "bun:test";
 import { initialPanelState, Panel, panelFocus, panelToggle } from "../hooks/use-panel-focus.js";
 import {
   getActivePanelsForLayout,
+  getBuiltInTuiRegistryEntries,
+  getPanelDefById,
   getPresetPanels,
   getRegistry,
   getRowFlex,
@@ -393,5 +395,64 @@ describe("getVisiblePanelsForLayout with allowedPanels", () => {
     expect(panelIds).toContain(Panel.Detail);
     expect(panelIds).toContain(Panel.Claims);
     expect(panelIds).not.toContain(Panel.Frontier);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stable panel IDs
+// ---------------------------------------------------------------------------
+
+describe("stable panel IDs", () => {
+  it("assigns a stable string id to every built-in panel definition", () => {
+    const registry = getRegistry();
+    const ids = registry.map((def) => def.id);
+
+    expect(ids).toEqual([
+      "dag",
+      "detail",
+      "frontier",
+      "claims",
+      "agents",
+      "terminal",
+      "artifact",
+      "vfs",
+      "activity",
+      "search",
+      "threads",
+      "outcomes",
+      "bounties",
+      "gossip",
+      "inbox",
+      "decisions",
+      "github",
+      "plan",
+    ]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("looks up a built-in panel definition by string id", () => {
+    expect(getPanelDefById("dag")?.panel).toBe(Panel.Dag);
+    expect(getPanelDefById("agents")?.panel).toBe(Panel.AgentList);
+    expect(getPanelDefById("github")?.panel).toBe(Panel.GitHub);
+  });
+
+  it("converts built-in panel definitions into TUI registry entries", () => {
+    const entries = getBuiltInTuiRegistryEntries();
+    expect(entries[0]).toEqual({
+      id: "dag",
+      label: "DAG",
+      slot: "operator-panel",
+      order: 0,
+      source: "builtin",
+      builtInPanel: Panel.Dag,
+    });
+    expect(entries.at(-1)).toEqual({
+      id: "plan",
+      label: "Plan",
+      slot: "operator-panel",
+      order: 17,
+      source: "builtin",
+      builtInPanel: Panel.Plan,
+    });
   });
 });

--- a/src/tui/panels/panel-registry.test.ts
+++ b/src/tui/panels/panel-registry.test.ts
@@ -512,4 +512,18 @@ describe("injectable registry helpers", () => {
     const active = getActivePanelsForLayout(initialPanelState(), "grid", registry);
     expect([...active]).toEqual([Panel.Dag, Panel.Claims]);
   });
+
+  it("computes active tab panels when injected registry includes the focused panel", () => {
+    const registry = getRegistry().filter((def) => def.id === "claims");
+    const state = panelFocus(initialPanelState(), Panel.Claims);
+    const active = getActivePanelsForLayout(state, "tab", registry);
+    expect([...active]).toEqual([Panel.Claims]);
+  });
+
+  it("computes no active tab panels when injected registry excludes the focused panel", () => {
+    const registry = getRegistry().filter((def) => def.id === "claims");
+    const state = panelFocus(initialPanelState(), Panel.Dag);
+    const active = getActivePanelsForLayout(state, "tab", registry);
+    expect([...active]).toEqual([]);
+  });
 });

--- a/src/tui/panels/panel-registry.test.ts
+++ b/src/tui/panels/panel-registry.test.ts
@@ -488,3 +488,28 @@ describe("stable panel IDs", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Injectable registry helpers
+// ---------------------------------------------------------------------------
+
+describe("injectable registry helpers", () => {
+  it("groups an injected registry instead of always reading PANEL_REGISTRY", () => {
+    const registry = getRegistry().filter((def) => def.id === "claims");
+    const groups = getRowGroups(registry);
+    expect(groups.size).toBe(1);
+    expect(groups.get(2)?.map((def) => def.id)).toEqual(["claims"]);
+  });
+
+  it("computes visible panels from an injected registry", () => {
+    const registry = getRegistry().filter((def) => def.id === "dag" || def.id === "claims");
+    const visible = getVisiblePanelsForLayout(initialPanelState(), "grid", undefined, registry);
+    expect(visible.map((def) => def.id)).toEqual(["dag", "claims"]);
+  });
+
+  it("computes active panels from an injected registry", () => {
+    const registry = getRegistry().filter((def) => def.id === "dag" || def.id === "claims");
+    const active = getActivePanelsForLayout(initialPanelState(), "grid", registry);
+    expect([...active]).toEqual([Panel.Dag, Panel.Claims]);
+  });
+});

--- a/src/tui/panels/panel-registry.test.ts
+++ b/src/tui/panels/panel-registry.test.ts
@@ -8,6 +8,7 @@ import {
   getActivePanelsForLayout,
   getBuiltInTuiRegistryEntries,
   getPanelDefById,
+  getPresetPanelIds,
   getPresetPanels,
   getRegistry,
   getRowFlex,
@@ -319,6 +320,37 @@ describe("PRESET_PANELS", () => {
     expect(PRESET_PANELS["review-loop"]).toBeDefined();
     expect(PRESET_PANELS["swarm-ops"]).toBeDefined();
     expect(PRESET_PANELS["federated-swarm"]).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPresetPanelIds()
+// ---------------------------------------------------------------------------
+
+describe("getPresetPanelIds", () => {
+  it("returns stable string IDs for review-loop", () => {
+    expect([...(getPresetPanelIds("review-loop") ?? [])]).toEqual([
+      "dag",
+      "detail",
+      "claims",
+      "terminal",
+    ]);
+  });
+
+  it("returns stable string IDs for swarm-ops", () => {
+    expect([...(getPresetPanelIds("swarm-ops") ?? [])]).toEqual([
+      "dag",
+      "detail",
+      "claims",
+      "terminal",
+      "frontier",
+      "outcomes",
+      "bounties",
+    ]);
+  });
+
+  it("returns undefined for unknown preset", () => {
+    expect(getPresetPanelIds("unknown-preset")).toBeUndefined();
   });
 });
 

--- a/src/tui/panels/panel-registry.test.ts
+++ b/src/tui/panels/panel-registry.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from "bun:test";
 import { initialPanelState, Panel, panelFocus, panelToggle } from "../hooks/use-panel-focus.js";
+import { panelToId } from "./panel-ids.js";
 import {
   getActivePanelsForLayout,
   getBuiltInTuiRegistryEntries,
@@ -347,6 +348,25 @@ describe("getPresetPanelIds", () => {
       "outcomes",
       "bounties",
     ]);
+  });
+
+  it("returns stable string IDs for federated-swarm", () => {
+    expect([...(getPresetPanelIds("federated-swarm") ?? [])]).toEqual([
+      "dag",
+      "detail",
+      "claims",
+      "terminal",
+      "frontier",
+      "gossip",
+    ]);
+  });
+
+  it("stays in sync with numeric preset membership", () => {
+    for (const [presetName, panels] of Object.entries(PRESET_PANELS)) {
+      expect([...(getPresetPanelIds(presetName) ?? [])]).toEqual(
+        [...panels].map((panel) => panelToId(panel)),
+      );
+    }
   });
 
   it("returns undefined for unknown preset", () => {

--- a/src/tui/panels/panel-registry.ts
+++ b/src/tui/panels/panel-registry.ts
@@ -10,6 +10,8 @@
 
 import type { PanelFocusState } from "../hooks/use-panel-focus.js";
 import { isPanelVisible, PANEL_LABELS, Panel } from "../hooks/use-panel-focus.js";
+import type { TuiRegistryEntry } from "../plugins/registry.js";
+import { type BuiltInPanelId, panelToId } from "./panel-ids.js";
 
 // ---------------------------------------------------------------------------
 // Per-preset panel visibility
@@ -58,7 +60,7 @@ export type LayoutMode = "grid" | "tab";
 // ---------------------------------------------------------------------------
 
 /** Layout metadata for a panel definition. */
-export interface PanelDef {
+interface PanelDefBase {
   /** The Panel enum value. */
   readonly panel: Panel;
   /** Display label (from PANEL_LABELS). */
@@ -75,6 +77,11 @@ export interface PanelDef {
    * Operator panels: key toggles the panel on/off.
    */
   readonly keybinding: string;
+}
+
+export interface PanelDef extends PanelDefBase {
+  readonly id: BuiltInPanelId;
+  readonly slot: "operator-panel";
 }
 
 // ---------------------------------------------------------------------------
@@ -95,7 +102,7 @@ export interface PanelDef {
  *   7 — Bounties + Gossip  (operator)
  *   8 — Inbox + Decisions + GitHub (operator)
  */
-export const PANEL_REGISTRY: readonly PanelDef[] = [
+const PANEL_REGISTRY_BASE: readonly PanelDefBase[] = [
   // Row 0: DAG + Detail (core)
   {
     panel: Panel.Dag,
@@ -258,6 +265,16 @@ export const PANEL_REGISTRY: readonly PanelDef[] = [
   },
 ] as const;
 
+export const PANEL_REGISTRY: readonly PanelDef[] = Object.freeze(
+  PANEL_REGISTRY_BASE.map((def) =>
+    Object.freeze({
+      ...def,
+      id: panelToId(def.panel),
+      slot: "operator-panel" as const,
+    }),
+  ),
+);
+
 // ---------------------------------------------------------------------------
 // Public query functions
 // ---------------------------------------------------------------------------
@@ -265,6 +282,21 @@ export const PANEL_REGISTRY: readonly PanelDef[] = [
 /** Returns the full panel registry. */
 export function getRegistry(): readonly PanelDef[] {
   return PANEL_REGISTRY;
+}
+
+export function getPanelDefById(id: BuiltInPanelId): PanelDef | undefined {
+  return PANEL_REGISTRY.find((def) => def.id === id);
+}
+
+export function getBuiltInTuiRegistryEntries(): readonly TuiRegistryEntry[] {
+  return PANEL_REGISTRY.map((def, order) => ({
+    id: def.id,
+    label: def.label,
+    slot: def.slot,
+    order,
+    source: "builtin",
+    builtInPanel: def.panel,
+  }));
 }
 
 /** Groups panel definitions by their row group number. */

--- a/src/tui/panels/panel-registry.ts
+++ b/src/tui/panels/panel-registry.ts
@@ -382,7 +382,8 @@ export function getActivePanelsForLayout(
   registry: readonly PanelDef[] = PANEL_REGISTRY,
 ): ReadonlySet<Panel> {
   if (mode === "tab") {
-    return new Set([panelState.focused]);
+    const def = registry.find((d) => d.panel === panelState.focused);
+    return def !== undefined ? new Set([panelState.focused]) : new Set();
   }
 
   // Grid mode: every visible panel is active.

--- a/src/tui/panels/panel-registry.ts
+++ b/src/tui/panels/panel-registry.ts
@@ -326,9 +326,11 @@ export function getBuiltInTuiRegistryEntries(): readonly TuiRegistryEntry[] {
 }
 
 /** Groups panel definitions by their row group number. */
-export function getRowGroups(): Map<number, readonly PanelDef[]> {
+export function getRowGroups(
+  registry: readonly PanelDef[] = PANEL_REGISTRY,
+): Map<number, readonly PanelDef[]> {
   const groups = new Map<number, PanelDef[]>();
-  for (const def of PANEL_REGISTRY) {
+  for (const def of registry) {
     let group = groups.get(def.rowGroup);
     if (group === undefined) {
       group = [];
@@ -351,15 +353,16 @@ export function getVisiblePanelsForLayout(
   panelState: PanelFocusState,
   mode: LayoutMode,
   allowedPanels?: ReadonlySet<Panel>,
+  registry: readonly PanelDef[] = PANEL_REGISTRY,
 ): readonly PanelDef[] {
   if (mode === "tab") {
-    const def = PANEL_REGISTRY.find((d) => d.panel === panelState.focused);
+    const def = registry.find((d) => d.panel === panelState.focused);
     return def !== undefined ? [def] : [];
   }
 
   // Grid mode: core panels always visible, operator panels per state.
   // Also filter by allowedPanels if provided (preset-based visibility).
-  return PANEL_REGISTRY.filter(
+  return registry.filter(
     (def) =>
       isPanelVisible(panelState, def.panel) &&
       (allowedPanels === undefined || allowedPanels.has(def.panel)),
@@ -376,6 +379,7 @@ export function getVisiblePanelsForLayout(
 export function getActivePanelsForLayout(
   panelState: PanelFocusState,
   mode: LayoutMode,
+  registry: readonly PanelDef[] = PANEL_REGISTRY,
 ): ReadonlySet<Panel> {
   if (mode === "tab") {
     return new Set([panelState.focused]);
@@ -383,7 +387,7 @@ export function getActivePanelsForLayout(
 
   // Grid mode: every visible panel is active.
   const active = new Set<Panel>();
-  for (const def of PANEL_REGISTRY) {
+  for (const def of registry) {
     if (isPanelVisible(panelState, def.panel)) {
       active.add(def.panel);
     }

--- a/src/tui/panels/panel-registry.ts
+++ b/src/tui/panels/panel-registry.ts
@@ -11,7 +11,7 @@
 import type { PanelFocusState } from "../hooks/use-panel-focus.js";
 import { isPanelVisible, PANEL_LABELS, Panel } from "../hooks/use-panel-focus.js";
 import type { TuiRegistryEntry } from "../plugins/registry.js";
-import { type BuiltInPanelId, panelToId } from "./panel-ids.js";
+import { type BuiltInPanelId, PanelId, panelToId } from "./panel-ids.js";
 
 // ---------------------------------------------------------------------------
 // Per-preset panel visibility
@@ -38,6 +38,32 @@ export const PRESET_PANELS: Readonly<Record<string, ReadonlySet<Panel>>> = {
     Panel.Gossip,
   ]),
 };
+
+export const PRESET_PANEL_IDS: Readonly<Record<string, ReadonlySet<BuiltInPanelId>>> = {
+  "review-loop": new Set([PanelId.Dag, PanelId.Detail, PanelId.Claims, PanelId.Terminal]),
+  "swarm-ops": new Set([
+    PanelId.Dag,
+    PanelId.Detail,
+    PanelId.Claims,
+    PanelId.Terminal,
+    PanelId.Frontier,
+    PanelId.Outcomes,
+    PanelId.Bounties,
+  ]),
+  "federated-swarm": new Set([
+    PanelId.Dag,
+    PanelId.Detail,
+    PanelId.Claims,
+    PanelId.Terminal,
+    PanelId.Frontier,
+    PanelId.Gossip,
+  ]),
+};
+
+export function getPresetPanelIds(presetName?: string): ReadonlySet<BuiltInPanelId> | undefined {
+  if (!presetName) return undefined;
+  return PRESET_PANEL_IDS[presetName];
+}
 
 /** Get the allowed panels for a preset. Returns undefined if all panels are allowed. */
 export function getPresetPanels(presetName?: string): ReadonlySet<Panel> | undefined {

--- a/src/tui/plugins/registry.test.ts
+++ b/src/tui/plugins/registry.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { Panel } from "../hooks/use-panel-focus.js";
+import { mergeTuiRegistrations, type TuiRegistryEntry } from "./registry.js";
+import type { TuiPanelRegistration } from "./types.js";
+
+const NullPanel = () => null;
+
+function builtIn(id: string, order: number, panel: Panel): TuiRegistryEntry {
+  return {
+    id,
+    label: id,
+    slot: "operator-panel",
+    order,
+    source: "builtin",
+    builtInPanel: panel,
+  };
+}
+
+function plugin(id: string, order?: number): TuiPanelRegistration {
+  return {
+    id,
+    label: id,
+    slot: "operator-panel",
+    ...(order === undefined ? {} : { order }),
+    component: NullPanel,
+  };
+}
+
+describe("mergeTuiRegistrations", () => {
+  test("orders built-in and plugin entries by order then id", () => {
+    const result = mergeTuiRegistrations({
+      builtIns: [builtIn("dag", 10, Panel.Dag), builtIn("claims", 30, Panel.Claims)],
+      plugins: [plugin("eval-results", 20), plugin("audit-feed", 20)],
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.entries.map((entry) => entry.id)).toEqual([
+      "dag",
+      "audit-feed",
+      "eval-results",
+      "claims",
+    ]);
+  });
+
+  test("skips plugin entries that duplicate built-in IDs", () => {
+    const result = mergeTuiRegistrations({
+      builtIns: [builtIn("dag", 10, Panel.Dag)],
+      plugins: [plugin("dag", 20)],
+    });
+
+    expect(result.entries.map((entry) => entry.id)).toEqual(["dag"]);
+    expect(result.diagnostics).toEqual([
+      {
+        id: "dag",
+        severity: "error",
+        message: "Duplicate TUI panel id: dag",
+      },
+    ]);
+  });
+
+  test("skips plugin entries with unsafe IDs", () => {
+    const result = mergeTuiRegistrations({
+      builtIns: [builtIn("dag", 10, Panel.Dag)],
+      plugins: [plugin("bad/id", 20), plugin("UpperCase", 30)],
+    });
+
+    expect(result.entries.map((entry) => entry.id)).toEqual(["dag"]);
+    expect(result.diagnostics).toEqual([
+      {
+        id: "bad/id",
+        severity: "error",
+        message: "Invalid TUI panel id: bad/id",
+      },
+      {
+        id: "UpperCase",
+        severity: "error",
+        message: "Invalid TUI panel id: UpperCase",
+      },
+    ]);
+  });
+
+  test("uses default plugin order after built-ins when order is omitted", () => {
+    const result = mergeTuiRegistrations({
+      builtIns: [builtIn("dag", 10, Panel.Dag)],
+      plugins: [plugin("eval-results")],
+    });
+
+    expect(result.entries.map((entry) => entry.id)).toEqual(["dag", "eval-results"]);
+    expect(result.entries[1]?.order).toBe(1000);
+  });
+});

--- a/src/tui/plugins/registry.test.ts
+++ b/src/tui/plugins/registry.test.ts
@@ -106,6 +106,34 @@ describe("mergeTuiRegistrations", () => {
     expect(result.entries[1]?.order).toBe(1000);
   });
 
+  test("uses default plugin order and reports diagnostics for invalid orders", () => {
+    const result = mergeTuiRegistrations({
+      builtIns: [builtIn("dag", 10, Panel.Dag)],
+      plugins: [
+        plugin("nan-order", Number.NaN),
+        plugin("infinite-order", Number.POSITIVE_INFINITY),
+      ],
+    });
+
+    expect(result.entries.map((entry) => [entry.id, entry.order])).toEqual([
+      ["dag", 10],
+      ["infinite-order", 1000],
+      ["nan-order", 1000],
+    ]);
+    expect(result.diagnostics).toEqual([
+      {
+        id: "nan-order",
+        severity: "error",
+        message: "Invalid TUI panel order for nan-order; using default order 1000",
+      },
+      {
+        id: "infinite-order",
+        severity: "error",
+        message: "Invalid TUI panel order for infinite-order; using default order 1000",
+      },
+    ]);
+  });
+
   test("throws when built-in panel ID is unsafe", () => {
     expect(() =>
       mergeTuiRegistrations({

--- a/src/tui/plugins/registry.test.ts
+++ b/src/tui/plugins/registry.test.ts
@@ -58,6 +58,23 @@ describe("mergeTuiRegistrations", () => {
     ]);
   });
 
+  test("keeps first plugin entry and skips duplicate plugin IDs", () => {
+    const result = mergeTuiRegistrations({
+      builtIns: [builtIn("dag", 10, Panel.Dag)],
+      plugins: [plugin("audit-feed", 20), plugin("audit-feed", 30)],
+    });
+
+    expect(result.entries.map((entry) => entry.id)).toEqual(["dag", "audit-feed"]);
+    expect(result.entries[1]?.order).toBe(20);
+    expect(result.diagnostics).toEqual([
+      {
+        id: "audit-feed",
+        severity: "error",
+        message: "Duplicate TUI panel id: audit-feed",
+      },
+    ]);
+  });
+
   test("skips plugin entries with unsafe IDs", () => {
     const result = mergeTuiRegistrations({
       builtIns: [builtIn("dag", 10, Panel.Dag)],
@@ -79,7 +96,7 @@ describe("mergeTuiRegistrations", () => {
     ]);
   });
 
-  test("uses default plugin order after built-ins when order is omitted", () => {
+  test("uses default plugin order 1000 when order is omitted", () => {
     const result = mergeTuiRegistrations({
       builtIns: [builtIn("dag", 10, Panel.Dag)],
       plugins: [plugin("eval-results")],
@@ -87,5 +104,21 @@ describe("mergeTuiRegistrations", () => {
 
     expect(result.entries.map((entry) => entry.id)).toEqual(["dag", "eval-results"]);
     expect(result.entries[1]?.order).toBe(1000);
+  });
+
+  test("throws when built-in panel ID is unsafe", () => {
+    expect(() =>
+      mergeTuiRegistrations({
+        builtIns: [builtIn("bad/id", 10, Panel.Dag)],
+      }),
+    ).toThrow("Built-in TUI panel has invalid id: bad/id");
+  });
+
+  test("throws when built-in panel ID is duplicated", () => {
+    expect(() =>
+      mergeTuiRegistrations({
+        builtIns: [builtIn("dag", 10, Panel.Dag), builtIn("dag", 20, Panel.Claims)],
+      }),
+    ).toThrow("Built-in TUI panel id is duplicated: dag");
   });
 });

--- a/src/tui/plugins/registry.ts
+++ b/src/tui/plugins/registry.ts
@@ -70,11 +70,12 @@ export function mergeTuiRegistrations(
       continue;
     }
     seen.add(registration.id);
+    const order = resolvePluginOrder(registration, diagnostics);
     entries.push({
       id: registration.id,
       label: registration.label,
       slot: registration.slot,
-      order: registration.order ?? DEFAULT_PLUGIN_ORDER,
+      order,
       source: "plugin",
       registration,
     });
@@ -96,4 +97,19 @@ export function mergeTuiRegistrations(
 
 function sourceRank(source: "builtin" | "plugin"): number {
   return source === "builtin" ? 0 : 1;
+}
+
+function resolvePluginOrder(
+  registration: TuiPanelRegistration,
+  diagnostics: TuiRegistryDiagnostic[],
+): number {
+  if (registration.order === undefined) return DEFAULT_PLUGIN_ORDER;
+  if (Number.isFinite(registration.order)) return registration.order;
+
+  diagnostics.push({
+    id: registration.id,
+    severity: "error",
+    message: `Invalid TUI panel order for ${registration.id}; using default order ${DEFAULT_PLUGIN_ORDER}`,
+  });
+  return DEFAULT_PLUGIN_ORDER;
 }

--- a/src/tui/plugins/registry.ts
+++ b/src/tui/plugins/registry.ts
@@ -1,0 +1,99 @@
+import type { Panel } from "../hooks/use-panel-focus.js";
+import type { TuiPanelRegistration, TuiSlot } from "./types.js";
+
+const DEFAULT_PLUGIN_ORDER = 1000;
+const SAFE_PANEL_ID = /^[a-z][a-z0-9.-]*$/;
+
+export interface TuiRegistryEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly slot: TuiSlot;
+  readonly order: number;
+  readonly source: "builtin" | "plugin";
+  readonly builtInPanel?: Panel | undefined;
+  readonly registration?: TuiPanelRegistration | undefined;
+}
+
+export interface TuiRegistryDiagnostic {
+  readonly id: string;
+  readonly severity: "error";
+  readonly message: string;
+}
+
+export interface MergeTuiRegistrationsInput {
+  readonly builtIns: readonly TuiRegistryEntry[];
+  readonly plugins?: readonly TuiPanelRegistration[] | undefined;
+}
+
+export interface MergeTuiRegistrationsResult {
+  readonly entries: readonly TuiRegistryEntry[];
+  readonly diagnostics: readonly TuiRegistryDiagnostic[];
+}
+
+export function isSafeTuiPanelId(id: string): boolean {
+  return SAFE_PANEL_ID.test(id);
+}
+
+export function mergeTuiRegistrations(
+  input: MergeTuiRegistrationsInput,
+): MergeTuiRegistrationsResult {
+  const entries: TuiRegistryEntry[] = [];
+  const diagnostics: TuiRegistryDiagnostic[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of input.builtIns) {
+    if (!isSafeTuiPanelId(entry.id)) {
+      throw new Error(`Built-in TUI panel has invalid id: ${entry.id}`);
+    }
+    if (seen.has(entry.id)) {
+      throw new Error(`Built-in TUI panel id is duplicated: ${entry.id}`);
+    }
+    seen.add(entry.id);
+    entries.push(entry);
+  }
+
+  for (const registration of input.plugins ?? []) {
+    if (!isSafeTuiPanelId(registration.id)) {
+      diagnostics.push({
+        id: registration.id,
+        severity: "error",
+        message: `Invalid TUI panel id: ${registration.id}`,
+      });
+      continue;
+    }
+    if (seen.has(registration.id)) {
+      diagnostics.push({
+        id: registration.id,
+        severity: "error",
+        message: `Duplicate TUI panel id: ${registration.id}`,
+      });
+      continue;
+    }
+    seen.add(registration.id);
+    entries.push({
+      id: registration.id,
+      label: registration.label,
+      slot: registration.slot,
+      order: registration.order ?? DEFAULT_PLUGIN_ORDER,
+      source: "plugin",
+      registration,
+    });
+  }
+
+  entries.sort((a, b) => {
+    const orderDelta = a.order - b.order;
+    if (orderDelta !== 0) return orderDelta;
+    const sourceDelta = sourceRank(a.source) - sourceRank(b.source);
+    if (sourceDelta !== 0) return sourceDelta;
+    return a.id.localeCompare(b.id);
+  });
+
+  return {
+    entries: Object.freeze(entries),
+    diagnostics: Object.freeze(diagnostics),
+  };
+}
+
+function sourceRank(source: "builtin" | "plugin"): number {
+  return source === "builtin" ? 0 : 1;
+}

--- a/src/tui/plugins/types.ts
+++ b/src/tui/plugins/types.ts
@@ -1,0 +1,34 @@
+import type React from "react";
+import type { AgentTopology } from "../../core/topology.js";
+import type { TuiDataProvider } from "../provider.js";
+
+export type TuiSlot =
+  | "operator-panel"
+  | "dashboard"
+  | "detail-adjacent"
+  | "footer"
+  | "command-palette";
+
+export interface TuiPluginManifest {
+  readonly id: string;
+  readonly name: string;
+  readonly version: string;
+  readonly slots: readonly TuiSlot[];
+}
+
+export interface TuiPluginContext {
+  readonly provider: TuiDataProvider;
+  readonly topology?: AgentTopology | undefined;
+  readonly selectedSession?: string | undefined;
+  readonly selectedCid?: string | undefined;
+  readonly density: "comfortable" | "compact";
+}
+
+export interface TuiPanelRegistration {
+  readonly id: string;
+  readonly label: string;
+  readonly slot: TuiSlot;
+  readonly defaultVisible?: boolean | undefined;
+  readonly order?: number | undefined;
+  readonly component: React.ComponentType<TuiPluginContext>;
+}


### PR DESCRIPTION
## Summary
- Keep the existing TUI registry/plugin foundation for #225 on this branch.
- Harden review-loop handoffs by tracking ACP runtime status through running/idle/crashed transitions and surfacing agent crashes to the orchestrator.
- Register local Grove sessions before MCP-backed agents start, resolve `grove mcp serve` through the active Bun executable, and make required role spawning all-or-nothing.
- Wait for ACP turns to settle before stopping achieved sessions so Codex -> Claude handoffs persist their work/review/done contributions.

Part of #225. Full remaining #225 scope is split into follow-up issues #440 through #447, with existing related trackers #189, #212, #193, #194, #275, and #276.

## Validation
- `PATH="$HOME/.bun/bin:$PATH" bun run typecheck`
- `PATH="$HOME/.bun/bin:$PATH" bun run check` (passes with existing warnings)
- `PATH="$HOME/.bun/bin:$PATH" bun run build`
- `git diff --check`
- `PATH="$HOME/.bun/bin:$PATH" bun test src/core/resolve-mcp-serve-path.test.ts src/core/acp-runtime.spawn.test.ts src/core/session-orchestrator.test.ts --timeout 60000` -> 62 pass / 0 fail; Bun exits 1 because repo coverage thresholds are global and this is a partial test run.
- Live Codex -> Claude SessionOrchestrator validation completed with 3 linked contributions: Codex work, Claude review, and Claude `[DONE]` approval.
- Tmux TUI e2e validation could not run literally because `tmux` is not installed in this environment; related e2e files were not included in this commit.

## Notes
- The branch already had PR #435 open, so this updates that PR instead of creating a duplicate PR from the same head branch.
