### PR TITLE
D3: Scheduler framework — Filter + Score + Permit + Bind plugins (#300)

### DIFF
--- a/docs/superpowers/plans/2026-05-16-review-loop-agent-task-migration.md
+++ b/docs/superpowers/plans/2026-05-16-review-loop-agent-task-migration.md
@@ -1,0 +1,2103 @@
+# Review-Loop → AgentTask Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route a codex → claude review loop end-to-end through `AgentTask` + `Scheduler`, with a new `grove review-loop` CLI, a `Succeeded` transition, and a server-mediated `/done` endpoint reachable from MCP.
+
+**Architecture:** Strangler-fig on top of PR #439. Add `DoneSignaled` condition; on grove-server, a new `POST /api/agent-tasks/:id/done` route writes the condition; in `TaskController`, `reconcileRunning` advances `DoneSignaled=True → Succeeded`; in `DefaultBind`, each task's prompt is wrapped with its `dependsOn` ancestors' `Succeeded` summaries. MCP `grove_done` POSTs to `/done` when the bound agent has `GROVE_AGENT_TASK_ID` in env. `grove session start` and legacy `contributeOperation` are untouched.
+
+**Tech Stack:** Bun + TypeScript w/ `isolatedDeclarations: true`, `bun:test`, Hono + zod for HTTP routes, tmux for E2E.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-review-loop-agent-task-migration-design.md`
+
+---
+
+## File Structure
+
+**New files**
+
+- `src/core/scheduler/upstream-prompt.ts` — `buildPromptWithUpstream` pure function.
+- `src/core/scheduler/upstream-prompt.test.ts`
+- `src/mcp/agent-task-context.ts` — env reader.
+- `src/mcp/agent-task-context.test.ts`
+- `src/mcp/agent-task-done.ts` — `POST /done` helper.
+- `src/mcp/agent-task-done.test.ts`
+- `src/cli/commands/review-loop.ts` — CLI subcommand handler.
+- `src/cli/commands/review-loop.test.ts`
+- `tests/e2e/review-loop-codex-claude-tmux.ts` — full tmux E2E.
+
+**Modified files**
+
+- `src/core/agent-task.ts` — add `DoneSignaled` to `AgentTaskConditionType`.
+- `src/core/task-controller.ts` — `Succeeded` transition + `sessionToCloseOnSuccess`.
+- `src/core/task-controller.test.ts` — tests for new transition + dependency unblocking chain.
+- `src/core/scheduler/framework.ts` — broaden `SchedulerContext.store` Pick.
+- `src/core/scheduler/plugins/default-bind.ts` — dependency prompt wrapping + env passthrough.
+- `src/core/scheduler/plugins/default-bind.test.ts` — tests for wrapping + env vars.
+- `src/server/routes/agent-tasks.ts` — `POST /:id/done` route (bearer-authed, before controller-token middleware).
+- `src/server/routes/agent-tasks.test.ts` — tests for `/done` route.
+- `src/server/serve.ts` — default `GROVE_SERVER_URL` + extract first bearer token to `GROVE_API_TOKEN` before constructing TaskController.
+- `src/mcp/tools/done.ts` — call done helper when `GROVE_AGENT_TASK_ID` set.
+- `src/mcp/tools/done.test.ts` — tests for done-endpoint branch.
+- `src/cli/main.ts` — register `review-loop` subcommand.
+
+---
+
+## Task 1: Add `DoneSignaled` to `AgentTaskConditionType`
+
+**Files:**
+- Modify: `src/core/agent-task.ts:15-26`
+
+- [ ] **Step 1: Write the failing test**
+
+Append two cases to `src/core/agent-task.condition-types.test.ts`:
+
+```ts
+test("includes DoneSignaled for agent-signaled completion", () => {
+  expect(AgentTaskConditionType.DoneSignaled).toBe("DoneSignaled");
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+`bun test src/core/agent-task.condition-types.test.ts` — expected FAIL on the new case.
+
+- [ ] **Step 3: Add the enum member**
+
+Edit `src/core/agent-task.ts`. The `AgentTaskConditionType` const becomes:
+
+```ts
+export const AgentTaskConditionType = {
+  Admitted: "Admitted",
+  Scheduled: "Scheduled",
+  Bound: "Bound",
+  Running: "Running",
+  AwaitingReview: "AwaitingReview",
+  Succeeded: "Succeeded",
+  Failed: "Failed",
+  Blocked: "Blocked",
+  Unschedulable: "Unschedulable",
+  PermitRequired: "PermitRequired",
+  DoneSignaled: "DoneSignaled",
+} as const;
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+`bun test src/core/agent-task.condition-types.test.ts src/core/agent-task.test.ts` — expected PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/agent-task.ts src/core/agent-task.condition-types.test.ts
+git commit -m "feat(core): add DoneSignaled condition type for AgentTask"
+```
+
+---
+
+## Task 2: `Succeeded` transition in `TaskController.reconcileRunning`
+
+**Files:**
+- Modify: `src/core/task-controller.ts`
+- Modify: `src/core/task-controller.test.ts`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/core/task-controller.test.ts` after the existing `TaskController + Scheduler integration` block (replace the helpers/imports if duplicated; see context):
+
+```ts
+describe("TaskController — DoneSignaled → Succeeded", () => {
+  function viewWithCondition(
+    overrides: { sessionId?: string; doneSummary?: string } = {},
+  ): AgentTaskView {
+    return taskView({
+      phase: AgentTaskPhase.Running,
+      sessionId: overrides.sessionId ?? "session-running",
+      observedGeneration: 1,
+      conditions: overrides.doneSummary === undefined
+        ? []
+        : [
+            makeCondition("DoneSignaled", {
+              status: "True",
+              reason: "agent-grove-done",
+              message: overrides.doneSummary,
+            }),
+          ],
+    });
+  }
+
+  test("Running task with DoneSignaled=True transitions to Succeeded", async () => {
+    const store = new FakeTaskStore();
+    store.seed(viewWithCondition({ doneSummary: "Approved by reviewer." }));
+    const runtime = new FakeRuntime();
+    runtime.sessions.set("session-running", {
+      id: "session-running",
+      role: "worker",
+      status: "running",
+    });
+    const controller = controllerFor(store, { runtime });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Succeeded);
+    expect(condition(patch.conditions, "Succeeded")?.status).toBe("True");
+    expect(condition(patch.conditions, "Succeeded")?.message).toBe("Approved by reviewer.");
+    expect(condition(patch.conditions, "Running")?.status).toBe("False");
+  });
+
+  test("DoneSignaled takes precedence over session-status-stopped", async () => {
+    const store = new FakeTaskStore();
+    store.seed(viewWithCondition({ doneSummary: "Done." }));
+    // Runtime returns no live session (agent already exited after grove_done)
+    const runtime = new FakeRuntime();
+    const controller = controllerFor(store, { runtime });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Succeeded);
+  });
+
+  test("Running task without DoneSignaled and lost session still fails (back-compat)", async () => {
+    const store = new FakeTaskStore();
+    store.seed(viewWithCondition({}));
+    const runtime = new FakeRuntime();
+    const controller = controllerFor(store, { runtime });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Failed);
+  });
+
+  test("Succeeded transition closes runtime session", async () => {
+    const store = new FakeTaskStore();
+    store.seed(viewWithCondition({ doneSummary: "ok" }));
+    const runtime = new FakeRuntime();
+    const session = {
+      id: "session-running",
+      role: "worker",
+      status: "running" as const,
+    };
+    runtime.sessions.set(session.id, session);
+    const controller = controllerFor(store, { runtime });
+
+    await controller.reconcileTask("task-1");
+
+    expect(runtime.closeCalls).toHaveLength(1);
+    expect(runtime.closeCalls[0]?.id).toBe(session.id);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+`bun test src/core/task-controller.test.ts` — expected FAIL on the four new tests (controller still falls through to failLostSession when session gone).
+
+- [ ] **Step 3: Add `sessionToCloseOnSuccess` to ReconciliationResult**
+
+Edit `src/core/task-controller.ts`. Find the `ReconciliationResult` interface and add the new field:
+
+```ts
+interface ReconciliationResult {
+  readonly patch: AgentTaskStatusPatch;
+  readonly transition: AgentTaskStatusTransition;
+  readonly sessionToCloseOnPatchFailure?: AgentSession | undefined;
+  readonly sessionToCloseOnSuccess?: AgentSession | undefined;
+}
+```
+
+- [ ] **Step 4: Replace `reconcileRunning` with the DoneSignaled-aware version**
+
+Locate the existing `reconcileRunning` method in `src/core/task-controller.ts` (around line 312-324). Replace its body:
+
+```ts
+private async reconcileRunning(task: AgentTaskView): Promise<ReconciliationResult | undefined> {
+  if (task.status.sessionId === undefined) {
+    return failLostSession(task, this.nowIso());
+  }
+
+  const doneCondition = task.status.conditions.find(
+    (c) => c.type === AgentTaskConditionType.DoneSignaled && c.status === "True",
+  );
+  if (doneCondition !== undefined) {
+    const sessions = await this.runtime.listSessions();
+    const session = sessions.find((s) => s.id === task.status.sessionId);
+    return succeedTask(task, doneCondition.message ?? "", this.nowIso(), session);
+  }
+
+  const sessions = await this.runtime.listSessions();
+  const session = sessions.find((candidate) => candidate.id === task.status.sessionId);
+  if (session !== undefined && (session.status === "running" || session.status === "idle")) {
+    return runningLiveCatchUp(task, this.nowIso());
+  }
+
+  return failLostSession(task, this.nowIso());
+}
+```
+
+Add this helper at module scope alongside `failLostSession` (after `runningLiveCatchUp`):
+
+```ts
+function succeedTask(
+  task: AgentTaskView,
+  summary: string,
+  nowIso: string,
+  session: AgentSession | undefined,
+): ReconciliationResult {
+  const conditions = upsertCondition(
+    upsertCondition(task.status.conditions, {
+      type: AgentTaskConditionType.Running,
+      status: "False",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "done-signaled",
+      message: "",
+    }),
+    {
+      type: AgentTaskConditionType.Succeeded,
+      status: "True",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "done-signaled",
+      message: summary,
+    },
+  );
+  return {
+    patch: {
+      phase: AgentTaskPhase.Succeeded,
+      observedGeneration: task.spec.generation,
+      conditions,
+      lastTransitionAt: nowIso,
+    },
+    transition: transition(task, AgentTaskPhase.Succeeded, "done-signaled"),
+    ...(session === undefined ? {} : { sessionToCloseOnSuccess: session }),
+  };
+}
+```
+
+- [ ] **Step 5: Honor `sessionToCloseOnSuccess` in `reconcileTask`**
+
+Locate `reconcileTask` (around line 136). After the successful `patchAgentTaskStatus` call (post-`onTransition?.(result.transition)`), close the session if requested. Replace the `try { await this.taskStore.patchAgentTaskStatus(taskId, result.patch); } catch ...` block with:
+
+```ts
+try {
+  await this.taskStore.patchAgentTaskStatus(taskId, result.patch);
+} catch (error) {
+  if (result.sessionToCloseOnPatchFailure !== undefined) {
+    await this.closeAfterPatchFailure(result.sessionToCloseOnPatchFailure);
+  }
+  throw error;
+}
+this.onTransition?.(result.transition);
+if (result.sessionToCloseOnSuccess !== undefined) {
+  await this.closeAfterPatchFailure(result.sessionToCloseOnSuccess);
+}
+return result.transition;
+```
+
+(`closeAfterPatchFailure` is already a swallow-all helper around `runtime.close`; reusing it gives us the right error-tolerance semantics.)
+
+- [ ] **Step 6: Run tests to verify pass**
+
+`bun test src/core/task-controller.test.ts` — expected PASS (existing + 4 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/task-controller.ts src/core/task-controller.test.ts
+git commit -m "feat(task-controller): Succeeded transition on DoneSignaled condition"
+```
+
+---
+
+## Task 3: Create `upstream-prompt.ts` pure function
+
+**Files:**
+- Create: `src/core/scheduler/upstream-prompt.ts`
+- Create: `src/core/scheduler/upstream-prompt.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `src/core/scheduler/upstream-prompt.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { buildPromptWithUpstream, type UpstreamSection } from "./upstream-prompt.js";
+
+describe("buildPromptWithUpstream", () => {
+  test("returns base prompt unchanged when no upstream sections", () => {
+    expect(buildPromptWithUpstream("do work", [])).toBe("do work");
+  });
+
+  test("wraps base prompt with single upstream section", () => {
+    const sections: UpstreamSection[] = [{ taskId: "coder-1", summary: "Implemented X." }];
+    const out = buildPromptWithUpstream("Review my changes.", sections);
+    expect(out).toContain("## Upstream output");
+    expect(out).toContain("### coder-1 (succeeded)");
+    expect(out).toContain("Implemented X.");
+    expect(out).toContain("## Your task");
+    expect(out).toContain("Review my changes.");
+  });
+
+  test("concatenates multiple sections in order", () => {
+    const sections: UpstreamSection[] = [
+      { taskId: "a", summary: "first" },
+      { taskId: "b", summary: "second" },
+    ];
+    const out = buildPromptWithUpstream("base", sections);
+    const aIdx = out.indexOf("### a (succeeded)");
+    const bIdx = out.indexOf("### b (succeeded)");
+    expect(aIdx).toBeGreaterThanOrEqual(0);
+    expect(bIdx).toBeGreaterThan(aIdx);
+  });
+
+  test("substitutes '(no summary)' when summary is empty", () => {
+    const sections: UpstreamSection[] = [{ taskId: "a", summary: "" }];
+    const out = buildPromptWithUpstream("base", sections);
+    expect(out).toContain("(no summary)");
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+`bun test src/core/scheduler/upstream-prompt.test.ts` — expected FAIL (module missing).
+
+- [ ] **Step 3: Implement**
+
+Create `src/core/scheduler/upstream-prompt.ts`:
+
+```ts
+export interface UpstreamSection {
+  readonly taskId: string;
+  readonly summary: string;
+}
+
+export function buildPromptWithUpstream(
+  basePrompt: string,
+  sections: readonly UpstreamSection[],
+): string {
+  if (sections.length === 0) return basePrompt;
+  const blocks = sections.map(
+    (s) => `### ${s.taskId} (succeeded)\n${s.summary.length > 0 ? s.summary : "(no summary)"}`,
+  );
+  return `## Upstream output\n\n${blocks.join("\n\n")}\n\n## Your task\n\n${basePrompt}`;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+`bun test src/core/scheduler/upstream-prompt.test.ts` — expected PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/upstream-prompt.ts src/core/scheduler/upstream-prompt.test.ts
+git commit -m "feat(scheduler): upstream-prompt builder for dependency context"
+```
+
+---
+
+## Task 4: Broaden `SchedulerContext.store` Pick to include `getAgentTask`
+
+**Files:**
+- Modify: `src/core/scheduler/framework.ts`
+
+- [ ] **Step 1: Edit the type**
+
+Open `src/core/scheduler/framework.ts`. Locate the `SchedulerContext` interface. Change the `store` field from:
+
+```ts
+readonly store: Pick<AgentTaskStore, "listAgentTaskEntities">;
+```
+
+to:
+
+```ts
+readonly store: Pick<AgentTaskStore, "listAgentTaskEntities" | "getAgentTask">;
+```
+
+- [ ] **Step 2: Run tests to confirm no breakage**
+
+`bun test src/core/scheduler/` — expected PASS. Existing tests pass `AgentTaskStore` instances that already satisfy the wider Pick (any test using a fake-store-with-only-listAgentTaskEntities will now fail — fix by adding a stub `getAgentTask`).
+
+- [ ] **Step 3: Fix any failing tests by adding `getAgentTask` stub**
+
+For each failing test, locate the inline `store: { listAgentTaskEntities: async () => [] }` literal and add:
+
+```ts
+store: {
+  listAgentTaskEntities: async () => [],
+  getAgentTask: async () => undefined,
+}
+```
+
+Affected files (search and patch each):
+- `src/core/scheduler/scheduler.test.ts`
+- `src/core/scheduler/plugins/runtime-capability.test.ts`
+- `src/core/scheduler/plugins/budget-remaining.test.ts`
+- `src/core/scheduler/plugins/task-affinity.test.ts`
+- `src/core/scheduler/plugins/auto-permit.test.ts`
+- `src/core/scheduler/plugins/user-confirm-permit.test.ts`
+- `src/core/scheduler/plugins/default-bind.test.ts`
+- `src/core/scheduler/plugins/worktree-exclusivity.test.ts`
+- `src/core/scheduler/acceptance-config-reweight.test.ts`
+
+Run `bun test src/core/scheduler/` after each batch until green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/scheduler/
+git commit -m "refactor(scheduler): broaden SchedulerContext.store Pick to include getAgentTask"
+```
+
+---
+
+## Task 5: `DefaultBind` reads dependencies + wraps prompt
+
+**Files:**
+- Modify: `src/core/scheduler/plugins/default-bind.ts`
+- Modify: `src/core/scheduler/plugins/default-bind.test.ts`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/core/scheduler/plugins/default-bind.test.ts`:
+
+```ts
+import type { AgentTaskView } from "../../agent-task.js";
+import { AgentTaskConditionType } from "../../agent-task.js";
+
+function makeView(id: string, doneSummary: string): AgentTaskView {
+  return {
+    spec: {
+      id,
+      worktree: "/tmp/w",
+      runtime: "codex",
+      role: "coder",
+      prompt: "x",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+    },
+    status: {
+      id,
+      phase: AgentTaskPhase.Succeeded,
+      contributions: [],
+      conditions: [
+        {
+          type: AgentTaskConditionType.Succeeded,
+          status: "True",
+          observedGeneration: 1,
+          lastTransitionTime: "2026-05-16T00:00:00.000Z",
+          reason: "done-signaled",
+          message: doneSummary,
+        },
+      ],
+      observedGeneration: 1,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 2,
+    },
+  };
+}
+
+describe("DefaultBindPlugin — dependency prompt wrapping", () => {
+  test("dependsOn=[] leaves prompt unchanged", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    const task = taskWith({ prompt: "base prompt", dependsOn: [] });
+    const ctx: SchedulerContext = {
+      task,
+      profiles: [],
+      store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+      now: () => 0,
+    };
+    await plugin.bind(ctx, profile);
+    expect(runtime.spawnCalls[0]?.config.prompt).toBe("base prompt");
+  });
+
+  test("dependsOn with Succeeded dependency wraps prompt", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    const task = taskWith({ prompt: "review my changes", dependsOn: ["coder-1"] });
+    const ctx: SchedulerContext = {
+      task,
+      profiles: [],
+      store: {
+        listAgentTaskEntities: async () => [],
+        getAgentTask: async (id) => (id === "coder-1" ? makeView("coder-1", "Implemented X") : undefined),
+      },
+      now: () => 0,
+    };
+    await plugin.bind(ctx, profile);
+    const prompt = runtime.spawnCalls[0]?.config.prompt ?? "";
+    expect(prompt).toContain("## Upstream output");
+    expect(prompt).toContain("### coder-1 (succeeded)");
+    expect(prompt).toContain("Implemented X");
+    expect(prompt).toContain("## Your task");
+    expect(prompt).toContain("review my changes");
+  });
+
+  test("dependsOn with multiple deps preserves declaration order", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    const task = taskWith({ prompt: "base", dependsOn: ["a", "b"] });
+    const ctx: SchedulerContext = {
+      task,
+      profiles: [],
+      store: {
+        listAgentTaskEntities: async () => [],
+        getAgentTask: async (id) => makeView(id, `summary-${id}`),
+      },
+      now: () => 0,
+    };
+    await plugin.bind(ctx, profile);
+    const prompt = runtime.spawnCalls[0]?.config.prompt ?? "";
+    const aIdx = prompt.indexOf("### a (succeeded)");
+    const bIdx = prompt.indexOf("### b (succeeded)");
+    expect(aIdx).toBeGreaterThan(-1);
+    expect(bIdx).toBeGreaterThan(aIdx);
+  });
+
+  test("missing dependency view falls back to '(no summary)'", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    const task = taskWith({ prompt: "x", dependsOn: ["ghost"] });
+    const ctx: SchedulerContext = {
+      task,
+      profiles: [],
+      store: {
+        listAgentTaskEntities: async () => [],
+        getAgentTask: async () => undefined,
+      },
+      now: () => 0,
+    };
+    await plugin.bind(ctx, profile);
+    const prompt = runtime.spawnCalls[0]?.config.prompt ?? "";
+    expect(prompt).toContain("(no summary)");
+  });
+});
+```
+
+(`taskWith`, `profile`, `FakeRuntime` are already defined earlier in the file.)
+
+- [ ] **Step 2: Run to confirm fail**
+
+`bun test src/core/scheduler/plugins/default-bind.test.ts` — expected FAIL on the 4 new tests.
+
+- [ ] **Step 3: Update `DefaultBind.bind`**
+
+Edit `src/core/scheduler/plugins/default-bind.ts`. Import the upstream prompt helper at the top:
+
+```ts
+import { buildPromptWithUpstream, type UpstreamSection } from "../upstream-prompt.js";
+```
+
+Replace the body of `bind` so it gathers dependency summaries and wraps the prompt:
+
+```ts
+async bind(ctx: SchedulerContext, profile: RuntimeProfile): Promise<BindResult> {
+  const upstreamSections: UpstreamSection[] = [];
+  for (const depId of ctx.task.spec.dependsOn) {
+    const dep = await ctx.store.getAgentTask(depId);
+    const succeeded = dep?.status.conditions.find(
+      (c) => c.type === "Succeeded" && c.status === "True",
+    );
+    upstreamSections.push({ taskId: depId, summary: succeeded?.message ?? "" });
+  }
+  const wrappedPrompt = buildPromptWithUpstream(ctx.task.spec.prompt, upstreamSections);
+
+  const model = profile.model ?? readBudgetString(ctx.task.spec.budget, "model");
+  const config: AgentConfig = {
+    role: ctx.task.spec.role,
+    command: profile.runtimeCommand,
+    cwd: ctx.task.spec.worktree,
+    goal: ctx.task.spec.prompt,
+    prompt: wrappedPrompt,
+    ...(profile.platform === undefined ? {} : { platform: profile.platform }),
+    ...(model === undefined ? {} : { model }),
+    env: {
+      GROVE_AGENT_TASK_ID: ctx.task.spec.id,
+      GROVE_AGENT_TASK_GENERATION: String(ctx.task.spec.generation),
+      GROVE_AGENT_TASK_RUNTIME: profile.runtimeCommand,
+    },
+  };
+  const session = await this.runtime.spawn(ctx.task.spec.role, config);
+  return { session };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+`bun test src/core/scheduler/plugins/default-bind.test.ts` — expected PASS (existing + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/plugins/default-bind.ts src/core/scheduler/plugins/default-bind.test.ts
+git commit -m "feat(scheduler): DefaultBind wraps prompt with dependency Succeeded summaries"
+```
+
+---
+
+## Task 6: `DefaultBind` passes through `GROVE_SERVER_URL` + `GROVE_API_TOKEN` env
+
+**Files:**
+- Modify: `src/core/scheduler/plugins/default-bind.ts`
+- Modify: `src/core/scheduler/plugins/default-bind.test.ts`
+
+- [ ] **Step 1: Append failing test**
+
+Append to `src/core/scheduler/plugins/default-bind.test.ts`:
+
+```ts
+describe("DefaultBindPlugin — env passthrough for AgentTask done", () => {
+  test("forwards GROVE_SERVER_URL and GROVE_API_TOKEN when set in process env", async () => {
+    const originalUrl = process.env.GROVE_SERVER_URL;
+    const originalToken = process.env.GROVE_API_TOKEN;
+    process.env.GROVE_SERVER_URL = "http://localhost:4515";
+    process.env.GROVE_API_TOKEN = "test-token-123";
+    try {
+      const runtime = new FakeRuntime();
+      const plugin = new DefaultBindPlugin({ runtime });
+      const task = taskWith({});
+      const ctx: SchedulerContext = {
+        task,
+        profiles: [],
+        store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+        now: () => 0,
+      };
+      await plugin.bind(ctx, profile);
+      const env = runtime.spawnCalls[0]?.config.env ?? {};
+      expect(env.GROVE_SERVER_URL).toBe("http://localhost:4515");
+      expect(env.GROVE_API_TOKEN).toBe("test-token-123");
+    } finally {
+      if (originalUrl === undefined) delete process.env.GROVE_SERVER_URL;
+      else process.env.GROVE_SERVER_URL = originalUrl;
+      if (originalToken === undefined) delete process.env.GROVE_API_TOKEN;
+      else process.env.GROVE_API_TOKEN = originalToken;
+    }
+  });
+
+  test("omits GROVE_SERVER_URL / GROVE_API_TOKEN when unset in process env", async () => {
+    const originalUrl = process.env.GROVE_SERVER_URL;
+    const originalToken = process.env.GROVE_API_TOKEN;
+    delete process.env.GROVE_SERVER_URL;
+    delete process.env.GROVE_API_TOKEN;
+    try {
+      const runtime = new FakeRuntime();
+      const plugin = new DefaultBindPlugin({ runtime });
+      const task = taskWith({});
+      const ctx: SchedulerContext = {
+        task,
+        profiles: [],
+        store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+        now: () => 0,
+      };
+      await plugin.bind(ctx, profile);
+      const env = runtime.spawnCalls[0]?.config.env ?? {};
+      expect(env.GROVE_SERVER_URL).toBeUndefined();
+      expect(env.GROVE_API_TOKEN).toBeUndefined();
+    } finally {
+      if (originalUrl !== undefined) process.env.GROVE_SERVER_URL = originalUrl;
+      if (originalToken !== undefined) process.env.GROVE_API_TOKEN = originalToken;
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+`bun test src/core/scheduler/plugins/default-bind.test.ts` — expected FAIL.
+
+- [ ] **Step 3: Add env passthrough**
+
+In `src/core/scheduler/plugins/default-bind.ts`, modify the `env:` block inside the `AgentConfig` object literal:
+
+```ts
+env: {
+  GROVE_AGENT_TASK_ID: ctx.task.spec.id,
+  GROVE_AGENT_TASK_GENERATION: String(ctx.task.spec.generation),
+  GROVE_AGENT_TASK_RUNTIME: profile.runtimeCommand,
+  ...(process.env.GROVE_SERVER_URL === undefined ? {} : { GROVE_SERVER_URL: process.env.GROVE_SERVER_URL }),
+  ...(process.env.GROVE_API_TOKEN === undefined ? {} : { GROVE_API_TOKEN: process.env.GROVE_API_TOKEN }),
+},
+```
+
+- [ ] **Step 4: Run tests**
+
+`bun test src/core/scheduler/plugins/default-bind.test.ts` — expected PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/plugins/default-bind.ts src/core/scheduler/plugins/default-bind.test.ts
+git commit -m "feat(scheduler): DefaultBind forwards GROVE_SERVER_URL+GROVE_API_TOKEN to agent env"
+```
+
+---
+
+## Task 7: `POST /api/agent-tasks/:id/done` route
+
+**Files:**
+- Modify: `src/server/routes/agent-tasks.ts`
+- Modify: `src/server/routes/agent-tasks.test.ts`
+
+- [ ] **Step 1: Read the existing route file**
+
+Open `src/server/routes/agent-tasks.ts`. Locate where `requireControllerToken` is applied (currently used on the `PATCH /:id/status` route at line ~270 — verify exact line). The new `POST /:id/done` route must be registered BEFORE any `agentTasks.use(requireControllerToken, ...)` group, or registered with explicit bearer-only middleware.
+
+In current code, `requireControllerToken` is applied per-route via wrapper rather than as a group middleware. Verify by reading the file. If per-route, the new route inherits no controller-token requirement by default — which is what we want.
+
+- [ ] **Step 2: Write failing test**
+
+Append to `src/server/routes/agent-tasks.test.ts`:
+
+```ts
+describe("POST /api/agent-tasks/:id/done", () => {
+  test("writes DoneSignaled condition with summary", async () => {
+    const { app, store } = await createTestApp();
+    await store.putAgentTaskSpec({
+      id: "task-x",
+      worktree: "/tmp/w",
+      runtime: "codex",
+      role: "coder",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+    });
+
+    const res = await app.request("/api/agent-tasks/task-x/done", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
+      body: JSON.stringify({ summary: "Approved." }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.taskId).toBe("task-x");
+
+    const updated = await store.getAgentTask("task-x");
+    const done = updated?.status.conditions.find((c) => c.type === "DoneSignaled");
+    expect(done?.status).toBe("True");
+    expect(done?.message).toBe("Approved.");
+    expect(done?.reason).toBe("agent-grove-done");
+  });
+
+  test("returns 404 for unknown task", async () => {
+    const { app } = await createTestApp();
+    const res = await app.request("/api/agent-tasks/missing/done", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
+      body: JSON.stringify({ summary: "x" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("does NOT require X-Grove-Controller-Token (bearer-only)", async () => {
+    const { app, store } = await createTestApp();
+    await store.putAgentTaskSpec({
+      id: "task-y",
+      worktree: "/tmp/w",
+      runtime: "codex",
+      role: "coder",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+    });
+
+    const res = await app.request("/api/agent-tasks/task-y/done", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: "Bearer test-token" },
+      // no X-Grove-Controller-Token header
+      body: JSON.stringify({ summary: "done" }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+(Use `createTestApp` if already defined in the test file; otherwise reuse the helper pattern already used by existing tests in the file. Inspect the file first.)
+
+- [ ] **Step 3: Run to confirm fail**
+
+`bun test src/server/routes/agent-tasks.test.ts` — expected FAIL (route undefined).
+
+- [ ] **Step 4: Add the route**
+
+Edit `src/server/routes/agent-tasks.ts`. Locate where existing routes are registered. Add this BEFORE the `PATCH /:id/status` registration (so the bearer-only `/done` is matched first):
+
+```ts
+agentTasks.post(
+  "/:id/done",
+  zValidator("json", z.object({ summary: z.string().max(2000) }).strict()),
+  async (c) => {
+    const deps = c.get("deps");
+    const taskId = c.req.param("id");
+    const body = c.req.valid("json" as never) as { summary: string };
+    const store = deps.agentTaskStore;
+    if (store === undefined) throw new Error("AgentTask store middleware did not run");
+
+    const current = await store.getAgentTask(taskId);
+    if (current === undefined) {
+      return c.json({ error: { code: "NOT_FOUND", message: `task '${taskId}' not found` } }, 404);
+    }
+
+    const nowIso = new Date().toISOString();
+    const condition: Condition = {
+      type: AgentTaskConditionType.DoneSignaled,
+      status: "True",
+      observedGeneration: current.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "agent-grove-done",
+      message: body.summary,
+    };
+    const nextConditions = upsertCondition(current.status.conditions, condition);
+
+    const result = await store.patchAgentTaskStatus(taskId, {
+      conditions: nextConditions,
+      observedGeneration: current.spec.generation,
+    });
+    if (result.kind === "rv-mismatch") {
+      const refreshed = await store.getAgentTask(taskId);
+      if (refreshed === undefined) {
+        return c.json({ error: { code: "NOT_FOUND", message: "task disappeared" } }, 404);
+      }
+      const retried = await store.patchAgentTaskStatus(taskId, {
+        conditions: upsertCondition(refreshed.status.conditions, {
+          ...condition,
+          observedGeneration: refreshed.spec.generation,
+        }),
+        observedGeneration: refreshed.spec.generation,
+      });
+      if (retried.kind === "rv-mismatch") {
+        return c.json({ error: { code: "CONFLICT", message: "concurrent update" } }, 409);
+      }
+    }
+    return c.json({ ok: true, taskId, condition: "DoneSignaled" });
+  },
+);
+```
+
+Required imports (add to the existing import block at the top of the file):
+
+```ts
+import { AgentTaskConditionType } from "../../core/agent-task.js";
+import type { Condition } from "../../core/entity.js";
+import { upsertCondition } from "../../core/condition-utils.js";
+```
+
+If `upsertCondition` is not yet exported from a shared module, copy the implementation from `src/core/task-controller.ts`. Check first:
+
+```bash
+grep -n "export function upsertCondition" src/core/
+```
+
+If absent, in this same task:
+1. Create `src/core/condition-utils.ts` exporting `upsertCondition` (extract from task-controller.ts).
+2. Update task-controller.ts to import from `./condition-utils.js` instead of the local copy.
+3. Add a tiny test `src/core/condition-utils.test.ts` exercising upsert behavior.
+
+- [ ] **Step 5: Run tests**
+
+`bun test src/server/routes/agent-tasks.test.ts src/core/task-controller.test.ts` — expected PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/routes/agent-tasks.ts src/server/routes/agent-tasks.test.ts src/core/condition-utils.ts src/core/condition-utils.test.ts src/core/task-controller.ts
+git commit -m "feat(server): POST /api/agent-tasks/:id/done bearer-authed endpoint"
+```
+
+---
+
+## Task 8: `serve.ts` exports `GROVE_SERVER_URL` and `GROVE_API_TOKEN`
+
+**Files:**
+- Modify: `src/server/serve.ts`
+
+- [ ] **Step 1: Locate setup**
+
+Open `src/server/serve.ts`. Find the early environment-setup block (after `PORT` is parsed). Identify where `GROVE_DIR`, `PORT`, etc. are set.
+
+- [ ] **Step 2: Add defaults**
+
+Immediately after `const PORT = parsePort(process.env.PORT, 4515);` (around line 55), add:
+
+```ts
+// Defaults for env that downstream agents inherit. DefaultBind forwards both to
+// MCP so grove_done can POST /api/agent-tasks/:id/done.
+if (process.env.GROVE_SERVER_URL === undefined) {
+  process.env.GROVE_SERVER_URL = `http://${HOST ?? "localhost"}:${PORT}`;
+}
+```
+
+For `GROVE_API_TOKEN`: it must be a valid bearer token. The existing setup reads `server-keys.yaml` later in the file. Add right after the `loadKeyRegistry` call (around line 152) — locate `const rawRegistry = loadKeyRegistry(...)`:
+
+```ts
+if (process.env.GROVE_API_TOKEN === undefined) {
+  const firstToken = Object.keys(rawRegistry.keys)[0];
+  if (firstToken !== undefined) {
+    process.env.GROVE_API_TOKEN = firstToken;
+  }
+}
+```
+
+If `rawRegistry` is empty (no keys yet), leave `GROVE_API_TOKEN` undefined — the agent will see a clear error when `grove_done` runs.
+
+- [ ] **Step 3: Smoke check**
+
+Add no new tests for serve.ts (it's process-level, excluded from coverage per file header). Just verify the file still compiles:
+
+`bun run -e 'import("./src/server/serve.ts")'` — should fail at runtime (no listen) but not at type-check. Alternative: just rely on the E2E in Task 16.
+
+Run `bun test src/server/` — confirm no existing tests break.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/serve.ts
+git commit -m "feat(server): default GROVE_SERVER_URL + extract GROVE_API_TOKEN for agent inherit"
+```
+
+---
+
+## Task 9: `src/mcp/agent-task-context.ts` env reader
+
+**Files:**
+- Create: `src/mcp/agent-task-context.ts`
+- Create: `src/mcp/agent-task-context.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `src/mcp/agent-task-context.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { readAgentTaskContext } from "./agent-task-context.js";
+
+describe("readAgentTaskContext", () => {
+  test("returns context when both env vars set", () => {
+    const ctx = readAgentTaskContext({
+      GROVE_AGENT_TASK_ID: "task-1",
+      GROVE_AGENT_TASK_GENERATION: "3",
+    });
+    expect(ctx).toEqual({ taskId: "task-1", generation: 3 });
+  });
+
+  test("returns undefined when taskId missing", () => {
+    const ctx = readAgentTaskContext({ GROVE_AGENT_TASK_GENERATION: "1" });
+    expect(ctx).toBeUndefined();
+  });
+
+  test("returns undefined when generation missing", () => {
+    const ctx = readAgentTaskContext({ GROVE_AGENT_TASK_ID: "x" });
+    expect(ctx).toBeUndefined();
+  });
+
+  test("returns undefined when generation is non-numeric", () => {
+    const ctx = readAgentTaskContext({
+      GROVE_AGENT_TASK_ID: "x",
+      GROVE_AGENT_TASK_GENERATION: "abc",
+    });
+    expect(ctx).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+`bun test src/mcp/agent-task-context.test.ts` — expected FAIL.
+
+- [ ] **Step 3: Implement**
+
+Create `src/mcp/agent-task-context.ts`:
+
+```ts
+export interface AgentTaskContext {
+  readonly taskId: string;
+  readonly generation: number;
+}
+
+export function readAgentTaskContext(
+  env: Readonly<Record<string, string | undefined>>,
+): AgentTaskContext | undefined {
+  const taskId = env.GROVE_AGENT_TASK_ID;
+  const gen = env.GROVE_AGENT_TASK_GENERATION;
+  if (taskId === undefined || gen === undefined) return undefined;
+  const generation = Number.parseInt(gen, 10);
+  if (!Number.isFinite(generation)) return undefined;
+  return { taskId, generation };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+`bun test src/mcp/agent-task-context.test.ts` — expected PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/agent-task-context.ts src/mcp/agent-task-context.test.ts
+git commit -m "feat(mcp): agent-task-context env reader"
+```
+
+---
+
+## Task 10: `src/mcp/agent-task-done.ts` POST helper
+
+**Files:**
+- Create: `src/mcp/agent-task-done.ts`
+- Create: `src/mcp/agent-task-done.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `src/mcp/agent-task-done.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { signalAgentTaskDone } from "./agent-task-done.js";
+
+describe("signalAgentTaskDone", () => {
+  test("POSTs to /api/agent-tasks/:id/done with bearer auth", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fakeFetch: typeof fetch = async (input, init) => {
+      calls.push({ url: String(input), init: init ?? {} });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+    await signalAgentTaskDone(
+      { taskId: "task-x", generation: 1 },
+      "review approved",
+      {
+        baseUrl: "http://localhost:4515",
+        token: "abc123",
+        fetchImpl: fakeFetch,
+      },
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("http://localhost:4515/api/agent-tasks/task-x/done");
+    expect((calls[0]?.init.headers as Record<string, string>).Authorization).toBe("Bearer abc123");
+    expect(calls[0]?.init.body).toBe(JSON.stringify({ summary: "review approved" }));
+  });
+
+  test("throws when baseUrl missing", async () => {
+    await expect(
+      signalAgentTaskDone({ taskId: "x", generation: 1 }, "s", {
+        baseUrl: undefined,
+        token: "t",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/GROVE_SERVER_URL/);
+  });
+
+  test("throws when token missing", async () => {
+    await expect(
+      signalAgentTaskDone({ taskId: "x", generation: 1 }, "s", {
+        baseUrl: "http://x",
+        token: undefined,
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/GROVE_API_TOKEN/);
+  });
+
+  test("throws on non-2xx response", async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response("not found", { status: 404 });
+    await expect(
+      signalAgentTaskDone({ taskId: "x", generation: 1 }, "s", {
+        baseUrl: "http://x",
+        token: "t",
+        fetchImpl: fakeFetch,
+      }),
+    ).rejects.toThrow(/404/);
+  });
+
+  test("encodes taskId for URL safety", async () => {
+    const calls: string[] = [];
+    const fakeFetch: typeof fetch = async (input) => {
+      calls.push(String(input));
+      return new Response("{}", { status: 200 });
+    };
+    await signalAgentTaskDone({ taskId: "task/with/slashes", generation: 1 }, "s", {
+      baseUrl: "http://x",
+      token: "t",
+      fetchImpl: fakeFetch,
+    });
+    expect(calls[0]).toBe("http://x/api/agent-tasks/task%2Fwith%2Fslashes/done");
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+`bun test src/mcp/agent-task-done.test.ts` — expected FAIL.
+
+- [ ] **Step 3: Implement**
+
+Create `src/mcp/agent-task-done.ts`:
+
+```ts
+import type { AgentTaskContext } from "./agent-task-context.js";
+
+export interface SignalAgentTaskDoneOptions {
+  readonly baseUrl: string | undefined;
+  readonly token: string | undefined;
+  readonly fetchImpl?: typeof fetch | undefined;
+}
+
+export async function signalAgentTaskDone(
+  ctx: AgentTaskContext,
+  summary: string,
+  options: SignalAgentTaskDoneOptions,
+): Promise<void> {
+  if (options.baseUrl === undefined || options.baseUrl.length === 0) {
+    throw new Error("GROVE_SERVER_URL not set; cannot signal AgentTask done");
+  }
+  if (options.token === undefined || options.token.length === 0) {
+    throw new Error("GROVE_API_TOKEN not set; cannot signal AgentTask done");
+  }
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `${options.baseUrl}/api/agent-tasks/${encodeURIComponent(ctx.taskId)}/done`;
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${options.token}`,
+    },
+    body: JSON.stringify({ summary }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`POST /done returned ${res.status}: ${text}`);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+`bun test src/mcp/agent-task-done.test.ts` — expected PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/agent-task-done.ts src/mcp/agent-task-done.test.ts
+git commit -m "feat(mcp): signalAgentTaskDone POST helper"
+```
+
+---
+
+## Task 11: Wire `grove_done` to call the done helper
+
+**Files:**
+- Modify: `src/mcp/tools/done.ts`
+- Modify: `src/mcp/tools/done.test.ts`
+
+- [ ] **Step 1: Read existing test file**
+
+Open `src/mcp/tools/done.test.ts` to understand its existing structure. Most likely uses `McpServer` test harness + a fake `contributeOperation`.
+
+- [ ] **Step 2: Append failing tests**
+
+Append to `src/mcp/tools/done.test.ts`:
+
+```ts
+describe("grove_done — AgentTask bridge", () => {
+  test("when GROVE_AGENT_TASK_ID set, POSTs /done before contributeOperation", async () => {
+    const order: string[] = [];
+    const fakeFetch: typeof fetch = async (input) => {
+      order.push(`fetch ${String(input)}`);
+      return new Response("{}", { status: 200 });
+    };
+    const originalEnv = {
+      taskId: process.env.GROVE_AGENT_TASK_ID,
+      gen: process.env.GROVE_AGENT_TASK_GENERATION,
+      url: process.env.GROVE_SERVER_URL,
+      token: process.env.GROVE_API_TOKEN,
+    };
+    process.env.GROVE_AGENT_TASK_ID = "task-1";
+    process.env.GROVE_AGENT_TASK_GENERATION = "1";
+    process.env.GROVE_SERVER_URL = "http://localhost:4515";
+    process.env.GROVE_API_TOKEN = "tok";
+    try {
+      // Construct a test MCP server with stub deps; invoke grove_done.
+      // (See existing test patterns in this file for the harness setup.)
+      const result = await invokeDoneTool({
+        summary: "looks good",
+        fetchImpl: fakeFetch,
+        contributeSpy: (call) => order.push(`contribute ${call.summary}`),
+      });
+      expect(order[0]).toBe("fetch http://localhost:4515/api/agent-tasks/task-1/done");
+      expect(order[1]).toBe("contribute [DONE] looks good");
+      expect(result.isError).toBeUndefined();
+    } finally {
+      // restore env
+      if (originalEnv.taskId === undefined) delete process.env.GROVE_AGENT_TASK_ID;
+      else process.env.GROVE_AGENT_TASK_ID = originalEnv.taskId;
+      if (originalEnv.gen === undefined) delete process.env.GROVE_AGENT_TASK_GENERATION;
+      else process.env.GROVE_AGENT_TASK_GENERATION = originalEnv.gen;
+      if (originalEnv.url === undefined) delete process.env.GROVE_SERVER_URL;
+      else process.env.GROVE_SERVER_URL = originalEnv.url;
+      if (originalEnv.token === undefined) delete process.env.GROVE_API_TOKEN;
+      else process.env.GROVE_API_TOKEN = originalEnv.token;
+    }
+  });
+
+  test("when env vars absent, skips POST and only writes contribution (back-compat)", async () => {
+    const originalEnv = process.env.GROVE_AGENT_TASK_ID;
+    delete process.env.GROVE_AGENT_TASK_ID;
+    try {
+      const order: string[] = [];
+      const result = await invokeDoneTool({
+        summary: "no task",
+        fetchImpl: async () => {
+          order.push("fetch");
+          return new Response("{}", { status: 200 });
+        },
+        contributeSpy: (call) => order.push(`contribute ${call.summary}`),
+      });
+      expect(order).toEqual(["contribute [DONE] no task"]); // no fetch
+      expect(result.isError).toBeUndefined();
+    } finally {
+      if (originalEnv !== undefined) process.env.GROVE_AGENT_TASK_ID = originalEnv;
+    }
+  });
+
+  test("POST failure logs warning but still writes contribution", async () => {
+    const originalEnv = {
+      taskId: process.env.GROVE_AGENT_TASK_ID,
+      gen: process.env.GROVE_AGENT_TASK_GENERATION,
+      url: process.env.GROVE_SERVER_URL,
+      token: process.env.GROVE_API_TOKEN,
+    };
+    process.env.GROVE_AGENT_TASK_ID = "task-1";
+    process.env.GROVE_AGENT_TASK_GENERATION = "1";
+    process.env.GROVE_SERVER_URL = "http://localhost:4515";
+    process.env.GROVE_API_TOKEN = "tok";
+    try {
+      const contributed: string[] = [];
+      const result = await invokeDoneTool({
+        summary: "x",
+        fetchImpl: async () => new Response("err", { status: 500 }),
+        contributeSpy: (call) => contributed.push(call.summary),
+      });
+      expect(contributed).toEqual(["[DONE] x"]);
+      expect(result.isError).toBeUndefined();
+    } finally {
+      if (originalEnv.taskId === undefined) delete process.env.GROVE_AGENT_TASK_ID;
+      else process.env.GROVE_AGENT_TASK_ID = originalEnv.taskId;
+      if (originalEnv.gen === undefined) delete process.env.GROVE_AGENT_TASK_GENERATION;
+      else process.env.GROVE_AGENT_TASK_GENERATION = originalEnv.gen;
+      if (originalEnv.url === undefined) delete process.env.GROVE_SERVER_URL;
+      else process.env.GROVE_SERVER_URL = originalEnv.url;
+      if (originalEnv.token === undefined) delete process.env.GROVE_API_TOKEN;
+      else process.env.GROVE_API_TOKEN = originalEnv.token;
+    }
+  });
+});
+
+// Test harness — adapt to match existing patterns. If existing tests use a different
+// harness, refactor these to match.
+async function invokeDoneTool(opts: {
+  readonly summary: string;
+  readonly fetchImpl: typeof fetch;
+  readonly contributeSpy: (call: { readonly summary: string }) => void;
+}): Promise<{ isError?: boolean }> {
+  // Build minimal McpDeps with a contributeOperation stub.
+  // ... (see McpDeps shape in src/mcp/deps.ts; use a stub operationDeps that
+  //      records contribute calls via contributeSpy)
+  throw new Error("implement using existing McpDeps test pattern");
+}
+```
+
+NOTE: the `invokeDoneTool` harness is intentionally pseudo-code — adapt to the test pattern already used in `src/mcp/tools/done.test.ts`. Read the existing file first to see how it constructs `McpDeps` and invokes the registered tool callback. Use that same pattern. Inject `fetch` either via a deps field or `globalThis.fetch` mock.
+
+- [ ] **Step 3: Run to confirm fail**
+
+`bun test src/mcp/tools/done.test.ts` — expected FAIL.
+
+- [ ] **Step 4: Update `done.ts`**
+
+Edit `src/mcp/tools/done.ts`. Add imports at the top:
+
+```ts
+import { readAgentTaskContext } from "../agent-task-context.js";
+import { signalAgentTaskDone } from "../agent-task-done.js";
+```
+
+Inside the `async (args) => { ... }` handler, BEFORE the `contributeOperation` call, add:
+
+```ts
+const taskCtx = readAgentTaskContext(process.env);
+if (taskCtx !== undefined) {
+  try {
+    await signalAgentTaskDone(taskCtx, args.summary, {
+      baseUrl: process.env.GROVE_SERVER_URL,
+      token: process.env.GROVE_API_TOKEN,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[grove-done] task=${taskCtx.taskId} POST /done failed (${err instanceof Error ? err.message : String(err)}); contribution write proceeding\n`,
+    );
+  }
+}
+```
+
+The existing `contributeOperation` call follows unchanged.
+
+- [ ] **Step 5: Run tests**
+
+`bun test src/mcp/tools/done.test.ts` — expected PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mcp/tools/done.ts src/mcp/tools/done.test.ts
+git commit -m "feat(mcp): grove_done signals AgentTask done before writing contribution"
+```
+
+---
+
+## Task 12: `grove review-loop start` CLI — args + workspace + POST coder
+
+**Files:**
+- Create: `src/cli/commands/review-loop.ts`
+- Create: `src/cli/commands/review-loop.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `src/cli/commands/review-loop.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseReviewLoopStartArgs, type ReviewLoopStartArgs } from "./review-loop.js";
+
+describe("parseReviewLoopStartArgs", () => {
+  test("requires --goal", () => {
+    expect(() => parseReviewLoopStartArgs([])).toThrow(/--goal/);
+  });
+
+  test("returns parsed args with defaults", () => {
+    const args = parseReviewLoopStartArgs(["--goal", "Build feature X"]);
+    expect(args).toEqual({
+      goal: "Build feature X",
+      coder: "codex",
+      reviewer: "claude",
+      watch: false,
+      groveUrl: "http://localhost:4515",
+      timeoutSec: 600,
+    } satisfies ReviewLoopStartArgs);
+  });
+
+  test("honors all flags", () => {
+    const args = parseReviewLoopStartArgs([
+      "--goal", "X",
+      "--coder", "codex-cli",
+      "--reviewer", "claude-code",
+      "--watch",
+      "--grove-url", "http://example:9999",
+      "--timeout", "120",
+    ]);
+    expect(args.coder).toBe("codex-cli");
+    expect(args.reviewer).toBe("claude-code");
+    expect(args.watch).toBe(true);
+    expect(args.groveUrl).toBe("http://example:9999");
+    expect(args.timeoutSec).toBe(120);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+`bun test src/cli/commands/review-loop.test.ts` — expected FAIL.
+
+- [ ] **Step 3: Implement skeleton**
+
+Create `src/cli/commands/review-loop.ts`:
+
+```ts
+import { parseArgs } from "node:util";
+
+export interface ReviewLoopStartArgs {
+  readonly goal: string;
+  readonly coder: string;
+  readonly reviewer: string;
+  readonly watch: boolean;
+  readonly groveUrl: string;
+  readonly timeoutSec: number;
+}
+
+export function parseReviewLoopStartArgs(args: readonly string[]): ReviewLoopStartArgs {
+  const { values } = parseArgs({
+    args: [...args],
+    options: {
+      goal: { type: "string" },
+      coder: { type: "string", default: "codex" },
+      reviewer: { type: "string", default: "claude" },
+      watch: { type: "boolean", default: false },
+      "grove-url": { type: "string", default: "http://localhost:4515" },
+      timeout: { type: "string", default: "600" },
+    },
+    strict: false,
+  });
+  const goal = values.goal as string | undefined;
+  if (goal === undefined || goal.length === 0) {
+    throw new Error("--goal is required");
+  }
+  return {
+    goal,
+    coder: values.coder as string,
+    reviewer: values.reviewer as string,
+    watch: values.watch as boolean,
+    groveUrl: values["grove-url"] as string,
+    timeoutSec: Number.parseInt(values.timeout as string, 10),
+  };
+}
+
+export async function executeReviewLoop(args: readonly string[]): Promise<void> {
+  const subcommand = args[0];
+  const rest = args.slice(1);
+  if (subcommand !== "start") {
+    console.log(`grove review-loop <subcommand>
+
+Subcommands:
+  start --goal <text> [--coder <runtime>] [--reviewer <runtime>] [--watch]
+                      [--grove-url <url>] [--timeout <seconds>]
+                          Start a codex → claude review loop via AgentTask + Scheduler.
+                          Requires a running grove-server with scheduler config in grove.json.`);
+    return;
+  }
+  // The full start handler is filled in by later tasks.
+  throw new Error("review-loop start not yet implemented");
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+`bun test src/cli/commands/review-loop.test.ts` — expected PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/commands/review-loop.ts src/cli/commands/review-loop.test.ts
+git commit -m "feat(cli): grove review-loop start arg parsing"
+```
+
+---
+
+## Task 13: `grove review-loop start` — workspace bootstrap + POST tasks
+
+**Files:**
+- Modify: `src/cli/commands/review-loop.ts`
+- Modify: `src/cli/commands/review-loop.test.ts`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/cli/commands/review-loop.test.ts`:
+
+```ts
+import { buildTaskSpecs } from "./review-loop.js";
+
+describe("buildTaskSpecs", () => {
+  test("constructs coder + reviewer specs with shared worktree", () => {
+    const specs = buildTaskSpecs({
+      goal: "Build X",
+      coder: "codex",
+      reviewer: "claude",
+      worktree: "/tmp/wt",
+      timestamp: "2026-05-16T10:00:00.000Z",
+    });
+    expect(specs.coder.id).toBe("review-loop-2026-05-16T10:00:00.000Z-coder");
+    expect(specs.coder.runtime).toBe("codex");
+    expect(specs.coder.role).toBe("coder");
+    expect(specs.coder.prompt).toBe("Build X");
+    expect(specs.coder.worktree).toBe("/tmp/wt");
+    expect(specs.coder.dependsOn).toEqual([]);
+    expect(specs.coder.generation).toBe(1);
+
+    expect(specs.reviewer.id).toBe("review-loop-2026-05-16T10:00:00.000Z-reviewer");
+    expect(specs.reviewer.runtime).toBe("claude");
+    expect(specs.reviewer.role).toBe("reviewer");
+    expect(specs.reviewer.prompt).toContain("Review the work completed for: Build X");
+    expect(specs.reviewer.worktree).toBe("/tmp/wt");
+    expect(specs.reviewer.dependsOn).toEqual([specs.coder.id]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+`bun test src/cli/commands/review-loop.test.ts` — expected FAIL.
+
+- [ ] **Step 3: Add `buildTaskSpecs` and implement `start`**
+
+Edit `src/cli/commands/review-loop.ts`. Add the export:
+
+```ts
+import type { AgentTaskSpecRecord } from "../../core/agent-task.js";
+
+export interface TaskSpecBuilderInputs {
+  readonly goal: string;
+  readonly coder: string;
+  readonly reviewer: string;
+  readonly worktree: string;
+  readonly timestamp: string;
+}
+
+export interface TaskSpecPair {
+  readonly coder: AgentTaskSpecRecord;
+  readonly reviewer: AgentTaskSpecRecord;
+}
+
+export function buildTaskSpecs(inputs: TaskSpecBuilderInputs): TaskSpecPair {
+  const baseId = `review-loop-${inputs.timestamp}`;
+  const coderId = `${baseId}-coder`;
+  const reviewerId = `${baseId}-reviewer`;
+  const coder: AgentTaskSpecRecord = {
+    id: coderId,
+    worktree: inputs.worktree,
+    runtime: inputs.coder,
+    role: "coder",
+    prompt: inputs.goal,
+    dependsOn: [],
+    generation: 1,
+    createdAt: inputs.timestamp,
+  };
+  const reviewer: AgentTaskSpecRecord = {
+    id: reviewerId,
+    worktree: inputs.worktree,
+    runtime: inputs.reviewer,
+    role: "reviewer",
+    prompt: `Review the work completed for: ${inputs.goal}`,
+    dependsOn: [coderId],
+    generation: 1,
+    createdAt: inputs.timestamp,
+  };
+  return { coder, reviewer };
+}
+```
+
+Replace the `throw new Error("review-loop start not yet implemented");` line with the full start flow:
+
+```ts
+import { mkdirSync, readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+import { join } from "node:path";
+
+// ... inside executeReviewLoop after the `subcommand === "start"` branch:
+const parsed = parseReviewLoopStartArgs(rest);
+const { findGroveDir } = await import("../context.js");
+const groveDir = findGroveDir(process.cwd());
+if (groveDir === undefined) {
+  throw new Error("Not inside a grove. Run 'grove init' first.");
+}
+
+// Discover bearer token from server-keys.yaml.
+const serverKeysPath = join(groveDir, "server-keys.yaml");
+const rawYaml = readFileSync(serverKeysPath, "utf-8");
+const keysFile = parseYaml(rawYaml) as {
+  keys: Record<string, { namespace: string; createdAt: string }>;
+};
+const token = Object.keys(keysFile.keys)[0];
+if (token === undefined) {
+  throw new Error(`No bearer token found in ${serverKeysPath}`);
+}
+
+// Provision a shared worktree dir under .grove/workspaces/review-loop-<ts>/.
+const timestamp = new Date().toISOString();
+const safeTs = timestamp.replace(/[:.]/g, "-");
+const worktree = join(groveDir, "workspaces", `review-loop-${safeTs}`);
+mkdirSync(worktree, { recursive: true });
+
+const specs = buildTaskSpecs({
+  goal: parsed.goal,
+  coder: parsed.coder,
+  reviewer: parsed.reviewer,
+  worktree,
+  timestamp,
+});
+
+// POST coder first; if it fails, abort before reviewer.
+await putAgentTask(parsed.groveUrl, token, specs.coder);
+try {
+  await putAgentTask(parsed.groveUrl, token, specs.reviewer);
+} catch (err) {
+  // Best-effort cleanup: try to delete coder if reviewer creation fails.
+  await deleteAgentTask(parsed.groveUrl, token, specs.coder.id).catch(() => undefined);
+  throw err;
+}
+
+const output = {
+  groveUrl: parsed.groveUrl,
+  worktree,
+  tasks: {
+    coder: { id: specs.coder.id, runtime: specs.coder.runtime, role: specs.coder.role },
+    reviewer: {
+      id: specs.reviewer.id,
+      runtime: specs.reviewer.runtime,
+      role: specs.reviewer.role,
+      dependsOn: specs.reviewer.dependsOn,
+    },
+  },
+};
+console.log(JSON.stringify(output, null, 2));
+
+if (parsed.watch) {
+  await watchTasks(parsed.groveUrl, token, [specs.coder.id, specs.reviewer.id], parsed.timeoutSec);
+}
+```
+
+Add the HTTP helpers (`putAgentTask`, `deleteAgentTask`, `watchTasks`) to the same file. `putAgentTask`:
+
+```ts
+async function putAgentTask(
+  baseUrl: string,
+  token: string,
+  spec: AgentTaskSpecRecord,
+): Promise<void> {
+  const url = `${baseUrl}/api/agent-tasks/${encodeURIComponent(spec.id)}`;
+  const body = {
+    worktree: spec.worktree,
+    runtime: spec.runtime,
+    role: spec.role,
+    prompt: spec.prompt,
+    dependsOn: spec.dependsOn,
+  };
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "If-Match": "*",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    if (res.status === 0 || res.status >= 500) {
+      throw new Error(
+        `PUT /api/agent-tasks/${spec.id} failed (${res.status}). Hint: is grove-server running? Try 'grove up' first.\n${text}`,
+      );
+    }
+    throw new Error(`PUT /api/agent-tasks/${spec.id} failed: ${res.status} ${text}`);
+  }
+}
+
+async function deleteAgentTask(baseUrl: string, token: string, id: string): Promise<void> {
+  await fetch(`${baseUrl}/api/agent-tasks/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  }).catch(() => undefined);
+}
+```
+
+`watchTasks` is implemented in Task 14.
+
+- [ ] **Step 4: Run unit tests**
+
+`bun test src/cli/commands/review-loop.test.ts` — expected PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/commands/review-loop.ts src/cli/commands/review-loop.test.ts
+git commit -m "feat(cli): grove review-loop start posts coder+reviewer AgentTasks"
+```
+
+---
+
+## Task 14: `grove review-loop --watch` polling loop
+
+**Files:**
+- Modify: `src/cli/commands/review-loop.ts`
+
+- [ ] **Step 1: Add `watchTasks` implementation**
+
+In `src/cli/commands/review-loop.ts`, add the polling helper (stub from Task 13 now gets the real body):
+
+```ts
+type AgentTaskStatusView = {
+  readonly spec: { readonly id: string };
+  readonly status: {
+    readonly phase: string;
+    readonly sessionId?: string;
+    readonly conditions?: ReadonlyArray<{ readonly type: string; readonly status: string }>;
+  };
+};
+
+async function fetchTask(baseUrl: string, token: string, id: string): Promise<AgentTaskStatusView | undefined> {
+  const res = await fetch(`${baseUrl}/api/agent-tasks/${encodeURIComponent(id)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (res.status === 404) return undefined;
+  if (!res.ok) {
+    throw new Error(`GET /api/agent-tasks/${id} failed: ${res.status}`);
+  }
+  return (await res.json()) as AgentTaskStatusView;
+}
+
+async function watchTasks(
+  baseUrl: string,
+  token: string,
+  taskIds: readonly string[],
+  timeoutSec: number,
+): Promise<void> {
+  const lastPhase = new Map<string, string>();
+  const deadline = Date.now() + timeoutSec * 1000;
+  const terminal = new Set(["Succeeded", "Failed"]);
+
+  while (Date.now() < deadline) {
+    let allTerminal = true;
+    for (const id of taskIds) {
+      const view = await fetchTask(baseUrl, token, id);
+      if (view === undefined) {
+        console.log(JSON.stringify({ event: "missing", taskId: id, at: new Date().toISOString() }));
+        process.exit(1);
+      }
+      const phase = view.status.phase;
+      const prev = lastPhase.get(id);
+      if (prev !== phase) {
+        console.log(
+          JSON.stringify({
+            event: "phase-change",
+            taskId: id,
+            from: prev ?? "(initial)",
+            to: phase,
+            at: new Date().toISOString(),
+          }),
+        );
+        lastPhase.set(id, phase);
+      }
+      if (!terminal.has(phase)) allTerminal = false;
+    }
+    if (allTerminal) {
+      const anyFailed = [...lastPhase.values()].some((p) => p === "Failed");
+      console.log(
+        JSON.stringify({
+          event: "complete",
+          exitCode: anyFailed ? 1 : 0,
+          finalPhases: Object.fromEntries(lastPhase),
+        }),
+      );
+      process.exit(anyFailed ? 1 : 0);
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  console.log(
+    JSON.stringify({
+      event: "timeout",
+      timeoutSec,
+      lastPhases: Object.fromEntries(lastPhase),
+    }),
+  );
+  process.exit(2);
+}
+```
+
+- [ ] **Step 2: Add unit test**
+
+Append to `src/cli/commands/review-loop.test.ts`:
+
+```ts
+describe("watchTasks (unit-level via mocked fetch)", () => {
+  test("exits 0 when both tasks reach Succeeded", async () => {
+    // Mock global fetch to return progressively-advancing task states.
+    const responses: Record<string, AgentTaskStatusView[]> = {
+      "a": [
+        { spec: { id: "a" }, status: { phase: "Pending", conditions: [] } },
+        { spec: { id: "a" }, status: { phase: "PendingBind", conditions: [] } },
+        { spec: { id: "a" }, status: { phase: "Running", sessionId: "s", conditions: [] } },
+        { spec: { id: "a" }, status: { phase: "Succeeded", sessionId: "s", conditions: [] } },
+      ],
+      "b": [
+        { spec: { id: "b" }, status: { phase: "Pending", conditions: [] } },
+        { spec: { id: "b" }, status: { phase: "Pending", conditions: [] } },
+        { spec: { id: "b" }, status: { phase: "Pending", conditions: [] } },
+        { spec: { id: "b" }, status: { phase: "Running", sessionId: "s", conditions: [] } },
+        { spec: { id: "b" }, status: { phase: "Succeeded", sessionId: "s", conditions: [] } },
+      ],
+    };
+    const counters = new Map<string, number>();
+    const originalFetch = globalThis.fetch;
+    const originalExit = process.exit;
+    let exitCode: number | undefined;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const match = url.match(/agent-tasks\/([^/]+)$/);
+      if (match === null) return new Response("not found", { status: 404 });
+      const id = match[1];
+      const idx = counters.get(id) ?? 0;
+      const responsesForId = responses[id] ?? [];
+      const view = responsesForId[Math.min(idx, responsesForId.length - 1)];
+      counters.set(id, idx + 1);
+      return new Response(JSON.stringify(view), { status: 200 });
+    }) as typeof fetch;
+    (process.exit as unknown) = ((code: number) => {
+      exitCode = code;
+      throw new Error("__exit__");
+    }) as typeof process.exit;
+    try {
+      // Call watchTasks via internal export (re-export for testing).
+      const { __testHooks } = await import("./review-loop.js");
+      await expect(
+        __testHooks.watchTasks("http://x", "t", ["a", "b"], 30),
+      ).rejects.toThrow("__exit__");
+      expect(exitCode).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+      (process.exit as unknown) = originalExit;
+    }
+  });
+});
+
+type AgentTaskStatusView = {
+  readonly spec: { readonly id: string };
+  readonly status: {
+    readonly phase: string;
+    readonly sessionId?: string;
+    readonly conditions?: ReadonlyArray<{ readonly type: string; readonly status: string }>;
+  };
+};
+```
+
+In `review-loop.ts`, add at the bottom for testing:
+
+```ts
+export const __testHooks = { watchTasks, fetchTask, putAgentTask, deleteAgentTask };
+```
+
+- [ ] **Step 3: Run tests**
+
+`bun test src/cli/commands/review-loop.test.ts` — expected PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cli/commands/review-loop.ts src/cli/commands/review-loop.test.ts
+git commit -m "feat(cli): grove review-loop --watch streams phase transitions"
+```
+
+---
+
+## Task 15: Register `review-loop` in `main.ts`
+
+**Files:**
+- Modify: `src/cli/main.ts`
+
+- [ ] **Step 1: Add the command entry**
+
+Open `src/cli/main.ts`. Find the array of command objects (starts around line 113 with `init`). Insert (alphabetically, after `review`):
+
+```ts
+{
+  name: "review-loop",
+  description: "Start a codex → claude review loop via AgentTask + Scheduler",
+  needsStore: false,
+  handler: async (args) => {
+    const { executeReviewLoop } = await import("./commands/review-loop.js");
+    await executeReviewLoop(args);
+  },
+},
+```
+
+- [ ] **Step 2: Run integration test**
+
+`bun run src/cli/main.ts review-loop` — should print the help text.
+`bun run src/cli/main.ts review-loop start` — should error with `--goal is required`.
+
+Also run `bun test src/cli/` — confirm no regression in existing CLI tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/main.ts
+git commit -m "feat(cli): register grove review-loop subcommand in main dispatch"
+```
+
+---
+
+## Task 16: tmux E2E `review-loop-codex-claude-tmux.ts`
+
+**Files:**
+- Create: `tests/e2e/review-loop-codex-claude-tmux.ts`
+
+- [ ] **Step 1: Create the harness file**
+
+Copy the structure from `tests/e2e/scheduler-pipeline-tmux.ts` (recently added in this PR). The new harness:
+
+1. Setup phase:
+   - `mkdtempSync` workdir, `mkdirSync` `.grove/` inside it.
+   - `grove init --preset review-loop --force review-loop-e2e` (in tmux pane 0 or via spawnSync).
+   - Overwrite `grove.json` with:
+
+```json
+{
+  "name": "review-loop-e2e",
+  "mode": "local",
+  "scheduler": {
+    "profiles": [
+      {
+        "name": "codex-default",
+        "platform": "codex",
+        "runtimeCommand": "codex",
+        "supportedRoles": ["coder"]
+      },
+      {
+        "name": "claude-default",
+        "platform": "claude-code",
+        "runtimeCommand": "claude",
+        "supportedRoles": ["reviewer"]
+      }
+    ],
+    "pipeline": {
+      "filters": ["RuntimeCapability", "BudgetRemaining", "WorktreeExclusivity"],
+      "scores": [{ "name": "TaskAffinity", "weight": 1 }],
+      "permits": ["AutoPermit"],
+      "bind": "DefaultBind"
+    }
+  }
+}
+```
+
+2. Start grove-server in a tmux pane on a unique port (e.g., 12795):
+
+```ts
+const env = [
+  `GROVE_DIR=${groveDir}`,
+  `PORT=${SERVER_PORT}`,
+  `GROVE_TASK_CONTROLLER=1`,
+].join(" ");
+// tmux new-session -d -s ... -x 220 -y 50 sh -c
+//   "${env} bun run ${PROJECT_ROOT}/src/server/serve.ts 2>&1 | tee ${serverLogFile}; cat"
+```
+
+3. Wait for `task-controller enabled (scheduler: 2 profiles, 3 filters)` in the server pane (proves wiring picked up grove.json).
+
+4. Wait for `listening` to confirm HTTP up.
+
+5. Read bearer token from `.grove/server-keys.yaml`.
+
+6. Run `grove review-loop start --goal "Print hello and call grove_done" --grove-url http://localhost:12795 --watch --timeout 120` as a subprocess. Capture stdout (line-delimited JSON).
+
+7. Assertions on the captured stream:
+   - Parse each line as JSON.
+   - There must be a `phase-change` event for both task IDs going `Pending → ... → Succeeded`.
+   - The final event must be `{ event: "complete", exitCode: 0, ... }`.
+   - The subprocess exit code must be 0.
+
+8. Final pane capture:
+   - Capture and print the server pane (last 200 lines) so the user sees `task-controller enabled` + transition logs.
+   - Capture and print the final GET for each task (to show the `Succeeded` condition messages).
+
+9. Cleanup (skip if `--keep`):
+   - Kill tmux server: `tmux -L <socket> kill-server`.
+   - Remove workdir.
+
+Naming:
+- `SOCKET = "grove-review-loop-e2e"`
+- `SESSION = "grove-review-loop-e2e"`
+- `SERVER_PORT = 12795`
+
+Reuse the `capturePane`, `waitForPane`, `sleep`, `cleanup` helpers from `scheduler-pipeline-tmux.ts` (copy them — the existing file is also standalone).
+
+- [ ] **Step 2: Make file executable as standalone**
+
+Add the same `// NOT wired into bun test — run as: bun run tests/e2e/review-loop-codex-claude-tmux.ts` header.
+
+- [ ] **Step 3: Commit (before running)**
+
+```bash
+git add tests/e2e/review-loop-codex-claude-tmux.ts
+git commit -m "test(review-loop): tmux E2E harness for codex → claude AgentTask flow"
+```
+
+(We commit the harness even before it passes so the next task can iterate on it.)
+
+---
+
+## Task 17: Run the E2E + iterate to green
+
+**Files:**
+- Modify (as needed): `tests/e2e/review-loop-codex-claude-tmux.ts` and any plumbing it surfaces issues with.
+
+- [ ] **Step 1: Run the harness**
+
+```bash
+bun run tests/e2e/review-loop-codex-claude-tmux.ts
+```
+
+- [ ] **Step 2: Diagnose any failure**
+
+Common failure points and the right fix:
+
+- `task-controller enabled (scheduler: 2 profiles, 3 filters)` line missing → Task 8's `GROVE_SERVER_URL` / `GROVE_API_TOKEN` setup is in the wrong place, OR `GROVE_DIR` doesn't contain a grove.json — fix harness.
+- `grove review-loop` exits non-zero with "connection refused" → port mismatch between harness and CLI invocation.
+- Coder task stuck in `Running`, never reaches `Succeeded` → `grove_done` POST not firing. Check:
+  - Does the server pane show `POST /api/agent-tasks/<id>/done`? If not, MCP env vars aren't reaching the agent. Verify `DefaultBind` env passthrough.
+  - Does `[grove-done] task=... POST /done failed` appear in MCP stderr? If yes, route or auth is wrong.
+- Reviewer task never unblocks → `dependsOn` check or `Succeeded` transition issue. Check `[task-controller] <id>: Running → Succeeded` log.
+- Real-spawn issues (claude/codex won't start) → may need login/auth. Diagnose; if blocked, mark E2E as MANUAL with documented setup steps and accept unit-level coverage.
+
+Make ONE good-faith fix attempt per identified issue. If after 3 iterations the E2E still fails for non-trivial reasons (e.g., real CLI behavior we can't control), commit the harness in a state that documents the failure mode and report BLOCKED.
+
+- [ ] **Step 3: Commit final harness state**
+
+If green:
+
+```bash
+git add tests/e2e/review-loop-codex-claude-tmux.ts
+git commit -m "test(review-loop): E2E green — codex → claude handoff via scheduler"
+```
+
+If blocked but harness improved:
+
+```bash
+git add tests/e2e/review-loop-codex-claude-tmux.ts
+git commit -m "test(review-loop): tmux E2E partially working — see harness header for status"
+```
+
+Either way, in the final user-facing report explicitly state: which assertions pass, which don't, why.
+
+---
+
+## Final verification
+
+- [ ] **Run the full test suite**
+
+```bash
+bun test src/
+```
+
+Expected: all pre-existing tests pass + the new unit tests from tasks 1-15.
+
+- [ ] **Compare scheduler-pipeline E2E + new E2E**
+
+```bash
+bun run tests/e2e/scheduler-pipeline-tmux.ts
+bun run tests/e2e/review-loop-codex-claude-tmux.ts
+```
+
+Both should exit 0 (or the review-loop E2E exits 0 if green; if BLOCKED, exit code documents why).
+
+- [ ] **Check the gap from PR #439 is closed**
+
+The original PR #439 noted: "the legacy review-loop (codex submits → claude reviews) still runs on the older session-orchestrator path, not via AgentTask". The new `grove review-loop` CLI proves an alternative path that DOES go through AgentTask + Scheduler. Confirm in your final summary.
+
+---
+
+## Out of scope (deferred to follow-ups)
+
+- Cascade cancellation when a dependency Fails (dependent stays Pending forever today).
+- Multi-reviewer fan-out (one coder, two reviewers in parallel).
+- Replacing `SessionOrchestrator` / migrating `grove session start`.
+- `AwaitingReview` phase semantics (currently in the enum but unused; would be relevant for richer review-cycle UX).
+- Permit decision store backing for `UserConfirmPermit` (UI prompts for "approve this profile?").
+- Chaos test: kill controller mid-Succeeded-transition.
+- Telemetry exporters (Prometheus, OpenTelemetry) for AgentTask transitions.

--- a/docs/superpowers/plans/2026-05-16-scheduler-framework.md
+++ b/docs/superpowers/plans/2026-05-16-scheduler-framework.md
@@ -1,0 +1,3374 @@
+# Scheduler Framework Implementation Plan (D3, #300)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Kubernetes-scheduler-style plugin pipeline (Filter → Score → Permit → Bind) that selects a `RuntimeProfile` for each `AgentTask` before bind, and wire it into `TaskController.reconcilePendingBind`.
+
+**Architecture:** New `src/core/scheduler/` module. Pure `Scheduler` class runs the four-stage pipeline over candidate `RuntimeProfile` records and returns a typed `SchedulingResult`. `TaskController` gains an optional `scheduler` option; when present, `reconcilePendingBind` calls `scheduler.schedule(task)` and maps the result variant to a status patch. When absent, today's direct-bind path is preserved.
+
+**Tech Stack:** TypeScript with `isolatedDeclarations`, `bun:test`, `zod` v4 for config validation.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-scheduler-framework-design.md`
+
+---
+
+## File Structure
+
+**New files**
+
+- `src/core/scheduler/framework.ts` — plugin interfaces, `SchedulerContext`, `SchedulingResult`, verdict types.
+- `src/core/scheduler/profile.ts` — `RuntimeProfile` type + `synthesizeFallbackProfile(task)`.
+- `src/core/scheduler/scheduler.ts` — `Scheduler` class.
+- `src/core/scheduler/scheduler.test.ts` — pipeline tests.
+- `src/core/scheduler/config.ts` — `SchedulerConfig` zod schema + `loadSchedulerConfig`.
+- `src/core/scheduler/config.test.ts` — config tests.
+- `src/core/scheduler/plugins/runtime-capability.ts` + `.test.ts`
+- `src/core/scheduler/plugins/budget-remaining.ts` + `.test.ts`
+- `src/core/scheduler/plugins/worktree-exclusivity.ts` + `.test.ts`
+- `src/core/scheduler/plugins/task-affinity.ts` + `.test.ts`
+- `src/core/scheduler/plugins/auto-permit.ts` + `.test.ts`
+- `src/core/scheduler/plugins/user-confirm-permit.ts` + `.test.ts`
+- `src/core/scheduler/plugins/default-bind.ts` + `.test.ts`
+- `src/core/scheduler/plugins/index.ts` — built-in plugin registry.
+- `src/core/scheduler/index.ts` — public re-exports.
+
+**Modified files**
+
+- `src/core/agent-task.ts` — extend `AgentTaskConditionType` enum.
+- `src/core/task-controller.ts` — add `scheduler?` option, `applyDecision`, new branch in `reconcilePendingBind`.
+- `src/core/task-controller.test.ts` — extend with scheduler-injected scenarios.
+- `src/core/index.ts` — re-export scheduler module.
+
+**Convention:** every file in `src/core/scheduler/` uses `.js` import suffixes to match the rest of the repo's ESM-style imports.
+
+---
+
+## Task 1: Extend `AgentTaskConditionType` with `Unschedulable` + `PermitRequired`
+
+**Files:**
+- Modify: `src/core/agent-task.ts:15-26`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/agent-task.condition-types.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { AgentTaskConditionType } from "./agent-task.js";
+
+describe("AgentTaskConditionType", () => {
+  test("includes Unschedulable for scheduler-rejected tasks", () => {
+    expect(AgentTaskConditionType.Unschedulable).toBe("Unschedulable");
+  });
+
+  test("includes PermitRequired for scheduler permit-wait", () => {
+    expect(AgentTaskConditionType.PermitRequired).toBe("PermitRequired");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/agent-task.condition-types.test.ts`
+Expected: FAIL — property `Unschedulable` does not exist on type.
+
+- [ ] **Step 3: Add the two enum members**
+
+Edit `src/core/agent-task.ts` lines 15-24, replacing the `AgentTaskConditionType` object with:
+
+```ts
+export const AgentTaskConditionType = {
+  Admitted: "Admitted",
+  Scheduled: "Scheduled",
+  Bound: "Bound",
+  Running: "Running",
+  AwaitingReview: "AwaitingReview",
+  Succeeded: "Succeeded",
+  Failed: "Failed",
+  Blocked: "Blocked",
+  Unschedulable: "Unschedulable",
+  PermitRequired: "PermitRequired",
+} as const;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/agent-task.condition-types.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run existing agent-task tests to confirm no regression**
+
+Run: `bun test src/core/agent-task.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/agent-task.ts src/core/agent-task.condition-types.test.ts
+git commit -m "feat(core): add Unschedulable + PermitRequired condition types (#300)"
+```
+
+---
+
+## Task 2: Define plugin interfaces (`framework.ts`)
+
+**Files:**
+- Create: `src/core/scheduler/framework.ts`
+
+This file is type-only (no runtime logic), so the "test" is a compile-time use site. We add a tiny `bun:test` smoke that imports every exported symbol so missing exports fail fast.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/framework.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type {
+  BindPlugin,
+  FilterPlugin,
+  FilterRejection,
+  FilterVerdict,
+  PermitPlugin,
+  PermitVerdict,
+  SchedulerContext,
+  SchedulingResult,
+  ScorePlugin,
+} from "./framework.js";
+
+describe("framework exports", () => {
+  test("FilterVerdict discriminates by admit", () => {
+    const admit: FilterVerdict = { admit: true };
+    const reject: FilterVerdict = { admit: false, reason: "x" };
+    expect(admit.admit).toBe(true);
+    expect(reject.admit).toBe(false);
+  });
+
+  test("PermitVerdict status union covers granted/denied/wait", () => {
+    const grants: PermitVerdict[] = [
+      { status: "granted" },
+      { status: "denied", reason: "no" },
+      { status: "wait", reason: "later" },
+    ];
+    expect(grants).toHaveLength(3);
+  });
+
+  test("SchedulingResult kind union covers four variants", () => {
+    const kinds: SchedulingResult["kind"][] = ["bound", "unschedulable", "wait", "denied"];
+    expect(kinds).toEqual(["bound", "unschedulable", "wait", "denied"]);
+  });
+
+  test("FilterRejection records plugin + reason", () => {
+    const rejection: FilterRejection = { plugin: "test", reason: "x" };
+    expect(rejection.plugin).toBe("test");
+  });
+
+  test("plugin interfaces have name field", () => {
+    const filter: FilterPlugin = {
+      name: "n",
+      filter: async () => ({ admit: true }),
+    };
+    const score: ScorePlugin = { name: "n", score: async () => 0 };
+    const permit: PermitPlugin = { name: "n", permit: async () => ({ status: "granted" }) };
+    const bind: BindPlugin = {
+      name: "n",
+      bind: async () => ({ session: { id: "s", role: "r", status: "running" } }),
+    };
+    expect(filter.name).toBe("n");
+    expect(score.name).toBe("n");
+    expect(permit.name).toBe("n");
+    expect(bind.name).toBe("n");
+  });
+
+  test("SchedulerContext shape compiles", () => {
+    const _ctx: Pick<SchedulerContext, "now"> = { now: () => 0 };
+    expect(typeof _ctx.now).toBe("function");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/framework.test.ts`
+Expected: FAIL — `framework.js` does not exist.
+
+- [ ] **Step 3: Create `framework.ts`**
+
+Create `src/core/scheduler/framework.ts`:
+
+```ts
+import type { AgentSession } from "../agent-runtime.js";
+import type { AgentTaskView } from "../agent-task.js";
+import type { AgentTaskStore } from "../store.js";
+import type { RuntimeProfile } from "./profile.js";
+
+export interface SchedulerContext {
+  readonly task: AgentTaskView;
+  readonly profiles: readonly RuntimeProfile[];
+  readonly store: Pick<AgentTaskStore, "listAgentTaskEntities">;
+  readonly now: () => number;
+}
+
+export type FilterVerdict =
+  | { readonly admit: true }
+  | { readonly admit: false; readonly reason: string; readonly message?: string | undefined };
+
+export interface FilterPlugin {
+  readonly name: string;
+  filter(ctx: SchedulerContext, profile: RuntimeProfile): Promise<FilterVerdict>;
+}
+
+export interface ScorePlugin {
+  readonly name: string;
+  score(ctx: SchedulerContext, profile: RuntimeProfile): Promise<number>;
+}
+
+export type PermitVerdict =
+  | { readonly status: "granted" }
+  | { readonly status: "denied"; readonly reason: string; readonly message?: string | undefined }
+  | { readonly status: "wait"; readonly reason: string; readonly message?: string | undefined };
+
+export interface PermitPlugin {
+  readonly name: string;
+  permit(ctx: SchedulerContext, profile: RuntimeProfile): Promise<PermitVerdict>;
+}
+
+export interface BindResult {
+  readonly session: AgentSession;
+}
+
+export interface BindPlugin {
+  readonly name: string;
+  bind(ctx: SchedulerContext, profile: RuntimeProfile): Promise<BindResult>;
+}
+
+export interface FilterRejection {
+  readonly plugin: string;
+  readonly reason: string;
+  readonly message?: string | undefined;
+}
+
+export interface ProfileRejection {
+  readonly profile: RuntimeProfile;
+  readonly rejections: readonly FilterRejection[];
+}
+
+export type SchedulingResult =
+  | {
+      readonly kind: "bound";
+      readonly profile: RuntimeProfile;
+      readonly session: AgentSession;
+      readonly reservationToken?: string | undefined;
+    }
+  | {
+      readonly kind: "unschedulable";
+      readonly rejections: readonly ProfileRejection[];
+    }
+  | {
+      readonly kind: "wait";
+      readonly plugin: string;
+      readonly reason: string;
+      readonly message?: string | undefined;
+      readonly profile: RuntimeProfile;
+    }
+  | {
+      readonly kind: "denied";
+      readonly plugin: string;
+      readonly reason: string;
+      readonly message?: string | undefined;
+    };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/scheduler/framework.test.ts`
+Expected: FAIL — `profile.js` does not exist yet (next task creates it).
+
+To unblock just this task, add a temporary stub `profile.ts`:
+
+```ts
+export interface RuntimeProfile {
+  readonly name: string;
+}
+```
+
+Run again: `bun test src/core/scheduler/framework.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/framework.ts src/core/scheduler/framework.test.ts src/core/scheduler/profile.ts
+git commit -m "feat(scheduler): plugin interfaces + scheduling result types (#300)"
+```
+
+---
+
+## Task 3: Implement `RuntimeProfile` + `synthesizeFallbackProfile` (`profile.ts`)
+
+**Files:**
+- Modify: `src/core/scheduler/profile.ts` (replacing the Task 2 stub)
+- Create: `src/core/scheduler/profile.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/profile.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentTaskView } from "../agent-task.js";
+import { AgentTaskPhase } from "../agent-task.js";
+import { synthesizeFallbackProfile } from "./profile.js";
+
+function taskWithRuntime(runtime: string, model?: string): AgentTaskView {
+  return {
+    spec: {
+      id: "task-1",
+      worktree: "/tmp/w",
+      runtime,
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      ...(model === undefined ? {} : { budget: { model } }),
+    },
+    status: {
+      id: "task-1",
+      phase: AgentTaskPhase.Pending,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+describe("synthesizeFallbackProfile", () => {
+  test("maps task.spec.runtime 'claude' to claude-code platform", () => {
+    const profile = synthesizeFallbackProfile(taskWithRuntime("claude"));
+    expect(profile.platform).toBe("claude-code");
+    expect(profile.runtimeCommand).toBe("claude");
+    expect(profile.name).toBe("fallback-claude");
+  });
+
+  test("maps 'codex' and 'gemini' to their platforms", () => {
+    expect(synthesizeFallbackProfile(taskWithRuntime("codex")).platform).toBe("codex");
+    expect(synthesizeFallbackProfile(taskWithRuntime("gemini")).platform).toBe("gemini");
+  });
+
+  test("uses undefined platform for unknown runtime", () => {
+    expect(synthesizeFallbackProfile(taskWithRuntime("custom")).platform).toBeUndefined();
+  });
+
+  test("carries model from task.spec.budget.model when present", () => {
+    expect(synthesizeFallbackProfile(taskWithRuntime("claude", "claude-opus-4-7")).model).toBe(
+      "claude-opus-4-7",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/profile.test.ts`
+Expected: FAIL — `synthesizeFallbackProfile` is not exported.
+
+- [ ] **Step 3: Replace `profile.ts` stub with the full implementation**
+
+Replace the contents of `src/core/scheduler/profile.ts`:
+
+```ts
+import type { AgentTaskView } from "../agent-task.js";
+import type { AgentPlatformType } from "../topology.js";
+
+export interface RuntimeProfileBudget {
+  readonly maxCostUsd?: number | undefined;
+  readonly maxTurns?: number | undefined;
+  readonly allowedModels?: readonly string[] | undefined;
+}
+
+export interface RuntimeProfile {
+  readonly name: string;
+  readonly platform: AgentPlatformType | undefined;
+  readonly runtimeCommand: string;
+  readonly model?: string | undefined;
+  readonly supportedRoles?: readonly string[] | undefined;
+  readonly budget?: RuntimeProfileBudget | undefined;
+  readonly labels?: Readonly<Record<string, string>> | undefined;
+}
+
+export function synthesizeFallbackProfile(task: AgentTaskView): RuntimeProfile {
+  const runtime = task.spec.runtime;
+  const model = readModelFromBudget(task.spec.budget);
+  return {
+    name: `fallback-${runtime}`,
+    platform: runtimeToPlatform(runtime),
+    runtimeCommand: runtime,
+    ...(model === undefined ? {} : { model }),
+  };
+}
+
+function runtimeToPlatform(runtime: string): AgentPlatformType | undefined {
+  if (runtime === "claude" || runtime === "claude-code") return "claude-code";
+  if (runtime === "codex") return "codex";
+  if (runtime === "gemini") return "gemini";
+  return undefined;
+}
+
+function readModelFromBudget(budget: unknown): string | undefined {
+  if (budget === null || typeof budget !== "object") return undefined;
+  const model = (budget as { model?: unknown }).model;
+  return typeof model === "string" ? model : undefined;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/profile.test.ts`
+Expected: PASS (4 tests).
+
+Run: `bun test src/core/scheduler/framework.test.ts`
+Expected: PASS (6 tests, still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/profile.ts src/core/scheduler/profile.test.ts
+git commit -m "feat(scheduler): RuntimeProfile type + fallback synthesis (#300)"
+```
+
+---
+
+## Task 4: Scheduler pipeline — `unschedulable` when all filters reject
+
+**Files:**
+- Create: `src/core/scheduler/scheduler.ts`
+- Create: `src/core/scheduler/scheduler.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/scheduler.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentSession } from "../agent-runtime.js";
+import type { AgentTaskEntity, AgentTaskView } from "../agent-task.js";
+import { AgentTaskPhase } from "../agent-task.js";
+import type {
+  BindPlugin,
+  FilterPlugin,
+  PermitPlugin,
+  ScorePlugin,
+} from "./framework.js";
+import type { RuntimeProfile } from "./profile.js";
+import { Scheduler } from "./scheduler.js";
+
+const TASK_ID = "task-1";
+
+function taskView(): AgentTaskView {
+  return {
+    spec: {
+      id: TASK_ID,
+      worktree: "/tmp/w",
+      runtime: "claude",
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+    },
+    status: {
+      id: TASK_ID,
+      phase: AgentTaskPhase.PendingBind,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function profile(name: string, overrides: Partial<RuntimeProfile> = {}): RuntimeProfile {
+  return {
+    name,
+    platform: "claude-code",
+    runtimeCommand: "claude",
+    ...overrides,
+  };
+}
+
+function emptyStore(): { listAgentTaskEntities: () => Promise<readonly AgentTaskEntity[]> } {
+  return { listAgentTaskEntities: async () => [] };
+}
+
+function alwaysReject(name: string, reason: string): FilterPlugin {
+  return { name, filter: async () => ({ admit: false, reason }) };
+}
+
+function alwaysAdmit(name: string): FilterPlugin {
+  return { name, filter: async () => ({ admit: true }) };
+}
+
+function constantScore(name: string, value: number): ScorePlugin {
+  return { name, score: async () => value };
+}
+
+function autoPermit(): PermitPlugin {
+  return { name: "auto", permit: async () => ({ status: "granted" }) };
+}
+
+function staticBind(session: AgentSession): BindPlugin {
+  return { name: "static", bind: async () => ({ session }) };
+}
+
+describe("Scheduler.schedule — unschedulable", () => {
+  test("returns unschedulable when all profiles are rejected", async () => {
+    const scheduler = new Scheduler({
+      profiles: [profile("a"), profile("b")],
+      filters: [alwaysReject("deny-all", "blocked")],
+      scores: [],
+      permits: [autoPermit()],
+      bindPlugin: staticBind({ id: "s", role: "worker", status: "running" }),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("unschedulable");
+    if (result.kind === "unschedulable") {
+      expect(result.rejections).toHaveLength(2);
+      expect(result.rejections[0]?.rejections[0]?.reason).toBe("blocked");
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/scheduler.test.ts`
+Expected: FAIL — `Scheduler` not exported.
+
+- [ ] **Step 3: Create `scheduler.ts`**
+
+Create `src/core/scheduler/scheduler.ts`:
+
+```ts
+import type { AgentTaskView } from "../agent-task.js";
+import type {
+  BindPlugin,
+  FilterPlugin,
+  FilterRejection,
+  PermitPlugin,
+  ProfileRejection,
+  SchedulerContext,
+  SchedulingResult,
+  ScorePlugin,
+} from "./framework.js";
+import type { RuntimeProfile } from "./profile.js";
+import { synthesizeFallbackProfile } from "./profile.js";
+
+export interface SchedulerOptions {
+  readonly profiles: readonly RuntimeProfile[];
+  readonly filters: readonly FilterPlugin[];
+  readonly scores: readonly ScorePluginEntry[];
+  readonly permits: readonly PermitPlugin[];
+  readonly bindPlugin: BindPlugin;
+  readonly store: SchedulerContext["store"];
+  readonly now?: (() => number) | undefined;
+}
+
+export interface ScorePluginEntry {
+  readonly plugin: ScorePlugin;
+  readonly weight?: number | undefined;
+}
+
+export class Scheduler {
+  private readonly profiles: readonly RuntimeProfile[];
+  private readonly filters: readonly FilterPlugin[];
+  private readonly scores: readonly ScorePluginEntry[];
+  private readonly permits: readonly PermitPlugin[];
+  private readonly bindPlugin: BindPlugin;
+  private readonly store: SchedulerContext["store"];
+  private readonly now: () => number;
+
+  constructor(options: SchedulerOptions) {
+    this.profiles = options.profiles;
+    this.filters = options.filters;
+    this.scores = normalizeScores(options.scores);
+    this.permits = options.permits;
+    this.bindPlugin = options.bindPlugin;
+    this.store = options.store;
+    this.now = options.now ?? Date.now;
+  }
+
+  async schedule(task: AgentTaskView): Promise<SchedulingResult> {
+    const profiles = this.profiles.length > 0 ? this.profiles : [synthesizeFallbackProfile(task)];
+    const ctx: SchedulerContext = {
+      task,
+      profiles,
+      store: this.store,
+      now: this.now,
+    };
+
+    const filtered = await this.runFilters(ctx);
+    const admitted = filtered.filter((entry) => entry.rejections.length === 0);
+    if (admitted.length === 0) {
+      return { kind: "unschedulable", rejections: filtered };
+    }
+
+    // Score/permit/bind are added in later tasks. For Task 4, take the first admitted profile.
+    const winner = admitted[0]!.profile;
+    const { session } = await this.bindPlugin.bind(ctx, winner);
+    return { kind: "bound", profile: winner, session, reservationToken: undefined };
+  }
+
+  private async runFilters(ctx: SchedulerContext): Promise<readonly ProfileRejection[]> {
+    return Promise.all(
+      ctx.profiles.map(async (profile) => {
+        const rejections: FilterRejection[] = [];
+        for (const plugin of this.filters) {
+          const verdict = await plugin.filter(ctx, profile);
+          if (!verdict.admit) {
+            rejections.push({
+              plugin: plugin.name,
+              reason: verdict.reason,
+              message: verdict.message,
+            });
+          }
+        }
+        return { profile, rejections } satisfies ProfileRejection;
+      }),
+    );
+  }
+}
+
+function normalizeScores(scores: readonly ScorePluginEntry[]): readonly ScorePluginEntry[] {
+  return scores.map((entry) => ({
+    plugin: entry.plugin,
+    weight: entry.weight ?? 1,
+  }));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/scheduler/scheduler.test.ts`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/scheduler.ts src/core/scheduler/scheduler.test.ts
+git commit -m "feat(scheduler): pipeline skeleton + unschedulable path (#300)"
+```
+
+---
+
+## Task 5: Scheduler scoring — highest score wins, config-order breaks ties
+
+**Files:**
+- Modify: `src/core/scheduler/scheduler.ts`
+- Modify: `src/core/scheduler/scheduler.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `src/core/scheduler/scheduler.test.ts`:
+
+```ts
+describe("Scheduler.schedule — scoring", () => {
+  test("highest weighted-sum score wins", async () => {
+    const session: AgentSession = { id: "s", role: "worker", status: "running" };
+    const scheduler = new Scheduler({
+      profiles: [profile("a"), profile("b")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [
+        { plugin: constantScoreFor(profile("a").name, 20, profile("b").name, 80), weight: 1 },
+      ],
+      permits: [autoPermit()],
+      bindPlugin: staticBind(session),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") expect(result.profile.name).toBe("b");
+  });
+
+  test("tie broken by config declaration order", async () => {
+    const session: AgentSession = { id: "s", role: "worker", status: "running" };
+    const scheduler = new Scheduler({
+      profiles: [profile("first"), profile("second")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [{ plugin: constantScore("flat", 50), weight: 1 }],
+      permits: [autoPermit()],
+      bindPlugin: staticBind(session),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") expect(result.profile.name).toBe("first");
+  });
+
+  test("weights multiply per-score contributions", async () => {
+    const session: AgentSession = { id: "s", role: "worker", status: "running" };
+    const scheduler = new Scheduler({
+      profiles: [profile("a"), profile("b")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [
+        { plugin: constantScoreFor("a", 100, "b", 0), weight: 1 },
+        { plugin: constantScoreFor("a", 0, "b", 100), weight: 2 },
+      ],
+      permits: [autoPermit()],
+      bindPlugin: staticBind(session),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") expect(result.profile.name).toBe("b");
+  });
+});
+
+function constantScoreFor(nameA: string, valueA: number, nameB: string, valueB: number): ScorePlugin {
+  return {
+    name: `pair-${nameA}-${nameB}`,
+    score: async (_ctx, profile) => {
+      if (profile.name === nameA) return valueA;
+      if (profile.name === nameB) return valueB;
+      return 0;
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/scheduler/scheduler.test.ts`
+Expected: FAIL — scoring not implemented; "first" profile wins regardless because Task 4 takes admitted[0].
+
+- [ ] **Step 3: Replace the post-filter logic in `scheduler.ts`**
+
+In `src/core/scheduler/scheduler.ts`, replace the body of `schedule` after the `admitted.length === 0` check with:
+
+```ts
+    const winner = await this.pickWinner(ctx, admitted.map((entry) => entry.profile));
+    const { session } = await this.bindPlugin.bind(ctx, winner);
+    return { kind: "bound", profile: winner, session, reservationToken: undefined };
+```
+
+Add the new private method below `runFilters`:
+
+```ts
+  private async pickWinner(
+    ctx: SchedulerContext,
+    admitted: readonly RuntimeProfile[],
+  ): Promise<RuntimeProfile> {
+    if (admitted.length === 1) return admitted[0]!;
+
+    const totals = new Map<string, number>();
+    for (const profile of admitted) totals.set(profile.name, 0);
+
+    for (const entry of this.scores) {
+      const weight = entry.weight ?? 1;
+      for (const profile of admitted) {
+        const raw = await entry.plugin.score(ctx, profile);
+        totals.set(profile.name, (totals.get(profile.name) ?? 0) + raw * weight);
+      }
+    }
+
+    const orderIndex = (profile: RuntimeProfile): number =>
+      ctx.profiles.findIndex((candidate) => candidate.name === profile.name);
+
+    const ranked = [...admitted].sort((a, b) => {
+      const diff = (totals.get(b.name) ?? 0) - (totals.get(a.name) ?? 0);
+      if (diff !== 0) return diff;
+      return orderIndex(a) - orderIndex(b);
+    });
+    return ranked[0]!;
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/scheduler.test.ts`
+Expected: PASS (4 tests total in scheduler.test.ts).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/scheduler.ts src/core/scheduler/scheduler.test.ts
+git commit -m "feat(scheduler): weighted scoring + stable tie-break (#300)"
+```
+
+---
+
+## Task 6: Permit stage — granted/wait/denied short-circuits
+
+**Files:**
+- Modify: `src/core/scheduler/scheduler.ts`
+- Modify: `src/core/scheduler/scheduler.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `src/core/scheduler/scheduler.test.ts`:
+
+```ts
+describe("Scheduler.schedule — permit stage", () => {
+  test("permit wait short-circuits before bind", async () => {
+    const bind = staticBind({ id: "s", role: "worker", status: "running" });
+    const bindSpy = { called: false };
+    const observingBind: BindPlugin = {
+      name: "watch",
+      bind: async (ctx, profile) => {
+        bindSpy.called = true;
+        return bind.bind(ctx, profile);
+      },
+    };
+    const scheduler = new Scheduler({
+      profiles: [profile("a")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [],
+      permits: [
+        { name: "manual", permit: async () => ({ status: "wait", reason: "awaiting-user" }) },
+      ],
+      bindPlugin: observingBind,
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("wait");
+    expect(bindSpy.called).toBe(false);
+    if (result.kind === "wait") {
+      expect(result.plugin).toBe("manual");
+      expect(result.reason).toBe("awaiting-user");
+      expect(result.profile.name).toBe("a");
+    }
+  });
+
+  test("permit denied short-circuits before bind", async () => {
+    const scheduler = new Scheduler({
+      profiles: [profile("a")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [],
+      permits: [
+        { name: "policy", permit: async () => ({ status: "denied", reason: "not-allowed" }) },
+      ],
+      bindPlugin: staticBind({ id: "s", role: "worker", status: "running" }),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("denied");
+    if (result.kind === "denied") {
+      expect(result.plugin).toBe("policy");
+      expect(result.reason).toBe("not-allowed");
+    }
+  });
+
+  test("permit stage stops at first non-granted verdict", async () => {
+    const calls: string[] = [];
+    const scheduler = new Scheduler({
+      profiles: [profile("a")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [],
+      permits: [
+        {
+          name: "first",
+          permit: async () => {
+            calls.push("first");
+            return { status: "wait", reason: "later" };
+          },
+        },
+        {
+          name: "second",
+          permit: async () => {
+            calls.push("second");
+            return { status: "granted" };
+          },
+        },
+      ],
+      bindPlugin: staticBind({ id: "s", role: "worker", status: "running" }),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    await scheduler.schedule(taskView());
+
+    expect(calls).toEqual(["first"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/scheduler/scheduler.test.ts`
+Expected: FAIL — permits not yet consulted, scheduler binds anyway.
+
+- [ ] **Step 3: Insert permit stage in `scheduler.ts`**
+
+In `src/core/scheduler/scheduler.ts`, change `schedule()` so the section between `pickWinner` and `bindPlugin.bind` becomes:
+
+```ts
+    const winner = await this.pickWinner(ctx, admitted.map((entry) => entry.profile));
+
+    for (const plugin of this.permits) {
+      const verdict = await plugin.permit(ctx, winner);
+      if (verdict.status === "denied") {
+        return {
+          kind: "denied",
+          plugin: plugin.name,
+          reason: verdict.reason,
+          message: verdict.message,
+        };
+      }
+      if (verdict.status === "wait") {
+        return {
+          kind: "wait",
+          plugin: plugin.name,
+          reason: verdict.reason,
+          message: verdict.message,
+          profile: winner,
+        };
+      }
+    }
+
+    const { session } = await this.bindPlugin.bind(ctx, winner);
+    return { kind: "bound", profile: winner, session, reservationToken: undefined };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/scheduler.test.ts`
+Expected: PASS (7 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/scheduler.ts src/core/scheduler/scheduler.test.ts
+git commit -m "feat(scheduler): permit stage short-circuits bind (#300)"
+```
+
+---
+
+## Task 7: Scheduler — empty profiles → fallback synthesized
+
+**Files:**
+- Modify: `src/core/scheduler/scheduler.test.ts`
+
+The fallback path was implemented in Task 4 (`profiles.length > 0 ? ... : synthesizeFallbackProfile(task)`). Add a test that proves it.
+
+- [ ] **Step 1: Add failing test**
+
+Append to `src/core/scheduler/scheduler.test.ts`:
+
+```ts
+describe("Scheduler.schedule — fallback profile", () => {
+  test("synthesizes a single profile from task.spec.runtime when none configured", async () => {
+    const bindCalls: RuntimeProfile[] = [];
+    const scheduler = new Scheduler({
+      profiles: [],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [],
+      permits: [autoPermit()],
+      bindPlugin: {
+        name: "capture",
+        bind: async (_ctx, profile) => {
+          bindCalls.push(profile);
+          return { session: { id: "s", role: "worker", status: "running" } };
+        },
+      },
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("bound");
+    expect(bindCalls).toHaveLength(1);
+    expect(bindCalls[0]?.name).toBe("fallback-claude");
+    expect(bindCalls[0]?.runtimeCommand).toBe("claude");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `bun test src/core/scheduler/scheduler.test.ts`
+Expected: PASS — falls out of existing fallback logic.
+
+If it fails, recheck Task 4 step 3's `profiles` resolution.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/scheduler/scheduler.test.ts
+git commit -m "test(scheduler): cover empty-profiles fallback synthesis (#300)"
+```
+
+---
+
+## Task 8: RuntimeCapability filter
+
+**Files:**
+- Create: `src/core/scheduler/plugins/runtime-capability.ts`
+- Create: `src/core/scheduler/plugins/runtime-capability.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/plugins/runtime-capability.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentTaskView } from "../../agent-task.js";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+import { RuntimeCapabilityFilter } from "./runtime-capability.js";
+
+function makeCtx(task: AgentTaskView, profiles: RuntimeProfile[] = []): SchedulerContext {
+  return {
+    task,
+    profiles,
+    store: { listAgentTaskEntities: async () => [] },
+    now: () => 0,
+  };
+}
+
+function task(overrides: Partial<AgentTaskView["spec"]> = {}): AgentTaskView {
+  return {
+    spec: {
+      id: "t",
+      worktree: "/tmp/w",
+      runtime: "claude",
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      ...overrides,
+    },
+    status: {
+      id: "t",
+      phase: AgentTaskPhase.PendingBind,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function profile(overrides: Partial<RuntimeProfile> = {}): RuntimeProfile {
+  return {
+    name: "p",
+    platform: "claude-code",
+    runtimeCommand: "claude",
+    ...overrides,
+  };
+}
+
+describe("RuntimeCapabilityFilter", () => {
+  const filter = new RuntimeCapabilityFilter();
+
+  test("admits when task.spec.runtime matches profile.runtimeCommand", async () => {
+    const verdict = await filter.filter(makeCtx(task()), profile());
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("rejects when task.spec.runtime mismatches profile.runtimeCommand", async () => {
+    const verdict = await filter.filter(
+      makeCtx(task({ runtime: "codex" })),
+      profile({ runtimeCommand: "claude" }),
+    );
+    expect(verdict).toEqual({
+      admit: false,
+      reason: "runtime-mismatch",
+      message: "task pins runtime 'codex' but profile runs 'claude'",
+    });
+  });
+
+  test("rejects when profile.supportedRoles excludes task.spec.role", async () => {
+    const verdict = await filter.filter(
+      makeCtx(task({ role: "reviewer" })),
+      profile({ supportedRoles: ["worker"] }),
+    );
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) expect(verdict.reason).toBe("role-unsupported");
+  });
+
+  test("admits when profile.supportedRoles is undefined regardless of role", async () => {
+    const verdict = await filter.filter(makeCtx(task({ role: "anything" })), profile());
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("rejects when task asks for a model not in profile.budget.allowedModels", async () => {
+    const verdict = await filter.filter(
+      makeCtx(task({ budget: { model: "claude-haiku-4-5" } })),
+      profile({ budget: { allowedModels: ["claude-opus-4-7"] } }),
+    );
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) expect(verdict.reason).toBe("model-not-allowed");
+  });
+
+  test("admits when budget.allowedModels is undefined", async () => {
+    const verdict = await filter.filter(
+      makeCtx(task({ budget: { model: "anything" } })),
+      profile(),
+    );
+    expect(verdict).toEqual({ admit: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/plugins/runtime-capability.test.ts`
+Expected: FAIL — `RuntimeCapabilityFilter` not exported.
+
+- [ ] **Step 3: Implement the plugin**
+
+Create `src/core/scheduler/plugins/runtime-capability.ts`:
+
+```ts
+import type { FilterPlugin, FilterVerdict, SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+
+export class RuntimeCapabilityFilter implements FilterPlugin {
+  readonly name = "RuntimeCapability";
+
+  async filter(ctx: SchedulerContext, profile: RuntimeProfile): Promise<FilterVerdict> {
+    const requestedRuntime = ctx.task.spec.runtime;
+    if (
+      typeof requestedRuntime === "string" &&
+      requestedRuntime.length > 0 &&
+      requestedRuntime !== profile.runtimeCommand
+    ) {
+      return {
+        admit: false,
+        reason: "runtime-mismatch",
+        message: `task pins runtime '${requestedRuntime}' but profile runs '${profile.runtimeCommand}'`,
+      };
+    }
+
+    if (profile.supportedRoles !== undefined && !profile.supportedRoles.includes(ctx.task.spec.role)) {
+      return {
+        admit: false,
+        reason: "role-unsupported",
+        message: `profile '${profile.name}' does not support role '${ctx.task.spec.role}'`,
+      };
+    }
+
+    const requestedModel = readBudgetString(ctx.task.spec.budget, "model");
+    const allowedModels = profile.budget?.allowedModels;
+    if (
+      requestedModel !== undefined &&
+      allowedModels !== undefined &&
+      !allowedModels.includes(requestedModel)
+    ) {
+      return {
+        admit: false,
+        reason: "model-not-allowed",
+        message: `profile '${profile.name}' does not allow model '${requestedModel}'`,
+      };
+    }
+
+    return { admit: true };
+  }
+}
+
+function readBudgetString(budget: unknown, key: string): string | undefined {
+  if (budget === null || typeof budget !== "object") return undefined;
+  const value = (budget as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/plugins/runtime-capability.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/plugins/runtime-capability.ts src/core/scheduler/plugins/runtime-capability.test.ts
+git commit -m "feat(scheduler): RuntimeCapability filter plugin (#300)"
+```
+
+---
+
+## Task 9: BudgetRemaining filter
+
+**Files:**
+- Create: `src/core/scheduler/plugins/budget-remaining.ts`
+- Create: `src/core/scheduler/plugins/budget-remaining.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/plugins/budget-remaining.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentTaskView } from "../../agent-task.js";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+import { BudgetRemainingFilter, type BudgetLedger } from "./budget-remaining.js";
+
+function makeCtx(task: AgentTaskView): SchedulerContext {
+  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+}
+
+function task(overrides: Partial<AgentTaskView["spec"]> = {}): AgentTaskView {
+  return {
+    spec: {
+      id: "t",
+      worktree: "/tmp/w",
+      runtime: "claude",
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      ...overrides,
+    },
+    status: {
+      id: "t",
+      phase: AgentTaskPhase.PendingBind,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function profile(overrides: Partial<RuntimeProfile> = {}): RuntimeProfile {
+  return { name: "p", platform: "claude-code", runtimeCommand: "claude", ...overrides };
+}
+
+describe("BudgetRemainingFilter", () => {
+  test("admits when task budget fits within profile budget", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(
+      makeCtx(task({ budget: { maxCostUsd: 5 }, maxTurns: 10 })),
+      profile({ budget: { maxCostUsd: 10, maxTurns: 50 } }),
+    );
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("rejects when task maxCostUsd exceeds profile maxCostUsd", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(
+      makeCtx(task({ budget: { maxCostUsd: 20 } })),
+      profile({ budget: { maxCostUsd: 10 } }),
+    );
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) expect(verdict.reason).toBe("budget-exceeds-profile");
+  });
+
+  test("rejects when task maxTurns exceeds profile maxTurns", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(
+      makeCtx(task({ maxTurns: 100 })),
+      profile({ budget: { maxTurns: 50 } }),
+    );
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) expect(verdict.reason).toBe("turns-exceeds-profile");
+  });
+
+  test("admits when profile budget is undefined regardless of task budget", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(
+      makeCtx(task({ budget: { maxCostUsd: 999 } })),
+      profile(),
+    );
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("admits when task budget is undefined", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(makeCtx(task()), profile({ budget: { maxCostUsd: 1 } }));
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("ledger that returns false rejects with ledger-exhausted reason", async () => {
+    const ledger: BudgetLedger = { hasRemaining: async () => false };
+    const filter = new BudgetRemainingFilter({ ledger });
+    const verdict = await filter.filter(makeCtx(task()), profile());
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) expect(verdict.reason).toBe("ledger-exhausted");
+  });
+
+  test("default ledger is permissive", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(makeCtx(task()), profile());
+    expect(verdict).toEqual({ admit: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/plugins/budget-remaining.test.ts`
+Expected: FAIL — `BudgetRemainingFilter` not exported.
+
+- [ ] **Step 3: Implement the plugin**
+
+Create `src/core/scheduler/plugins/budget-remaining.ts`:
+
+```ts
+import type { FilterPlugin, FilterVerdict, SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+import type { AgentTaskView } from "../../agent-task.js";
+
+export interface BudgetLedger {
+  hasRemaining(profile: RuntimeProfile, task: AgentTaskView): Promise<boolean>;
+}
+
+const PERMISSIVE_LEDGER: BudgetLedger = {
+  hasRemaining: async () => true,
+};
+
+export interface BudgetRemainingFilterOptions {
+  readonly ledger?: BudgetLedger | undefined;
+}
+
+export class BudgetRemainingFilter implements FilterPlugin {
+  readonly name = "BudgetRemaining";
+  private readonly ledger: BudgetLedger;
+
+  constructor(options: BudgetRemainingFilterOptions = {}) {
+    this.ledger = options.ledger ?? PERMISSIVE_LEDGER;
+  }
+
+  async filter(ctx: SchedulerContext, profile: RuntimeProfile): Promise<FilterVerdict> {
+    const requestedCost = readBudgetNumber(ctx.task.spec.budget, "maxCostUsd");
+    if (
+      requestedCost !== undefined &&
+      profile.budget?.maxCostUsd !== undefined &&
+      requestedCost > profile.budget.maxCostUsd
+    ) {
+      return {
+        admit: false,
+        reason: "budget-exceeds-profile",
+        message: `task wants $${requestedCost} but profile '${profile.name}' caps at $${profile.budget.maxCostUsd}`,
+      };
+    }
+
+    const requestedTurns = ctx.task.spec.maxTurns;
+    if (
+      requestedTurns !== undefined &&
+      profile.budget?.maxTurns !== undefined &&
+      requestedTurns > profile.budget.maxTurns
+    ) {
+      return {
+        admit: false,
+        reason: "turns-exceeds-profile",
+        message: `task wants ${requestedTurns} turns but profile '${profile.name}' caps at ${profile.budget.maxTurns}`,
+      };
+    }
+
+    const hasRemaining = await this.ledger.hasRemaining(profile, ctx.task);
+    if (!hasRemaining) {
+      return {
+        admit: false,
+        reason: "ledger-exhausted",
+        message: `ledger reports no remaining budget for profile '${profile.name}'`,
+      };
+    }
+
+    return { admit: true };
+  }
+}
+
+function readBudgetNumber(budget: unknown, key: string): number | undefined {
+  if (budget === null || typeof budget !== "object") return undefined;
+  const value = (budget as Record<string, unknown>)[key];
+  return typeof value === "number" ? value : undefined;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/plugins/budget-remaining.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/plugins/budget-remaining.ts src/core/scheduler/plugins/budget-remaining.test.ts
+git commit -m "feat(scheduler): BudgetRemaining filter plugin (#300)"
+```
+
+---
+
+## Task 10: WorktreeExclusivity filter
+
+**Files:**
+- Create: `src/core/scheduler/plugins/worktree-exclusivity.ts`
+- Create: `src/core/scheduler/plugins/worktree-exclusivity.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/plugins/worktree-exclusivity.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentTaskEntity, AgentTaskView } from "../../agent-task.js";
+import { AgentTaskPhase, agentTaskViewToEntity } from "../../agent-task.js";
+import type { SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+import { WorktreeExclusivityFilter } from "./worktree-exclusivity.js";
+
+function view(id: string, worktree: string, phase: AgentTaskPhase): AgentTaskView {
+  return {
+    spec: {
+      id,
+      worktree,
+      runtime: "claude",
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+    },
+    status: {
+      id,
+      phase,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function ctxWith(task: AgentTaskView, others: readonly AgentTaskView[]): SchedulerContext {
+  const entities: AgentTaskEntity[] = [task, ...others].map((v) => agentTaskViewToEntity(v));
+  return {
+    task,
+    profiles: [],
+    store: { listAgentTaskEntities: async () => entities },
+    now: () => 0,
+  };
+}
+
+const profile: RuntimeProfile = { name: "p", platform: "claude-code", runtimeCommand: "claude" };
+
+describe("WorktreeExclusivityFilter", () => {
+  const filter = new WorktreeExclusivityFilter();
+
+  test("admits when no other task shares the worktree", async () => {
+    const task = view("self", "/w/a", AgentTaskPhase.PendingBind);
+    const verdict = await filter.filter(ctxWith(task, []), profile);
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("rejects when another Running task shares the worktree", async () => {
+    const task = view("self", "/w/a", AgentTaskPhase.PendingBind);
+    const other = view("other", "/w/a", AgentTaskPhase.Running);
+    const verdict = await filter.filter(ctxWith(task, [other]), profile);
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) {
+      expect(verdict.reason).toBe("worktree-busy");
+      expect(verdict.message).toContain("other");
+    }
+  });
+
+  test("admits when other task on same worktree is Succeeded", async () => {
+    const task = view("self", "/w/a", AgentTaskPhase.PendingBind);
+    const other = view("other", "/w/a", AgentTaskPhase.Succeeded);
+    const verdict = await filter.filter(ctxWith(task, [other]), profile);
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("admits when other Running task is on a different worktree", async () => {
+    const task = view("self", "/w/a", AgentTaskPhase.PendingBind);
+    const other = view("other", "/w/b", AgentTaskPhase.Running);
+    const verdict = await filter.filter(ctxWith(task, [other]), profile);
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("admits when the only Running task on the worktree is the task itself", async () => {
+    const task = view("self", "/w/a", AgentTaskPhase.Running);
+    const verdict = await filter.filter(ctxWith(task, []), profile);
+    expect(verdict).toEqual({ admit: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/plugins/worktree-exclusivity.test.ts`
+Expected: FAIL — plugin missing.
+
+- [ ] **Step 3: Implement the plugin**
+
+Create `src/core/scheduler/plugins/worktree-exclusivity.ts`:
+
+```ts
+import type { FilterPlugin, FilterVerdict, SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+
+export class WorktreeExclusivityFilter implements FilterPlugin {
+  readonly name = "WorktreeExclusivity";
+
+  async filter(ctx: SchedulerContext, _profile: RuntimeProfile): Promise<FilterVerdict> {
+    const entities = await ctx.store.listAgentTaskEntities();
+    const worktree = ctx.task.spec.worktree;
+    const selfId = ctx.task.spec.id;
+    const conflict = entities.find(
+      (entity) =>
+        entity.id !== selfId &&
+        entity.spec.worktree === worktree &&
+        entity.status.phase === "Running",
+    );
+    if (conflict !== undefined) {
+      return {
+        admit: false,
+        reason: "worktree-busy",
+        message: `running task '${conflict.id}' holds worktree '${worktree}'`,
+      };
+    }
+    return { admit: true };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/plugins/worktree-exclusivity.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/plugins/worktree-exclusivity.ts src/core/scheduler/plugins/worktree-exclusivity.test.ts
+git commit -m "feat(scheduler): WorktreeExclusivity filter plugin (#300)"
+```
+
+---
+
+## Task 11: TaskAffinity score
+
+**Files:**
+- Create: `src/core/scheduler/plugins/task-affinity.ts`
+- Create: `src/core/scheduler/plugins/task-affinity.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/plugins/task-affinity.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentTaskView } from "../../agent-task.js";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+import { TaskAffinityScore } from "./task-affinity.js";
+
+function ctxWith(task: AgentTaskView): SchedulerContext {
+  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+}
+
+function task(
+  overrides: { runtime?: string; affinity?: Readonly<Record<string, string>> } = {},
+): AgentTaskView {
+  return {
+    spec: {
+      id: "t",
+      worktree: "/tmp/w",
+      runtime: overrides.runtime ?? "claude",
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      ...(overrides.affinity === undefined ? {} : { budget: { affinity: overrides.affinity } }),
+    },
+    status: {
+      id: "t",
+      phase: AgentTaskPhase.PendingBind,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function profile(labels?: Record<string, string>): RuntimeProfile {
+  return {
+    name: "p",
+    platform: "claude-code",
+    runtimeCommand: "claude",
+    ...(labels === undefined ? {} : { labels }),
+  };
+}
+
+describe("TaskAffinityScore", () => {
+  const score = new TaskAffinityScore();
+
+  test("returns 100 when every requested label matches", async () => {
+    const value = await score.score(
+      ctxWith(task({ affinity: { tier: "premium", region: "us" } })),
+      profile({ tier: "premium", region: "us" }),
+    );
+    expect(value).toBe(100);
+  });
+
+  test("returns 50 when half the requested labels match", async () => {
+    const value = await score.score(
+      ctxWith(task({ affinity: { tier: "premium", region: "us" } })),
+      profile({ tier: "premium", region: "eu" }),
+    );
+    expect(value).toBe(50);
+  });
+
+  test("returns 0 when no requested labels match", async () => {
+    const value = await score.score(
+      ctxWith(task({ affinity: { tier: "premium" } })),
+      profile({ tier: "free" }),
+    );
+    expect(value).toBe(0);
+  });
+
+  test("returns neutral 50 when no affinity requested and no runtime hint", async () => {
+    const value = await score.score(ctxWith(task({ runtime: "" })), profile());
+    expect(value).toBe(50);
+  });
+
+  test("derives default affinity from task.spec.runtime when budget.affinity absent", async () => {
+    const match = await score.score(ctxWith(task({ runtime: "claude" })), profile({ runtime: "claude" }));
+    const miss = await score.score(ctxWith(task({ runtime: "claude" })), profile({ runtime: "codex" }));
+    expect(match).toBe(100);
+    expect(miss).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/plugins/task-affinity.test.ts`
+Expected: FAIL — plugin missing.
+
+- [ ] **Step 3: Implement the plugin**
+
+Create `src/core/scheduler/plugins/task-affinity.ts`:
+
+```ts
+import type { SchedulerContext, ScorePlugin } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+
+const NEUTRAL_SCORE = 50;
+
+export class TaskAffinityScore implements ScorePlugin {
+  readonly name = "TaskAffinity";
+
+  async score(ctx: SchedulerContext, profile: RuntimeProfile): Promise<number> {
+    const requested = resolveRequestedLabels(ctx);
+    const keys = Object.keys(requested);
+    if (keys.length === 0) return NEUTRAL_SCORE;
+
+    const labels = profile.labels ?? {};
+    let matched = 0;
+    for (const key of keys) {
+      if (labels[key] === requested[key]) matched += 1;
+    }
+    return Math.round((100 * matched) / keys.length);
+  }
+}
+
+function resolveRequestedLabels(ctx: SchedulerContext): Readonly<Record<string, string>> {
+  const fromBudget = readAffinityFromBudget(ctx.task.spec.budget);
+  if (fromBudget !== undefined && Object.keys(fromBudget).length > 0) return fromBudget;
+
+  const runtime = ctx.task.spec.runtime;
+  if (typeof runtime === "string" && runtime.length > 0) return { runtime };
+
+  return {};
+}
+
+function readAffinityFromBudget(budget: unknown): Readonly<Record<string, string>> | undefined {
+  if (budget === null || typeof budget !== "object") return undefined;
+  const value = (budget as { affinity?: unknown }).affinity;
+  if (value === null || typeof value !== "object") return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/plugins/task-affinity.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/plugins/task-affinity.ts src/core/scheduler/plugins/task-affinity.test.ts
+git commit -m "feat(scheduler): TaskAffinity score plugin (#300)"
+```
+
+---
+
+## Task 12: AutoPermit
+
+**Files:**
+- Create: `src/core/scheduler/plugins/auto-permit.ts`
+- Create: `src/core/scheduler/plugins/auto-permit.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/plugins/auto-permit.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { AgentTaskView } from "../../agent-task.js";
+import { AutoPermit } from "./auto-permit.js";
+
+const task: AgentTaskView = {
+  spec: {
+    id: "t",
+    worktree: "/tmp/w",
+    runtime: "claude",
+    role: "worker",
+    prompt: "p",
+    dependsOn: [],
+    generation: 1,
+    createdAt: "2026-05-16T00:00:00.000Z",
+  },
+  status: {
+    id: "t",
+    phase: AgentTaskPhase.PendingBind,
+    contributions: [],
+    conditions: [],
+    observedGeneration: 0,
+    lastTransitionAt: "2026-05-16T00:00:00.000Z",
+    revision: 1,
+  },
+};
+
+describe("AutoPermit", () => {
+  test("always grants", async () => {
+    const permit = new AutoPermit();
+    const ctx = { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+    const verdict = await permit.permit(ctx, {
+      name: "p",
+      platform: "claude-code",
+      runtimeCommand: "claude",
+    });
+    expect(verdict).toEqual({ status: "granted" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/plugins/auto-permit.test.ts`
+Expected: FAIL — `AutoPermit` not exported.
+
+- [ ] **Step 3: Implement the plugin**
+
+Create `src/core/scheduler/plugins/auto-permit.ts`:
+
+```ts
+import type { PermitPlugin, PermitVerdict } from "../framework.js";
+
+export class AutoPermit implements PermitPlugin {
+  readonly name = "AutoPermit";
+
+  async permit(): Promise<PermitVerdict> {
+    return { status: "granted" };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/plugins/auto-permit.test.ts`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/plugins/auto-permit.ts src/core/scheduler/plugins/auto-permit.test.ts
+git commit -m "feat(scheduler): AutoPermit plugin (#300)"
+```
+
+---
+
+## Task 13: UserConfirmPermit (shape + in-memory store)
+
+**Files:**
+- Create: `src/core/scheduler/plugins/user-confirm-permit.ts`
+- Create: `src/core/scheduler/plugins/user-confirm-permit.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/plugins/user-confirm-permit.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { AgentTaskView } from "../../agent-task.js";
+import type { SchedulerContext } from "../framework.js";
+import {
+  InMemoryPermitDecisionStore,
+  UserConfirmPermit,
+} from "./user-confirm-permit.js";
+
+function ctx(task: AgentTaskView): SchedulerContext {
+  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+}
+
+const task: AgentTaskView = {
+  spec: {
+    id: "t",
+    worktree: "/tmp/w",
+    runtime: "claude",
+    role: "worker",
+    prompt: "p",
+    dependsOn: [],
+    generation: 1,
+    createdAt: "2026-05-16T00:00:00.000Z",
+  },
+  status: {
+    id: "t",
+    phase: AgentTaskPhase.PendingBind,
+    contributions: [],
+    conditions: [],
+    observedGeneration: 0,
+    lastTransitionAt: "2026-05-16T00:00:00.000Z",
+    revision: 1,
+  },
+};
+
+const profile = { name: "p", platform: "claude-code", runtimeCommand: "claude" } as const;
+
+describe("UserConfirmPermit", () => {
+  test("returns wait when no decision present", async () => {
+    const store = new InMemoryPermitDecisionStore();
+    const permit = new UserConfirmPermit({ store });
+    const verdict = await permit.permit(ctx(task), profile);
+    expect(verdict).toEqual({
+      status: "wait",
+      reason: "awaiting-user-confirmation",
+      message: "no decision recorded for task 't' / profile 'p' / generation 1",
+    });
+  });
+
+  test("returns granted when decision approved", async () => {
+    const store = new InMemoryPermitDecisionStore();
+    await store.record({ taskId: "t", profileName: "p", generation: 1, approved: true });
+    const permit = new UserConfirmPermit({ store });
+    expect(await permit.permit(ctx(task), profile)).toEqual({ status: "granted" });
+  });
+
+  test("returns denied with stored reason when decision rejected", async () => {
+    const store = new InMemoryPermitDecisionStore();
+    await store.record({
+      taskId: "t",
+      profileName: "p",
+      generation: 1,
+      approved: false,
+      reason: "too-expensive",
+    });
+    const permit = new UserConfirmPermit({ store });
+    const verdict = await permit.permit(ctx(task), profile);
+    expect(verdict).toEqual({ status: "denied", reason: "too-expensive" });
+  });
+
+  test("decisions for older generations do not apply to newer task generations", async () => {
+    const store = new InMemoryPermitDecisionStore();
+    await store.record({ taskId: "t", profileName: "p", generation: 1, approved: true });
+    const newer: AgentTaskView = {
+      spec: { ...task.spec, generation: 2 },
+      status: task.status,
+    };
+    const permit = new UserConfirmPermit({ store });
+    const verdict = await permit.permit(ctx(newer), profile);
+    expect(verdict.status).toBe("wait");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/plugins/user-confirm-permit.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the plugin + in-memory store**
+
+Create `src/core/scheduler/plugins/user-confirm-permit.ts`:
+
+```ts
+import type { PermitPlugin, PermitVerdict, SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+
+export interface PermitDecision {
+  readonly approved: boolean;
+  readonly reason?: string | undefined;
+}
+
+export interface PermitDecisionLookup {
+  readonly taskId: string;
+  readonly profileName: string;
+  readonly generation: number;
+}
+
+export interface PermitDecisionRecord extends PermitDecisionLookup, PermitDecision {}
+
+export interface PermitDecisionStore {
+  lookup(query: PermitDecisionLookup): Promise<PermitDecision | undefined>;
+}
+
+export class InMemoryPermitDecisionStore implements PermitDecisionStore {
+  private readonly map = new Map<string, PermitDecision>();
+
+  async record(record: PermitDecisionRecord): Promise<void> {
+    const { approved } = record;
+    const decision: PermitDecision = record.reason === undefined ? { approved } : { approved, reason: record.reason };
+    this.map.set(keyOf(record), decision);
+  }
+
+  async lookup(query: PermitDecisionLookup): Promise<PermitDecision | undefined> {
+    return this.map.get(keyOf(query));
+  }
+}
+
+export interface UserConfirmPermitOptions {
+  readonly store: PermitDecisionStore;
+}
+
+export class UserConfirmPermit implements PermitPlugin {
+  readonly name = "UserConfirmPermit";
+  private readonly store: PermitDecisionStore;
+
+  constructor(options: UserConfirmPermitOptions) {
+    this.store = options.store;
+  }
+
+  async permit(ctx: SchedulerContext, profile: RuntimeProfile): Promise<PermitVerdict> {
+    const decision = await this.store.lookup({
+      taskId: ctx.task.spec.id,
+      profileName: profile.name,
+      generation: ctx.task.spec.generation,
+    });
+    if (decision === undefined) {
+      return {
+        status: "wait",
+        reason: "awaiting-user-confirmation",
+        message: `no decision recorded for task '${ctx.task.spec.id}' / profile '${profile.name}' / generation ${ctx.task.spec.generation}`,
+      };
+    }
+    if (decision.approved) return { status: "granted" };
+    return decision.reason === undefined
+      ? { status: "denied", reason: "user-denied" }
+      : { status: "denied", reason: decision.reason };
+  }
+}
+
+function keyOf(query: PermitDecisionLookup): string {
+  return `${query.taskId}::${query.profileName}::${query.generation}`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/plugins/user-confirm-permit.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/plugins/user-confirm-permit.ts src/core/scheduler/plugins/user-confirm-permit.test.ts
+git commit -m "feat(scheduler): UserConfirmPermit shape + in-memory store (#300)"
+```
+
+---
+
+## Task 14: DefaultBind plugin
+
+**Files:**
+- Create: `src/core/scheduler/plugins/default-bind.ts`
+- Create: `src/core/scheduler/plugins/default-bind.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/plugins/default-bind.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentConfig, AgentRuntime, AgentSession } from "../../agent-runtime.js";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { AgentTaskView } from "../../agent-task.js";
+import type { AgentSessionEntity } from "../../entity.js";
+import type { SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+import { DefaultBindPlugin } from "./default-bind.js";
+
+class FakeRuntime implements AgentRuntime {
+  spawnCalls: Array<{ role: string; config: AgentConfig }> = [];
+  async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
+    this.spawnCalls.push({ role, config });
+    return { id: "s-1", role, status: "running", platform: config.platform, model: config.model };
+  }
+  async send(): Promise<never> {
+    throw new Error("unused");
+  }
+  async close(): Promise<void> {}
+  onIdle(): void {}
+  async listSessions(): Promise<readonly AgentSession[]> {
+    return [];
+  }
+  async listSessionEntities(): Promise<readonly AgentSessionEntity[]> {
+    return [];
+  }
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+}
+
+function ctx(task: AgentTaskView): SchedulerContext {
+  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+}
+
+function taskWith(spec: Partial<AgentTaskView["spec"]>): AgentTaskView {
+  return {
+    spec: {
+      id: "t",
+      worktree: "/tmp/w",
+      runtime: "codex",
+      role: "worker",
+      prompt: "do work",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      ...spec,
+    },
+    status: {
+      id: "t",
+      phase: AgentTaskPhase.PendingBind,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+const profile: RuntimeProfile = {
+  name: "claude-opus",
+  platform: "claude-code",
+  runtimeCommand: "claude",
+  model: "claude-opus-4-7",
+};
+
+describe("DefaultBindPlugin", () => {
+  test("profile fields override task.spec.runtime when spawning", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    await plugin.bind(ctx(taskWith({ runtime: "codex" })), profile);
+    const call = runtime.spawnCalls[0];
+    expect(call?.config.command).toBe("claude");
+    expect(call?.config.platform).toBe("claude-code");
+    expect(call?.config.model).toBe("claude-opus-4-7");
+  });
+
+  test("falls back to task budget.model when profile.model undefined", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    await plugin.bind(
+      ctx(taskWith({ budget: { model: "claude-haiku" } })),
+      { ...profile, model: undefined },
+    );
+    expect(runtime.spawnCalls[0]?.config.model).toBe("claude-haiku");
+  });
+
+  test("injects GROVE_AGENT_TASK_* env vars", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    await plugin.bind(ctx(taskWith({ id: "task-42", generation: 7 })), profile);
+    const env = runtime.spawnCalls[0]?.config.env ?? {};
+    expect(env.GROVE_AGENT_TASK_ID).toBe("task-42");
+    expect(env.GROVE_AGENT_TASK_GENERATION).toBe("7");
+    expect(env.GROVE_AGENT_TASK_RUNTIME).toBe("claude");
+  });
+
+  test("returns session id from runtime.spawn", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    const result = await plugin.bind(ctx(taskWith({})), profile);
+    expect(result.session.id).toBe("s-1");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/plugins/default-bind.test.ts`
+Expected: FAIL — `DefaultBindPlugin` not exported.
+
+- [ ] **Step 3: Implement the plugin**
+
+Create `src/core/scheduler/plugins/default-bind.ts`:
+
+```ts
+import type { AgentConfig, AgentRuntime } from "../../agent-runtime.js";
+import type { BindPlugin, BindResult, SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+
+export interface DefaultBindPluginOptions {
+  readonly runtime: Pick<AgentRuntime, "spawn">;
+}
+
+export class DefaultBindPlugin implements BindPlugin {
+  readonly name = "DefaultBind";
+  private readonly runtime: Pick<AgentRuntime, "spawn">;
+
+  constructor(options: DefaultBindPluginOptions) {
+    this.runtime = options.runtime;
+  }
+
+  async bind(ctx: SchedulerContext, profile: RuntimeProfile): Promise<BindResult> {
+    const model = profile.model ?? readBudgetString(ctx.task.spec.budget, "model");
+    const config: AgentConfig = {
+      role: ctx.task.spec.role,
+      command: profile.runtimeCommand,
+      cwd: ctx.task.spec.worktree,
+      goal: ctx.task.spec.prompt,
+      prompt: ctx.task.spec.prompt,
+      ...(profile.platform === undefined ? {} : { platform: profile.platform }),
+      ...(model === undefined ? {} : { model }),
+      env: {
+        GROVE_AGENT_TASK_ID: ctx.task.spec.id,
+        GROVE_AGENT_TASK_GENERATION: String(ctx.task.spec.generation),
+        GROVE_AGENT_TASK_RUNTIME: profile.runtimeCommand,
+      },
+    };
+    const session = await this.runtime.spawn(ctx.task.spec.role, config);
+    return { session };
+  }
+}
+
+function readBudgetString(budget: unknown, key: string): string | undefined {
+  if (budget === null || typeof budget !== "object") return undefined;
+  const value = (budget as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/plugins/default-bind.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/plugins/default-bind.ts src/core/scheduler/plugins/default-bind.test.ts
+git commit -m "feat(scheduler): DefaultBind plugin (#300)"
+```
+
+---
+
+## Task 15: Built-in plugin registry
+
+**Files:**
+- Create: `src/core/scheduler/plugins/index.ts`
+- Create: `src/core/scheduler/plugins/index.test.ts`
+
+The registry exports plugin factories keyed by the names used in config (`RuntimeCapability`, `BudgetRemaining`, etc.).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/plugins/index.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentRuntime } from "../../agent-runtime.js";
+import type { AgentSessionEntity } from "../../entity.js";
+import {
+  BUILTIN_FILTER_FACTORIES,
+  BUILTIN_SCORE_FACTORIES,
+  BUILTIN_PERMIT_FACTORIES,
+  BUILTIN_BIND_FACTORIES,
+  builtinPluginNames,
+} from "./index.js";
+
+function fakeRuntime(): AgentRuntime {
+  return {
+    spawn: async () => ({ id: "s", role: "r", status: "running" }),
+    send: async () => {
+      throw new Error("unused");
+    },
+    close: async () => {},
+    onIdle: () => {},
+    listSessions: async () => [],
+    listSessionEntities: async () => [] as readonly AgentSessionEntity[],
+    isAvailable: async () => true,
+  };
+}
+
+describe("builtin plugin registry", () => {
+  test("filter factories include the three default filters", () => {
+    expect(Object.keys(BUILTIN_FILTER_FACTORIES).sort()).toEqual([
+      "BudgetRemaining",
+      "RuntimeCapability",
+      "WorktreeExclusivity",
+    ]);
+  });
+
+  test("score factories include TaskAffinity", () => {
+    expect(Object.keys(BUILTIN_SCORE_FACTORIES)).toContain("TaskAffinity");
+  });
+
+  test("permit factories include AutoPermit and UserConfirmPermit", () => {
+    expect(Object.keys(BUILTIN_PERMIT_FACTORIES).sort()).toEqual(["AutoPermit", "UserConfirmPermit"]);
+  });
+
+  test("bind factories include DefaultBind", () => {
+    expect(Object.keys(BUILTIN_BIND_FACTORIES)).toEqual(["DefaultBind"]);
+  });
+
+  test("builtinPluginNames lists every plugin", () => {
+    expect(builtinPluginNames()).toEqual(
+      expect.arrayContaining([
+        "RuntimeCapability",
+        "BudgetRemaining",
+        "WorktreeExclusivity",
+        "TaskAffinity",
+        "AutoPermit",
+        "UserConfirmPermit",
+        "DefaultBind",
+      ]),
+    );
+  });
+
+  test("factories produce instances with the expected name", () => {
+    const filter = BUILTIN_FILTER_FACTORIES.RuntimeCapability({});
+    const score = BUILTIN_SCORE_FACTORIES.TaskAffinity({});
+    const permit = BUILTIN_PERMIT_FACTORIES.AutoPermit({});
+    const bind = BUILTIN_BIND_FACTORIES.DefaultBind({ runtime: fakeRuntime() });
+    expect(filter.name).toBe("RuntimeCapability");
+    expect(score.name).toBe("TaskAffinity");
+    expect(permit.name).toBe("AutoPermit");
+    expect(bind.name).toBe("DefaultBind");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/plugins/index.test.ts`
+Expected: FAIL — registry not exported.
+
+- [ ] **Step 3: Implement the registry**
+
+Create `src/core/scheduler/plugins/index.ts`:
+
+```ts
+import type { AgentRuntime } from "../../agent-runtime.js";
+import type { BindPlugin, FilterPlugin, PermitPlugin, ScorePlugin } from "../framework.js";
+import { AutoPermit } from "./auto-permit.js";
+import { BudgetRemainingFilter, type BudgetLedger } from "./budget-remaining.js";
+import { DefaultBindPlugin } from "./default-bind.js";
+import { RuntimeCapabilityFilter } from "./runtime-capability.js";
+import { TaskAffinityScore } from "./task-affinity.js";
+import {
+  InMemoryPermitDecisionStore,
+  type PermitDecisionStore,
+  UserConfirmPermit,
+} from "./user-confirm-permit.js";
+import { WorktreeExclusivityFilter } from "./worktree-exclusivity.js";
+
+export interface FilterFactoryArgs {
+  readonly ledger?: BudgetLedger | undefined;
+}
+
+export interface ScoreFactoryArgs {
+  readonly weight?: number | undefined;
+}
+
+export interface PermitFactoryArgs {
+  readonly permitDecisionStore?: PermitDecisionStore | undefined;
+}
+
+export interface BindFactoryArgs {
+  readonly runtime: AgentRuntime;
+}
+
+export const BUILTIN_FILTER_FACTORIES: Readonly<
+  Record<string, (args: FilterFactoryArgs) => FilterPlugin>
+> = Object.freeze({
+  RuntimeCapability: () => new RuntimeCapabilityFilter(),
+  BudgetRemaining: (args) =>
+    new BudgetRemainingFilter(args.ledger === undefined ? {} : { ledger: args.ledger }),
+  WorktreeExclusivity: () => new WorktreeExclusivityFilter(),
+});
+
+export const BUILTIN_SCORE_FACTORIES: Readonly<
+  Record<string, (args: ScoreFactoryArgs) => ScorePlugin>
+> = Object.freeze({
+  TaskAffinity: () => new TaskAffinityScore(),
+});
+
+export const BUILTIN_PERMIT_FACTORIES: Readonly<
+  Record<string, (args: PermitFactoryArgs) => PermitPlugin>
+> = Object.freeze({
+  AutoPermit: () => new AutoPermit(),
+  UserConfirmPermit: (args) =>
+    new UserConfirmPermit({ store: args.permitDecisionStore ?? new InMemoryPermitDecisionStore() }),
+});
+
+export const BUILTIN_BIND_FACTORIES: Readonly<
+  Record<string, (args: BindFactoryArgs) => BindPlugin>
+> = Object.freeze({
+  DefaultBind: (args) => new DefaultBindPlugin({ runtime: args.runtime }),
+});
+
+export function builtinPluginNames(): readonly string[] {
+  return [
+    ...Object.keys(BUILTIN_FILTER_FACTORIES),
+    ...Object.keys(BUILTIN_SCORE_FACTORIES),
+    ...Object.keys(BUILTIN_PERMIT_FACTORIES),
+    ...Object.keys(BUILTIN_BIND_FACTORIES),
+  ];
+}
+
+export {
+  AutoPermit,
+  BudgetRemainingFilter,
+  DefaultBindPlugin,
+  InMemoryPermitDecisionStore,
+  RuntimeCapabilityFilter,
+  TaskAffinityScore,
+  UserConfirmPermit,
+  WorktreeExclusivityFilter,
+};
+export type { BudgetLedger, PermitDecisionStore };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/plugins/index.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/plugins/index.ts src/core/scheduler/plugins/index.test.ts
+git commit -m "feat(scheduler): builtin plugin registry (#300)"
+```
+
+---
+
+## Task 16: `SchedulerConfig` zod schema + `loadSchedulerConfig`
+
+**Files:**
+- Create: `src/core/scheduler/config.ts`
+- Create: `src/core/scheduler/config.test.ts`
+
+`loadSchedulerConfig` accepts the typed config and the runtime (needed by Bind factory). Returns `{ profiles, filters, scores, permits, bindPlugin }` ready for the `Scheduler` constructor.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/config.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentRuntime } from "../agent-runtime.js";
+import type { AgentSessionEntity } from "../entity.js";
+import { loadSchedulerConfig, SchedulerConfigSchema } from "./config.js";
+
+function fakeRuntime(): AgentRuntime {
+  return {
+    spawn: async () => ({ id: "s", role: "r", status: "running" }),
+    send: async () => {
+      throw new Error("unused");
+    },
+    close: async () => {},
+    onIdle: () => {},
+    listSessions: async () => [],
+    listSessionEntities: async () => [] as readonly AgentSessionEntity[],
+    isAvailable: async () => true,
+  };
+}
+
+describe("SchedulerConfigSchema", () => {
+  test("accepts a minimal config", () => {
+    const parsed = SchedulerConfigSchema.parse({
+      profiles: [
+        { name: "p", platform: "claude-code", runtimeCommand: "claude" },
+      ],
+      pipeline: {
+        filters: ["RuntimeCapability"],
+        scores: [{ name: "TaskAffinity", weight: 1 }],
+        permits: ["AutoPermit"],
+        bind: "DefaultBind",
+      },
+    });
+    expect(parsed.profiles).toHaveLength(1);
+  });
+
+  test("rejects negative score weight", () => {
+    expect(() =>
+      SchedulerConfigSchema.parse({
+        profiles: [],
+        pipeline: {
+          filters: [],
+          scores: [{ name: "TaskAffinity", weight: -1 }],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing platform", () => {
+    expect(() =>
+      SchedulerConfigSchema.parse({
+        profiles: [{ name: "p", runtimeCommand: "claude" }],
+        pipeline: {
+          filters: [],
+          scores: [],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("loadSchedulerConfig", () => {
+  test("resolves plugin names against the built-in registry", () => {
+    const opts = loadSchedulerConfig(
+      {
+        profiles: [
+          { name: "p", platform: "claude-code", runtimeCommand: "claude" },
+        ],
+        pipeline: {
+          filters: ["RuntimeCapability", "BudgetRemaining", "WorktreeExclusivity"],
+          scores: [{ name: "TaskAffinity", weight: 1 }],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      },
+      { runtime: fakeRuntime() },
+    );
+    expect(opts.filters.map((f) => f.name)).toEqual([
+      "RuntimeCapability",
+      "BudgetRemaining",
+      "WorktreeExclusivity",
+    ]);
+    expect(opts.scores).toHaveLength(1);
+    expect(opts.scores[0]?.plugin.name).toBe("TaskAffinity");
+    expect(opts.scores[0]?.weight).toBe(1);
+    expect(opts.permits[0]?.name).toBe("AutoPermit");
+    expect(opts.bindPlugin.name).toBe("DefaultBind");
+    expect(opts.profiles).toHaveLength(1);
+  });
+
+  test("unknown plugin name yields a descriptive error listing known plugins", () => {
+    expect(() =>
+      loadSchedulerConfig(
+        {
+          profiles: [],
+          pipeline: {
+            filters: ["NotARealFilter"],
+            scores: [],
+            permits: ["AutoPermit"],
+            bind: "DefaultBind",
+          },
+        },
+        { runtime: fakeRuntime() },
+      ),
+    ).toThrow(/NotARealFilter.*known plugins/i);
+  });
+
+  test("default ledger is permissive", () => {
+    const opts = loadSchedulerConfig(
+      {
+        profiles: [],
+        pipeline: {
+          filters: ["BudgetRemaining"],
+          scores: [],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      },
+      { runtime: fakeRuntime() },
+    );
+    expect(opts.filters[0]?.name).toBe("BudgetRemaining");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/scheduler/config.test.ts`
+Expected: FAIL — `config.js` does not exist.
+
+- [ ] **Step 3: Implement the schema + loader**
+
+Create `src/core/scheduler/config.ts`:
+
+```ts
+import { z } from "zod";
+import type { AgentRuntime } from "../agent-runtime.js";
+import type { BindPlugin, FilterPlugin, PermitPlugin, ScorePlugin } from "./framework.js";
+import {
+  BUILTIN_BIND_FACTORIES,
+  BUILTIN_FILTER_FACTORIES,
+  BUILTIN_PERMIT_FACTORIES,
+  BUILTIN_SCORE_FACTORIES,
+  builtinPluginNames,
+  type BudgetLedger,
+  type PermitDecisionStore,
+} from "./plugins/index.js";
+import type { RuntimeProfile } from "./profile.js";
+import type { ScorePluginEntry } from "./scheduler.js";
+
+const PlatformSchema = z.enum(["claude-code", "codex", "gemini"]);
+
+const RuntimeProfileBudgetSchema = z
+  .object({
+    maxCostUsd: z.number().nonnegative().optional(),
+    maxTurns: z.number().int().nonnegative().optional(),
+    allowedModels: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+const RuntimeProfileSchema = z
+  .object({
+    name: z.string().min(1).max(128),
+    platform: PlatformSchema,
+    runtimeCommand: z.string().min(1).max(128),
+    model: z.string().min(1).max(128).optional(),
+    supportedRoles: z.array(z.string().min(1).max(64)).optional(),
+    budget: RuntimeProfileBudgetSchema.optional(),
+    labels: z.record(z.string().min(1), z.string()).optional(),
+  })
+  .strict();
+
+const PipelineSchema = z
+  .object({
+    filters: z.array(z.string().min(1)).default([]),
+    scores: z
+      .array(
+        z
+          .object({
+            name: z.string().min(1),
+            weight: z.number().nonnegative().default(1),
+          })
+          .strict(),
+      )
+      .default([]),
+    permits: z.array(z.string().min(1)).default(["AutoPermit"]),
+    bind: z.string().min(1).default("DefaultBind"),
+  })
+  .strict();
+
+export const SchedulerConfigSchema = z
+  .object({
+    profiles: z.array(RuntimeProfileSchema).default([]),
+    pipeline: PipelineSchema.default({
+      filters: [],
+      scores: [],
+      permits: ["AutoPermit"],
+      bind: "DefaultBind",
+    }),
+  })
+  .strict();
+
+export type SchedulerConfig = z.infer<typeof SchedulerConfigSchema>;
+
+export interface LoadSchedulerConfigDeps {
+  readonly runtime: AgentRuntime;
+  readonly ledger?: BudgetLedger | undefined;
+  readonly permitDecisionStore?: PermitDecisionStore | undefined;
+}
+
+export interface LoadedSchedulerConfig {
+  readonly profiles: readonly RuntimeProfile[];
+  readonly filters: readonly FilterPlugin[];
+  readonly scores: readonly ScorePluginEntry[];
+  readonly permits: readonly PermitPlugin[];
+  readonly bindPlugin: BindPlugin;
+}
+
+export function loadSchedulerConfig(
+  raw: unknown,
+  deps: LoadSchedulerConfigDeps,
+): LoadedSchedulerConfig {
+  const config = SchedulerConfigSchema.parse(raw);
+
+  const filters = config.pipeline.filters.map((name) => {
+    const factory = BUILTIN_FILTER_FACTORIES[name];
+    if (factory === undefined) throw unknownPluginError("filter", name);
+    return factory(deps.ledger === undefined ? {} : { ledger: deps.ledger });
+  });
+
+  const scores: ScorePluginEntry[] = config.pipeline.scores.map((entry) => {
+    const factory = BUILTIN_SCORE_FACTORIES[entry.name];
+    if (factory === undefined) throw unknownPluginError("score", entry.name);
+    return { plugin: factory({}), weight: entry.weight };
+  });
+
+  const permits = config.pipeline.permits.map((name) => {
+    const factory = BUILTIN_PERMIT_FACTORIES[name];
+    if (factory === undefined) throw unknownPluginError("permit", name);
+    return factory(
+      deps.permitDecisionStore === undefined
+        ? {}
+        : { permitDecisionStore: deps.permitDecisionStore },
+    );
+  });
+
+  const bindFactory = BUILTIN_BIND_FACTORIES[config.pipeline.bind];
+  if (bindFactory === undefined) throw unknownPluginError("bind", config.pipeline.bind);
+  const bindPlugin = bindFactory({ runtime: deps.runtime });
+
+  const profiles: readonly RuntimeProfile[] = config.profiles.map((profile) => ({
+    name: profile.name,
+    platform: profile.platform,
+    runtimeCommand: profile.runtimeCommand,
+    ...(profile.model === undefined ? {} : { model: profile.model }),
+    ...(profile.supportedRoles === undefined ? {} : { supportedRoles: profile.supportedRoles }),
+    ...(profile.budget === undefined ? {} : { budget: profile.budget }),
+    ...(profile.labels === undefined ? {} : { labels: profile.labels }),
+  }));
+
+  return { profiles, filters, scores, permits, bindPlugin };
+}
+
+function unknownPluginError(kind: string, name: string): Error {
+  const known = builtinPluginNames().sort().join(", ");
+  return new Error(
+    `unknown scheduler ${kind} plugin '${name}'. Known plugins: ${known}.`,
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/scheduler/config.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/config.ts src/core/scheduler/config.test.ts
+git commit -m "feat(scheduler): SchedulerConfig zod schema + loader (#300)"
+```
+
+---
+
+## Task 17: `index.ts` re-exports + `src/core/index.ts` wiring
+
+**Files:**
+- Create: `src/core/scheduler/index.ts`
+- Modify: `src/core/index.ts`
+
+- [ ] **Step 1: Create the module index**
+
+Create `src/core/scheduler/index.ts`:
+
+```ts
+export type {
+  BindPlugin,
+  BindResult,
+  FilterPlugin,
+  FilterRejection,
+  FilterVerdict,
+  PermitPlugin,
+  PermitVerdict,
+  ProfileRejection,
+  SchedulerContext,
+  SchedulingResult,
+  ScorePlugin,
+} from "./framework.js";
+export { Scheduler } from "./scheduler.js";
+export type { ScorePluginEntry, SchedulerOptions } from "./scheduler.js";
+export type { RuntimeProfile, RuntimeProfileBudget } from "./profile.js";
+export { synthesizeFallbackProfile } from "./profile.js";
+export {
+  loadSchedulerConfig,
+  SchedulerConfigSchema,
+  type LoadedSchedulerConfig,
+  type LoadSchedulerConfigDeps,
+  type SchedulerConfig,
+} from "./config.js";
+export {
+  AutoPermit,
+  BudgetRemainingFilter,
+  builtinPluginNames,
+  BUILTIN_BIND_FACTORIES,
+  BUILTIN_FILTER_FACTORIES,
+  BUILTIN_PERMIT_FACTORIES,
+  BUILTIN_SCORE_FACTORIES,
+  DefaultBindPlugin,
+  InMemoryPermitDecisionStore,
+  RuntimeCapabilityFilter,
+  TaskAffinityScore,
+  UserConfirmPermit,
+  WorktreeExclusivityFilter,
+  type BudgetLedger,
+  type PermitDecisionStore,
+} from "./plugins/index.js";
+```
+
+- [ ] **Step 2: Add re-export to `src/core/index.ts`**
+
+Find the existing re-export block in `src/core/index.ts` and add this line near other module re-exports (alphabetical order):
+
+```ts
+export * as scheduler from "./scheduler/index.js";
+```
+
+If you cannot tell where to slot it, append the line at the end of the existing `export *` lines.
+
+- [ ] **Step 3: Run a smoke import test**
+
+Create `src/core/scheduler/index.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+  Scheduler,
+  SchedulerConfigSchema,
+  loadSchedulerConfig,
+  synthesizeFallbackProfile,
+} from "./index.js";
+
+describe("scheduler module re-exports", () => {
+  test("Scheduler class is exported", () => {
+    expect(typeof Scheduler).toBe("function");
+  });
+  test("SchedulerConfigSchema is exported", () => {
+    expect(typeof SchedulerConfigSchema.parse).toBe("function");
+  });
+  test("loadSchedulerConfig is exported", () => {
+    expect(typeof loadSchedulerConfig).toBe("function");
+  });
+  test("synthesizeFallbackProfile is exported", () => {
+    expect(typeof synthesizeFallbackProfile).toBe("function");
+  });
+});
+```
+
+Run: `bun test src/core/scheduler/index.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 4: Verify the whole scheduler module compiles**
+
+Run: `bun test src/core/scheduler/`
+Expected: every test in `src/core/scheduler/**` passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/scheduler/index.ts src/core/scheduler/index.test.ts src/core/index.ts
+git commit -m "feat(scheduler): module re-exports + core index wiring (#300)"
+```
+
+---
+
+## Task 18: Wire `Scheduler` into `TaskController.reconcilePendingBind`
+
+**Files:**
+- Modify: `src/core/task-controller.ts`
+- Modify: `src/core/task-controller.test.ts`
+
+- [ ] **Step 1: Add failing controller integration tests**
+
+Append to `src/core/task-controller.test.ts` (after the existing `describe(...)` blocks):
+
+```ts
+import { Scheduler } from "./scheduler/scheduler.js";
+import type { BindPlugin, FilterPlugin, PermitPlugin } from "./scheduler/framework.js";
+import type { RuntimeProfile } from "./scheduler/profile.js";
+
+function profile(name = "primary"): RuntimeProfile {
+  return { name, platform: "claude-code", runtimeCommand: "claude" };
+}
+
+function alwaysAdmit(name = "admit"): FilterPlugin {
+  return { name, filter: async () => ({ admit: true }) };
+}
+
+function alwaysReject(reason: string): FilterPlugin {
+  return { name: "reject", filter: async () => ({ admit: false, reason }) };
+}
+
+function autoPermit(): PermitPlugin {
+  return { name: "auto", permit: async () => ({ status: "granted" }) };
+}
+
+function denyPermit(reason: string): PermitPlugin {
+  return { name: "deny", permit: async () => ({ status: "denied", reason }) };
+}
+
+function waitPermit(reason: string): PermitPlugin {
+  return { name: "wait", permit: async () => ({ status: "wait", reason }) };
+}
+
+function recordingBind(): BindPlugin & { calls: number } {
+  const plugin = {
+    name: "rec",
+    calls: 0,
+    async bind() {
+      plugin.calls += 1;
+      return { session: { id: "boundsess", role: "worker", status: "running" } as AgentSession };
+    },
+  };
+  return plugin;
+}
+
+describe("TaskController + Scheduler integration", () => {
+  test("bound decision transitions PendingBind → Running with sessionId", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const bindPlugin = recordingBind();
+    const scheduler = new Scheduler({
+      profiles: [profile()],
+      filters: [alwaysAdmit()],
+      scores: [],
+      permits: [autoPermit()],
+      bindPlugin,
+      store: { listAgentTaskEntities: store.listAgentTaskEntities },
+      now: () => FIXED_NOW_MS,
+    });
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      scheduler,
+      now: () => FIXED_NOW_MS,
+    });
+
+    await controller.reconcileTask("task-1");
+
+    expect(bindPlugin.calls).toBe(1);
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Running);
+    expect(patch.sessionId).toBe("boundsess");
+    expect(condition(patch.conditions, "Bound")?.status).toBe("True");
+    expect(condition(patch.conditions, "Running")?.status).toBe("True");
+  });
+
+  test("unschedulable result keeps PendingBind and sets Unschedulable condition", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const scheduler = new Scheduler({
+      profiles: [profile()],
+      filters: [alwaysReject("filter-x")],
+      scores: [],
+      permits: [autoPermit()],
+      bindPlugin: recordingBind(),
+      store: { listAgentTaskEntities: store.listAgentTaskEntities },
+      now: () => FIXED_NOW_MS,
+    });
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      scheduler,
+      now: () => FIXED_NOW_MS,
+    });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBeUndefined();
+    expect(condition(patch.conditions, "Unschedulable")?.status).toBe("True");
+    expect(condition(patch.conditions, "Unschedulable")?.message).toContain("filter-x");
+  });
+
+  test("wait result keeps PendingBind and sets PermitRequired condition", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const scheduler = new Scheduler({
+      profiles: [profile()],
+      filters: [alwaysAdmit()],
+      scores: [],
+      permits: [waitPermit("awaiting-user")],
+      bindPlugin: recordingBind(),
+      store: { listAgentTaskEntities: store.listAgentTaskEntities },
+      now: () => FIXED_NOW_MS,
+    });
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      scheduler,
+      now: () => FIXED_NOW_MS,
+    });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBeUndefined();
+    expect(condition(patch.conditions, "PermitRequired")?.reason).toBe("awaiting-user");
+  });
+
+  test("denied result transitions to Failed", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const scheduler = new Scheduler({
+      profiles: [profile()],
+      filters: [alwaysAdmit()],
+      scores: [],
+      permits: [denyPermit("not-allowed")],
+      bindPlugin: recordingBind(),
+      store: { listAgentTaskEntities: store.listAgentTaskEntities },
+      now: () => FIXED_NOW_MS,
+    });
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      scheduler,
+      now: () => FIXED_NOW_MS,
+    });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Failed);
+    expect(condition(patch.conditions, "Failed")?.reason).toBe("not-allowed");
+  });
+
+  test("controller without scheduler still uses direct binder path (back-compat)", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const binder = new FakeBinder();
+    const controller = controllerFor(store, { binder });
+
+    await controller.reconcileTask("task-1");
+
+    expect(binder.calls).toHaveLength(1);
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Running);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/task-controller.test.ts`
+Expected: FAIL — `scheduler` not yet an option on `TaskController`.
+
+- [ ] **Step 3: Add `scheduler?` to `TaskControllerOptions` and rewrite `reconcilePendingBind`**
+
+In `src/core/task-controller.ts`:
+
+(a) Add an import at the top of the file (after the existing imports):
+
+```ts
+import type { Scheduler } from "./scheduler/scheduler.js";
+import type { SchedulingResult } from "./scheduler/framework.js";
+```
+
+(b) Add the option field. Inside `TaskControllerOptions`, append:
+
+```ts
+  readonly scheduler?: Scheduler | undefined;
+```
+
+(c) Add the private field + constructor assignment. In the class, alongside the other private fields, add:
+
+```ts
+  private readonly scheduler: Scheduler | undefined;
+```
+
+In the constructor, add (anywhere among the existing assignments):
+
+```ts
+    this.scheduler = options.scheduler;
+```
+
+(d) Replace `reconcilePendingBind` (currently lines 271-310) with the dispatching version:
+
+```ts
+  private async reconcilePendingBind(
+    task: AgentTaskView,
+  ): Promise<ReconciliationResult | undefined> {
+    if (task.status.sessionId !== undefined) {
+      return this.reconcileRunning(task);
+    }
+
+    if (this.scheduler === undefined) {
+      return this.directBindPendingBind(task);
+    }
+
+    const decision = await this.scheduler.schedule(task);
+    return this.applySchedulingDecision(task, decision);
+  }
+
+  private async directBindPendingBind(
+    task: AgentTaskView,
+  ): Promise<ReconciliationResult | undefined> {
+    const { session } = await this.binder.bind({ task });
+    const nowIso = this.nowIso();
+    const conditions = upsertCondition(
+      upsertCondition(task.status.conditions, {
+        type: AgentTaskConditionType.Bound,
+        status: "True",
+        observedGeneration: task.spec.generation,
+        lastTransitionTime: nowIso,
+        reason: "session-bound",
+        message: "",
+      }),
+      {
+        type: AgentTaskConditionType.Running,
+        status: "True",
+        observedGeneration: task.spec.generation,
+        lastTransitionTime: nowIso,
+        reason: "session-running",
+        message: "",
+      },
+    );
+
+    return {
+      patch: {
+        phase: AgentTaskPhase.Running,
+        sessionId: session.id,
+        observedGeneration: task.spec.generation,
+        conditions,
+        lastTransitionAt: nowIso,
+      },
+      transition: transition(task, AgentTaskPhase.Running, "session-bound"),
+      sessionToCloseOnPatchFailure: session,
+    };
+  }
+
+  private applySchedulingDecision(
+    task: AgentTaskView,
+    decision: SchedulingResult,
+  ): ReconciliationResult | undefined {
+    const nowIso = this.nowIso();
+
+    if (decision.kind === "bound") {
+      const conditions = upsertCondition(
+        upsertCondition(task.status.conditions, {
+          type: AgentTaskConditionType.Bound,
+          status: "True",
+          observedGeneration: task.spec.generation,
+          lastTransitionTime: nowIso,
+          reason: "session-bound",
+          message: "",
+        }),
+        {
+          type: AgentTaskConditionType.Running,
+          status: "True",
+          observedGeneration: task.spec.generation,
+          lastTransitionTime: nowIso,
+          reason: "session-running",
+          message: "",
+        },
+      );
+      return {
+        patch: {
+          phase: AgentTaskPhase.Running,
+          sessionId: decision.session.id,
+          observedGeneration: task.spec.generation,
+          conditions,
+          lastTransitionAt: nowIso,
+        },
+        transition: transition(task, AgentTaskPhase.Running, "session-bound"),
+        sessionToCloseOnPatchFailure: decision.session,
+      };
+    }
+
+    if (decision.kind === "unschedulable") {
+      const reasons = decision.rejections
+        .flatMap((entry) =>
+          entry.rejections.map((r) => `${entry.profile.name}/${r.plugin}:${r.reason}`),
+        )
+        .slice(0, 3);
+      const message = reasons.length === 0 ? "no candidate profiles" : reasons.join("; ");
+      const conditions = upsertCondition(task.status.conditions, {
+        type: AgentTaskConditionType.Unschedulable,
+        status: "True",
+        observedGeneration: task.spec.generation,
+        lastTransitionTime: nowIso,
+        reason: "no-candidate",
+        message,
+      });
+      return {
+        patch: {
+          observedGeneration: task.spec.generation,
+          conditions,
+        },
+        transition: transition(task, AgentTaskPhase.PendingBind, "unschedulable"),
+      };
+    }
+
+    if (decision.kind === "wait") {
+      const conditions = upsertCondition(task.status.conditions, {
+        type: AgentTaskConditionType.PermitRequired,
+        status: "True",
+        observedGeneration: task.spec.generation,
+        lastTransitionTime: nowIso,
+        reason: decision.reason,
+        message: decision.message ?? `permit '${decision.plugin}' is waiting`,
+      });
+      return {
+        patch: {
+          observedGeneration: task.spec.generation,
+          conditions,
+        },
+        transition: transition(task, AgentTaskPhase.PendingBind, "permit-wait"),
+      };
+    }
+
+    // decision.kind === "denied"
+    const conditions = upsertCondition(task.status.conditions, {
+      type: AgentTaskConditionType.Failed,
+      status: "True",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: decision.reason,
+      message: decision.message ?? `permit '${decision.plugin}' denied`,
+    });
+    return {
+      patch: {
+        phase: AgentTaskPhase.Failed,
+        observedGeneration: task.spec.generation,
+        conditions,
+        lastTransitionAt: nowIso,
+      },
+      transition: transition(task, AgentTaskPhase.Failed, decision.reason),
+    };
+  }
+```
+
+- [ ] **Step 4: Run controller tests to verify they pass**
+
+Run: `bun test src/core/task-controller.test.ts`
+Expected: PASS — all existing tests + 5 new scheduler-integration tests.
+
+- [ ] **Step 5: Run the full core test directory to catch regressions**
+
+Run: `bun test src/core/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/task-controller.ts src/core/task-controller.test.ts
+git commit -m "feat(scheduler): wire Scheduler into TaskController.reconcilePendingBind (#300)"
+```
+
+---
+
+## Task 19: Acceptance test — config-only reweight changes winner
+
+**Files:**
+- Create: `src/core/scheduler/acceptance-config-reweight.test.ts`
+
+This proves the acceptance criterion: *"new filter/score plugin added via config (no code change)"*. Two configs differ only in the `pipeline.scores` list (built-in plugins, no new TS); the same task produces a different winning profile.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/scheduler/acceptance-config-reweight.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentConfig, AgentRuntime, AgentSession } from "../agent-runtime.js";
+import type { AgentTaskView } from "../agent-task.js";
+import { AgentTaskPhase } from "../agent-task.js";
+import type { AgentSessionEntity } from "../entity.js";
+import { loadSchedulerConfig } from "./config.js";
+import { Scheduler } from "./scheduler.js";
+
+class RecordingRuntime implements AgentRuntime {
+  spawnCalls: Array<{ role: string; command: string; model: string | undefined }> = [];
+  async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
+    this.spawnCalls.push({ role, command: config.command, model: config.model });
+    return { id: "s", role, status: "running" };
+  }
+  async send(): Promise<never> {
+    throw new Error("unused");
+  }
+  async close(): Promise<void> {}
+  onIdle(): void {}
+  async listSessions(): Promise<readonly AgentSession[]> {
+    return [];
+  }
+  async listSessionEntities(): Promise<readonly AgentSessionEntity[]> {
+    return [];
+  }
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+}
+
+const task: AgentTaskView = {
+  spec: {
+    id: "t",
+    worktree: "/tmp/w",
+    runtime: "",
+    role: "worker",
+    prompt: "p",
+    dependsOn: [],
+    generation: 1,
+    createdAt: "2026-05-16T00:00:00.000Z",
+    budget: { affinity: { tier: "premium" } },
+  },
+  status: {
+    id: "t",
+    phase: AgentTaskPhase.PendingBind,
+    contributions: [],
+    conditions: [],
+    observedGeneration: 0,
+    lastTransitionAt: "2026-05-16T00:00:00.000Z",
+    revision: 1,
+  },
+};
+
+const profiles = [
+  { name: "free-tier", platform: "claude-code", runtimeCommand: "claude", labels: { tier: "free" } },
+  {
+    name: "premium-tier",
+    platform: "claude-code",
+    runtimeCommand: "claude",
+    labels: { tier: "premium" },
+  },
+];
+
+describe("acceptance: config-only reweight changes winner", () => {
+  test("with TaskAffinity enabled, premium-tier wins on premium affinity", async () => {
+    const runtime = new RecordingRuntime();
+    const loaded = loadSchedulerConfig(
+      {
+        profiles,
+        pipeline: {
+          filters: [],
+          scores: [{ name: "TaskAffinity", weight: 1 }],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      },
+      { runtime },
+    );
+    const scheduler = new Scheduler({
+      profiles: loaded.profiles,
+      filters: loaded.filters,
+      scores: loaded.scores,
+      permits: loaded.permits,
+      bindPlugin: loaded.bindPlugin,
+      store: { listAgentTaskEntities: async () => [] },
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(task);
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") expect(result.profile.name).toBe("premium-tier");
+  });
+
+  test("with TaskAffinity removed, declaration order wins (free-tier first)", async () => {
+    const runtime = new RecordingRuntime();
+    const loaded = loadSchedulerConfig(
+      {
+        profiles,
+        pipeline: {
+          filters: [],
+          scores: [],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      },
+      { runtime },
+    );
+    const scheduler = new Scheduler({
+      profiles: loaded.profiles,
+      filters: loaded.filters,
+      scores: loaded.scores,
+      permits: loaded.permits,
+      bindPlugin: loaded.bindPlugin,
+      store: { listAgentTaskEntities: async () => [] },
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(task);
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") expect(result.profile.name).toBe("free-tier");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify both pass**
+
+Run: `bun test src/core/scheduler/acceptance-config-reweight.test.ts`
+Expected: PASS (2 tests).
+
+If the second test fails because Scheduler shortcuts the one-admitted path before reaching `pickWinner` — that's intentional (only one profile case), but here there are two. Confirm both profiles are passed.
+
+- [ ] **Step 3: Run the whole scheduler test directory + task-controller**
+
+Run: `bun test src/core/scheduler/ src/core/task-controller.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/scheduler/acceptance-config-reweight.test.ts
+git commit -m "test(scheduler): acceptance — config-only reweight changes winner (#300)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full test suite**
+
+Run: `bun test`
+Expected: PASS (entire suite green).
+
+- [ ] **Run any biome/lint hooks that the repo uses**
+
+Run: `bun run check 2>/dev/null || bunx biome check src/core/scheduler src/core/task-controller.ts src/core/agent-task.ts`
+Expected: no lint errors. Fix anything reported (typically import order or unused imports). If you make changes, commit with `chore(scheduler): lint fixes (#300)`.
+
+- [ ] **Verify acceptance criteria from spec**
+
+Confirm each of the issue's acceptance items maps to a test that just passed:
+- Plugin interface documented — spec + framework.ts JSDoc.
+- New filter/score plugin added via config — `acceptance-config-reweight.test.ts`.
+- Default plugins cover runtime-capability + budget + affinity — `runtime-capability.test.ts`, `budget-remaining.test.ts`, `task-affinity.test.ts`.
+
+---
+
+## Out of scope (deferred to follow-up issues)
+
+- `HistoricalSuccessRate` and `LoadBalancing` score plugins.
+- Persistent `PermitDecisionStore` + TUI wiring for `UserConfirmPermit`.
+- Global `BudgetLedger` implementation backed by credits / bounty data.
+- Two-phase reservation, CAS on status, transition graph (#305).
+- Removing the `TaskBinder` interface once #305 forces the plugin path.
+- Per-plugin `errorPolicy: "tolerate"`. The spec describes this; #300 ships strict-default only (plugin throws bubble up to the controller's existing retry loop). Tolerate mode lands with a follow-up issue if the need arises.

--- a/docs/superpowers/specs/2026-05-16-review-loop-agent-task-migration-design.md
+++ b/docs/superpowers/specs/2026-05-16-review-loop-agent-task-migration-design.md
@@ -1,0 +1,353 @@
+# Review-Loop → AgentTask Migration Design
+
+## Summary
+
+This design closes the gap left open by PR #439 (scheduler framework, #300): the legacy review-loop (codex submits → claude reviews) still runs on the `SessionOrchestrator` path and never reaches the new `TaskController`/`Scheduler`. This spec adds an opt-in path that routes a full codex→claude review loop through `AgentTask` + the scheduler, with no changes to the existing `grove session start` flow.
+
+The core moves are:
+
+- A new `grove review-loop` CLI command that POSTs two chained `AgentTask` records (coder + reviewer with `dependsOn`) to a running grove-server.
+- A `Succeeded` transition in `TaskController` driven by a new `DoneSignaled` condition.
+- An MCP-side change to `grove_done` that PATCHes the bound task with `DoneSignaled=True` before writing the legacy contribution.
+- A small `DefaultBind` extension that prepends each dependency's `Succeeded` condition message to the new task's prompt, so the reviewer sees what the coder did.
+
+Result: a real codex→claude handoff runs filter → score → permit → bind for each agent, blocks on `dependsOn`, and exits cleanly when both reach `Succeeded`.
+
+## Goals
+
+- Add an opt-in `grove review-loop start` CLI that creates two `AgentTask` records (coder, reviewer with `dependsOn=[coder-id]`).
+- Add a `Succeeded` transition path in `TaskController.reconcileRunning` driven by a `DoneSignaled=True` condition.
+- Wire `grove_done` MCP tool to PATCH the bound `AgentTask` status when `GROVE_AGENT_TASK_ID` is set in the agent process env.
+- Extend `DefaultBind` to prepend each dependency's `Succeeded` summary into the bound task's prompt.
+- Provide a tmux E2E that runs a real codex→claude review loop end-to-end against grove-server.
+- Preserve back-compat: `grove session start`, `SessionOrchestrator`, the contribution/handoff/bounty pipeline, and the legacy `grove_done` behavior are unchanged for agents not bound to an `AgentTask`.
+
+## Non-Goals
+
+- Replacing `SessionOrchestrator` or migrating `grove session start` to the new path.
+- Migrating contribution/bounty/handoff stores or routes to `AgentTask`.
+- Multi-reviewer fan-out (one coder, multiple reviewers in parallel).
+- Cascade cancellation of dependent tasks when a dependency moves to `Failed`. Today's behavior is "dependent stays Pending forever"; that's a `TaskController` policy gap to revisit in #285's remaining issues (likely #306 GC or a follow-up).
+- New metrics / Prometheus endpoint. The existing watch protocol already emits `entity.changed` envelopes for AgentTask writes.
+- Dynamic task creation at handoff time (e.g., codex's `grove_submit_work` spawning a new reviewer task). Static `dependsOn` at creation only.
+
+## Current State
+
+`grove session start` constructs a `SessionOrchestrator` (`src/core/session-orchestrator.ts`, 890 LOC) that owns the entire review loop in-process: workspace bootstrap, agent spawn via `runtime.spawn`, topology routing, contribution polling, and session termination on a "done" contribution from a required-terminator role.
+
+`grove_done` MCP tool (`src/mcp/tools/done.ts`) writes a contribution with `context.done=true` via `contributeOperation`. Session ends when a required-terminator role's done marker is observed.
+
+`TaskController` (PR #439) handles `AgentTask` reconciliation: `Pending → PendingBind → Running → Failed`. `reconcileRunning` checks for live session via `runtime.listSessions()` — alive → catch up; gone → `failLostSession`. The `Succeeded` phase exists in the enum and `dependsOn` checks look for it (`task-controller.ts:446`), but no code ever writes `Succeeded`. So `dependsOn` chains never unblock today.
+
+`AgentTaskConditionType` (post-PR #439): `Admitted | Scheduled | Bound | Running | AwaitingReview | Succeeded | Failed | Blocked | Unschedulable | PermitRequired`.
+
+`DefaultBind` (`src/core/scheduler/plugins/default-bind.ts`) reads `task.spec.prompt` verbatim into `AgentConfig.prompt` and injects `GROVE_AGENT_TASK_ID` + `GROVE_AGENT_TASK_GENERATION` into the agent's process env.
+
+`grove-server` already exposes `PUT /api/agent-tasks/:id` (create/update spec) and `PATCH /api/agent-tasks/:id/status` (controller-owned status writes guarded by `X-Grove-Controller-Token`). The MCP server does NOT have controller-token access, so `grove_done`'s PATCH from MCP goes through the bearer-token path used by other agent-task routes — verify route accepts MCP-bearer for `conditions` patches (existing tests in `agent-tasks.test.ts` may already cover this).
+
+## Architecture
+
+### Module map
+
+**New files**
+
+- `src/cli/commands/review-loop.ts` — CLI subcommand handler. ~250 LOC. Mirrors `session.ts` structure.
+- `src/cli/commands/review-loop.test.ts` — unit tests for prompt + payload construction.
+- `src/core/scheduler/upstream-prompt.ts` — pure function `buildPromptWithUpstream(basePrompt, sections)`.
+- `src/core/scheduler/upstream-prompt.test.ts` — unit tests.
+- `src/mcp/agent-task-context.ts` — env reader `readAgentTaskContext(env)`.
+- `src/mcp/agent-task-context.test.ts` — env-parsing tests.
+- `tests/e2e/review-loop-codex-claude-tmux.ts` — full tmux E2E. ~350 LOC.
+
+**Modified files**
+
+- `src/core/agent-task.ts` — add `DoneSignaled` to `AgentTaskConditionType`.
+- `src/core/task-controller.ts` — add `Succeeded` transition path in `reconcileRunning`; add `sessionToCloseOnSuccess` field to `ReconciliationResult`.
+- `src/core/scheduler/framework.ts` — broaden `SchedulerContext.store` Pick to include `getAgentTask`.
+- `src/core/scheduler/plugins/default-bind.ts` — fetch dependency `Succeeded` conditions; wrap prompt.
+- `src/core/scheduler/plugins/default-bind.test.ts` — tests for dependency prompt wrapping.
+- `src/core/task-controller.test.ts` — tests for `Succeeded` transition + `dependsOn` unblocking chain.
+- `src/mcp/tools/done.ts` — PATCH bound AgentTask before writing contribution.
+- `src/mcp/tools/done.test.ts` — tests for PATCH branch.
+- `src/cli/main.ts` — register `review-loop` subcommand.
+- `src/server/routes/agent-tasks.test.ts` — explicit test that status PATCH with conditions+`DoneSignaled` works via bearer auth.
+
+### Coexistence (strangler-fig)
+
+The new `grove review-loop` path runs entirely on top of `AgentTask` + `Scheduler`. The legacy `grove session start` continues to use `SessionOrchestrator` and is untouched. MCP tools work for both paths:
+
+- `grove_done` from an agent bound to an `AgentTask` (env vars present) → PATCH then contribution.
+- `grove_done` from an agent spawned by `SessionOrchestrator` (no env vars) → contribution only (today's behavior).
+
+Both `contributeOperation` calls keep firing because contributions still power the TUI contribution view, bounty store, and downstream consumers that the AgentTask system does not yet replace.
+
+### Data flow (codex → claude review)
+
+1. User runs `grove review-loop start --goal "X" --watch`.
+2. CLI discovers `.grove/` dir, reads bearer token from `server-keys.yaml`, provisions one shared worktree under `.grove/workspaces/review-loop-<ts>/`.
+3. CLI POSTs two tasks via `PUT /api/agent-tasks/<id>`:
+   - `task-coder`: `runtime=codex`, `role=coder`, `prompt=goal`, `dependsOn=[]`.
+   - `task-reviewer`: `runtime=claude`, `role=reviewer`, `prompt="Review the work completed for: <goal>"`, `dependsOn=[task-coder.id]`.
+4. Server's `TaskController` (with `Scheduler` already wired per PR #439) reconciles:
+   - `task-coder` advances `Pending → PendingBind`. Scheduler picks codex profile. `DefaultBind` calls `runtime.spawn` with prompt and env vars. `task-coder.status.sessionId` set.
+   - `task-reviewer` stays `Pending` (blocked on `dependsOn`).
+5. Codex runs. When finished, it calls `grove_done(summary="...")`. The MCP `done.ts` handler:
+   - Reads `GROVE_AGENT_TASK_ID` + `GROVE_AGENT_TASK_GENERATION` from env.
+   - PATCHes `/api/agent-tasks/<task-coder.id>/status` with a new `DoneSignaled=True` condition carrying `summary` as `message`.
+   - Writes the legacy contribution (back-compat).
+6. Controller's next reconcile of `task-coder` sees `DoneSignaled=True` and transitions `Running → Succeeded`. Closes the runtime session.
+7. Controller's next reconcile of `task-reviewer` finds the dependency satisfied. `Pending → PendingBind`. Scheduler picks claude profile. `DefaultBind` reads `task-coder.status.conditions[DoneSignaled].message` and constructs the reviewer prompt:
+
+   ```
+   ## Upstream output
+
+   ### review-loop-<ts>-coder (succeeded)
+   <coder's grove_done summary>
+
+   ## Your task
+
+   Review the work completed for: <goal>
+   ```
+
+8. Claude reviews same worktree (file changes visible from coder), calls `grove_done(summary)`. Same sequence: `DoneSignaled` → `Succeeded` → session closed.
+9. CLI `--watch` sees both tasks Succeeded, exits 0.
+
+## Component Details
+
+### `DoneSignaled` condition
+
+Add to `AgentTaskConditionType`:
+
+```ts
+DoneSignaled: "DoneSignaled",
+```
+
+Set only by `grove_done` MCP tool. Status `True`, reason `"agent-grove-done"`, message = the agent's `summary` argument. Carried on `AgentTaskStatus.conditions`.
+
+### `TaskController.reconcileRunning` extension
+
+```ts
+private async reconcileRunning(task: AgentTaskView): Promise<ReconciliationResult | undefined> {
+  if (task.status.sessionId === undefined) return failLostSession(task, this.nowIso());
+
+  // NEW: agent signaled done → Succeeded (checked before session-status to win the race
+  // where the agent process exits immediately after grove_done).
+  const doneCondition = task.status.conditions.find(
+    (c) => c.type === AgentTaskConditionType.DoneSignaled && c.status === "True",
+  );
+  if (doneCondition !== undefined) {
+    const session = (await this.runtime.listSessions()).find(
+      (s) => s.id === task.status.sessionId,
+    );
+    return succeedTask(task, doneCondition.message ?? "", this.nowIso(), session);
+  }
+
+  const sessions = await this.runtime.listSessions();
+  const session = sessions.find((s) => s.id === task.status.sessionId);
+  if (session !== undefined && (session.status === "running" || session.status === "idle")) {
+    return runningLiveCatchUp(task, this.nowIso());
+  }
+  return failLostSession(task, this.nowIso());
+}
+
+function succeedTask(
+  task: AgentTaskView,
+  summary: string,
+  nowIso: string,
+  session: AgentSession | undefined,
+): ReconciliationResult {
+  const conditions = upsertCondition(
+    upsertCondition(task.status.conditions, {
+      type: AgentTaskConditionType.Running,
+      status: "False",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "done-signaled",
+      message: "",
+    }),
+    {
+      type: AgentTaskConditionType.Succeeded,
+      status: "True",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "done-signaled",
+      message: summary,
+    },
+  );
+  return {
+    patch: {
+      phase: AgentTaskPhase.Succeeded,
+      observedGeneration: task.spec.generation,
+      conditions,
+      lastTransitionAt: nowIso,
+    },
+    transition: transition(task, AgentTaskPhase.Succeeded, "done-signaled"),
+    ...(session === undefined ? {} : { sessionToCloseOnSuccess: session }),
+  };
+}
+```
+
+Extend `ReconciliationResult`:
+
+```ts
+interface ReconciliationResult {
+  readonly patch: AgentTaskStatusPatch;
+  readonly transition: AgentTaskStatusTransition;
+  readonly sessionToCloseOnPatchFailure?: AgentSession | undefined;
+  readonly sessionToCloseOnSuccess?: AgentSession | undefined;
+}
+```
+
+`TaskController.reconcileTask` calls `runtime.close(sessionToCloseOnSuccess)` after a successful status patch. Mirror of `sessionToCloseOnPatchFailure` but on the success path. Errors during close are logged but not rethrown (best-effort cleanup).
+
+### `dependsOn` unblocking
+
+No code change in `reconcilePending`. The existing `blockingDependencies` check at `task-controller.ts:445` already returns blocked when a dependency is not `Succeeded`. Once Section 2's transition lands, dependents unblock automatically on the next reconcile.
+
+### `DefaultBind` prompt wrapping
+
+`SchedulerContext.store` interface changes from `Pick<AgentTaskStore, "listAgentTaskEntities">` to `Pick<AgentTaskStore, "listAgentTaskEntities" | "getAgentTask">`. Backwards-compatible: callers passing the full `AgentTaskStore` auto-satisfy the wider Pick. `Scheduler` constructor and existing tests pass through unchanged.
+
+`DefaultBind.bind`:
+
+```ts
+async bind(ctx: SchedulerContext, profile: RuntimeProfile): Promise<BindResult> {
+  const upstreamSections: UpstreamSection[] = [];
+  for (const depId of ctx.task.spec.dependsOn) {
+    const dep = await ctx.store.getAgentTask(depId);
+    const succeededCondition = dep?.status.conditions.find(
+      (c) => c.type === "Succeeded" && c.status === "True",
+    );
+    upstreamSections.push({
+      taskId: depId,
+      summary: succeededCondition?.message ?? "",
+    });
+  }
+  const wrappedPrompt = buildPromptWithUpstream(ctx.task.spec.prompt, upstreamSections);
+
+  const config: AgentConfig = {
+    role: ctx.task.spec.role,
+    command: profile.runtimeCommand,
+    cwd: ctx.task.spec.worktree,
+    goal: ctx.task.spec.prompt,    // unwrapped goal kept on `goal` for back-compat
+    prompt: wrappedPrompt,         // wrapped prompt is what the agent receives
+    ...(profile.platform === undefined ? {} : { platform: profile.platform }),
+    ...(model === undefined ? {} : { model }),
+    env: {
+      GROVE_AGENT_TASK_ID: ctx.task.spec.id,
+      GROVE_AGENT_TASK_GENERATION: String(ctx.task.spec.generation),
+      GROVE_AGENT_TASK_RUNTIME: profile.runtimeCommand,
+    },
+  };
+  return { session: await this.runtime.spawn(ctx.task.spec.role, config) };
+}
+```
+
+`buildPromptWithUpstream` is the pure module from `upstream-prompt.ts`.
+
+### `grove_done` MCP-side patch
+
+`src/mcp/agent-task-context.ts`:
+
+```ts
+export interface AgentTaskContext {
+  readonly taskId: string;
+  readonly generation: number;
+}
+
+export function readAgentTaskContext(
+  env: Readonly<Record<string, string | undefined>>,
+): AgentTaskContext | undefined {
+  const taskId = env.GROVE_AGENT_TASK_ID;
+  const gen = env.GROVE_AGENT_TASK_GENERATION;
+  if (taskId === undefined || gen === undefined) return undefined;
+  const generation = Number.parseInt(gen, 10);
+  if (!Number.isFinite(generation)) return undefined;
+  return { taskId, generation };
+}
+```
+
+`done.ts`:
+
+```ts
+const ctx = readAgentTaskContext(process.env);
+if (ctx !== undefined) {
+  try {
+    await patchAgentTaskDoneSignaled(deps, ctx, args.summary);
+  } catch (err) {
+    process.stderr.write(
+      `[grove-done] task=${ctx.taskId} patch failed (${(err as Error).message}); ` +
+        `contribution write proceeding\n`,
+    );
+  }
+}
+// existing contributeOperation call unchanged
+```
+
+`patchAgentTaskDoneSignaled` is a new helper in `src/mcp/agent-task-patch.ts` (or co-located in `done.ts`):
+
+1. `GET /api/agent-tasks/<taskId>` → read current view.
+2. Compose patch body: `{ conditions: [...current, { type: "DoneSignaled", status: "True", observedGeneration, lastTransitionTime, reason: "agent-grove-done", message: summary }], observedGeneration }`. Use the existing `upsertCondition` semantics (server-side merges).
+3. `PATCH /api/agent-tasks/<taskId>/status` with `If-Match: <resourceVersion>`.
+4. On 409 → re-GET once, recompose, retry.
+5. On second 409 or other error → throw (caught by outer try/catch in done.ts, which logs and continues with contribution write).
+
+Server URL discovered from `process.env.GROVE_NEXUS_URL` or `process.env.GROVE_SERVER_URL` (whichever the MCP server already uses for HTTP calls — verify existing pattern in `src/mcp/`). Bearer token from existing MCP HTTP helper.
+
+### `grove review-loop` CLI
+
+See Section 5. Subcommands `start`, `status`. Stretch: `cancel`.
+
+Required flags on `start`: `--goal`. Optional: `--coder`, `--reviewer`, `--watch`, `--grove-url`, `--timeout`.
+
+Watch output is line-buffered JSON, one phase-change per line, `{"event":"complete",...}` final line. Exit codes: 0 success, 1 failure (Failed/Unschedulable), 2 timeout.
+
+### Telemetry
+
+- Controller stderr: `[task-controller] <task-id>: <from> → <to> (reason: <r>, gen: <n>)` on every transition.
+- MCP stderr: `[grove-done] task=<id> gen=<n> patched DoneSignaled` on success, warning on failure.
+- CLI stdout: JSON event stream per phase change + final `complete` event.
+
+No new metrics endpoint, no event-bus changes. Existing `entity.changed` envelopes via watch hub already cover external subscribers.
+
+## Testing
+
+### Unit tests
+
+- `src/core/task-controller.test.ts` — 5 new cases (Succeeded transition, race-free ordering, back-compat, dependent unblocking, session close on success).
+- `src/core/scheduler/upstream-prompt.test.ts` — 4 cases (no deps, one dep, multi deps, missing summary fallback).
+- `src/core/scheduler/plugins/default-bind.test.ts` — 2 new cases (deps with summary; legacy SchedulerContext shape behavior).
+- `src/mcp/agent-task-context.test.ts` — 3 cases (both env vars, one missing, non-numeric gen).
+- `src/mcp/tools/done.test.ts` — 4 new cases (PATCH-then-contribution flow, 409 retry, no-env-vars no-PATCH, network error tolerance).
+- `src/cli/commands/review-loop.test.ts` — workspace bootstrap, two-task PUT, dependsOn wiring, connection-refused error message.
+
+### Server integration test
+
+- `src/server/routes/agent-tasks.test.ts` — explicit test: bearer-authed PATCH with `conditions: [{type: "DoneSignaled", status: "True", ...}]` is accepted and persisted.
+
+### E2E
+
+- `tests/e2e/review-loop-codex-claude-tmux.ts` — standalone bun script:
+  1. `grove init` + write `grove.json` with scheduler block (codex-default + claude-default profiles).
+  2. Start grove-server in tmux pane (matches `scheduler-pipeline-tmux.ts` pattern).
+  3. Driver process: `grove review-loop start --goal "Print hello and call grove_done" --watch --timeout 120`.
+  4. Assert sequenced events: coder Pending→Running→Succeeded, reviewer Pending→PendingBind→Running→Succeeded, exit 0.
+  5. Capture pane + final task status as evidence.
+  6. Cleanup on `--keep`-aware exit handler.
+
+E2E runs against real `codex` and `claude` binaries (verified installed). Prompts kept trivial; budget 120s.
+
+### Acceptance verification
+
+- "Closes the migration gap": E2E exits 0 with both tasks `Succeeded`.
+- "Scheduler runs for both agents": E2E pane shows `[task-controller] <coder-id>: PendingBind → Running` AND same for reviewer, both with scheduler-picked profile names in conditions.
+- "Back-compat preserved": existing `bun test src/core/task-controller.test.ts src/mcp/tools/done.test.ts` passes without regression.
+
+## Risks and Open Questions
+
+- **Dependency in Failed state cascades to dependent stuck-forever.** `dependsOn` unblock requires `Succeeded`. A Failed coder leaves the reviewer in Pending forever. Not catastrophic (operator can DELETE the task), but worth a follow-up (cascade-cancel policy or auto-fail of dependents). Logged as risk; revisit in #285.
+- **MCP server's URL discovery for grove-server.** This spec assumes `process.env.GROVE_NEXUS_URL` or a similar var the MCP server already uses. Verify during implementation; if absent, add `GROVE_SERVER_URL` to the env injected by `DefaultBind`.
+- **Conditions-array PATCH semantics.** Server-side `patchAgentTaskStatus` likely treats `conditions` as a full replacement (per `AgentTaskStatusPatch.conditions`). The MCP helper must therefore include ALL existing conditions plus the new `DoneSignaled` — not just the diff. This is why step 1 GETs the current view first. If the route accepts a partial-merge JSON Patch in the future, this can simplify.
+- **Race between `grove_done` PATCH and controller's `runtime.close`.** When the controller reconciles `Succeeded` it closes the session. If the agent process is still executing post-`grove_done`, close kills it mid-cleanup. Acceptable for review loops (agent has signaled done; nothing more to do) but worth noting. Future: add a `grace-period` field on `AgentTask` if needed.
+- **Worktree concurrency.** Both tasks share the worktree path. `WorktreeExclusivity` filter rejects two simultaneously-Running tasks on the same worktree, so the reviewer can only start after coder exits — that's exactly the desired sequencing. No conflict, but called out so reviewers understand why exclusivity matters here.
+- **`TaskBinder` interface vs scheduler-driven path.** PR #439 kept `TaskBinder` for back-compat. After this migration, both paths still coexist; #305's two-phase reservation work may remove `TaskBinder` as planned. No additional cleanup needed here.

--- a/docs/superpowers/specs/2026-05-16-review-loop-agent-task-migration-design.md
+++ b/docs/superpowers/specs/2026-05-16-review-loop-agent-task-migration-design.md
@@ -8,7 +8,7 @@ The core moves are:
 
 - A new `grove review-loop` CLI command that POSTs two chained `AgentTask` records (coder + reviewer with `dependsOn`) to a running grove-server.
 - A `Succeeded` transition in `TaskController` driven by a new `DoneSignaled` condition.
-- An MCP-side change to `grove_done` that PATCHes the bound task with `DoneSignaled=True` before writing the legacy contribution.
+- A new bearer-authed endpoint `POST /api/agent-tasks/:id/done` and an MCP-side change to `grove_done` that calls it before writing the legacy contribution. (Direct `PATCH /status` is controller-token-gated and out of reach for MCP — see Architecture for the server-mediated endpoint design.)
 - A small `DefaultBind` extension that prepends each dependency's `Succeeded` condition message to the new task's prompt, so the reviewer sees what the coder did.
 
 Result: a real codex→claude handoff runs filter → score → permit → bind for each agent, blocks on `dependsOn`, and exits cleanly when both reach `Succeeded`.
@@ -17,7 +17,7 @@ Result: a real codex→claude handoff runs filter → score → permit → bind 
 
 - Add an opt-in `grove review-loop start` CLI that creates two `AgentTask` records (coder, reviewer with `dependsOn=[coder-id]`).
 - Add a `Succeeded` transition path in `TaskController.reconcileRunning` driven by a `DoneSignaled=True` condition.
-- Wire `grove_done` MCP tool to PATCH the bound `AgentTask` status when `GROVE_AGENT_TASK_ID` is set in the agent process env.
+- Wire `grove_done` MCP tool to call a new server-mediated endpoint `POST /api/agent-tasks/:id/done` (bearer-authed) that writes the `DoneSignaled` condition server-side using the controller's own privilege. Triggered when `GROVE_AGENT_TASK_ID` is set in the agent process env.
 - Extend `DefaultBind` to prepend each dependency's `Succeeded` summary into the bound task's prompt.
 - Provide a tmux E2E that runs a real codex→claude review loop end-to-end against grove-server.
 - Preserve back-compat: `grove session start`, `SessionOrchestrator`, the contribution/handoff/bounty pipeline, and the legacy `grove_done` behavior are unchanged for agents not bound to an `AgentTask`.
@@ -43,7 +43,9 @@ Result: a real codex→claude handoff runs filter → score → permit → bind 
 
 `DefaultBind` (`src/core/scheduler/plugins/default-bind.ts`) reads `task.spec.prompt` verbatim into `AgentConfig.prompt` and injects `GROVE_AGENT_TASK_ID` + `GROVE_AGENT_TASK_GENERATION` into the agent's process env.
 
-`grove-server` already exposes `PUT /api/agent-tasks/:id` (create/update spec) and `PATCH /api/agent-tasks/:id/status` (controller-owned status writes guarded by `X-Grove-Controller-Token`). The MCP server does NOT have controller-token access, so `grove_done`'s PATCH from MCP goes through the bearer-token path used by other agent-task routes — verify route accepts MCP-bearer for `conditions` patches (existing tests in `agent-tasks.test.ts` may already cover this).
+`grove-server` exposes `PUT /api/agent-tasks/:id` (bearer-authed spec writes) and `PATCH /api/agent-tasks/:id/status` (controller-token gated — see `requireControllerToken` middleware in `src/server/routes/agent-tasks.ts:120`). The MCP server runs in a separate process that holds the bearer token only; it has no access to the controller token and intentionally must not — exposing the privileged status-patch path to MCP would let any agent forge phase transitions.
+
+To bridge this, the migration adds one bearer-authed route `POST /api/agent-tasks/:id/done` that accepts a small payload (`summary: string`) and internally writes the `DoneSignaled` condition + `observedGeneration` bump using the server's own privilege. The route's authorization rule: any bearer-token-authenticated caller may signal done for the task identified in the URL — agent identity is not cross-checked. This is acceptable here because (a) the bearer token is namespace-scoped (an agent in another namespace cannot reach this task) and (b) `DoneSignaled` only triggers a Succeeded transition; it cannot set phase=Running or other arbitrary states.
 
 ## Architecture
 
@@ -67,10 +69,11 @@ Result: a real codex→claude handoff runs filter → score → permit → bind 
 - `src/core/scheduler/plugins/default-bind.ts` — fetch dependency `Succeeded` conditions; wrap prompt.
 - `src/core/scheduler/plugins/default-bind.test.ts` — tests for dependency prompt wrapping.
 - `src/core/task-controller.test.ts` — tests for `Succeeded` transition + `dependsOn` unblocking chain.
-- `src/mcp/tools/done.ts` — PATCH bound AgentTask before writing contribution.
-- `src/mcp/tools/done.test.ts` — tests for PATCH branch.
+- `src/mcp/tools/done.ts` — POST to `/api/agent-tasks/:id/done` before writing contribution.
+- `src/mcp/tools/done.test.ts` — tests for done-endpoint branch.
 - `src/cli/main.ts` — register `review-loop` subcommand.
-- `src/server/routes/agent-tasks.test.ts` — explicit test that status PATCH with conditions+`DoneSignaled` works via bearer auth.
+- `src/server/routes/agent-tasks.ts` — add `POST /:id/done` route (bearer-authed, writes `DoneSignaled` condition).
+- `src/server/routes/agent-tasks.test.ts` — tests for the new `/done` endpoint.
 
 ### Coexistence (strangler-fig)
 
@@ -237,6 +240,11 @@ async bind(ctx: SchedulerContext, profile: RuntimeProfile): Promise<BindResult> 
       GROVE_AGENT_TASK_ID: ctx.task.spec.id,
       GROVE_AGENT_TASK_GENERATION: String(ctx.task.spec.generation),
       GROVE_AGENT_TASK_RUNTIME: profile.runtimeCommand,
+      // Required for grove_done's POST /api/agent-tasks/:id/done call. Pass-through from
+      // server env; absent if the controller wasn't launched with these set, in which case
+      // grove_done's POST will log a clear error and fall through to the contribution path.
+      ...(process.env.GROVE_SERVER_URL === undefined ? {} : { GROVE_SERVER_URL: process.env.GROVE_SERVER_URL }),
+      ...(process.env.GROVE_API_TOKEN === undefined ? {} : { GROVE_API_TOKEN: process.env.GROVE_API_TOKEN }),
     },
   };
   return { session: await this.runtime.spawn(ctx.task.spec.role, config) };
@@ -245,7 +253,66 @@ async bind(ctx: SchedulerContext, profile: RuntimeProfile): Promise<BindResult> 
 
 `buildPromptWithUpstream` is the pure module from `upstream-prompt.ts`.
 
-### `grove_done` MCP-side patch
+### Server-mediated `/done` endpoint
+
+New route in `src/server/routes/agent-tasks.ts`, registered alongside the existing routes (BEFORE the `requireControllerToken` middleware is applied so it stays bearer-only):
+
+```ts
+agentTasks.post(
+  "/:id/done",
+  zValidator("json", z.object({ summary: z.string().max(2000) }).strict()),
+  async (c) => {
+    const deps = c.get("deps");
+    const taskId = c.req.param("id");
+    const body = c.req.valid("json" as never) as { summary: string };
+    const store = deps.agentTaskStore;
+    if (store === undefined) throw new Error("AgentTask store middleware did not run");
+
+    const current = await store.getAgentTask(taskId);
+    if (current === undefined) {
+      return c.json({ error: { code: "NOT_FOUND", message: `task '${taskId}' not found` } }, 404);
+    }
+
+    const nowIso = new Date().toISOString();
+    const condition: Condition = {
+      type: AgentTaskConditionType.DoneSignaled,
+      status: "True",
+      observedGeneration: current.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "agent-grove-done",
+      message: body.summary,
+    };
+    const conditions = upsertCondition(current.status.conditions, condition);
+
+    const result = await store.patchAgentTaskStatus(taskId, {
+      conditions,
+      observedGeneration: current.spec.generation,
+    });
+    if (result.kind === "rv-mismatch") {
+      // One retry — refetch + reapply. Subsequent mismatch returns 409.
+      const refreshed = await store.getAgentTask(taskId);
+      if (refreshed === undefined) {
+        return c.json({ error: { code: "NOT_FOUND", message: "task disappeared" } }, 404);
+      }
+      const retried = await store.patchAgentTaskStatus(taskId, {
+        conditions: upsertCondition(refreshed.status.conditions, {
+          ...condition,
+          observedGeneration: refreshed.spec.generation,
+        }),
+        observedGeneration: refreshed.spec.generation,
+      });
+      if (retried.kind === "rv-mismatch") {
+        return c.json({ error: { code: "CONFLICT", message: "concurrent update" } }, 409);
+      }
+    }
+    return c.json({ ok: true, taskId, condition: "DoneSignaled" });
+  },
+);
+```
+
+Apply route registration BEFORE `agentTasks.use(requireControllerToken)` so the `/done` path stays bearer-only. Order matters in Hono — register the new POST route, then apply the controller-token middleware to status routes.
+
+### `grove_done` MCP-side call
 
 `src/mcp/agent-task-context.ts`:
 
@@ -273,10 +340,10 @@ export function readAgentTaskContext(
 const ctx = readAgentTaskContext(process.env);
 if (ctx !== undefined) {
   try {
-    await patchAgentTaskDoneSignaled(deps, ctx, args.summary);
+    await signalAgentTaskDone(deps, ctx, args.summary);
   } catch (err) {
     process.stderr.write(
-      `[grove-done] task=${ctx.taskId} patch failed (${(err as Error).message}); ` +
+      `[grove-done] task=${ctx.taskId} POST /done failed (${(err as Error).message}); ` +
         `contribution write proceeding\n`,
     );
   }
@@ -284,15 +351,37 @@ if (ctx !== undefined) {
 // existing contributeOperation call unchanged
 ```
 
-`patchAgentTaskDoneSignaled` is a new helper in `src/mcp/agent-task-patch.ts` (or co-located in `done.ts`):
+`signalAgentTaskDone` is a new helper in `src/mcp/agent-task-done.ts`:
 
-1. `GET /api/agent-tasks/<taskId>` → read current view.
-2. Compose patch body: `{ conditions: [...current, { type: "DoneSignaled", status: "True", observedGeneration, lastTransitionTime, reason: "agent-grove-done", message: summary }], observedGeneration }`. Use the existing `upsertCondition` semantics (server-side merges).
-3. `PATCH /api/agent-tasks/<taskId>/status` with `If-Match: <resourceVersion>`.
-4. On 409 → re-GET once, recompose, retry.
-5. On second 409 or other error → throw (caught by outer try/catch in done.ts, which logs and continues with contribution write).
+```ts
+export async function signalAgentTaskDone(
+  deps: McpDeps,
+  ctx: AgentTaskContext,
+  summary: string,
+): Promise<void> {
+  const baseUrl = process.env.GROVE_SERVER_URL ?? process.env.GROVE_NEXUS_URL;
+  if (baseUrl === undefined) {
+    throw new Error("GROVE_SERVER_URL / GROVE_NEXUS_URL not set; cannot signal AgentTask done");
+  }
+  const token = process.env.GROVE_API_TOKEN;
+  if (token === undefined) {
+    throw new Error("GROVE_API_TOKEN not set; cannot signal AgentTask done");
+  }
+  const res = await fetch(`${baseUrl}/api/agent-tasks/${encodeURIComponent(ctx.taskId)}/done`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ summary }),
+  });
+  if (!res.ok) {
+    throw new Error(`POST /done returned ${res.status}: ${await res.text()}`);
+  }
+}
+```
 
-Server URL discovered from `process.env.GROVE_NEXUS_URL` or `process.env.GROVE_SERVER_URL` (whichever the MCP server already uses for HTTP calls — verify existing pattern in `src/mcp/`). Bearer token from existing MCP HTTP helper.
+`GROVE_SERVER_URL` and `GROVE_API_TOKEN` are injected by `DefaultBind` (Section 4 will add them). Existing MCP env (`GROVE_NEXUS_URL`) is checked as a fallback to ease local testing where the same URL serves grove + nexus.
 
 ### `grove review-loop` CLI
 
@@ -346,8 +435,8 @@ E2E runs against real `codex` and `claude` binaries (verified installed). Prompt
 ## Risks and Open Questions
 
 - **Dependency in Failed state cascades to dependent stuck-forever.** `dependsOn` unblock requires `Succeeded`. A Failed coder leaves the reviewer in Pending forever. Not catastrophic (operator can DELETE the task), but worth a follow-up (cascade-cancel policy or auto-fail of dependents). Logged as risk; revisit in #285.
-- **MCP server's URL discovery for grove-server.** This spec assumes `process.env.GROVE_NEXUS_URL` or a similar var the MCP server already uses. Verify during implementation; if absent, add `GROVE_SERVER_URL` to the env injected by `DefaultBind`.
-- **Conditions-array PATCH semantics.** Server-side `patchAgentTaskStatus` likely treats `conditions` as a full replacement (per `AgentTaskStatusPatch.conditions`). The MCP helper must therefore include ALL existing conditions plus the new `DoneSignaled` — not just the diff. This is why step 1 GETs the current view first. If the route accepts a partial-merge JSON Patch in the future, this can simplify.
+- **`GROVE_SERVER_URL` + `GROVE_API_TOKEN` must be present in the grove-server process env.** `DefaultBind` passes them through to agents and on to MCP. If they are missing at server startup, `grove_done` cannot POST to `/done` and the task only reaches `Succeeded` via legacy paths (which don't exist for the AgentTask flow), so it ends as Failed when the session exits. The CLI `grove review-loop start` should pre-flight check these vars and fail-fast with a clear message before posting tasks.
+- **Conditions-array PATCH semantics.** `AgentTaskStatusPatch.conditions` is a full replacement, so the new `POST /done` route GETs the current view, merges via `upsertCondition`, and writes back. The 409 retry path re-GETs to handle interleaved controller writes.
 - **Race between `grove_done` PATCH and controller's `runtime.close`.** When the controller reconciles `Succeeded` it closes the session. If the agent process is still executing post-`grove_done`, close kills it mid-cleanup. Acceptable for review loops (agent has signaled done; nothing more to do) but worth noting. Future: add a `grace-period` field on `AgentTask` if needed.
 - **Worktree concurrency.** Both tasks share the worktree path. `WorktreeExclusivity` filter rejects two simultaneously-Running tasks on the same worktree, so the reviewer can only start after coder exits — that's exactly the desired sequencing. No conflict, but called out so reviewers understand why exclusivity matters here.
 - **`TaskBinder` interface vs scheduler-driven path.** PR #439 kept `TaskBinder` for back-compat. After this migration, both paths still coexist; #305's two-phase reservation work may remove `TaskBinder` as planned. No additional cleanup needed here.

--- a/docs/superpowers/specs/2026-05-16-scheduler-framework-design.md
+++ b/docs/superpowers/specs/2026-05-16-scheduler-framework-design.md
@@ -1,0 +1,371 @@
+# Scheduler Framework Design (D3, #300)
+
+## Summary
+
+Issue #300 introduces a Kubernetes-scheduler-style plugin pipeline that selects a runtime profile for each `AgentTask` before bind. The pipeline runs four stages — Filter, Score, Permit, Bind — over a configurable set of candidate `RuntimeProfile` records. The scheduler lives in a new `src/core/scheduler/` module and is injected into `TaskController`. When set, `reconcilePendingBind` delegates profile selection to the scheduler instead of calling the binder directly. When unset, the controller preserves today's single-runtime direct-bind path.
+
+This PR ships the framework, the default plugin set required by the acceptance criteria (`RuntimeCapability`, `BudgetRemaining`, `WorktreeExclusivity` filters; `TaskAffinity` score; `AutoPermit` permit; `DefaultBind` bind), and the config seam that lets new plugins be enabled by editing config rather than code. A reservation-token field on the scheduler's result type is reserved for #305 but always `undefined` here.
+
+## Goals
+
+- Add `Scheduler` class that runs the Filter→Score→Permit→Bind pipeline over a list of candidate `RuntimeProfile` records and returns a typed `SchedulingResult`.
+- Define plugin interfaces (`FilterPlugin`, `ScorePlugin`, `PermitPlugin`, `BindPlugin`) that are easy to implement, test in isolation, and register through config.
+- Wire `TaskController.reconcilePendingBind` to the scheduler when an instance is injected, mapping each result variant to a status patch.
+- Ship the four acceptance plugins plus `AutoPermit` and `DefaultBind` so out-of-the-box behavior matches today's controller for single-runtime configs.
+- Surface scheduling outcomes as `AgentTask` conditions (`Unschedulable`, `PermitRequired`) so the TUI can render them without new IPC.
+- Load profiles and pipeline configuration from the existing config system; validate with zod.
+- Reserve a `reservationToken?` field on `SchedulingResult.bound` so #305 can wrap the call without changing the scheduler signature.
+
+## Non-Goals
+
+- Two-phase reservation, CAS on status, transition-graph enforcement: all #305.
+- `HistoricalSuccessRate` and `LoadBalancing` score plugins. Interfaces support them; implementations land in a follow-up issue.
+- TUI wiring for `UserConfirmPermit`. The plugin's shape ships behind an in-memory decision store; the persistent store and TUI prompts are a follow-up.
+- Global cost/turn ledger for `BudgetRemaining`. The filter takes a `BudgetLedger` interface with a permissive no-op default; real ledger lands later (likely alongside Nexus credits work).
+- Multi-runtime registry. Profiles are config records; all profiles back through the single injected `AgentRuntime` for now. A runtime registry can be added without changing the scheduler API.
+- TUI permit prompt end-to-end test.
+
+## Current State
+
+`TaskController.reconcilePendingBind` (`src/core/task-controller.ts`) calls `DefaultTaskBinder.bind(task)` directly, which builds an `AgentConfig` from `task.spec` and calls `runtime.spawn`. There is no concept of candidate selection — the task's `spec.runtime` string is passed straight through. `TaskBinder` is a single-method interface (`bind(request) -> {session}`).
+
+`AgentTask` carries `spec.runtime`, `spec.role`, `spec.budget?`, `spec.dependsOn`, and `status.phase` (`Pending` | `PendingBind` | `Running` | `AwaitingReview` | `Succeeded` | `Failed`). Conditions are appended via `upsertCondition`; the current set is `Admitted | Scheduled | Bound | Running | AwaitingReview | Succeeded | Failed | Blocked`.
+
+`AgentRuntime` is a single interface (`spawn`, `send`, `close`, `onIdle`, `listSessions`, `listSessionEntities`, `isAvailable`). There is no runtime pool. `task.spec.runtime` is the string mapped to `AgentConfig.command`.
+
+Config (`src/core/config.ts`) uses zod schemas and a file-loaded record. There is no `scheduler` section today.
+
+## Architecture
+
+### Module layout — `src/core/scheduler/`
+
+- `framework.ts` — plugin interfaces (`FilterPlugin`, `ScorePlugin`, `PermitPlugin`, `BindPlugin`), `SchedulerContext`, `SchedulingResult`, verdict types.
+- `scheduler.ts` — `Scheduler` class. Owns the pipeline and the plugin instances. Pure: reads task + profiles + store, returns a result. Does not write.
+- `profile.ts` — `RuntimeProfile` type and a `synthesizeFallbackProfile(task)` helper invoked per scheduling call when no profiles are configured.
+- `config.ts` — `SchedulerConfig` zod schema, `loadSchedulerConfig(config)` adapter, plugin-name → impl resolution with an explicit registry of built-in plugins.
+- `plugins/runtime-capability.ts`
+- `plugins/budget-remaining.ts`
+- `plugins/worktree-exclusivity.ts`
+- `plugins/task-affinity.ts`
+- `plugins/auto-permit.ts`
+- `plugins/user-confirm-permit.ts`
+- `plugins/default-bind.ts`
+- `plugins/index.ts` — built-in plugin registry consumed by `config.ts`.
+- `index.ts` — public re-exports.
+
+### Integration seam
+
+`TaskControllerOptions` gains:
+
+```ts
+readonly scheduler?: Scheduler | undefined;
+```
+
+`reconcilePendingBind` becomes:
+
+```ts
+if (task.status.sessionId !== undefined) return this.reconcileRunning(task);
+if (this.scheduler === undefined) return this.directBind(task);  // today's path
+const decision = await this.scheduler.schedule(task);
+return this.applyDecision(task, decision);
+```
+
+`directBind` is today's bind logic (kept for back-compat and for tests that do not wire a scheduler). `applyDecision` maps every `SchedulingResult` variant to a `ReconciliationResult`.
+
+## Plugin Interfaces (`framework.ts`)
+
+```ts
+export interface SchedulerContext {
+  readonly task: AgentTaskView;
+  readonly profiles: readonly RuntimeProfile[];
+  readonly store: Pick<AgentTaskStore, "listAgentTaskEntities">;
+  readonly now: () => number;
+}
+
+export interface FilterPlugin {
+  readonly name: string;
+  filter(ctx: SchedulerContext, profile: RuntimeProfile): Promise<FilterVerdict>;
+}
+export type FilterVerdict =
+  | { readonly admit: true }
+  | { readonly admit: false; readonly reason: string; readonly message?: string };
+
+export interface ScorePlugin {
+  readonly name: string;
+  score(ctx: SchedulerContext, profile: RuntimeProfile): Promise<number>;  // 0–100
+}
+
+export interface PermitPlugin {
+  readonly name: string;
+  permit(ctx: SchedulerContext, profile: RuntimeProfile): Promise<PermitVerdict>;
+}
+export type PermitVerdict =
+  | { readonly status: "granted" }
+  | { readonly status: "denied"; readonly reason: string; readonly message?: string }
+  | { readonly status: "wait";   readonly reason: string; readonly message?: string };
+
+export interface BindPlugin {
+  readonly name: string;
+  bind(ctx: SchedulerContext, profile: RuntimeProfile): Promise<TaskBindResult>;
+}
+```
+
+`FilterVerdict.reason` and `PermitVerdict.reason` use stable kebab-case identifiers (`runtime-mismatch`, `budget-exceeds-profile`, `worktree-busy`, `awaiting-user-confirmation`, …). Reasons surface in conditions and tests assert on them.
+
+## Pipeline Execution (`scheduler.ts`)
+
+```ts
+class Scheduler {
+  async schedule(task: AgentTaskView): Promise<SchedulingResult> {
+    const ctx = this.buildContext(task);
+
+    // 1. Filter
+    const filtered = await Promise.all(ctx.profiles.map(async (profile) => {
+      const rejections: FilterRejection[] = [];
+      for (const plugin of this.filters) {
+        const v = await this.runFilter(plugin, ctx, profile);
+        if (!v.admit) rejections.push({ plugin: plugin.name, reason: v.reason, message: v.message });
+      }
+      return { profile, rejections };
+    }));
+    const admitted = filtered.filter((c) => c.rejections.length === 0).map((c) => c.profile);
+    if (admitted.length === 0) return { kind: "unschedulable", rejections: filtered };
+
+    // 2. Score (highest wins, stable order breaks ties)
+    const scored = await Promise.all(admitted.map(async (profile) => ({
+      profile,
+      score: await this.scoreProfile(ctx, profile),
+    })));
+    scored.sort((a, b) => b.score - a.score || configOrderIndex(a.profile) - configOrderIndex(b.profile));
+    const winner = scored[0]!.profile;
+
+    // 3. Permit (first non-granted wins)
+    for (const plugin of this.permits) {
+      const v = await plugin.permit(ctx, winner);
+      if (v.status === "denied") return { kind: "denied", plugin: plugin.name, reason: v.reason, message: v.message };
+      if (v.status === "wait")   return { kind: "wait",   plugin: plugin.name, reason: v.reason, message: v.message, profile: winner };
+    }
+
+    // 4. Bind
+    const { session } = await this.bindPlugin.bind(ctx, winner);
+    return { kind: "bound", profile: winner, session, reservationToken: undefined };
+  }
+}
+```
+
+### Result variants
+
+```ts
+export type SchedulingResult =
+  | { kind: "bound";          profile: RuntimeProfile; session: AgentSession; reservationToken?: string | undefined }
+  | { kind: "unschedulable";  rejections: ReadonlyArray<{ profile: RuntimeProfile; rejections: readonly FilterRejection[] }> }
+  | { kind: "wait";           plugin: string; reason: string; message?: string; profile: RuntimeProfile }
+  | { kind: "denied";         plugin: string; reason: string; message?: string };
+```
+
+### Plugin error policy
+
+`runFilter` (and the score/permit equivalents) wrap plugin calls. If a plugin throws and its config entry sets `errorPolicy: "tolerate"`, the verdict is treated as `{ admit: false, reason: "plugin-error", message: <err> }`. Default policy (`"strict"`) re-throws; the controller's existing retry loop covers it. Mirrors k8s scheduler behavior.
+
+### Single-pass guarantee
+
+One `schedule()` call performs at most one bind attempt. The scheduler does not loop on its own. Reservation/retry are external concerns owned by the controller (today) and the reservation layer (in #305).
+
+## Runtime Profile + Config (`profile.ts`, `config.ts`)
+
+```ts
+export interface RuntimeProfile {
+  readonly name: string;
+  readonly platform: AgentPlatformType;             // "claude-code" | "codex" | "gemini"
+  readonly runtimeCommand: string;                  // AgentConfig.command
+  readonly model?: string | undefined;
+  readonly supportedRoles?: readonly string[] | undefined;  // undefined = any
+  readonly budget?: {
+    readonly maxCostUsd?: number;
+    readonly maxTurns?: number;
+    readonly allowedModels?: readonly string[];
+  };
+  readonly labels?: Readonly<Record<string, string>>;
+}
+```
+
+Config shape:
+
+```yaml
+scheduler:
+  profiles:
+    - name: claude-opus-default
+      platform: claude-code
+      runtimeCommand: claude
+      model: claude-opus-4-7
+      supportedRoles: [implementer, reviewer]
+      budget: { maxCostUsd: 10, maxTurns: 50 }
+      labels: { tier: premium }
+    - name: codex-default
+      platform: codex
+      runtimeCommand: codex
+      supportedRoles: [implementer]
+
+  pipeline:
+    filters: [RuntimeCapability, BudgetRemaining, WorktreeExclusivity]
+    scores:
+      - { name: TaskAffinity, weight: 100 }
+    permits: [AutoPermit]
+    bind:    DefaultBind
+```
+
+Plugin-name resolution: `config.ts` keeps a `BUILTIN_PLUGINS` record mapping the name strings used in config to factory functions. Unknown names yield a loader error listing the known names — never silent fallthrough.
+
+### Empty / missing config
+
+When `scheduler.profiles` is empty or absent, `loadSchedulerConfig` returns the default pipeline and an empty profile list. The `Scheduler` then calls `synthesizeFallbackProfile(task)` per scheduling call to derive a single profile from `task.spec.runtime`. This preserves single-runtime behavior for tests and existing deployments that do not yet set a `scheduler:` block.
+
+### `task.spec.runtime` semantics
+
+Stays a string. When set, `RuntimeCapability` rejects profiles where `profile.runtimeCommand !== task.spec.runtime`, preserving pin-to-runtime semantics. When empty, the scheduler picks among all eligible profiles.
+
+## Controller Integration (`task-controller.ts`)
+
+`applyDecision(task, decision)` mapping table:
+
+| `decision.kind` | Resulting patch | Phase transition | Notes |
+|---|---|---|---|
+| `bound` | `phase=Running`, `sessionId`, `Bound`+`Running` conditions, `lastTransitionAt` | `PendingBind → Running` | Identical to today's success patch. `sessionToCloseOnPatchFailure` set so a failed status write still closes the runtime session. |
+| `unschedulable` | `Scheduled=False`, `Unschedulable=True` condition (reasons joined, capped at first 3 entries; `observedGeneration` advanced) | none (stays `PendingBind`) | Resync retries; cheap because filters are fast. |
+| `wait` | `PermitRequired=True` condition (plugin + reason + message) | none (stays `PendingBind`) | Resync re-enters scheduler; `AutoPermit` always grants so this path only fires for `UserConfirmPermit` etc. |
+| `denied` | `Failed=True` condition with denied reason; `phase=Failed` | `PendingBind → Failed` | Terminal. |
+
+### New condition types
+
+Add to `AgentTaskConditionType`:
+
+- `Unschedulable`
+- `PermitRequired`
+
+Existing `Scheduled`, `Bound`, `Running`, `Failed` are reused.
+
+### Back-compat path
+
+If `scheduler` is not provided, `reconcilePendingBind` keeps today's `directBind` branch, which calls `this.binder.bind(task)`. Every existing test continues to pass without modification.
+
+### Reservation seam for #305
+
+`SchedulingResult.bound.reservationToken` is always `undefined` in this PR. #305 will:
+
+1. Before calling `scheduler.schedule`, mint a token and write `status.reservation = { token, expiresAt }`.
+2. Pass the token into a wrapper around `schedule` that validates it on bind and clears it on commit.
+3. Add a `reconcilePendingBindReservation` step that scans for expired reservations and rolls back.
+
+None of this requires changing the `Scheduler` API. `TaskBinder` interface is removed once #305 lands and the plugin path becomes the only path.
+
+## Default Plugins
+
+### Filters
+
+**`RuntimeCapability`** (`plugins/runtime-capability.ts`)
+
+- Reject when `task.spec.runtime` is set and `profile.runtimeCommand !== task.spec.runtime`. Reason: `runtime-mismatch`.
+- Reject when `profile.supportedRoles` is defined and does not include `task.spec.role`. Reason: `role-unsupported`.
+- Reject when `task.spec.budget?.model` is set, `profile.budget?.allowedModels` is defined, and the requested model is not in the allowlist. Reason: `model-not-allowed`.
+
+**`BudgetRemaining`** (`plugins/budget-remaining.ts`)
+
+- Reject when `task.spec.budget?.maxCostUsd` exceeds `profile.budget?.maxCostUsd`. Reason: `budget-exceeds-profile`.
+- Reject when `task.spec.maxTurns` exceeds `profile.budget?.maxTurns`. Reason: `turns-exceeds-profile`.
+- Constructor takes an optional `BudgetLedger` interface (`hasRemaining(profile, task): Promise<boolean>`); default impl always returns `true`.
+
+**`WorktreeExclusivity`** (`plugins/worktree-exclusivity.ts`)
+
+- Reads `store.listAgentTaskEntities()` once per call (memoized in `SchedulerContext`).
+- Reject every profile when another `AgentTask` with `status.phase === "Running"` shares `task.spec.worktree`. Reason: `worktree-busy`, message: `running task: <id>`.
+- The pipeline still applies this per-profile (uniform reject); a small optimization caches the verdict for the rest of the loop.
+
+### Score
+
+**`TaskAffinity`** (`plugins/task-affinity.ts`)
+
+- Requested labels come from `task.spec.budget?.affinity` (new optional `Record<string, string>` field on the task budget object) or default to `{ runtime: task.spec.runtime }` when `runtime` is set.
+- Score = `round(100 * matched / requested)`. No labels requested → neutral `50`.
+- Exact-match on values; no fuzzy matching.
+
+### Permit
+
+**`AutoPermit`** (`plugins/auto-permit.ts`) — always returns `{ status: "granted" }`. Default.
+
+**`UserConfirmPermit`** (`plugins/user-confirm-permit.ts`) — shape only:
+
+- Constructor takes a `PermitDecisionStore` interface with `lookup(taskId, profileName, generation): Promise<{ approved: boolean; reason?: string } | undefined>`.
+- No decision → `{ status: "wait", reason: "awaiting-user-confirmation" }`.
+- Approved → `granted`. Denied → `denied` with stored reason.
+- Default `PermitDecisionStore` is an in-memory map for unit tests. Persistent store + TUI wiring are a follow-up.
+
+### Bind
+
+**`DefaultBind`** (`plugins/default-bind.ts`)
+
+- Builds `AgentConfig` from `profile` (taking precedence) merged with `task.spec` (for prompt, cwd, env, role).
+- Specifically: `command` ← `profile.runtimeCommand`; `platform` ← `profile.platform`; `model` ← `profile.model ?? task.spec.budget?.model`.
+- Calls `runtime.spawn(task.spec.role, config)` and returns `{ session }`.
+
+## Deferred Items
+
+Listed here so reviewers can confirm the interfaces leave room for them. Each becomes its own follow-up issue:
+
+- `HistoricalSuccessRate` score plugin (derives from store's terminal `AgentTask` entities; in-memory aggregator updated on `onTransition`).
+- `LoadBalancing` score plugin.
+- `UserConfirmPermit` TUI wiring and persistent `PermitDecisionStore`.
+- Global `BudgetLedger` implementation backed by credits/bounty data.
+
+## Testing
+
+### Plugin unit tests — `src/core/scheduler/plugins/*.test.ts`
+
+- `runtime-capability.test.ts` — matrix of `task.spec.runtime` × `profile.runtimeCommand` × `supportedRoles`, with both pinned and unpinned task variants.
+- `budget-remaining.test.ts` — cost and turn limits, model allowlist, permissive default ledger, custom ledger that returns `false`.
+- `worktree-exclusivity.test.ts` — fixture store with Running on other worktree (admit), Running on same worktree (reject), Succeeded on same worktree (admit), Pending on same worktree (admit).
+- `task-affinity.test.ts` — full match, partial match, zero match, no-requested-labels neutral case.
+- `auto-permit.test.ts` — always granted.
+- `user-confirm-permit.test.ts` — wait → granted → bound, wait → denied → failed, in-memory decision store fixture.
+- `default-bind.test.ts` — profile precedence over spec, model fallback chain, env vars preserved.
+
+### Pipeline tests — `src/core/scheduler/scheduler.test.ts`
+
+- All filters pass → highest-scoring profile bound.
+- Some filters reject → admitted set excludes them; `unschedulable` only when all profiles rejected.
+- Scoring tie → earlier profile in config declaration order wins.
+- Permit `wait` short-circuits before Bind.
+- Permit `denied` short-circuits before Bind.
+- Plugin throws under `errorPolicy: "strict"` → schedule throws.
+- Plugin throws under `errorPolicy: "tolerate"` → treated as reject with `reason: plugin-error`.
+- Empty profiles config → fallback profile synthesized from `task.spec.runtime`, scheduler still binds.
+
+### Controller integration tests — extend `src/core/task-controller.test.ts`
+
+- No scheduler injected → today's direct-bind path unchanged (back-compat).
+- Scheduler injected + `bound` result → patch shape identical to today's success patch.
+- `unschedulable` → stays `PendingBind`, `Unschedulable` condition set; next resync re-enters scheduler.
+- `wait` → stays `PendingBind`, `PermitRequired` condition set; resync re-enters.
+- `denied` → transitions to `Failed`, `Failed` condition with denied reason.
+- Scheduler throws → `onError` fires, queue retries with backoff.
+- Status patch fails after a `bound` decision → runtime session is closed (existing `sessionToCloseOnPatchFailure` path verified).
+
+### Config tests — `src/core/scheduler/config.test.ts`
+
+- Zod validation: missing platform, invalid plugin name, negative weight, missing required pipeline section.
+- Plugin-name resolution: unknown name → loader error listing available plugins.
+- Two configs differing only in `pipeline.scores` weights produce different winners for the same task (acceptance: "new filter/score plugin added via config, no code change").
+
+## Acceptance Mapping
+
+| Issue acceptance | Where verified |
+|---|---|
+| Plugin interface documented | This spec + JSDoc on `framework.ts`. |
+| New filter/score plugin added via config (no code change) | `config.test.ts` reweight test using existing plugin code. |
+| Default plugins cover runtime-capability + budget + affinity | `runtime-capability.test.ts`, `budget-remaining.test.ts`, `task-affinity.test.ts`. |
+
+## Risks and Open Questions
+
+- **Affinity field on spec.** Adding `affinity` to `task.spec.budget` is a soft schema change. Optional, defaulted; no migration needed. Alternative: separate `task.spec.affinity` top-level. Chose `budget.affinity` to avoid touching `AgentTaskSpec` shape beyond what's already optional. Revisit if scoring grows beyond affinity.
+- **`WorktreeExclusivity` and parallel pipelines.** Memory note `feedback_e2e_use_nexus` flags Nexus store as source of truth. The filter reads `listAgentTaskEntities` which today resolves to the local/Nexus-backed `AgentTaskStore` — consistent with the controller's existing reads. No new wiring needed.
+- **Removing `TaskBinder` later.** Once #305 lands, the only path is plugin-driven. Spec calls this out so reviewers know `TaskBinder` is a temporary interface, not a long-term abstraction.
+- **Plugin error wrapping cost.** Each plugin call goes through a try/catch. Negligible perf; explicit so plugin authors get predictable behavior.

--- a/src/core/acp-runtime.test.ts
+++ b/src/core/acp-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   AcpRuntime,
   buildAcpLaunchArgs,
   buildAcpLaunchEnv,
+  isBootstrapFailure,
   prepareIsolatedCodexHome,
 } from "./acp-runtime.js";
 import { DENY_ALL_RESOLVER } from "./permission-resolver.js";
@@ -265,6 +266,36 @@ describe("buildAcpLaunchArgs", () => {
         { GROVE_ALLOW_ALL_PERMISSIONS: "1" },
       ),
     ).toEqual(["claude-agent-acp.js"]);
+  });
+});
+
+describe("isBootstrapFailure", () => {
+  test("end_turn → false (successful turn completion)", () => {
+    expect(isBootstrapFailure("end_turn")).toBe(false);
+  });
+
+  test("cancelled → false (voluntary exit, e.g. after grove_done)", () => {
+    expect(isBootstrapFailure("cancelled")).toBe(false);
+  });
+
+  test("undefined → false (no stopReason present)", () => {
+    expect(isBootstrapFailure(undefined)).toBe(false);
+  });
+
+  test("error → true (real failure)", () => {
+    expect(isBootstrapFailure("error")).toBe(true);
+  });
+
+  test("refusal → true (real failure)", () => {
+    expect(isBootstrapFailure("refusal")).toBe(true);
+  });
+
+  test("max_tokens → true (real failure)", () => {
+    expect(isBootstrapFailure("max_tokens")).toBe(true);
+  });
+
+  test("max_turn_requests → true (real failure)", () => {
+    expect(isBootstrapFailure("max_turn_requests")).toBe(true);
   });
 });
 

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -775,6 +775,10 @@ export class AcpRuntime implements AgentRuntime {
       void bootstrap.result
         .then((r) => {
           if (r.stopReason === "end_turn") return;
+          if (r.stopReason === "cancelled") {
+            // Agent voluntarily exited (e.g., after calling grove_done). Not a failure.
+            return;
+          }
           const msg = r.error?.message ?? r.stopReason;
           process.stderr.write(
             `[acp-runtime] bootstrap prompt failed for ${id} (stopReason=${r.stopReason}): ${msg}\n`,
@@ -1008,4 +1012,16 @@ export class AcpRuntime implements AgentRuntime {
       },
     };
   }
+}
+
+/**
+ * Returns true if the given ACP stopReason indicates a real bootstrap failure
+ * that should mark the session as crashed. Returns false for normal terminal
+ * reasons (end_turn = successful completion, cancelled = voluntary agent exit).
+ */
+export function isBootstrapFailure(stopReason: string | undefined): boolean {
+  if (stopReason === undefined) return false;
+  if (stopReason === "end_turn") return false;
+  if (stopReason === "cancelled") return false;
+  return true;
 }

--- a/src/core/agent-task.condition-types.test.ts
+++ b/src/core/agent-task.condition-types.test.ts
@@ -9,4 +9,8 @@ describe("AgentTaskConditionType", () => {
   test("includes PermitRequired for scheduler permit-wait", () => {
     expect(AgentTaskConditionType.PermitRequired).toBe("PermitRequired");
   });
+
+  test("includes DoneSignaled for agent-signaled completion", () => {
+    expect(AgentTaskConditionType.DoneSignaled).toBe("DoneSignaled");
+  });
 });

--- a/src/core/agent-task.condition-types.test.ts
+++ b/src/core/agent-task.condition-types.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { AgentTaskConditionType } from "./agent-task.js";
+
+describe("AgentTaskConditionType", () => {
+  test("includes Unschedulable for scheduler-rejected tasks", () => {
+    expect(AgentTaskConditionType.Unschedulable).toBe("Unschedulable");
+  });
+
+  test("includes PermitRequired for scheduler permit-wait", () => {
+    expect(AgentTaskConditionType.PermitRequired).toBe("PermitRequired");
+  });
+});

--- a/src/core/agent-task.ts
+++ b/src/core/agent-task.ts
@@ -21,6 +21,8 @@ export const AgentTaskConditionType = {
   Succeeded: "Succeeded",
   Failed: "Failed",
   Blocked: "Blocked",
+  Unschedulable: "Unschedulable",
+  PermitRequired: "PermitRequired",
 } as const;
 export type AgentTaskConditionType =
   (typeof AgentTaskConditionType)[keyof typeof AgentTaskConditionType];

--- a/src/core/agent-task.ts
+++ b/src/core/agent-task.ts
@@ -23,6 +23,7 @@ export const AgentTaskConditionType = {
   Blocked: "Blocked",
   Unschedulable: "Unschedulable",
   PermitRequired: "PermitRequired",
+  DoneSignaled: "DoneSignaled",
 } as const;
 export type AgentTaskConditionType =
   (typeof AgentTaskConditionType)[keyof typeof AgentTaskConditionType];

--- a/src/core/condition-utils.test.ts
+++ b/src/core/condition-utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { upsertCondition } from "./condition-utils.js";
+import type { Condition } from "./entity.js";
+
+const makeCondition = (overrides?: Partial<Condition>): Condition => ({
+  type: "Bound",
+  status: "True",
+  observedGeneration: 1,
+  lastTransitionTime: "2026-01-01T00:00:00Z",
+  reason: "x",
+  message: "",
+  ...overrides,
+});
+
+describe("upsertCondition", () => {
+  test("inserts new condition when type absent", () => {
+    const out = upsertCondition([], makeCondition());
+    expect(out).toHaveLength(1);
+    expect(out[0]?.type).toBe("Bound");
+  });
+
+  test("replaces existing condition of same type", () => {
+    const a = makeCondition({ status: "True", reason: "a", observedGeneration: 1 });
+    const b = makeCondition({
+      status: "False",
+      reason: "b",
+      message: "x",
+      observedGeneration: 2,
+      lastTransitionTime: "2026-01-02T00:00:00Z",
+    });
+    const out = upsertCondition([a], b);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.status).toBe("False");
+    expect(out[0]?.reason).toBe("b");
+  });
+
+  test("preserves lastTransitionTime when status/reason/message unchanged", () => {
+    const original = makeCondition({
+      lastTransitionTime: "2026-01-01T00:00:00Z",
+      status: "True",
+      reason: "same",
+      message: "",
+    });
+    const updated = makeCondition({
+      lastTransitionTime: "2026-01-02T00:00:00Z",
+      status: "True",
+      reason: "same",
+      message: "",
+      observedGeneration: 2,
+    });
+    const out = upsertCondition([original], updated);
+    // lastTransitionTime must be preserved from original
+    expect(out[0]?.lastTransitionTime).toBe("2026-01-01T00:00:00Z");
+  });
+
+  test("returns same array reference when nothing changed", () => {
+    const cond = makeCondition();
+    const arr = [cond] as const;
+    const out = upsertCondition(arr, { ...cond });
+    expect(out).toBe(arr); // same reference — no allocation when equal
+  });
+
+  test("appends second condition of different type", () => {
+    const bound = makeCondition({ type: "Bound" });
+    const running = makeCondition({ type: "Running" });
+    const out = upsertCondition([bound], running);
+    expect(out).toHaveLength(2);
+  });
+});

--- a/src/core/condition-utils.ts
+++ b/src/core/condition-utils.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared utilities for managing Kubernetes-style condition arrays.
+ *
+ * Extracted from task-controller.ts and claim-controller.ts so that
+ * server-side route handlers (e.g. POST /api/agent-tasks/:id/done) can
+ * perform condition upserts without pulling in controller-specific deps.
+ */
+
+import type { Condition } from "./entity.js";
+
+/**
+ * Upsert a condition into an immutable conditions array.
+ *
+ * - If no condition of the same type exists, appends the desired condition.
+ * - If a matching condition exists and its status/reason/message are
+ *   unchanged, preserves the original `lastTransitionTime`.
+ * - Returns the original array reference when nothing changed (cheap equality
+ *   check via `conditionEqual`).
+ */
+export function upsertCondition(
+  conditions: readonly Condition[],
+  desired: Condition,
+): readonly Condition[] {
+  const index = conditions.findIndex((condition) => condition.type === desired.type);
+  if (index === -1) {
+    return [...conditions, desired];
+  }
+
+  const existing = conditions[index];
+  if (existing === undefined) return conditions;
+  const next: Condition =
+    existing.status === desired.status &&
+    existing.reason === desired.reason &&
+    existing.message === desired.message
+      ? {
+          ...desired,
+          lastTransitionTime: existing.lastTransitionTime,
+        }
+      : desired;
+
+  if (conditionEqual(existing, next)) return conditions;
+
+  return conditions.map((condition, conditionIndex) =>
+    conditionIndex === index ? next : condition,
+  );
+}
+
+export function conditionEqual(left: Condition, right: Condition): boolean {
+  return (
+    left.type === right.type &&
+    left.status === right.status &&
+    left.observedGeneration === right.observedGeneration &&
+    left.lastTransitionTime === right.lastTransitionTime &&
+    left.reason === right.reason &&
+    left.message === right.message
+  );
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -8,6 +8,7 @@
 import { Buffer } from "node:buffer";
 import { writeFileSync } from "node:fs";
 import { z } from "zod";
+import { SchedulerConfigSchema, type SchedulerConfig } from "./scheduler/config.js";
 
 // ---------------------------------------------------------------------------
 // Zod Schema
@@ -73,6 +74,7 @@ export interface GroveConfig {
   readonly nexusChannel?: string | undefined;
   readonly skillCatalog?: SkillCatalogConfig | undefined;
   readonly runtimeSkills?: RuntimeSkillsConfig | undefined;
+  readonly scheduler?: SchedulerConfig | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -162,6 +164,7 @@ export const GroveConfigSchema: z.ZodType<GroveConfig> = z
     nexusChannel: z.string().min(1).max(64).optional(),
     skillCatalog: SkillCatalogConfigSchema.optional(),
     runtimeSkills: RuntimeSkillsConfigSchema.optional(),
+    scheduler: SchedulerConfigSchema.optional(),
   })
   .strict()
   .superRefine((config, ctx) => {
@@ -228,6 +231,7 @@ export function writeGroveConfig(config: GroveConfig, path: string): void {
   if (config.nexusChannel !== undefined) obj.nexusChannel = config.nexusChannel;
   if (config.skillCatalog !== undefined) obj.skillCatalog = config.skillCatalog;
   if (config.runtimeSkills !== undefined) obj.runtimeSkills = config.runtimeSkills;
+  if (config.scheduler !== undefined) obj.scheduler = config.scheduler;
 
   writeFileSync(path, `${JSON.stringify(obj, null, 2)}\n`, "utf-8");
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -387,3 +387,4 @@ export type {
   WorkspaceViolation,
 } from "./workspace-validator.js";
 export { validateWorkspaceMutations } from "./workspace-validator.js";
+export * as scheduler from "./scheduler/index.js";

--- a/src/core/review-loop/start.test.ts
+++ b/src/core/review-loop/start.test.ts
@@ -34,7 +34,7 @@ describe("startReviewLoop", () => {
     expect(coderBody.role).toBe("coder");
     expect(coderBody.dependsOn).toEqual([]);
     expect(coderBody.worktree).toBe(result.worktree);
-    expect(coderBody.prompt).toBe("Implement feature X");
+    expect(coderBody.prompt).toContain("Implement feature X");
 
     const reviewerBody = JSON.parse(calls[1]!.body!);
     expect(reviewerBody.runtime).toBe("claude");
@@ -125,6 +125,46 @@ describe("startReviewLoop", () => {
       }),
     ).rejects.toThrow(/500/);
     expect(deleteCount).toBe(1);
+  });
+
+  test("coder prompt contains grove_done call instruction", async () => {
+    const bodies: Array<{ role: string; prompt: string }> = [];
+    const fakeFetch: typeof fetch = async (_input, init) => {
+      const body = JSON.parse(init?.body as string);
+      bodies.push({ role: body.role, prompt: body.prompt });
+      return new Response("{}", { status: 201 });
+    };
+    await startReviewLoop({
+      goal: "Implement X",
+      groveUrl: "http://x",
+      token: "t",
+      groveDir: "/tmp",
+      fetchImpl: fakeFetch,
+      mkdirImpl: () => {},
+    });
+    const coderPrompt = bodies.find((b) => b.role === "coder")?.prompt ?? "";
+    expect(coderPrompt).toContain("Implement X");
+    expect(coderPrompt).toMatch(/grove_done/i);
+  });
+
+  test("reviewer prompt contains grove_done call instruction", async () => {
+    const bodies: Array<{ role: string; prompt: string }> = [];
+    const fakeFetch: typeof fetch = async (_input, init) => {
+      const body = JSON.parse(init?.body as string);
+      bodies.push({ role: body.role, prompt: body.prompt });
+      return new Response("{}", { status: 201 });
+    };
+    await startReviewLoop({
+      goal: "Implement X",
+      groveUrl: "http://x",
+      token: "t",
+      groveDir: "/tmp",
+      fetchImpl: fakeFetch,
+      mkdirImpl: () => {},
+    });
+    const reviewerPrompt = bodies.find((b) => b.role === "reviewer")?.prompt ?? "";
+    expect(reviewerPrompt).toContain("Implement X");
+    expect(reviewerPrompt).toMatch(/grove_done/i);
   });
 
   test("non-2xx PUT for coder throws and skips reviewer", async () => {

--- a/src/core/review-loop/start.test.ts
+++ b/src/core/review-loop/start.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import { startReviewLoop } from "./start.js";
+
+describe("startReviewLoop", () => {
+  test("posts coder + reviewer with dependsOn chain", async () => {
+    const calls: Array<{ url: string; method: string; body: string | undefined }> = [];
+    const fakeFetch: typeof fetch = async (input, init) => {
+      calls.push({
+        url: String(input),
+        method: init?.method ?? "GET",
+        body: typeof init?.body === "string" ? init.body : undefined,
+      });
+      return new Response("{}", { status: 201 });
+    };
+    const mkdirCalls: string[] = [];
+    const result = await startReviewLoop({
+      goal: "Implement feature X",
+      groveUrl: "http://localhost:4515",
+      token: "tok",
+      groveDir: "/tmp/grove",
+      now: () => new Date("2026-05-16T10:00:00.000Z"),
+      fetchImpl: fakeFetch,
+      mkdirImpl: (p) => mkdirCalls.push(p),
+    });
+
+    expect(result.worktree).toBe("/tmp/grove/workspaces/review-loop-2026-05-16T10-00-00-000Z");
+    expect(result.coderId).toBe("review-loop-2026-05-16T10-00-00-000Z-coder");
+    expect(result.reviewerId).toBe("review-loop-2026-05-16T10-00-00-000Z-reviewer");
+    expect(mkdirCalls).toEqual([result.worktree]);
+    expect(calls).toHaveLength(2);
+
+    const coderBody = JSON.parse(calls[0]!.body!);
+    expect(coderBody.runtime).toBe("codex");
+    expect(coderBody.role).toBe("coder");
+    expect(coderBody.dependsOn).toEqual([]);
+    expect(coderBody.worktree).toBe(result.worktree);
+    expect(coderBody.prompt).toBe("Implement feature X");
+
+    const reviewerBody = JSON.parse(calls[1]!.body!);
+    expect(reviewerBody.runtime).toBe("claude");
+    expect(reviewerBody.role).toBe("reviewer");
+    expect(reviewerBody.dependsOn).toEqual([result.coderId]);
+    expect(reviewerBody.worktree).toBe(result.worktree);
+    expect(reviewerBody.prompt).toContain("Implement feature X");
+  });
+
+  test("honors runtime overrides", async () => {
+    const calls: string[] = [];
+    const fakeFetch: typeof fetch = async (_input, init) => {
+      const body = JSON.parse(init?.body as string);
+      calls.push(body.runtime);
+      return new Response("{}", { status: 201 });
+    };
+    await startReviewLoop({
+      goal: "x",
+      groveUrl: "http://x",
+      token: "t",
+      groveDir: "/tmp",
+      coderRuntime: "codex-cli",
+      reviewerRuntime: "claude-code",
+      fetchImpl: fakeFetch,
+      mkdirImpl: () => {},
+    });
+    expect(calls).toEqual(["codex-cli", "claude-code"]);
+  });
+
+  test("rejects empty goal / url / token", async () => {
+    const noop: typeof fetch = async () => new Response("{}", { status: 201 });
+    await expect(
+      startReviewLoop({
+        goal: "",
+        groveUrl: "x",
+        token: "y",
+        groveDir: "/",
+        fetchImpl: noop,
+        mkdirImpl: () => {},
+      }),
+    ).rejects.toThrow(/goal/);
+    await expect(
+      startReviewLoop({
+        goal: "g",
+        groveUrl: "",
+        token: "y",
+        groveDir: "/",
+        fetchImpl: noop,
+        mkdirImpl: () => {},
+      }),
+    ).rejects.toThrow(/groveUrl/);
+    await expect(
+      startReviewLoop({
+        goal: "g",
+        groveUrl: "x",
+        token: "",
+        groveDir: "/",
+        fetchImpl: noop,
+        mkdirImpl: () => {},
+      }),
+    ).rejects.toThrow(/token/);
+  });
+
+  test("cleans up coder when reviewer PUT fails", async () => {
+    let putCount = 0;
+    let deleteCount = 0;
+    const fakeFetch: typeof fetch = async (input, init) => {
+      const method = init?.method ?? "GET";
+      if (method === "PUT") {
+        putCount += 1;
+        if (putCount === 2) return new Response("nope", { status: 500 });
+        return new Response("{}", { status: 201 });
+      }
+      if (method === "DELETE") {
+        deleteCount += 1;
+        return new Response("{}", { status: 204 });
+      }
+      return new Response("", { status: 404 });
+    };
+    await expect(
+      startReviewLoop({
+        goal: "g",
+        groveUrl: "http://x",
+        token: "t",
+        groveDir: "/tmp",
+        fetchImpl: fakeFetch,
+        mkdirImpl: () => {},
+      }),
+    ).rejects.toThrow(/500/);
+    expect(deleteCount).toBe(1);
+  });
+
+  test("non-2xx PUT for coder throws and skips reviewer", async () => {
+    let putCount = 0;
+    const fakeFetch: typeof fetch = async () => {
+      putCount += 1;
+      return new Response("server down", { status: 503 });
+    };
+    await expect(
+      startReviewLoop({
+        goal: "g",
+        groveUrl: "http://x",
+        token: "t",
+        groveDir: "/tmp",
+        fetchImpl: fakeFetch,
+        mkdirImpl: () => {},
+      }),
+    ).rejects.toThrow(/503/);
+    expect(putCount).toBe(1);
+  });
+});

--- a/src/core/review-loop/start.ts
+++ b/src/core/review-loop/start.ts
@@ -1,0 +1,124 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+export interface StartReviewLoopInputs {
+  readonly goal: string;
+  readonly coderRuntime?: string | undefined; // default "codex"
+  readonly reviewerRuntime?: string | undefined; // default "claude"
+  readonly groveUrl: string;
+  readonly token: string;
+  readonly groveDir: string;
+  readonly now?: (() => Date) | undefined;
+  readonly fetchImpl?: typeof fetch | undefined;
+  readonly mkdirImpl?: ((path: string) => void) | undefined;
+}
+
+export interface StartReviewLoopResult {
+  readonly worktree: string;
+  readonly coderId: string;
+  readonly reviewerId: string;
+}
+
+export async function startReviewLoop(
+  inputs: StartReviewLoopInputs,
+): Promise<StartReviewLoopResult> {
+  if (inputs.goal.length === 0) throw new Error("goal must not be empty");
+  if (inputs.groveUrl.length === 0) throw new Error("groveUrl must not be empty");
+  if (inputs.token.length === 0) throw new Error("token must not be empty");
+
+  const now = (inputs.now ?? (() => new Date()))();
+  const isoStamp = now.toISOString();
+  const safeStamp = isoStamp.replace(/[:.]/g, "-");
+
+  const worktree = join(inputs.groveDir, "workspaces", `review-loop-${safeStamp}`);
+  (inputs.mkdirImpl ?? ((p) => mkdirSync(p, { recursive: true })))(worktree);
+
+  const coderId = `review-loop-${safeStamp}-coder`;
+  const reviewerId = `review-loop-${safeStamp}-reviewer`;
+
+  const coderRuntime = inputs.coderRuntime ?? "codex";
+  const reviewerRuntime = inputs.reviewerRuntime ?? "claude";
+
+  await putTask(
+    inputs.groveUrl,
+    inputs.token,
+    coderId,
+    {
+      worktree,
+      runtime: coderRuntime,
+      role: "coder",
+      prompt: inputs.goal,
+      dependsOn: [],
+    },
+    inputs.fetchImpl,
+  );
+
+  try {
+    await putTask(
+      inputs.groveUrl,
+      inputs.token,
+      reviewerId,
+      {
+        worktree,
+        runtime: reviewerRuntime,
+        role: "reviewer",
+        prompt: `Review the work completed for: ${inputs.goal}`,
+        dependsOn: [coderId],
+      },
+      inputs.fetchImpl,
+    );
+  } catch (err) {
+    // Best-effort cleanup of coder if reviewer creation fails.
+    await deleteTask(inputs.groveUrl, inputs.token, coderId, inputs.fetchImpl).catch(
+      () => undefined,
+    );
+    throw err;
+  }
+
+  return { worktree, coderId, reviewerId };
+}
+
+interface TaskBody {
+  readonly worktree: string;
+  readonly runtime: string;
+  readonly role: string;
+  readonly prompt: string;
+  readonly dependsOn: readonly string[];
+}
+
+async function putTask(
+  baseUrl: string,
+  token: string,
+  id: string,
+  body: TaskBody,
+  fetchImpl?: typeof fetch,
+): Promise<void> {
+  const fetcher = fetchImpl ?? fetch;
+  const url = `${baseUrl}/api/agent-tasks/${encodeURIComponent(id)}`;
+  const res = await fetcher(url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "If-Match": "*",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`PUT /api/agent-tasks/${id} failed: ${res.status} ${text}`);
+  }
+}
+
+async function deleteTask(
+  baseUrl: string,
+  token: string,
+  id: string,
+  fetchImpl?: typeof fetch,
+): Promise<void> {
+  const fetcher = fetchImpl ?? fetch;
+  await fetcher(`${baseUrl}/api/agent-tasks/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}

--- a/src/core/review-loop/start.ts
+++ b/src/core/review-loop/start.ts
@@ -39,6 +39,9 @@ export async function startReviewLoop(
   const coderRuntime = inputs.coderRuntime ?? "codex";
   const reviewerRuntime = inputs.reviewerRuntime ?? "claude";
 
+  const coderPrompt = `${inputs.goal}\n\nWhen you have finished the task, call the grove_done MCP tool with a one-line summary of what you did. Do not do anything else after grove_done.`;
+  const reviewerPrompt = `Review the work completed for: ${inputs.goal}\n\nThe coder's summary is included above as upstream output. Read the changes in the worktree, decide if they are correct, then call the grove_done MCP tool with a one-line summary of your review (e.g. "approved" or "rejected: <reason>"). Do not do anything else after grove_done.`;
+
   await putTask(
     inputs.groveUrl,
     inputs.token,
@@ -47,7 +50,7 @@ export async function startReviewLoop(
       worktree,
       runtime: coderRuntime,
       role: "coder",
-      prompt: inputs.goal,
+      prompt: coderPrompt,
       dependsOn: [],
     },
     inputs.fetchImpl,
@@ -62,7 +65,7 @@ export async function startReviewLoop(
         worktree,
         runtime: reviewerRuntime,
         role: "reviewer",
-        prompt: `Review the work completed for: ${inputs.goal}`,
+        prompt: reviewerPrompt,
         dependsOn: [coderId],
       },
       inputs.fetchImpl,

--- a/src/core/scheduler/acceptance-config-reweight.test.ts
+++ b/src/core/scheduler/acceptance-config-reweight.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentConfig, AgentRuntime, AgentSession } from "../agent-runtime.js";
+import type { AgentTaskView } from "../agent-task.js";
+import { AgentTaskPhase } from "../agent-task.js";
+import type { AgentSessionEntity } from "../entity.js";
+import { loadSchedulerConfig } from "./config.js";
+import { Scheduler } from "./scheduler.js";
+
+class RecordingRuntime implements AgentRuntime {
+  spawnCalls: Array<{ role: string; command: string; model: string | undefined }> = [];
+  async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
+    this.spawnCalls.push({ role, command: config.command, model: config.model });
+    return { id: "s", role, status: "running" };
+  }
+  async send(): Promise<never> {
+    throw new Error("unused");
+  }
+  async close(): Promise<void> {}
+  onIdle(): void {}
+  async listSessions(): Promise<readonly AgentSession[]> {
+    return [];
+  }
+  async listSessionEntities(): Promise<readonly AgentSessionEntity[]> {
+    return [];
+  }
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+}
+
+const task: AgentTaskView = {
+  spec: {
+    id: "t",
+    worktree: "/tmp/w",
+    runtime: "",
+    role: "worker",
+    prompt: "p",
+    dependsOn: [],
+    generation: 1,
+    createdAt: "2026-05-16T00:00:00.000Z",
+    budget: { affinity: { tier: "premium" } },
+  },
+  status: {
+    id: "t",
+    phase: AgentTaskPhase.PendingBind,
+    contributions: [],
+    conditions: [],
+    observedGeneration: 0,
+    lastTransitionAt: "2026-05-16T00:00:00.000Z",
+    revision: 1,
+  },
+};
+
+const profiles = [
+  { name: "free-tier", platform: "claude-code", runtimeCommand: "claude", labels: { tier: "free" } },
+  {
+    name: "premium-tier",
+    platform: "claude-code",
+    runtimeCommand: "claude",
+    labels: { tier: "premium" },
+  },
+];
+
+describe("acceptance: config-only reweight changes winner", () => {
+  test("with TaskAffinity enabled, premium-tier wins on premium affinity", async () => {
+    const runtime = new RecordingRuntime();
+    const loaded = loadSchedulerConfig(
+      {
+        profiles,
+        pipeline: {
+          filters: [],
+          scores: [{ name: "TaskAffinity", weight: 1 }],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      },
+      { runtime },
+    );
+    const scheduler = new Scheduler({
+      profiles: loaded.profiles,
+      filters: loaded.filters,
+      scores: loaded.scores,
+      permits: loaded.permits,
+      bindPlugin: loaded.bindPlugin,
+      store: { listAgentTaskEntities: async () => [] },
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(task);
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") expect(result.profile.name).toBe("premium-tier");
+  });
+
+  test("with TaskAffinity removed, declaration order wins (free-tier first)", async () => {
+    const runtime = new RecordingRuntime();
+    const loaded = loadSchedulerConfig(
+      {
+        profiles,
+        pipeline: {
+          filters: [],
+          scores: [],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      },
+      { runtime },
+    );
+    const scheduler = new Scheduler({
+      profiles: loaded.profiles,
+      filters: loaded.filters,
+      scores: loaded.scores,
+      permits: loaded.permits,
+      bindPlugin: loaded.bindPlugin,
+      store: { listAgentTaskEntities: async () => [] },
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(task);
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") expect(result.profile.name).toBe("free-tier");
+  });
+});

--- a/src/core/scheduler/acceptance-config-reweight.test.ts
+++ b/src/core/scheduler/acceptance-config-reweight.test.ts
@@ -52,7 +52,12 @@ const task: AgentTaskView = {
 };
 
 const profiles = [
-  { name: "free-tier", platform: "claude-code", runtimeCommand: "claude", labels: { tier: "free" } },
+  {
+    name: "free-tier",
+    platform: "claude-code",
+    runtimeCommand: "claude",
+    labels: { tier: "free" },
+  },
   {
     name: "premium-tier",
     platform: "claude-code",
@@ -82,7 +87,7 @@ describe("acceptance: config-only reweight changes winner", () => {
       scores: loaded.scores,
       permits: loaded.permits,
       bindPlugin: loaded.bindPlugin,
-      store: { listAgentTaskEntities: async () => [] },
+      store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
       now: () => 0,
     });
 
@@ -112,7 +117,7 @@ describe("acceptance: config-only reweight changes winner", () => {
       scores: loaded.scores,
       permits: loaded.permits,
       bindPlugin: loaded.bindPlugin,
-      store: { listAgentTaskEntities: async () => [] },
+      store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
       now: () => 0,
     });
 

--- a/src/core/scheduler/config.test.ts
+++ b/src/core/scheduler/config.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentRuntime } from "../agent-runtime.js";
+import type { AgentSessionEntity } from "../entity.js";
+import { loadSchedulerConfig, SchedulerConfigSchema } from "./config.js";
+
+function fakeRuntime(): AgentRuntime {
+  return {
+    spawn: async () => ({ id: "s", role: "r", status: "running" }),
+    send: async () => {
+      throw new Error("unused");
+    },
+    close: async () => {},
+    onIdle: () => {},
+    listSessions: async () => [],
+    listSessionEntities: async () => [] as readonly AgentSessionEntity[],
+    isAvailable: async () => true,
+  };
+}
+
+describe("SchedulerConfigSchema", () => {
+  test("accepts a minimal config", () => {
+    const parsed = SchedulerConfigSchema.parse({
+      profiles: [
+        { name: "p", platform: "claude-code", runtimeCommand: "claude" },
+      ],
+      pipeline: {
+        filters: ["RuntimeCapability"],
+        scores: [{ name: "TaskAffinity", weight: 1 }],
+        permits: ["AutoPermit"],
+        bind: "DefaultBind",
+      },
+    });
+    expect(parsed.profiles).toHaveLength(1);
+  });
+
+  test("rejects negative score weight", () => {
+    expect(() =>
+      SchedulerConfigSchema.parse({
+        profiles: [],
+        pipeline: {
+          filters: [],
+          scores: [{ name: "TaskAffinity", weight: -1 }],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing platform", () => {
+    expect(() =>
+      SchedulerConfigSchema.parse({
+        profiles: [{ name: "p", runtimeCommand: "claude" }],
+        pipeline: {
+          filters: [],
+          scores: [],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("loadSchedulerConfig", () => {
+  test("resolves plugin names against the built-in registry", () => {
+    const opts = loadSchedulerConfig(
+      {
+        profiles: [
+          { name: "p", platform: "claude-code", runtimeCommand: "claude" },
+        ],
+        pipeline: {
+          filters: ["RuntimeCapability", "BudgetRemaining", "WorktreeExclusivity"],
+          scores: [{ name: "TaskAffinity", weight: 1 }],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      },
+      { runtime: fakeRuntime() },
+    );
+    expect(opts.filters.map((f) => f.name)).toEqual([
+      "RuntimeCapability",
+      "BudgetRemaining",
+      "WorktreeExclusivity",
+    ]);
+    expect(opts.scores).toHaveLength(1);
+    expect(opts.scores[0]?.plugin.name).toBe("TaskAffinity");
+    expect(opts.scores[0]?.weight).toBe(1);
+    expect(opts.permits[0]?.name).toBe("AutoPermit");
+    expect(opts.bindPlugin.name).toBe("DefaultBind");
+    expect(opts.profiles).toHaveLength(1);
+  });
+
+  test("unknown plugin name yields a descriptive error listing known plugins", () => {
+    expect(() =>
+      loadSchedulerConfig(
+        {
+          profiles: [],
+          pipeline: {
+            filters: ["NotARealFilter"],
+            scores: [],
+            permits: ["AutoPermit"],
+            bind: "DefaultBind",
+          },
+        },
+        { runtime: fakeRuntime() },
+      ),
+    ).toThrow(/NotARealFilter.*known plugins/i);
+  });
+
+  test("default ledger is permissive", () => {
+    const opts = loadSchedulerConfig(
+      {
+        profiles: [],
+        pipeline: {
+          filters: ["BudgetRemaining"],
+          scores: [],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      },
+      { runtime: fakeRuntime() },
+    );
+    expect(opts.filters[0]?.name).toBe("BudgetRemaining");
+  });
+});

--- a/src/core/scheduler/config.ts
+++ b/src/core/scheduler/config.ts
@@ -127,7 +127,7 @@ export function loadSchedulerConfig(
 }
 
 function unknownPluginError(kind: string, name: string): Error {
-  const known = builtinPluginNames().sort().join(", ");
+  const known = [...builtinPluginNames()].sort().join(", ");
   return new Error(
     `unknown scheduler ${kind} plugin '${name}'. Known plugins: ${known}.`,
   );

--- a/src/core/scheduler/config.ts
+++ b/src/core/scheduler/config.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+import type { AgentRuntime } from "../agent-runtime.js";
+import type { BindPlugin, FilterPlugin, PermitPlugin, ScorePlugin } from "./framework.js";
+import {
+  BUILTIN_BIND_FACTORIES,
+  BUILTIN_FILTER_FACTORIES,
+  BUILTIN_PERMIT_FACTORIES,
+  BUILTIN_SCORE_FACTORIES,
+  builtinPluginNames,
+  type BudgetLedger,
+  type PermitDecisionStore,
+} from "./plugins/index.js";
+import type { RuntimeProfile } from "./profile.js";
+import type { ScorePluginEntry } from "./scheduler.js";
+
+const PlatformSchema = z.enum(["claude-code", "codex", "gemini", "custom"]);
+
+const RuntimeProfileBudgetSchema = z
+  .object({
+    maxCostUsd: z.number().nonnegative().optional(),
+    maxTurns: z.number().int().nonnegative().optional(),
+    allowedModels: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+const RuntimeProfileSchema = z
+  .object({
+    name: z.string().min(1).max(128),
+    platform: PlatformSchema,
+    runtimeCommand: z.string().min(1).max(128),
+    model: z.string().min(1).max(128).optional(),
+    supportedRoles: z.array(z.string().min(1).max(64)).optional(),
+    budget: RuntimeProfileBudgetSchema.optional(),
+    labels: z.record(z.string().min(1), z.string()).optional(),
+  })
+  .strict();
+
+const PipelineSchema = z
+  .object({
+    filters: z.array(z.string().min(1)).default([]),
+    scores: z
+      .array(
+        z
+          .object({
+            name: z.string().min(1),
+            weight: z.number().nonnegative().default(1),
+          })
+          .strict(),
+      )
+      .default([]),
+    permits: z.array(z.string().min(1)).default(["AutoPermit"]),
+    bind: z.string().min(1).default("DefaultBind"),
+  })
+  .strict();
+
+export const SchedulerConfigSchema = z
+  .object({
+    profiles: z.array(RuntimeProfileSchema).default([]),
+    pipeline: PipelineSchema.default({
+      filters: [],
+      scores: [],
+      permits: ["AutoPermit"],
+      bind: "DefaultBind",
+    }),
+  })
+  .strict();
+
+export type SchedulerConfig = z.infer<typeof SchedulerConfigSchema>;
+
+export interface LoadSchedulerConfigDeps {
+  readonly runtime: AgentRuntime;
+  readonly ledger?: BudgetLedger | undefined;
+  readonly permitDecisionStore?: PermitDecisionStore | undefined;
+}
+
+export interface LoadedSchedulerConfig {
+  readonly profiles: readonly RuntimeProfile[];
+  readonly filters: readonly FilterPlugin[];
+  readonly scores: readonly ScorePluginEntry[];
+  readonly permits: readonly PermitPlugin[];
+  readonly bindPlugin: BindPlugin;
+}
+
+export function loadSchedulerConfig(
+  raw: unknown,
+  deps: LoadSchedulerConfigDeps,
+): LoadedSchedulerConfig {
+  const config = SchedulerConfigSchema.parse(raw);
+
+  const filters = config.pipeline.filters.map((name) => {
+    const factory = BUILTIN_FILTER_FACTORIES[name];
+    if (factory === undefined) throw unknownPluginError("filter", name);
+    return factory(deps.ledger === undefined ? {} : { ledger: deps.ledger });
+  });
+
+  const scores: ScorePluginEntry[] = config.pipeline.scores.map((entry) => {
+    const factory = BUILTIN_SCORE_FACTORIES[entry.name];
+    if (factory === undefined) throw unknownPluginError("score", entry.name);
+    return { plugin: factory({}), weight: entry.weight };
+  });
+
+  const permits = config.pipeline.permits.map((name) => {
+    const factory = BUILTIN_PERMIT_FACTORIES[name];
+    if (factory === undefined) throw unknownPluginError("permit", name);
+    return factory(
+      deps.permitDecisionStore === undefined
+        ? {}
+        : { permitDecisionStore: deps.permitDecisionStore },
+    );
+  });
+
+  const bindFactory = BUILTIN_BIND_FACTORIES[config.pipeline.bind];
+  if (bindFactory === undefined) throw unknownPluginError("bind", config.pipeline.bind);
+  const bindPlugin = bindFactory({ runtime: deps.runtime });
+
+  const profiles: readonly RuntimeProfile[] = config.profiles.map((profile) => ({
+    name: profile.name,
+    platform: profile.platform,
+    runtimeCommand: profile.runtimeCommand,
+    ...(profile.model === undefined ? {} : { model: profile.model }),
+    ...(profile.supportedRoles === undefined ? {} : { supportedRoles: profile.supportedRoles }),
+    ...(profile.budget === undefined ? {} : { budget: profile.budget }),
+    ...(profile.labels === undefined ? {} : { labels: profile.labels }),
+  }));
+
+  return { profiles, filters, scores, permits, bindPlugin };
+}
+
+function unknownPluginError(kind: string, name: string): Error {
+  const known = builtinPluginNames().sort().join(", ");
+  return new Error(
+    `unknown scheduler ${kind} plugin '${name}'. Known plugins: ${known}.`,
+  );
+}

--- a/src/core/scheduler/config.ts
+++ b/src/core/scheduler/config.ts
@@ -13,7 +13,7 @@ import {
 import type { RuntimeProfile } from "./profile.js";
 import type { ScorePluginEntry } from "./scheduler.js";
 
-const PlatformSchema = z.enum(["claude-code", "codex", "gemini", "custom"]);
+const PlatformSchema = z.enum(["claude-code", "codex", "gemini"]);
 
 const RuntimeProfileBudgetSchema = z
   .object({

--- a/src/core/scheduler/framework.test.ts
+++ b/src/core/scheduler/framework.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  BindPlugin,
+  FilterPlugin,
+  FilterRejection,
+  FilterVerdict,
+  PermitPlugin,
+  PermitVerdict,
+  SchedulerContext,
+  SchedulingResult,
+  ScorePlugin,
+} from "./framework.js";
+
+describe("framework exports", () => {
+  test("FilterVerdict discriminates by admit", () => {
+    const admit: FilterVerdict = { admit: true };
+    const reject: FilterVerdict = { admit: false, reason: "x" };
+    expect(admit.admit).toBe(true);
+    expect(reject.admit).toBe(false);
+  });
+
+  test("PermitVerdict status union covers granted/denied/wait", () => {
+    const grants: PermitVerdict[] = [
+      { status: "granted" },
+      { status: "denied", reason: "no" },
+      { status: "wait", reason: "later" },
+    ];
+    expect(grants).toHaveLength(3);
+  });
+
+  test("SchedulingResult kind union covers four variants", () => {
+    const kinds: SchedulingResult["kind"][] = ["bound", "unschedulable", "wait", "denied"];
+    expect(kinds).toEqual(["bound", "unschedulable", "wait", "denied"]);
+  });
+
+  test("FilterRejection records plugin + reason", () => {
+    const rejection: FilterRejection = { plugin: "test", reason: "x" };
+    expect(rejection.plugin).toBe("test");
+  });
+
+  test("plugin interfaces have name field", () => {
+    const filter: FilterPlugin = {
+      name: "n",
+      filter: async () => ({ admit: true }),
+    };
+    const score: ScorePlugin = { name: "n", score: async () => 0 };
+    const permit: PermitPlugin = { name: "n", permit: async () => ({ status: "granted" }) };
+    const bind: BindPlugin = {
+      name: "n",
+      bind: async () => ({ session: { id: "s", role: "r", status: "running" } }),
+    };
+    expect(filter.name).toBe("n");
+    expect(score.name).toBe("n");
+    expect(permit.name).toBe("n");
+    expect(bind.name).toBe("n");
+  });
+
+  test("SchedulerContext shape compiles", () => {
+    const _ctx: Pick<SchedulerContext, "now"> = { now: () => 0 };
+    expect(typeof _ctx.now).toBe("function");
+  });
+});

--- a/src/core/scheduler/framework.ts
+++ b/src/core/scheduler/framework.ts
@@ -1,0 +1,80 @@
+import type { AgentSession } from "../agent-runtime.js";
+import type { AgentTaskView } from "../agent-task.js";
+import type { AgentTaskStore } from "../store.js";
+import type { RuntimeProfile } from "./profile.js";
+
+export interface SchedulerContext {
+  readonly task: AgentTaskView;
+  readonly profiles: readonly RuntimeProfile[];
+  readonly store: Pick<AgentTaskStore, "listAgentTaskEntities">;
+  readonly now: () => number;
+}
+
+export type FilterVerdict =
+  | { readonly admit: true }
+  | { readonly admit: false; readonly reason: string; readonly message?: string | undefined };
+
+export interface FilterPlugin {
+  readonly name: string;
+  filter(ctx: SchedulerContext, profile: RuntimeProfile): Promise<FilterVerdict>;
+}
+
+export interface ScorePlugin {
+  readonly name: string;
+  score(ctx: SchedulerContext, profile: RuntimeProfile): Promise<number>;
+}
+
+export type PermitVerdict =
+  | { readonly status: "granted" }
+  | { readonly status: "denied"; readonly reason: string; readonly message?: string | undefined }
+  | { readonly status: "wait"; readonly reason: string; readonly message?: string | undefined };
+
+export interface PermitPlugin {
+  readonly name: string;
+  permit(ctx: SchedulerContext, profile: RuntimeProfile): Promise<PermitVerdict>;
+}
+
+export interface BindResult {
+  readonly session: AgentSession;
+}
+
+export interface BindPlugin {
+  readonly name: string;
+  bind(ctx: SchedulerContext, profile: RuntimeProfile): Promise<BindResult>;
+}
+
+export interface FilterRejection {
+  readonly plugin: string;
+  readonly reason: string;
+  readonly message?: string | undefined;
+}
+
+export interface ProfileRejection {
+  readonly profile: RuntimeProfile;
+  readonly rejections: readonly FilterRejection[];
+}
+
+export type SchedulingResult =
+  | {
+      readonly kind: "bound";
+      readonly profile: RuntimeProfile;
+      readonly session: AgentSession;
+      readonly reservationToken?: string | undefined;
+    }
+  | {
+      readonly kind: "unschedulable";
+      readonly rejections: readonly ProfileRejection[];
+    }
+  | {
+      readonly kind: "wait";
+      readonly plugin: string;
+      readonly reason: string;
+      readonly message?: string | undefined;
+      readonly profile: RuntimeProfile;
+    }
+  | {
+      readonly kind: "denied";
+      readonly plugin: string;
+      readonly reason: string;
+      readonly message?: string | undefined;
+    };

--- a/src/core/scheduler/framework.ts
+++ b/src/core/scheduler/framework.ts
@@ -6,7 +6,7 @@ import type { RuntimeProfile } from "./profile.js";
 export interface SchedulerContext {
   readonly task: AgentTaskView;
   readonly profiles: readonly RuntimeProfile[];
-  readonly store: Pick<AgentTaskStore, "listAgentTaskEntities">;
+  readonly store: Pick<AgentTaskStore, "listAgentTaskEntities" | "getAgentTask">;
   readonly now: () => number;
 }
 

--- a/src/core/scheduler/index.test.ts
+++ b/src/core/scheduler/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import {
+  Scheduler,
+  SchedulerConfigSchema,
+  loadSchedulerConfig,
+  synthesizeFallbackProfile,
+} from "./index.js";
+
+describe("scheduler module re-exports", () => {
+  test("Scheduler class is exported", () => {
+    expect(typeof Scheduler).toBe("function");
+  });
+  test("SchedulerConfigSchema is exported", () => {
+    expect(typeof SchedulerConfigSchema.parse).toBe("function");
+  });
+  test("loadSchedulerConfig is exported", () => {
+    expect(typeof loadSchedulerConfig).toBe("function");
+  });
+  test("synthesizeFallbackProfile is exported", () => {
+    expect(typeof synthesizeFallbackProfile).toBe("function");
+  });
+});

--- a/src/core/scheduler/index.ts
+++ b/src/core/scheduler/index.ts
@@ -1,0 +1,41 @@
+export type {
+  BindPlugin,
+  BindResult,
+  FilterPlugin,
+  FilterRejection,
+  FilterVerdict,
+  PermitPlugin,
+  PermitVerdict,
+  ProfileRejection,
+  SchedulerContext,
+  SchedulingResult,
+  ScorePlugin,
+} from "./framework.js";
+export { Scheduler } from "./scheduler.js";
+export type { ScorePluginEntry, SchedulerOptions } from "./scheduler.js";
+export type { RuntimeProfile, RuntimeProfileBudget } from "./profile.js";
+export { synthesizeFallbackProfile } from "./profile.js";
+export {
+  loadSchedulerConfig,
+  SchedulerConfigSchema,
+  type LoadedSchedulerConfig,
+  type LoadSchedulerConfigDeps,
+  type SchedulerConfig,
+} from "./config.js";
+export {
+  AutoPermit,
+  BudgetRemainingFilter,
+  builtinPluginNames,
+  BUILTIN_BIND_FACTORIES,
+  BUILTIN_FILTER_FACTORIES,
+  BUILTIN_PERMIT_FACTORIES,
+  BUILTIN_SCORE_FACTORIES,
+  DefaultBindPlugin,
+  InMemoryPermitDecisionStore,
+  RuntimeCapabilityFilter,
+  TaskAffinityScore,
+  UserConfirmPermit,
+  WorktreeExclusivityFilter,
+  type BudgetLedger,
+  type PermitDecisionStore,
+} from "./plugins/index.js";

--- a/src/core/scheduler/plugins/auto-permit.test.ts
+++ b/src/core/scheduler/plugins/auto-permit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { AgentTaskView } from "../../agent-task.js";
+import { AutoPermit } from "./auto-permit.js";
+
+const task: AgentTaskView = {
+  spec: {
+    id: "t",
+    worktree: "/tmp/w",
+    runtime: "claude",
+    role: "worker",
+    prompt: "p",
+    dependsOn: [],
+    generation: 1,
+    createdAt: "2026-05-16T00:00:00.000Z",
+  },
+  status: {
+    id: "t",
+    phase: AgentTaskPhase.PendingBind,
+    contributions: [],
+    conditions: [],
+    observedGeneration: 0,
+    lastTransitionAt: "2026-05-16T00:00:00.000Z",
+    revision: 1,
+  },
+};
+
+describe("AutoPermit", () => {
+  test("always grants", async () => {
+    const permit = new AutoPermit();
+    const ctx = { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+    const verdict = await permit.permit(ctx, {
+      name: "p",
+      platform: "claude-code",
+      runtimeCommand: "claude",
+    });
+    expect(verdict).toEqual({ status: "granted" });
+  });
+});

--- a/src/core/scheduler/plugins/auto-permit.test.ts
+++ b/src/core/scheduler/plugins/auto-permit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { AgentTaskPhase } from "../../agent-task.js";
 import type { AgentTaskView } from "../../agent-task.js";
+import { AgentTaskPhase } from "../../agent-task.js";
 import { AutoPermit } from "./auto-permit.js";
 
 const task: AgentTaskView = {
@@ -28,7 +28,12 @@ const task: AgentTaskView = {
 describe("AutoPermit", () => {
   test("always grants", async () => {
     const permit = new AutoPermit();
-    const ctx = { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+    const ctx = {
+      task,
+      profiles: [],
+      store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+      now: () => 0,
+    };
     const verdict = await permit.permit(ctx, {
       name: "p",
       platform: "claude-code",

--- a/src/core/scheduler/plugins/auto-permit.ts
+++ b/src/core/scheduler/plugins/auto-permit.ts
@@ -1,9 +1,10 @@
-import type { PermitPlugin, PermitVerdict } from "../framework.js";
+import type { PermitPlugin, PermitVerdict, SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
 
 export class AutoPermit implements PermitPlugin {
   readonly name = "AutoPermit";
 
-  async permit(): Promise<PermitVerdict> {
+  async permit(_ctx: SchedulerContext, _profile: RuntimeProfile): Promise<PermitVerdict> {
     return { status: "granted" };
   }
 }

--- a/src/core/scheduler/plugins/auto-permit.ts
+++ b/src/core/scheduler/plugins/auto-permit.ts
@@ -1,0 +1,9 @@
+import type { PermitPlugin, PermitVerdict } from "../framework.js";
+
+export class AutoPermit implements PermitPlugin {
+  readonly name = "AutoPermit";
+
+  async permit(): Promise<PermitVerdict> {
+    return { status: "granted" };
+  }
+}

--- a/src/core/scheduler/plugins/budget-remaining.test.ts
+++ b/src/core/scheduler/plugins/budget-remaining.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentTaskView } from "../../agent-task.js";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+import { BudgetRemainingFilter, type BudgetLedger } from "./budget-remaining.js";
+
+function makeCtx(task: AgentTaskView): SchedulerContext {
+  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+}
+
+function task(overrides: Partial<AgentTaskView["spec"]> = {}): AgentTaskView {
+  return {
+    spec: {
+      id: "t",
+      worktree: "/tmp/w",
+      runtime: "claude",
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      ...overrides,
+    },
+    status: {
+      id: "t",
+      phase: AgentTaskPhase.PendingBind,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function profile(overrides: Partial<RuntimeProfile> = {}): RuntimeProfile {
+  return { name: "p", platform: "claude-code", runtimeCommand: "claude", ...overrides };
+}
+
+describe("BudgetRemainingFilter", () => {
+  test("admits when task budget fits within profile budget", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(
+      makeCtx(task({ budget: { maxCostUsd: 5 }, maxTurns: 10 })),
+      profile({ budget: { maxCostUsd: 10, maxTurns: 50 } }),
+    );
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("rejects when task maxCostUsd exceeds profile maxCostUsd", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(
+      makeCtx(task({ budget: { maxCostUsd: 20 } })),
+      profile({ budget: { maxCostUsd: 10 } }),
+    );
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) expect(verdict.reason).toBe("budget-exceeds-profile");
+  });
+
+  test("rejects when task maxTurns exceeds profile maxTurns", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(
+      makeCtx(task({ maxTurns: 100 })),
+      profile({ budget: { maxTurns: 50 } }),
+    );
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) expect(verdict.reason).toBe("turns-exceeds-profile");
+  });
+
+  test("admits when profile budget is undefined regardless of task budget", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(
+      makeCtx(task({ budget: { maxCostUsd: 999 } })),
+      profile(),
+    );
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("admits when task budget is undefined", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(makeCtx(task()), profile({ budget: { maxCostUsd: 1 } }));
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("ledger that returns false rejects with ledger-exhausted reason", async () => {
+    const ledger: BudgetLedger = { hasRemaining: async () => false };
+    const filter = new BudgetRemainingFilter({ ledger });
+    const verdict = await filter.filter(makeCtx(task()), profile());
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) expect(verdict.reason).toBe("ledger-exhausted");
+  });
+
+  test("default ledger is permissive", async () => {
+    const filter = new BudgetRemainingFilter();
+    const verdict = await filter.filter(makeCtx(task()), profile());
+    expect(verdict).toEqual({ admit: true });
+  });
+});

--- a/src/core/scheduler/plugins/budget-remaining.test.ts
+++ b/src/core/scheduler/plugins/budget-remaining.test.ts
@@ -3,10 +3,15 @@ import type { AgentTaskView } from "../../agent-task.js";
 import { AgentTaskPhase } from "../../agent-task.js";
 import type { SchedulerContext } from "../framework.js";
 import type { RuntimeProfile } from "../profile.js";
-import { BudgetRemainingFilter, type BudgetLedger } from "./budget-remaining.js";
+import { type BudgetLedger, BudgetRemainingFilter } from "./budget-remaining.js";
 
 function makeCtx(task: AgentTaskView): SchedulerContext {
-  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+  return {
+    task,
+    profiles: [],
+    store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+    now: () => 0,
+  };
 }
 
 function task(overrides: Partial<AgentTaskView["spec"]> = {}): AgentTaskView {
@@ -70,10 +75,7 @@ describe("BudgetRemainingFilter", () => {
 
   test("admits when profile budget is undefined regardless of task budget", async () => {
     const filter = new BudgetRemainingFilter();
-    const verdict = await filter.filter(
-      makeCtx(task({ budget: { maxCostUsd: 999 } })),
-      profile(),
-    );
+    const verdict = await filter.filter(makeCtx(task({ budget: { maxCostUsd: 999 } })), profile());
     expect(verdict).toEqual({ admit: true });
   });
 

--- a/src/core/scheduler/plugins/budget-remaining.ts
+++ b/src/core/scheduler/plugins/budget-remaining.ts
@@ -1,0 +1,69 @@
+import type { AgentTaskView } from "../../agent-task.js";
+import type { FilterPlugin, FilterVerdict, SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+
+export interface BudgetLedger {
+  hasRemaining(profile: RuntimeProfile, task: AgentTaskView): Promise<boolean>;
+}
+
+const PERMISSIVE_LEDGER: BudgetLedger = {
+  hasRemaining: async () => true,
+};
+
+export interface BudgetRemainingFilterOptions {
+  readonly ledger?: BudgetLedger | undefined;
+}
+
+export class BudgetRemainingFilter implements FilterPlugin {
+  readonly name = "BudgetRemaining";
+  private readonly ledger: BudgetLedger;
+
+  constructor(options: BudgetRemainingFilterOptions = {}) {
+    this.ledger = options.ledger ?? PERMISSIVE_LEDGER;
+  }
+
+  async filter(ctx: SchedulerContext, profile: RuntimeProfile): Promise<FilterVerdict> {
+    const requestedCost = readBudgetNumber(ctx.task.spec.budget, "maxCostUsd");
+    if (
+      requestedCost !== undefined &&
+      profile.budget?.maxCostUsd !== undefined &&
+      requestedCost > profile.budget.maxCostUsd
+    ) {
+      return {
+        admit: false,
+        reason: "budget-exceeds-profile",
+        message: `task wants $${requestedCost} but profile '${profile.name}' caps at $${profile.budget.maxCostUsd}`,
+      };
+    }
+
+    const requestedTurns = ctx.task.spec.maxTurns;
+    if (
+      requestedTurns !== undefined &&
+      profile.budget?.maxTurns !== undefined &&
+      requestedTurns > profile.budget.maxTurns
+    ) {
+      return {
+        admit: false,
+        reason: "turns-exceeds-profile",
+        message: `task wants ${requestedTurns} turns but profile '${profile.name}' caps at ${profile.budget.maxTurns}`,
+      };
+    }
+
+    const hasRemaining = await this.ledger.hasRemaining(profile, ctx.task);
+    if (!hasRemaining) {
+      return {
+        admit: false,
+        reason: "ledger-exhausted",
+        message: `ledger reports no remaining budget for profile '${profile.name}'`,
+      };
+    }
+
+    return { admit: true };
+  }
+}
+
+function readBudgetNumber(budget: unknown, key: string): number | undefined {
+  if (budget === null || typeof budget !== "object") return undefined;
+  const value = (budget as Record<string, unknown>)[key];
+  return typeof value === "number" ? value : undefined;
+}

--- a/src/core/scheduler/plugins/default-bind.test.ts
+++ b/src/core/scheduler/plugins/default-bind.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentConfig, AgentRuntime, AgentSession } from "../../agent-runtime.js";
-import { AgentTaskPhase } from "../../agent-task.js";
 import type { AgentTaskView } from "../../agent-task.js";
+import { AgentTaskPhase } from "../../agent-task.js";
 import type { AgentSessionEntity } from "../../entity.js";
 import type { SchedulerContext } from "../framework.js";
 import type { RuntimeProfile } from "../profile.js";
@@ -30,7 +30,12 @@ class FakeRuntime implements AgentRuntime {
 }
 
 function ctx(task: AgentTaskView): SchedulerContext {
-  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+  return {
+    task,
+    profiles: [],
+    store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+    now: () => 0,
+  };
 }
 
 function taskWith(spec: Partial<AgentTaskView["spec"]>): AgentTaskView {
@@ -79,10 +84,10 @@ describe("DefaultBindPlugin", () => {
   test("falls back to task budget.model when profile.model undefined", async () => {
     const runtime = new FakeRuntime();
     const plugin = new DefaultBindPlugin({ runtime });
-    await plugin.bind(
-      ctx(taskWith({ budget: { model: "claude-haiku" } })),
-      { ...profile, model: undefined },
-    );
+    await plugin.bind(ctx(taskWith({ budget: { model: "claude-haiku" } })), {
+      ...profile,
+      model: undefined,
+    });
     expect(runtime.spawnCalls[0]?.config.model).toBe("claude-haiku");
   });
 

--- a/src/core/scheduler/plugins/default-bind.test.ts
+++ b/src/core/scheduler/plugins/default-bind.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentConfig, AgentRuntime, AgentSession } from "../../agent-runtime.js";
 import type { AgentTaskView } from "../../agent-task.js";
-import { AgentTaskPhase } from "../../agent-task.js";
+import { AgentTaskConditionType, AgentTaskPhase } from "../../agent-task.js";
 import type { AgentSessionEntity } from "../../entity.js";
 import type { SchedulerContext } from "../framework.js";
 import type { RuntimeProfile } from "../profile.js";
@@ -106,5 +106,116 @@ describe("DefaultBindPlugin", () => {
     const plugin = new DefaultBindPlugin({ runtime });
     const result = await plugin.bind(ctx(taskWith({})), profile);
     expect(result.session.id).toBe("s-1");
+  });
+});
+
+function makeSucceededView(id: string, doneSummary: string): AgentTaskView {
+  return {
+    spec: {
+      id,
+      worktree: "/tmp/w",
+      runtime: "codex",
+      role: "coder",
+      prompt: "x",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+    },
+    status: {
+      id,
+      phase: AgentTaskPhase.Succeeded,
+      contributions: [],
+      conditions: [
+        {
+          type: AgentTaskConditionType.Succeeded,
+          status: "True",
+          observedGeneration: 1,
+          lastTransitionTime: "2026-05-16T00:00:00.000Z",
+          reason: "done-signaled",
+          message: doneSummary,
+        },
+      ],
+      observedGeneration: 1,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 2,
+    },
+  };
+}
+
+describe("DefaultBindPlugin — dependency prompt wrapping", () => {
+  test("dependsOn=[] leaves prompt unchanged", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    const task = taskWith({ prompt: "base prompt", dependsOn: [] });
+    const ctxObj: SchedulerContext = {
+      task,
+      profiles: [],
+      store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+      now: () => 0,
+    };
+    await plugin.bind(ctxObj, profile);
+    expect(runtime.spawnCalls[0]?.config.prompt).toBe("base prompt");
+  });
+
+  test("dependsOn with Succeeded dependency wraps prompt", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    const task = taskWith({ prompt: "review my changes", dependsOn: ["coder-1"] });
+    const ctxObj: SchedulerContext = {
+      task,
+      profiles: [],
+      store: {
+        listAgentTaskEntities: async () => [],
+        getAgentTask: async (id) =>
+          id === "coder-1" ? makeSucceededView("coder-1", "Implemented X") : undefined,
+      },
+      now: () => 0,
+    };
+    await plugin.bind(ctxObj, profile);
+    const prompt = runtime.spawnCalls[0]?.config.prompt ?? "";
+    expect(prompt).toContain("## Upstream output");
+    expect(prompt).toContain("### coder-1 (succeeded)");
+    expect(prompt).toContain("Implemented X");
+    expect(prompt).toContain("## Your task");
+    expect(prompt).toContain("review my changes");
+  });
+
+  test("dependsOn with multiple deps preserves declaration order", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    const task = taskWith({ prompt: "base", dependsOn: ["a", "b"] });
+    const ctxObj: SchedulerContext = {
+      task,
+      profiles: [],
+      store: {
+        listAgentTaskEntities: async () => [],
+        getAgentTask: async (id) => makeSucceededView(id, `summary-${id}`),
+      },
+      now: () => 0,
+    };
+    await plugin.bind(ctxObj, profile);
+    const prompt = runtime.spawnCalls[0]?.config.prompt ?? "";
+    const aIdx = prompt.indexOf("### a (succeeded)");
+    const bIdx = prompt.indexOf("### b (succeeded)");
+    expect(aIdx).toBeGreaterThan(-1);
+    expect(bIdx).toBeGreaterThan(aIdx);
+  });
+
+  test("missing dependency view falls back to '(no summary)'", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    const task = taskWith({ prompt: "x", dependsOn: ["ghost"] });
+    const ctxObj: SchedulerContext = {
+      task,
+      profiles: [],
+      store: {
+        listAgentTaskEntities: async () => [],
+        getAgentTask: async () => undefined,
+      },
+      now: () => 0,
+    };
+    await plugin.bind(ctxObj, profile);
+    const prompt = runtime.spawnCalls[0]?.config.prompt ?? "";
+    expect(prompt).toContain("(no summary)");
   });
 });

--- a/src/core/scheduler/plugins/default-bind.test.ts
+++ b/src/core/scheduler/plugins/default-bind.test.ts
@@ -220,6 +220,92 @@ describe("DefaultBindPlugin — dependency prompt wrapping", () => {
   });
 });
 
+describe("DefaultBindPlugin — grove MCP injection", () => {
+  test("injects grove MCP server when GROVE_DIR set", async () => {
+    const originalGroveDir = process.env.GROVE_DIR;
+    process.env.GROVE_DIR = "/tmp/test-project/.grove";
+    try {
+      const runtime = new FakeRuntime();
+      const plugin = new DefaultBindPlugin({ runtime });
+      const task = taskWith({});
+      const ctxObj: SchedulerContext = {
+        task,
+        profiles: [],
+        store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+        now: () => 0,
+      };
+      await plugin.bind(ctxObj, profile);
+      const mcps = runtime.spawnCalls[0]?.config.mcpServers ?? [];
+      const grove = mcps.find((m) => m.name === "grove");
+      expect(grove).toBeDefined();
+      expect(grove?.command).toBe("bun");
+      expect(grove?.args?.[0]).toBe("run");
+      expect(grove?.env?.GROVE_DIR).toBe("/tmp/test-project/.grove");
+      expect(grove?.env?.GROVE_AGENT_ROLE).toBe(task.spec.role);
+      expect(grove?.env?.GROVE_AGENT_TASK_ID).toBe(task.spec.id);
+    } finally {
+      if (originalGroveDir === undefined) delete process.env.GROVE_DIR;
+      else process.env.GROVE_DIR = originalGroveDir;
+    }
+  });
+
+  test("forwards GROVE_SERVER_URL + GROVE_API_TOKEN into MCP env (for /done route)", async () => {
+    const originals = {
+      groveDir: process.env.GROVE_DIR,
+      url: process.env.GROVE_SERVER_URL,
+      token: process.env.GROVE_API_TOKEN,
+    };
+    process.env.GROVE_DIR = "/tmp/test-project/.grove";
+    process.env.GROVE_SERVER_URL = "http://localhost:4515";
+    process.env.GROVE_API_TOKEN = "tok-xyz";
+    try {
+      const runtime = new FakeRuntime();
+      const plugin = new DefaultBindPlugin({ runtime });
+      const task = taskWith({});
+      const ctxObj: SchedulerContext = {
+        task,
+        profiles: [],
+        store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+        now: () => 0,
+      };
+      await plugin.bind(ctxObj, profile);
+      const grove = (runtime.spawnCalls[0]?.config.mcpServers ?? []).find(
+        (m) => m.name === "grove",
+      );
+      expect(grove?.env?.GROVE_SERVER_URL).toBe("http://localhost:4515");
+      expect(grove?.env?.GROVE_API_TOKEN).toBe("tok-xyz");
+    } finally {
+      for (const [k, v] of Object.entries(originals)) {
+        const envKey =
+          k === "groveDir" ? "GROVE_DIR" : k === "url" ? "GROVE_SERVER_URL" : "GROVE_API_TOKEN";
+        if (v === undefined) delete process.env[envKey];
+        else process.env[envKey] = v;
+      }
+    }
+  });
+
+  test("omits grove MCP server when GROVE_DIR unset", async () => {
+    const original = process.env.GROVE_DIR;
+    delete process.env.GROVE_DIR;
+    try {
+      const runtime = new FakeRuntime();
+      const plugin = new DefaultBindPlugin({ runtime });
+      const task = taskWith({});
+      const ctxObj: SchedulerContext = {
+        task,
+        profiles: [],
+        store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+        now: () => 0,
+      };
+      await plugin.bind(ctxObj, profile);
+      const mcps = runtime.spawnCalls[0]?.config.mcpServers ?? [];
+      expect(mcps.find((m) => m.name === "grove")).toBeUndefined();
+    } finally {
+      if (original !== undefined) process.env.GROVE_DIR = original;
+    }
+  });
+});
+
 describe("DefaultBindPlugin — env passthrough for AgentTask done", () => {
   test("forwards GROVE_SERVER_URL and GROVE_API_TOKEN when set in process env", async () => {
     const originalUrl = process.env.GROVE_SERVER_URL;

--- a/src/core/scheduler/plugins/default-bind.test.ts
+++ b/src/core/scheduler/plugins/default-bind.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentConfig, AgentRuntime, AgentSession } from "../../agent-runtime.js";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { AgentTaskView } from "../../agent-task.js";
+import type { AgentSessionEntity } from "../../entity.js";
+import type { SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+import { DefaultBindPlugin } from "./default-bind.js";
+
+class FakeRuntime implements AgentRuntime {
+  spawnCalls: Array<{ role: string; config: AgentConfig }> = [];
+  async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
+    this.spawnCalls.push({ role, config });
+    return { id: "s-1", role, status: "running", platform: config.platform, model: config.model };
+  }
+  async send(): Promise<never> {
+    throw new Error("unused");
+  }
+  async close(): Promise<void> {}
+  onIdle(): void {}
+  async listSessions(): Promise<readonly AgentSession[]> {
+    return [];
+  }
+  async listSessionEntities(): Promise<readonly AgentSessionEntity[]> {
+    return [];
+  }
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+}
+
+function ctx(task: AgentTaskView): SchedulerContext {
+  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+}
+
+function taskWith(spec: Partial<AgentTaskView["spec"]>): AgentTaskView {
+  return {
+    spec: {
+      id: "t",
+      worktree: "/tmp/w",
+      runtime: "codex",
+      role: "worker",
+      prompt: "do work",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      ...spec,
+    },
+    status: {
+      id: "t",
+      phase: AgentTaskPhase.PendingBind,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+const profile: RuntimeProfile = {
+  name: "claude-opus",
+  platform: "claude-code",
+  runtimeCommand: "claude",
+  model: "claude-opus-4-7",
+};
+
+describe("DefaultBindPlugin", () => {
+  test("profile fields override task.spec.runtime when spawning", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    await plugin.bind(ctx(taskWith({ runtime: "codex" })), profile);
+    const call = runtime.spawnCalls[0];
+    expect(call?.config.command).toBe("claude");
+    expect(call?.config.platform).toBe("claude-code");
+    expect(call?.config.model).toBe("claude-opus-4-7");
+  });
+
+  test("falls back to task budget.model when profile.model undefined", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    await plugin.bind(
+      ctx(taskWith({ budget: { model: "claude-haiku" } })),
+      { ...profile, model: undefined },
+    );
+    expect(runtime.spawnCalls[0]?.config.model).toBe("claude-haiku");
+  });
+
+  test("injects GROVE_AGENT_TASK_* env vars", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    await plugin.bind(ctx(taskWith({ id: "task-42", generation: 7 })), profile);
+    const env = runtime.spawnCalls[0]?.config.env ?? {};
+    expect(env.GROVE_AGENT_TASK_ID).toBe("task-42");
+    expect(env.GROVE_AGENT_TASK_GENERATION).toBe("7");
+    expect(env.GROVE_AGENT_TASK_RUNTIME).toBe("claude");
+  });
+
+  test("returns session id from runtime.spawn", async () => {
+    const runtime = new FakeRuntime();
+    const plugin = new DefaultBindPlugin({ runtime });
+    const result = await plugin.bind(ctx(taskWith({})), profile);
+    expect(result.session.id).toBe("s-1");
+  });
+});

--- a/src/core/scheduler/plugins/default-bind.test.ts
+++ b/src/core/scheduler/plugins/default-bind.test.ts
@@ -219,3 +219,57 @@ describe("DefaultBindPlugin — dependency prompt wrapping", () => {
     expect(prompt).toContain("(no summary)");
   });
 });
+
+describe("DefaultBindPlugin — env passthrough for AgentTask done", () => {
+  test("forwards GROVE_SERVER_URL and GROVE_API_TOKEN when set in process env", async () => {
+    const originalUrl = process.env.GROVE_SERVER_URL;
+    const originalToken = process.env.GROVE_API_TOKEN;
+    process.env.GROVE_SERVER_URL = "http://localhost:4515";
+    process.env.GROVE_API_TOKEN = "test-token-123";
+    try {
+      const runtime = new FakeRuntime();
+      const plugin = new DefaultBindPlugin({ runtime });
+      const task = taskWith({});
+      const ctxObj: SchedulerContext = {
+        task,
+        profiles: [],
+        store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+        now: () => 0,
+      };
+      await plugin.bind(ctxObj, profile);
+      const env = runtime.spawnCalls[0]?.config.env ?? {};
+      expect(env.GROVE_SERVER_URL).toBe("http://localhost:4515");
+      expect(env.GROVE_API_TOKEN).toBe("test-token-123");
+    } finally {
+      if (originalUrl === undefined) delete process.env.GROVE_SERVER_URL;
+      else process.env.GROVE_SERVER_URL = originalUrl;
+      if (originalToken === undefined) delete process.env.GROVE_API_TOKEN;
+      else process.env.GROVE_API_TOKEN = originalToken;
+    }
+  });
+
+  test("omits GROVE_SERVER_URL / GROVE_API_TOKEN when unset in process env", async () => {
+    const originalUrl = process.env.GROVE_SERVER_URL;
+    const originalToken = process.env.GROVE_API_TOKEN;
+    delete process.env.GROVE_SERVER_URL;
+    delete process.env.GROVE_API_TOKEN;
+    try {
+      const runtime = new FakeRuntime();
+      const plugin = new DefaultBindPlugin({ runtime });
+      const task = taskWith({});
+      const ctxObj: SchedulerContext = {
+        task,
+        profiles: [],
+        store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+        now: () => 0,
+      };
+      await plugin.bind(ctxObj, profile);
+      const env = runtime.spawnCalls[0]?.config.env ?? {};
+      expect(env.GROVE_SERVER_URL).toBeUndefined();
+      expect(env.GROVE_API_TOKEN).toBeUndefined();
+    } finally {
+      if (originalUrl !== undefined) process.env.GROVE_SERVER_URL = originalUrl;
+      if (originalToken !== undefined) process.env.GROVE_API_TOKEN = originalToken;
+    }
+  });
+});

--- a/src/core/scheduler/plugins/default-bind.ts
+++ b/src/core/scheduler/plugins/default-bind.ts
@@ -1,0 +1,42 @@
+import type { AgentConfig, AgentRuntime } from "../../agent-runtime.js";
+import type { BindPlugin, BindResult, SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+
+export interface DefaultBindPluginOptions {
+  readonly runtime: Pick<AgentRuntime, "spawn">;
+}
+
+export class DefaultBindPlugin implements BindPlugin {
+  readonly name = "DefaultBind";
+  private readonly runtime: Pick<AgentRuntime, "spawn">;
+
+  constructor(options: DefaultBindPluginOptions) {
+    this.runtime = options.runtime;
+  }
+
+  async bind(ctx: SchedulerContext, profile: RuntimeProfile): Promise<BindResult> {
+    const model = profile.model ?? readBudgetString(ctx.task.spec.budget, "model");
+    const config: AgentConfig = {
+      role: ctx.task.spec.role,
+      command: profile.runtimeCommand,
+      cwd: ctx.task.spec.worktree,
+      goal: ctx.task.spec.prompt,
+      prompt: ctx.task.spec.prompt,
+      ...(profile.platform === undefined ? {} : { platform: profile.platform }),
+      ...(model === undefined ? {} : { model }),
+      env: {
+        GROVE_AGENT_TASK_ID: ctx.task.spec.id,
+        GROVE_AGENT_TASK_GENERATION: String(ctx.task.spec.generation),
+        GROVE_AGENT_TASK_RUNTIME: profile.runtimeCommand,
+      },
+    };
+    const session = await this.runtime.spawn(ctx.task.spec.role, config);
+    return { session };
+  }
+}
+
+function readBudgetString(budget: unknown, key: string): string | undefined {
+  if (budget === null || typeof budget !== "object") return undefined;
+  const value = (budget as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/core/scheduler/plugins/default-bind.ts
+++ b/src/core/scheduler/plugins/default-bind.ts
@@ -1,6 +1,7 @@
 import type { AgentConfig, AgentRuntime } from "../../agent-runtime.js";
 import type { BindPlugin, BindResult, SchedulerContext } from "../framework.js";
 import type { RuntimeProfile } from "../profile.js";
+import { buildPromptWithUpstream, type UpstreamSection } from "../upstream-prompt.js";
 
 export interface DefaultBindPluginOptions {
   readonly runtime: Pick<AgentRuntime, "spawn">;
@@ -15,13 +16,23 @@ export class DefaultBindPlugin implements BindPlugin {
   }
 
   async bind(ctx: SchedulerContext, profile: RuntimeProfile): Promise<BindResult> {
+    const upstreamSections: UpstreamSection[] = [];
+    for (const depId of ctx.task.spec.dependsOn) {
+      const dep = await ctx.store.getAgentTask(depId);
+      const succeeded = dep?.status.conditions.find(
+        (c) => c.type === "Succeeded" && c.status === "True",
+      );
+      upstreamSections.push({ taskId: depId, summary: succeeded?.message ?? "" });
+    }
+    const wrappedPrompt = buildPromptWithUpstream(ctx.task.spec.prompt, upstreamSections);
+
     const model = profile.model ?? readBudgetString(ctx.task.spec.budget, "model");
     const config: AgentConfig = {
       role: ctx.task.spec.role,
       command: profile.runtimeCommand,
       cwd: ctx.task.spec.worktree,
       goal: ctx.task.spec.prompt,
-      prompt: ctx.task.spec.prompt,
+      prompt: wrappedPrompt,
       ...(profile.platform === undefined ? {} : { platform: profile.platform }),
       ...(model === undefined ? {} : { model }),
       env: {

--- a/src/core/scheduler/plugins/default-bind.ts
+++ b/src/core/scheduler/plugins/default-bind.ts
@@ -39,6 +39,12 @@ export class DefaultBindPlugin implements BindPlugin {
         GROVE_AGENT_TASK_ID: ctx.task.spec.id,
         GROVE_AGENT_TASK_GENERATION: String(ctx.task.spec.generation),
         GROVE_AGENT_TASK_RUNTIME: profile.runtimeCommand,
+        ...(process.env.GROVE_SERVER_URL === undefined
+          ? {}
+          : { GROVE_SERVER_URL: process.env.GROVE_SERVER_URL }),
+        ...(process.env.GROVE_API_TOKEN === undefined
+          ? {}
+          : { GROVE_API_TOKEN: process.env.GROVE_API_TOKEN }),
       },
     };
     const session = await this.runtime.spawn(ctx.task.spec.role, config);

--- a/src/core/scheduler/plugins/default-bind.ts
+++ b/src/core/scheduler/plugins/default-bind.ts
@@ -1,4 +1,7 @@
+import { dirname } from "node:path";
 import type { AgentConfig, AgentRuntime } from "../../agent-runtime.js";
+import type { AgentTaskView } from "../../agent-task.js";
+import { resolveMcpServePath } from "../../resolve-mcp-serve-path.js";
 import type { BindPlugin, BindResult, SchedulerContext } from "../framework.js";
 import type { RuntimeProfile } from "../profile.js";
 import { buildPromptWithUpstream, type UpstreamSection } from "../upstream-prompt.js";
@@ -27,6 +30,7 @@ export class DefaultBindPlugin implements BindPlugin {
     const wrappedPrompt = buildPromptWithUpstream(ctx.task.spec.prompt, upstreamSections);
 
     const model = profile.model ?? readBudgetString(ctx.task.spec.budget, "model");
+    const groveMcp = buildGroveMcpServer(ctx.task);
     const config: AgentConfig = {
       role: ctx.task.spec.role,
       command: profile.runtimeCommand,
@@ -46,6 +50,7 @@ export class DefaultBindPlugin implements BindPlugin {
           ? {}
           : { GROVE_API_TOKEN: process.env.GROVE_API_TOKEN }),
       },
+      ...(groveMcp === undefined ? {} : { mcpServers: [groveMcp] }),
     };
     const session = await this.runtime.spawn(ctx.task.spec.role, config);
     return { session };
@@ -56,4 +61,29 @@ function readBudgetString(budget: unknown, key: string): string | undefined {
   if (budget === null || typeof budget !== "object") return undefined;
   const value = (budget as Record<string, unknown>)[key];
   return typeof value === "string" ? value : undefined;
+}
+
+function buildGroveMcpServer(
+  task: AgentTaskView,
+): NonNullable<AgentConfig["mcpServers"]>[number] | undefined {
+  const groveDir = process.env.GROVE_DIR;
+  if (groveDir === undefined) return undefined;
+  const projectRoot = dirname(groveDir);
+  const env: Record<string, string> = {
+    GROVE_DIR: groveDir,
+    GROVE_AGENT_ROLE: task.spec.role,
+    GROVE_AGENT_TASK_ID: task.spec.id,
+    GROVE_AGENT_TASK_GENERATION: String(task.spec.generation),
+  };
+  if (process.env.GROVE_SERVER_URL !== undefined)
+    env.GROVE_SERVER_URL = process.env.GROVE_SERVER_URL;
+  if (process.env.GROVE_API_TOKEN !== undefined) env.GROVE_API_TOKEN = process.env.GROVE_API_TOKEN;
+  if (process.env.GROVE_NEXUS_URL !== undefined) env.GROVE_NEXUS_URL = process.env.GROVE_NEXUS_URL;
+  if (process.env.NEXUS_API_KEY !== undefined) env.NEXUS_API_KEY = process.env.NEXUS_API_KEY;
+  return {
+    name: "grove",
+    command: "bun",
+    args: ["run", resolveMcpServePath(projectRoot)],
+    env,
+  };
 }

--- a/src/core/scheduler/plugins/index.test.ts
+++ b/src/core/scheduler/plugins/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentRuntime } from "../../agent-runtime.js";
+import type { AgentSessionEntity } from "../../entity.js";
+import {
+  BUILTIN_FILTER_FACTORIES,
+  BUILTIN_SCORE_FACTORIES,
+  BUILTIN_PERMIT_FACTORIES,
+  BUILTIN_BIND_FACTORIES,
+  builtinPluginNames,
+} from "./index.js";
+
+function fakeRuntime(): AgentRuntime {
+  return {
+    spawn: async () => ({ id: "s", role: "r", status: "running" }),
+    send: async () => {
+      throw new Error("unused");
+    },
+    close: async () => {},
+    onIdle: () => {},
+    listSessions: async () => [],
+    listSessionEntities: async () => [] as readonly AgentSessionEntity[],
+    isAvailable: async () => true,
+  };
+}
+
+describe("builtin plugin registry", () => {
+  test("filter factories include the three default filters", () => {
+    expect(Object.keys(BUILTIN_FILTER_FACTORIES).sort()).toEqual([
+      "BudgetRemaining",
+      "RuntimeCapability",
+      "WorktreeExclusivity",
+    ]);
+  });
+
+  test("score factories include TaskAffinity", () => {
+    expect(Object.keys(BUILTIN_SCORE_FACTORIES)).toContain("TaskAffinity");
+  });
+
+  test("permit factories include AutoPermit and UserConfirmPermit", () => {
+    expect(Object.keys(BUILTIN_PERMIT_FACTORIES).sort()).toEqual(["AutoPermit", "UserConfirmPermit"]);
+  });
+
+  test("bind factories include DefaultBind", () => {
+    expect(Object.keys(BUILTIN_BIND_FACTORIES)).toEqual(["DefaultBind"]);
+  });
+
+  test("builtinPluginNames lists every plugin", () => {
+    expect(builtinPluginNames()).toEqual(
+      expect.arrayContaining([
+        "RuntimeCapability",
+        "BudgetRemaining",
+        "WorktreeExclusivity",
+        "TaskAffinity",
+        "AutoPermit",
+        "UserConfirmPermit",
+        "DefaultBind",
+      ]),
+    );
+  });
+
+  test("factories produce instances with the expected name", () => {
+    const filter = BUILTIN_FILTER_FACTORIES.RuntimeCapability({});
+    const score = BUILTIN_SCORE_FACTORIES.TaskAffinity({});
+    const permit = BUILTIN_PERMIT_FACTORIES.AutoPermit({});
+    const bind = BUILTIN_BIND_FACTORIES.DefaultBind({ runtime: fakeRuntime() });
+    expect(filter.name).toBe("RuntimeCapability");
+    expect(score.name).toBe("TaskAffinity");
+    expect(permit.name).toBe("AutoPermit");
+    expect(bind.name).toBe("DefaultBind");
+  });
+});

--- a/src/core/scheduler/plugins/index.ts
+++ b/src/core/scheduler/plugins/index.ts
@@ -1,0 +1,79 @@
+import type { AgentRuntime } from "../../agent-runtime.js";
+import type { BindPlugin, FilterPlugin, PermitPlugin, ScorePlugin } from "../framework.js";
+import { AutoPermit } from "./auto-permit.js";
+import { BudgetRemainingFilter, type BudgetLedger } from "./budget-remaining.js";
+import { DefaultBindPlugin } from "./default-bind.js";
+import { RuntimeCapabilityFilter } from "./runtime-capability.js";
+import { TaskAffinityScore } from "./task-affinity.js";
+import {
+  InMemoryPermitDecisionStore,
+  type PermitDecisionStore,
+  UserConfirmPermit,
+} from "./user-confirm-permit.js";
+import { WorktreeExclusivityFilter } from "./worktree-exclusivity.js";
+
+export interface FilterFactoryArgs {
+  readonly ledger?: BudgetLedger | undefined;
+}
+
+export interface ScoreFactoryArgs {
+  readonly weight?: number | undefined;
+}
+
+export interface PermitFactoryArgs {
+  readonly permitDecisionStore?: PermitDecisionStore | undefined;
+}
+
+export interface BindFactoryArgs {
+  readonly runtime: AgentRuntime;
+}
+
+export const BUILTIN_FILTER_FACTORIES: Readonly<
+  Record<string, (args: FilterFactoryArgs) => FilterPlugin>
+> = Object.freeze({
+  RuntimeCapability: () => new RuntimeCapabilityFilter(),
+  BudgetRemaining: (args) =>
+    new BudgetRemainingFilter(args.ledger === undefined ? {} : { ledger: args.ledger }),
+  WorktreeExclusivity: () => new WorktreeExclusivityFilter(),
+});
+
+export const BUILTIN_SCORE_FACTORIES: Readonly<
+  Record<string, (args: ScoreFactoryArgs) => ScorePlugin>
+> = Object.freeze({
+  TaskAffinity: () => new TaskAffinityScore(),
+});
+
+export const BUILTIN_PERMIT_FACTORIES: Readonly<
+  Record<string, (args: PermitFactoryArgs) => PermitPlugin>
+> = Object.freeze({
+  AutoPermit: () => new AutoPermit(),
+  UserConfirmPermit: (args) =>
+    new UserConfirmPermit({ store: args.permitDecisionStore ?? new InMemoryPermitDecisionStore() }),
+});
+
+export const BUILTIN_BIND_FACTORIES: Readonly<
+  Record<string, (args: BindFactoryArgs) => BindPlugin>
+> = Object.freeze({
+  DefaultBind: (args) => new DefaultBindPlugin({ runtime: args.runtime }),
+});
+
+export function builtinPluginNames(): readonly string[] {
+  return [
+    ...Object.keys(BUILTIN_FILTER_FACTORIES),
+    ...Object.keys(BUILTIN_SCORE_FACTORIES),
+    ...Object.keys(BUILTIN_PERMIT_FACTORIES),
+    ...Object.keys(BUILTIN_BIND_FACTORIES),
+  ];
+}
+
+export {
+  AutoPermit,
+  BudgetRemainingFilter,
+  DefaultBindPlugin,
+  InMemoryPermitDecisionStore,
+  RuntimeCapabilityFilter,
+  TaskAffinityScore,
+  UserConfirmPermit,
+  WorktreeExclusivityFilter,
+};
+export type { BudgetLedger, PermitDecisionStore };

--- a/src/core/scheduler/plugins/runtime-capability.test.ts
+++ b/src/core/scheduler/plugins/runtime-capability.test.ts
@@ -9,7 +9,7 @@ function makeCtx(task: AgentTaskView, profiles: RuntimeProfile[] = []): Schedule
   return {
     task,
     profiles,
-    store: { listAgentTaskEntities: async () => [] },
+    store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
     now: () => 0,
   };
 }

--- a/src/core/scheduler/plugins/runtime-capability.test.ts
+++ b/src/core/scheduler/plugins/runtime-capability.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentTaskView } from "../../agent-task.js";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+import { RuntimeCapabilityFilter } from "./runtime-capability.js";
+
+function makeCtx(task: AgentTaskView, profiles: RuntimeProfile[] = []): SchedulerContext {
+  return {
+    task,
+    profiles,
+    store: { listAgentTaskEntities: async () => [] },
+    now: () => 0,
+  };
+}
+
+function task(overrides: Partial<AgentTaskView["spec"]> = {}): AgentTaskView {
+  return {
+    spec: {
+      id: "t",
+      worktree: "/tmp/w",
+      runtime: "claude",
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      ...overrides,
+    },
+    status: {
+      id: "t",
+      phase: AgentTaskPhase.PendingBind,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function profile(overrides: Partial<RuntimeProfile> = {}): RuntimeProfile {
+  return {
+    name: "p",
+    platform: "claude-code",
+    runtimeCommand: "claude",
+    ...overrides,
+  };
+}
+
+describe("RuntimeCapabilityFilter", () => {
+  const filter = new RuntimeCapabilityFilter();
+
+  test("admits when task.spec.runtime matches profile.runtimeCommand", async () => {
+    const verdict = await filter.filter(makeCtx(task()), profile());
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("rejects when task.spec.runtime mismatches profile.runtimeCommand", async () => {
+    const verdict = await filter.filter(
+      makeCtx(task({ runtime: "codex" })),
+      profile({ runtimeCommand: "claude" }),
+    );
+    expect(verdict).toEqual({
+      admit: false,
+      reason: "runtime-mismatch",
+      message: "task pins runtime 'codex' but profile runs 'claude'",
+    });
+  });
+
+  test("rejects when profile.supportedRoles excludes task.spec.role", async () => {
+    const verdict = await filter.filter(
+      makeCtx(task({ role: "reviewer" })),
+      profile({ supportedRoles: ["worker"] }),
+    );
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) expect(verdict.reason).toBe("role-unsupported");
+  });
+
+  test("admits when profile.supportedRoles is undefined regardless of role", async () => {
+    const verdict = await filter.filter(makeCtx(task({ role: "anything" })), profile());
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("rejects when task asks for a model not in profile.budget.allowedModels", async () => {
+    const verdict = await filter.filter(
+      makeCtx(task({ budget: { model: "claude-haiku-4-5" } })),
+      profile({ budget: { allowedModels: ["claude-opus-4-7"] } }),
+    );
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) expect(verdict.reason).toBe("model-not-allowed");
+  });
+
+  test("admits when budget.allowedModels is undefined", async () => {
+    const verdict = await filter.filter(
+      makeCtx(task({ budget: { model: "anything" } })),
+      profile(),
+    );
+    expect(verdict).toEqual({ admit: true });
+  });
+});

--- a/src/core/scheduler/plugins/runtime-capability.ts
+++ b/src/core/scheduler/plugins/runtime-capability.ts
@@ -1,0 +1,54 @@
+import type { FilterPlugin, FilterVerdict, SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+
+export class RuntimeCapabilityFilter implements FilterPlugin {
+  readonly name = "RuntimeCapability";
+
+  async filter(ctx: SchedulerContext, profile: RuntimeProfile): Promise<FilterVerdict> {
+    const requestedRuntime = ctx.task.spec.runtime;
+    if (
+      typeof requestedRuntime === "string" &&
+      requestedRuntime.length > 0 &&
+      requestedRuntime !== profile.runtimeCommand
+    ) {
+      return {
+        admit: false,
+        reason: "runtime-mismatch",
+        message: `task pins runtime '${requestedRuntime}' but profile runs '${profile.runtimeCommand}'`,
+      };
+    }
+
+    if (
+      profile.supportedRoles !== undefined &&
+      !profile.supportedRoles.includes(ctx.task.spec.role)
+    ) {
+      return {
+        admit: false,
+        reason: "role-unsupported",
+        message: `profile '${profile.name}' does not support role '${ctx.task.spec.role}'`,
+      };
+    }
+
+    const requestedModel = readBudgetString(ctx.task.spec.budget, "model");
+    const allowedModels = profile.budget?.allowedModels;
+    if (
+      requestedModel !== undefined &&
+      allowedModels !== undefined &&
+      !allowedModels.includes(requestedModel)
+    ) {
+      return {
+        admit: false,
+        reason: "model-not-allowed",
+        message: `profile '${profile.name}' does not allow model '${requestedModel}'`,
+      };
+    }
+
+    return { admit: true };
+  }
+}
+
+function readBudgetString(budget: unknown, key: string): string | undefined {
+  if (budget === null || typeof budget !== "object") return undefined;
+  const value = (budget as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/core/scheduler/plugins/task-affinity.test.ts
+++ b/src/core/scheduler/plugins/task-affinity.test.ts
@@ -6,7 +6,12 @@ import type { RuntimeProfile } from "../profile.js";
 import { TaskAffinityScore } from "./task-affinity.js";
 
 function ctxWith(task: AgentTaskView): SchedulerContext {
-  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+  return {
+    task,
+    profiles: [],
+    store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+    now: () => 0,
+  };
 }
 
 function task(
@@ -78,8 +83,14 @@ describe("TaskAffinityScore", () => {
   });
 
   test("derives default affinity from task.spec.runtime when budget.affinity absent", async () => {
-    const match = await score.score(ctxWith(task({ runtime: "claude" })), profile({ runtime: "claude" }));
-    const miss = await score.score(ctxWith(task({ runtime: "claude" })), profile({ runtime: "codex" }));
+    const match = await score.score(
+      ctxWith(task({ runtime: "claude" })),
+      profile({ runtime: "claude" }),
+    );
+    const miss = await score.score(
+      ctxWith(task({ runtime: "claude" })),
+      profile({ runtime: "codex" }),
+    );
     expect(match).toBe(100);
     expect(miss).toBe(0);
   });

--- a/src/core/scheduler/plugins/task-affinity.test.ts
+++ b/src/core/scheduler/plugins/task-affinity.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentTaskView } from "../../agent-task.js";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+import { TaskAffinityScore } from "./task-affinity.js";
+
+function ctxWith(task: AgentTaskView): SchedulerContext {
+  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+}
+
+function task(
+  overrides: { runtime?: string; affinity?: Readonly<Record<string, string>> } = {},
+): AgentTaskView {
+  return {
+    spec: {
+      id: "t",
+      worktree: "/tmp/w",
+      runtime: overrides.runtime ?? "claude",
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      ...(overrides.affinity === undefined ? {} : { budget: { affinity: overrides.affinity } }),
+    },
+    status: {
+      id: "t",
+      phase: AgentTaskPhase.PendingBind,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function profile(labels?: Record<string, string>): RuntimeProfile {
+  return {
+    name: "p",
+    platform: "claude-code",
+    runtimeCommand: "claude",
+    ...(labels === undefined ? {} : { labels }),
+  };
+}
+
+describe("TaskAffinityScore", () => {
+  const score = new TaskAffinityScore();
+
+  test("returns 100 when every requested label matches", async () => {
+    const value = await score.score(
+      ctxWith(task({ affinity: { tier: "premium", region: "us" } })),
+      profile({ tier: "premium", region: "us" }),
+    );
+    expect(value).toBe(100);
+  });
+
+  test("returns 50 when half the requested labels match", async () => {
+    const value = await score.score(
+      ctxWith(task({ affinity: { tier: "premium", region: "us" } })),
+      profile({ tier: "premium", region: "eu" }),
+    );
+    expect(value).toBe(50);
+  });
+
+  test("returns 0 when no requested labels match", async () => {
+    const value = await score.score(
+      ctxWith(task({ affinity: { tier: "premium" } })),
+      profile({ tier: "free" }),
+    );
+    expect(value).toBe(0);
+  });
+
+  test("returns neutral 50 when no affinity requested and no runtime hint", async () => {
+    const value = await score.score(ctxWith(task({ runtime: "" })), profile());
+    expect(value).toBe(50);
+  });
+
+  test("derives default affinity from task.spec.runtime when budget.affinity absent", async () => {
+    const match = await score.score(ctxWith(task({ runtime: "claude" })), profile({ runtime: "claude" }));
+    const miss = await score.score(ctxWith(task({ runtime: "claude" })), profile({ runtime: "codex" }));
+    expect(match).toBe(100);
+    expect(miss).toBe(0);
+  });
+});

--- a/src/core/scheduler/plugins/task-affinity.ts
+++ b/src/core/scheduler/plugins/task-affinity.ts
@@ -1,0 +1,42 @@
+import type { SchedulerContext, ScorePlugin } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+
+const NEUTRAL_SCORE = 50;
+
+export class TaskAffinityScore implements ScorePlugin {
+  readonly name = "TaskAffinity";
+
+  async score(ctx: SchedulerContext, profile: RuntimeProfile): Promise<number> {
+    const requested = resolveRequestedLabels(ctx);
+    const keys = Object.keys(requested);
+    if (keys.length === 0) return NEUTRAL_SCORE;
+
+    const labels = profile.labels ?? {};
+    let matched = 0;
+    for (const key of keys) {
+      if (labels[key] === requested[key]) matched += 1;
+    }
+    return Math.round((100 * matched) / keys.length);
+  }
+}
+
+function resolveRequestedLabels(ctx: SchedulerContext): Readonly<Record<string, string>> {
+  const fromBudget = readAffinityFromBudget(ctx.task.spec.budget);
+  if (fromBudget !== undefined && Object.keys(fromBudget).length > 0) return fromBudget;
+
+  const runtime = ctx.task.spec.runtime;
+  if (typeof runtime === "string" && runtime.length > 0) return { runtime };
+
+  return {};
+}
+
+function readAffinityFromBudget(budget: unknown): Readonly<Record<string, string>> | undefined {
+  if (budget === null || typeof budget !== "object") return undefined;
+  const value = (budget as { affinity?: unknown }).affinity;
+  if (value === null || typeof value !== "object") return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
+}

--- a/src/core/scheduler/plugins/user-confirm-permit.test.ts
+++ b/src/core/scheduler/plugins/user-confirm-permit.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import { AgentTaskPhase } from "../../agent-task.js";
 import type { AgentTaskView } from "../../agent-task.js";
+import { AgentTaskPhase } from "../../agent-task.js";
 import type { SchedulerContext } from "../framework.js";
-import {
-  InMemoryPermitDecisionStore,
-  UserConfirmPermit,
-} from "./user-confirm-permit.js";
+import { InMemoryPermitDecisionStore, UserConfirmPermit } from "./user-confirm-permit.js";
 
 function ctx(task: AgentTaskView): SchedulerContext {
-  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+  return {
+    task,
+    profiles: [],
+    store: { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined },
+    now: () => 0,
+  };
 }
 
 const task: AgentTaskView = {

--- a/src/core/scheduler/plugins/user-confirm-permit.test.ts
+++ b/src/core/scheduler/plugins/user-confirm-permit.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { AgentTaskPhase } from "../../agent-task.js";
+import type { AgentTaskView } from "../../agent-task.js";
+import type { SchedulerContext } from "../framework.js";
+import {
+  InMemoryPermitDecisionStore,
+  UserConfirmPermit,
+} from "./user-confirm-permit.js";
+
+function ctx(task: AgentTaskView): SchedulerContext {
+  return { task, profiles: [], store: { listAgentTaskEntities: async () => [] }, now: () => 0 };
+}
+
+const task: AgentTaskView = {
+  spec: {
+    id: "t",
+    worktree: "/tmp/w",
+    runtime: "claude",
+    role: "worker",
+    prompt: "p",
+    dependsOn: [],
+    generation: 1,
+    createdAt: "2026-05-16T00:00:00.000Z",
+  },
+  status: {
+    id: "t",
+    phase: AgentTaskPhase.PendingBind,
+    contributions: [],
+    conditions: [],
+    observedGeneration: 0,
+    lastTransitionAt: "2026-05-16T00:00:00.000Z",
+    revision: 1,
+  },
+};
+
+const profile = { name: "p", platform: "claude-code", runtimeCommand: "claude" } as const;
+
+describe("UserConfirmPermit", () => {
+  test("returns wait when no decision present", async () => {
+    const store = new InMemoryPermitDecisionStore();
+    const permit = new UserConfirmPermit({ store });
+    const verdict = await permit.permit(ctx(task), profile);
+    expect(verdict).toEqual({
+      status: "wait",
+      reason: "awaiting-user-confirmation",
+      message: "no decision recorded for task 't' / profile 'p' / generation 1",
+    });
+  });
+
+  test("returns granted when decision approved", async () => {
+    const store = new InMemoryPermitDecisionStore();
+    await store.record({ taskId: "t", profileName: "p", generation: 1, approved: true });
+    const permit = new UserConfirmPermit({ store });
+    expect(await permit.permit(ctx(task), profile)).toEqual({ status: "granted" });
+  });
+
+  test("returns denied with stored reason when decision rejected", async () => {
+    const store = new InMemoryPermitDecisionStore();
+    await store.record({
+      taskId: "t",
+      profileName: "p",
+      generation: 1,
+      approved: false,
+      reason: "too-expensive",
+    });
+    const permit = new UserConfirmPermit({ store });
+    const verdict = await permit.permit(ctx(task), profile);
+    expect(verdict).toEqual({ status: "denied", reason: "too-expensive" });
+  });
+
+  test("decisions for older generations do not apply to newer task generations", async () => {
+    const store = new InMemoryPermitDecisionStore();
+    await store.record({ taskId: "t", profileName: "p", generation: 1, approved: true });
+    const newer: AgentTaskView = {
+      spec: { ...task.spec, generation: 2 },
+      status: task.status,
+    };
+    const permit = new UserConfirmPermit({ store });
+    const verdict = await permit.permit(ctx(newer), profile);
+    expect(verdict.status).toBe("wait");
+  });
+});

--- a/src/core/scheduler/plugins/user-confirm-permit.ts
+++ b/src/core/scheduler/plugins/user-confirm-permit.ts
@@ -1,0 +1,69 @@
+import type { PermitPlugin, PermitVerdict, SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+
+export interface PermitDecision {
+  readonly approved: boolean;
+  readonly reason?: string | undefined;
+}
+
+export interface PermitDecisionLookup {
+  readonly taskId: string;
+  readonly profileName: string;
+  readonly generation: number;
+}
+
+export interface PermitDecisionRecord extends PermitDecisionLookup, PermitDecision {}
+
+export interface PermitDecisionStore {
+  lookup(query: PermitDecisionLookup): Promise<PermitDecision | undefined>;
+}
+
+export class InMemoryPermitDecisionStore implements PermitDecisionStore {
+  private readonly map = new Map<string, PermitDecision>();
+
+  async record(record: PermitDecisionRecord): Promise<void> {
+    const { approved } = record;
+    const decision: PermitDecision = record.reason === undefined ? { approved } : { approved, reason: record.reason };
+    this.map.set(keyOf(record), decision);
+  }
+
+  async lookup(query: PermitDecisionLookup): Promise<PermitDecision | undefined> {
+    return this.map.get(keyOf(query));
+  }
+}
+
+export interface UserConfirmPermitOptions {
+  readonly store: PermitDecisionStore;
+}
+
+export class UserConfirmPermit implements PermitPlugin {
+  readonly name = "UserConfirmPermit";
+  private readonly store: PermitDecisionStore;
+
+  constructor(options: UserConfirmPermitOptions) {
+    this.store = options.store;
+  }
+
+  async permit(ctx: SchedulerContext, profile: RuntimeProfile): Promise<PermitVerdict> {
+    const decision = await this.store.lookup({
+      taskId: ctx.task.spec.id,
+      profileName: profile.name,
+      generation: ctx.task.spec.generation,
+    });
+    if (decision === undefined) {
+      return {
+        status: "wait",
+        reason: "awaiting-user-confirmation",
+        message: `no decision recorded for task '${ctx.task.spec.id}' / profile '${profile.name}' / generation ${ctx.task.spec.generation}`,
+      };
+    }
+    if (decision.approved) return { status: "granted" };
+    return decision.reason === undefined
+      ? { status: "denied", reason: "user-denied" }
+      : { status: "denied", reason: decision.reason };
+  }
+}
+
+function keyOf(query: PermitDecisionLookup): string {
+  return `${query.taskId}::${query.profileName}::${query.generation}`;
+}

--- a/src/core/scheduler/plugins/worktree-exclusivity.test.ts
+++ b/src/core/scheduler/plugins/worktree-exclusivity.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentTaskEntity, AgentTaskView } from "../../agent-task.js";
+import { AgentTaskPhase, agentTaskViewToEntity } from "../../agent-task.js";
+import type { SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+import { WorktreeExclusivityFilter } from "./worktree-exclusivity.js";
+
+function view(id: string, worktree: string, phase: AgentTaskPhase): AgentTaskView {
+  return {
+    spec: {
+      id,
+      worktree,
+      runtime: "claude",
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+    },
+    status: {
+      id,
+      phase,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function ctxWith(task: AgentTaskView, others: readonly AgentTaskView[]): SchedulerContext {
+  const entities: AgentTaskEntity[] = [task, ...others].map((v) => agentTaskViewToEntity(v));
+  return {
+    task,
+    profiles: [],
+    store: { listAgentTaskEntities: async () => entities },
+    now: () => 0,
+  };
+}
+
+const profile: RuntimeProfile = { name: "p", platform: "claude-code", runtimeCommand: "claude" };
+
+describe("WorktreeExclusivityFilter", () => {
+  const filter = new WorktreeExclusivityFilter();
+
+  test("admits when no other task shares the worktree", async () => {
+    const task = view("self", "/w/a", AgentTaskPhase.PendingBind);
+    const verdict = await filter.filter(ctxWith(task, []), profile);
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("rejects when another Running task shares the worktree", async () => {
+    const task = view("self", "/w/a", AgentTaskPhase.PendingBind);
+    const other = view("other", "/w/a", AgentTaskPhase.Running);
+    const verdict = await filter.filter(ctxWith(task, [other]), profile);
+    expect(verdict.admit).toBe(false);
+    if (!verdict.admit) {
+      expect(verdict.reason).toBe("worktree-busy");
+      expect(verdict.message).toContain("other");
+    }
+  });
+
+  test("admits when other task on same worktree is Succeeded", async () => {
+    const task = view("self", "/w/a", AgentTaskPhase.PendingBind);
+    const other = view("other", "/w/a", AgentTaskPhase.Succeeded);
+    const verdict = await filter.filter(ctxWith(task, [other]), profile);
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("admits when other Running task is on a different worktree", async () => {
+    const task = view("self", "/w/a", AgentTaskPhase.PendingBind);
+    const other = view("other", "/w/b", AgentTaskPhase.Running);
+    const verdict = await filter.filter(ctxWith(task, [other]), profile);
+    expect(verdict).toEqual({ admit: true });
+  });
+
+  test("admits when the only Running task on the worktree is the task itself", async () => {
+    const task = view("self", "/w/a", AgentTaskPhase.Running);
+    const verdict = await filter.filter(ctxWith(task, []), profile);
+    expect(verdict).toEqual({ admit: true });
+  });
+});

--- a/src/core/scheduler/plugins/worktree-exclusivity.test.ts
+++ b/src/core/scheduler/plugins/worktree-exclusivity.test.ts
@@ -34,7 +34,7 @@ function ctxWith(task: AgentTaskView, others: readonly AgentTaskView[]): Schedul
   return {
     task,
     profiles: [],
-    store: { listAgentTaskEntities: async () => entities },
+    store: { listAgentTaskEntities: async () => entities, getAgentTask: async () => undefined },
     now: () => 0,
   };
 }

--- a/src/core/scheduler/plugins/worktree-exclusivity.ts
+++ b/src/core/scheduler/plugins/worktree-exclusivity.ts
@@ -1,0 +1,26 @@
+import type { FilterPlugin, FilterVerdict, SchedulerContext } from "../framework.js";
+import type { RuntimeProfile } from "../profile.js";
+
+export class WorktreeExclusivityFilter implements FilterPlugin {
+  readonly name = "WorktreeExclusivity";
+
+  async filter(ctx: SchedulerContext, _profile: RuntimeProfile): Promise<FilterVerdict> {
+    const entities = await ctx.store.listAgentTaskEntities();
+    const worktree = ctx.task.spec.worktree;
+    const selfId = ctx.task.spec.id;
+    const conflict = entities.find(
+      (entity) =>
+        entity.id !== selfId &&
+        entity.spec.worktree === worktree &&
+        entity.status.phase === "Running",
+    );
+    if (conflict !== undefined) {
+      return {
+        admit: false,
+        reason: "worktree-busy",
+        message: `running task '${conflict.id}' holds worktree '${worktree}'`,
+      };
+    }
+    return { admit: true };
+  }
+}

--- a/src/core/scheduler/profile.test.ts
+++ b/src/core/scheduler/profile.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentTaskView } from "../agent-task.js";
+import { AgentTaskPhase } from "../agent-task.js";
+import { synthesizeFallbackProfile } from "./profile.js";
+
+function taskWithRuntime(runtime: string, model?: string): AgentTaskView {
+  return {
+    spec: {
+      id: "task-1",
+      worktree: "/tmp/w",
+      runtime,
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      ...(model === undefined ? {} : { budget: { model } }),
+    },
+    status: {
+      id: "task-1",
+      phase: AgentTaskPhase.Pending,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+describe("synthesizeFallbackProfile", () => {
+  test("maps task.spec.runtime 'claude' to claude-code platform", () => {
+    const profile = synthesizeFallbackProfile(taskWithRuntime("claude"));
+    expect(profile.platform).toBe("claude-code");
+    expect(profile.runtimeCommand).toBe("claude");
+    expect(profile.name).toBe("fallback-claude");
+  });
+
+  test("maps 'codex' and 'gemini' to their platforms", () => {
+    expect(synthesizeFallbackProfile(taskWithRuntime("codex")).platform).toBe("codex");
+    expect(synthesizeFallbackProfile(taskWithRuntime("gemini")).platform).toBe("gemini");
+  });
+
+  test("uses undefined platform for unknown runtime", () => {
+    expect(synthesizeFallbackProfile(taskWithRuntime("custom")).platform).toBeUndefined();
+  });
+
+  test("carries model from task.spec.budget.model when present", () => {
+    expect(synthesizeFallbackProfile(taskWithRuntime("claude", "claude-opus-4-7")).model).toBe(
+      "claude-opus-4-7",
+    );
+  });
+});

--- a/src/core/scheduler/profile.ts
+++ b/src/core/scheduler/profile.ts
@@ -1,0 +1,3 @@
+export interface RuntimeProfile {
+  readonly name: string;
+}

--- a/src/core/scheduler/profile.ts
+++ b/src/core/scheduler/profile.ts
@@ -1,3 +1,42 @@
+import type { AgentTaskView } from "../agent-task.js";
+import type { AgentPlatformType } from "../topology.js";
+
+export interface RuntimeProfileBudget {
+  readonly maxCostUsd?: number | undefined;
+  readonly maxTurns?: number | undefined;
+  readonly allowedModels?: readonly string[] | undefined;
+}
+
 export interface RuntimeProfile {
   readonly name: string;
+  readonly platform: AgentPlatformType | undefined;
+  readonly runtimeCommand: string;
+  readonly model?: string | undefined;
+  readonly supportedRoles?: readonly string[] | undefined;
+  readonly budget?: RuntimeProfileBudget | undefined;
+  readonly labels?: Readonly<Record<string, string>> | undefined;
+}
+
+export function synthesizeFallbackProfile(task: AgentTaskView): RuntimeProfile {
+  const runtime = task.spec.runtime;
+  const model = readModelFromBudget(task.spec.budget);
+  return {
+    name: `fallback-${runtime}`,
+    platform: runtimeToPlatform(runtime),
+    runtimeCommand: runtime,
+    ...(model === undefined ? {} : { model }),
+  };
+}
+
+function runtimeToPlatform(runtime: string): AgentPlatformType | undefined {
+  if (runtime === "claude" || runtime === "claude-code") return "claude-code";
+  if (runtime === "codex") return "codex";
+  if (runtime === "gemini") return "gemini";
+  return undefined;
+}
+
+function readModelFromBudget(budget: unknown): string | undefined {
+  if (budget === null || typeof budget !== "object") return undefined;
+  const model = (budget as { model?: unknown }).model;
+  return typeof model === "string" ? model : undefined;
 }

--- a/src/core/scheduler/scheduler.test.ts
+++ b/src/core/scheduler/scheduler.test.ts
@@ -252,3 +252,31 @@ describe("Scheduler.schedule — permit stage", () => {
     expect(calls).toEqual(["first"]);
   });
 });
+
+describe("Scheduler.schedule — fallback profile", () => {
+  test("synthesizes a single profile from task.spec.runtime when none configured", async () => {
+    const bindCalls: RuntimeProfile[] = [];
+    const scheduler = new Scheduler({
+      profiles: [],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [],
+      permits: [autoPermit()],
+      bindPlugin: {
+        name: "capture",
+        bind: async (_ctx, profile) => {
+          bindCalls.push(profile);
+          return { session: { id: "s", role: "worker", status: "running" } };
+        },
+      },
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("bound");
+    expect(bindCalls).toHaveLength(1);
+    expect(bindCalls[0]?.name).toBe("fallback-claude");
+    expect(bindCalls[0]?.runtimeCommand).toBe("claude");
+  });
+});

--- a/src/core/scheduler/scheduler.test.ts
+++ b/src/core/scheduler/scheduler.test.ts
@@ -2,12 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { AgentSession } from "../agent-runtime.js";
 import type { AgentTaskEntity, AgentTaskView } from "../agent-task.js";
 import { AgentTaskPhase } from "../agent-task.js";
-import type {
-  BindPlugin,
-  FilterPlugin,
-  PermitPlugin,
-  ScorePlugin,
-} from "./framework.js";
+import type { BindPlugin, FilterPlugin, PermitPlugin, ScorePlugin } from "./framework.js";
 import type { RuntimeProfile } from "./profile.js";
 import { Scheduler } from "./scheduler.js";
 
@@ -46,8 +41,11 @@ function profile(name: string, overrides: Partial<RuntimeProfile> = {}): Runtime
   };
 }
 
-function emptyStore(): { listAgentTaskEntities: () => Promise<readonly AgentTaskEntity[]> } {
-  return { listAgentTaskEntities: async () => [] };
+function emptyStore(): {
+  listAgentTaskEntities: () => Promise<readonly AgentTaskEntity[]>;
+  getAgentTask: () => Promise<undefined>;
+} {
+  return { listAgentTaskEntities: async () => [], getAgentTask: async () => undefined };
 }
 
 function alwaysReject(name: string, reason: string): FilterPlugin {
@@ -153,7 +151,12 @@ describe("Scheduler.schedule — scoring", () => {
   });
 });
 
-function constantScoreFor(nameA: string, valueA: number, nameB: string, valueB: number): ScorePlugin {
+function constantScoreFor(
+  nameA: string,
+  valueA: number,
+  nameB: string,
+  valueB: number,
+): ScorePlugin {
   return {
     name: `pair-${nameA}-${nameB}`,
     score: async (_ctx, profile) => {

--- a/src/core/scheduler/scheduler.test.ts
+++ b/src/core/scheduler/scheduler.test.ts
@@ -91,3 +91,75 @@ describe("Scheduler.schedule — unschedulable", () => {
     }
   });
 });
+
+describe("Scheduler.schedule — scoring", () => {
+  test("highest weighted-sum score wins", async () => {
+    const session: AgentSession = { id: "s", role: "worker", status: "running" };
+    const scheduler = new Scheduler({
+      profiles: [profile("a"), profile("b")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [
+        { plugin: constantScoreFor(profile("a").name, 20, profile("b").name, 80), weight: 1 },
+      ],
+      permits: [autoPermit()],
+      bindPlugin: staticBind(session),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") expect(result.profile.name).toBe("b");
+  });
+
+  test("tie broken by config declaration order", async () => {
+    const session: AgentSession = { id: "s", role: "worker", status: "running" };
+    const scheduler = new Scheduler({
+      profiles: [profile("first"), profile("second")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [{ plugin: constantScore("flat", 50), weight: 1 }],
+      permits: [autoPermit()],
+      bindPlugin: staticBind(session),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") expect(result.profile.name).toBe("first");
+  });
+
+  test("weights multiply per-score contributions", async () => {
+    const session: AgentSession = { id: "s", role: "worker", status: "running" };
+    const scheduler = new Scheduler({
+      profiles: [profile("a"), profile("b")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [
+        { plugin: constantScoreFor("a", 100, "b", 0), weight: 1 },
+        { plugin: constantScoreFor("a", 0, "b", 100), weight: 2 },
+      ],
+      permits: [autoPermit()],
+      bindPlugin: staticBind(session),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") expect(result.profile.name).toBe("b");
+  });
+});
+
+function constantScoreFor(nameA: string, valueA: number, nameB: string, valueB: number): ScorePlugin {
+  return {
+    name: `pair-${nameA}-${nameB}`,
+    score: async (_ctx, profile) => {
+      if (profile.name === nameA) return valueA;
+      if (profile.name === nameB) return valueB;
+      return 0;
+    },
+  };
+}

--- a/src/core/scheduler/scheduler.test.ts
+++ b/src/core/scheduler/scheduler.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentSession } from "../agent-runtime.js";
+import type { AgentTaskEntity, AgentTaskView } from "../agent-task.js";
+import { AgentTaskPhase } from "../agent-task.js";
+import type {
+  BindPlugin,
+  FilterPlugin,
+  PermitPlugin,
+  ScorePlugin,
+} from "./framework.js";
+import type { RuntimeProfile } from "./profile.js";
+import { Scheduler } from "./scheduler.js";
+
+const TASK_ID = "task-1";
+
+function taskView(): AgentTaskView {
+  return {
+    spec: {
+      id: TASK_ID,
+      worktree: "/tmp/w",
+      runtime: "claude",
+      role: "worker",
+      prompt: "p",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+    },
+    status: {
+      id: TASK_ID,
+      phase: AgentTaskPhase.PendingBind,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+function profile(name: string, overrides: Partial<RuntimeProfile> = {}): RuntimeProfile {
+  return {
+    name,
+    platform: "claude-code",
+    runtimeCommand: "claude",
+    ...overrides,
+  };
+}
+
+function emptyStore(): { listAgentTaskEntities: () => Promise<readonly AgentTaskEntity[]> } {
+  return { listAgentTaskEntities: async () => [] };
+}
+
+function alwaysReject(name: string, reason: string): FilterPlugin {
+  return { name, filter: async () => ({ admit: false, reason }) };
+}
+
+function alwaysAdmit(name: string): FilterPlugin {
+  return { name, filter: async () => ({ admit: true }) };
+}
+
+function constantScore(name: string, value: number): ScorePlugin {
+  return { name, score: async () => value };
+}
+
+function autoPermit(): PermitPlugin {
+  return { name: "auto", permit: async () => ({ status: "granted" }) };
+}
+
+function staticBind(session: AgentSession): BindPlugin {
+  return { name: "static", bind: async () => ({ session }) };
+}
+
+describe("Scheduler.schedule — unschedulable", () => {
+  test("returns unschedulable when all profiles are rejected", async () => {
+    const scheduler = new Scheduler({
+      profiles: [profile("a"), profile("b")],
+      filters: [alwaysReject("deny-all", "blocked")],
+      scores: [],
+      permits: [autoPermit()],
+      bindPlugin: staticBind({ id: "s", role: "worker", status: "running" }),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("unschedulable");
+    if (result.kind === "unschedulable") {
+      expect(result.rejections).toHaveLength(2);
+      expect(result.rejections[0]?.rejections[0]?.reason).toBe("blocked");
+    }
+  });
+});

--- a/src/core/scheduler/scheduler.test.ts
+++ b/src/core/scheduler/scheduler.test.ts
@@ -163,3 +163,92 @@ function constantScoreFor(nameA: string, valueA: number, nameB: string, valueB: 
     },
   };
 }
+
+describe("Scheduler.schedule — permit stage", () => {
+  test("permit wait short-circuits before bind", async () => {
+    const bind = staticBind({ id: "s", role: "worker", status: "running" });
+    const bindSpy = { called: false };
+    const observingBind: BindPlugin = {
+      name: "watch",
+      bind: async (ctx, profile) => {
+        bindSpy.called = true;
+        return bind.bind(ctx, profile);
+      },
+    };
+    const scheduler = new Scheduler({
+      profiles: [profile("a")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [],
+      permits: [
+        { name: "manual", permit: async () => ({ status: "wait", reason: "awaiting-user" }) },
+      ],
+      bindPlugin: observingBind,
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("wait");
+    expect(bindSpy.called).toBe(false);
+    if (result.kind === "wait") {
+      expect(result.plugin).toBe("manual");
+      expect(result.reason).toBe("awaiting-user");
+      expect(result.profile.name).toBe("a");
+    }
+  });
+
+  test("permit denied short-circuits before bind", async () => {
+    const scheduler = new Scheduler({
+      profiles: [profile("a")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [],
+      permits: [
+        { name: "policy", permit: async () => ({ status: "denied", reason: "not-allowed" }) },
+      ],
+      bindPlugin: staticBind({ id: "s", role: "worker", status: "running" }),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    const result = await scheduler.schedule(taskView());
+
+    expect(result.kind).toBe("denied");
+    if (result.kind === "denied") {
+      expect(result.plugin).toBe("policy");
+      expect(result.reason).toBe("not-allowed");
+    }
+  });
+
+  test("permit stage stops at first non-granted verdict", async () => {
+    const calls: string[] = [];
+    const scheduler = new Scheduler({
+      profiles: [profile("a")],
+      filters: [alwaysAdmit("admit-all")],
+      scores: [],
+      permits: [
+        {
+          name: "first",
+          permit: async () => {
+            calls.push("first");
+            return { status: "wait", reason: "later" };
+          },
+        },
+        {
+          name: "second",
+          permit: async () => {
+            calls.push("second");
+            return { status: "granted" };
+          },
+        },
+      ],
+      bindPlugin: staticBind({ id: "s", role: "worker", status: "running" }),
+      store: emptyStore(),
+      now: () => 0,
+    });
+
+    await scheduler.schedule(taskView());
+
+    expect(calls).toEqual(["first"]);
+  });
+});

--- a/src/core/scheduler/scheduler.ts
+++ b/src/core/scheduler/scheduler.ts
@@ -62,6 +62,28 @@ export class Scheduler {
     }
 
     const winner = await this.pickWinner(ctx, admitted.map((entry) => entry.profile));
+
+    for (const plugin of this.permits) {
+      const verdict = await plugin.permit(ctx, winner);
+      if (verdict.status === "denied") {
+        return {
+          kind: "denied",
+          plugin: plugin.name,
+          reason: verdict.reason,
+          message: verdict.message,
+        };
+      }
+      if (verdict.status === "wait") {
+        return {
+          kind: "wait",
+          plugin: plugin.name,
+          reason: verdict.reason,
+          message: verdict.message,
+          profile: winner,
+        };
+      }
+    }
+
     const { session } = await this.bindPlugin.bind(ctx, winner);
     return { kind: "bound", profile: winner, session, reservationToken: undefined };
   }

--- a/src/core/scheduler/scheduler.ts
+++ b/src/core/scheduler/scheduler.ts
@@ -61,8 +61,7 @@ export class Scheduler {
       return { kind: "unschedulable", rejections: filtered };
     }
 
-    // Score/permit/bind are added in later tasks. For Task 4, take the first admitted profile.
-    const winner = admitted[0]!.profile;
+    const winner = await this.pickWinner(ctx, admitted.map((entry) => entry.profile));
     const { session } = await this.bindPlugin.bind(ctx, winner);
     return { kind: "bound", profile: winner, session, reservationToken: undefined };
   }
@@ -84,6 +83,34 @@ export class Scheduler {
         return { profile, rejections } satisfies ProfileRejection;
       }),
     );
+  }
+
+  private async pickWinner(
+    ctx: SchedulerContext,
+    admitted: readonly RuntimeProfile[],
+  ): Promise<RuntimeProfile> {
+    if (admitted.length === 1) return admitted[0]!;
+
+    const totals = new Map<string, number>();
+    for (const profile of admitted) totals.set(profile.name, 0);
+
+    for (const entry of this.scores) {
+      const weight = entry.weight ?? 1;
+      for (const profile of admitted) {
+        const raw = await entry.plugin.score(ctx, profile);
+        totals.set(profile.name, (totals.get(profile.name) ?? 0) + raw * weight);
+      }
+    }
+
+    const orderIndex = (profile: RuntimeProfile): number =>
+      ctx.profiles.findIndex((candidate) => candidate.name === profile.name);
+
+    const ranked = [...admitted].sort((a, b) => {
+      const diff = (totals.get(b.name) ?? 0) - (totals.get(a.name) ?? 0);
+      if (diff !== 0) return diff;
+      return orderIndex(a) - orderIndex(b);
+    });
+    return ranked[0]!;
   }
 }
 

--- a/src/core/scheduler/scheduler.ts
+++ b/src/core/scheduler/scheduler.ts
@@ -1,0 +1,95 @@
+import type { AgentTaskView } from "../agent-task.js";
+import type {
+  BindPlugin,
+  FilterPlugin,
+  FilterRejection,
+  PermitPlugin,
+  ProfileRejection,
+  SchedulerContext,
+  SchedulingResult,
+  ScorePlugin,
+} from "./framework.js";
+import type { RuntimeProfile } from "./profile.js";
+import { synthesizeFallbackProfile } from "./profile.js";
+
+export interface SchedulerOptions {
+  readonly profiles: readonly RuntimeProfile[];
+  readonly filters: readonly FilterPlugin[];
+  readonly scores: readonly ScorePluginEntry[];
+  readonly permits: readonly PermitPlugin[];
+  readonly bindPlugin: BindPlugin;
+  readonly store: SchedulerContext["store"];
+  readonly now?: (() => number) | undefined;
+}
+
+export interface ScorePluginEntry {
+  readonly plugin: ScorePlugin;
+  readonly weight?: number | undefined;
+}
+
+export class Scheduler {
+  private readonly profiles: readonly RuntimeProfile[];
+  private readonly filters: readonly FilterPlugin[];
+  private readonly scores: readonly ScorePluginEntry[];
+  private readonly permits: readonly PermitPlugin[];
+  private readonly bindPlugin: BindPlugin;
+  private readonly store: SchedulerContext["store"];
+  private readonly now: () => number;
+
+  constructor(options: SchedulerOptions) {
+    this.profiles = options.profiles;
+    this.filters = options.filters;
+    this.scores = normalizeScores(options.scores);
+    this.permits = options.permits;
+    this.bindPlugin = options.bindPlugin;
+    this.store = options.store;
+    this.now = options.now ?? Date.now;
+  }
+
+  async schedule(task: AgentTaskView): Promise<SchedulingResult> {
+    const profiles = this.profiles.length > 0 ? this.profiles : [synthesizeFallbackProfile(task)];
+    const ctx: SchedulerContext = {
+      task,
+      profiles,
+      store: this.store,
+      now: this.now,
+    };
+
+    const filtered = await this.runFilters(ctx);
+    const admitted = filtered.filter((entry) => entry.rejections.length === 0);
+    if (admitted.length === 0) {
+      return { kind: "unschedulable", rejections: filtered };
+    }
+
+    // Score/permit/bind are added in later tasks. For Task 4, take the first admitted profile.
+    const winner = admitted[0]!.profile;
+    const { session } = await this.bindPlugin.bind(ctx, winner);
+    return { kind: "bound", profile: winner, session, reservationToken: undefined };
+  }
+
+  private async runFilters(ctx: SchedulerContext): Promise<readonly ProfileRejection[]> {
+    return Promise.all(
+      ctx.profiles.map(async (profile) => {
+        const rejections: FilterRejection[] = [];
+        for (const plugin of this.filters) {
+          const verdict = await plugin.filter(ctx, profile);
+          if (!verdict.admit) {
+            rejections.push({
+              plugin: plugin.name,
+              reason: verdict.reason,
+              message: verdict.message,
+            });
+          }
+        }
+        return { profile, rejections } satisfies ProfileRejection;
+      }),
+    );
+  }
+}
+
+function normalizeScores(scores: readonly ScorePluginEntry[]): readonly ScorePluginEntry[] {
+  return scores.map((entry) => ({
+    plugin: entry.plugin,
+    weight: entry.weight ?? 1,
+  }));
+}

--- a/src/core/scheduler/upstream-prompt.test.ts
+++ b/src/core/scheduler/upstream-prompt.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { buildPromptWithUpstream, type UpstreamSection } from "./upstream-prompt.js";
+
+describe("buildPromptWithUpstream", () => {
+  test("returns base prompt unchanged when no upstream sections", () => {
+    expect(buildPromptWithUpstream("do work", [])).toBe("do work");
+  });
+
+  test("wraps base prompt with single upstream section", () => {
+    const sections: UpstreamSection[] = [{ taskId: "coder-1", summary: "Implemented X." }];
+    const out = buildPromptWithUpstream("Review my changes.", sections);
+    expect(out).toContain("## Upstream output");
+    expect(out).toContain("### coder-1 (succeeded)");
+    expect(out).toContain("Implemented X.");
+    expect(out).toContain("## Your task");
+    expect(out).toContain("Review my changes.");
+  });
+
+  test("concatenates multiple sections in order", () => {
+    const sections: UpstreamSection[] = [
+      { taskId: "a", summary: "first" },
+      { taskId: "b", summary: "second" },
+    ];
+    const out = buildPromptWithUpstream("base", sections);
+    const aIdx = out.indexOf("### a (succeeded)");
+    const bIdx = out.indexOf("### b (succeeded)");
+    expect(aIdx).toBeGreaterThanOrEqual(0);
+    expect(bIdx).toBeGreaterThan(aIdx);
+  });
+
+  test("substitutes '(no summary)' when summary is empty", () => {
+    const sections: UpstreamSection[] = [{ taskId: "a", summary: "" }];
+    const out = buildPromptWithUpstream("base", sections);
+    expect(out).toContain("(no summary)");
+  });
+});

--- a/src/core/scheduler/upstream-prompt.ts
+++ b/src/core/scheduler/upstream-prompt.ts
@@ -1,0 +1,15 @@
+export interface UpstreamSection {
+  readonly taskId: string;
+  readonly summary: string;
+}
+
+export function buildPromptWithUpstream(
+  basePrompt: string,
+  sections: readonly UpstreamSection[],
+): string {
+  if (sections.length === 0) return basePrompt;
+  const blocks = sections.map(
+    (s) => `### ${s.taskId} (succeeded)\n${s.summary.length > 0 ? s.summary : "(no summary)"}`,
+  );
+  return `## Upstream output\n\n${blocks.join("\n\n")}\n\n## Your task\n\n${basePrompt}`;
+}

--- a/src/core/task-controller.test.ts
+++ b/src/core/task-controller.test.ts
@@ -9,6 +9,9 @@ import {
 } from "./agent-task.js";
 import { type CasMutationResult, type CasOpts, casOk } from "./cas.js";
 import type { Condition } from "./entity.js";
+import type { BindPlugin, FilterPlugin, PermitPlugin } from "./scheduler/framework.js";
+import type { RuntimeProfile } from "./scheduler/profile.js";
+import { Scheduler } from "./scheduler/scheduler.js";
 import type { AgentTaskStatusPatch } from "./store.js";
 import {
   DefaultTaskBinder,
@@ -18,9 +21,6 @@ import {
   type TaskControllerStore,
 } from "./task-controller.js";
 import { KeyedWorkQueue } from "./workqueue.js";
-import { Scheduler } from "./scheduler/scheduler.js";
-import type { BindPlugin, FilterPlugin, PermitPlugin } from "./scheduler/framework.js";
-import type { RuntimeProfile } from "./scheduler/profile.js";
 
 const FIXED_NOW_MS = Date.parse("2026-05-14T12:00:00.000Z");
 const FIXED_NOW_ISO = "2026-05-14T12:00:00.000Z";
@@ -928,6 +928,81 @@ describe("TaskController + Scheduler integration", () => {
     expect(binder.calls).toHaveLength(1);
     const patch = onlyPatch(store).patch;
     expect(patch.phase).toBe(AgentTaskPhase.Running);
+  });
+});
+
+describe("TaskController — cascade-fail on Failed dependency", () => {
+  test("Pending task with Failed dependency transitions to Failed", async () => {
+    const store = new FakeTaskStore();
+    store.seed(
+      taskView({
+        id: "dep-1",
+        phase: AgentTaskPhase.Failed,
+        observedGeneration: 1,
+      }),
+    );
+    store.seed(
+      taskView({
+        id: "task-2",
+        phase: AgentTaskPhase.Pending,
+        dependsOn: ["dep-1"],
+        observedGeneration: 1,
+      }),
+    );
+    const controller = controllerFor(store);
+
+    await controller.reconcileTask("task-2");
+
+    const patch = store.patches.find((p) => p.taskId === "task-2")?.patch;
+    expect(patch?.phase).toBe(AgentTaskPhase.Failed);
+    expect(condition(patch?.conditions, "Failed")?.reason).toBe("dependency-failed");
+    expect(condition(patch?.conditions, "Failed")?.message).toContain("dep-1");
+  });
+
+  test("Pending task with Succeeded dependency advances normally", async () => {
+    const store = new FakeTaskStore();
+    store.seed(
+      taskView({
+        id: "dep-1",
+        phase: AgentTaskPhase.Succeeded,
+        observedGeneration: 1,
+      }),
+    );
+    store.seed(
+      taskView({
+        id: "task-2",
+        phase: AgentTaskPhase.Pending,
+        dependsOn: ["dep-1"],
+        observedGeneration: 1,
+      }),
+    );
+    const controller = controllerFor(store);
+
+    await controller.reconcileTask("task-2");
+
+    const patch = store.patches.find((p) => p.taskId === "task-2")?.patch;
+    expect(patch?.phase).toBe(AgentTaskPhase.PendingBind);
+  });
+
+  test("Pending task with mix of Failed + Pending deps fails (Failed wins)", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ id: "dep-a", phase: AgentTaskPhase.Failed, observedGeneration: 1 }));
+    store.seed(taskView({ id: "dep-b", phase: AgentTaskPhase.Pending, observedGeneration: 1 }));
+    store.seed(
+      taskView({
+        id: "task-x",
+        phase: AgentTaskPhase.Pending,
+        dependsOn: ["dep-a", "dep-b"],
+        observedGeneration: 1,
+      }),
+    );
+    const controller = controllerFor(store);
+
+    await controller.reconcileTask("task-x");
+
+    const patch = store.patches.find((p) => p.taskId === "task-x")?.patch;
+    expect(patch?.phase).toBe(AgentTaskPhase.Failed);
+    expect(condition(patch?.conditions, "Failed")?.message).toContain("dep-a");
   });
 });
 

--- a/src/core/task-controller.test.ts
+++ b/src/core/task-controller.test.ts
@@ -18,6 +18,9 @@ import {
   type TaskControllerStore,
 } from "./task-controller.js";
 import { KeyedWorkQueue } from "./workqueue.js";
+import { Scheduler } from "./scheduler/scheduler.js";
+import type { BindPlugin, FilterPlugin, PermitPlugin } from "./scheduler/framework.js";
+import type { RuntimeProfile } from "./scheduler/profile.js";
 
 const FIXED_NOW_MS = Date.parse("2026-05-14T12:00:00.000Z");
 const FIXED_NOW_ISO = "2026-05-14T12:00:00.000Z";
@@ -767,3 +770,163 @@ async function waitFor(predicate: () => boolean): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 1));
   }
 }
+
+function profile(name = "primary"): RuntimeProfile {
+  return { name, platform: "claude-code", runtimeCommand: "claude" };
+}
+
+function alwaysAdmit(name = "admit"): FilterPlugin {
+  return { name, filter: async () => ({ admit: true }) };
+}
+
+function alwaysReject(reason: string): FilterPlugin {
+  return { name: "reject", filter: async () => ({ admit: false, reason }) };
+}
+
+function autoPermit(): PermitPlugin {
+  return { name: "auto", permit: async () => ({ status: "granted" }) };
+}
+
+function denyPermit(reason: string): PermitPlugin {
+  return { name: "deny", permit: async () => ({ status: "denied", reason }) };
+}
+
+function waitPermit(reason: string): PermitPlugin {
+  return { name: "wait", permit: async () => ({ status: "wait", reason }) };
+}
+
+function recordingBind(): BindPlugin & { calls: number } {
+  const plugin = {
+    name: "rec",
+    calls: 0,
+    async bind() {
+      plugin.calls += 1;
+      return { session: { id: "boundsess", role: "worker", status: "running" } as AgentSession };
+    },
+  };
+  return plugin;
+}
+
+describe("TaskController + Scheduler integration", () => {
+  test("bound decision transitions PendingBind → Running with sessionId", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const bindPlugin = recordingBind();
+    const scheduler = new Scheduler({
+      profiles: [profile()],
+      filters: [alwaysAdmit()],
+      scores: [],
+      permits: [autoPermit()],
+      bindPlugin,
+      store: { listAgentTaskEntities: store.listAgentTaskEntities },
+      now: () => FIXED_NOW_MS,
+    });
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      scheduler,
+      now: () => FIXED_NOW_MS,
+    });
+
+    await controller.reconcileTask("task-1");
+
+    expect(bindPlugin.calls).toBe(1);
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Running);
+    expect(patch.sessionId).toBe("boundsess");
+    expect(condition(patch.conditions, "Bound")?.status).toBe("True");
+    expect(condition(patch.conditions, "Running")?.status).toBe("True");
+  });
+
+  test("unschedulable result keeps PendingBind and sets Unschedulable condition", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const scheduler = new Scheduler({
+      profiles: [profile()],
+      filters: [alwaysReject("filter-x")],
+      scores: [],
+      permits: [autoPermit()],
+      bindPlugin: recordingBind(),
+      store: { listAgentTaskEntities: store.listAgentTaskEntities },
+      now: () => FIXED_NOW_MS,
+    });
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      scheduler,
+      now: () => FIXED_NOW_MS,
+    });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBeUndefined();
+    expect(condition(patch.conditions, "Unschedulable")?.status).toBe("True");
+    expect(condition(patch.conditions, "Unschedulable")?.message).toContain("filter-x");
+  });
+
+  test("wait result keeps PendingBind and sets PermitRequired condition", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const scheduler = new Scheduler({
+      profiles: [profile()],
+      filters: [alwaysAdmit()],
+      scores: [],
+      permits: [waitPermit("awaiting-user")],
+      bindPlugin: recordingBind(),
+      store: { listAgentTaskEntities: store.listAgentTaskEntities },
+      now: () => FIXED_NOW_MS,
+    });
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      scheduler,
+      now: () => FIXED_NOW_MS,
+    });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBeUndefined();
+    expect(condition(patch.conditions, "PermitRequired")?.reason).toBe("awaiting-user");
+  });
+
+  test("denied result transitions to Failed", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const scheduler = new Scheduler({
+      profiles: [profile()],
+      filters: [alwaysAdmit()],
+      scores: [],
+      permits: [denyPermit("not-allowed")],
+      bindPlugin: recordingBind(),
+      store: { listAgentTaskEntities: store.listAgentTaskEntities },
+      now: () => FIXED_NOW_MS,
+    });
+    const controller = new TaskController({
+      taskStore: store,
+      runtime: new FakeRuntime(),
+      scheduler,
+      now: () => FIXED_NOW_MS,
+    });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Failed);
+    expect(condition(patch.conditions, "Failed")?.reason).toBe("not-allowed");
+  });
+
+  test("controller without scheduler still uses direct binder path (back-compat)", async () => {
+    const store = new FakeTaskStore();
+    store.seed(taskView({ phase: AgentTaskPhase.PendingBind, observedGeneration: 1 }));
+    const binder = new FakeBinder();
+    const controller = controllerFor(store, { binder });
+
+    await controller.reconcileTask("task-1");
+
+    expect(binder.calls).toHaveLength(1);
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Running);
+  });
+});

--- a/src/core/task-controller.test.ts
+++ b/src/core/task-controller.test.ts
@@ -930,3 +930,87 @@ describe("TaskController + Scheduler integration", () => {
     expect(patch.phase).toBe(AgentTaskPhase.Running);
   });
 });
+
+describe("TaskController — DoneSignaled → Succeeded", () => {
+  function viewWithCondition(
+    overrides: { sessionId?: string; doneSummary?: string } = {},
+  ): AgentTaskView {
+    return taskView({
+      phase: AgentTaskPhase.Running,
+      sessionId: overrides.sessionId ?? "session-running",
+      observedGeneration: 1,
+      conditions:
+        overrides.doneSummary === undefined
+          ? []
+          : [
+              makeCondition("DoneSignaled", {
+                status: "True",
+                reason: "agent-grove-done",
+                message: overrides.doneSummary,
+              }),
+            ],
+    });
+  }
+
+  test("Running task with DoneSignaled=True transitions to Succeeded", async () => {
+    const store = new FakeTaskStore();
+    store.seed(viewWithCondition({ doneSummary: "Approved by reviewer." }));
+    const runtime = new FakeRuntime();
+    runtime.sessions.set("session-running", {
+      id: "session-running",
+      role: "worker",
+      status: "running",
+    });
+    const controller = controllerFor(store, { runtime });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Succeeded);
+    expect(condition(patch.conditions, "Succeeded")?.status).toBe("True");
+    expect(condition(patch.conditions, "Succeeded")?.message).toBe("Approved by reviewer.");
+    expect(condition(patch.conditions, "Running")?.status).toBe("False");
+  });
+
+  test("DoneSignaled takes precedence over session-status-stopped", async () => {
+    const store = new FakeTaskStore();
+    store.seed(viewWithCondition({ doneSummary: "Done." }));
+    const runtime = new FakeRuntime(); // no live session
+    const controller = controllerFor(store, { runtime });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Succeeded);
+  });
+
+  test("Running task without DoneSignaled and lost session still fails (back-compat)", async () => {
+    const store = new FakeTaskStore();
+    store.seed(viewWithCondition({}));
+    const runtime = new FakeRuntime();
+    const controller = controllerFor(store, { runtime });
+
+    await controller.reconcileTask("task-1");
+
+    const patch = onlyPatch(store).patch;
+    expect(patch.phase).toBe(AgentTaskPhase.Failed);
+  });
+
+  test("Succeeded transition closes runtime session", async () => {
+    const store = new FakeTaskStore();
+    store.seed(viewWithCondition({ doneSummary: "ok" }));
+    const runtime = new FakeRuntime();
+    const session = {
+      id: "session-running",
+      role: "worker",
+      status: "running" as const,
+    };
+    runtime.sessions.set(session.id, session);
+    const controller = controllerFor(store, { runtime });
+
+    await controller.reconcileTask("task-1");
+
+    expect(runtime.closeCalls).toHaveLength(1);
+    expect(runtime.closeCalls[0]?.id).toBe(session.id);
+  });
+});

--- a/src/core/task-controller.ts
+++ b/src/core/task-controller.ts
@@ -55,6 +55,7 @@ interface ReconciliationResult {
   readonly patch: AgentTaskStatusPatch;
   readonly transition: AgentTaskStatusTransition;
   readonly sessionToCloseOnPatchFailure?: AgentSession | undefined;
+  readonly sessionToCloseOnSuccess?: AgentSession | undefined;
 }
 
 const DEFAULT_RESYNC_INTERVAL_MS = 30_000;
@@ -154,6 +155,9 @@ export class TaskController {
       throw error;
     }
     this.onTransition?.(result.transition);
+    if (result.sessionToCloseOnSuccess !== undefined) {
+      await this.closeAfterPatchFailure(result.sessionToCloseOnSuccess);
+    }
     return result.transition;
   }
 
@@ -430,6 +434,15 @@ export class TaskController {
       return failLostSession(task, this.nowIso());
     }
 
+    const doneCondition = task.status.conditions.find(
+      (c) => c.type === AgentTaskConditionType.DoneSignaled && c.status === "True",
+    );
+    if (doneCondition !== undefined) {
+      const sessions = await this.runtime.listSessions();
+      const session = sessions.find((s) => s.id === task.status.sessionId);
+      return succeedTask(task, doneCondition.message ?? "", this.nowIso(), session);
+    }
+
     const sessions = await this.runtime.listSessions();
     const session = sessions.find((candidate) => candidate.id === task.status.sessionId);
     if (session !== undefined && (session.status === "running" || session.status === "idle")) {
@@ -498,6 +511,42 @@ function runningLiveCatchUp(task: AgentTaskView, nowIso: string): Reconciliation
         patch,
         transition: transition(task, AgentTaskPhase.Running, "session-running"),
       };
+}
+
+function succeedTask(
+  task: AgentTaskView,
+  summary: string,
+  nowIso: string,
+  session: AgentSession | undefined,
+): ReconciliationResult {
+  const conditions = upsertCondition(
+    upsertCondition(task.status.conditions, {
+      type: AgentTaskConditionType.Running,
+      status: "False",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "done-signaled",
+      message: "",
+    }),
+    {
+      type: AgentTaskConditionType.Succeeded,
+      status: "True",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "done-signaled",
+      message: summary,
+    },
+  );
+  return {
+    patch: {
+      phase: AgentTaskPhase.Succeeded,
+      observedGeneration: task.spec.generation,
+      conditions,
+      lastTransitionAt: nowIso,
+    },
+    transition: transition(task, AgentTaskPhase.Succeeded, "done-signaled"),
+    ...(session === undefined ? {} : { sessionToCloseOnSuccess: session }),
+  };
 }
 
 function failLostSession(task: AgentTaskView, nowIso: string): ReconciliationResult {

--- a/src/core/task-controller.ts
+++ b/src/core/task-controller.ts
@@ -235,10 +235,40 @@ export class TaskController {
   }
 
   private async reconcilePending(task: AgentTaskView): Promise<ReconciliationResult | undefined> {
-    const blockedOn = await this.blockingDependencies(task);
+    const { blocked, failed } = await this.dependencyStates(task);
     const nowIso = this.nowIso();
 
-    if (blockedOn.length > 0) {
+    if (failed.length > 0) {
+      const conditions = upsertCondition(
+        upsertCondition(task.status.conditions, {
+          type: AgentTaskConditionType.Blocked,
+          status: "False",
+          observedGeneration: task.spec.generation,
+          lastTransitionTime: nowIso,
+          reason: "dependency-failed",
+          message: "",
+        }),
+        {
+          type: AgentTaskConditionType.Failed,
+          status: "True",
+          observedGeneration: task.spec.generation,
+          lastTransitionTime: nowIso,
+          reason: "dependency-failed",
+          message: `Dependency failed: ${failed.join(", ")}`,
+        },
+      );
+      return {
+        patch: {
+          phase: AgentTaskPhase.Failed,
+          observedGeneration: task.spec.generation,
+          conditions,
+          lastTransitionAt: nowIso,
+        },
+        transition: transition(task, AgentTaskPhase.Failed, "dependency-failed"),
+      };
+    }
+
+    if (blocked.length > 0) {
       const patch: AgentTaskStatusPatch = {
         phase: AgentTaskPhase.Pending,
         observedGeneration: task.spec.generation,
@@ -248,7 +278,7 @@ export class TaskController {
           observedGeneration: task.spec.generation,
           lastTransitionTime: nowIso,
           reason: "depends-on",
-          message: `Waiting for ${blockedOn.join(", ")}`,
+          message: `Waiting for ${blocked.join(", ")}`,
         }),
       };
       return statusPatchIsNoOp(task, patch)
@@ -453,15 +483,21 @@ export class TaskController {
     return failLostSession(task, this.nowIso());
   }
 
-  private async blockingDependencies(task: AgentTaskView): Promise<readonly string[]> {
+  private async dependencyStates(
+    task: AgentTaskView,
+  ): Promise<{ blocked: readonly string[]; failed: readonly string[] }> {
     const blocked: string[] = [];
+    const failed: string[] = [];
     for (const dependencyId of task.spec.dependsOn) {
       const dependency = await this.taskStore.getAgentTask(dependencyId);
-      if (dependency?.status.phase !== AgentTaskPhase.Succeeded) {
+      const phase = dependency?.status.phase;
+      if (phase === AgentTaskPhase.Failed) {
+        failed.push(dependencyId);
+      } else if (phase !== AgentTaskPhase.Succeeded) {
         blocked.push(dependencyId);
       }
     }
-    return blocked;
+    return { blocked, failed };
   }
 
   private nowIso(): string {

--- a/src/core/task-controller.ts
+++ b/src/core/task-controller.ts
@@ -6,6 +6,8 @@ import {
   type AgentTaskView,
 } from "./agent-task.js";
 import type { Condition } from "./entity.js";
+import type { SchedulingResult } from "./scheduler/framework.js";
+import type { Scheduler } from "./scheduler/scheduler.js";
 import type { AgentTaskStatusPatch, AgentTaskStore } from "./store.js";
 import { KeyedWorkQueue, QueueClosedError, type WorkItemResult } from "./workqueue.js";
 
@@ -46,6 +48,7 @@ export interface TaskControllerOptions {
   readonly now?: (() => number) | undefined;
   readonly onError?: ((error: unknown, taskId: string) => void) | undefined;
   readonly onTransition?: ((transition: AgentTaskStatusTransition) => void) | undefined;
+  readonly scheduler?: Scheduler | undefined;
 }
 
 interface ReconciliationResult {
@@ -92,6 +95,7 @@ export class TaskController {
   private readonly taskStore: TaskControllerStore;
   private readonly runtime: TaskControllerRuntime;
   private readonly binder: TaskBinder;
+  private readonly scheduler: Scheduler | undefined;
   private readonly queue: KeyedWorkQueue;
   private readonly now: () => number;
   private readonly resyncIntervalMs: number;
@@ -107,6 +111,7 @@ export class TaskController {
     this.taskStore = options.taskStore;
     this.runtime = options.runtime;
     this.binder = options.binder ?? new DefaultTaskBinder(options.runtime);
+    this.scheduler = options.scheduler;
     this.now = options.now ?? Date.now;
     this.queue = options.queue ?? new KeyedWorkQueue({ now: this.now });
     this.resyncIntervalMs = options.resyncIntervalMs ?? DEFAULT_RESYNC_INTERVAL_MS;
@@ -275,6 +280,17 @@ export class TaskController {
       return this.reconcileRunning(task);
     }
 
+    if (this.scheduler === undefined) {
+      return this.directBindPendingBind(task);
+    }
+
+    const decision = await this.scheduler.schedule(task);
+    return this.applySchedulingDecision(task, decision);
+  }
+
+  private async directBindPendingBind(
+    task: AgentTaskView,
+  ): Promise<ReconciliationResult | undefined> {
     const { session } = await this.binder.bind({ task });
     const nowIso = this.nowIso();
     const conditions = upsertCondition(
@@ -306,6 +322,106 @@ export class TaskController {
       },
       transition: transition(task, AgentTaskPhase.Running, "session-bound"),
       sessionToCloseOnPatchFailure: session,
+    };
+  }
+
+  private applySchedulingDecision(
+    task: AgentTaskView,
+    decision: SchedulingResult,
+  ): ReconciliationResult | undefined {
+    const nowIso = this.nowIso();
+
+    if (decision.kind === "bound") {
+      const conditions = upsertCondition(
+        upsertCondition(task.status.conditions, {
+          type: AgentTaskConditionType.Bound,
+          status: "True",
+          observedGeneration: task.spec.generation,
+          lastTransitionTime: nowIso,
+          reason: "session-bound",
+          message: "",
+        }),
+        {
+          type: AgentTaskConditionType.Running,
+          status: "True",
+          observedGeneration: task.spec.generation,
+          lastTransitionTime: nowIso,
+          reason: "session-running",
+          message: "",
+        },
+      );
+      return {
+        patch: {
+          phase: AgentTaskPhase.Running,
+          sessionId: decision.session.id,
+          observedGeneration: task.spec.generation,
+          conditions,
+          lastTransitionAt: nowIso,
+        },
+        transition: transition(task, AgentTaskPhase.Running, "session-bound"),
+        sessionToCloseOnPatchFailure: decision.session,
+      };
+    }
+
+    if (decision.kind === "unschedulable") {
+      const reasons = decision.rejections
+        .flatMap((entry) =>
+          entry.rejections.map((r) => `${entry.profile.name}/${r.plugin}:${r.reason}`),
+        )
+        .slice(0, 3);
+      const message = reasons.length === 0 ? "no candidate profiles" : reasons.join("; ");
+      const conditions = upsertCondition(task.status.conditions, {
+        type: AgentTaskConditionType.Unschedulable,
+        status: "True",
+        observedGeneration: task.spec.generation,
+        lastTransitionTime: nowIso,
+        reason: "no-candidate",
+        message,
+      });
+      return {
+        patch: {
+          observedGeneration: task.spec.generation,
+          conditions,
+        },
+        transition: transition(task, AgentTaskPhase.PendingBind, "unschedulable"),
+      };
+    }
+
+    if (decision.kind === "wait") {
+      const conditions = upsertCondition(task.status.conditions, {
+        type: AgentTaskConditionType.PermitRequired,
+        status: "True",
+        observedGeneration: task.spec.generation,
+        lastTransitionTime: nowIso,
+        reason: decision.reason,
+        message: decision.message ?? `permit '${decision.plugin}' is waiting`,
+      });
+      return {
+        patch: {
+          observedGeneration: task.spec.generation,
+          conditions,
+        },
+        transition: transition(task, AgentTaskPhase.PendingBind, "permit-wait"),
+      };
+    }
+
+    // decision.kind === "denied"
+    const conditions = upsertCondition(task.status.conditions, {
+      type: AgentTaskConditionType.Failed,
+      status: "True",
+      observedGeneration: task.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: decision.reason,
+      message: decision.message ?? `permit '${decision.plugin}' denied`,
+    });
+    return {
+      patch: {
+        phase: AgentTaskPhase.Failed,
+        observedGeneration: task.spec.generation,
+        conditions,
+        lastTransitionAt: nowIso,
+      },
+      transition: transition(task, AgentTaskPhase.Failed, decision.reason),
     };
   }
 

--- a/src/core/task-controller.ts
+++ b/src/core/task-controller.ts
@@ -5,6 +5,7 @@ import {
   AgentTaskPhase,
   type AgentTaskView,
 } from "./agent-task.js";
+import { conditionEqual, upsertCondition } from "./condition-utils.js";
 import type { Condition } from "./entity.js";
 import type { SchedulingResult } from "./scheduler/framework.js";
 import type { Scheduler } from "./scheduler/scheduler.js";
@@ -660,43 +661,4 @@ function transition(
     reason,
     observedGeneration: task.spec.generation,
   };
-}
-
-function upsertCondition(
-  conditions: readonly Condition[],
-  desired: Condition,
-): readonly Condition[] {
-  const index = conditions.findIndex((condition) => condition.type === desired.type);
-  if (index === -1) {
-    return [...conditions, desired];
-  }
-
-  const existing = conditions[index];
-  if (existing === undefined) return conditions;
-  const next: Condition =
-    existing.status === desired.status &&
-    existing.reason === desired.reason &&
-    existing.message === desired.message
-      ? {
-          ...desired,
-          lastTransitionTime: existing.lastTransitionTime,
-        }
-      : desired;
-
-  if (conditionEqual(existing, next)) return conditions;
-
-  return conditions.map((condition, conditionIndex) =>
-    conditionIndex === index ? next : condition,
-  );
-}
-
-function conditionEqual(left: Condition, right: Condition): boolean {
-  return (
-    left.type === right.type &&
-    left.status === right.status &&
-    left.observedGeneration === right.observedGeneration &&
-    left.lastTransitionTime === right.lastTransitionTime &&
-    left.reason === right.reason &&
-    left.message === right.message
-  );
 }

--- a/src/mcp/agent-task-context.test.ts
+++ b/src/mcp/agent-task-context.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { readAgentTaskContext } from "./agent-task-context.js";
+
+describe("readAgentTaskContext", () => {
+  test("returns context when both env vars set", () => {
+    const ctx = readAgentTaskContext({
+      GROVE_AGENT_TASK_ID: "task-1",
+      GROVE_AGENT_TASK_GENERATION: "3",
+    });
+    expect(ctx).toEqual({ taskId: "task-1", generation: 3 });
+  });
+
+  test("returns undefined when taskId missing", () => {
+    const ctx = readAgentTaskContext({ GROVE_AGENT_TASK_GENERATION: "1" });
+    expect(ctx).toBeUndefined();
+  });
+
+  test("returns undefined when generation missing", () => {
+    const ctx = readAgentTaskContext({ GROVE_AGENT_TASK_ID: "x" });
+    expect(ctx).toBeUndefined();
+  });
+
+  test("returns undefined when generation is non-numeric", () => {
+    const ctx = readAgentTaskContext({
+      GROVE_AGENT_TASK_ID: "x",
+      GROVE_AGENT_TASK_GENERATION: "abc",
+    });
+    expect(ctx).toBeUndefined();
+  });
+});

--- a/src/mcp/agent-task-context.ts
+++ b/src/mcp/agent-task-context.ts
@@ -1,0 +1,15 @@
+export interface AgentTaskContext {
+  readonly taskId: string;
+  readonly generation: number;
+}
+
+export function readAgentTaskContext(
+  env: Readonly<Record<string, string | undefined>>,
+): AgentTaskContext | undefined {
+  const taskId = env.GROVE_AGENT_TASK_ID;
+  const gen = env.GROVE_AGENT_TASK_GENERATION;
+  if (taskId === undefined || gen === undefined) return undefined;
+  const generation = Number.parseInt(gen, 10);
+  if (!Number.isFinite(generation)) return undefined;
+  return { taskId, generation };
+}

--- a/src/mcp/agent-task-done.test.ts
+++ b/src/mcp/agent-task-done.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { signalAgentTaskDone } from "./agent-task-done.js";
+
+describe("signalAgentTaskDone", () => {
+  test("POSTs to /api/agent-tasks/:id/done with bearer auth", async () => {
+    type CallRecord = { url: string; init: RequestInit };
+    const calls: Array<CallRecord> = [];
+    const fakeFetch: typeof fetch = async (input, init) => {
+      const url = String(input);
+      calls.push({ url, init: init ?? {} });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+    const ctx = { taskId: "task-x", generation: 1 };
+    const opts = {
+      baseUrl: "http://localhost:4515",
+      token: "abc123",
+      fetchImpl: fakeFetch,
+    };
+    await signalAgentTaskDone(ctx, "review approved", opts);
+    expect(calls).toHaveLength(1);
+    const expectedUrl = "http://localhost:4515/api/agent-tasks/task-x/done";
+    expect(calls[0]?.url).toBe(expectedUrl);
+    const headers = calls[0]?.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer abc123");
+    const expectedBody = JSON.stringify({ summary: "review approved" });
+    expect(calls[0]?.init.body).toBe(expectedBody);
+  });
+
+  test("throws when baseUrl missing", async () => {
+    await expect(
+      signalAgentTaskDone({ taskId: "x", generation: 1 }, "s", {
+        baseUrl: undefined,
+        token: "t",
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/GROVE_SERVER_URL/);
+  });
+
+  test("throws when token missing", async () => {
+    await expect(
+      signalAgentTaskDone({ taskId: "x", generation: 1 }, "s", {
+        baseUrl: "http://x",
+        token: undefined,
+        fetchImpl: fetch,
+      }),
+    ).rejects.toThrow(/GROVE_API_TOKEN/);
+  });
+
+  test("throws on non-2xx response", async () => {
+    const fakeFetch: typeof fetch = async () => {
+      return new Response("not found", { status: 404 });
+    };
+    const ctx = { taskId: "x", generation: 1 };
+    const opts = { baseUrl: "http://x", token: "t", fetchImpl: fakeFetch };
+    await expect(signalAgentTaskDone(ctx, "s", opts)).rejects.toThrow(/404/);
+  });
+
+  test("encodes taskId for URL safety", async () => {
+    const calls: string[] = [];
+    const fakeFetch: typeof fetch = async (input) => {
+      calls.push(String(input));
+      return new Response("{}", { status: 200 });
+    };
+    const ctx = { taskId: "task/with/slashes", generation: 1 };
+    const opts = { baseUrl: "http://x", token: "t", fetchImpl: fakeFetch };
+    await signalAgentTaskDone(ctx, "s", opts);
+    const encoded = "http://x/api/agent-tasks/task%2Fwith%2Fslashes/done";
+    expect(calls[0]).toBe(encoded);
+  });
+});

--- a/src/mcp/agent-task-done.ts
+++ b/src/mcp/agent-task-done.ts
@@ -1,0 +1,35 @@
+import type { AgentTaskContext } from "./agent-task-context.js";
+
+export interface SignalAgentTaskDoneOptions {
+  readonly baseUrl: string | undefined;
+  readonly token: string | undefined;
+  readonly fetchImpl?: typeof fetch | undefined;
+}
+
+export async function signalAgentTaskDone(
+  ctx: AgentTaskContext,
+  summary: string,
+  options: SignalAgentTaskDoneOptions,
+): Promise<void> {
+  if (options.baseUrl === undefined || options.baseUrl.length === 0) {
+    throw new Error("GROVE_SERVER_URL not set; cannot signal AgentTask done");
+  }
+  if (options.token === undefined || options.token.length === 0) {
+    throw new Error("GROVE_API_TOKEN not set; cannot signal AgentTask done");
+  }
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const taskIdPath = encodeURIComponent(ctx.taskId);
+  const url = `${options.baseUrl}/api/agent-tasks/${taskIdPath}/done`;
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${options.token}`,
+    },
+    body: JSON.stringify({ summary }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`POST /done returned ${res.status}: ${text}`);
+  }
+}

--- a/src/mcp/tools/done.test.ts
+++ b/src/mcp/tools/done.test.ts
@@ -28,6 +28,139 @@ async function callTool(
   };
 }
 
+const agentArgs = { agentId: "test-agent", role: "reviewer" };
+
+describe("grove_done — AgentTask bridge", () => {
+  let testDeps: TestMcpDeps;
+  let deps: McpDeps;
+  let server: McpServer;
+
+  beforeEach(async () => {
+    testDeps = await createTestMcpDeps();
+    deps = testDeps.deps;
+    server = new McpServer({ name: "test", version: "0.0.1" }, { capabilities: { tools: {} } });
+    registerDoneTools(server, deps);
+  });
+
+  afterEach(async () => {
+    await testDeps.cleanup();
+  });
+
+  test("when GROVE_AGENT_TASK_ID set, POSTs /done before contributeOperation", async () => {
+    const originalEnv = {
+      taskId: process.env.GROVE_AGENT_TASK_ID,
+      gen: process.env.GROVE_AGENT_TASK_GENERATION,
+      url: process.env.GROVE_SERVER_URL,
+      token: process.env.GROVE_API_TOKEN,
+    };
+    process.env.GROVE_AGENT_TASK_ID = "task-1";
+    process.env.GROVE_AGENT_TASK_GENERATION = "1";
+    process.env.GROVE_SERVER_URL = "http://localhost:4515";
+    process.env.GROVE_API_TOKEN = "tok";
+
+    const order: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      order.push(`fetch ${String(input)}`);
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const result = await callTool(server, "grove_done", {
+        summary: "looks good",
+        agent: agentArgs,
+      });
+
+      expect(result.isError).toBeUndefined();
+      // fetch came first
+      expect(order.length).toBe(1);
+      expect(order[0]).toContain("http://localhost:4515/api/agent-tasks/task-1/done");
+      // contribution was still written
+      const data = JSON.parse(result.text) as { cid: string };
+      const stored = await deps.contributionStore.get(data.cid);
+      expect(stored?.context?.done).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalEnv.taskId === undefined) delete process.env.GROVE_AGENT_TASK_ID;
+      else process.env.GROVE_AGENT_TASK_ID = originalEnv.taskId;
+      if (originalEnv.gen === undefined) delete process.env.GROVE_AGENT_TASK_GENERATION;
+      else process.env.GROVE_AGENT_TASK_GENERATION = originalEnv.gen;
+      if (originalEnv.url === undefined) delete process.env.GROVE_SERVER_URL;
+      else process.env.GROVE_SERVER_URL = originalEnv.url;
+      if (originalEnv.token === undefined) delete process.env.GROVE_API_TOKEN;
+      else process.env.GROVE_API_TOKEN = originalEnv.token;
+    }
+  });
+
+  test("when env vars absent, no fetch and contribution still writes (back-compat)", async () => {
+    const original = process.env.GROVE_AGENT_TASK_ID;
+    delete process.env.GROVE_AGENT_TASK_ID;
+
+    let fetched = false;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetched = true;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const result = await callTool(server, "grove_done", {
+        summary: "no task context",
+        agent: agentArgs,
+      });
+
+      expect(fetched).toBe(false);
+      expect(result.isError).toBeUndefined();
+      const data = JSON.parse(result.text) as { cid: string };
+      const stored = await deps.contributionStore.get(data.cid);
+      expect(stored?.context?.done).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (original !== undefined) process.env.GROVE_AGENT_TASK_ID = original;
+    }
+  });
+
+  test("POST failure logs warning but contribution still writes", async () => {
+    const originalEnv = {
+      taskId: process.env.GROVE_AGENT_TASK_ID,
+      gen: process.env.GROVE_AGENT_TASK_GENERATION,
+      url: process.env.GROVE_SERVER_URL,
+      token: process.env.GROVE_API_TOKEN,
+    };
+    process.env.GROVE_AGENT_TASK_ID = "task-1";
+    process.env.GROVE_AGENT_TASK_GENERATION = "1";
+    process.env.GROVE_SERVER_URL = "http://localhost:4515";
+    process.env.GROVE_API_TOKEN = "tok";
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response("server down", { status: 500 })) as typeof fetch;
+
+    try {
+      const result = await callTool(server, "grove_done", {
+        summary: "done despite server error",
+        agent: agentArgs,
+      });
+
+      // must not throw — tool should swallow the POST failure
+      expect(result.isError).toBeUndefined();
+      // contribution was still written
+      const data = JSON.parse(result.text) as { cid: string };
+      const stored = await deps.contributionStore.get(data.cid);
+      expect(stored?.context?.done).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalEnv.taskId === undefined) delete process.env.GROVE_AGENT_TASK_ID;
+      else process.env.GROVE_AGENT_TASK_ID = originalEnv.taskId;
+      if (originalEnv.gen === undefined) delete process.env.GROVE_AGENT_TASK_GENERATION;
+      else process.env.GROVE_AGENT_TASK_GENERATION = originalEnv.gen;
+      if (originalEnv.url === undefined) delete process.env.GROVE_SERVER_URL;
+      else process.env.GROVE_SERVER_URL = originalEnv.url;
+      if (originalEnv.token === undefined) delete process.env.GROVE_API_TOKEN;
+      else process.env.GROVE_API_TOKEN = originalEnv.token;
+    }
+  });
+});
+
 describe("grove_done", () => {
   let testDeps: TestMcpDeps;
   let deps: McpDeps;

--- a/src/mcp/tools/done.ts
+++ b/src/mcp/tools/done.ts
@@ -18,6 +18,8 @@ import type { JsonValue } from "../../core/models.js";
 import type { AgentOverrides } from "../../core/operations/agent.js";
 import { contributeOperation } from "../../core/operations/index.js";
 import { bindAgentIdentity } from "../agent-binding.js";
+import { readAgentTaskContext } from "../agent-task-context.js";
+import { signalAgentTaskDone } from "../agent-task-done.js";
 import type { McpDeps } from "../deps.js";
 import { toMcpResult, toOperationDeps } from "../operation-adapter.js";
 import { agentSchema } from "../schemas.js";
@@ -43,6 +45,20 @@ export function registerDoneTools(server: McpServer, deps: McpDeps): void {
       inputSchema: doneInputSchema,
     },
     async (args) => {
+      const taskCtx = readAgentTaskContext(process.env);
+      if (taskCtx !== undefined) {
+        try {
+          await signalAgentTaskDone(taskCtx, args.summary, {
+            baseUrl: process.env.GROVE_SERVER_URL,
+            token: process.env.GROVE_API_TOKEN,
+          });
+        } catch (err) {
+          process.stderr.write(
+            `[grove-done] task=${taskCtx.taskId} POST /done failed (${err instanceof Error ? err.message : String(err)}); contribution write proceeding\n`,
+          );
+        }
+      }
+
       const result = await contributeOperation(
         {
           kind: "discussion",

--- a/src/server/routes/agent-tasks.test.ts
+++ b/src/server/routes/agent-tasks.test.ts
@@ -365,3 +365,73 @@ describe("PATCH /api/agent-tasks/:id/status — @Dangerous + If-Match plumbing (
     expect(view?.status.phase).toBe(AgentTaskPhase.Running);
   });
 });
+
+describe("POST /api/agent-tasks/:id/done", () => {
+  async function seedTask(store: TestAgentTaskStore, id: string): Promise<void> {
+    await store.putAgentTaskSpec({
+      id,
+      worktree: "wt-test",
+      runtime: "claude",
+      role: "agent",
+      prompt: "do the thing",
+      dependsOn: [],
+      generation: 0,
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  test("writes DoneSignaled condition with summary", async () => {
+    const agentTaskStore = new TestAgentTaskStore();
+    await seedTask(agentTaskStore, "done-task-1");
+
+    const { app } = createTestApp({ agentTaskStore });
+    const res = await app.request("/api/agent-tasks/done-task-1/done", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({ summary: "Completed all work successfully." }),
+    });
+
+    expect(res.status).toBe(200);
+    // biome-ignore lint/suspicious/noExplicitAny: test file
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(true);
+    expect(body.taskId).toBe("done-task-1");
+    expect(body.condition).toBe("DoneSignaled");
+
+    const view = await agentTaskStore.getAgentTask("done-task-1");
+    const doneCondition = view?.status.conditions.find((c) => c.type === "DoneSignaled");
+    expect(doneCondition).toBeDefined();
+    expect(doneCondition?.status).toBe("True");
+    expect(doneCondition?.message).toBe("Completed all work successfully.");
+  });
+
+  test("returns 404 for unknown task", async () => {
+    const agentTaskStore = new TestAgentTaskStore();
+    const { app } = createTestApp({ agentTaskStore });
+    const res = await app.request("/api/agent-tasks/missing-task/done", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({ summary: "done" }),
+    });
+
+    expect(res.status).toBe(404);
+    // biome-ignore lint/suspicious/noExplicitAny: test file
+    const body = (await res.json()) as any;
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  test("does NOT require X-Grove-Controller-Token (bearer-only)", async () => {
+    const agentTaskStore = new TestAgentTaskStore();
+    await seedTask(agentTaskStore, "done-task-bearer");
+
+    // Note: no TEST_CONTROLLER_HEADERS — bearer token only
+    const { app } = createTestApp({ agentTaskStore, controllerToken: TEST_CONTROLLER_TOKEN });
+    const res = await app.request("/api/agent-tasks/done-task-bearer/done", {
+      method: "POST",
+      headers: { ...TEST_AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({ summary: "bearer only, no controller token" }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/server/routes/agent-tasks.ts
+++ b/src/server/routes/agent-tasks.ts
@@ -12,7 +12,13 @@ import type { Hono as HonoType, MiddlewareHandler } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import type { AgentTaskSpecRecord } from "../../core/agent-task.js";
-import { AgentTaskPhase, agentTaskViewToEntity } from "../../core/agent-task.js";
+import {
+  AgentTaskConditionType,
+  AgentTaskPhase,
+  agentTaskViewToEntity,
+} from "../../core/agent-task.js";
+import { upsertCondition } from "../../core/condition-utils.js";
+import type { Condition } from "../../core/entity.js";
 import type { JsonValue } from "../../core/models.js";
 import type { AgentTaskStatusPatch } from "../../core/store.js";
 import { hasAgentTaskWriteCallback } from "../agent-task-store-wiring.js";
@@ -259,6 +265,72 @@ agentTasks.get("/:id", async (c) => {
   }
   return c.json(view);
 });
+
+/**
+ * POST /api/agent-tasks/:id/done — Bearer-authed agent completion signal.
+ *
+ * Writes a `DoneSignaled` condition to the task's status. Requires only the
+ * bearer token (no controller token) so that MCP processes running inside
+ * agent worktrees can call it without server-side secrets.
+ *
+ * The route retries once on an optimistic-concurrency mismatch and returns
+ * 409 only if a second concurrent write races it.
+ */
+agentTasks.post(
+  "/:id/done",
+  zValidator("json", z.object({ summary: z.string().max(2000) }).strict()),
+  async (c) => {
+    const deps = c.get("deps");
+    const taskId = c.req.param("id");
+    const body = c.req.valid("json" as never) as { summary: string };
+    const store = deps.agentTaskStore;
+    if (store === undefined) throw new Error("AgentTask store middleware did not run");
+
+    const current = await store.getAgentTask(taskId);
+    if (current === undefined) {
+      return c.json({ error: { code: "NOT_FOUND", message: `task '${taskId}' not found` } }, 404);
+    }
+
+    const nowIso = new Date().toISOString();
+    const condition: Condition = {
+      type: AgentTaskConditionType.DoneSignaled,
+      status: "True",
+      observedGeneration: current.spec.generation,
+      lastTransitionTime: nowIso,
+      reason: "agent-grove-done",
+      message: body.summary,
+    };
+    const nextConditions = upsertCondition(current.status.conditions, condition);
+
+    const patch: AgentTaskStatusPatch = {
+      conditions: nextConditions as AgentTaskStatusPatch["conditions"],
+      observedGeneration: current.spec.generation,
+    };
+    const result = await store.patchAgentTaskStatus(taskId, patch);
+    if (result.kind === "rv-mismatch") {
+      // Retry once with the latest snapshot.
+      const refreshed = await store.getAgentTask(taskId);
+      if (refreshed === undefined) {
+        return c.json({ error: { code: "NOT_FOUND", message: "task disappeared" } }, 404);
+      }
+      const retryCondition: Condition = {
+        ...condition,
+        observedGeneration: refreshed.spec.generation,
+      };
+      const retried = await store.patchAgentTaskStatus(taskId, {
+        conditions: upsertCondition(
+          refreshed.status.conditions,
+          retryCondition,
+        ) as AgentTaskStatusPatch["conditions"],
+        observedGeneration: refreshed.spec.generation,
+      });
+      if (retried.kind === "rv-mismatch") {
+        return c.json({ error: { code: "CONFLICT", message: "concurrent update" } }, 409);
+      }
+    }
+    return c.json({ ok: true, taskId, condition: "DoneSignaled" });
+  },
+);
 
 /**
  * PATCH /api/agent-tasks/:id/status — Controller-owned task status patch.

--- a/src/server/scheduler-wiring.test.ts
+++ b/src/server/scheduler-wiring.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for buildSchedulerFromConfig wiring helper.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { AgentConfig, AgentRuntime, AgentSession } from "../core/agent-runtime.js";
+import type { AgentSessionEntity } from "../core/entity.js";
+import type { AgentTaskEntity, AgentTaskView } from "../core/agent-task.js";
+import { AgentTaskPhase } from "../core/agent-task.js";
+import type { GroveConfig } from "../core/config.js";
+import type { AcpxTurn } from "../acp/types.js";
+import { buildSchedulerFromConfig } from "./scheduler-wiring.js";
+
+// ---------------------------------------------------------------------------
+// Fake runtime that records spawn calls
+// ---------------------------------------------------------------------------
+
+interface SpawnCall {
+  role: string;
+  config: AgentConfig;
+}
+
+function makeFakeRuntime(): AgentRuntime & { spawnCalls: SpawnCall[] } {
+  const spawnCalls: SpawnCall[] = [];
+  return {
+    spawnCalls,
+    async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
+      spawnCalls.push({ role, config });
+      return { id: `session-${role}`, role, status: "running" };
+    },
+    async send(_session: AgentSession, _message: string): Promise<AcpxTurn> {
+      throw new Error("not implemented");
+    },
+    async close(_session: AgentSession): Promise<void> {},
+    onIdle(_session: AgentSession, _callback: () => void): void {},
+    async listSessions(): Promise<readonly AgentSession[]> {
+      return [];
+    },
+    async listSessionEntities(): Promise<readonly AgentSessionEntity[]> {
+      return [];
+    },
+    async isAvailable(): Promise<boolean> {
+      return true;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fake store with empty entities
+// ---------------------------------------------------------------------------
+
+function emptyStore(): { listAgentTaskEntities: () => Promise<readonly AgentTaskEntity[]> } {
+  return { listAgentTaskEntities: async () => [] };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: minimal task view
+// ---------------------------------------------------------------------------
+
+function taskView(): AgentTaskView {
+  return {
+    spec: {
+      id: "task-1",
+      worktree: "/tmp/worktree",
+      runtime: "claude",
+      role: "worker",
+      prompt: "do the thing",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-05-16T00:00:00.000Z",
+    },
+    status: {
+      id: "task-1",
+      phase: AgentTaskPhase.PendingBind,
+      contributions: [],
+      conditions: [],
+      observedGeneration: 0,
+      lastTransitionAt: "2026-05-16T00:00:00.000Z",
+      revision: 1,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildSchedulerFromConfig", () => {
+  test("returns undefined when config.scheduler is undefined", () => {
+    const config: GroveConfig = { name: "my-grove", mode: "local" };
+    const runtime = makeFakeRuntime();
+    const store = emptyStore();
+
+    const result = buildSchedulerFromConfig({ config, runtime, store });
+
+    expect(result).toBeUndefined();
+  });
+
+  test("returns a Scheduler when config has a scheduler block", () => {
+    const config: GroveConfig = {
+      name: "my-grove",
+      mode: "local",
+      scheduler: {
+        profiles: [
+          {
+            name: "claude-default",
+            platform: "claude-code",
+            runtimeCommand: "claude",
+          },
+        ],
+        pipeline: {
+          filters: [],
+          scores: [],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      },
+    };
+    const runtime = makeFakeRuntime();
+    const store = emptyStore();
+
+    const result = buildSchedulerFromConfig({ config, runtime, store });
+
+    expect(result).toBeDefined();
+  });
+
+  test("returned Scheduler.schedule() calls runtime.spawn with the configured profile", async () => {
+    const config: GroveConfig = {
+      name: "my-grove",
+      mode: "local",
+      scheduler: {
+        profiles: [
+          {
+            name: "claude-default",
+            platform: "claude-code",
+            runtimeCommand: "claude",
+          },
+        ],
+        pipeline: {
+          filters: [],
+          scores: [],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      },
+    };
+    const runtime = makeFakeRuntime();
+    const store = emptyStore();
+
+    const scheduler = buildSchedulerFromConfig({ config, runtime, store });
+    expect(scheduler).toBeDefined();
+
+    const result = await scheduler!.schedule(taskView());
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") {
+      expect(result.profile.name).toBe("claude-default");
+    }
+    expect(runtime.spawnCalls).toHaveLength(1);
+    expect(runtime.spawnCalls[0]?.role).toBe("worker");
+    expect(runtime.spawnCalls[0]?.config.command).toBe("claude");
+  });
+
+  test("Scheduler respects pipeline filters — all-reject yields unschedulable", async () => {
+    // No built-in filter that always rejects, so we test the no-filter happy path
+    // and confirm the scheduler wiring plumbs profiles through correctly.
+    const config: GroveConfig = {
+      name: "my-grove",
+      mode: "local",
+      scheduler: {
+        profiles: [
+          {
+            name: "codex-default",
+            platform: "codex",
+            runtimeCommand: "codex",
+          },
+        ],
+        pipeline: {
+          filters: [],
+          scores: [],
+          permits: ["AutoPermit"],
+          bind: "DefaultBind",
+        },
+      },
+    };
+    const runtime = makeFakeRuntime();
+    const store = emptyStore();
+
+    const scheduler = buildSchedulerFromConfig({ config, runtime, store });
+    expect(scheduler).toBeDefined();
+
+    const result = await scheduler!.schedule(taskView());
+
+    expect(result.kind).toBe("bound");
+    if (result.kind === "bound") {
+      expect(result.profile.name).toBe("codex-default");
+      expect(result.profile.platform).toBe("codex");
+    }
+  });
+});

--- a/src/server/scheduler-wiring.ts
+++ b/src/server/scheduler-wiring.ts
@@ -1,0 +1,26 @@
+import type { AgentRuntime } from "../core/agent-runtime.js";
+import type { GroveConfig } from "../core/config.js";
+import { type LoadedSchedulerConfig, loadSchedulerConfig } from "../core/scheduler/config.js";
+import { Scheduler } from "../core/scheduler/scheduler.js";
+import type { AgentTaskStore } from "../core/store.js";
+
+export interface SchedulerWiringDeps {
+  readonly config: GroveConfig;
+  readonly runtime: AgentRuntime;
+  readonly store: Pick<AgentTaskStore, "listAgentTaskEntities">;
+}
+
+export function buildSchedulerFromConfig(deps: SchedulerWiringDeps): Scheduler | undefined {
+  if (deps.config.scheduler === undefined) return undefined;
+  const loaded: LoadedSchedulerConfig = loadSchedulerConfig(deps.config.scheduler, {
+    runtime: deps.runtime,
+  });
+  return new Scheduler({
+    profiles: loaded.profiles,
+    filters: loaded.filters,
+    scores: loaded.scores,
+    permits: loaded.permits,
+    bindPlugin: loaded.bindPlugin,
+    store: deps.store,
+  });
+}

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -11,9 +11,8 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { parseGroveConfig, type GroveConfig } from "../core/config.js";
-import { buildSchedulerFromConfig } from "./scheduler-wiring.js";
 import { agentTaskViewToEntity } from "../core/agent-task.js";
+import { type GroveConfig, parseGroveConfig } from "../core/config.js";
 import {
   claimToEntity,
   contributionToEntity,
@@ -48,6 +47,7 @@ import { wireAgentTaskStoreWrites } from "./agent-task-store-wiring.js";
 import { createApp } from "./app.js";
 import type { ServerDeps } from "./deps.js";
 import { loadKeyRegistry } from "./middleware/namespace-auth.js";
+import { buildSchedulerFromConfig } from "./scheduler-wiring.js";
 import { SessionService } from "./session-service.js";
 import { memoizeContributionStoreForSession } from "./session-store-factory.js";
 import { createServerAgentRuntime, taskControllerEnabled } from "./task-controller-wiring.js";
@@ -57,6 +57,11 @@ import { createWsHandler } from "./ws-handler.js";
 const GROVE_DIR = process.env.GROVE_DIR ?? join(process.cwd(), ".grove");
 const PORT = parsePort(process.env.PORT, 4515);
 const HOST = process.env.HOST; // optional — defaults to localhost via Bun
+// Defaults for env that downstream agents inherit. DefaultBind forwards both to
+// MCP so grove_done can POST /api/agent-tasks/:id/done.
+if (process.env.GROVE_SERVER_URL === undefined) {
+  process.env.GROVE_SERVER_URL = `http://${HOST ?? "localhost"}:${PORT}`;
+}
 // Nexus env vars — when GROVE_NEXUS_URL is set, contribution/claim/bounty/
 // outcome/CAS reads and writes go through Nexus stores so this process sees
 // the same data MCP agents produce. See the store-construction block below.
@@ -153,6 +158,12 @@ if (!zoneId) {
 }
 
 const rawRegistry = loadKeyRegistry(join(GROVE_DIR, "server-keys.yaml"));
+if (process.env.GROVE_API_TOKEN === undefined) {
+  const firstToken = [...rawRegistry.keys()][0];
+  if (firstToken !== undefined) {
+    process.env.GROVE_API_TOKEN = firstToken;
+  }
+}
 // Scope registry to this server's own namespace only — reject keys for other worktrees.
 // This server is one-namespace-per-process: all stores are process-global and
 // scoped to zoneId. Keys for other namespaces would allow cross-namespace access.

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -9,7 +9,10 @@
  * This is the only file excluded from test coverage — use createApp() for testing.
  */
 
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { parseGroveConfig, type GroveConfig } from "../core/config.js";
+import { buildSchedulerFromConfig } from "./scheduler-wiring.js";
 import { agentTaskViewToEntity } from "../core/agent-task.js";
 import {
   claimToEntity,
@@ -645,9 +648,29 @@ function startServer() {
 const server = startServer();
 
 if (taskControllerEnabled(process.env) && runtime.agentTaskStore !== undefined) {
+  const sharedRuntime = await getSharedAgentRuntime();
+  let groveConfig: GroveConfig | undefined;
+  const groveJsonPath = join(GROVE_DIR, "grove.json");
+  if (existsSync(groveJsonPath)) {
+    try {
+      groveConfig = parseGroveConfig(readFileSync(groveJsonPath, "utf-8"));
+    } catch (err) {
+      console.error(`grove-server: failed to parse ${groveJsonPath}: ${(err as Error).message}`);
+    }
+  }
+  const scheduler =
+    groveConfig === undefined
+      ? undefined
+      : buildSchedulerFromConfig({
+          config: groveConfig,
+          runtime: sharedRuntime,
+          store: runtime.agentTaskStore,
+        });
+
   taskController = new TaskController({
     taskStore: runtime.agentTaskStore,
-    runtime: await getSharedAgentRuntime(),
+    runtime: sharedRuntime,
+    ...(scheduler === undefined ? {} : { scheduler }),
     onError(error, taskId) {
       const detail = error instanceof Error ? error.message : String(error);
       process.stderr.write(`[task-controller] ${taskId}: ${detail}\n`);
@@ -655,7 +678,11 @@ if (taskControllerEnabled(process.env) && runtime.agentTaskStore !== undefined) 
   });
   await taskController.resync();
   taskController.start();
-  console.log("task-controller enabled");
+  console.log(
+    scheduler === undefined
+      ? "task-controller enabled"
+      : `task-controller enabled (scheduler: ${groveConfig?.scheduler?.profiles?.length ?? 0} profiles, ${groveConfig?.scheduler?.pipeline?.filters?.length ?? 0} filters)`,
+  );
 }
 
 // Start gossip after server is listening

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -23,6 +23,7 @@ import type { ContributionEntity } from "../../core/entity.js";
 import type { EventBus } from "../../core/event-bus.js";
 import type { Handoff } from "../../core/handoff.js";
 import type { Contribution } from "../../core/models.js";
+import { startReviewLoop } from "../../core/review-loop/start.js";
 import type { AgentTopology } from "../../core/topology.js";
 import { useInterval } from "../../local/use-interval.js";
 import { compareTimestampsAscNewestLast, compareTimestampsDesc } from "../../shared/format.js";
@@ -49,6 +50,7 @@ import { AgentListView } from "../views/agent-list.js";
 import { AgentTasksView } from "../views/agent-tasks.js";
 import { DagView } from "../views/dag.js";
 import { HandoffsView } from "../views/handoffs-view.js";
+import { ReviewLoopPrompt } from "../views/review-loop-prompt.js";
 import { TerminalView } from "../views/terminal.js";
 import { TracePane } from "../views/trace-pane.js";
 import { VfsBrowserView } from "../views/vfs-browser.js";
@@ -232,6 +234,12 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     const [vfsCursor, setVfsCursor] = useState(0);
     const [vfsNavTrigger, setVfsNavTrigger] = useState(0);
 
+    // ─── Review-loop prompt state ───
+    const [reviewLoopMode, setReviewLoopMode] = useState(false);
+    const [reviewLoopText, setReviewLoopText] = useState("");
+    const [reviewLoopError, setReviewLoopError] = useState<string | undefined>(undefined);
+    const [reviewLoopSubmitting, setReviewLoopSubmitting] = useState(false);
+
     // ─── Prompt state ───
     const [promptMode, setPromptMode] = useState(false);
     const [promptText, setPromptText] = useState("");
@@ -264,6 +272,45 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
       setFlashError(msg);
       setTimeout(() => setFlashError((current) => (current === msg ? null : current)), ms);
     }, []);
+
+    // ─── Review-loop submit handler ───
+    const handleReviewLoopSubmit = useCallback(
+      (goal: string) => {
+        if (reviewLoopSubmitting) return;
+        const trimmed = goal.trim();
+        if (!trimmed) return;
+        // Extract groveUrl + token from provider (duck-type) or env.
+        const rp = provider as unknown as {
+          baseUrl?: string;
+          httpAuthHeaders?: Record<string, string>;
+        };
+        const groveUrl = rp.baseUrl ?? process.env.GROVE_SERVER_URL ?? "http://localhost:4515";
+        const authHeader = rp.httpAuthHeaders?.Authorization ?? "";
+        const token = authHeader.startsWith("Bearer ")
+          ? authHeader.slice(7)
+          : (process.env.GROVE_API_TOKEN ?? "");
+        const resolvedGroveDir = groveDir ?? process.cwd();
+        setReviewLoopSubmitting(true);
+        setReviewLoopError(undefined);
+        void startReviewLoop({
+          goal: trimmed,
+          groveUrl,
+          token,
+          groveDir: resolvedGroveDir,
+        })
+          .then((result) => {
+            setReviewLoopMode(false);
+            setReviewLoopText("");
+            setReviewLoopSubmitting(false);
+            flash(`Review loop started: ${result.coderId}`);
+          })
+          .catch((err: unknown) => {
+            setReviewLoopSubmitting(false);
+            setReviewLoopError(err instanceof Error ? err.message : "Failed to start review loop");
+          });
+      },
+      [provider, groveDir, flash, reviewLoopSubmitting],
+    );
 
     useEffect(() => {
       if (!groveDir) return;
@@ -1050,6 +1097,27 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             return;
           }
 
+          // ─── Review-loop prompt mode: swallows all keys ───
+          if (reviewLoopMode) {
+            if (key.name === "escape") {
+              setReviewLoopMode(false);
+              setReviewLoopText("");
+              setReviewLoopError(undefined);
+            } else if (key.name === "return") {
+              handleReviewLoopSubmit(reviewLoopText);
+            } else if (key.name === "backspace") {
+              setReviewLoopText((t) => t.slice(0, -1));
+              setReviewLoopError(undefined);
+            } else if (key.name === "space") {
+              setReviewLoopText((t) => `${t} `);
+              setReviewLoopError(undefined);
+            } else if (key.sequence && key.sequence.length === 1 && !key.ctrl && !key.meta) {
+              setReviewLoopText((t) => t + key.sequence);
+              setReviewLoopError(undefined);
+            }
+            return;
+          }
+
           // Live snapshot of cmdMode/cmdText/filterQuery from refs — needed
           // because keyboardState's useMemo only re-runs after React commits,
           // and a burst of keys arriving in a single tick would otherwise see
@@ -1061,6 +1129,20 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             filterQuery: filterQueryRef.current,
             confirmModalOpen,
           };
+          // ─── r: open review-loop prompt (when no ask_user pending) ───
+          if (
+            key.name === "r" &&
+            !liveState.promptMode &&
+            liveState.cmdMode === "none" &&
+            !liveState.showHelp &&
+            !liveState.showVfs &&
+            !keyboardActions.hasAskUser
+          ) {
+            setReviewLoopMode(true);
+            setReviewLoopText("");
+            setReviewLoopError(undefined);
+            return;
+          }
           routeRunningKey(key, liveState, keyboardActions);
         },
         [
@@ -1072,6 +1154,9 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           promptMode,
           showHelp,
           confirmModalOpen,
+          reviewLoopMode,
+          reviewLoopText,
+          handleReviewLoopSubmit,
         ],
       ),
     );
@@ -1210,6 +1295,13 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
               !showHelp &&
               !showVfs,
           })}
+          {reviewLoopMode && (
+            <ReviewLoopPrompt
+              text={reviewLoopText}
+              error={reviewLoopError}
+              submitting={reviewLoopSubmitting}
+            />
+          )}
           {renderStatusBar(
             expandedPanel,
             zoomLevel,
@@ -1306,6 +1398,13 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             gotoSuggestions,
             flashError,
           )}
+          {reviewLoopMode && (
+            <ReviewLoopPrompt
+              text={reviewLoopText}
+              error={reviewLoopError}
+              submitting={reviewLoopSubmitting}
+            />
+          )}
           {renderStatusBar(
             expandedPanel,
             zoomLevel,
@@ -1368,6 +1467,15 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           cmdState,
           gotoSuggestions,
           flashError,
+        )}
+
+        {/* Review-loop prompt (r key) */}
+        {reviewLoopMode && (
+          <ReviewLoopPrompt
+            text={reviewLoopText}
+            error={reviewLoopError}
+            submitting={reviewLoopSubmitting}
+          />
         )}
 
         {/* Help overlay */}

--- a/src/tui/views/review-loop-prompt.tsx
+++ b/src/tui/views/review-loop-prompt.tsx
@@ -1,0 +1,61 @@
+/**
+ * Review-loop prompt — modal input bar that captures a goal and POSTs
+ * two AgentTask records (coder + reviewer) via startReviewLoop().
+ *
+ * Displayed inline in RunningView when the user presses `r` (and there
+ * is no pending ask_user contribution). The component is a controlled
+ * input bar: the parent owns `text` + `onChar` + `onBackspace` so the
+ * same reducer/ref pattern used for promptMode in running-view works here.
+ *
+ * Error messages are displayed inline and clear when the user starts
+ * typing again.
+ */
+
+import React from "react";
+import { theme } from "../theme.js";
+
+export interface ReviewLoopPromptProps {
+  /** Current goal text typed by the user. */
+  readonly text: string;
+  /** Error message to display (from a failed startReviewLoop call). */
+  readonly error?: string | undefined;
+  /** Whether the prompt is in a "submitting" (loading) state. */
+  readonly submitting?: boolean | undefined;
+}
+
+/**
+ * Inline input bar for the review-loop goal prompt.
+ *
+ * Rendered at the bottom of RunningView (similar to the Prompt component)
+ * when reviewLoopMode is active. The parent wires key events via the
+ * keyboard handler.
+ */
+export const ReviewLoopPrompt: React.NamedExoticComponent<ReviewLoopPromptProps> = React.memo(
+  function ReviewLoopPrompt({ text, error, submitting }: ReviewLoopPromptProps): React.ReactNode {
+    if (submitting) {
+      return (
+        <box paddingLeft={1} paddingRight={1} flexDirection="row">
+          <text color={theme.warning}>[REVIEW LOOP]</text>
+          <text color={theme.secondary}> Creating tasks...</text>
+        </box>
+      );
+    }
+
+    return (
+      <box flexDirection="column">
+        {error !== undefined && error.length > 0 && (
+          <box paddingLeft={1} paddingRight={1}>
+            <text color={theme.error}>{error}</text>
+          </box>
+        )}
+        <box paddingLeft={1} paddingRight={1} flexDirection="row">
+          <text color={theme.warning}>[REVIEW LOOP]</text>
+          <text color={theme.secondary}> Goal: </text>
+          <text color={theme.text}>{text}</text>
+          <text color={theme.secondary}>█</text>
+          <text color={theme.secondary}> — Enter to start, Esc to cancel</text>
+        </box>
+      </box>
+    );
+  },
+);

--- a/tests/e2e/review-loop-tui-tmux.ts
+++ b/tests/e2e/review-loop-tui-tmux.ts
@@ -435,7 +435,7 @@ async function main(): Promise<void> {
       "[note] TUI keybind verified in source (running-view.tsx calls same startReviewLoop lib)",
     );
     console.log(
-      "[note] done-signaling via REST POST /done (scheduler DefaultBind lacks grove MCP wiring)",
+      "[note] done-signaling via REST POST /done (lib-direct approach — real codex agents call grove_done via MCP, now wired in DefaultBind)",
     );
     process.exit(0);
   }

--- a/tests/e2e/review-loop-tui-tmux.ts
+++ b/tests/e2e/review-loop-tui-tmux.ts
@@ -318,10 +318,21 @@ async function main(): Promise<void> {
     throw new Error(`startReviewLoop failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 
-  // 9. Poll /api/agent-tasks until coder + reviewer both reach Succeeded (or timeout/failure)
+  // 9. Poll /api/agent-tasks until coder + reviewer both reach Succeeded (or timeout/failure).
+  //
+  // NOTE on done-signaling: the scheduler-spawned agents use DefaultBind which does NOT
+  // configure the grove MCP server (mcpServers=[]).  Consequently the `grove_done` MCP
+  // tool is unavailable to codex, so the task would never leave Running via the MCP path.
+  //
+  // Workaround: once the coder reaches Running (scheduler spawned the agent), the harness
+  // calls POST /api/agent-tasks/:id/done directly — the same REST endpoint that grove_done
+  // hits internally.  This validates the scheduling + task-state-machine while honestly
+  // documenting that the production MCP wiring for scheduler-spawned agents is incomplete.
   const deadline = Date.now() + BUDGET_MS;
   let lastCoderPhase = "";
   let lastReviewerPhase = "";
+  let coderDoneSignaled = false;
+  let reviewerDoneSignaled = false;
 
   while (Date.now() < deadline) {
     let listRes: Response;
@@ -356,6 +367,44 @@ async function main(): Promise<void> {
         }
       }
 
+      // Signal done via REST once each agent reaches Running.
+      // This substitutes for the grove_done MCP call that production agents
+      // would make (scheduler DefaultBind doesn't wire the grove MCP server yet).
+      if (lastCoderPhase === "Running" && !coderDoneSignaled) {
+        coderDoneSignaled = true;
+        await sleep(2000); // let codex settle for a moment
+        console.log(`[harness] POST /api/agent-tasks/${coderId}/done (simulating grove_done)`);
+        const doneRes = await fetch(
+          `${baseUrl}/api/agent-tasks/${encodeURIComponent(coderId)}/done`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ summary: "coder completed (harness-signaled)" }),
+          },
+        );
+        console.log(`[harness] coder done → ${doneRes.status}`);
+      }
+      if (lastReviewerPhase === "Running" && !reviewerDoneSignaled) {
+        reviewerDoneSignaled = true;
+        await sleep(2000);
+        console.log(`[harness] POST /api/agent-tasks/${reviewerId}/done (simulating grove_done)`);
+        const doneRes = await fetch(
+          `${baseUrl}/api/agent-tasks/${encodeURIComponent(reviewerId)}/done`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ summary: "reviewer completed (harness-signaled)" }),
+          },
+        );
+        console.log(`[harness] reviewer done → ${doneRes.status}`);
+      }
+
       if (lastCoderPhase === "Succeeded" && lastReviewerPhase === "Succeeded") {
         break;
       }
@@ -384,6 +433,9 @@ async function main(): Promise<void> {
     );
     console.log(
       "[note] TUI keybind verified in source (running-view.tsx calls same startReviewLoop lib)",
+    );
+    console.log(
+      "[note] done-signaling via REST POST /done (scheduler DefaultBind lacks grove MCP wiring)",
     );
     process.exit(0);
   }

--- a/tests/e2e/review-loop-tui-tmux.ts
+++ b/tests/e2e/review-loop-tui-tmux.ts
@@ -1,0 +1,379 @@
+/**
+ * Tmux-driven E2E for the TUI-triggered review loop.
+ *
+ * Starts grove-server with scheduler config, launches grove TUI in a second pane,
+ * sends `r` + goal text + Enter to drive ReviewLoopPrompt, then polls the server
+ * until both AgentTask records reach Succeeded.
+ *
+ * NOT wired into `bun test` — run as:
+ *   bun run tests/e2e/review-loop-tui-tmux.ts
+ *
+ * Flags:
+ *   --keep             Leave tmux session + workdir for inspection
+ *   --timeout <ms>     Overall budget (default 180000)
+ *   --goal <text>      Override goal (default: trivial smoke prompt)
+ *
+ * Known risks (do not fix here — tracked separately):
+ *   - TUI keymap: `r` may be consumed differently when a list widget has focus.
+ *   - ReviewLoopPrompt regex (`/REVIEW LOOP/`) must match the rendered header.
+ *   - Both `codex` and `claude` CLIs must be installed and authenticated locally.
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { parse as parseYaml } from "yaml";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SOCKET = "grove-review-loop-tui-e2e";
+const SESSION = "grove-review-loop-tui-e2e";
+const PROJECT_ROOT = join(import.meta.dir, "..", "..");
+const SERVER_PORT = 12796;
+const DEFAULT_GOAL =
+  "Print 'hello-from-coder' to stdout then immediately call grove_done with summary='ready for review'.";
+
+// ─── Args ─────────────────────────────────────────────────────────────────────
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    keep: { type: "boolean", default: false },
+    timeout: { type: "string", default: "180000" },
+    goal: { type: "string" },
+  },
+});
+const KEEP = values.keep;
+const BUDGET_MS = Number.parseInt(values.timeout as string, 10);
+const GOAL = (values.goal as string | undefined) ?? DEFAULT_GOAL;
+
+// ─── tmux helpers ─────────────────────────────────────────────────────────────
+
+function capturePane(target: string): string {
+  const out = spawnSync("tmux", ["-L", SOCKET, "capture-pane", "-t", target, "-p", "-S", "-5000"], {
+    encoding: "utf-8",
+  });
+  return out.stdout;
+}
+
+function sendKeys(target: string, keys: string[]): void {
+  spawnSync("tmux", ["-L", SOCKET, "send-keys", "-t", target, ...keys], { stdio: "ignore" });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitForPane(
+  target: string,
+  predicate: (pane: string) => boolean,
+  phase: string,
+  maxMs = 60000,
+): Promise<string> {
+  const deadline = Date.now() + maxMs;
+  let last = "";
+  while (Date.now() < deadline) {
+    last = capturePane(target);
+    if (predicate(last)) {
+      console.log(`[${phase}] matched`);
+      return last;
+    }
+    await sleep(500);
+  }
+  console.error(`\n──── pane dump (${phase}) target=${target} ────`);
+  console.error(last);
+  console.error("──── end pane dump ────\n");
+  throw new Error(`[${phase}] predicate did not match within ${maxMs}ms`);
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+const workDir = mkdtempSync(join(tmpdir(), "grove-review-loop-tui-"));
+const groveDir = join(workDir, ".grove");
+console.log(`[setup] workDir=${workDir}`);
+
+function cleanup(): void {
+  if (KEEP) {
+    console.log(`[keep] workDir=${workDir}`);
+    console.log(`[keep] tmux -L ${SOCKET} attach -t ${SESSION}`);
+    return;
+  }
+  try {
+    execSync(`tmux -L ${SOCKET} kill-server 2>/dev/null`, { stdio: "ignore" });
+  } catch {
+    /* already dead */
+  }
+  try {
+    rmSync(workDir, { recursive: true, force: true });
+  } catch {
+    /* ok */
+  }
+}
+
+process.on("exit", cleanup);
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+
+// ─── Grove config with scheduler block (codex coder + claude reviewer) ────────
+
+const GROVE_JSON = {
+  name: "review-loop-tui-e2e",
+  mode: "local",
+  scheduler: {
+    profiles: [
+      {
+        name: "codex-default",
+        platform: "codex",
+        runtimeCommand: "codex",
+        supportedRoles: ["coder"],
+      },
+      {
+        name: "claude-default",
+        platform: "claude-code",
+        runtimeCommand: "claude",
+        supportedRoles: ["reviewer"],
+      },
+    ],
+    pipeline: {
+      filters: ["RuntimeCapability", "BudgetRemaining", "WorktreeExclusivity"],
+      scores: [{ name: "TaskAffinity", weight: 1 }],
+      permits: ["AutoPermit"],
+      bind: "DefaultBind",
+    },
+  },
+};
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  // Kill any leftover tmux socket from a previous run
+  try {
+    execSync(`tmux -L ${SOCKET} kill-server 2>/dev/null`, { stdio: "ignore" });
+  } catch {
+    /* already dead */
+  }
+
+  // 1. grove init — creates .grove/server-keys.yaml, grove.json, etc.
+  console.log("[setup] grove init --preset review-loop");
+  mkdirSync(workDir, { recursive: true });
+  execSync(
+    `GROVE_DIR=${groveDir} bun run ${join(PROJECT_ROOT, "src/cli/main.ts")} init --preset review-loop --force review-loop-tui-e2e`,
+    { cwd: workDir, stdio: "inherit" },
+  );
+
+  // 2. Overwrite grove.json with scheduler block (codex coder + claude reviewer)
+  const groveJsonPath = join(groveDir, "grove.json");
+  writeFileSync(groveJsonPath, `${JSON.stringify(GROVE_JSON, null, 2)}\n`);
+  console.log(`[setup] wrote ${groveJsonPath}`);
+
+  // 3. Read bearer token from .grove/server-keys.yaml
+  const serverKeysPath = join(groveDir, "server-keys.yaml");
+  if (!existsSync(serverKeysPath)) {
+    throw new Error(`server-keys.yaml not found at ${serverKeysPath}`);
+  }
+  const rawYaml = readFileSync(serverKeysPath, "utf8");
+  const keysFile = parseYaml(rawYaml) as {
+    version: number;
+    keys: Record<string, { namespace: string; createdAt: string }>;
+  };
+  const token = Object.keys(keysFile.keys)[0];
+  if (!token) throw new Error("No bearer token found in server-keys.yaml");
+  console.log(`[setup] token=${token.slice(0, 8)}... (first 8 chars)`);
+
+  const baseUrl = `http://localhost:${SERVER_PORT}`;
+  console.log(`[setup] baseUrl=${baseUrl}`);
+
+  const serverLog = join(workDir, "server.log");
+  const tuiLog = join(workDir, "tui.log");
+
+  // 4. Start tmux session — pane 0 = grove-server
+  const serverCmd = [
+    `GROVE_DIR=${groveDir}`,
+    `PORT=${SERVER_PORT}`,
+    `GROVE_TASK_CONTROLLER=1`,
+    `bun run ${join(PROJECT_ROOT, "src/server/serve.ts")} 2>&1 | tee ${serverLog}`,
+  ].join(" ");
+
+  spawnSync(
+    "tmux",
+    [
+      "-L",
+      SOCKET,
+      "new-session",
+      "-d",
+      "-s",
+      SESSION,
+      "-x",
+      "220",
+      "-y",
+      "50",
+      "sh",
+      "-c",
+      `${serverCmd}; cat`,
+    ],
+    { stdio: "inherit" },
+  );
+  console.log(`[tmux] server pane started. Attach: tmux -L ${SOCKET} attach -t ${SESSION}`);
+
+  // 5. Wait for scheduler wiring log line, then for server listening
+  await waitForPane(
+    SESSION,
+    (p) => /task-controller enabled \(scheduler: 2 profiles, 3 filters\)/.test(p),
+    "scheduler-wired",
+    30000,
+  );
+  console.log("[phase 1] scheduler wired (2 profiles, 3 filters confirmed)");
+
+  await waitForPane(SESSION, (p) => /listening/.test(p), "server-ready", 10000);
+  console.log("[phase 2] server listening");
+
+  // 6. Split pane — pane 1 = grove TUI
+  const tuiCmd = [
+    `GROVE_DIR=${groveDir}`,
+    `GROVE_SERVER_URL=${baseUrl}`,
+    `GROVE_API_TOKEN=${token}`,
+    `bun run ${join(PROJECT_ROOT, "src/cli/main.ts")} tui 2>&1 | tee ${tuiLog}`,
+  ].join(" ");
+
+  spawnSync(
+    "tmux",
+    ["-L", SOCKET, "split-window", "-t", SESSION, "-h", "sh", "-c", `${tuiCmd}; cat`],
+    { stdio: "inherit" },
+  );
+  const tuiTarget = `${SESSION}.1`;
+  console.log("[tmux] TUI pane started");
+
+  // 7. Wait for TUI dashboard to render
+  await waitForPane(
+    tuiTarget,
+    (p) => /AGENTS|DASHBOARD|RUNNING|ACTIVITY|TASKS|grove/.test(p),
+    "tui-up",
+    30000,
+  );
+  console.log("[tui] dashboard visible");
+  await sleep(1500); // let initial render settle
+
+  // 8. Send `r` to open the review-loop prompt
+  sendKeys(tuiTarget, ["r"]);
+  await waitForPane(tuiTarget, (p) => /REVIEW LOOP/.test(p), "prompt-open", 10000);
+  console.log("[tui] review-loop prompt open");
+
+  // 9. Type goal character-by-character (mimics real typing; avoids paste-mode issues)
+  for (const ch of GOAL) {
+    sendKeys(tuiTarget, [ch === " " ? "Space" : ch]);
+    await sleep(15);
+  }
+  await sleep(300);
+  sendKeys(tuiTarget, ["Enter"]);
+  console.log("[tui] goal submitted, awaiting AgentTask creation");
+
+  // 10. Poll /api/agent-tasks until coder + reviewer both reach Succeeded (or timeout/failure)
+  const deadline = Date.now() + BUDGET_MS;
+  let coderId: string | undefined;
+  let reviewerId: string | undefined;
+  let lastCoderPhase = "";
+  let lastReviewerPhase = "";
+
+  while (Date.now() < deadline) {
+    let listRes: Response;
+    try {
+      listRes = await fetch(`${baseUrl}/api/agent-tasks`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    } catch {
+      await sleep(1500);
+      continue;
+    }
+
+    if (listRes.ok) {
+      const body = (await listRes.json()) as {
+        tasks?: Array<{
+          spec: { id: string; role: string };
+          status: { phase: string };
+        }>;
+      };
+      const tasks = body.tasks ?? [];
+
+      for (const t of tasks) {
+        if (t.spec.role === "coder" && coderId === undefined) {
+          coderId = t.spec.id;
+          console.log(`[poll] found coder task id=${coderId}`);
+        }
+        if (t.spec.role === "reviewer" && reviewerId === undefined) {
+          reviewerId = t.spec.id;
+          console.log(`[poll] found reviewer task id=${reviewerId}`);
+        }
+        if (t.spec.id === coderId && t.status.phase !== lastCoderPhase) {
+          console.log(
+            `[coder ${coderId}] phase: ${lastCoderPhase || "(initial)"} → ${t.status.phase}`,
+          );
+          lastCoderPhase = t.status.phase;
+        }
+        if (t.spec.id === reviewerId && t.status.phase !== lastReviewerPhase) {
+          console.log(
+            `[reviewer ${reviewerId}] phase: ${lastReviewerPhase || "(initial)"} → ${t.status.phase}`,
+          );
+          lastReviewerPhase = t.status.phase;
+        }
+      }
+
+      if (lastCoderPhase === "Succeeded" && lastReviewerPhase === "Succeeded") {
+        break;
+      }
+      if (lastCoderPhase === "Failed" || lastReviewerPhase === "Failed") {
+        break;
+      }
+    }
+
+    await sleep(1500);
+  }
+
+  // 11. Final pane dumps
+  console.log("\n──── TUI PANE ────");
+  console.log(capturePane(tuiTarget));
+  console.log("──── end TUI pane ────\n");
+
+  console.log("──── SERVER PANE (tail 60) ────");
+  const serverPane = capturePane(SESSION);
+  console.log(serverPane.split("\n").slice(-60).join("\n"));
+  console.log("──── end server pane ────\n");
+
+  // 12. Verdict
+  if (lastCoderPhase === "Succeeded" && lastReviewerPhase === "Succeeded") {
+    console.log("[smoke] OK — coder + reviewer both reached Succeeded via TUI-triggered scheduler");
+    process.exit(0);
+  }
+
+  console.error(
+    `[smoke] FAIL — coder=${lastCoderPhase || "(never seen)"}, reviewer=${lastReviewerPhase || "(never seen)"}`,
+  );
+
+  // Dump server log tail for diagnosis
+  console.error("\n──── server log tail ────");
+  try {
+    console.error(execSync(`tail -80 ${serverLog}`, { encoding: "utf-8" }));
+  } catch {
+    /* no log file yet */
+  }
+
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(`[fatal] ${err instanceof Error ? err.message : String(err)}`);
+  if (err instanceof Error && err.stack) console.error(err.stack);
+
+  console.error("\n──── server pane (fatal) ────");
+  try {
+    console.error(capturePane(SESSION));
+  } catch {
+    /* tmux already dead */
+  }
+  console.error("──── end server pane (fatal) ────");
+
+  process.exit(2);
+});

--- a/tests/e2e/review-loop-tui-tmux.ts
+++ b/tests/e2e/review-loop-tui-tmux.ts
@@ -14,11 +14,35 @@
  *
  * Flags:
  *   --keep             Leave tmux session + workdir for inspection
- *   --timeout <ms>     Overall budget (default 180000)
+ *   --timeout <ms>     Overall budget (default 600000 = 10 min)
  *   --goal <text>      Override goal (default: trivial smoke prompt)
+ *
+ * Real-agent mode (current):
+ *   - Both codex (coder) and claude (reviewer) are spawned by the scheduler
+ *     via DefaultBind, which wires the grove MCP server in mcpServers.
+ *   - grove_done MCP tool is registered by grove MCP serve.ts always.
+ *   - Agents are expected to call grove_done themselves.
+ *   - No harness-side /done shortcut.
+ *
+ * MCP wiring summary (verified against source):
+ *   - DefaultBind (src/core/scheduler/plugins/default-bind.ts) sets
+ *     mcpServers=[{name:"grove", command:"bun", args:["run", mcp/serve.ts], env:{…}}]
+ *     on AgentConfig whenever GROVE_DIR is set.
+ *   - AcpRuntime (src/core/acp-runtime.ts):
+ *       - For codex: writes mcpServers into the ephemeral CODEX_HOME/config.toml
+ *         via buildCodexMcpConfigBlock, AND appends -c flags via
+ *         appendCodexMcpServerOverrides. Both paths forward the grove server.
+ *       - For claude: passes mcpServers through ACP newSession call so the
+ *         claude CLI loads them.
+ *   - GROVE_SERVER_URL defaults to http://localhost:{PORT} in serve.ts (line 63).
+ *   - GROVE_API_TOKEN is auto-populated from server-keys.yaml in serve.ts (line 162).
+ *   - DefaultBind forwards both to agents via env and groveMcp.env.
+ *   - grove_done tool (src/mcp/tools/done.ts) calls signalAgentTaskDone which
+ *     POSTs to GROVE_SERVER_URL/api/agent-tasks/:id/done with GROVE_API_TOKEN.
  *
  * Known risks (do not fix here — tracked separately):
  *   - Both `codex` and `claude` CLIs must be installed and authenticated locally.
+ *   - First-turn latency for codex can be 60-90s; claude similar.
  */
 
 import { execSync, spawnSync } from "node:child_process";
@@ -35,8 +59,15 @@ const SOCKET = "grove-review-loop-tui-e2e";
 const SESSION = "grove-review-loop-tui-e2e";
 const PROJECT_ROOT = join(import.meta.dir, "..", "..");
 const SERVER_PORT = 12796;
+// The goal is used for the coder's prompt verbatim, and the reviewer's prompt
+// is: "Review the work completed for: <GOAL>". So the goal must be phrased
+// such that both roles know to call grove_done:
+// - Coder: reads the goal and calls grove_done.
+// - Reviewer: reads "Review the work completed for: <GOAL>" and calls grove_done.
 const DEFAULT_GOAL =
-  "Print 'hello-from-coder' to stdout then immediately call grove_done with summary='ready for review'.";
+  "Print 'hello-from-coder' to stdout. " +
+  "Coder: call grove_done with summary='coder done'. " +
+  "Reviewer: after reading the coder's summary, call grove_done with summary='reviewer approved'.";
 
 // ─── Args ─────────────────────────────────────────────────────────────────────
 
@@ -44,7 +75,7 @@ const { values } = parseArgs({
   args: process.argv.slice(2),
   options: {
     keep: { type: "boolean", default: false },
-    timeout: { type: "string", default: "180000" },
+    timeout: { type: "string", default: "600000" },
     goal: { type: "string" },
   },
 });
@@ -194,11 +225,14 @@ async function main(): Promise<void> {
   //   `-c sandbox_mode="danger-full-access" -c approval_policy="never"` to
   //   codex so it runs non-interactively in the scheduler context (no TTY).
   //   Without this, codex cancels tasks when it encounters permission prompts.
+  // GROVE_DEBUG_ACP=1: tees agent stderr (including grove-mcp stderr) to the
+  //   server log so we can see whether agents reach grove_done or fail before.
   const serverCmd = [
     `GROVE_DIR=${groveDir}`,
     `PORT=${SERVER_PORT}`,
     `GROVE_TASK_CONTROLLER=1`,
     `GROVE_ALLOW_ALL_PERMISSIONS=1`,
+    `GROVE_DEBUG_ACP=1`,
     `bun run ${join(PROJECT_ROOT, "src/server/serve.ts")} 2>&1 | tee ${serverLog}`,
   ].join(" ");
 
@@ -302,6 +336,7 @@ async function main(): Promise<void> {
   // import here.  The TUI pane above proves the TUI is wired and launching.
   // We exercise the lib (and thereby the scheduler + task pipeline) end-to-end.
   console.log("[lib] calling startReviewLoop directly (approach C)");
+  console.log(`[lib] goal="${GOAL}"`);
   let coderId: string;
   let reviewerId: string;
   try {
@@ -320,19 +355,41 @@ async function main(): Promise<void> {
 
   // 9. Poll /api/agent-tasks until coder + reviewer both reach Succeeded (or timeout/failure).
   //
-  // NOTE on done-signaling: the scheduler-spawned agents use DefaultBind which does NOT
-  // configure the grove MCP server (mcpServers=[]).  Consequently the `grove_done` MCP
-  // tool is unavailable to codex, so the task would never leave Running via the MCP path.
-  //
-  // Workaround: once the coder reaches Running (scheduler spawned the agent), the harness
-  // calls POST /api/agent-tasks/:id/done directly — the same REST endpoint that grove_done
-  // hits internally.  This validates the scheduling + task-state-machine while honestly
-  // documenting that the production MCP wiring for scheduler-spawned agents is incomplete.
+  // Real-agent mode: agents call grove_done via MCP themselves.
+  // - DefaultBind wires mcpServers=[grove] with GROVE_SERVER_URL + GROVE_API_TOKEN.
+  // - grove_done MCP tool calls signalAgentTaskDone → POST /api/agent-tasks/:id/done.
+  //   On success, the /done route sets DoneSignaled condition; no log line emitted.
+  //   On failure only: [grove-done] stderr appears in MCP server process (not in server.log).
+  // - The harness does NOT call /done on behalf of agents.
+  // - If tasks stall in Running for 60+ seconds, log server log and task conditions.
   const deadline = Date.now() + BUDGET_MS;
+  const startMs = Date.now();
   let lastCoderPhase = "";
   let lastReviewerPhase = "";
+  let coderRunningAt: number | undefined;
+  let reviewerRunningAt: number | undefined;
   let coderDoneSignaled = false;
   let reviewerDoneSignaled = false;
+  let coderStallLogged = false;
+  let reviewerStallLogged = false;
+
+  type TaskEntry = {
+    spec: { id: string; role: string };
+    status: { phase: string; conditions?: Array<{ type: string; status: string }> };
+  };
+
+  async function fetchTaskConditions(taskId: string): Promise<string[]> {
+    try {
+      const res = await fetch(`${baseUrl}/api/agent-tasks/${encodeURIComponent(taskId)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) return [];
+      const task = (await res.json()) as TaskEntry;
+      return (task.status.conditions ?? []).filter((c) => c.status === "True").map((c) => c.type);
+    } catch {
+      return [];
+    }
+  }
 
   while (Date.now() < deadline) {
     let listRes: Response;
@@ -347,62 +404,93 @@ async function main(): Promise<void> {
 
     if (listRes.ok) {
       // GET /api/agent-tasks returns AgentTaskView[] directly (not wrapped)
-      const tasks = (await listRes.json()) as Array<{
-        spec: { id: string; role: string };
-        status: { phase: string };
-      }>;
+      const tasks = (await listRes.json()) as TaskEntry[];
+
+      const now = Date.now();
+      const elapsed = Math.round((now - startMs) / 1000);
 
       for (const t of tasks) {
         if (t.spec.id === coderId && t.status.phase !== lastCoderPhase) {
+          const conds = (t.status.conditions ?? [])
+            .filter((c) => c.status === "True")
+            .map((c) => c.type);
           console.log(
-            `[coder ${coderId}] phase: ${lastCoderPhase || "(initial)"} → ${t.status.phase}`,
+            `[coder] phase: ${lastCoderPhase || "(initial)"} → ${t.status.phase} (t+${elapsed}s) conditions=[${conds.join(",")}]`,
           );
           lastCoderPhase = t.status.phase;
+          if (t.status.phase === "Running") coderRunningAt = now;
         }
         if (t.spec.id === reviewerId && t.status.phase !== lastReviewerPhase) {
+          const conds = (t.status.conditions ?? [])
+            .filter((c) => c.status === "True")
+            .map((c) => c.type);
           console.log(
-            `[reviewer ${reviewerId}] phase: ${lastReviewerPhase || "(initial)"} → ${t.status.phase}`,
+            `[reviewer] phase: ${lastReviewerPhase || "(initial)"} → ${t.status.phase} (t+${elapsed}s) conditions=[${conds.join(",")}]`,
           );
           lastReviewerPhase = t.status.phase;
+          if (t.status.phase === "Running") reviewerRunningAt = now;
+        }
+        // Track DoneSignaled condition (set by POST /done from grove_done MCP)
+        const conditions = (t.status.conditions ?? [])
+          .filter((c) => c.status === "True")
+          .map((c) => c.type);
+        if (t.spec.id === coderId && conditions.includes("DoneSignaled") && !coderDoneSignaled) {
+          coderDoneSignaled = true;
+          console.log(
+            `[coder] DoneSignaled condition set — grove_done MCP call succeeded (t+${elapsed}s)`,
+          );
+        }
+        if (
+          t.spec.id === reviewerId &&
+          conditions.includes("DoneSignaled") &&
+          !reviewerDoneSignaled
+        ) {
+          reviewerDoneSignaled = true;
+          console.log(
+            `[reviewer] DoneSignaled condition set — grove_done MCP call succeeded (t+${elapsed}s)`,
+          );
         }
       }
 
-      // Signal done via REST once each agent reaches Running.
-      // This substitutes for the grove_done MCP call that production agents
-      // would make (scheduler DefaultBind doesn't wire the grove MCP server yet).
-      if (lastCoderPhase === "Running" && !coderDoneSignaled) {
-        coderDoneSignaled = true;
-        await sleep(2000); // let codex settle for a moment
-        console.log(`[harness] POST /api/agent-tasks/${coderId}/done (simulating grove_done)`);
-        const doneRes = await fetch(
-          `${baseUrl}/api/agent-tasks/${encodeURIComponent(coderId)}/done`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${token}`,
-            },
-            body: JSON.stringify({ summary: "coder completed (harness-signaled)" }),
-          },
-        );
-        console.log(`[harness] coder done → ${doneRes.status}`);
+      // Progress logging: if a task stays in Running for 60+ seconds without
+      // transitioning, log server log and fetch task conditions for diagnosis.
+      if (
+        lastCoderPhase === "Running" &&
+        coderRunningAt !== undefined &&
+        Date.now() - coderRunningAt > 60_000 &&
+        !coderStallLogged
+      ) {
+        coderStallLogged = true;
+        console.warn(`[coder] stalled in Running for >60s (t+${elapsed}s) — checking conditions`);
+        const conds = await fetchTaskConditions(coderId);
+        console.warn(`[coder] live conditions: [${conds.join(",")}]`);
+        console.warn("──── server log tail (coder stall) ────");
+        try {
+          console.warn(execSync(`tail -60 ${serverLog}`, { encoding: "utf-8" }));
+        } catch {
+          /* */
+        }
+        console.warn("──── end server log tail ────");
       }
-      if (lastReviewerPhase === "Running" && !reviewerDoneSignaled) {
-        reviewerDoneSignaled = true;
-        await sleep(2000);
-        console.log(`[harness] POST /api/agent-tasks/${reviewerId}/done (simulating grove_done)`);
-        const doneRes = await fetch(
-          `${baseUrl}/api/agent-tasks/${encodeURIComponent(reviewerId)}/done`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${token}`,
-            },
-            body: JSON.stringify({ summary: "reviewer completed (harness-signaled)" }),
-          },
+      if (
+        lastReviewerPhase === "Running" &&
+        reviewerRunningAt !== undefined &&
+        Date.now() - reviewerRunningAt > 60_000 &&
+        !reviewerStallLogged
+      ) {
+        reviewerStallLogged = true;
+        console.warn(
+          `[reviewer] stalled in Running for >60s (t+${elapsed}s) — checking conditions`,
         );
-        console.log(`[harness] reviewer done → ${doneRes.status}`);
+        const conds = await fetchTaskConditions(reviewerId);
+        console.warn(`[reviewer] live conditions: [${conds.join(",")}]`);
+        console.warn("──── server log tail (reviewer stall) ────");
+        try {
+          console.warn(execSync(`tail -60 ${serverLog}`, { encoding: "utf-8" }));
+        } catch {
+          /* */
+        }
+        console.warn("──── end server log tail ────");
       }
 
       if (lastCoderPhase === "Succeeded" && lastReviewerPhase === "Succeeded") {
@@ -426,16 +514,27 @@ async function main(): Promise<void> {
   console.log(serverPane.split("\n").slice(-60).join("\n"));
   console.log("──── end server pane ────\n");
 
+  // Check DoneSignaled state (proxy for grove_done MCP call):
+  // - DoneSignaled condition is set by POST /api/agent-tasks/:id/done, which is
+  //   called by the grove_done MCP tool (signalAgentTaskDone in agent-task-done.ts).
+  // - If DoneSignaled was observed during polling, the agent called grove_done.
+  // - Note: [grove-done] stderr only appears on FAILURE; success has no server log line.
+  console.log(`[grove-done] coder DoneSignaled seen during poll: ${coderDoneSignaled}`);
+  console.log(`[grove-done] reviewer DoneSignaled seen during poll: ${reviewerDoneSignaled}`);
+
   // 11. Verdict
   if (lastCoderPhase === "Succeeded" && lastReviewerPhase === "Succeeded") {
     console.log(
-      "[smoke] OK — coder + reviewer both reached Succeeded via lib-direct startReviewLoop",
+      "[smoke] OK — coder + reviewer both reached Succeeded via real-agent grove_done MCP calls",
+    );
+    console.log(
+      `[note] coder DoneSignaled observed: ${coderDoneSignaled} (confirms grove_done MCP call)`,
+    );
+    console.log(
+      `[note] reviewer DoneSignaled observed: ${reviewerDoneSignaled} (confirms grove_done MCP call)`,
     );
     console.log(
       "[note] TUI keybind verified in source (running-view.tsx calls same startReviewLoop lib)",
-    );
-    console.log(
-      "[note] done-signaling via REST POST /done (lib-direct approach — real codex agents call grove_done via MCP, now wired in DefaultBind)",
     );
     process.exit(0);
   }
@@ -447,7 +546,7 @@ async function main(): Promise<void> {
   // Dump server log tail for diagnosis
   console.error("\n──── server log tail ────");
   try {
-    console.error(execSync(`tail -80 ${serverLog}`, { encoding: "utf-8" }));
+    console.error(execSync(`tail -120 ${serverLog}`, { encoding: "utf-8" }));
   } catch {
     /* no log file yet */
   }

--- a/tests/e2e/review-loop-tui-tmux.ts
+++ b/tests/e2e/review-loop-tui-tmux.ts
@@ -1,9 +1,13 @@
 /**
  * Tmux-driven E2E for the TUI-triggered review loop.
  *
- * Starts grove-server with scheduler config, launches grove TUI in a second pane,
- * sends `r` + goal text + Enter to drive ReviewLoopPrompt, then polls the server
- * until both AgentTask records reach Succeeded.
+ * Approach C (lib-direct):
+ *   - Server in pane 0.
+ *   - TUI in pane 1 (no `tee` — raw TTY so OpenTUI renders correctly).
+ *   - startReviewLoop called directly from this harness (same lib the `r`
+ *     keybind in running-view.tsx invokes).  The keybind is verified in
+ *     source at commit 61e840b8; we exercise the lib end-to-end here.
+ *   - Poll /api/agent-tasks until coder + reviewer both reach Succeeded.
  *
  * NOT wired into `bun test` — run as:
  *   bun run tests/e2e/review-loop-tui-tmux.ts
@@ -14,8 +18,6 @@
  *   --goal <text>      Override goal (default: trivial smoke prompt)
  *
  * Known risks (do not fix here — tracked separately):
- *   - TUI keymap: `r` may be consumed differently when a list widget has focus.
- *   - ReviewLoopPrompt regex (`/REVIEW LOOP/`) must match the rendered header.
  *   - Both `codex` and `claude` CLIs must be installed and authenticated locally.
  */
 
@@ -25,6 +27,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { parse as parseYaml } from "yaml";
+import { startReviewLoop } from "../../src/core/review-loop/start.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -56,10 +59,6 @@ function capturePane(target: string): string {
     encoding: "utf-8",
   });
   return out.stdout;
-}
-
-function sendKeys(target: string, keys: string[]): void {
-  spawnSync("tmux", ["-L", SOCKET, "send-keys", "-t", target, ...keys], { stdio: "ignore" });
 }
 
 function sleep(ms: number): Promise<void> {
@@ -188,13 +187,18 @@ async function main(): Promise<void> {
   console.log(`[setup] baseUrl=${baseUrl}`);
 
   const serverLog = join(workDir, "server.log");
-  const tuiLog = join(workDir, "tui.log");
 
   // 4. Start tmux session — pane 0 = grove-server
+  // Server still pipes through tee so we have a log file for diagnosis.
+  // GROVE_ALLOW_ALL_PERMISSIONS=1: tells the ACP runtime to pass
+  //   `-c sandbox_mode="danger-full-access" -c approval_policy="never"` to
+  //   codex so it runs non-interactively in the scheduler context (no TTY).
+  //   Without this, codex cancels tasks when it encounters permission prompts.
   const serverCmd = [
     `GROVE_DIR=${groveDir}`,
     `PORT=${SERVER_PORT}`,
     `GROVE_TASK_CONTROLLER=1`,
+    `GROVE_ALLOW_ALL_PERMISSIONS=1`,
     `bun run ${join(PROJECT_ROOT, "src/server/serve.ts")} 2>&1 | tee ${serverLog}`,
   ].join(" ");
 
@@ -231,50 +235,91 @@ async function main(): Promise<void> {
   await waitForPane(SESSION, (p) => /listening/.test(p), "server-ready", 10000);
   console.log("[phase 2] server listening");
 
-  // 6. Split pane — pane 1 = grove TUI
+  // 6. Split pane — pane 1 = grove TUI (raw TTY, no pipes)
+  //
+  // The TUI must be a direct TTY — piping stdout through `tee` breaks
+  // OpenTUI's cursor-position queries (DSR / CPR) which the Zig renderer uses
+  // to detect viewport size. Without a real TTY, the renderer hangs waiting
+  // for a cursor-position reply that never arrives.
+  //
+  // Approach C (lib-direct): we DON'T drive the TUI via key injection.
+  // Instead we verify the TUI process launched (no immediate exit), then call
+  // startReviewLoop() directly from this harness. The TUI is visual evidence
+  // that the app launches; the `r` keybind in running-view.tsx calls the same
+  // lib we invoke below.
   const tuiCmd = [
     `GROVE_DIR=${groveDir}`,
     `GROVE_SERVER_URL=${baseUrl}`,
     `GROVE_API_TOKEN=${token}`,
-    `bun run ${join(PROJECT_ROOT, "src/cli/main.ts")} tui 2>&1 | tee ${tuiLog}`,
+    `bun run ${join(PROJECT_ROOT, "src/cli/main.ts")} tui`,
   ].join(" ");
 
   spawnSync(
     "tmux",
-    ["-L", SOCKET, "split-window", "-t", SESSION, "-h", "sh", "-c", `${tuiCmd}; cat`],
+    [
+      "-L",
+      SOCKET,
+      "split-window",
+      "-t",
+      SESSION,
+      "-h",
+      "sh",
+      "-c",
+      `${tuiCmd}; echo TUI_EXITED; cat`,
+    ],
     { stdio: "inherit" },
   );
   const tuiTarget = `${SESSION}.1`;
-  console.log("[tmux] TUI pane started");
+  console.log("[tmux] TUI pane started (raw TTY, direct — no pipe)");
 
-  // 7. Wait for TUI dashboard to render
-  await waitForPane(
-    tuiTarget,
-    (p) => /AGENTS|DASHBOARD|RUNNING|ACTIVITY|TASKS|grove/.test(p),
-    "tui-up",
-    30000,
-  );
-  console.log("[tui] dashboard visible");
-  await sleep(1500); // let initial render settle
-
-  // 8. Send `r` to open the review-loop prompt
-  sendKeys(tuiTarget, ["r"]);
-  await waitForPane(tuiTarget, (p) => /REVIEW LOOP/.test(p), "prompt-open", 10000);
-  console.log("[tui] review-loop prompt open");
-
-  // 9. Type goal character-by-character (mimics real typing; avoids paste-mode issues)
-  for (const ch of GOAL) {
-    sendKeys(tuiTarget, [ch === " " ? "Space" : ch]);
-    await sleep(15);
+  // 7. Wait 5s then verify TUI didn't immediately crash.
+  // capture-pane reads the tmux cell grid. OpenTUI uses tmux-passthrough
+  // escape sequences and Zig-native rendering; the rendered text may not
+  // appear in the tmux cell grid until the process exits (race with the
+  // renderer). The key check is that the pane does NOT immediately show
+  // "TUI_EXITED" — if it does, the process crashed.
+  await sleep(5000);
+  const tuiInitialPane = capturePane(tuiTarget);
+  const tuiCrashed = /TUI_EXITED/.test(tuiInitialPane);
+  if (tuiCrashed) {
+    console.warn("[tui] WARNING: TUI exited immediately — may have crashed");
+  } else {
+    console.log("[tui] TUI pane is active (no immediate crash)");
   }
-  await sleep(300);
-  sendKeys(tuiTarget, ["Enter"]);
-  console.log("[tui] goal submitted, awaiting AgentTask creation");
 
-  // 10. Poll /api/agent-tasks until coder + reviewer both reach Succeeded (or timeout/failure)
+  // Log whatever is visible in the TUI pane (may be empty or partial render)
+  console.log("\n──── TUI initial render (may be blank — renderer uses native Zig FFI) ────");
+  console.log(
+    tuiInitialPane.split("\n").slice(0, 10).join("\n") || "(blank — normal for OpenTUI in tmux)",
+  );
+  console.log("──── end TUI initial render ────\n");
+
+  // 8. Approach C (lib-direct): call startReviewLoop from this harness.
+  //
+  // Rationale: The TUI starts at the welcome screen (no sessions exist), and
+  // navigating welcome → RunningView → `r` is too fragile.  The `r` keybind in
+  // running-view.tsx calls startReviewLoop() — the exact same function we
+  // import here.  The TUI pane above proves the TUI is wired and launching.
+  // We exercise the lib (and thereby the scheduler + task pipeline) end-to-end.
+  console.log("[lib] calling startReviewLoop directly (approach C)");
+  let coderId: string;
+  let reviewerId: string;
+  try {
+    const result = await startReviewLoop({
+      goal: GOAL,
+      groveUrl: baseUrl,
+      token,
+      groveDir,
+    });
+    coderId = result.coderId;
+    reviewerId = result.reviewerId;
+    console.log(`[lib] tasks created: coder=${coderId}, reviewer=${reviewerId}`);
+  } catch (err) {
+    throw new Error(`startReviewLoop failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // 9. Poll /api/agent-tasks until coder + reviewer both reach Succeeded (or timeout/failure)
   const deadline = Date.now() + BUDGET_MS;
-  let coderId: string | undefined;
-  let reviewerId: string | undefined;
   let lastCoderPhase = "";
   let lastReviewerPhase = "";
 
@@ -290,23 +335,13 @@ async function main(): Promise<void> {
     }
 
     if (listRes.ok) {
-      const body = (await listRes.json()) as {
-        tasks?: Array<{
-          spec: { id: string; role: string };
-          status: { phase: string };
-        }>;
-      };
-      const tasks = body.tasks ?? [];
+      // GET /api/agent-tasks returns AgentTaskView[] directly (not wrapped)
+      const tasks = (await listRes.json()) as Array<{
+        spec: { id: string; role: string };
+        status: { phase: string };
+      }>;
 
       for (const t of tasks) {
-        if (t.spec.role === "coder" && coderId === undefined) {
-          coderId = t.spec.id;
-          console.log(`[poll] found coder task id=${coderId}`);
-        }
-        if (t.spec.role === "reviewer" && reviewerId === undefined) {
-          reviewerId = t.spec.id;
-          console.log(`[poll] found reviewer task id=${reviewerId}`);
-        }
         if (t.spec.id === coderId && t.status.phase !== lastCoderPhase) {
           console.log(
             `[coder ${coderId}] phase: ${lastCoderPhase || "(initial)"} → ${t.status.phase}`,
@@ -332,8 +367,8 @@ async function main(): Promise<void> {
     await sleep(1500);
   }
 
-  // 11. Final pane dumps
-  console.log("\n──── TUI PANE ────");
+  // 10. Final pane dumps
+  console.log("\n──── TUI PANE (final) ────");
   console.log(capturePane(tuiTarget));
   console.log("──── end TUI pane ────\n");
 
@@ -342,9 +377,14 @@ async function main(): Promise<void> {
   console.log(serverPane.split("\n").slice(-60).join("\n"));
   console.log("──── end server pane ────\n");
 
-  // 12. Verdict
+  // 11. Verdict
   if (lastCoderPhase === "Succeeded" && lastReviewerPhase === "Succeeded") {
-    console.log("[smoke] OK — coder + reviewer both reached Succeeded via TUI-triggered scheduler");
+    console.log(
+      "[smoke] OK — coder + reviewer both reached Succeeded via lib-direct startReviewLoop",
+    );
+    console.log(
+      "[note] TUI keybind verified in source (running-view.tsx calls same startReviewLoop lib)",
+    );
     process.exit(0);
   }
 

--- a/tests/e2e/scheduler-pipeline-tmux.ts
+++ b/tests/e2e/scheduler-pipeline-tmux.ts
@@ -1,0 +1,422 @@
+/**
+ * Tmux-driven E2E smoke test for the production scheduler wiring (#300, PR #439).
+ *
+ * Starts a real grove-server with a grove.json containing a `scheduler:` block
+ * (2 profiles, 3 filters), proves the server wires up the Scheduler from config,
+ * and validates both the happy-path (worker task → Running) and the rejection
+ * path (nonexistent-role task → Unschedulable condition).
+ *
+ * NOT wired into `bun test` — run as:
+ *   bun run tests/e2e/scheduler-pipeline-tmux.ts
+ *
+ * Flags:
+ *   --keep          Leave tmux session + workdir for inspection
+ *   --timeout <ms>  Overall budget (default 60000)
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { parse as parseYaml } from "yaml";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SOCKET = "grove-scheduler-e2e";
+const SESSION = "grove-scheduler-e2e";
+const PROJECT_ROOT = join(import.meta.dir, "..", "..");
+const SERVER_PORT = 12794;
+
+// ─── Args ─────────────────────────────────────────────────────────────────────
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    keep: { type: "boolean", default: false },
+    timeout: { type: "string", default: "60000" },
+  },
+});
+const KEEP = values.keep;
+const BUDGET_MS = Number.parseInt(values.timeout as string, 10);
+
+// ─── tmux helpers ─────────────────────────────────────────────────────────────
+
+function capturePane(target = SESSION): string {
+  const out = spawnSync("tmux", ["-L", SOCKET, "capture-pane", "-t", target, "-p", "-S", "-5000"], {
+    encoding: "utf-8",
+  });
+  return out.stdout;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitForPane(
+  predicate: (pane: string) => boolean,
+  phase: string,
+  maxMs = 30000,
+  target = SESSION,
+): Promise<string> {
+  const deadline = Date.now() + maxMs;
+  let last = "";
+  while (Date.now() < deadline) {
+    last = capturePane(target);
+    if (predicate(last)) {
+      console.log(`[${phase}] matched`);
+      return last;
+    }
+    await sleep(500);
+  }
+  console.error(`\n──── pane dump (${phase}) ────`);
+  console.error(last);
+  console.error("──── end pane dump ────\n");
+  throw new Error(`[${phase}] predicate did not match within ${maxMs}ms`);
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+const workDir = mkdtempSync(join(tmpdir(), "grove-scheduler-e2e-"));
+const groveDir = join(workDir, ".grove");
+console.log(`[setup] workDir=${workDir}`);
+
+function cleanup() {
+  try {
+    execSync(`tmux -L ${SOCKET} kill-server 2>/dev/null`, { stdio: "ignore" });
+  } catch {
+    /* already dead */
+  }
+  if (!KEEP && existsSync(workDir)) {
+    rmSync(workDir, { recursive: true, force: true });
+  } else if (KEEP) {
+    console.log(`[cleanup] kept workDir=${workDir} (--keep)`);
+  }
+}
+
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+
+// ─── Grove config with scheduler block ───────────────────────────────────────
+
+const GROVE_JSON = {
+  name: "scheduler-e2e",
+  mode: "local",
+  scheduler: {
+    profiles: [
+      {
+        name: "claude-premium",
+        platform: "claude-code",
+        runtimeCommand: "claude",
+        supportedRoles: ["worker"],
+        labels: { tier: "premium" },
+      },
+      {
+        name: "claude-free",
+        platform: "claude-code",
+        runtimeCommand: "claude",
+        supportedRoles: ["worker"],
+        labels: { tier: "free" },
+      },
+    ],
+    pipeline: {
+      filters: ["RuntimeCapability", "BudgetRemaining", "WorktreeExclusivity"],
+      scores: [{ name: "TaskAffinity", weight: 1 }],
+      permits: ["AutoPermit"],
+      bind: "DefaultBind",
+    },
+  },
+};
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  // Kill any leftover tmux socket
+  try {
+    execSync(`tmux -L ${SOCKET} kill-server 2>/dev/null`, { stdio: "ignore" });
+  } catch {
+    /* already dead */
+  }
+
+  // 1. Init grove inside workDir (creates .grove/server-keys.yaml, api-key, project-id)
+  console.log("[setup] grove init --preset review-loop");
+  mkdirSync(workDir, { recursive: true });
+  execSync(
+    `GROVE_DIR=${groveDir} bun run ${join(PROJECT_ROOT, "src/cli/main.ts")} init --preset review-loop --force scheduler-e2e`,
+    { cwd: workDir, stdio: "inherit" },
+  );
+
+  // 2. Overwrite grove.json with our scheduler config
+  const groveJsonPath = join(groveDir, "grove.json");
+  writeFileSync(groveJsonPath, JSON.stringify(GROVE_JSON, null, 2));
+  console.log(`[setup] wrote ${groveJsonPath}`);
+
+  // 3. Read bearer token from .grove/server-keys.yaml
+  const serverKeysPath = join(groveDir, "server-keys.yaml");
+  if (!existsSync(serverKeysPath)) {
+    throw new Error(`server-keys.yaml not found at ${serverKeysPath}`);
+  }
+  const rawYaml = readFileSync(serverKeysPath, "utf8");
+  const keysFile = parseYaml(rawYaml) as {
+    version: number;
+    keys: Record<string, { namespace: string; createdAt: string }>;
+  };
+  const token = Object.keys(keysFile.keys)[0];
+  if (!token) throw new Error("No bearer token found in server-keys.yaml");
+  console.log(`[setup] token=${token.slice(0, 8)}... (first 8 chars)`);
+
+  const baseUrl = `http://localhost:${SERVER_PORT}`;
+  console.log(`[setup] baseUrl=${baseUrl}`);
+
+  const serverLogFile = join(workDir, "server.log");
+
+  // 4. Create tmux session (server pane)
+  const envStr = [
+    `GROVE_DIR=${groveDir}`,
+    `PORT=${SERVER_PORT}`,
+    `GROVE_TASK_CONTROLLER=1`,
+  ].join(" ");
+  const serverCmd = `${envStr} bun run ${join(PROJECT_ROOT, "src/server/serve.ts")} 2>&1 | tee ${serverLogFile}`;
+
+  spawnSync(
+    "tmux",
+    [
+      "-L",
+      SOCKET,
+      "new-session",
+      "-d",
+      "-s",
+      SESSION,
+      "-x",
+      "220",
+      "-y",
+      "50",
+      "sh",
+      "-c",
+      `${serverCmd}; cat`,
+    ],
+    { stdio: "inherit" },
+  );
+  console.log(`[tmux] server pane started. Attach: tmux -L ${SOCKET} attach -t ${SESSION}`);
+
+  // 5. Wait for server to be listening
+  await waitForPane((p) => /listening/.test(p), "server-ready", 30000);
+  console.log("[phase 1] server listening");
+
+  // 6. Wait for scheduler wiring log line — proves grove.json was parsed and Scheduler built
+  await waitForPane(
+    (p) => /task-controller enabled \(scheduler: 2 profiles, 3 filters\)/.test(p),
+    "scheduler-wired",
+    15000,
+  );
+  console.log("[phase 2] scheduler wired (2 profiles, 3 filters confirmed)");
+
+  // Helper: POST an agent task spec via PUT /api/agent-tasks/:id
+  // If-Match: * is accepted for new task creation (dangerous() middleware
+  // only requires a non-empty If-Match; stores accept any value for inserts).
+  async function putTask(
+    id: string,
+    role: string,
+    budgetAffinity: Record<string, string> | undefined,
+  ): Promise<void> {
+    const body = {
+      worktree: workDir,
+      // Use "claude" — matches runtimeCommand in both profiles (no pin behaviour:
+      // RuntimeCapabilityFilter passes when requestedRuntime === profile.runtimeCommand).
+      runtime: "claude",
+      role,
+      prompt: "echo scheduler-e2e",
+      dependsOn: [],
+      ...(budgetAffinity !== undefined ? { budget: { affinity: budgetAffinity } } : {}),
+    };
+
+    const res = await fetch(`${baseUrl}/api/agent-tasks/${encodeURIComponent(id)}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        // If-Match: * is required by dangerous() middleware; accepted for new tasks
+        "If-Match": "*",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`PUT /api/agent-tasks/${id} failed (${res.status}): ${text}`);
+    }
+    console.log(`[driver] PUT /api/agent-tasks/${id} → ${res.status}`);
+  }
+
+  // Helper: poll GET /api/agent-tasks/:id
+  async function getTask(id: string): Promise<unknown> {
+    const res = await fetch(`${baseUrl}/api/agent-tasks/${encodeURIComponent(id)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`GET /api/agent-tasks/${id} failed (${res.status}): ${text}`);
+    }
+    return res.json();
+  }
+
+  // ─── Task 1: worker role + affinity:premium ───────────────────────────────
+  // Expects: scheduler runs filter→score→permit→bind pipeline and either:
+  //   (a) transitions to Running (phase=Running + sessionId set), OR
+  //   (b) conditions include Bound or Running (intermediate proof), OR
+  //   (c) conditions include Unschedulable (if WorktreeExclusivity rejects on re-queue)
+  // All of these prove the scheduler ran.
+
+  const TASK1_ID = "task-affinity-premium";
+  console.log(`\n[phase 3] POST task1 id=${TASK1_ID}`);
+  await putTask(TASK1_ID, "worker", { tier: "premium" });
+
+  let task1View: unknown;
+  let task1Passed = false;
+  const task1Deadline = Date.now() + 30000;
+  while (Date.now() < task1Deadline) {
+    task1View = await getTask(TASK1_ID);
+    const view = task1View as {
+      status?: {
+        phase?: string;
+        sessionId?: string;
+        conditions?: Array<{ type: string; status: string }>;
+      };
+    };
+    const phase = view.status?.phase;
+    const sessionId = view.status?.sessionId;
+    const conditions = view.status?.conditions ?? [];
+
+    if (phase === "Running" && sessionId) {
+      console.log("[task1] PASS — phase=Running + sessionId set");
+      task1Passed = true;
+      break;
+    }
+    if (
+      conditions.some(
+        (c) => (c.type === "Bound" || c.type === "Running") && c.status === "True",
+      )
+    ) {
+      console.log("[task1] PASS — Bound or Running condition present");
+      task1Passed = true;
+      break;
+    }
+    // Also accept Unschedulable — can happen if WorktreeExclusivity blocks after first bind
+    if (conditions.some((c) => c.type === "Unschedulable" && c.status === "True")) {
+      console.log("[task1] PASS — Unschedulable reached (scheduler ran through full pipeline)");
+      task1Passed = true;
+      break;
+    }
+    // Also accept PendingBind with Scheduled condition (proves Pending→PendingBind ran)
+    if (
+      phase === "PendingBind" &&
+      conditions.some((c) => c.type === "Scheduled" && c.status === "True")
+    ) {
+      console.log("[task1] PASS — PendingBind+Scheduled (scheduler running)");
+      task1Passed = true;
+      break;
+    }
+    await sleep(500);
+  }
+
+  if (!task1View) {
+    task1View = await getTask(TASK1_ID).catch(() => ({ error: "fetch failed" }));
+  }
+
+  console.log("[task1] final status:", JSON.stringify(task1View, null, 2));
+
+  // ─── Task 2: nonexistent-role → Unschedulable ─────────────────────────────
+  // Both profiles have supportedRoles: ["worker"], so RuntimeCapabilityFilter
+  // rejects role "nonexistent-role" for all profiles → scheduler marks Unschedulable.
+
+  const TASK2_ID = "task-unschedulable-role";
+  console.log(`\n[phase 4] POST task2 id=${TASK2_ID} (role=nonexistent-role)`);
+  await putTask(TASK2_ID, "nonexistent-role", undefined);
+
+  let task2View: unknown;
+  let task2Passed = false;
+  const task2Deadline = Date.now() + 30000;
+  while (Date.now() < task2Deadline) {
+    task2View = await getTask(TASK2_ID);
+    const view = task2View as {
+      status?: {
+        phase?: string;
+        conditions?: Array<{ type: string; status: string }>;
+      };
+    };
+    const conditions = view.status?.conditions ?? [];
+
+    if (conditions.some((c) => c.type === "Unschedulable" && c.status === "True")) {
+      console.log("[task2] PASS — Unschedulable condition confirmed");
+      task2Passed = true;
+      break;
+    }
+    await sleep(500);
+  }
+
+  if (!task2View) {
+    task2View = await getTask(TASK2_ID).catch(() => ({ error: "fetch failed" }));
+  }
+
+  console.log("[task2] final status:", JSON.stringify(task2View, null, 2));
+
+  // ─── Final pane capture ───────────────────────────────────────────────────
+
+  console.log("\n──── server pane (final) ────");
+  console.log(capturePane(SESSION));
+  console.log("──── end server pane ────\n");
+
+  // ─── Assertions ──────────────────────────────────────────────────────────
+
+  const failures: string[] = [];
+
+  if (!task1Passed) {
+    failures.push(
+      `task1 (${TASK1_ID}): scheduler did not reach Running/Bound/Unschedulable within 30s. Final status: ${JSON.stringify(task1View)}`,
+    );
+  }
+
+  if (!task2Passed) {
+    failures.push(
+      `task2 (${TASK2_ID}): Unschedulable condition not set within 30s. Final status: ${JSON.stringify(task2View)}`,
+    );
+  }
+
+  if (failures.length > 0) {
+    console.error("\n[FAIL] Scheduler E2E assertions failed:");
+    for (const f of failures) {
+      console.error(`  - ${f}`);
+    }
+    console.error("\n──── server log tail ────");
+    try {
+      console.error(execSync(`tail -80 ${serverLogFile}`, { encoding: "utf-8" }));
+    } catch {
+      /* no log */
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    "[smoke] OK — scheduler wiring + pipeline validated (wired log confirmed, task1 scheduler ran, task2 unschedulable)",
+  );
+}
+
+main()
+  .then(() => {
+    cleanup();
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("[FAIL]", err);
+    console.error("\n──── server pane (error) ────");
+    try {
+      console.error(capturePane(SESSION));
+    } catch {
+      /* tmux already dead */
+    }
+    console.error("──── end server pane (error) ────");
+    cleanup();
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

- Adds k8s-scheduler-style plugin pipeline (`Filter → Score → Permit → Bind`) under `src/core/scheduler/`, with config-driven plugin registration and a typed `SchedulingResult`.
- Wires `Scheduler` into `TaskController.reconcilePendingBind` as an optional injection seam; the original direct-bind path is preserved when no scheduler is configured.
- Ships the acceptance-required default plugins: `RuntimeCapability`, `BudgetRemaining`, `WorktreeExclusivity` filters; `TaskAffinity` score; `AutoPermit` + `UserConfirmPermit` (shape only); `DefaultBind`.

Closes #300. Spec: `docs/superpowers/specs/2026-05-16-scheduler-framework-design.md`. Plan: `docs/superpowers/plans/2026-05-16-scheduler-framework.md`.

## Test plan

- [ ] `bun test src/core/scheduler/ src/core/task-controller.test.ts src/core/agent-task.condition-types.test.ts` — 95 pass / 0 fail.
- [ ] `bun test src/core/` — confirm no regressions vs base (7 pre-existing unrelated failures, identical at HEAD).
- [ ] Acceptance: `bun test src/core/scheduler/acceptance-config-reweight.test.ts` — two configs differing only in `pipeline.scores` produce different winning profiles (no code change).
- [ ] Back-compat: existing `TaskController` tests pass without injecting a scheduler.
- [ ] `bunx tsc --noEmit` — no new type errors introduced by this PR.

## Acceptance criteria mapping (#300)

- Plugin interface documented — spec + JSDoc on `src/core/scheduler/framework.ts`.
- New filter/score plugin added via config (no code change) — `src/core/scheduler/acceptance-config-reweight.test.ts`.
- Default plugins cover runtime-capability + budget + affinity — `plugins/runtime-capability.test.ts`, `plugins/budget-remaining.test.ts`, `plugins/task-affinity.test.ts`.

## Deferred to follow-ups

`HistoricalSuccessRate` + `LoadBalancing` score plugins; persistent `PermitDecisionStore` + TUI wiring for `UserConfirmPermit`; global `BudgetLedger` impl; two-phase reservation + CAS (#305); per-plugin `errorPolicy: "tolerate"` (strict default ships now).