### PR TITLE
TUI: LogView with backpressure (#310)

### DIFF
--- a/docs/superpowers/plans/2026-05-16-310-logview.md
+++ b/docs/superpowers/plans/2026-05-16-310-logview.md
@@ -1,0 +1,1150 @@
+# LogView with backpressure — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #310 — a TUI `<LogView sessionId>` that live-tails a single agent's stdout with 50ms flush, pause/resume, substring filter, and autoscroll, replacing `<TerminalView>` for ACPX-streamed sessions.
+
+**Architecture:** Three units. (1) `AgentLogBuffer` gains an optional `flushMs` constructor arg (default 16). (2) New pure `<LogViewport>` component subscribes to a buffer and renders the viewport with filter + pause + autoscroll. (3) New `<LogView>` controlled wrapper consumes `<LogViewport>` and exposes its state to the existing `running-keyboard.ts` central dispatcher. `<TracePane>` is refactored to reuse `<LogViewport>` for its right column. The mount swap in `running-view.tsx` selects `<LogView>` over `<TerminalView>` for ACPX sessions.
+
+**Tech Stack:** TypeScript, React 18, OpenTUI (`<box>`, `<text>`), bun:test, `react-test-renderer`.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-310-logview-design.md`
+
+---
+
+## File map
+
+- **Create:**
+  - `src/tui/components/log-viewport.tsx` — pure render component
+  - `src/tui/components/log-viewport.test.tsx` — render correctness tests
+  - `src/tui/views/log-view.tsx` — controlled wrapper component
+  - `src/tui/views/log-view.test.tsx` — keyboard wiring tests
+  - `src/tui/data/agent-log-buffer.backpressure.test.ts` — acceptance test
+- **Modify:**
+  - `src/tui/data/agent-log-buffer.ts` — add optional `flushMs` constructor arg
+  - `src/tui/views/trace-pane.tsx` — replace inline right-pane with `<LogViewport>`
+  - `src/tui/screens/running-keyboard.ts` — add LogView dispatch branch
+  - `src/tui/screens/running-view.tsx` — mount swap for ACPX sessions (and route keys to LogView state)
+
+---
+
+## Task 1: Make `AgentLogBuffer` flush cadence configurable
+
+**Files:**
+- Modify: `src/tui/data/agent-log-buffer.ts`
+- Test: `src/tui/data/agent-log-buffer.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/tui/data/agent-log-buffer.test.ts` (at the end of the file, before the final closing brace if there is a trailing `describe`, otherwise at file end):
+
+```ts
+describe("AgentLogBuffer flushMs", () => {
+  test("constructor accepts custom flushMs (50ms) and coalesces notifies", async () => {
+    const buf = new AgentLogBuffer("coder", "sess-flush", 10_000, 50);
+    let notifies = 0;
+    buf.subscribe(() => {
+      notifies += 1;
+    });
+
+    // Burst 100 pushes synchronously
+    for (let i = 0; i < 100; i++) {
+      buf.push({ ts: Date.now(), line: `line-${i}`, type: "output" });
+    }
+
+    // Sync: no notify yet (still scheduled)
+    expect(notifies).toBe(0);
+
+    // Wait one flush window
+    await new Promise((r) => setTimeout(r, 80));
+
+    // All 100 writes landed; subscriber fired exactly once
+    expect(buf.size).toBe(100);
+    expect(notifies).toBe(1);
+
+    buf.dispose();
+  });
+
+  test("defaults to 16ms when flushMs is not supplied", async () => {
+    const buf = new AgentLogBuffer("coder", "sess-default");
+    let notifies = 0;
+    buf.subscribe(() => {
+      notifies += 1;
+    });
+    buf.push({ ts: 0, line: "x", type: "output" });
+    await new Promise((r) => setTimeout(r, 40));
+    expect(notifies).toBe(1);
+    buf.dispose();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/tui/data/agent-log-buffer.test.ts -t "flushMs"`
+Expected: FAIL — current constructor signature is `(role, sessionId, capacity?)`, no 4th argument. The `, 50` argument is silently ignored, but the 80ms wait is enough for the 16ms default timer to fire, so `notifies === 1` will pass. The first test will pass spuriously. **Adjust the test to also assert the timer interval explicitly** by spying on `setTimeout` — instead, simplify: shrink the wait below 16ms (default) and above 0ms to expose the missing parameter:
+
+Replace the first test's wait+assertion section with:
+
+```ts
+    // Wait < default 16ms but enough time for a 50ms-buffered notify NOT to fire
+    await new Promise((r) => setTimeout(r, 5));
+    // With flushMs=50, notify should not have fired yet
+    // (With the broken implementation defaulting to 16ms, this also won't fire — keep going)
+
+    // Wait past the 16ms default but still under 50ms
+    await new Promise((r) => setTimeout(r, 20));  // total ~25ms
+    // If flushMs=50 was honored: still 0 notifies. If ignored (default 16): 1.
+    expect(notifies).toBe(0);
+
+    // Wait past 50ms total
+    await new Promise((r) => setTimeout(r, 40));  // total ~65ms
+    expect(buf.size).toBe(100);
+    expect(notifies).toBe(1);
+```
+
+Run: `bun test src/tui/data/agent-log-buffer.test.ts -t "flushMs"`
+Expected: FAIL with `expected 0, got 1` on the mid-wait assertion.
+
+- [ ] **Step 3: Add the `flushMs` parameter to `AgentLogBuffer`**
+
+In `src/tui/data/agent-log-buffer.ts`, change the constant `FLUSH_INTERVAL_MS` and the constructor:
+
+```ts
+const DEFAULT_CAPACITY = 10_000;
+const DEFAULT_FLUSH_INTERVAL_MS = 16; // ~60fps
+```
+
+Update the class:
+
+```ts
+export class AgentLogBuffer {
+  readonly role: string;
+  readonly sessionId: string;
+  readonly flushMs: number;
+
+  private readonly buffer: RingBuffer<LogLine>;
+  private readonly listeners = new Set<LogBufferListener>();
+  private dirty = false;
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private reader: IncrementalLogReader | null = null;
+  private readerPath: string | null = null;
+  private readonly seekedPositions = new Map<string, number>();
+
+  constructor(
+    role: string,
+    sessionId: string,
+    capacity: number = DEFAULT_CAPACITY,
+    flushMs: number = DEFAULT_FLUSH_INTERVAL_MS,
+  ) {
+    this.role = role;
+    this.sessionId = sessionId;
+    this.flushMs = flushMs;
+    this.buffer = new RingBuffer<LogLine>(capacity);
+  }
+```
+
+Replace the `scheduleBatchedFlush` method:
+
+```ts
+  private scheduleBatchedFlush(): void {
+    this.dirty = true;
+    if (this.flushTimer === null) {
+      this.flushTimer = setTimeout(() => {
+        this.flushTimer = null;
+        if (this.dirty) {
+          this.dirty = false;
+          this.notifyListeners();
+        }
+      }, this.flushMs);
+    }
+  }
+```
+
+Remove the old `FLUSH_INTERVAL_MS` constant.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/tui/data/agent-log-buffer.test.ts`
+Expected: all tests pass (including the two new `flushMs` tests).
+
+- [ ] **Step 5: Run the full suite to catch regressions**
+
+Run: `bun test src/tui/data/`
+Expected: no failures. `trace-persistence.test.ts` constructs `AgentLogBuffer(role, sessionId)` — the new optional argument has a safe default, so those tests keep working unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui/data/agent-log-buffer.ts src/tui/data/agent-log-buffer.test.ts
+git commit -m "feat(tui): make AgentLogBuffer flush cadence configurable (#310)
+
+Add optional flushMs constructor argument (default 16ms preserves
+existing TracePane behavior). LogView will pass 50ms per issue spec."
+```
+
+---
+
+## Task 2: Backpressure acceptance test
+
+**Files:**
+- Create: `src/tui/data/agent-log-buffer.backpressure.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tui/data/agent-log-buffer.backpressure.test.ts`:
+
+```ts
+/**
+ * Acceptance test for issue #310: 1k lines/sec, no drops, coalesced notifies.
+ *
+ * Pushes 1000 lines synchronously into an AgentLogBuffer constructed with
+ * flushMs=50. Asserts:
+ *   - every write reaches the buffer (lossless ingest)
+ *   - subscriber is notified at most ceil(elapsed / 50) + 1 times (coalesced)
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AgentLogBuffer } from "./agent-log-buffer.js";
+
+describe("AgentLogBuffer backpressure (#310)", () => {
+  test("1000 sync pushes: lossless and coalesced at 50ms", async () => {
+    const buf = new AgentLogBuffer("coder", "sess-bp", 10_000, 50);
+    let notifies = 0;
+    buf.subscribe(() => {
+      notifies += 1;
+    });
+
+    const start = Date.now();
+    for (let i = 0; i < 1000; i++) {
+      buf.push({ ts: start + i, line: `line-${i}`, type: "output" });
+    }
+
+    // Wait long enough for the flush timer to fire
+    await new Promise((r) => setTimeout(r, 80));
+
+    const elapsedMs = Date.now() - start;
+    const maxNotifies = Math.ceil(elapsedMs / 50) + 1;
+
+    expect(buf.size).toBe(1000); // lossless
+    expect(notifies).toBeGreaterThan(0);
+    expect(notifies).toBeLessThanOrEqual(maxNotifies); // coalesced
+
+    buf.dispose();
+  });
+
+  test("staggered pushes across 200ms: still lossless", async () => {
+    const buf = new AgentLogBuffer("coder", "sess-bp2", 10_000, 50);
+    const start = Date.now();
+
+    // Push 5 batches of 200 over ~200ms
+    for (let batch = 0; batch < 5; batch++) {
+      for (let i = 0; i < 200; i++) {
+        buf.push({ ts: Date.now(), line: `b${batch}-${i}`, type: "output" });
+      }
+      await new Promise((r) => setTimeout(r, 40));
+    }
+
+    await new Promise((r) => setTimeout(r, 80));
+    expect(buf.size).toBe(1000); // every push landed
+    void start;
+
+    buf.dispose();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `bun test src/tui/data/agent-log-buffer.backpressure.test.ts`
+Expected: both tests PASS. (After Task 1, `flushMs` is honored, so this exercise confirms the acceptance criterion holds with no new implementation.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/data/agent-log-buffer.backpressure.test.ts
+git commit -m "test(tui): backpressure acceptance for LogView (#310)
+
+1k pushes synchronously: every write applied (lossless), subscriber
+notifies coalesced into ~1 per flush window."
+```
+
+---
+
+## Task 3: `<LogViewport>` pure component
+
+**Files:**
+- Create: `src/tui/components/log-viewport.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/tui/components/log-viewport.test.tsx`:
+
+```tsx
+/**
+ * Render correctness tests for <LogViewport>: viewport slicing, filter,
+ * pause-freeze, autoscroll re-clamp. Pure component — no SSE.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { AgentLogBuffer } from "../data/agent-log-buffer.js";
+import { LogViewport } from "./log-viewport.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function makeBuffer(n: number, flushMs = 50): AgentLogBuffer {
+  const buf = new AgentLogBuffer("coder", "sess-vp", 10_000, flushMs);
+  for (let i = 0; i < n; i++) {
+    buf.push({ ts: i, line: `line-${i}`, type: "output" });
+  }
+  return buf;
+}
+
+describe("LogViewport", () => {
+  test("renders the last `viewportLines` lines when scrollOffset=0", async () => {
+    const buf = makeBuffer(100);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogViewport
+            buffer={buf}
+            paused={false}
+            filter=""
+            scrollOffset={0}
+            viewportLines={5}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("line-95");
+    expect(flat).toContain("line-99");
+    expect(flat).not.toContain("line-94");
+    renderer.unmount();
+    buf.dispose();
+  });
+
+  test("scrollOffset>0 pins viewport above the tail", async () => {
+    const buf = makeBuffer(100);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogViewport
+            buffer={buf}
+            paused={false}
+            filter=""
+            scrollOffset={10}
+            viewportLines={5}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    // total=100, offset=10 → end=90, start=85
+    expect(flat).toContain("line-85");
+    expect(flat).toContain("line-89");
+    expect(flat).not.toContain("line-90");
+    renderer.unmount();
+    buf.dispose();
+  });
+
+  test("filter restricts to matching lines and shows match count", async () => {
+    const buf = new AgentLogBuffer("coder", "sess-f", 10_000, 50);
+    buf.push({ ts: 0, line: "apple pie", type: "output" });
+    buf.push({ ts: 1, line: "banana bread", type: "output" });
+    buf.push({ ts: 2, line: "apple cider", type: "output" });
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogViewport
+            buffer={buf}
+            paused={false}
+            filter="apple"
+            scrollOffset={0}
+            viewportLines={10}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("apple pie");
+    expect(flat).toContain("apple cider");
+    expect(flat).not.toContain("banana bread");
+    // match-count badge
+    expect(flat).toContain("2/3");
+    renderer.unmount();
+    buf.dispose();
+  });
+
+  test("paused=true freezes the rendered tail despite new pushes", async () => {
+    const buf = makeBuffer(10);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogViewport
+            buffer={buf}
+            paused={true}
+            filter=""
+            scrollOffset={0}
+            viewportLines={5}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+
+    // Push more lines after pause
+    await act(async () => {
+      buf.push({ ts: 100, line: "line-99-after-pause", type: "output" });
+      await new Promise((r) => setTimeout(r, 80));
+    });
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("line-5");
+    expect(flat).toContain("line-9");
+    expect(flat).not.toContain("after-pause");
+    expect(flat).toContain("PAUSED");
+    renderer.unmount();
+    buf.dispose();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/tui/components/log-viewport.test.tsx`
+Expected: all FAIL — `LogViewport` module does not exist.
+
+- [ ] **Step 3: Implement `<LogViewport>`**
+
+Create `src/tui/components/log-viewport.tsx`:
+
+```tsx
+/**
+ * LogViewport — pure render component for a single agent's log tail.
+ *
+ * Subscribes to an AgentLogBuffer and renders a viewport slice with optional
+ * substring filter, pause-freeze (frozen snapshot taken at the pause edge),
+ * and autoscroll (scrollOffset === 0 means "stick to tail").
+ *
+ * Owns no keyboard input. State (paused, filter, scrollOffset) is supplied by
+ * the parent — typically <LogView> or <TracePane>.
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import type { AgentLogBuffer, LogLine } from "../data/agent-log-buffer.js";
+import { theme } from "../theme.js";
+
+export interface LogViewportProps {
+  readonly buffer: AgentLogBuffer;
+  readonly paused: boolean;
+  readonly filter: string;
+  readonly scrollOffset: number;
+  readonly viewportLines?: number;
+  readonly title?: string;
+}
+
+const DEFAULT_VIEWPORT_LINES = 30;
+
+function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  const h = String(d.getHours()).padStart(2, "0");
+  const m = String(d.getMinutes()).padStart(2, "0");
+  const s = String(d.getSeconds()).padStart(2, "0");
+  return `${h}:${m}:${s}`;
+}
+
+export const LogViewport: React.NamedExoticComponent<LogViewportProps> = React.memo(
+  function LogViewport({
+    buffer,
+    paused,
+    filter,
+    scrollOffset,
+    viewportLines = DEFAULT_VIEWPORT_LINES,
+    title,
+  }: LogViewportProps): React.ReactNode {
+    // Re-render on buffer flush
+    const [, setTick] = useState(0);
+    useEffect(() => {
+      const listener = (): void => setTick((t) => t + 1);
+      buffer.subscribe(listener);
+      return () => buffer.unsubscribe(listener);
+    }, [buffer]);
+
+    // Capture/release frozen snapshot at pause edges
+    const frozenRef = useRef<readonly LogLine[] | null>(null);
+    useEffect(() => {
+      if (paused) {
+        frozenRef.current = buffer.toArray();
+      } else {
+        frozenRef.current = null;
+      }
+    }, [paused, buffer]);
+
+    // Source lines (live or frozen)
+    const allLines: readonly LogLine[] = paused
+      ? (frozenRef.current ?? buffer.toArray())
+      : buffer.slice(0, buffer.size);
+
+    // Apply substring filter (view-only)
+    const visible = useMemo<readonly LogLine[]>(() => {
+      if (!filter) return allLines;
+      return allLines.filter((l) => l.line.includes(filter));
+    }, [allLines, filter]);
+
+    // Viewport slice
+    const total = visible.length;
+    const end = Math.max(0, total - scrollOffset);
+    const start = Math.max(0, end - viewportLines);
+    const displayLines = visible.slice(start, end);
+
+    const isAutoScroll = scrollOffset === 0;
+    const matchCountChip = filter ? `${visible.length}/${allLines.length}` : "";
+
+    return (
+      <box flexDirection="column" flexGrow={1}>
+        <box flexDirection="row" paddingX={1}>
+          <text color={theme.focus} bold>
+            {title ?? `session: ${buffer.sessionId}`}
+          </text>
+          <text color={theme.secondary}>
+            {` | ${allLines.length} lines | auto: ${isAutoScroll ? "ON" : `OFF (${scrollOffset}↑)`}`}
+          </text>
+          {filter && (
+            <text color={theme.warning}>
+              {` | /${filter} (${matchCountChip})`}
+            </text>
+          )}
+          {paused && (
+            <text color={theme.warning} bold>
+              {" | ❚❚ PAUSED"}
+            </text>
+          )}
+        </box>
+        {displayLines.length === 0 ? (
+          <box paddingX={1}>
+            <text color={theme.secondary}>
+              {filter ? "(no matching lines)" : "(no output yet)"}
+            </text>
+          </box>
+        ) : (
+          <box flexDirection="column" paddingX={1}>
+            {displayLines.map((line, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: log lines have no stable identity
+              <box key={i} flexDirection="row">
+                <text color={theme.disabled}>{formatTimestamp(line.ts)} </text>
+                <text opacity={line.historical ? 0.5 : 1}>{line.line}</text>
+              </box>
+            ))}
+          </box>
+        )}
+      </box>
+    );
+  },
+);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/tui/components/log-viewport.test.tsx`
+Expected: all four tests PASS.
+
+- [ ] **Step 5: Run the typechecker**
+
+Run: `tsc --noEmit`
+Expected: no errors in the new files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui/components/log-viewport.tsx src/tui/components/log-viewport.test.tsx
+git commit -m "feat(tui): add LogViewport pure component (#310)
+
+Subscribes to AgentLogBuffer and renders viewport slice with substring
+filter (view-only), pause-freeze (snapshot at pause edge), and
+autoscroll (scrollOffset=0 sticks to tail). No keyboard input."
+```
+
+---
+
+## Task 4: `<LogView>` controlled wrapper
+
+**Files:**
+- Create: `src/tui/views/log-view.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/tui/views/log-view.test.tsx`:
+
+```tsx
+/**
+ * Tests for <LogView>: prop wiring and rendering. State (paused, filter,
+ * scrollOffset) is controlled by the parent; LogView just forwards to
+ * <LogViewport>. Keyboard dispatch lives in running-keyboard.ts and is
+ * exercised in its own test suite.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { AgentLogBuffer } from "../data/agent-log-buffer.js";
+import { LogView } from "./log-view.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function makeBuffer(n: number): AgentLogBuffer {
+  const buf = new AgentLogBuffer("coder", "sess-lv", 10_000, 50);
+  for (let i = 0; i < n; i++) {
+    buf.push({ ts: i, line: `line-${i}`, type: "output" });
+  }
+  return buf;
+}
+
+describe("LogView", () => {
+  test("renders nothing useful when buffer is undefined", async () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogView
+            sessionId="missing"
+            buffer={undefined}
+            paused={false}
+            filter=""
+            filterMode={false}
+            scrollOffset={0}
+          />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("No log buffer");
+    renderer.unmount();
+  });
+
+  test("forwards state to LogViewport: pause badge shown when paused=true", async () => {
+    const buf = makeBuffer(10);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogView
+            sessionId="sess-lv"
+            buffer={buf}
+            paused={true}
+            filter=""
+            filterMode={false}
+            scrollOffset={0}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("PAUSED");
+    renderer.unmount();
+    buf.dispose();
+  });
+
+  test("filterMode renders the filter prompt", async () => {
+    const buf = makeBuffer(5);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogView
+            sessionId="sess-lv"
+            buffer={buf}
+            paused={false}
+            filter="abc"
+            filterMode={true}
+            scrollOffset={0}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    // Filter prompt is visible
+    expect(flat).toContain("filter:");
+    expect(flat).toContain("abc");
+    renderer.unmount();
+    buf.dispose();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/tui/views/log-view.test.tsx`
+Expected: all FAIL — `LogView` module does not exist.
+
+- [ ] **Step 3: Implement `<LogView>`**
+
+Create `src/tui/views/log-view.tsx`:
+
+```tsx
+/**
+ * LogView — single-session live log tail (issue #310).
+ *
+ * Controlled component: state (paused, filter, filterMode, scrollOffset) is
+ * owned by the parent (running-view) and mutated by the central keyboard
+ * dispatcher (running-keyboard.ts). LogView is the bridge between that state
+ * and the pure <LogViewport> renderer.
+ *
+ * Renders an "filter:" prompt line when filterMode is true, otherwise just
+ * the viewport.
+ */
+
+import React from "react";
+import type { AgentLogBuffer } from "../data/agent-log-buffer.js";
+import { LogViewport } from "../components/log-viewport.js";
+import { theme } from "../theme.js";
+
+export interface LogViewProps {
+  readonly sessionId: string;
+  /** Pre-resolved buffer for this session/role. Caller owns lifecycle. */
+  readonly buffer: AgentLogBuffer | undefined;
+  readonly paused: boolean;
+  readonly filter: string;
+  readonly filterMode: boolean;
+  readonly scrollOffset: number;
+  readonly viewportLines?: number;
+}
+
+export const LogView: React.NamedExoticComponent<LogViewProps> = React.memo(
+  function LogView({
+    sessionId,
+    buffer,
+    paused,
+    filter,
+    filterMode,
+    scrollOffset,
+    viewportLines,
+  }: LogViewProps): React.ReactNode {
+    if (!buffer) {
+      return (
+        <box flexDirection="column" paddingX={1}>
+          <text color={theme.secondary}>{`No log buffer for ${sessionId}`}</text>
+        </box>
+      );
+    }
+    return (
+      <box flexDirection="column" flexGrow={1}>
+        {filterMode && (
+          <box flexDirection="row" paddingX={1}>
+            <text color={theme.focus}>filter: </text>
+            <text>{filter}</text>
+            <text color={theme.focus}>_</text>
+          </box>
+        )}
+        <LogViewport
+          buffer={buffer}
+          paused={paused}
+          filter={filter}
+          scrollOffset={scrollOffset}
+          {...(viewportLines !== undefined ? { viewportLines } : {})}
+        />
+      </box>
+    );
+  },
+);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/tui/views/log-view.test.tsx`
+Expected: all three tests PASS.
+
+- [ ] **Step 5: Run typechecker**
+
+Run: `tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui/views/log-view.tsx src/tui/views/log-view.test.tsx
+git commit -m "feat(tui): add LogView controlled wrapper (#310)
+
+Bridges parent-owned state (paused, filter, filterMode, scrollOffset)
+to <LogViewport>. Shows filter input prompt when filterMode=true.
+Renders 'No log buffer' fallback when buffer is missing."
+```
+
+---
+
+## Task 5: Refactor `<TracePane>` to reuse `<LogViewport>`
+
+**Files:**
+- Modify: `src/tui/views/trace-pane.tsx`
+
+**Background:** `<TracePane>` currently inlines viewport slicing (`getViewportLines`), header rendering (line count, auto-scroll state), and the buffer subscription (`useEffect` with `setTick`). All three responsibilities are now in `<LogViewport>`. Replacing the right column with `<LogViewport buffer={selectedBuffer} paused={false} filter="" scrollOffset={traceScrollOffset} />` removes the duplication. The left column (agent list) is unchanged.
+
+- [ ] **Step 1: Read the current `trace-pane.tsx`**
+
+Run: `cat src/tui/views/trace-pane.tsx`
+
+Expected content: see file in repo. Note lines 80-90 (buffer subscribe), 117-128 (`getViewportLines`), 157-185 (right column header + render).
+
+- [ ] **Step 2: Replace the right column with `<LogViewport>`**
+
+Edit `src/tui/views/trace-pane.tsx`:
+
+Add to imports at the top, alongside the existing `import type { AgentLogBuffer, LogLine }`:
+
+```tsx
+import { LogViewport } from "../components/log-viewport.js";
+```
+
+`LogLine` is no longer used directly; remove it from the type import if your linter flags it:
+
+```tsx
+import type { AgentLogBuffer } from "../data/agent-log-buffer.js";
+```
+
+Remove the now-unused buffer subscription:
+
+```tsx
+  // DELETE these lines (≈80-90):
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!selectedBuffer) return;
+    const listener = () => setTick((t) => t + 1);
+    selectedBuffer.subscribe(listener);
+    return () => selectedBuffer.unsubscribe(listener);
+  }, [selectedBuffer]);
+```
+
+Remove the `getViewportLines` callback and `displayLines`/`isAutoScroll`/`totalLines` locals:
+
+```tsx
+  // DELETE these lines (≈117-128):
+  const getViewportLines = useCallback((): LogLine[] => { /* ... */ }, [...]);
+  const displayLines = getViewportLines();
+  const isAutoScroll = traceScrollOffset === 0;
+  const totalLines = selectedBuffer?.size ?? 0;
+```
+
+Remove the now-unused `useCallback`, `useEffect`, `useState`, `formatTimestamp` imports/helpers if they have no other use. Keep `React.memo`.
+
+Replace the right column JSX (the second top-level `<box>` inside the row) with:
+
+```tsx
+        {/* Right: trace output */}
+        <box
+          flexDirection="column"
+          flexGrow={1}
+          borderStyle="round"
+          borderColor={theme.focus}
+        >
+          {selectedBuffer ? (
+            <LogViewport
+              buffer={selectedBuffer}
+              paused={false}
+              filter=""
+              scrollOffset={traceScrollOffset}
+              viewportLines={viewportLines}
+              title={`${selectedRole ?? "—"} trace`}
+            />
+          ) : (
+            <box paddingX={1}>
+              <text color={theme.secondary}>(no agent selected)</text>
+            </box>
+          )}
+        </box>
+```
+
+- [ ] **Step 3: Run existing TracePane tests**
+
+There is no dedicated TracePane test file; verify the trace pane is still rendered correctly by running the full TUI test suite:
+
+Run: `bun test src/tui/`
+Expected: all tests pass. Pay attention to anything in `running-view*.test.tsx` that may exercise trace pane mounting.
+
+- [ ] **Step 4: Run typechecker**
+
+Run: `tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/views/trace-pane.tsx
+git commit -m "refactor(tui): TracePane right column uses LogViewport (#310)
+
+Replaces inlined viewport slicing, header rendering, and buffer
+subscription with the shared <LogViewport> component. Behavior
+unchanged (paused=false, no filter, same scroll model). Left agent
+list untouched."
+```
+
+---
+
+## Task 6: Wire LogView state into the central keyboard dispatcher
+
+**Files:**
+- Modify: `src/tui/screens/running-keyboard.ts`
+- Modify: `src/tui/screens/running-view.tsx`
+
+**Background:** The existing `running-keyboard.ts` exposes a state shape with `expandedPanel`, `traceScrollOffset`, etc. and methods like `traceScrollDown`, `traceScrollUp`, `traceScrollToBottom`, `traceScrollToTop`. Add the LogView siblings.
+
+- [ ] **Step 1: Open `running-keyboard.ts`**
+
+Run: `grep -n "traceScrollDown\|traceScrollUp\|traceScrollToBottom\|traceScrollToTop\|filterQuery" src/tui/screens/running-keyboard.ts`
+
+Note line numbers for the corresponding state fields and handler definitions; you will add `log*` siblings next to them.
+
+- [ ] **Step 2: Add LogView state fields**
+
+In the state-shape interface (near the existing `traceScrollOffset` and `filterQuery` definitions), add:
+
+```ts
+  /** LogView (#310) — pause/filter/scroll state. */
+  readonly logPaused: boolean;
+  readonly logFilter: string;
+  readonly logFilterMode: boolean;
+  readonly logScrollOffset: number;
+```
+
+In the handler interface (near `traceScrollDown` etc.), add:
+
+```ts
+  /** LogView (#310) handlers. */
+  readonly logTogglePause: () => void;
+  readonly logScrollDown: () => void;
+  readonly logScrollUp: () => void;
+  readonly logScrollToBottom: () => void;
+  readonly logScrollToTop: () => void;
+  readonly logEnterFilterMode: () => void;
+  readonly logCommitFilter: () => void;
+  readonly logCancelFilter: () => void;
+  readonly logFilterAppend: (ch: string) => void;
+  readonly logFilterBackspace: () => void;
+```
+
+- [ ] **Step 3: Add reducers**
+
+In the same file, add reducers next to the existing `traceScroll*` reducers. For each handler in step 2 add the corresponding state transition. Example for `logTogglePause`:
+
+```ts
+function logTogglePause(state: RunningKeyboardState): RunningKeyboardState {
+  return { ...state, logPaused: !state.logPaused };
+}
+
+function logScrollDown(state: RunningKeyboardState): RunningKeyboardState {
+  return { ...state, logScrollOffset: Math.max(0, state.logScrollOffset - 1) };
+}
+
+function logScrollUp(state: RunningKeyboardState): RunningKeyboardState {
+  return { ...state, logScrollOffset: state.logScrollOffset + 1 };
+}
+
+function logScrollToBottom(state: RunningKeyboardState): RunningKeyboardState {
+  return { ...state, logScrollOffset: 0 };
+}
+
+function logScrollToTop(state: RunningKeyboardState): RunningKeyboardState {
+  // A large enough offset that the viewport clamps to the top of the buffer.
+  // LogViewport clamps internally via `Math.max(0, end - viewportLines)`.
+  return { ...state, logScrollOffset: Number.MAX_SAFE_INTEGER };
+}
+
+function logEnterFilterMode(state: RunningKeyboardState): RunningKeyboardState {
+  return { ...state, logFilterMode: true };
+}
+
+function logCommitFilter(state: RunningKeyboardState): RunningKeyboardState {
+  return { ...state, logFilterMode: false };
+}
+
+function logCancelFilter(state: RunningKeyboardState): RunningKeyboardState {
+  return { ...state, logFilterMode: false, logFilter: "" };
+}
+
+function logFilterAppend(state: RunningKeyboardState, ch: string): RunningKeyboardState {
+  return { ...state, logFilter: state.logFilter + ch };
+}
+
+function logFilterBackspace(state: RunningKeyboardState): RunningKeyboardState {
+  return { ...state, logFilter: state.logFilter.slice(0, -1) };
+}
+```
+
+(If `RunningKeyboardState` is not the actual state type name, use whatever the file uses.)
+
+- [ ] **Step 4: Initial state**
+
+Find the initial-state literal (typically near `traceScrollOffset: 0`) and add:
+
+```ts
+  logPaused: false,
+  logFilter: "",
+  logFilterMode: false,
+  logScrollOffset: 0,
+```
+
+- [ ] **Step 5: Key dispatch**
+
+Find the key-switch that maps input keys to handlers (where `space`, `j`, `k`, `G`, `g`, etc. are handled near line 220 and 249). Add a "log panel active" branch that mirrors the trace branch:
+
+```ts
+// Inside the active-panel === "logs" (or whatever the LogView panel id is) branch:
+if (logFilterMode) {
+  if (input === "return") { return logCommitFilter(state); }
+  if (input === "escape") { return logCancelFilter(state); }
+  if (input === "backspace") { return logFilterBackspace(state); }
+  if (input.length === 1) { return logFilterAppend(state, input); }
+  return state;
+}
+
+switch (input) {
+  case "space": return logTogglePause(state);
+  case "/": return logEnterFilterMode(state);
+  case "j":
+  case "down": return logScrollDown(state);
+  case "k":
+  case "up": return logScrollUp(state);
+  case "G": return logScrollToBottom(state);
+  case "g": /* handle gg pair via existing pending-prefix mechanism, or do single g = top */
+    return logScrollToTop(state);
+  default: return state;
+}
+```
+
+(Use the file's actual dispatch shape — switch, if-chain, or table.)
+
+If the file does not yet have a "logs" panel id, see Step 7 below where `RunningPanel` gets a `"logs"` member.
+
+- [ ] **Step 6: Add the `"logs"` panel id**
+
+Open `src/tui/panels/panel-registry.ts` (the file referenced at running-keyboard.ts:11). Locate the `RunningPanel` union/enum and add `"logs"` next to the existing terminal panel id:
+
+```ts
+export type RunningPanel = /* existing members */ | "logs";
+```
+
+(If the union already includes `"terminal"`, the `"logs"` panel is the same logical slot — see Task 7 for the mount-time selection.)
+
+- [ ] **Step 7: Wire props through to `<LogView>` in `running-view.tsx`**
+
+In `src/tui/screens/running-view.tsx`, where `<TerminalView>` is mounted (search for `<TerminalView`), import `LogView`:
+
+```tsx
+import { LogView } from "../views/log-view.js";
+```
+
+Add a feature gate: select `<LogView>` when the agent session was launched via ACPX, otherwise keep `<TerminalView>`. Locate the active session object (`spawnManager.getSession(role)` or similar — exact accessor depends on local code) and check `session?.runtime === "acpx"`:
+
+```tsx
+const useLogView = activeSession?.runtime === "acpx";
+const buffer = logBuffers?.get(activeRole);
+
+return useLogView ? (
+  <LogView
+    sessionId={buffer?.sessionId ?? activeRole ?? ""}
+    buffer={buffer}
+    paused={kbState.logPaused}
+    filter={kbState.logFilter}
+    filterMode={kbState.logFilterMode}
+    scrollOffset={kbState.logScrollOffset}
+  />
+) : (
+  <TerminalView /* existing props */ />
+);
+```
+
+Use the variable name your file uses for the keyboard state (`kbState`, `runningKb`, `keyboard.state`, etc.).
+
+If `session.runtime` is not exposed in the codebase yet, use a feature flag instead: `const useLogView = process.env.GROVE_LOGVIEW === "1";` — and TODO note the proper gate as a follow-up.
+
+- [ ] **Step 8: Run the full test suite**
+
+Run: `bun test src/tui/`
+Expected: all tests pass. If `running-keyboard.test.ts` exercises state-shape exhaustively, the new fields must have explicit defaults — verify the initial-state literal in Step 4.
+
+- [ ] **Step 9: Run typechecker**
+
+Run: `tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 10: Run lint**
+
+Run: `biome check src/tui/screens/running-keyboard.ts src/tui/screens/running-view.tsx src/tui/views/log-view.tsx src/tui/components/log-viewport.tsx src/tui/panels/panel-registry.ts`
+Expected: clean.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/tui/screens/running-keyboard.ts src/tui/screens/running-view.tsx src/tui/panels/panel-registry.ts
+git commit -m "feat(tui): wire LogView keyboard dispatch (#310)
+
+Adds logPaused, logFilter, logFilterMode, logScrollOffset to the
+running-keyboard state, with reducers and key dispatch matching the
+issue spec (space pause, /foo filter, j/k scroll, G/gg jump). Mounts
+<LogView> in place of <TerminalView> for ACPX sessions in running-view."
+```
+
+---
+
+## Task 7: Issue link and final sweep
+
+- [ ] **Step 1: Run the whole TUI test suite once more**
+
+Run: `bun test src/tui/`
+Expected: every test passes, no skipped suites added by this work.
+
+- [ ] **Step 2: Run typecheck and lint together**
+
+Run: `tsc --noEmit && biome check src/tui/`
+Expected: clean.
+
+- [ ] **Step 3: Final commit (only if anything changed)**
+
+If steps 1–2 surfaced any fixups, fold them into a final commit:
+
+```bash
+git add -u
+git commit -m "chore(tui): typecheck/lint sweep for #310"
+```
+
+If nothing changed, skip this step.
+
+- [ ] **Step 4: Verify the issue acceptance criteria**
+
+Walk through the three acceptance bullets manually:
+
+1. **1k lines/sec no drops** — covered by `src/tui/data/agent-log-buffer.backpressure.test.ts` (Task 2).
+2. **`space` pauses** — covered by `src/tui/components/log-viewport.test.tsx` (Task 3) + reducer test path through `logTogglePause` (Task 6).
+3. **`/foo` filters tail buffer** — covered by `src/tui/components/log-viewport.test.tsx` filter test (Task 3) + reducer path (Task 6).
+
+If any criterion is not transparently covered, add a test before declaring the issue done.
+
+---
+
+## Self-review notes
+
+**Spec coverage check:**
+- Acceptance #1 (1k/sec no drops) → Task 2 backpressure test
+- Acceptance #2 (space pauses) → Task 3 viewport pause test + Task 6 reducer
+- Acceptance #3 (/foo filter) → Task 3 viewport filter test + Task 6 reducer
+- Architecture unit 1 (`AgentLogBuffer.flushMs`) → Task 1
+- Architecture unit 2 (`LogViewport`) → Task 3
+- Architecture unit 3 (`LogView`) → Task 4
+- TracePane refactor → Task 5
+- Mount swap in running-view → Task 6 step 7
+- Keyboard dispatch → Task 6 steps 1–5
+
+**Known imprecisions (resolved during implementation, not by the planner):**
+- Task 6 references symbols (`RunningKeyboardState`, `kbState`, `activeSession.runtime`) by likely names — the exact identifiers are defined in `running-keyboard.ts` / `running-view.tsx` and must be matched on the spot. A `grep` in the file is enough to confirm.
+- Task 6 step 7 falls back to a `GROVE_LOGVIEW` env flag if `session.runtime` is not exposed; this is explicitly noted as a TODO follow-up gate.
+- Task 6 step 5's "gg pair" handling is delegated to the file's existing pending-prefix mechanism if present; single `g` falls back to "jump to top" which still satisfies acceptance (vim-style `gg` is conventional but not in the issue acceptance).

--- a/docs/superpowers/specs/2026-05-16-310-logview-design.md
+++ b/docs/superpowers/specs/2026-05-16-310-logview-design.md
@@ -1,0 +1,196 @@
+# LogView with backpressure — design
+
+**Issue**: [#310](https://github.com/windoliver/grove/issues/310)
+**Parent epic**: #286 (Polish: Log / Pulse / Hot-Reload)
+**Source roadmap**: `docs/proposals/tui-orchestration-roadmap.md` #17
+**Depends on**: #296 (central store, closed), #301 (EntityView, closed)
+
+## Goal
+
+Live-tail a single agent's stdout in the TUI with bounded memory, lossless ingest, fast filter, and pause/resume — replacing the current tmux-capture-based `<TerminalView>` for ACPX-streamed sessions.
+
+## Acceptance (from issue)
+
+1. 1k lines/sec sustained — no drops (writes always reach the buffer).
+2. `space` pauses rendering; the view stops advancing until resumed.
+3. `/foo` filters the visible tail buffer by substring.
+
+## Non-goals
+
+- ANSI color rendering (current `TerminalView` provides this via xterm-headless; LogView strips ANSI like `AgentLogBuffer` already does). Color support is a follow-up.
+- Regex / multi-line filter — substring only.
+- Persisted filter / pause state across mounts.
+- Per-line type icons beyond the existing classifier output.
+
+## Architecture
+
+Three units, each with one responsibility.
+
+### 1. `AgentLogBuffer` (existing — minor change)
+
+`src/tui/data/agent-log-buffer.ts`
+
+Already lossless: every `push()` writes to the ring buffer synchronously; subscribers are notified at most once per flush window. Only change: constructor takes an optional `flushMs` (default `16`). LogView constructs its buffer with `flushMs: 50` per the acceptance criterion. TracePane keeps the 16ms default.
+
+```ts
+new AgentLogBuffer(role, sessionId, capacity?: number, flushMs?: number)
+```
+
+Default of 16 preserves current TracePane behavior. No other callers touched.
+
+### 2. `LogViewport` (new)
+
+`src/tui/components/log-viewport.tsx`
+
+Pure render component. Subscribes to an `AgentLogBuffer`, slices the viewport, applies a substring filter, dims historical lines, and renders a header (line count, auto-scroll state, filter chip, pause badge). Knows nothing about keyboard or routing.
+
+```ts
+interface LogViewportProps {
+  readonly buffer: AgentLogBuffer;
+  readonly paused: boolean;
+  readonly filter: string;          // empty = no filter
+  readonly scrollOffset: number;    // 0 = autoscroll
+  readonly viewportLines?: number;  // default: rows - chrome
+  readonly title?: string;          // header label
+}
+```
+
+Behavior:
+
+- Re-renders on `buffer.subscribe()` notify (coalesced by the buffer's flush).
+- When `paused`, captures a `frozenLines` snapshot via `buffer.toArray()` once at the pause edge and renders from it until unpaused.
+- Filter applies to the (live or frozen) sliced lines: `lines.filter(l => l.line.includes(filter))`. View-only — buffer is not mutated. Match-count is shown in the header as `42/1.2k` when the filter is non-empty.
+- Autoscroll: when `scrollOffset === 0`, the slice ends at `buffer.size`. Any positive offset pins the view.
+- Historical lines (`line.historical === true`) render dimmed.
+
+### 3. `LogView` (new)
+
+`src/tui/views/log-view.tsx`
+
+Stateful wrapper. Owns:
+
+- buffer lookup by `sessionId` (reads from the running-view's existing `Map<role, AgentLogBuffer>`),
+- local state: `paused`, `filterText`, `filterMode` (input-active flag), `scrollOffset`,
+- keyboard handlers (registered through the same keymap surface as other views).
+
+```ts
+interface LogViewProps {
+  readonly sessionId: string;
+  readonly buffer: AgentLogBuffer;   // pre-resolved by caller; LogView does not manage lifecycle
+  readonly active: boolean;
+  readonly mode: InputMode;
+}
+```
+
+Delegates render to `<LogViewport>`.
+
+### 4. TracePane refactor
+
+`src/tui/views/trace-pane.tsx`
+
+Right-hand trace column replaced with `<LogViewport>`. Left-hand agent list, status icons, and scroll math are unchanged. This eliminates the duplicated viewport-slicing block at trace-pane.tsx:117-128 and the duplicated header rendering at trace-pane.tsx:157-169.
+
+### 5. Mount swap
+
+`src/tui/views/running-view.tsx` (and the agent-split-pane that hosts `TerminalView`)
+
+Where the running-view currently mounts `<TerminalView sessionName>`, mount `<LogView sessionId>` instead **when the agent was launched through ACPX** (the SSE-streamed path that produces real per-line log file output). For tmux-managed legacy sessions where only `tmux.capturePanes` is available, keep `<TerminalView>` as fallback — those sessions don't have a line-stream source and would render empty in LogView.
+
+Selection signal: the existing `spawnManager` already distinguishes acpx vs tmux sessions (see `src/tui/spawn-manager.ts`); LogView is selected when `session.runtime === "acpx"` (or equivalent — exact field confirmed during implementation).
+
+## Data flow
+
+```
+ACPX log file (or acp.message SSE event)
+   │  existing path: pollLogFile() / pushRawLines()
+   ▼
+AgentLogBuffer (ring, lossless, 50ms notify coalesce)
+   │  subscribe()
+   ▼
+LogViewport ──┬─ if !paused: read buffer.slice(start, end)
+              │  if paused:  read frozen snapshot taken at pause edge
+              ▼
+           substring filter (view-only) → render
+```
+
+Writes are never blocked. Flush is just a notify cadence. Pause does not detach the SSE/ingest path — only freezes the render snapshot.
+
+## Keyboard
+
+LogView installs handlers when `active && mode === "terminal"`:
+
+| Key | Action |
+|-----|--------|
+| `space` | Toggle pause. Captures `frozenLines = buffer.toArray()` on pause edge; clears it on resume. |
+| `/` | Enter filter-input sub-mode. Cursor moves to one-line filter prompt in the header. |
+| `Enter` (filter sub-mode) | Commit filter text; exit sub-mode. |
+| `Esc` (filter sub-mode) | Clear filter text; exit sub-mode. |
+| `j` / `↓` | Scroll one line up (increases `scrollOffset`). |
+| `k` / `↑` | Scroll one line down (decreases `scrollOffset`, clamped at 0). |
+| `G` | Jump to bottom: `scrollOffset = 0`, resumes autoscroll. |
+| `g g` | Jump to top: `scrollOffset = buffer.size - viewportLines`. |
+
+Filter sub-mode swallows printable keys into `filterText`; outside the sub-mode, all keys above behave normally. Keys are dispatched from the existing `src/tui/screens/running-keyboard.ts` switch when the active panel resolves to the log view (same pattern the trace pane and terminal panel already use). LogView exposes setters via context or props so the central handler can mutate its state without LogView owning input subscription.
+
+Header layout:
+
+```
+session: coder-abc123 │ 1.2k lines │ auto: ON │ /foo (42 matches) │ ❚❚ PAUSED
+```
+
+## Error handling
+
+- Missing `buffer` (sessionId not in the map): render `<EmptyState title="No log buffer for <sessionId>" />` — same component used elsewhere in the TUI.
+- `buffer.toArray()` on pause is O(buffer.size); capacity is bounded (default 10k) so this is safe.
+- Filter input never throws — pure substring match on stripped text.
+
+## Testing
+
+Three new test files (each follows existing patterns under `src/tui/views/` and `src/tui/components/`):
+
+1. **`src/tui/components/log-viewport.test.tsx`** — render correctness.
+   - Mounts with a fixture buffer; asserts viewport slicing at various `scrollOffset` values.
+   - Asserts filter masks non-matching lines and updates the match-count badge.
+   - Asserts pause-freeze: pushing new lines after `paused=true` does not change rendered output.
+   - Asserts autoscroll re-clamps to bottom on buffer growth when `scrollOffset === 0`.
+
+2. **`src/tui/views/log-view.test.tsx`** — keyboard wiring.
+   - Simulates `space` → asserts `paused` toggles and frozen snapshot is taken.
+   - Simulates `/foo<Enter>` → asserts filter is applied and sub-mode exits.
+   - Simulates `j` / `k` → asserts `scrollOffset` increments/decrements.
+   - Simulates `G` → asserts `scrollOffset === 0` and autoscroll resumes.
+
+3. **`src/tui/data/agent-log-buffer.backpressure.test.ts`** — acceptance test for the "1k lines/sec no drops" criterion.
+   - Push 1000 lines synchronously into a buffer constructed with `flushMs: 50`.
+   - Assert `buffer.size === 1000` (every write applied — lossless).
+   - Assert subscriber `listener` fired `≤ ceil(elapsed_ms / 50) + 1` times (coalesced — not 1000 renders).
+
+No new test infrastructure. Uses existing `@opentui/testing` setup that already powers `entity-view.test.tsx`.
+
+## Risks and mitigations
+
+- **Losing ANSI colors for ACPX sessions.** Current `TerminalView` provides full xterm color rendering; LogView strips ANSI. Mitigation: scope the mount swap to ACPX paths only on first landing; revisit color rendering in a follow-up. Document this in the running-view comment where the swap happens.
+- **`AgentLogBuffer` constructor signature change.** Adding an optional `flushMs` parameter could surprise external callers. Mitigation: default is 16 (current behavior); audit existing call sites during implementation and verify no breakage.
+- **Pause snapshot allocates `buffer.size` array.** At default 10k capacity, that's 10k object refs — cheap. If capacity grows, revisit with a copy-on-write view. Out of scope here.
+
+## Out of scope (explicit)
+
+- ANSI/xterm color rendering in LogView.
+- Regex filter.
+- Filter persistence across sessions or remounts.
+- Pulse dashboard (#308), hot-reload (#289) — sibling issues under epic #286.
+
+## Files
+
+New:
+- `src/tui/components/log-viewport.tsx`
+- `src/tui/components/log-viewport.test.tsx`
+- `src/tui/views/log-view.tsx`
+- `src/tui/views/log-view.test.tsx`
+- `src/tui/data/agent-log-buffer.backpressure.test.ts`
+
+Modified:
+- `src/tui/data/agent-log-buffer.ts` — add `flushMs` constructor arg, default 16
+- `src/tui/views/trace-pane.tsx` — use `<LogViewport>` for the right pane
+- `src/tui/views/running-view.tsx` (and `src/tui/components/agent-split-pane.tsx`) — swap `<TerminalView>` → `<LogView>` for ACPX sessions
+- `src/tui/screens/running-keyboard.ts` — add LogView key handling branch (`space`, `/`, `j`/`k`, `G`, `g g`) gated on the active panel being the log view

--- a/src/tui/components/log-viewport.test.tsx
+++ b/src/tui/components/log-viewport.test.tsx
@@ -112,4 +112,37 @@ describe("LogViewport", () => {
     renderer.unmount();
     buf.dispose();
   });
+
+  test("autoscroll re-clamps to bottom when buffer grows with scrollOffset=0", async () => {
+    const buf = makeBuffer(10);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogViewport buffer={buf} paused={false} filter="" scrollOffset={0} viewportLines={5} />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+
+    // Initial viewport tail: line-5..line-9.
+    let flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("line-9");
+
+    // Push new lines while autoscroll is on; viewport must advance.
+    await act(async () => {
+      buf.push({ ts: 100, line: "line-fresh-A", type: "output" });
+      buf.push({ ts: 101, line: "line-fresh-B", type: "output" });
+      await new Promise((r) => setTimeout(r, 80));
+    });
+
+    flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("line-fresh-A");
+    expect(flat).toContain("line-fresh-B");
+    // Tail advanced: line-5 should have fallen off the 5-line viewport.
+    expect(flat).not.toContain("line-5");
+
+    renderer.unmount();
+    buf.dispose();
+  });
 });

--- a/src/tui/components/log-viewport.test.tsx
+++ b/src/tui/components/log-viewport.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Render correctness tests for <LogViewport>: viewport slicing, filter,
+ * pause-freeze, autoscroll re-clamp. Pure component — no SSE.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { AgentLogBuffer } from "../data/agent-log-buffer.js";
+import { LogViewport } from "./log-viewport.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function makeBuffer(n: number, flushMs = 50): AgentLogBuffer {
+  const buf = new AgentLogBuffer("coder", "sess-vp", 10_000, flushMs);
+  for (let i = 0; i < n; i++) {
+    buf.push({ ts: i, line: `line-${i}`, type: "output" });
+  }
+  return buf;
+}
+
+describe("LogViewport", () => {
+  test("renders the last `viewportLines` lines when scrollOffset=0", async () => {
+    const buf = makeBuffer(100);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogViewport
+            buffer={buf}
+            paused={false}
+            filter=""
+            scrollOffset={0}
+            viewportLines={5}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("line-95");
+    expect(flat).toContain("line-99");
+    expect(flat).not.toContain("line-94");
+    renderer.unmount();
+    buf.dispose();
+  });
+
+  test("scrollOffset>0 pins viewport above the tail", async () => {
+    const buf = makeBuffer(100);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogViewport
+            buffer={buf}
+            paused={false}
+            filter=""
+            scrollOffset={10}
+            viewportLines={5}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("line-85");
+    expect(flat).toContain("line-89");
+    expect(flat).not.toContain("line-90");
+    renderer.unmount();
+    buf.dispose();
+  });
+
+  test("filter restricts to matching lines and shows match count", async () => {
+    const buf = new AgentLogBuffer("coder", "sess-f", 10_000, 50);
+    buf.push({ ts: 0, line: "apple pie", type: "output" });
+    buf.push({ ts: 1, line: "banana bread", type: "output" });
+    buf.push({ ts: 2, line: "apple cider", type: "output" });
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogViewport
+            buffer={buf}
+            paused={false}
+            filter="apple"
+            scrollOffset={0}
+            viewportLines={10}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("apple pie");
+    expect(flat).toContain("apple cider");
+    expect(flat).not.toContain("banana bread");
+    expect(flat).toContain("2/3");
+    renderer.unmount();
+    buf.dispose();
+  });
+
+  test("paused=true freezes the rendered tail despite new pushes", async () => {
+    const buf = makeBuffer(10);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogViewport
+            buffer={buf}
+            paused={true}
+            filter=""
+            scrollOffset={0}
+            viewportLines={5}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+
+    await act(async () => {
+      buf.push({ ts: 100, line: "line-99-after-pause", type: "output" });
+      await new Promise((r) => setTimeout(r, 80));
+    });
+
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("line-5");
+    expect(flat).toContain("line-9");
+    expect(flat).not.toContain("after-pause");
+    expect(flat).toContain("PAUSED");
+    renderer.unmount();
+    buf.dispose();
+  });
+});

--- a/src/tui/components/log-viewport.test.tsx
+++ b/src/tui/components/log-viewport.test.tsx
@@ -26,13 +26,7 @@ describe("LogViewport", () => {
     await act(async () => {
       renderer = TestRenderer.create(
         (
-          <LogViewport
-            buffer={buf}
-            paused={false}
-            filter=""
-            scrollOffset={0}
-            viewportLines={5}
-          />
+          <LogViewport buffer={buf} paused={false} filter="" scrollOffset={0} viewportLines={5} />
         ) as React.ReactElement,
       );
       await new Promise((r) => setTimeout(r, 80));
@@ -51,13 +45,7 @@ describe("LogViewport", () => {
     await act(async () => {
       renderer = TestRenderer.create(
         (
-          <LogViewport
-            buffer={buf}
-            paused={false}
-            filter=""
-            scrollOffset={10}
-            viewportLines={5}
-          />
+          <LogViewport buffer={buf} paused={false} filter="" scrollOffset={10} viewportLines={5} />
         ) as React.ReactElement,
       );
       await new Promise((r) => setTimeout(r, 80));
@@ -105,13 +93,7 @@ describe("LogViewport", () => {
     await act(async () => {
       renderer = TestRenderer.create(
         (
-          <LogViewport
-            buffer={buf}
-            paused={true}
-            filter=""
-            scrollOffset={0}
-            viewportLines={5}
-          />
+          <LogViewport buffer={buf} paused={true} filter="" scrollOffset={0} viewportLines={5} />
         ) as React.ReactElement,
       );
       await new Promise((r) => setTimeout(r, 80));

--- a/src/tui/components/log-viewport.tsx
+++ b/src/tui/components/log-viewport.tsx
@@ -83,11 +83,7 @@ export const LogViewport: React.NamedExoticComponent<LogViewportProps> = React.m
           <text color={theme.secondary}>
             {` | ${allLines.length} lines | auto: ${isAutoScroll ? "ON" : `OFF (${scrollOffset}↑)`}`}
           </text>
-          {filter && (
-            <text color={theme.warning}>
-              {` | /${filter} (${matchCountChip})`}
-            </text>
-          )}
+          {filter && <text color={theme.warning}>{` | /${filter} (${matchCountChip})`}</text>}
           {paused && (
             <text color={theme.warning} bold>
               {" | ❚❚ PAUSED"}

--- a/src/tui/components/log-viewport.tsx
+++ b/src/tui/components/log-viewport.tsx
@@ -1,0 +1,117 @@
+/**
+ * LogViewport — pure render component for a single agent's log tail.
+ *
+ * Subscribes to an AgentLogBuffer and renders a viewport slice with optional
+ * substring filter, pause-freeze (frozen snapshot taken at the pause edge),
+ * and autoscroll (scrollOffset === 0 means "stick to tail").
+ *
+ * Owns no keyboard input. State (paused, filter, scrollOffset) is supplied by
+ * the parent — typically <LogView> or <TracePane>.
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import type { AgentLogBuffer, LogLine } from "../data/agent-log-buffer.js";
+import { theme } from "../theme.js";
+
+export interface LogViewportProps {
+  readonly buffer: AgentLogBuffer;
+  readonly paused: boolean;
+  readonly filter: string;
+  readonly scrollOffset: number;
+  readonly viewportLines?: number;
+  readonly title?: string;
+}
+
+const DEFAULT_VIEWPORT_LINES = 30;
+
+function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  const h = String(d.getHours()).padStart(2, "0");
+  const m = String(d.getMinutes()).padStart(2, "0");
+  const s = String(d.getSeconds()).padStart(2, "0");
+  return `${h}:${m}:${s}`;
+}
+
+export const LogViewport: React.NamedExoticComponent<LogViewportProps> = React.memo(
+  function LogViewport({
+    buffer,
+    paused,
+    filter,
+    scrollOffset,
+    viewportLines = DEFAULT_VIEWPORT_LINES,
+    title,
+  }: LogViewportProps): React.ReactNode {
+    const [, setTick] = useState(0);
+    useEffect(() => {
+      const listener = (): void => setTick((t) => t + 1);
+      buffer.subscribe(listener);
+      return () => buffer.unsubscribe(listener);
+    }, [buffer]);
+
+    const frozenRef = useRef<readonly LogLine[] | null>(null);
+    useEffect(() => {
+      if (paused) {
+        frozenRef.current = buffer.toArray();
+      } else {
+        frozenRef.current = null;
+      }
+    }, [paused, buffer]);
+
+    const allLines: readonly LogLine[] = paused
+      ? (frozenRef.current ?? buffer.toArray())
+      : buffer.slice(0, buffer.size);
+
+    const visible = useMemo<readonly LogLine[]>(() => {
+      if (!filter) return allLines;
+      return allLines.filter((l) => l.line.includes(filter));
+    }, [allLines, filter]);
+
+    const total = visible.length;
+    const end = Math.max(0, total - scrollOffset);
+    const start = Math.max(0, end - viewportLines);
+    const displayLines = visible.slice(start, end);
+
+    const isAutoScroll = scrollOffset === 0;
+    const matchCountChip = filter ? `${visible.length}/${allLines.length}` : "";
+
+    return (
+      <box flexDirection="column" flexGrow={1}>
+        <box flexDirection="row" paddingX={1}>
+          <text color={theme.focus} bold>
+            {title ?? `session: ${buffer.sessionId}`}
+          </text>
+          <text color={theme.secondary}>
+            {` | ${allLines.length} lines | auto: ${isAutoScroll ? "ON" : `OFF (${scrollOffset}↑)`}`}
+          </text>
+          {filter && (
+            <text color={theme.warning}>
+              {` | /${filter} (${matchCountChip})`}
+            </text>
+          )}
+          {paused && (
+            <text color={theme.warning} bold>
+              {" | ❚❚ PAUSED"}
+            </text>
+          )}
+        </box>
+        {displayLines.length === 0 ? (
+          <box paddingX={1}>
+            <text color={theme.secondary}>
+              {filter ? "(no matching lines)" : "(no output yet)"}
+            </text>
+          </box>
+        ) : (
+          <box flexDirection="column" paddingX={1}>
+            {displayLines.map((line, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: log lines have no stable identity
+              <box key={i} flexDirection="row">
+                <text color={theme.disabled}>{formatTimestamp(line.ts)} </text>
+                <text opacity={line.historical ? 0.5 : 1}>{line.line}</text>
+              </box>
+            ))}
+          </box>
+        )}
+      </box>
+    );
+  },
+);

--- a/src/tui/data/agent-log-buffer.backpressure.test.ts
+++ b/src/tui/data/agent-log-buffer.backpressure.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Acceptance test for issue #310: 1k lines/sec, no drops, coalesced notifies.
+ *
+ * Pushes 1000 lines synchronously into an AgentLogBuffer constructed with
+ * flushMs=50. Asserts:
+ *   - every write reaches the buffer (lossless ingest)
+ *   - subscriber is notified at most ceil(elapsed / 50) + 1 times (coalesced)
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AgentLogBuffer } from "./agent-log-buffer.js";
+
+describe("AgentLogBuffer backpressure (#310)", () => {
+  test("1000 sync pushes: lossless and coalesced at 50ms", async () => {
+    const buf = new AgentLogBuffer("coder", "sess-bp", 10_000, 50);
+    let notifies = 0;
+    buf.subscribe(() => {
+      notifies += 1;
+    });
+
+    const start = Date.now();
+    for (let i = 0; i < 1000; i++) {
+      buf.push({ ts: start + i, line: `line-${i}`, type: "output" });
+    }
+
+    await new Promise((r) => setTimeout(r, 120));
+
+    const elapsedMs = Date.now() - start;
+    const maxNotifies = Math.ceil(elapsedMs / 50) + 1;
+
+    expect(buf.size).toBe(1000);
+    expect(notifies).toBeGreaterThan(0);
+    expect(notifies).toBeLessThanOrEqual(maxNotifies);
+
+    buf.dispose();
+  });
+
+  test("staggered pushes across 200ms: still lossless", async () => {
+    const buf = new AgentLogBuffer("coder", "sess-bp2", 10_000, 50);
+
+    for (let batch = 0; batch < 5; batch++) {
+      for (let i = 0; i < 200; i++) {
+        buf.push({ ts: Date.now(), line: `b${batch}-${i}`, type: "output" });
+      }
+      await new Promise((r) => setTimeout(r, 40));
+    }
+
+    await new Promise((r) => setTimeout(r, 120));
+    expect(buf.size).toBe(1000);
+
+    buf.dispose();
+  });
+});

--- a/src/tui/data/agent-log-buffer.test.ts
+++ b/src/tui/data/agent-log-buffer.test.ts
@@ -313,8 +313,8 @@ describe("clear", () => {
 });
 
 describe("AgentLogBuffer flushMs", () => {
-  test("constructor accepts custom flushMs (50ms) and coalesces notifies", async () => {
-    const buf = new AgentLogBuffer("coder", "sess-flush", 10_000, 50);
+  test("constructor accepts custom flushMs and coalesces notifies", async () => {
+    const buf = new AgentLogBuffer("coder", "sess-flush", 10_000, 100);
     let notifies = 0;
     buf.subscribe(() => {
       notifies += 1;
@@ -325,11 +325,12 @@ describe("AgentLogBuffer flushMs", () => {
     }
     expect(notifies).toBe(0);
 
-    await new Promise((r) => setTimeout(r, 5));
-    await new Promise((r) => setTimeout(r, 20));
+    // Wait well under flushMs=100: notify should not have fired.
+    await new Promise((r) => setTimeout(r, 40));
     expect(notifies).toBe(0);
 
-    await new Promise((r) => setTimeout(r, 40));
+    // Wait past flushMs: notify fires exactly once for the burst.
+    await new Promise((r) => setTimeout(r, 120));
     expect(buf.size).toBe(100);
     expect(notifies).toBe(1);
 
@@ -338,6 +339,8 @@ describe("AgentLogBuffer flushMs", () => {
 
   test("defaults to 16ms when flushMs is not supplied", async () => {
     const buf = new AgentLogBuffer("coder", "sess-default");
+    expect(buf.flushMs).toBe(16);
+
     let notifies = 0;
     buf.subscribe(() => {
       notifies += 1;
@@ -346,5 +349,12 @@ describe("AgentLogBuffer flushMs", () => {
     await new Promise((r) => setTimeout(r, 40));
     expect(notifies).toBe(1);
     buf.dispose();
+  });
+
+  test("invalid flushMs (<=0, NaN, Infinity) falls back to default 16ms", () => {
+    expect(new AgentLogBuffer("a", "s", 100, 0).flushMs).toBe(16);
+    expect(new AgentLogBuffer("a", "s", 100, -5).flushMs).toBe(16);
+    expect(new AgentLogBuffer("a", "s", 100, Number.NaN).flushMs).toBe(16);
+    expect(new AgentLogBuffer("a", "s", 100, Number.POSITIVE_INFINITY).flushMs).toBe(16);
   });
 });

--- a/src/tui/data/agent-log-buffer.test.ts
+++ b/src/tui/data/agent-log-buffer.test.ts
@@ -311,3 +311,40 @@ describe("clear", () => {
     expect(buf.isEmpty).toBe(true);
   });
 });
+
+describe("AgentLogBuffer flushMs", () => {
+  test("constructor accepts custom flushMs (50ms) and coalesces notifies", async () => {
+    const buf = new AgentLogBuffer("coder", "sess-flush", 10_000, 50);
+    let notifies = 0;
+    buf.subscribe(() => {
+      notifies += 1;
+    });
+
+    for (let i = 0; i < 100; i++) {
+      buf.push({ ts: Date.now(), line: `line-${i}`, type: "output" });
+    }
+    expect(notifies).toBe(0);
+
+    await new Promise((r) => setTimeout(r, 5));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(notifies).toBe(0);
+
+    await new Promise((r) => setTimeout(r, 40));
+    expect(buf.size).toBe(100);
+    expect(notifies).toBe(1);
+
+    buf.dispose();
+  });
+
+  test("defaults to 16ms when flushMs is not supplied", async () => {
+    const buf = new AgentLogBuffer("coder", "sess-default");
+    let notifies = 0;
+    buf.subscribe(() => {
+      notifies += 1;
+    });
+    buf.push({ ts: 0, line: "x", type: "output" });
+    await new Promise((r) => setTimeout(r, 40));
+    expect(notifies).toBe(1);
+    buf.dispose();
+  });
+});

--- a/src/tui/data/agent-log-buffer.ts
+++ b/src/tui/data/agent-log-buffer.ts
@@ -2,9 +2,9 @@
  * Per-agent log buffer — composes RingBuffer + IncrementalLogReader.
  *
  * Owns the full trace history for one agent role in one session.
- * Subscribers are notified at most once per 16ms frame (batched flush)
- * to avoid flooding React with re-renders when multiple agents produce
- * output simultaneously.
+ * Subscribers are notified at most once per flushMs window (batched flush,
+ * default 16ms) to avoid flooding React with re-renders when multiple agents
+ * produce output simultaneously.
  *
  * Role and sessionId are stored on the buffer instance, not on each LogLine,
  * to save ~30% memory at 10K lines per agent.
@@ -87,7 +87,7 @@ export class AgentLogBuffer {
   ) {
     this.role = role;
     this.sessionId = sessionId;
-    this.flushMs = flushMs;
+    this.flushMs = Number.isFinite(flushMs) && flushMs > 0 ? flushMs : DEFAULT_FLUSH_INTERVAL_MS;
     this.buffer = new RingBuffer<LogLine>(capacity);
   }
 
@@ -198,7 +198,7 @@ export class AgentLogBuffer {
 
   // ─── Subscription ───
 
-  /** Subscribe to buffer changes. Listener is called at most once per 16ms. */
+  /** Subscribe to buffer changes. Listener is called at most once per flushMs (default 16ms). */
   subscribe(listener: LogBufferListener): void {
     this.listeners.add(listener);
   }

--- a/src/tui/data/agent-log-buffer.ts
+++ b/src/tui/data/agent-log-buffer.ts
@@ -55,11 +55,12 @@ export function classifyLine(line: string): LogLineType {
 // ---------------------------------------------------------------------------
 
 const DEFAULT_CAPACITY = 10_000;
-const FLUSH_INTERVAL_MS = 16; // ~60fps
+const DEFAULT_FLUSH_INTERVAL_MS = 16; // ~60fps
 
 export class AgentLogBuffer {
   readonly role: string;
   readonly sessionId: string;
+  readonly flushMs: number;
 
   private readonly buffer: RingBuffer<LogLine>;
   private readonly listeners = new Set<LogBufferListener>();
@@ -78,9 +79,15 @@ export class AgentLogBuffer {
    */
   private readonly seekedPositions = new Map<string, number>();
 
-  constructor(role: string, sessionId: string, capacity: number = DEFAULT_CAPACITY) {
+  constructor(
+    role: string,
+    sessionId: string,
+    capacity: number = DEFAULT_CAPACITY,
+    flushMs: number = DEFAULT_FLUSH_INTERVAL_MS,
+  ) {
     this.role = role;
     this.sessionId = sessionId;
+    this.flushMs = flushMs;
     this.buffer = new RingBuffer<LogLine>(capacity);
   }
 
@@ -288,7 +295,7 @@ export class AgentLogBuffer {
           this.dirty = false;
           this.notifyListeners();
         }
-      }, FLUSH_INTERVAL_MS);
+      }, this.flushMs);
     }
   }
 

--- a/src/tui/screens/running-keyboard.test.ts
+++ b/src/tui/screens/running-keyboard.test.ts
@@ -1000,11 +1000,7 @@ describe("routeRunningKey — LogView mode (#310)", () => {
 
   test("'/' enters filter mode (overrides global C2 filter)", () => {
     const { actions, log } = mockActions({ logViewActive: true });
-    const handled = routeRunningKey(
-      keyEvent("/", { sequence: "/" }),
-      logActiveState(),
-      actions,
-    );
+    const handled = routeRunningKey(keyEvent("/", { sequence: "/" }), logActiveState(), actions);
     expect(handled).toBe(true);
     expect(log.calls).toContain("logEnterFilterMode");
     expect(log.calls).not.toContain("enterFilterMode");
@@ -1068,11 +1064,7 @@ describe("routeRunningKey — LogView mode (#310)", () => {
 
   test("in filter mode, printable keys append to filter buffer", () => {
     const { actions, log } = mockActions({ logViewActive: true });
-    const handled = routeRunningKey(
-      keyEvent("a", { sequence: "a" }),
-      logFilterState(),
-      actions,
-    );
+    const handled = routeRunningKey(keyEvent("a", { sequence: "a" }), logFilterState(), actions);
     expect(handled).toBe(true);
     expect(log.args.logFilterAppend).toEqual(["a"]);
   });

--- a/src/tui/screens/running-keyboard.test.ts
+++ b/src/tui/screens/running-keyboard.test.ts
@@ -70,6 +70,7 @@ function defaultState(overrides?: Partial<RunningKeyboardState>): RunningKeyboar
     cmdText: "",
     filterQuery: "",
     confirmModalOpen: false,
+    logFilterMode: false,
     ...overrides,
   };
 }
@@ -80,6 +81,7 @@ function mockActions(overrides?: {
   hasSendToAgent?: boolean;
   feedLength?: number;
   hasAskUser?: boolean;
+  logViewActive?: boolean;
 }): { actions: RunningKeyboardActions; log: ActionLog } {
   const log: ActionLog = { calls: [], args: {} };
 
@@ -123,6 +125,16 @@ function mockActions(overrides?: {
     traceScrollToBottom: () => record("traceScrollToBottom"),
     traceScrollToTop: () => record("traceScrollToTop"),
     traceCycleAgent: () => record("traceCycleAgent"),
+    logTogglePause: () => record("logTogglePause"),
+    logScrollDown: () => record("logScrollDown"),
+    logScrollUp: () => record("logScrollUp"),
+    logScrollToBottom: () => record("logScrollToBottom"),
+    logScrollToTop: () => record("logScrollToTop"),
+    logEnterFilterMode: () => record("logEnterFilterMode"),
+    logCommitFilter: () => record("logCommitFilter"),
+    logCancelFilter: () => record("logCancelFilter"),
+    logFilterAppend: (c: string) => record("logFilterAppend", c),
+    logFilterBackspace: () => record("logFilterBackspace"),
     openDetail: () => record("openDetail"),
     enterInspect: () => record("enterInspect"),
     quit: () => record("quit"),
@@ -134,6 +146,7 @@ function mockActions(overrides?: {
     hasSendToAgent: overrides?.hasSendToAgent ?? false,
     feedLength: overrides?.feedLength ?? 10,
     hasAskUser: overrides?.hasAskUser ?? false,
+    logViewActive: overrides?.logViewActive ?? false,
   };
 
   return { actions, log };
@@ -957,5 +970,146 @@ describe("RunningPanel new entries", () => {
     expect(RUNNING_PANEL_LABELS[RunningPanel.Sessions]).toBe("Sessions");
     expect(RUNNING_PANEL_LABELS[RunningPanel.Tasks]).toBe("Tasks");
     expect(RUNNING_PANEL_LABELS[RunningPanel.Reviews]).toBe("Reviews");
+  });
+});
+
+// ===========================================================================
+// LogView keyboard routing (#310)
+// ===========================================================================
+
+describe("routeRunningKey — LogView mode (#310)", () => {
+  const logActiveState = () =>
+    defaultState({
+      expandedPanel: RunningPanel.Terminal,
+      zoomLevel: "half",
+      logFilterMode: false,
+    });
+  const logFilterState = () =>
+    defaultState({
+      expandedPanel: RunningPanel.Terminal,
+      zoomLevel: "half",
+      logFilterMode: true,
+    });
+
+  test("space toggles pause when LogView is active", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    const handled = routeRunningKey(keyEvent("space"), logActiveState(), actions);
+    expect(handled).toBe(true);
+    expect(log.calls).toContain("logTogglePause");
+  });
+
+  test("'/' enters filter mode (overrides global C2 filter)", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    const handled = routeRunningKey(
+      keyEvent("/", { sequence: "/" }),
+      logActiveState(),
+      actions,
+    );
+    expect(handled).toBe(true);
+    expect(log.calls).toContain("logEnterFilterMode");
+    expect(log.calls).not.toContain("enterFilterMode");
+  });
+
+  test("j scrolls log down", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    routeRunningKey(keyEvent("j"), logActiveState(), actions);
+    expect(log.calls).toContain("logScrollDown");
+    expect(log.calls).not.toContain("feedCursorDown");
+  });
+
+  test("k scrolls log up", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    routeRunningKey(keyEvent("k"), logActiveState(), actions);
+    expect(log.calls).toContain("logScrollUp");
+    expect(log.calls).not.toContain("feedCursorUp");
+  });
+
+  test("down/up arrows scroll log", () => {
+    const { actions: a1, log: l1 } = mockActions({ logViewActive: true });
+    routeRunningKey(keyEvent("down"), logActiveState(), a1);
+    expect(l1.calls).toContain("logScrollDown");
+
+    const { actions: a2, log: l2 } = mockActions({ logViewActive: true });
+    routeRunningKey(keyEvent("up"), logActiveState(), a2);
+    expect(l2.calls).toContain("logScrollUp");
+  });
+
+  test("Shift+G jumps to bottom (resume tail)", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    routeRunningKey(keyEvent("g", { shift: true, sequence: "G" }), logActiveState(), actions);
+    expect(log.calls).toContain("logScrollToBottom");
+    expect(log.calls).not.toContain("logScrollToTop");
+  });
+
+  test("g jumps to top", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    routeRunningKey(keyEvent("g"), logActiveState(), actions);
+    expect(log.calls).toContain("logScrollToTop");
+  });
+
+  test("in filter mode, Enter commits filter", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    routeRunningKey(keyEvent("return"), logFilterState(), actions);
+    expect(log.calls).toContain("logCommitFilter");
+  });
+
+  test("in filter mode, Escape cancels filter (does not collapse panel)", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    routeRunningKey(keyEvent("escape"), logFilterState(), actions);
+    expect(log.calls).toContain("logCancelFilter");
+    expect(log.calls).not.toContain("collapsePanel");
+  });
+
+  test("in filter mode, backspace drops last char", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    routeRunningKey(keyEvent("backspace"), logFilterState(), actions);
+    expect(log.calls).toContain("logFilterBackspace");
+  });
+
+  test("in filter mode, printable keys append to filter buffer", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    const handled = routeRunningKey(
+      keyEvent("a", { sequence: "a" }),
+      logFilterState(),
+      actions,
+    );
+    expect(handled).toBe(true);
+    expect(log.args.logFilterAppend).toEqual(["a"]);
+  });
+
+  test("in filter mode, non-printable keys are swallowed (not routed to feed)", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    // 'tab' is not handled by the filter-mode branch; it should be swallowed.
+    const handled = routeRunningKey(keyEvent("tab"), logFilterState(), actions);
+    expect(handled).toBe(true);
+    expect(log.calls).not.toContain("feedCursorDown");
+    expect(log.calls).not.toContain("traceCycleAgent");
+  });
+
+  test("LogView keys are inert when logViewActive is false", () => {
+    const { actions, log } = mockActions({ logViewActive: false });
+    const handled = routeRunningKey(keyEvent("space"), logActiveState(), actions);
+    // 'space' has no global handler outside LogView/cmd-mode → returns false.
+    expect(handled).toBe(false);
+    expect(log.calls).not.toContain("logTogglePause");
+  });
+
+  test("LogView keys are inert when Terminal panel is not expanded", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    const state = defaultState({ expandedPanel: RunningPanel.Dag, zoomLevel: "half" });
+    routeRunningKey(keyEvent("space"), state, actions);
+    expect(log.calls).not.toContain("logTogglePause");
+  });
+
+  test("panel-switch shortcuts still work over LogView (fallthrough)", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    routeRunningKey(keyEvent("3"), logActiveState(), actions);
+    expect(log.args.expandPanel).toEqual([RunningPanel.Dag]);
+  });
+
+  test("? still toggles help when LogView is active", () => {
+    const { actions, log } = mockActions({ logViewActive: true });
+    routeRunningKey(keyEvent("?", { shift: true, sequence: "?" }), logActiveState(), actions);
+    expect(log.calls).toContain("toggleHelp");
   });
 });

--- a/src/tui/screens/running-keyboard.ts
+++ b/src/tui/screens/running-keyboard.ts
@@ -74,6 +74,13 @@ export interface RunningKeyboardState {
    * approve/deny a pending tmux permission prompt.
    */
   readonly confirmModalOpen: boolean;
+  /**
+   * #310: LogView filter-input mode. When true, the dispatcher swallows
+   * printable keys into the LogView filter buffer instead of routing them
+   * to normal-mode handlers. Only meaningful when LogView is mounted
+   * (Terminal panel expanded + actions.logViewActive).
+   */
+  readonly logFilterMode: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -131,12 +138,31 @@ export interface RunningKeyboardActions {
   // Permission
   readonly approvePermission: () => void;
   readonly denyPermission: () => void;
+  // LogView (#310): controlled-state action callbacks for the live-log pane.
+  // State (logPaused/logFilter/logFilterMode/logScrollOffset) lives in
+  // running-view; the dispatcher fires these when the Terminal panel is
+  // expanded AND running-view chose to mount <LogView> (logViewActive=true).
+  readonly logTogglePause: () => void;
+  readonly logScrollDown: () => void;
+  readonly logScrollUp: () => void;
+  readonly logScrollToBottom: () => void;
+  readonly logScrollToTop: () => void;
+  readonly logEnterFilterMode: () => void;
+  readonly logCommitFilter: () => void;
+  readonly logCancelFilter: () => void;
+  readonly logFilterAppend: (ch: string) => void;
+  readonly logFilterBackspace: () => void;
   // Context flags (not actions, just state the handler needs to make decisions)
   readonly hasPermissions: boolean;
   readonly hasActiveRoles: boolean;
   readonly hasSendToAgent: boolean;
   readonly feedLength: number;
   readonly hasAskUser: boolean;
+  /**
+   * #310: true when running-view has chosen to render <LogView> in the
+   * Terminal panel slot. Gates the LogView key-dispatch block.
+   */
+  readonly logViewActive: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -260,6 +286,62 @@ export function routeRunningKey(
       return true;
     }
     return true; // Swallow keys in help mode
+  }
+
+  // ─── LogView mode (#310): live-log keys when Terminal panel hosts LogView ───
+  // Active only when running-view chose to mount <LogView> in the Terminal
+  // panel slot (e.g., ACPX sessions, currently gated by GROVE_LOGVIEW=1).
+  // Placed BEFORE normal-mode handlers because LogView shadows '/', escape,
+  // and j/k/g/G with its own behavior. Unmatched keys fall through to
+  // global handlers so the operator can still press 1-5 to switch panels,
+  // 'q' to quit, etc.
+  if (state.expandedPanel === RunningPanel.Terminal && actions.logViewActive) {
+    if (state.logFilterMode) {
+      if (input === "return") {
+        actions.logCommitFilter();
+        return true;
+      }
+      if (input === "escape") {
+        actions.logCancelFilter();
+        return true;
+      }
+      if (input === "backspace") {
+        actions.logFilterBackspace();
+        return true;
+      }
+      if (key.sequence && key.sequence.length === 1 && !key.ctrl && !key.meta) {
+        actions.logFilterAppend(key.sequence);
+        return true;
+      }
+      return true; // swallow other keys while filter prompt is open
+    }
+
+    if (input === "space") {
+      actions.logTogglePause();
+      return true;
+    }
+    if (input === "/" || key.sequence === "/") {
+      actions.logEnterFilterMode();
+      return true;
+    }
+    // Shift+G must be checked before plain "g" since input === "g" matches both.
+    if (key.shift && input === "g") {
+      actions.logScrollToBottom();
+      return true;
+    }
+    if (input === "g") {
+      actions.logScrollToTop();
+      return true;
+    }
+    if (input === "j" || input === "down") {
+      actions.logScrollDown();
+      return true;
+    }
+    if (input === "k" || input === "up") {
+      actions.logScrollUp();
+      return true;
+    }
+    // Unmatched keys fall through to global handlers.
   }
 
   // ─── Normal mode ───

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -104,6 +104,13 @@ const RUNNING_PANEL_PARAM: Readonly<Record<RunningPanel, string | undefined>> = 
   [RunningPanel.Reviews]: "reviews",
 });
 
+// #310: LogView mount gate. Read process.env once at module load — env vars
+// don't change at runtime, so re-reading on every render is wasted work and
+// (more importantly) churns useMemo deps that include `useLogView`.
+// TODO(#310): swap for session.runtime==="acpx" detection once session
+// metadata is plumbed through to running-view.
+const useLogView = process.env.GROVE_LOGVIEW === "1";
+
 /** Props for the RunningView screen. */
 export interface RunningViewProps {
   readonly provider: TuiDataProvider;
@@ -225,13 +232,23 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     const [traceScrollOffset, setTraceScrollOffset] = useState(0);
 
     // ─── LogView state (#310): controlled by central keyboard dispatcher ───
-    // TODO(#310): swap the GROVE_LOGVIEW env gate for session.runtime==="acpx"
-    // detection once session metadata is plumbed through to running-view.
-    const useLogView = process.env.GROVE_LOGVIEW === "1";
+    // Mount gate lives at module scope (`useLogView`) so env reads don't
+    // churn useMemo deps each render.
     const [logPaused, setLogPaused] = useState(false);
     const [logFilter, setLogFilter] = useState("");
-    const [logFilterMode, setLogFilterMode] = useState(false);
+    const [logFilterMode, setLogFilterModeRaw] = useState(false);
     const [logScrollOffset, setLogScrollOffset] = useState(0);
+    // Mirror `logFilterMode` into a ref so the keyboard dispatcher sees the
+    // latest value within a same-tick burst (paste / scripted input) — same
+    // race rationale as `cmdStateRef` below. Without this, a burst like
+    // `/foo` after committing the prior filter could see stale
+    // `logFilterMode === false` between `setLogFilterMode(true)` and React's
+    // commit, sending printable chars to normal-mode handlers.
+    const logFilterModeRef = useRef<boolean>(false);
+    const setLogFilterMode = useCallback((next: boolean) => {
+      logFilterModeRef.current = next;
+      setLogFilterModeRaw(next);
+    }, []);
 
     // ─── Overlay state ───
     const [showVfs, setShowVfs] = useState(false);
@@ -1024,8 +1041,12 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
         // latest value via React's reducer form.
         setCmdState,
         setFilterQuery,
-        // #310: LogView mount gate; flips action surface for the Terminal panel.
-        useLogView,
+        // #310: ref-mirrored setter (stable identity per render via
+        // useCallback) — keeps logEnterFilterMode/logCommitFilter/
+        // logCancelFilter exhaustive without churning the memo each render.
+        setLogFilterMode,
+        // #310: `useLogView` lives at module scope (env-derived constant), so
+        // it isn't a dep — kept out of the array deliberately.
       ],
     );
 
@@ -1081,17 +1102,18 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             return;
           }
 
-          // Live snapshot of cmdMode/cmdText/filterQuery from refs — needed
-          // because keyboardState's useMemo only re-runs after React commits,
-          // and a burst of keys arriving in a single tick would otherwise see
-          // stale state. See cmdState refs above for the race rationale.
+          // Live snapshot of cmdMode/cmdText/filterQuery/logFilterMode from
+          // refs — needed because keyboardState's useMemo only re-runs after
+          // React commits, and a burst of keys arriving in a single tick
+          // would otherwise see stale state. See cmdState refs above for the
+          // race rationale; logFilterMode follows the same pattern (#310).
           const liveState: RunningKeyboardState = {
             ...keyboardState,
             cmdMode: cmdStateRef.current.mode,
             cmdText: cmdStateRef.current.text,
             filterQuery: filterQueryRef.current,
             confirmModalOpen,
-            logFilterMode,
+            logFilterMode: logFilterModeRef.current,
           };
           routeRunningKey(key, liveState, keyboardActions);
         },
@@ -1104,7 +1126,10 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           promptMode,
           showHelp,
           confirmModalOpen,
-          logFilterMode,
+          // #310: logFilterMode read via logFilterModeRef (synchronous) so a
+          // same-tick burst sees the latest mode. keyboardState already lists
+          // logFilterMode in its memo deps for rendering, so committed state
+          // changes still re-create the callback through that path.
         ],
       ),
     );
@@ -1317,6 +1342,11 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
                 logBuffers,
                 traceSelectedAgent,
                 traceScrollOffset,
+                logViewActive: useLogView,
+                logPaused,
+                logFilter,
+                logFilterMode,
+                logScrollOffset,
                 sessionStartedAt,
                 handoffs,
                 activeRoles,

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -49,6 +49,7 @@ import { AgentListView } from "../views/agent-list.js";
 import { AgentTasksView } from "../views/agent-tasks.js";
 import { DagView } from "../views/dag.js";
 import { HandoffsView } from "../views/handoffs-view.js";
+import { LogView } from "../views/log-view.js";
 import { TerminalView } from "../views/terminal.js";
 import { TracePane } from "../views/trace-pane.js";
 import { VfsBrowserView } from "../views/vfs-browser.js";
@@ -222,6 +223,15 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
       () => savedState?.traceSelectedAgent ?? 0,
     );
     const [traceScrollOffset, setTraceScrollOffset] = useState(0);
+
+    // ─── LogView state (#310): controlled by central keyboard dispatcher ───
+    // TODO(#310): swap the GROVE_LOGVIEW env gate for session.runtime==="acpx"
+    // detection once session metadata is plumbed through to running-view.
+    const useLogView = process.env.GROVE_LOGVIEW === "1";
+    const [logPaused, setLogPaused] = useState(false);
+    const [logFilter, setLogFilter] = useState("");
+    const [logFilterMode, setLogFilterMode] = useState(false);
+    const [logScrollOffset, setLogScrollOffset] = useState(0);
 
     // ─── Overlay state ───
     const [showVfs, setShowVfs] = useState(false);
@@ -713,6 +723,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
         cmdText: cmdState.text,
         filterQuery,
         confirmModalOpen,
+        logFilterMode,
       }),
       [
         expandedPanel,
@@ -726,6 +737,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
         cmdState.text,
         filterQuery,
         confirmModalOpen,
+        logFilterMode,
       ],
     );
 
@@ -848,6 +860,23 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           setTraceSelectedAgent((a) => (a + 1) % Math.max(1, roleCount));
           setTraceScrollOffset(0);
         },
+        // LogView actions (#310): mirror trace-pane controlled-component pattern.
+        logTogglePause: () => setLogPaused((p) => !p),
+        logScrollDown: () => setLogScrollOffset((n) => n + 1),
+        logScrollUp: () => setLogScrollOffset((n) => Math.max(0, n - 1)),
+        logScrollToBottom: () => setLogScrollOffset(0),
+        // LogViewport clamps with Math.max(0, end - viewportLines), so a huge
+        // offset maps to "top of buffer".
+        logScrollToTop: () => setLogScrollOffset(Number.MAX_SAFE_INTEGER),
+        logEnterFilterMode: () => setLogFilterMode(true),
+        logCommitFilter: () => setLogFilterMode(false), // keep logFilter
+        logCancelFilter: () => {
+          setLogFilterMode(false);
+          setLogFilter("");
+        },
+        logFilterAppend: (ch: string) => setLogFilter((f) => f + ch),
+        logFilterBackspace: () => setLogFilter((f) => f.slice(0, -1)),
+        logViewActive: useLogView,
         // openDetail kept as an interface field for future detail-route work,
         // but wired to a no-op so Enter cannot accidentally enter inspect.
         openDetail: () => {},
@@ -995,6 +1024,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
         // latest value via React's reducer form.
         setCmdState,
         setFilterQuery,
+        // #310: LogView mount gate; flips action surface for the Terminal panel.
+        useLogView,
       ],
     );
 
@@ -1060,6 +1091,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             cmdText: cmdStateRef.current.text,
             filterQuery: filterQueryRef.current,
             confirmModalOpen,
+            logFilterMode,
           };
           routeRunningKey(key, liveState, keyboardActions);
         },
@@ -1072,6 +1104,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           promptMode,
           showHelp,
           confirmModalOpen,
+          logFilterMode,
         ],
       ),
     );
@@ -1198,6 +1231,11 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             logBuffers,
             traceSelectedAgent,
             traceScrollOffset,
+            logViewActive: useLogView,
+            logPaused,
+            logFilter,
+            logFilterMode,
+            logScrollOffset,
             sessionStartedAt,
             handoffs,
             activeRoles,
@@ -1633,6 +1671,13 @@ interface PanelRenderContext {
   readonly logBuffers?: ReadonlyMap<string, AgentLogBuffer> | undefined;
   readonly traceSelectedAgent?: number;
   readonly traceScrollOffset?: number;
+  // #310: LogView controlled-component state. Optional so existing tests and
+  // non-ACPX call sites need no changes. Wired from running-view useState.
+  readonly logViewActive?: boolean;
+  readonly logPaused?: boolean;
+  readonly logFilter?: string;
+  readonly logFilterMode?: boolean;
+  readonly logScrollOffset?: number;
   readonly sessionStartedAt?: string | undefined;
   readonly handoffs?: readonly import("../../core/handoff.js").Handoff[] | undefined;
   readonly activeRoles?: readonly string[] | undefined;
@@ -1683,7 +1728,27 @@ function renderExpandedPanel(panel: RunningPanel, ctx: PanelRenderContext): Reac
         />
       );
 
-    case RunningPanel.Terminal:
+    case RunningPanel.Terminal: {
+      // #310: when ACPX/log-streaming is in use, render LogView instead of
+      // TerminalView. Gate is currently env-driven; TODO follow-up: switch
+      // to session.runtime === "acpx" once session metadata reaches the ctx.
+      if (ctx.logViewActive) {
+        // Temporary: pick the first available role's buffer. Future work:
+        // track the operator's selected agent and route to its buffer
+        // (mirrors traceSelectedAgent in TracePane).
+        const firstRole = ctx.topology?.roles?.[0]?.name;
+        const buffer = firstRole ? ctx.logBuffers?.get(firstRole) : undefined;
+        return (
+          <LogView
+            sessionId={buffer?.sessionId ?? firstRole ?? ""}
+            buffer={buffer}
+            paused={ctx.logPaused ?? false}
+            filter={ctx.logFilter ?? ""}
+            filterMode={ctx.logFilterMode ?? false}
+            scrollOffset={ctx.logScrollOffset ?? 0}
+          />
+        );
+      }
       return (
         <TerminalView
           tmux={ctx.tmux}
@@ -1692,6 +1757,7 @@ function renderExpandedPanel(panel: RunningPanel, ctx: PanelRenderContext): Reac
           mode={InputMode.Normal}
         />
       );
+    }
 
     case RunningPanel.Trace: {
       const roles = (ctx.topology?.roles ?? []).map((r) => r.name);

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -107,8 +107,10 @@ const RUNNING_PANEL_PARAM: Readonly<Record<RunningPanel, string | undefined>> = 
 // #310: LogView mount gate. Read process.env once at module load — env vars
 // don't change at runtime, so re-reading on every render is wasted work and
 // (more importantly) churns useMemo deps that include `useLogView`.
-// TODO(#310): swap for session.runtime==="acpx" detection once session
-// metadata is plumbed through to running-view.
+// TODO(#310): when ACPX session metadata reaches running-view (e.g. via
+// spawnManager.getSession(role).runtime), drop the env gate and detect
+// per-role: useLogView = session?.runtime === "acpx". Tracked as a
+// follow-up of issue #310.
 const useLogView = process.env.GROVE_LOGVIEW === "1";
 
 /** Props for the RunningView screen. */
@@ -1760,8 +1762,11 @@ function renderExpandedPanel(panel: RunningPanel, ctx: PanelRenderContext): Reac
 
     case RunningPanel.Terminal: {
       // #310: when ACPX/log-streaming is in use, render LogView instead of
-      // TerminalView. Gate is currently env-driven; TODO follow-up: switch
-      // to session.runtime === "acpx" once session metadata reaches the ctx.
+      // TerminalView. Gate is currently env-driven.
+      // TODO(#310): when ACPX session metadata reaches running-view (e.g. via
+      // spawnManager.getSession(role).runtime), drop the env gate and detect
+      // per-role: useLogView = session?.runtime === "acpx". Tracked as a
+      // follow-up of issue #310.
       if (ctx.logViewActive) {
         // Temporary: pick the first available role's buffer. Future work:
         // track the operator's selected agent and route to its buffer

--- a/src/tui/views/log-view.test.tsx
+++ b/src/tui/views/log-view.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Tests for <LogView>: prop wiring and rendering. State (paused, filter,
+ * scrollOffset) is controlled by the parent; LogView just forwards to
+ * <LogViewport>. Keyboard dispatch lives in running-keyboard.ts and is
+ * exercised in its own test suite.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { AgentLogBuffer } from "../data/agent-log-buffer.js";
+import { LogView } from "./log-view.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function makeBuffer(n: number): AgentLogBuffer {
+  const buf = new AgentLogBuffer("coder", "sess-lv", 10_000, 50);
+  for (let i = 0; i < n; i++) {
+    buf.push({ ts: i, line: `line-${i}`, type: "output" });
+  }
+  return buf;
+}
+
+describe("LogView", () => {
+  test("renders fallback when buffer is undefined", async () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogView
+            sessionId="missing"
+            buffer={undefined}
+            paused={false}
+            filter=""
+            filterMode={false}
+            scrollOffset={0}
+          />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("No log buffer");
+    renderer.unmount();
+  });
+
+  test("forwards state to LogViewport: pause badge shown when paused=true", async () => {
+    const buf = makeBuffer(10);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogView
+            sessionId="sess-lv"
+            buffer={buf}
+            paused={true}
+            filter=""
+            filterMode={false}
+            scrollOffset={0}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("PAUSED");
+    renderer.unmount();
+    buf.dispose();
+  });
+
+  test("filterMode renders the filter prompt", async () => {
+    const buf = makeBuffer(5);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <LogView
+            sessionId="sess-lv"
+            buffer={buf}
+            paused={false}
+            filter="abc"
+            filterMode={true}
+            scrollOffset={0}
+          />
+        ) as React.ReactElement,
+      );
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("filter:");
+    expect(flat).toContain("abc");
+    renderer.unmount();
+    buf.dispose();
+  });
+});

--- a/src/tui/views/log-view.tsx
+++ b/src/tui/views/log-view.tsx
@@ -1,0 +1,65 @@
+/**
+ * LogView — single-session live log tail (issue #310).
+ *
+ * Controlled component: state (paused, filter, filterMode, scrollOffset) is
+ * owned by the parent (running-view) and mutated by the central keyboard
+ * dispatcher (running-keyboard.ts). LogView is the bridge between that state
+ * and the pure <LogViewport> renderer.
+ *
+ * Renders an "filter:" prompt line when filterMode is true, otherwise just
+ * the viewport.
+ */
+
+import React from "react";
+import type { AgentLogBuffer } from "../data/agent-log-buffer.js";
+import { LogViewport } from "../components/log-viewport.js";
+import { theme } from "../theme.js";
+
+export interface LogViewProps {
+  readonly sessionId: string;
+  /** Pre-resolved buffer for this session/role. Caller owns lifecycle. */
+  readonly buffer: AgentLogBuffer | undefined;
+  readonly paused: boolean;
+  readonly filter: string;
+  readonly filterMode: boolean;
+  readonly scrollOffset: number;
+  readonly viewportLines?: number;
+}
+
+export const LogView: React.NamedExoticComponent<LogViewProps> = React.memo(
+  function LogView({
+    sessionId,
+    buffer,
+    paused,
+    filter,
+    filterMode,
+    scrollOffset,
+    viewportLines,
+  }: LogViewProps): React.ReactNode {
+    if (!buffer) {
+      return (
+        <box flexDirection="column" paddingX={1}>
+          <text color={theme.secondary}>{`No log buffer for ${sessionId}`}</text>
+        </box>
+      );
+    }
+    return (
+      <box flexDirection="column" flexGrow={1}>
+        {filterMode && (
+          <box flexDirection="row" paddingX={1}>
+            <text color={theme.focus}>filter: </text>
+            <text>{filter}</text>
+            <text color={theme.focus}>_</text>
+          </box>
+        )}
+        <LogViewport
+          buffer={buffer}
+          paused={paused}
+          filter={filter}
+          scrollOffset={scrollOffset}
+          {...(viewportLines !== undefined ? { viewportLines } : {})}
+        />
+      </box>
+    );
+  },
+);

--- a/src/tui/views/log-view.tsx
+++ b/src/tui/views/log-view.tsx
@@ -11,8 +11,8 @@
  */
 
 import React from "react";
-import type { AgentLogBuffer } from "../data/agent-log-buffer.js";
 import { LogViewport } from "../components/log-viewport.js";
+import type { AgentLogBuffer } from "../data/agent-log-buffer.js";
 import { theme } from "../theme.js";
 
 export interface LogViewProps {
@@ -26,40 +26,38 @@ export interface LogViewProps {
   readonly viewportLines?: number;
 }
 
-export const LogView: React.NamedExoticComponent<LogViewProps> = React.memo(
-  function LogView({
-    sessionId,
-    buffer,
-    paused,
-    filter,
-    filterMode,
-    scrollOffset,
-    viewportLines,
-  }: LogViewProps): React.ReactNode {
-    if (!buffer) {
-      return (
-        <box flexDirection="column" paddingX={1}>
-          <text color={theme.secondary}>{`No log buffer for ${sessionId}`}</text>
-        </box>
-      );
-    }
+export const LogView: React.NamedExoticComponent<LogViewProps> = React.memo(function LogView({
+  sessionId,
+  buffer,
+  paused,
+  filter,
+  filterMode,
+  scrollOffset,
+  viewportLines,
+}: LogViewProps): React.ReactNode {
+  if (!buffer) {
     return (
-      <box flexDirection="column" flexGrow={1}>
-        {filterMode && (
-          <box flexDirection="row" paddingX={1}>
-            <text color={theme.focus}>filter: </text>
-            <text>{filter}</text>
-            <text color={theme.focus}>_</text>
-          </box>
-        )}
-        <LogViewport
-          buffer={buffer}
-          paused={paused}
-          filter={filter}
-          scrollOffset={scrollOffset}
-          {...(viewportLines !== undefined ? { viewportLines } : {})}
-        />
+      <box flexDirection="column" paddingX={1}>
+        <text color={theme.secondary}>{`No log buffer for ${sessionId}`}</text>
       </box>
     );
-  },
-);
+  }
+  return (
+    <box flexDirection="column" flexGrow={1}>
+      {filterMode && (
+        <box flexDirection="row" paddingX={1}>
+          <text color={theme.focus}>filter: </text>
+          <text>{filter}</text>
+          <text color={theme.focus}>_</text>
+        </box>
+      )}
+      <LogViewport
+        buffer={buffer}
+        paused={paused}
+        filter={filter}
+        scrollOffset={scrollOffset}
+        {...(viewportLines !== undefined ? { viewportLines } : {})}
+      />
+    </box>
+  );
+});

--- a/src/tui/views/trace-pane.tsx
+++ b/src/tui/views/trace-pane.tsx
@@ -2,9 +2,10 @@
  * TracePane — k9s-style split-pane agent trace viewer.
  *
  * Left column:  scrollable agent list with status indicators
- * Right column: selected agent's full scrollable trace (viewport sliced)
+ * Right column: selected agent's full scrollable trace, rendered via
+ *               the shared <LogViewport> component (which owns its own
+ *               buffer subscription + viewport slicing + header).
  *
- * Uses AgentLogBuffer ring buffers for O(viewport) rendering.
  * Auto-scroll follows new output; scrolling up pauses auto-scroll.
  * Historical lines (from resume) are rendered dimmed.
  *
@@ -17,8 +18,9 @@
  * j/k:select agent  J/K:scroll trace  f:full  Esc:close
  */
 
-import React, { useCallback, useEffect, useState } from "react";
-import type { AgentLogBuffer, LogLine } from "../data/agent-log-buffer.js";
+import React from "react";
+import { LogViewport } from "../components/log-viewport.js";
+import type { AgentLogBuffer } from "../data/agent-log-buffer.js";
 import { agentStatusIcon, theme } from "../theme.js";
 
 // ---------------------------------------------------------------------------
@@ -55,14 +57,6 @@ export interface TracePaneProps {
   readonly viewportLines?: number;
 }
 
-function formatTimestamp(ts: number): string {
-  const d = new Date(ts);
-  const h = String(d.getHours()).padStart(2, "0");
-  const m = String(d.getMinutes()).padStart(2, "0");
-  const s = String(d.getSeconds()).padStart(2, "0");
-  return `${h}:${m}:${s}`;
-}
-
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -76,18 +70,8 @@ export const TracePane: React.NamedExoticComponent<TracePaneProps> = React.memo(
   traceScrollOffset,
   viewportLines = DEFAULT_VIEWPORT_LINES,
 }: TracePaneProps): React.ReactNode {
-  // Subscribe to the selected agent's buffer for live updates
   const selectedRole = roles[selectedAgent];
   const selectedBuffer = selectedRole ? buffers.get(selectedRole) : undefined;
-
-  // Force re-render when buffer changes (via 16ms batched flush)
-  const [, setTick] = useState(0);
-  useEffect(() => {
-    if (!selectedBuffer) return;
-    const listener = () => setTick((t) => t + 1);
-    selectedBuffer.subscribe(listener);
-    return () => selectedBuffer.unsubscribe(listener);
-  }, [selectedBuffer]);
 
   // ─── Left column: agent list ───
   const agentList = roles.map((role, idx) => {
@@ -95,7 +79,7 @@ export const TracePane: React.NamedExoticComponent<TracePaneProps> = React.memo(
     const status = agentStatuses.get(role) ?? "idle";
     const badge = agentStatusIcon(status, status === "running" ? spinnerFrame : undefined);
     const lineCount = buffers.get(role)?.size ?? 0;
-    const selector = isSelected ? "\u25b6" : " ";
+    const selector = isSelected ? "▶" : " ";
 
     return (
       <box
@@ -106,25 +90,12 @@ export const TracePane: React.NamedExoticComponent<TracePaneProps> = React.memo(
         <text color={isSelected ? theme.focus : theme.secondary}>{selector} </text>
         <text color={badge.color}>{badge.icon} </text>
         <text color={isSelected ? theme.text : theme.secondary} bold={isSelected}>
-          {role.length > 12 ? `${role.slice(0, 11)}\u2026` : role.padEnd(12)}
+          {role.length > 12 ? `${role.slice(0, 11)}…` : role.padEnd(12)}
         </text>
         <text color={theme.secondary}> {lineCount > 0 ? String(lineCount) : ""}</text>
       </box>
     );
   });
-
-  // ─── Right column: trace output (viewport sliced) ───
-  const getViewportLines = useCallback((): LogLine[] => {
-    if (!selectedBuffer || selectedBuffer.isEmpty) return [];
-    const total = selectedBuffer.size;
-    const end = Math.max(0, total - traceScrollOffset);
-    const start = Math.max(0, end - viewportLines);
-    return selectedBuffer.slice(start, end);
-  }, [selectedBuffer, traceScrollOffset, viewportLines]);
-
-  const displayLines = getViewportLines();
-  const isAutoScroll = traceScrollOffset === 0;
-  const totalLines = selectedBuffer?.size ?? 0;
 
   // ─── Render ───
   if (roles.length === 0) {
@@ -153,33 +124,20 @@ export const TracePane: React.NamedExoticComponent<TracePaneProps> = React.memo(
           {agentList}
         </box>
 
-        {/* Right: Trace output */}
+        {/* Right: trace output */}
         <box flexDirection="column" flexGrow={1} borderStyle="round" borderColor={theme.focus}>
-          <box flexDirection="row" paddingX={1}>
-            <text color={theme.focus} bold>
-              {selectedRole ?? "—"} trace
-            </text>
-            <text color={theme.secondary}>
-              {" "}
-              {totalLines} lines
-              {isAutoScroll
-                ? " | auto-scroll: ON"
-                : ` | auto-scroll: OFF (${traceScrollOffset}\u2191)`}
-            </text>
-          </box>
-          {displayLines.length === 0 ? (
-            <box paddingX={1}>
-              <text color={theme.secondary}>(no output yet)</text>
-            </box>
+          {selectedBuffer ? (
+            <LogViewport
+              buffer={selectedBuffer}
+              paused={false}
+              filter=""
+              scrollOffset={traceScrollOffset}
+              viewportLines={viewportLines}
+              title={`${selectedRole ?? "—"} trace`}
+            />
           ) : (
-            <box flexDirection="column" paddingX={1}>
-              {displayLines.map((line, i) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: trace lines have no stable identity
-                <box key={i} flexDirection="row">
-                  <text color={theme.disabled}>{formatTimestamp(line.ts)} </text>
-                  <text>{line.line}</text>
-                </box>
-              ))}
+            <box paddingX={1}>
+              <text color={theme.secondary}>(no agent selected)</text>
             </box>
           )}
         </box>


### PR DESCRIPTION
## Summary

Implements [#310](https://github.com/windoliver/grove/issues/310) — a TUI `<LogView sessionId>` that live-tails a single agent's log buffer with backpressure.

- **AgentLogBuffer** gains an optional `flushMs` constructor argument (default 16ms preserves existing TracePane behavior). Invalid values (`<=0`, `NaN`, `Infinity`) fall back to default.
- **`<LogViewport>`** (new, `src/tui/components/log-viewport.tsx`) — pure render component. Subscribes to an `AgentLogBuffer` and renders a viewport with substring filter (view-only), pause-freeze (snapshot at pause edge), and autoscroll (`scrollOffset === 0` sticks to tail).
- **`<LogView>`** (new, `src/tui/views/log-view.tsx`) — controlled wrapper. State (`paused`, `filter`, `filterMode`, `scrollOffset`) lives in `running-view`; LogView bridges to `<LogViewport>`.
- **TracePane** refactored to reuse `<LogViewport>` for its right column (-42 LOC duplication).
- **Keyboard dispatch** wired into `running-keyboard.ts`: `space` pause, `/foo` filter, `j/k` (or arrows) scroll, `Shift+G` jump to bottom, `g` jump to top. Filter mode swallows printable keys via a ref-mirrored flag (same race-avoidance pattern as `cmdStateRef`).
- **Mount swap**: `<LogView>` replaces `<TerminalView>` in the Terminal panel slot when `GROVE_LOGVIEW=1` is set. Proper detection via `spawnManager.getSession(role).runtime === "acpx"` is a deliberate follow-up.

## Acceptance (#310)

- [x] 1k lines/sec no drops — `src/tui/data/agent-log-buffer.backpressure.test.ts` (2 tests).
- [x] `space` pauses — `log-viewport.test.tsx` pause-freeze + `running-keyboard.test.ts` LogView-mode space-toggle.
- [x] `/foo` filters tail buffer — `log-viewport.test.tsx` filter test + `running-keyboard.test.ts` filter-mode tests.

Plus autoscroll re-clamp positive case (viewport advances on growth when `scrollOffset === 0`).

## Test Plan

- [ ] `bun test src/tui/` green (1428 pass; pre-existing `config-watcher.ts` chokidar fail/error unrelated to this PR).
- [ ] `bun test src/tui/data/agent-log-buffer.backpressure.test.ts` — backpressure acceptance passes.
- [ ] `bun test src/tui/components/log-viewport.test.tsx` — 5/5.
- [ ] `bun test src/tui/views/log-view.test.tsx` — 3/3.
- [ ] `bun test src/tui/screens/running-keyboard.test.ts` — 16 new tests in `LogView mode` block pass; no regressions in existing 101 tests.
- [ ] `bunx tsc --noEmit` clean (excluding pre-existing `config-watcher` errors).
- [ ] `bunx biome check src/tui/` clean.
- [ ] Manual: run TUI with `GROVE_LOGVIEW=1`, expand Terminal panel (`4`), verify LogView renders, exercise `space`, `/`, `j/k`, `G`, `g`.

## Docs

- Spec: `docs/superpowers/specs/2026-05-16-310-logview-design.md`
- Plan: `docs/superpowers/plans/2026-05-16-310-logview.md`

## Follow-ups

- Replace `GROVE_LOGVIEW=1` gate with `session.runtime === "acpx"` detection (TODOs in `running-view.tsx` reference `spawnManager.getSession(role).runtime`).
- Add an operator-selected agent picker for LogView (mount currently uses `topology.roles[0]`).
- Restore ANSI color rendering on the LogView path (out of scope per spec; xterm-color is still available on the TerminalView fallback).