### PR TITLE
feat(tui): agent supervision hero surface (#193)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ coverage/
 nexus-data/
 nexus-stack.yml
 nexus.yaml
+
+# Visual companion brainstorming sessions
+.superpowers/

--- a/docs/superpowers/plans/2026-05-18-tui-agent-supervision-hero.md
+++ b/docs/superpowers/plans/2026-05-18-tui-agent-supervision-hero.md
@@ -1,0 +1,2275 @@
+# TUI Agent Supervision — Hero Surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the feed-default body of `RunningView` with a fleet-rail + detail-rail supervision surface that surfaces blocked/stuck/thrashing/silent agents, inlines approvals, and persists agent selection across panel drill-downs. Behind env flag `GROVE_SUPERVISION=1` until stable.
+
+**Architecture:** New module `src/tui/screens/supervision/` exports pure derivation (`agent-health`, `supervision-actions`), a join hook (`use-fleet-model`), and three React components (`fleet-rail`, `detail-rail`, `supervision`). `useAgentMonitor` gets a small additive timestamp map. `running-view.tsx` swaps its default body when the flag is on; the floating Permission Request overlay moves into the detail rail. `DagView` / `HandoffsView` gain optional `filterAgentId` props so drill-downs inherit the selected agent.
+
+**Tech Stack:** TypeScript, React + `@opentui/react`, `bun:test`, `useEntities` informer push, existing `useAgentMonitor` / `useEventDrivenData` hooks.
+
+**Spec:** `docs/superpowers/specs/2026-05-18-tui-agent-supervision-hero-design.md`
+
+---
+
+## File Structure
+
+**New (in order of dependency):**
+- `src/tui/screens/supervision/agent-health.ts` — pure: `AgentHealth` union, thresholds, `deriveAgentHealth(input, now)`
+- `src/tui/screens/supervision/agent-health.test.ts`
+- `src/tui/screens/supervision/supervision-actions.ts` — pure: `SupervisionAction` enum, `actionEnabled(action, health)`
+- `src/tui/screens/supervision/supervision-actions.test.ts`
+- `src/tui/screens/supervision/use-fleet-model.ts` — hook: join claims × tmux × cost × handoffs × permissions × monitor → `FleetAgent[]`
+- `src/tui/screens/supervision/use-fleet-model.test.ts`
+- `src/tui/screens/supervision/fleet-rail.tsx` — left rail
+- `src/tui/screens/supervision/fleet-rail.test.tsx`
+- `src/tui/screens/supervision/detail-rail.tsx` — right rail
+- `src/tui/screens/supervision/detail-rail.test.tsx`
+- `src/tui/screens/supervision/supervision-keyboard.ts` — pure key router for the supervision body
+- `src/tui/screens/supervision/supervision-keyboard.test.ts`
+- `src/tui/screens/supervision/supervision.tsx` — composition root + state
+- `src/tui/screens/supervision/supervision.test.tsx`
+- `tests/tui/supervision-e2e.ts` — integration smoke (nexus + 2 ACPX agents)
+
+**Modified:**
+- `src/tui/hooks/use-agent-monitor.ts` — add `agentOutputTimestamps` to state (additive)
+- `src/tui/hooks/use-agent-monitor.test.ts` — add timestamp assertion
+- `src/tui/views/dag.tsx` — additive `filterAgentId?: string` prop
+- `src/tui/views/handoffs-view.tsx` — additive `filterAgentId?: string` prop
+- `src/tui/screens/running-view.tsx` — flag-gated body swap; remove floating Permission Request box when flag is on; thread `selectedAgentId` to drill-down panels; help-overlay update
+
+---
+
+## Task 1: Extend `useAgentMonitor` with output timestamps
+
+**Why:** `deriveAgentHealth` needs to detect `silent` ( = no output for N minutes). The current monitor stores only line arrays, no timestamps. Additive extension keeps existing consumers unaffected.
+
+**Files:**
+- Modify: `src/tui/hooks/use-agent-monitor.ts`
+- Test: `src/tui/hooks/use-agent-monitor.test.ts`
+
+- [ ] **Step 1: Write a failing test for the new map**
+
+Append to `src/tui/hooks/use-agent-monitor.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { mergeOutputs } from "./use-agent-monitor.js";
+
+describe("mergeOutputs", () => {
+  test("returns next outputs and a parallel timestamp map keyed by role", () => {
+    const now = new Date("2026-05-18T12:00:00Z").toISOString();
+    const { outputs, timestamps } = mergeOutputs(
+      new Map([["coder", ["old"]]]),
+      new Map(),
+      new Map([["coder", ["old", "new"]]]),
+      now,
+    );
+    expect(outputs.get("coder")).toEqual(["old", "new"]);
+    expect(timestamps.get("coder")).toBe(now);
+  });
+
+  test("preserves prior timestamps for roles whose outputs did not change", () => {
+    const prior = new Date("2026-05-18T11:00:00Z").toISOString();
+    const now = new Date("2026-05-18T12:00:00Z").toISOString();
+    const { timestamps } = mergeOutputs(
+      new Map([["coder", ["x"]]]),
+      new Map([["coder", prior]]),
+      new Map([["coder", ["x"]]]), // same content
+      now,
+    );
+    expect(timestamps.get("coder")).toBe(prior);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `bun test src/tui/hooks/use-agent-monitor.test.ts -t mergeOutputs`
+Expected: FAIL — `mergeOutputs` not exported.
+
+- [ ] **Step 3: Add `mergeOutputs` and wire it into the hook**
+
+Edit `src/tui/hooks/use-agent-monitor.ts`:
+
+1. Add `mergeOutputs` near the other exported pure helpers (around line 137, after `parseLogContent`):
+
+```ts
+/**
+ * Merge a fresh outputs snapshot with the prior state and produce a parallel
+ * timestamp map. A role's timestamp is bumped to `now` only when its line
+ * array changed. Pure — exported for testing.
+ */
+export function mergeOutputs(
+  priorOutputs: ReadonlyMap<string, readonly string[]>,
+  priorTimestamps: ReadonlyMap<string, string>,
+  nextOutputs: ReadonlyMap<string, readonly string[]>,
+  now: string,
+): {
+  readonly outputs: ReadonlyMap<string, readonly string[]>;
+  readonly timestamps: ReadonlyMap<string, string>;
+} {
+  const timestamps = new Map<string, string>(priorTimestamps);
+  for (const [role, lines] of nextOutputs) {
+    const prior = priorOutputs.get(role);
+    const changed =
+      !prior ||
+      prior.length !== lines.length ||
+      prior.some((line, i) => line !== lines[i]);
+    if (changed) timestamps.set(role, now);
+  }
+  return { outputs: nextOutputs, timestamps };
+}
+```
+
+2. Extend the `AgentMonitorState` interface:
+
+```ts
+export interface AgentMonitorState {
+  readonly agentOutputs: ReadonlyMap<string, readonly string[]>;
+  /** ISO timestamp of the most recent change per role. Updated only when the
+   *  role's line array differs from its prior value. */
+  readonly agentOutputTimestamps: ReadonlyMap<string, string>;
+  readonly pendingPermissions: readonly PermissionPrompt[];
+  readonly ipcMessages: readonly IpcMessage[];
+  readonly spinnerFrame: number;
+}
+```
+
+3. Inside `useAgentMonitor`:
+   - Add a new state: `const [agentOutputTimestamps, setAgentOutputTimestamps] = useState<ReadonlyMap<string, string>>(new Map());`
+   - Replace both `setAgentOutputs(outputs)` calls (one in `logPoll`, one in `tmuxPoll`) with:
+
+```ts
+const now = new Date().toISOString();
+setAgentOutputs((prior) => {
+  const merged = mergeOutputs(prior, agentOutputTimestamps, outputs, now);
+  setAgentOutputTimestamps(merged.timestamps);
+  return merged.outputs;
+});
+```
+
+   - Add `agentOutputTimestamps` to the returned object.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `bun test src/tui/hooks/use-agent-monitor.test.ts`
+Expected: PASS (existing tests + the two new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/hooks/use-agent-monitor.ts src/tui/hooks/use-agent-monitor.test.ts
+git commit -m "feat(tui): add per-role output timestamps to useAgentMonitor (#193)"
+```
+
+---
+
+## Task 2: Pure `agent-health` module
+
+**Files:**
+- Create: `src/tui/screens/supervision/agent-health.ts`
+- Create: `src/tui/screens/supervision/agent-health.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `src/tui/screens/supervision/agent-health.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { deriveAgentHealth, HEALTH_THRESHOLDS, type HealthInput } from "./agent-health.js";
+
+const NOW = new Date("2026-05-18T12:00:00Z").getTime();
+const minutesAgo = (m: number): string =>
+  new Date(NOW - m * 60_000).toISOString();
+
+function baseInput(over: Partial<HealthInput> = {}): HealthInput {
+  return {
+    role: "coder",
+    leaseExpiresAt: new Date(NOW + 60_000).toISOString(),
+    heartbeatAt: minutesAgo(0),
+    attemptCount: 0,
+    lastRetryAt: undefined,
+    lastOutputAt: minutesAgo(0),
+    currentTask: "task-a",
+    currentTaskSinceMs: 1_000,
+    pendingApproval: undefined,
+    blockedOn: undefined,
+    blockedSinceMs: 0,
+    agentFailure: undefined,
+    ...over,
+  };
+}
+
+describe("deriveAgentHealth", () => {
+  test("agentFailure → error (highest priority)", () => {
+    const out = deriveAgentHealth(
+      baseInput({
+        agentFailure: "auth failed",
+        pendingApproval: { sessionName: "grove-coder-x", agentRole: "coder", command: "ls" },
+      }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out).toEqual({ kind: "error", reason: "auth failed" });
+  });
+
+  test("pendingApproval beats blocked beats stuck", () => {
+    const out = deriveAgentHealth(
+      baseInput({
+        pendingApproval: { sessionName: "s", agentRole: "coder", command: "rm" },
+      }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out).toEqual({ kind: "approval", cmd: "rm" });
+  });
+
+  test("lease expired → expired", () => {
+    const out = deriveAgentHealth(
+      baseInput({ leaseExpiresAt: new Date(NOW - 1).toISOString() }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).toBe("expired");
+  });
+
+  test("attemptCount >= threshold and recent retry → thrashing", () => {
+    const out = deriveAgentHealth(
+      baseInput({ attemptCount: 4, lastRetryAt: new Date(NOW - 10_000).toISOString() }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out).toEqual({ kind: "thrashing", retries: 4 });
+  });
+
+  test("blockedOn set and past min duration → blocked", () => {
+    const out = deriveAgentHealth(
+      baseInput({ blockedOn: "coordinator", blockedSinceMs: 120_000 }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out).toEqual({ kind: "blocked", on: "coordinator", sinceMs: 120_000 });
+  });
+
+  test("no output for > SILENT_MS → silent", () => {
+    const out = deriveAgentHealth(
+      baseInput({ lastOutputAt: minutesAgo(6) }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).toBe("silent");
+  });
+
+  test("task unchanged longer than STUCK_MS but output recent → stuck", () => {
+    const out = deriveAgentHealth(
+      baseInput({ currentTaskSinceMs: 9 * 60_000, lastOutputAt: minutesAgo(0) }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).toBe("stuck");
+  });
+
+  test("heartbeat lapse > 60s → silent (heartbeat path)", () => {
+    const out = deriveAgentHealth(
+      baseInput({ heartbeatAt: minutesAgo(2), lastOutputAt: minutesAgo(0) }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).toBe("silent");
+  });
+
+  test("recent output + recent heartbeat → running", () => {
+    const out = deriveAgentHealth(baseInput(), NOW, HEALTH_THRESHOLDS);
+    expect(out.kind).toBe("running");
+  });
+
+  test("no output ever + no task → idle", () => {
+    const out = deriveAgentHealth(
+      baseInput({ lastOutputAt: undefined, currentTask: undefined }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).toBe("idle");
+  });
+
+  test("threshold edge: SILENT_MS - 1 → not silent", () => {
+    const out = deriveAgentHealth(
+      baseInput({ lastOutputAt: new Date(NOW - HEALTH_THRESHOLDS.silentMs + 1).toISOString() }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).not.toBe("silent");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `bun test src/tui/screens/supervision/agent-health.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `agent-health.ts`**
+
+Create `src/tui/screens/supervision/agent-health.ts`:
+
+```ts
+/**
+ * Pure derivation of agent supervision health (issue #193).
+ *
+ * Inputs come from the fleet model (claim + monitor output timestamps +
+ * handoffs + permissions). The first matching rule wins.
+ */
+
+import type { PermissionPrompt } from "../../hooks/use-agent-monitor.js";
+
+export interface HealthThresholds {
+  /** No output for longer than this → silent. */
+  readonly silentMs: number;
+  /** currentTask unchanged for longer than this (with recent output) → stuck. */
+  readonly stuckMs: number;
+  /** attemptCount >= this with a recent retry → thrashing. */
+  readonly thrashRetries: number;
+  /** "Recent retry" window: lastRetryAt within this from now. */
+  readonly thrashWindowMs: number;
+  /** Minimum blocked age before health flips to "blocked". */
+  readonly blockedMinMs: number;
+  /** Heartbeat lapse beyond this counts as silent. */
+  readonly heartbeatLapseMs: number;
+}
+
+export const HEALTH_THRESHOLDS: HealthThresholds = {
+  silentMs: 5 * 60_000,
+  stuckMs: 8 * 60_000,
+  thrashRetries: 3,
+  thrashWindowMs: 30_000,
+  blockedMinMs: 60_000,
+  heartbeatLapseMs: 60_000,
+};
+
+export type AgentHealth =
+  | { kind: "running" }
+  | { kind: "idle" }
+  | { kind: "approval"; cmd: string }
+  | { kind: "blocked"; on: string; sinceMs: number }
+  | { kind: "stuck"; sinceMs: number }
+  | { kind: "thrashing"; retries: number }
+  | { kind: "silent"; sinceMs: number }
+  | { kind: "error"; reason: string }
+  | { kind: "expired" };
+
+export interface HealthInput {
+  readonly role: string;
+  readonly leaseExpiresAt: string;
+  readonly heartbeatAt: string;
+  readonly attemptCount: number;
+  readonly lastRetryAt: string | undefined;
+  readonly lastOutputAt: string | undefined;
+  readonly currentTask: string | undefined;
+  readonly currentTaskSinceMs: number;
+  readonly pendingApproval: PermissionPrompt | undefined;
+  readonly blockedOn: string | undefined;
+  readonly blockedSinceMs: number;
+  readonly agentFailure: string | undefined;
+}
+
+/** Sort weight — lower = surfaced first. */
+export function healthPriority(h: AgentHealth): number {
+  switch (h.kind) {
+    case "error": return 0;
+    case "approval": return 1;
+    case "blocked": return 2;
+    case "stuck": return 3;
+    case "thrashing": return 4;
+    case "silent": return 5;
+    case "running": return 6;
+    case "idle": return 7;
+    case "expired": return 8;
+  }
+}
+
+export function deriveAgentHealth(
+  i: HealthInput,
+  nowMs: number,
+  t: HealthThresholds,
+): AgentHealth {
+  if (i.agentFailure) return { kind: "error", reason: i.agentFailure };
+  if (i.pendingApproval) return { kind: "approval", cmd: i.pendingApproval.command };
+
+  const leaseMs = new Date(i.leaseExpiresAt).getTime();
+  if (leaseMs <= nowMs) return { kind: "expired" };
+
+  if (
+    i.attemptCount >= t.thrashRetries &&
+    i.lastRetryAt !== undefined &&
+    nowMs - new Date(i.lastRetryAt).getTime() <= t.thrashWindowMs
+  ) {
+    return { kind: "thrashing", retries: i.attemptCount };
+  }
+
+  if (i.blockedOn !== undefined && i.blockedSinceMs > t.blockedMinMs) {
+    return { kind: "blocked", on: i.blockedOn, sinceMs: i.blockedSinceMs };
+  }
+
+  const lastOutMs = i.lastOutputAt ? new Date(i.lastOutputAt).getTime() : undefined;
+  if (lastOutMs !== undefined && nowMs - lastOutMs > t.silentMs) {
+    return { kind: "silent", sinceMs: nowMs - lastOutMs };
+  }
+
+  if (i.currentTask !== undefined && i.currentTaskSinceMs > t.stuckMs && lastOutMs !== undefined) {
+    return { kind: "stuck", sinceMs: i.currentTaskSinceMs };
+  }
+
+  const heartMs = new Date(i.heartbeatAt).getTime();
+  if (nowMs - heartMs > t.heartbeatLapseMs) {
+    return { kind: "silent", sinceMs: nowMs - heartMs };
+  }
+
+  if (lastOutMs !== undefined) return { kind: "running" };
+  return { kind: "idle" };
+}
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `bun test src/tui/screens/supervision/agent-health.test.ts`
+Expected: PASS — all 11 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/supervision/agent-health.ts src/tui/screens/supervision/agent-health.test.ts
+git commit -m "feat(tui): pure agent-health derivation for supervision (#193)"
+```
+
+---
+
+## Task 3: Pure `supervision-actions` module
+
+**Files:**
+- Create: `src/tui/screens/supervision/supervision-actions.ts`
+- Create: `src/tui/screens/supervision/supervision-actions.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tui/screens/supervision/supervision-actions.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { actionEnabled, SUPERVISION_ACTIONS, type SupervisionAction } from "./supervision-actions.js";
+import type { AgentHealth } from "./agent-health.js";
+
+const RUNNING: AgentHealth = { kind: "running" };
+const APPROVAL: AgentHealth = { kind: "approval", cmd: "rm -rf /" };
+const BLOCKED: AgentHealth = { kind: "blocked", on: "coordinator", sinceMs: 120_000 };
+const EXPIRED: AgentHealth = { kind: "expired" };
+
+describe("actionEnabled", () => {
+  test("approve / deny / always require approval health", () => {
+    expect(actionEnabled("approve", APPROVAL)).toBe(true);
+    expect(actionEnabled("approve", RUNNING)).toBe(false);
+    expect(actionEnabled("deny", BLOCKED)).toBe(false);
+    expect(actionEnabled("always", APPROVAL)).toBe(true);
+  });
+
+  test("reroute requires blocked health", () => {
+    expect(actionEnabled("reroute", BLOCKED)).toBe(true);
+    expect(actionEnabled("reroute", RUNNING)).toBe(false);
+  });
+
+  test("kill enabled for everything except expired", () => {
+    expect(actionEnabled("kill", RUNNING)).toBe(true);
+    expect(actionEnabled("kill", APPROVAL)).toBe(true);
+    expect(actionEnabled("kill", EXPIRED)).toBe(false);
+  });
+
+  test("tail / dag / message always enabled", () => {
+    for (const action of ["tail", "dag", "message"] as SupervisionAction[]) {
+      expect(actionEnabled(action, EXPIRED)).toBe(true);
+    }
+  });
+
+  test("SUPERVISION_ACTIONS lists each action exactly once", () => {
+    const set = new Set(SUPERVISION_ACTIONS);
+    expect(set.size).toBe(SUPERVISION_ACTIONS.length);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `bun test src/tui/screens/supervision/supervision-actions.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Create `supervision-actions.ts`**
+
+```ts
+/**
+ * Supervision action descriptors. Pure module — pairs an action key with an
+ * enablement predicate based on the selected agent's health.
+ */
+
+import type { AgentHealth } from "./agent-health.js";
+
+export type SupervisionAction =
+  | "approve"
+  | "deny"
+  | "always"
+  | "reroute"
+  | "kill"
+  | "tail"
+  | "dag"
+  | "message";
+
+export const SUPERVISION_ACTIONS: readonly SupervisionAction[] = [
+  "approve",
+  "deny",
+  "always",
+  "reroute",
+  "kill",
+  "tail",
+  "dag",
+  "message",
+];
+
+export function actionEnabled(action: SupervisionAction, health: AgentHealth): boolean {
+  switch (action) {
+    case "approve":
+    case "deny":
+    case "always":
+      return health.kind === "approval";
+    case "reroute":
+      return health.kind === "blocked";
+    case "kill":
+      return health.kind !== "expired";
+    case "tail":
+    case "dag":
+    case "message":
+      return true;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `bun test src/tui/screens/supervision/supervision-actions.test.ts`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/supervision/supervision-actions.ts src/tui/screens/supervision/supervision-actions.test.ts
+git commit -m "feat(tui): supervision action descriptors + enablement (#193)"
+```
+
+---
+
+## Task 4: `useFleetModel` join hook
+
+**Files:**
+- Create: `src/tui/screens/supervision/use-fleet-model.ts`
+- Create: `src/tui/screens/supervision/use-fleet-model.test.ts`
+
+This task tests the **pure join function** (`buildFleet`) that the hook wraps. The hook itself is exercised by `supervision.test.tsx` in Task 8.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tui/screens/supervision/use-fleet-model.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { ClaimEntity } from "../../../core/entity.js";
+import { type Handoff, HandoffStatus } from "../../../core/handoff.js";
+import { buildFleet, type FleetSources } from "./use-fleet-model.js";
+
+const NOW = new Date("2026-05-18T12:00:00Z").getTime();
+
+function claim(
+  agentId: string,
+  role: string,
+  over: Partial<ClaimEntity["status"]> = {},
+): ClaimEntity {
+  return {
+    kind: "Claim",
+    id: `claim-${agentId}`,
+    metadata: { creationTimestamp: new Date(NOW - 60_000).toISOString() },
+    spec: {
+      agent: { agentId, agentName: agentId, role, platform: "claude" },
+      targetRef: `target-${agentId}`,
+      intentSummary: "do thing",
+      context: {},
+    },
+    status: {
+      phase: "active",
+      heartbeatAt: new Date(NOW).toISOString(),
+      leaseExpiresAt: new Date(NOW + 60_000).toISOString(),
+      attemptCount: 0,
+      ...over,
+    },
+  } as ClaimEntity;
+}
+
+const baseSources: FleetSources = {
+  claims: [],
+  tmuxSessions: [],
+  costs: new Map(),
+  agentOutputs: new Map(),
+  agentOutputTimestamps: new Map(),
+  pendingPermissions: [],
+  handoffs: [],
+  agentFailures: new Map(),
+  filterText: undefined,
+  nowMs: NOW,
+};
+
+describe("buildFleet", () => {
+  test("sorts problem agents before running agents", () => {
+    const fleet = buildFleet({
+      ...baseSources,
+      claims: [
+        claim("a-run", "coder"),
+        claim("b-fail", "coder"),
+      ],
+      agentFailures: new Map([["coder", "ACP auth failed"]]),
+    });
+    expect(fleet[0]?.agentId).toBe("b-fail");
+    expect(fleet[0]?.health.kind).toBe("error");
+  });
+
+  test("session field undefined when no tmux session matches", () => {
+    const fleet = buildFleet({
+      ...baseSources,
+      claims: [claim("a", "coder")],
+      tmuxSessions: ["grove-other-xyz"],
+    });
+    expect(fleet[0]?.session).toBeUndefined();
+  });
+
+  test("cost rollup matches by agentId", () => {
+    const fleet = buildFleet({
+      ...baseSources,
+      claims: [claim("a", "coder")],
+      costs: new Map([["a", { costUsd: 1.23, tokens: 4567 }]]),
+    });
+    expect(fleet[0]?.cost?.usd).toBe(1.23);
+  });
+
+  test("filterText narrows by case-insensitive substring across role/name/target", () => {
+    const fleet = buildFleet({
+      ...baseSources,
+      claims: [claim("alpha", "coder"), claim("beta", "reviewer")],
+      filterText: "REV",
+    });
+    expect(fleet.map((f) => f.agentId)).toEqual(["beta"]);
+  });
+
+  test("handoff blockedOn aggregated from oldest pending inbound", () => {
+    const handoff: Handoff = {
+      handoffId: "h1",
+      fromRole: "coordinator",
+      toRole: "coder",
+      status: HandoffStatus.PendingPickup,
+      sourceCid: "cid-1",
+      createdAt: new Date(NOW - 5 * 60_000).toISOString(),
+    } as Handoff;
+    const fleet = buildFleet({
+      ...baseSources,
+      claims: [claim("a", "coder")],
+      handoffs: [handoff],
+    });
+    expect(fleet[0]?.handoffs.blockedOn).toBe("coordinator");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `bun test src/tui/screens/supervision/use-fleet-model.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Create `use-fleet-model.ts`**
+
+```ts
+/**
+ * Fleet model — join active claims with tmux session, cost, monitor outputs,
+ * pending permissions, handoffs, and per-role failure messages, and derive
+ * AgentHealth per agent. Sorted problem-first.
+ *
+ * The hook subscribes to the existing entity informer + monitor; all sources
+ * are push-driven so the model recomputes only when inputs change.
+ */
+
+import { useCallback, useMemo } from "react";
+import { type ClaimEntity, claimToEntity } from "../../../core/entity.js";
+import type { Handoff } from "../../../core/handoff.js";
+import { HandoffStatus } from "../../../core/handoff.js";
+import { agentIdFromSession } from "../../agents/tmux-manager.js";
+import { useEventDrivenData } from "../../hooks/use-event-driven-data.js";
+import type { AgentMonitorState, PermissionPrompt } from "../../hooks/use-agent-monitor.js";
+import type { TuiDataProvider } from "../../provider.js";
+import { isHandoffProvider } from "../../provider.js";
+import {
+  type AgentHealth,
+  deriveAgentHealth,
+  HEALTH_THRESHOLDS,
+  healthPriority,
+} from "./agent-health.js";
+
+export interface FleetCost {
+  readonly usd: number;
+  readonly tokens: number;
+  readonly ctxPercent?: number;
+}
+
+export interface FleetAgent {
+  readonly agentId: string;
+  readonly agentName: string;
+  readonly role: string;
+  readonly platform: string;
+  readonly session: string | undefined;
+  readonly claim: ClaimEntity;
+  readonly health: AgentHealth;
+  readonly currentTask: string | undefined;
+  readonly lastAction: string | undefined;
+  readonly lastOutputAt: string | undefined;
+  readonly cost: FleetCost | undefined;
+  readonly handoffs: { pendingOut: number; overdueIn: number; blockedOn?: string };
+  readonly pendingApproval: PermissionPrompt | undefined;
+  readonly attemptCount: number;
+}
+
+export interface FleetSources {
+  readonly claims: readonly ClaimEntity[];
+  readonly tmuxSessions: readonly string[];
+  readonly costs: ReadonlyMap<string, FleetCost>;
+  readonly agentOutputs: ReadonlyMap<string, readonly string[]>;
+  readonly agentOutputTimestamps: ReadonlyMap<string, string>;
+  readonly pendingPermissions: readonly PermissionPrompt[];
+  readonly handoffs: readonly Handoff[];
+  readonly agentFailures: ReadonlyMap<string, string>;
+  readonly filterText: string | undefined;
+  readonly nowMs: number;
+}
+
+const matchesFilter = (a: FleetAgent, q: string): boolean => {
+  const haystack = `${a.agentName} ${a.agentId} ${a.role} ${a.platform} ${a.claim.spec.targetRef}`.toLowerCase();
+  return haystack.includes(q);
+};
+
+/** Build a sorted FleetAgent list. Pure — exported for testing. */
+export function buildFleet(s: FleetSources): readonly FleetAgent[] {
+  const tmuxByAgent = new Map<string, string>();
+  for (const session of s.tmuxSessions) {
+    const id = agentIdFromSession(session);
+    if (id) tmuxByAgent.set(id, session);
+  }
+
+  const inboundByRole = new Map<string, Handoff[]>();
+  for (const h of s.handoffs) {
+    if (h.status !== HandoffStatus.PendingPickup) continue;
+    const list = inboundByRole.get(h.toRole) ?? [];
+    list.push(h);
+    inboundByRole.set(h.toRole, list);
+  }
+  const outboundByRole = new Map<string, number>();
+  for (const h of s.handoffs) {
+    if (h.status !== HandoffStatus.PendingPickup) continue;
+    outboundByRole.set(h.fromRole, (outboundByRole.get(h.fromRole) ?? 0) + 1);
+  }
+
+  const agents: FleetAgent[] = [];
+  for (const claim of s.claims) {
+    const role = claim.spec.agent.role ?? "worker";
+    const agentId = claim.spec.agent.agentId;
+    const session = tmuxByAgent.get(agentId);
+    const outputs = s.agentOutputs.get(role) ?? [];
+    const lastAction = outputs.length > 0 ? outputs[outputs.length - 1] : undefined;
+    const lastOutputAt = s.agentOutputTimestamps.get(role);
+    const pendingApproval = s.pendingPermissions.find((p) => p.agentRole === role);
+    const inbound = inboundByRole.get(role) ?? [];
+    const oldestInbound = inbound
+      .slice()
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt))[0];
+    const blockedOn = oldestInbound?.fromRole;
+    const blockedSinceMs = oldestInbound
+      ? s.nowMs - new Date(oldestInbound.createdAt).getTime()
+      : 0;
+    const overdueIn = inbound.filter(
+      (h) =>
+        h.replyDueAt !== undefined && new Date(h.replyDueAt).getTime() < s.nowMs,
+    ).length;
+
+    const health = deriveAgentHealth(
+      {
+        role,
+        leaseExpiresAt: claim.status.leaseExpiresAt,
+        heartbeatAt: claim.status.heartbeatAt,
+        attemptCount: claim.status.attemptCount,
+        lastRetryAt: undefined,
+        lastOutputAt,
+        currentTask: claim.spec.intentSummary,
+        currentTaskSinceMs: s.nowMs - new Date(claim.metadata.creationTimestamp ?? claim.status.heartbeatAt).getTime(),
+        pendingApproval,
+        blockedOn,
+        blockedSinceMs,
+        agentFailure: s.agentFailures.get(role),
+      },
+      s.nowMs,
+      HEALTH_THRESHOLDS,
+    );
+
+    agents.push({
+      agentId,
+      agentName: claim.spec.agent.agentName ?? agentId,
+      role,
+      platform: claim.spec.agent.platform ?? "-",
+      session,
+      claim,
+      health,
+      currentTask: claim.spec.intentSummary,
+      lastAction,
+      lastOutputAt,
+      cost: s.costs.get(agentId),
+      handoffs: {
+        pendingOut: outboundByRole.get(role) ?? 0,
+        overdueIn,
+        ...(blockedOn ? { blockedOn } : {}),
+      },
+      pendingApproval,
+      attemptCount: claim.status.attemptCount,
+    });
+  }
+
+  const q = s.filterText?.trim().toLowerCase();
+  const filtered = q ? agents.filter((a) => matchesFilter(a, q)) : agents;
+
+  return filtered.slice().sort((a, b) => {
+    const pa = healthPriority(a.health);
+    const pb = healthPriority(b.health);
+    if (pa !== pb) return pa - pb;
+    if (a.role === "coordinator" && b.role !== "coordinator") return -1;
+    if (b.role === "coordinator" && a.role !== "coordinator") return 1;
+    return a.agentName.localeCompare(b.agentName);
+  });
+}
+
+export interface UseFleetModelArgs {
+  readonly provider: TuiDataProvider;
+  readonly monitor: AgentMonitorState;
+  readonly agentFailures: ReadonlyMap<string, string> | undefined;
+  readonly tmux: import("../../agents/tmux-manager.js").TmuxManager | undefined;
+  readonly filterText: string | undefined;
+  readonly active: boolean;
+}
+
+const NAMESPACE = "default";
+
+export function useFleetModel(args: UseFleetModelArgs): readonly FleetAgent[] {
+  // Active claims (mirrors AgentListView's fallback fetcher pattern).
+  const claimsFetcher = useCallback(async (): Promise<readonly ClaimEntity[]> => {
+    const flat = await args.provider.getClaims({ status: "active" });
+    return flat.map((c) => claimToEntity(c, () => Date.now(), NAMESPACE));
+  }, [args.provider]);
+  const { data: claims } = useEventDrivenData<readonly ClaimEntity[]>(
+    claimsFetcher,
+    undefined,
+    undefined,
+    args.active,
+  );
+
+  // Tmux sessions (same pattern as AgentListView).
+  const tmuxFetcher = useCallback(async (): Promise<readonly string[]> => {
+    if (!args.tmux) return [];
+    return (await args.tmux.isAvailable()) ? args.tmux.listSessions() : [];
+  }, [args.tmux]);
+  const { data: tmuxSessions } = useEventDrivenData<readonly string[]>(
+    tmuxFetcher,
+    undefined,
+    undefined,
+    args.active && !!args.tmux,
+  );
+
+  // Session costs (same pattern as AgentListView).
+  const costsFetcher = useCallback(async (): Promise<ReadonlyMap<string, FleetCost>> => {
+    const cp = args.provider as unknown as {
+      getSessionCosts?: () => Promise<{
+        byAgent: readonly { agentId: string; costUsd: number; tokens: number; contextPercent?: number }[];
+      }>;
+    };
+    if (!cp.getSessionCosts) return new Map();
+    const out = await cp.getSessionCosts();
+    const m = new Map<string, FleetCost>();
+    for (const a of out.byAgent) {
+      m.set(a.agentId, {
+        usd: a.costUsd,
+        tokens: a.tokens,
+        ...(a.contextPercent !== undefined ? { ctxPercent: a.contextPercent } : {}),
+      });
+    }
+    return m;
+  }, [args.provider]);
+  const { data: costs } = useEventDrivenData<ReadonlyMap<string, FleetCost>>(
+    costsFetcher,
+    undefined,
+    undefined,
+    args.active,
+  );
+
+  // Handoffs (same pattern as HandoffsView).
+  const handoffsFetcher = useCallback(async (): Promise<readonly Handoff[]> => {
+    if (!isHandoffProvider(args.provider)) return [];
+    return args.provider.getHandoffs({ limit: 200 });
+  }, [args.provider]);
+  const { data: handoffs } = useEventDrivenData<readonly Handoff[]>(
+    handoffsFetcher,
+    undefined,
+    undefined,
+    args.active && isHandoffProvider(args.provider),
+  );
+
+  const failures = args.agentFailures ?? new Map<string, string>();
+
+  return useMemo(
+    () =>
+      buildFleet({
+        claims: claims ?? [],
+        tmuxSessions: tmuxSessions ?? [],
+        costs: costs ?? new Map(),
+        agentOutputs: args.monitor.agentOutputs,
+        agentOutputTimestamps: args.monitor.agentOutputTimestamps,
+        pendingPermissions: args.monitor.pendingPermissions,
+        handoffs: handoffs ?? [],
+        agentFailures: failures,
+        filterText: args.filterText,
+        nowMs: Date.now(),
+      }),
+    [
+      claims,
+      tmuxSessions,
+      costs,
+      args.monitor.agentOutputs,
+      args.monitor.agentOutputTimestamps,
+      args.monitor.pendingPermissions,
+      handoffs,
+      failures,
+      args.filterText,
+    ],
+  );
+}
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `bun test src/tui/screens/supervision/use-fleet-model.test.ts`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/supervision/use-fleet-model.ts src/tui/screens/supervision/use-fleet-model.test.ts
+git commit -m "feat(tui): fleet-model join + health sort (#193)"
+```
+
+---
+
+## Task 5: `<FleetRail>` component
+
+**Files:**
+- Create: `src/tui/screens/supervision/fleet-rail.tsx`
+- Create: `src/tui/screens/supervision/fleet-rail.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tui/screens/supervision/fleet-rail.test.tsx`:
+
+```tsx
+import { describe, expect, test } from "bun:test";
+import React from "react";
+import { render } from "@opentui/react";
+import type { FleetAgent } from "./use-fleet-model.js";
+import { FleetRail } from "./fleet-rail.js";
+
+function agent(over: Partial<FleetAgent>): FleetAgent {
+  return {
+    agentId: "a",
+    agentName: "agent-a",
+    role: "coder",
+    platform: "claude",
+    session: undefined,
+    claim: {} as FleetAgent["claim"],
+    health: { kind: "running" },
+    currentTask: "do thing",
+    lastAction: undefined,
+    lastOutputAt: undefined,
+    cost: undefined,
+    handoffs: { pendingOut: 0, overdueIn: 0 },
+    pendingApproval: undefined,
+    attemptCount: 0,
+    ...over,
+  };
+}
+
+describe("FleetRail", () => {
+  test("renders one row per fleet agent with health icon prefix", () => {
+    const r = render(
+      <FleetRail
+        agents={[
+          agent({ agentId: "a1", health: { kind: "running" } }),
+          agent({ agentId: "a2", health: { kind: "blocked", on: "coord", sinceMs: 120_000 } }),
+        ]}
+        cursor={0}
+        selectedAgentId="a1"
+      />,
+    );
+    const out = r.toString();
+    expect(out).toContain("a1");
+    expect(out).toContain("a2");
+    expect(out).toContain("BLOCKED");
+  });
+
+  test("approval lane shows [y/n] suffix", () => {
+    const r = render(
+      <FleetRail
+        agents={[agent({ agentId: "a1", health: { kind: "approval", cmd: "rm" } })]}
+        cursor={0}
+        selectedAgentId="a1"
+      />,
+    );
+    expect(r.toString()).toContain("[y/n]");
+  });
+
+  test("empty state copy", () => {
+    const r = render(
+      <FleetRail agents={[]} cursor={0} selectedAgentId={undefined} />,
+    );
+    expect(r.toString()).toContain("No agents registered");
+  });
+
+  test("header reports problem count", () => {
+    const r = render(
+      <FleetRail
+        agents={[
+          agent({ agentId: "ok", health: { kind: "running" } }),
+          agent({ agentId: "bad", health: { kind: "stuck", sinceMs: 9 * 60_000 } }),
+        ]}
+        cursor={0}
+        selectedAgentId="ok"
+      />,
+    );
+    expect(r.toString()).toMatch(/Fleet \(2 · 1 problem\)/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `bun test src/tui/screens/supervision/fleet-rail.test.tsx`
+Expected: FAIL — component missing.
+
+- [ ] **Step 3: Create `fleet-rail.tsx`**
+
+```tsx
+/**
+ * Fleet rail — dense one-row-per-agent list (issue #193).
+ *
+ * Renders the FleetAgent[] from useFleetModel. Cursor row is highlighted;
+ * problem agents show ALL-CAPS health label and any blocked-on attribution.
+ */
+
+import React from "react";
+import { EmptyState } from "../../components/empty-state.js";
+import { agentStatusIcon, theme } from "../../theme.js";
+import type { AgentHealth } from "./agent-health.js";
+import type { FleetAgent } from "./use-fleet-model.js";
+
+export interface FleetRailProps {
+  readonly agents: readonly FleetAgent[];
+  readonly cursor: number;
+  readonly selectedAgentId: string | undefined;
+}
+
+const PROBLEM_KINDS = new Set<AgentHealth["kind"]>([
+  "error",
+  "approval",
+  "blocked",
+  "stuck",
+  "thrashing",
+  "silent",
+]);
+
+const trunc = (s: string, n: number): string =>
+  s.length > n ? `${s.slice(0, n - 1)}…` : s;
+
+const mins = (ms: number): string => {
+  const m = Math.floor(ms / 60_000);
+  if (m < 60) return `${m}m`;
+  return `${Math.floor(m / 60)}h`;
+};
+
+function healthLabel(h: AgentHealth): { label: string; color: string } {
+  switch (h.kind) {
+    case "running": return { label: "run", color: theme.running };
+    case "idle": return { label: "idle", color: theme.idle };
+    case "approval": return { label: "APPROVAL", color: theme.warning };
+    case "blocked": return { label: `BLOCKED ${mins(h.sinceMs)}`, color: theme.error };
+    case "stuck": return { label: `STUCK ${mins(h.sinceMs)}`, color: theme.warning };
+    case "thrashing": return { label: `THRASH x${h.retries}`, color: theme.warning };
+    case "silent": return { label: `SILENT ${mins(h.sinceMs)}`, color: theme.warning };
+    case "error": return { label: "ERROR", color: theme.error };
+    case "expired": return { label: "expired", color: theme.idle };
+  }
+}
+
+export const FleetRail = React.memo(function FleetRail({
+  agents,
+  cursor,
+  selectedAgentId,
+}: FleetRailProps): React.ReactNode {
+  if (agents.length === 0) {
+    return (
+      <box flexDirection="column">
+        <box marginBottom={1}>
+          <text>Fleet (0)</text>
+        </box>
+        <EmptyState
+          title="No agents registered."
+          hint="Press r to register, or Ctrl+P to spawn."
+        />
+      </box>
+    );
+  }
+
+  const problemCount = agents.filter((a) => PROBLEM_KINDS.has(a.health.kind)).length;
+  const header = `Fleet (${agents.length}${problemCount > 0 ? ` · ${problemCount} problem` : ""})`;
+
+  return (
+    <box flexDirection="column">
+      <box marginBottom={1}>
+        <text bold>{header}</text>
+      </box>
+      {agents.map((a, i) => {
+        const isCursor = i === cursor;
+        const isSelected = a.agentId === selectedAgentId;
+        const { icon } = agentStatusIcon(
+          a.health.kind === "running" ? "running" : a.health.kind === "idle" ? "idle" : "error",
+        );
+        const lbl = healthLabel(a.health);
+        const prefix = isCursor ? "►" : " ";
+        const action = a.lastAction ?? a.currentTask ?? "";
+        return (
+          <box key={a.agentId} flexDirection="row" backgroundColor={isSelected ? theme.focus : undefined}>
+            <text>{`${prefix} `}</text>
+            <text color={lbl.color}>{`${icon} ${lbl.label.padEnd(14)}`}</text>
+            <text color={theme.secondary}>{` ${a.role.padEnd(10)} `}</text>
+            <text>{trunc(a.agentName, 14).padEnd(14)}</text>
+            <text color={theme.secondary}>{` ${trunc(action, 40)}`}</text>
+            {a.health.kind === "blocked" ? (
+              <text color={theme.error}>{` ← ${a.health.on}`}</text>
+            ) : null}
+            {a.health.kind === "approval" ? (
+              <text color={theme.warning}>{" [y/n]"}</text>
+            ) : null}
+            {a.cost ? (
+              <text color={theme.secondary}>{`  $${a.cost.usd.toFixed(2)}`}</text>
+            ) : null}
+          </box>
+        );
+      })}
+    </box>
+  );
+});
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `bun test src/tui/screens/supervision/fleet-rail.test.tsx`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/supervision/fleet-rail.tsx src/tui/screens/supervision/fleet-rail.test.tsx
+git commit -m "feat(tui): fleet rail dense lane list (#193)"
+```
+
+---
+
+## Task 6: `<DetailRail>` component
+
+**Files:**
+- Create: `src/tui/screens/supervision/detail-rail.tsx`
+- Create: `src/tui/screens/supervision/detail-rail.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tui/screens/supervision/detail-rail.test.tsx`:
+
+```tsx
+import { describe, expect, test } from "bun:test";
+import React from "react";
+import { render } from "@opentui/react";
+import { DetailRail } from "./detail-rail.js";
+import type { FleetAgent } from "./use-fleet-model.js";
+
+const baseAgent: FleetAgent = {
+  agentId: "a1",
+  agentName: "alpha",
+  role: "coder",
+  platform: "claude",
+  session: "grove-coder-x",
+  claim: {} as FleetAgent["claim"],
+  health: { kind: "running" },
+  currentTask: "edit login.ts",
+  lastAction: undefined,
+  lastOutputAt: undefined,
+  cost: { usd: 1.18, tokens: 42_000 },
+  handoffs: { pendingOut: 1, overdueIn: 0 },
+  pendingApproval: undefined,
+  attemptCount: 0,
+};
+
+describe("DetailRail", () => {
+  test("renders placeholder when no agent selected", () => {
+    const r = render(
+      <DetailRail agent={undefined} tail={[]} />,
+    );
+    expect(r.toString()).toContain("Select an agent");
+  });
+
+  test("renders task + cost + handoffs for selected agent", () => {
+    const r = render(<DetailRail agent={baseAgent} tail={["line 1", "line 2"]} />);
+    const out = r.toString();
+    expect(out).toContain("alpha");
+    expect(out).toContain("edit login.ts");
+    expect(out).toContain("$1.18");
+    expect(out).toContain("1 pending out");
+    expect(out).toContain("line 2");
+  });
+
+  test("approval section appears only when health is approval", () => {
+    const approvalAgent: FleetAgent = {
+      ...baseAgent,
+      health: { kind: "approval", cmd: "rm -rf foo" },
+      pendingApproval: { sessionName: "s", agentRole: "coder", command: "rm -rf foo" },
+    };
+    const r = render(<DetailRail agent={approvalAgent} tail={[]} />);
+    expect(r.toString()).toContain("rm -rf foo");
+    expect(r.toString()).toContain("[y]allow");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `bun test src/tui/screens/supervision/detail-rail.test.tsx`
+Expected: FAIL — component missing.
+
+- [ ] **Step 3: Create `detail-rail.tsx`**
+
+```tsx
+/**
+ * Detail rail — selected-agent context (issue #193).
+ *
+ * Stacked sections: header, approval (when present), task, tail, handoffs,
+ * cost, action footer.
+ */
+
+import React from "react";
+import { theme } from "../../theme.js";
+import type { AgentHealth } from "./agent-health.js";
+import type { FleetAgent } from "./use-fleet-model.js";
+
+export interface DetailRailProps {
+  readonly agent: FleetAgent | undefined;
+  readonly tail: readonly string[];
+}
+
+const mins = (ms: number): string => {
+  const m = Math.floor(ms / 60_000);
+  if (m < 60) return `${m}m`;
+  return `${Math.floor(m / 60)}h`;
+};
+
+function healthHeader(h: AgentHealth): { text: string; color: string } {
+  switch (h.kind) {
+    case "running": return { text: "RUNNING", color: theme.running };
+    case "idle": return { text: "IDLE", color: theme.idle };
+    case "approval": return { text: "APPROVAL PENDING", color: theme.warning };
+    case "blocked": return { text: `BLOCKED ${mins(h.sinceMs)} on ${h.on}`, color: theme.error };
+    case "stuck": return { text: `STUCK ${mins(h.sinceMs)}`, color: theme.warning };
+    case "thrashing": return { text: `THRASHING (${h.retries} retries)`, color: theme.warning };
+    case "silent": return { text: `SILENT ${mins(h.sinceMs)}`, color: theme.warning };
+    case "error": return { text: `ERROR: ${h.reason}`, color: theme.error };
+    case "expired": return { text: "EXPIRED", color: theme.idle };
+  }
+}
+
+export const DetailRail = React.memo(function DetailRail({
+  agent,
+  tail,
+}: DetailRailProps): React.ReactNode {
+  if (!agent) {
+    return (
+      <box flexDirection="column" paddingX={1}>
+        <text opacity={0.5}>Select an agent (j/k) to view context</text>
+      </box>
+    );
+  }
+
+  const hdr = healthHeader(agent.health);
+
+  return (
+    <box flexDirection="column" paddingX={1}>
+      <box flexDirection="row" marginBottom={1}>
+        <text bold>{agent.agentName}</text>
+        <text color={theme.secondary}>{`  (${agent.role}/${agent.platform})  `}</text>
+        <text color={hdr.color} bold>{hdr.text}</text>
+      </box>
+
+      {agent.health.kind === "approval" ? (
+        <box flexDirection="column" marginBottom={1} borderStyle="round" borderColor={theme.warning} paddingX={1}>
+          <text color={theme.warning} bold>Wants to run:</text>
+          <text>{agent.health.cmd}</text>
+          <text color={theme.secondary}>[y]allow [n]deny [a]always</text>
+        </box>
+      ) : null}
+
+      <box flexDirection="column" marginBottom={1}>
+        <text color={theme.secondary} bold>Task</text>
+        <text>{agent.currentTask ?? "(no task)"}</text>
+        <text color={theme.secondary}>target: {agent.claim.spec?.targetRef ?? "-"}</text>
+      </box>
+
+      <box flexDirection="column" marginBottom={1}>
+        <text color={theme.secondary} bold>Tail</text>
+        {tail.length === 0 ? (
+          <text opacity={0.4}>(no output)</text>
+        ) : (
+          tail.slice(-8).map((line, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: ephemeral lines
+            <text key={i}>{line}</text>
+          ))
+        )}
+      </box>
+
+      <box flexDirection="row" marginBottom={1}>
+        <text color={theme.secondary}>Handoffs: </text>
+        <text>{`${agent.handoffs.pendingOut} pending out`}</text>
+        {agent.handoffs.overdueIn > 0 ? (
+          <text color={theme.error}>{`  ${agent.handoffs.overdueIn} overdue in`}</text>
+        ) : null}
+        {agent.handoffs.blockedOn ? (
+          <text color={theme.error}>{`  blocked on ${agent.handoffs.blockedOn}`}</text>
+        ) : null}
+      </box>
+
+      <box flexDirection="row" marginBottom={1}>
+        <text color={theme.secondary}>Cost: </text>
+        <text>{agent.cost ? `$${agent.cost.usd.toFixed(2)} · ${agent.cost.tokens.toLocaleString()} tok` : "-"}</text>
+      </box>
+
+      <box flexDirection="row">
+        <text color={theme.secondary}>[t]ail [d]ag [r]eroute [K]ill [m]essage</text>
+      </box>
+    </box>
+  );
+});
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `bun test src/tui/screens/supervision/detail-rail.test.tsx`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/supervision/detail-rail.tsx src/tui/screens/supervision/detail-rail.test.tsx
+git commit -m "feat(tui): detail rail with stacked sections (#193)"
+```
+
+---
+
+## Task 7: Pure supervision keyboard router
+
+**Files:**
+- Create: `src/tui/screens/supervision/supervision-keyboard.ts`
+- Create: `src/tui/screens/supervision/supervision-keyboard.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tui/screens/supervision/supervision-keyboard.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+  routeSupervisionKey,
+  type SupervisionKeyboardActions,
+  type SupervisionKeyboardState,
+} from "./supervision-keyboard.js";
+import type { AgentHealth } from "./agent-health.js";
+
+function calls() {
+  const log: string[] = [];
+  const actions: SupervisionKeyboardActions = {
+    moveCursor: (delta) => log.push(`move:${delta}`),
+    pinSelection: () => log.push("pin"),
+    jumpTop: () => log.push("top"),
+    jumpBottom: () => log.push("bottom"),
+    approve: () => log.push("approve"),
+    deny: () => log.push("deny"),
+    always: () => log.push("always"),
+    openTail: () => log.push("tail"),
+    openDag: () => log.push("dag"),
+    reroute: () => log.push("reroute"),
+    kill: () => log.push("kill"),
+    openMessage: () => log.push("msg"),
+  };
+  return { actions, log };
+}
+
+function state(over: Partial<SupervisionKeyboardState> = {}): SupervisionKeyboardState {
+  return {
+    fleetSize: 3,
+    selectedHealth: { kind: "running" } as AgentHealth,
+    ...over,
+  };
+}
+
+describe("routeSupervisionKey", () => {
+  test("j moves cursor down, k moves up", () => {
+    const { actions, log } = calls();
+    routeSupervisionKey({ name: "j" }, state(), actions);
+    routeSupervisionKey({ name: "k" }, state(), actions);
+    expect(log).toEqual(["move:1", "move:-1"]);
+  });
+
+  test("y triggers approve only when health is approval", () => {
+    const { actions: a1, log: l1 } = calls();
+    routeSupervisionKey(
+      { name: "y" },
+      state({ selectedHealth: { kind: "approval", cmd: "rm" } }),
+      a1,
+    );
+    expect(l1).toEqual(["approve"]);
+
+    const { actions: a2, log: l2 } = calls();
+    routeSupervisionKey({ name: "y" }, state(), a2);
+    expect(l2).toEqual([]);
+  });
+
+  test("r triggers reroute only when blocked", () => {
+    const { actions, log } = calls();
+    routeSupervisionKey(
+      { name: "r" },
+      state({ selectedHealth: { kind: "blocked", on: "x", sinceMs: 9e5 } }),
+      actions,
+    );
+    expect(log).toEqual(["reroute"]);
+  });
+
+  test("returns true when handled, false otherwise", () => {
+    const { actions } = calls();
+    expect(routeSupervisionKey({ name: "j" }, state(), actions)).toBe(true);
+    expect(routeSupervisionKey({ name: "z" }, state(), actions)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `bun test src/tui/screens/supervision/supervision-keyboard.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Create `supervision-keyboard.ts`**
+
+```ts
+/**
+ * Pure keyboard router for the supervision body (issue #193).
+ *
+ * Returns true if it consumed the key. Caller passes through to the global
+ * router otherwise.
+ */
+
+import type { AgentHealth } from "./agent-health.js";
+import { actionEnabled } from "./supervision-actions.js";
+
+export interface SupervisionKey {
+  readonly name: string;
+}
+
+export interface SupervisionKeyboardState {
+  readonly fleetSize: number;
+  readonly selectedHealth: AgentHealth | undefined;
+}
+
+export interface SupervisionKeyboardActions {
+  readonly moveCursor: (delta: number) => void;
+  readonly pinSelection: () => void;
+  readonly jumpTop: () => void;
+  readonly jumpBottom: () => void;
+  readonly approve: () => void;
+  readonly deny: () => void;
+  readonly always: () => void;
+  readonly openTail: () => void;
+  readonly openDag: () => void;
+  readonly reroute: () => void;
+  readonly kill: () => void;
+  readonly openMessage: () => void;
+}
+
+export function routeSupervisionKey(
+  key: SupervisionKey,
+  state: SupervisionKeyboardState,
+  actions: SupervisionKeyboardActions,
+): boolean {
+  const health = state.selectedHealth;
+  switch (key.name) {
+    case "j":
+      actions.moveCursor(1);
+      return true;
+    case "k":
+      actions.moveCursor(-1);
+      return true;
+    case "return":
+    case "enter":
+      actions.pinSelection();
+      return true;
+    case "g":
+      actions.jumpTop();
+      return true;
+    case "G":
+      actions.jumpBottom();
+      return true;
+    case "y":
+      if (health && actionEnabled("approve", health)) {
+        actions.approve();
+        return true;
+      }
+      return false;
+    case "n":
+      if (health && actionEnabled("deny", health)) {
+        actions.deny();
+        return true;
+      }
+      return false;
+    case "a":
+      if (health && actionEnabled("always", health)) {
+        actions.always();
+        return true;
+      }
+      return false;
+    case "t":
+      if (health && actionEnabled("tail", health)) {
+        actions.openTail();
+        return true;
+      }
+      return false;
+    case "d":
+      if (health && actionEnabled("dag", health)) {
+        actions.openDag();
+        return true;
+      }
+      return false;
+    case "r":
+      if (health && actionEnabled("reroute", health)) {
+        actions.reroute();
+        return true;
+      }
+      return false;
+    case "K":
+      if (health && actionEnabled("kill", health)) {
+        actions.kill();
+        return true;
+      }
+      return false;
+    case "m":
+      if (health && actionEnabled("message", health)) {
+        actions.openMessage();
+        return true;
+      }
+      return false;
+    default:
+      return false;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `bun test src/tui/screens/supervision/supervision-keyboard.test.ts`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/supervision/supervision-keyboard.ts src/tui/screens/supervision/supervision-keyboard.test.ts
+git commit -m "feat(tui): supervision keyboard router (#193)"
+```
+
+---
+
+## Task 8: `<Supervision>` composition + state
+
+**Files:**
+- Create: `src/tui/screens/supervision/supervision.tsx`
+- Create: `src/tui/screens/supervision/supervision.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tui/screens/supervision/supervision.test.tsx`:
+
+```tsx
+import { describe, expect, test } from "bun:test";
+import React from "react";
+import { render } from "@opentui/react";
+import { Supervision } from "./supervision.js";
+import type { FleetAgent } from "./use-fleet-model.js";
+
+function agent(over: Partial<FleetAgent>): FleetAgent {
+  return {
+    agentId: "a",
+    agentName: "agent-a",
+    role: "coder",
+    platform: "claude",
+    session: undefined,
+    claim: { spec: { targetRef: "t" } } as FleetAgent["claim"],
+    health: { kind: "running" },
+    currentTask: "task",
+    lastAction: undefined,
+    lastOutputAt: undefined,
+    cost: undefined,
+    handoffs: { pendingOut: 0, overdueIn: 0 },
+    pendingApproval: undefined,
+    attemptCount: 0,
+    ...over,
+  };
+}
+
+describe("Supervision", () => {
+  test("auto-selects highest-priority agent on mount", () => {
+    const r = render(
+      <Supervision
+        agents={[
+          agent({ agentId: "ok", health: { kind: "running" } }),
+          agent({ agentId: "bad", health: { kind: "error", reason: "boom" } }),
+        ]}
+        tail={[]}
+        actions={{}}
+      />,
+    );
+    const out = r.toString();
+    // detail rail header echoes agent name when selected
+    expect(out).toContain("bad");
+    expect(out).toContain("ERROR: boom");
+  });
+
+  test("placeholder when fleet empty", () => {
+    const r = render(<Supervision agents={[]} tail={[]} actions={{}} />);
+    expect(r.toString()).toContain("No agents registered");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `bun test src/tui/screens/supervision/supervision.test.tsx`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Create `supervision.tsx`**
+
+```tsx
+/**
+ * Supervision body — fleet rail + detail rail (issue #193).
+ *
+ * Owns selection state. Auto-selects the highest-priority agent until the
+ * operator pins (Enter). On new approval, auto-selects the approving agent
+ * unless pinned.
+ *
+ * Keyboard wiring lives in the caller (running-view.tsx) via
+ * routeSupervisionKey + the actions passed in here.
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import { theme } from "../../theme.js";
+import { DetailRail } from "./detail-rail.js";
+import { FleetRail } from "./fleet-rail.js";
+import type { FleetAgent } from "./use-fleet-model.js";
+
+export interface SupervisionProps {
+  readonly agents: readonly FleetAgent[];
+  readonly tail: readonly string[];
+  /** Optional callbacks for tests; production wiring lives in running-view. */
+  readonly actions: Partial<{
+    onSelect: (agentId: string | undefined) => void;
+  }>;
+}
+
+export const Supervision = React.memo(function Supervision({
+  agents,
+  tail,
+  actions,
+}: SupervisionProps): React.ReactNode {
+  const [cursor, setCursor] = useState(0);
+  const [pinnedAgentId, setPinnedAgentId] = useState<string | undefined>(undefined);
+  const lastApprovalRef = useRef<string | undefined>(undefined);
+
+  // Clamp cursor when fleet size changes.
+  useEffect(() => {
+    if (cursor >= agents.length) setCursor(Math.max(0, agents.length - 1));
+  }, [agents.length, cursor]);
+
+  // Auto-select on new approval (unless operator has pinned someone else).
+  useEffect(() => {
+    const approval = agents.find((a) => a.health.kind === "approval");
+    if (approval && approval.agentId !== lastApprovalRef.current) {
+      lastApprovalRef.current = approval.agentId;
+      if (!pinnedAgentId) {
+        const idx = agents.findIndex((a) => a.agentId === approval.agentId);
+        if (idx >= 0) setCursor(idx);
+      }
+    } else if (!approval) {
+      lastApprovalRef.current = undefined;
+    }
+  }, [agents, pinnedAgentId]);
+
+  const selectedAgent =
+    (pinnedAgentId
+      ? agents.find((a) => a.agentId === pinnedAgentId)
+      : agents[cursor]) ?? agents[0];
+
+  useEffect(() => {
+    actions.onSelect?.(selectedAgent?.agentId);
+  }, [selectedAgent?.agentId, actions]);
+
+  // Mark `setPinnedAgentId` as intentionally unused-via-prop here; the caller
+  // wires Enter through actions in a follow-up commit. Keep the setter alive
+  // for future use without lint complaints.
+  void setPinnedAgentId;
+
+  return (
+    <box flexDirection="row" flexGrow={1}>
+      <box flexDirection="column" flexBasis="40%" paddingX={1}>
+        <FleetRail
+          agents={agents}
+          cursor={cursor}
+          selectedAgentId={selectedAgent?.agentId}
+        />
+      </box>
+      <box
+        flexDirection="column"
+        flexBasis="60%"
+        borderStyle="round"
+        borderColor={theme.focus}
+      >
+        <DetailRail agent={selectedAgent} tail={tail} />
+      </box>
+    </box>
+  );
+});
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `bun test src/tui/screens/supervision/supervision.test.tsx`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/supervision/supervision.tsx src/tui/screens/supervision/supervision.test.tsx
+git commit -m "feat(tui): supervision composition root (#193)"
+```
+
+---
+
+## Task 9: Additive `filterAgentId` prop on `DagView` and `HandoffsView`
+
+**Why:** When the operator presses `d` (open DAG) or `5` (handoffs) from supervision, the drilled-down view should highlight or narrow to the selected agent.
+
+**Files:**
+- Modify: `src/tui/views/dag.tsx`
+- Modify: `src/tui/views/handoffs-view.tsx`
+- Modify: `src/tui/views/dag.test.tsx` (extend)
+- Modify: `src/tui/views/handoffs-view.test.tsx` (create if missing)
+
+- [ ] **Step 1: Write the failing test for DagView (extend `dag.test.tsx`)**
+
+Append to `src/tui/views/dag.test.tsx`:
+
+```tsx
+test("renders without crash when filterAgentId prop is supplied", () => {
+  const r = render(
+    <DagView
+      provider={{} as unknown as never}
+      active={false}
+      cursor={0}
+      filterAgentId="agent-a"
+    />,
+  );
+  expect(r).toBeDefined();
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `bun test src/tui/views/dag.test.tsx -t filterAgentId`
+Expected: FAIL — prop type does not include `filterAgentId`.
+
+- [ ] **Step 3: Add the prop**
+
+Edit `src/tui/views/dag.tsx`, append to `DagProps` (around line 132):
+
+```ts
+  /** Optional: when set, the DAG biases focus / highlights toward this
+   *  agent. Default behavior (unfiltered) is preserved when omitted. */
+  readonly filterAgentId?: string | undefined;
+```
+
+Edit the component signature to accept it, but do not implement narrowing in this task — that's a follow-up. The prop is plumbed for callers; behavior change is out of scope.
+
+Same change for `src/tui/views/handoffs-view.tsx` — append to `HandoffsViewProps`:
+
+```ts
+  /** Optional: scope handoffs to those touching this agent's role. */
+  readonly filterAgentId?: string | undefined;
+```
+
+Inside `HandoffsView`, narrow the fetched result:
+
+```ts
+const scoped =
+  filterAgentId
+    ? handoffs.filter((h) =>
+        // best-effort: match by role from agentId prefix
+        h.fromRole === filterAgentId || h.toRole === filterAgentId,
+      )
+    : handoffs;
+```
+
+…and use `scoped` where `handoffs` is consumed in the render block.
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `bun test src/tui/views/dag.test.tsx src/tui/views/handoffs-view.test.ts*`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/views/dag.tsx src/tui/views/handoffs-view.tsx src/tui/views/dag.test.tsx
+git commit -m "feat(tui): additive filterAgentId on dag and handoffs views (#193)"
+```
+
+---
+
+## Task 10: Wire `GROVE_SUPERVISION` flag into `RunningView`
+
+**Files:**
+- Modify: `src/tui/screens/running-view.tsx`
+
+- [ ] **Step 1: Read the supervision-flag gate location**
+
+Open `src/tui/screens/running-view.tsx`. Find the module-scope env gate near line 114:
+
+```ts
+const useLogView = process.env.GROVE_LOGVIEW === "1";
+```
+
+- [ ] **Step 2: Add the supervision gate next to it**
+
+Insert after the `useLogView` line:
+
+```ts
+const useSupervision = process.env.GROVE_SUPERVISION === "1";
+```
+
+- [ ] **Step 3: Import the supervision module**
+
+Near the other view imports (after line 55 `import { VfsBrowserView }`), add:
+
+```ts
+import { Supervision } from "./supervision/supervision.js";
+import { useFleetModel } from "./supervision/use-fleet-model.js";
+import { routeSupervisionKey } from "./supervision/supervision-keyboard.js";
+```
+
+- [ ] **Step 4: Call `useFleetModel` near the existing data hooks**
+
+Inside `RunningView`, after `dashboard` is defined (around line 535), add:
+
+```ts
+const fleet = useFleetModel({
+  provider,
+  monitor,
+  agentFailures,
+  tmux,
+  filterText: filterQuery,
+  active: useSupervision && expandedPanel === null,
+});
+
+const [selectedSupervisionAgent, setSelectedSupervisionAgent] = useState<string | undefined>(undefined);
+const selectedAgent = useMemo(
+  () => fleet.find((a) => a.agentId === selectedSupervisionAgent) ?? fleet[0],
+  [fleet, selectedSupervisionAgent],
+);
+const selectedRole = selectedAgent?.role;
+const selectedTail = useMemo<readonly string[]>(
+  () => (selectedRole ? monitor.agentOutputs.get(selectedRole) ?? [] : []),
+  [selectedRole, monitor.agentOutputs],
+);
+```
+
+- [ ] **Step 5: Swap the default body**
+
+Find the no-panel-expanded render path. Search for `renderAgentSection(` and the surrounding block (around line 1404–1426). Replace that block with a flag-gated branch:
+
+```tsx
+{useSupervision ? (
+  <Supervision
+    agents={fleet}
+    tail={selectedTail}
+    actions={{ onSelect: (id) => setSelectedSupervisionAgent(id) }}
+  />
+) : (
+  <>
+    {renderAgentSection(
+      topology,
+      dashboard,
+      monitor,
+      agentFailures,
+      sessionStartedAt,
+      feed.length,
+    )}
+    {renderFeedSection(
+      feed,
+      cursor,
+      goal,
+      pendingAskUser,
+      frontier,
+      autoFollow,
+      newSinceFreeze,
+      activeRoles,
+      agentFailures,
+    )}
+  </>
+)}
+```
+
+- [ ] **Step 6: Wire the supervision keyboard router**
+
+Inside the existing `useKeyboard(...)` handler (search for `routeRunningKey`), add a guard before the global router:
+
+```ts
+if (useSupervision && expandedPanel === null) {
+  const handled = routeSupervisionKey(
+    { name: key.name },
+    {
+      fleetSize: fleet.length,
+      selectedHealth: selectedAgent?.health,
+    },
+    {
+      moveCursor: (delta) => {
+        const idx = Math.max(0, Math.min(fleet.length - 1, (cursor ?? 0) + delta));
+        setCursor(idx);
+        setSelectedSupervisionAgent(fleet[idx]?.agentId);
+      },
+      pinSelection: () => setSelectedSupervisionAgent(selectedAgent?.agentId),
+      jumpTop: () => {
+        setCursor(0);
+        setSelectedSupervisionAgent(fleet[0]?.agentId);
+      },
+      jumpBottom: () => {
+        const last = Math.max(0, fleet.length - 1);
+        setCursor(last);
+        setSelectedSupervisionAgent(fleet[last]?.agentId);
+      },
+      approve: () => {
+        const p = selectedAgent?.pendingApproval;
+        if (p && tmux) void tmux.sendKeys(p.sessionName, "y");
+      },
+      deny: () => {
+        const p = selectedAgent?.pendingApproval;
+        if (p && tmux) void tmux.sendKeys(p.sessionName, "n");
+      },
+      always: () => {
+        const p = selectedAgent?.pendingApproval;
+        if (p && tmux) void tmux.sendKeys(p.sessionName, "a");
+      },
+      openTail: () => actions.expandPanel(RunningPanel.Terminal),
+      openDag: () => actions.expandPanel(RunningPanel.Dag),
+      reroute: () => {
+        // Reroute lands with #163; surface a flash message until then.
+        setFlashError("Reroute lands with #163");
+      },
+      kill: () => {
+        // No provider.revokeClaim today; flash a placeholder until that lands.
+        // Tracked as follow-up in the spec's "Out of scope" section.
+        setFlashError("Kill action lands with claim-revoke provider API");
+      },
+      openMessage: () => {
+        if (selectedRole) {
+          setPromptMode(true);
+          setPromptTarget(
+            (activeRoles ?? []).findIndex((r) => r === selectedRole),
+          );
+        }
+      },
+    },
+  );
+  if (handled) return;
+}
+```
+
+Note: `cursor` and `setCursor` are reused from the existing `RunningView` state (the cmd-mode / feed cursor). If that's not desirable, declare a new local `[fleetCursor, setFleetCursor]` and use those instead — same wiring.
+
+- [ ] **Step 7: Run the full TUI test suite to confirm no regressions**
+
+Run: `bun test src/tui/`
+Expected: PASS — all existing tests still pass with `GROVE_SUPERVISION` unset.
+
+- [ ] **Step 8: Manual smoke with the flag on**
+
+```bash
+GROVE_SUPERVISION=1 bun run grove up
+```
+Expected: TUI launches; default body is the fleet+detail rail. With the flag unset (`bun run grove up`), the old feed+agents body renders.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/tui/screens/running-view.tsx
+git commit -m "feat(tui): GROVE_SUPERVISION flag swaps default body to fleet/detail rail (#193)"
+```
+
+---
+
+## Task 11: Remove floating Permission Request box when supervision is on
+
+**Files:**
+- Modify: `src/tui/screens/running-view.tsx`
+
+The floating overlay (`monitor.pendingPermissions.length > 0` block at lines ~1873–1894) now lives inside DetailRail. With `GROVE_SUPERVISION=1` it must not render, or operator sees duplicate prompts.
+
+- [ ] **Step 1: Write a regression test**
+
+Create `src/tui/screens/running-view-supervision.test.tsx`:
+
+```tsx
+import { describe, expect, test } from "bun:test";
+import React from "react";
+import { render } from "@opentui/react";
+// Minimal RunningView harness: only the bottom chrome render path is exercised.
+import { renderBottomChromeForTest } from "./running-view.js";
+
+describe("renderBottomChrome under GROVE_SUPERVISION", () => {
+  test("does not render the Permission Request overlay when supervision is on", () => {
+    const r = renderBottomChromeForTest({
+      supervisionOn: true,
+      pendingPermissions: [
+        { sessionName: "s", agentRole: "coder", command: "rm -rf x" },
+      ],
+    });
+    expect(r.toString()).not.toContain("Permission Request");
+  });
+
+  test("still renders the overlay when supervision is off", () => {
+    const r = renderBottomChromeForTest({
+      supervisionOn: false,
+      pendingPermissions: [
+        { sessionName: "s", agentRole: "coder", command: "rm -rf x" },
+      ],
+    });
+    expect(r.toString()).toContain("Permission Request");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `bun test src/tui/screens/running-view-supervision.test.tsx`
+Expected: FAIL — `renderBottomChromeForTest` not exported.
+
+- [ ] **Step 3: Extract and gate the overlay**
+
+In `src/tui/screens/running-view.tsx`, modify `renderBottomChrome` (around line 1856–1956). Replace:
+
+```tsx
+{monitor.pendingPermissions.length > 0 ? (
+  <box ...>...Permission Request...</box>
+) : null}
+```
+
+with:
+
+```tsx
+{!supervisionOn && monitor.pendingPermissions.length > 0 ? (
+  <box ...>...Permission Request...</box>
+) : null}
+```
+
+Add `supervisionOn` to `renderBottomChrome`'s parameter list; pass `useSupervision` from the caller. Export a thin test wrapper:
+
+```tsx
+export function renderBottomChromeForTest(args: {
+  readonly supervisionOn: boolean;
+  readonly pendingPermissions: readonly PermissionPrompt[];
+}): React.ReactNode {
+  return renderBottomChrome(
+    {
+      pendingPermissions: args.pendingPermissions,
+      ipcMessages: [],
+      agentOutputs: new Map(),
+      agentOutputTimestamps: new Map(),
+      spinnerFrame: 0,
+    },
+    false,
+    undefined,
+    undefined,
+    false,
+    "",
+    0,
+    undefined,
+    { mode: "none", text: "", suggestionIndex: 0, history: [] } as never,
+    [],
+    null,
+    args.supervisionOn,
+  );
+}
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+Run: `bun test src/tui/screens/running-view-supervision.test.tsx`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/running-view.tsx src/tui/screens/running-view-supervision.test.tsx
+git commit -m "feat(tui): hide floating Permission Request when supervision body owns it (#193)"
+```
+
+---
+
+## Task 12: Help overlay — add Supervision section
+
+**Files:**
+- Modify: `src/tui/screens/running-view.tsx` (the `renderHelpOverlay` function around line 1959)
+
+- [ ] **Step 1: Locate the help overlay function**
+
+Find `function renderHelpOverlay()` near line 1959. Note its structure: a column of `<text>` entries.
+
+- [ ] **Step 2: Append a Supervision section**
+
+Inside `renderHelpOverlay`, after the existing key list, before the closing `</box>`, append:
+
+```tsx
+<text> </text>
+<text color={theme.focus} bold>
+  Supervision (GROVE_SUPERVISION=1)
+</text>
+<text color={theme.text}> j/k Move fleet cursor / G g top/bottom</text>
+<text color={theme.text}> Enter Pin selection</text>
+<text color={theme.text}> y/n/a Approve / deny / always-allow</text>
+<text color={theme.text}> t Open Terminal (scoped to selected)</text>
+<text color={theme.text}> d Open DAG (scoped to selected)</text>
+<text color={theme.text}> r Reroute blocked handoff</text>
+<text color={theme.text}> K Kill / revoke claim</text>
+<text color={theme.text}> m Message the selected agent</text>
+```
+
+- [ ] **Step 3: Manual verify**
+
+```bash
+GROVE_SUPERVISION=1 bun run grove up
+# press ? to open help overlay
+```
+Expected: New Supervision section appears at the bottom.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tui/screens/running-view.tsx
+git commit -m "docs(tui): help overlay lists supervision shortcuts (#193)"
+```
+
+---
+
+## Task 13: E2E smoke — supervision with two ACPX agents
+
+**Files:**
+- Create: `tests/tui/supervision-e2e.ts`
+
+This is an integration test that follows the launch recipe in `[[project_pr438_logview_validated]]`. Use `grove up`, hit Nexus stores. Force one agent into stalled state and assert the lane shows `SILENT` plus detail-rail tail.
+
+- [ ] **Step 1: Copy the existing tmux+grove harness as the starting point**
+
+Use `tests/tui/typed-acp-tmux-e2e.ts` as the template. Copy it to `tests/tui/supervision-e2e.ts`. Replace the assertion section with the supervision-specific checks below.
+
+- [ ] **Step 2: Add supervision-specific assertions**
+
+Inside the test body, after launching grove with two ACPX agents (coder + reviewer):
+
+```ts
+// Force the reviewer into silent state: kill its tmux pane writer.
+await tmux.sendKeys(`grove-reviewer-${runId}`, "C-c");
+// Wait beyond SILENT_MS (5m) — for the test, override via env:
+process.env.GROVE_SUPERVISION_SILENT_MS = "2000";
+await sleep(3000);
+
+const frame = await captureTuiFrame();
+expect(frame).toContain("Fleet (2");
+expect(frame).toContain("SILENT");
+expect(frame).toContain("reviewer");
+```
+
+- [ ] **Step 3: Run the smoke**
+
+Run: `GROVE_SUPERVISION=1 bun test tests/tui/supervision-e2e.ts --timeout 120000`
+Expected: PASS — the captured frame contains the SILENT badge on the reviewer lane.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/tui/supervision-e2e.ts
+git commit -m "test(tui): supervision e2e — silent agent surfaces in fleet rail (#193)"
+```
+
+---
+
+## Wrap-up
+
+After Task 13:
+
+```bash
+bun test                               # full suite
+bun run check                          # biome/lint
+GROVE_SUPERVISION=1 bun run grove up   # final manual smoke
+```
+
+Open a draft PR titled `feat(tui): supervision hero surface (#193)` with the spec link in the description. Mark it draft until the env-flag flip is approved.
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Task |
+|---|---|
+| `AgentHealth` union + thresholds | Task 2 |
+| Derivation rules (error → idle priority) | Task 2 |
+| `FleetAgent` shape | Task 4 |
+| Sort order (problem-first) | Task 4 |
+| `useAgentMonitor` extension (`agentOutputTimestamps`) | Task 1 |
+| `<FleetRail>` lane rendering | Task 5 |
+| `<DetailRail>` stacked sections + approval | Task 6 |
+| `<Supervision>` selection state + auto-select | Task 8 |
+| Supervision keyboard routing | Task 7 (router) + Task 10 (wiring) |
+| Drill-down inherits selection (filterAgentId) | Task 9 |
+| Flag-gated body swap | Task 10 |
+| Floating Permission Request overlay removal | Task 11 |
+| Help overlay update | Task 12 |
+| Integration smoke | Task 13 |
+
+Out-of-scope items are tracked in the spec's "Out of scope" section; do not implement reroute, contribution history, per-agent IPC filter, or collapsible detail sections in this plan.

--- a/docs/superpowers/specs/2026-05-18-tui-agent-supervision-hero-design.md
+++ b/docs/superpowers/specs/2026-05-18-tui-agent-supervision-hero-design.md
@@ -1,0 +1,264 @@
+# TUI Agent Supervision — Hero Surface (issue #193)
+
+**Date**: 2026-05-18
+**Issue**: [windoliver/grove#193](https://github.com/windoliver/grove/issues/193)
+**Related**: #163 (stale-blocked handoff detection), #175 (agent monitor extraction), #310 (LogView)
+**Status**: Draft — awaiting user review
+
+## Problem
+
+Grove's strongest UX opportunity is supervising many agents, but that experience is split across status lists (`AgentListView`), the contribution feed, terminal panes (`TerminalView`), handoffs (`HandoffsView`), and a floating Permission Request overlay. The operator surface should feel more like a live control room: lanes/cards per agent, clear health states, last action, current task, approval needs, cost, and one-keystroke jumps into related claims/contributions/output.
+
+### Today's gaps (from `running-view.tsx` audit)
+
+- **No fleet-glance surface.** Operators must page through panels (`1` feed, `2` agents, `3` DAG, `4` terminal) one at a time. None of these is a hero.
+- **Status semantics are too coarse.** `deriveAgentStatus` in `agent-columns.ts` returns only `running | claimed | stalled | idle | expired | error`. The issue calls for `blocked / stuck / thrashing / silent`.
+- **Approvals are divorced from agent context.** The Permission Request overlay (lines ~1873–1894 of `running-view.tsx`) floats above the bottom bar, not attached to the agent's lane.
+- **Selected-agent context requires panel hops.** Pick agent in panel `2`, lose it on switch to panel `3` or `4`.
+
+## Acceptance criteria (verbatim from #193)
+
+- An operator can understand the fleet state at a glance.
+- Problem agents stand out immediately.
+- Approvals and interventions are reachable from the same supervision surface.
+- Agent-level navigation is faster than today.
+
+## Decision
+
+Replace the feed-default body of `RunningView` with a new supervision body composed of a **dense fleet rail** (left, ~40% width) plus a **detail rail** (right, ~60% width) that always reflects the selected agent. Approvals become a row badge on the lane plus an in-rail prompt. Existing panels (Feed, DAG, Terminal, Trace, Handoffs) remain reachable but become drill-downs from the supervision body, and they inherit the selected-agent identity.
+
+Three implementation alternatives were considered and rejected:
+
+1. **Net-new screen** — duplicates state pipes, creates two mental models. Rejected.
+2. **Hero-default refactor of RunningView** — selected. One supervision surface, reuses `useAgentMonitor`, `useEntities`, `useEventDrivenData`.
+3. **Cards-on-Agents-panel only** — stays hidden behind key `2`. Fails the "hero" and "at-a-glance" acceptance criteria. Rejected.
+
+## Module layout
+
+```
+src/tui/screens/supervision/
+  fleet-rail.tsx           // left rail — dense lanes, cursor-driven
+  detail-rail.tsx          // right rail — selected agent context
+  agent-health.ts          // pure: derive blocked/stuck/thrashing/silent
+  agent-health.test.ts
+  supervision-actions.ts   // pure: action descriptors and enablement
+  supervision-actions.test.ts
+  use-fleet-model.ts       // hook: join claims+tmux+cost+handoffs+permissions
+  use-fleet-model.test.ts
+  supervision.tsx          // composes fleet-rail + detail-rail; owns selection
+  supervision.test.tsx
+```
+
+`running-view.tsx` changes:
+
+- When no panel is expanded, render `<Supervision />` instead of the feed body.
+- Keep `RunningPanel.Feed` reachable (`1`); demoted to non-default.
+- Remove the floating Permission Request overlay (~25 lines); supervision owns it.
+- Net change: ~50 added, ~25 removed in `running-view.tsx`. New code lives in dedicated files ≤ ~250 lines each.
+
+## Data model
+
+`FleetAgent` (output of `useFleetModel`):
+
+```ts
+interface FleetAgent {
+  readonly agentId: string;
+  readonly agentName: string;
+  readonly role: string;
+  readonly platform: string;
+  readonly session: string | undefined;
+  readonly claim: ClaimEntity;
+  readonly health: AgentHealth;
+  readonly currentTask: string | undefined;
+  readonly lastAction: string | undefined;
+  readonly lastOutputAt: string | undefined;
+  readonly cost: { usd: number; tokens: number; ctxPercent?: number } | undefined;
+  readonly handoffs: { pendingOut: number; overdueIn: number; blockedOn?: string };
+  readonly pendingApproval: PermissionPrompt | undefined;
+  readonly attemptCount: number;
+}
+```
+
+`AgentHealth` — discriminated union replacing today's status string:
+
+```ts
+type AgentHealth =
+  | { kind: "running" }
+  | { kind: "idle" }
+  | { kind: "approval"; cmd: string }
+  | { kind: "blocked"; on: string; sinceMs: number }
+  | { kind: "stuck"; sinceMs: number }
+  | { kind: "thrashing"; retries: number }
+  | { kind: "silent"; sinceMs: number }
+  | { kind: "error"; reason: string }
+  | { kind: "expired" };
+```
+
+### Derivation rules (`deriveAgentHealth(fleet, now, thresholds)` in `agent-health.ts`)
+
+Evaluated top-down; first match wins.
+
+| Priority | Condition | Result |
+|---|---|---|
+| 1 | `agentFailures.has(role)` | `error` (uses ACP bootstrap/auth failure message) |
+| 2 | `pendingApproval !== undefined` | `approval` |
+| 3 | `lease expired` | `expired` |
+| 4 | `attemptCount >= 3` and last claim retry within 30 s | `thrashing` |
+| 5 | `handoff.blockedOn !== undefined` and `sinceMs > 60_000` | `blocked` |
+| 6 | `now - lastOutputAt > SILENT_MS` (default 5 min) | `silent` |
+| 7 | `currentTask unchanged for STUCK_MS` (default 8 min) and `lastOutputAt` recent | `stuck` |
+| 8 | `now - claim.heartbeatAt > 60_000` | `silent` (heartbeat lapse) |
+| 9 | session alive + recent output | `running` |
+| 10 | otherwise | `idle` |
+
+Thresholds are exported constants for test overrides:
+`SILENT_MS = 5 * 60_000`, `STUCK_MS = 8 * 60_000`, `THRASH_RETRIES = 3`, `THRASH_WINDOW_MS = 30_000`, `BLOCKED_MIN_MS = 60_000`.
+
+### Sort order (problem-first)
+
+`error > approval > blocked > stuck > thrashing > silent > running > idle > expired`; ties broken by role (`coordinator` first) then `agentName`.
+
+## Components
+
+### `<Supervision>`
+
+- Owns: `selectedAgentId`, `cursor`, `pinnedSelection` ref, `filterText` (from C2 cmd-mode).
+- Calls `useFleetModel({ provider, monitor, eventBus, topology, filterText })`.
+- Renders fleet-rail and detail-rail in a horizontal box.
+- Auto-selects highest-priority agent on mount and on new-approval events (skipped when `pinnedSelection.current === true`).
+- After approve/deny resolves, unpins so the next problem agent floats up.
+- Dispatches `onAction(agentId, action)` from key handlers and from detail-rail action footer.
+
+### `<FleetRail>`
+
+- Header: `Fleet (N · {x problem})` with counts by health kind.
+- Each lane: `[health-icon] [role-badge] [agentName trunc14] [task/last-action trunc40] [age] [cost]`.
+- Cursor row gets `►` prefix + `theme.focus` background.
+- Approval lanes show `[y/n]` suffix in `theme.warning`.
+- Blocked lanes show `← from-role` in `theme.error`.
+- Empty state mirrors current `AgentListView` copy: "No agents registered. Press r to register, or Ctrl+P to spawn."
+
+### `<DetailRail>`
+
+Stacked sections, top-down:
+
+1. **Header** — agent name + role + health badge with sinceMs ("STUCK 8m", "BLOCKED 3m on coordinator").
+2. **Task** — `currentTask`, `targetRef`, claim age.
+3. **Approval** (only when `health.kind === "approval"`) — full command + key hints `[y]allow [n]deny [a]always`.
+4. **Tail** — last 8 lines from `monitor.agentOutputs.get(role)`.
+5. **Handoffs** — counts and `blockedOn` line if any.
+6. **Cost** — `$X · Y tok · Z% ctx`.
+7. **Actions footer** — keyhints `[t]ail · [d]ag · [r]eroute · [k]ill · [m]essage`.
+
+Placeholder when `selectedAgentId === undefined`: "Select an agent (j/k) to view context".
+
+### Existing-view reuse
+
+- `<TerminalView>` unchanged; reached via `t` from detail rail (fullscreens scoped to selected agent).
+- `<DagView>`, `<HandoffsView>` gain an additive optional prop `filterAgentId` so drill-downs inherit the selected agent. Default behavior unchanged when prop omitted.
+- The Permission Request overlay block in `running-view.tsx` is removed; supervision is the only host.
+
+## Keyboard model
+
+New keys apply only when no panel is expanded (`expandedPanel === null`). They run before the global router:
+
+```
+if (expandedPanel === null) supervisionKeyboard.handle(key) ?? globalRouter.handle(key)
+```
+
+| Key | Action |
+|---|---|
+| `j` / `k` | Move fleet-rail cursor (also applies inside expanded Agents panel for consistency) |
+| `Enter` | Pin selection |
+| `g` / `G` | Top / bottom of fleet |
+| `y` / `n` / `a` | Approve / deny / always-allow on the selected agent's approval |
+| `t` | Open Terminal panel scoped to selected agent |
+| `d` | Open DAG panel scoped to selected agent |
+| `r` | Reroute blocked handoff (only when `health.kind === "blocked"`); confirmation via existing safety/useConfirmAndMutate |
+| `K` (capital) | Kill / revoke claim (safety-confirmed) |
+| `m` | Open `<Prompt>` to message the selected agent's role |
+| `1`–`4` | Expand panel (unchanged); panel inherits `selectedAgentId` |
+| `/` / `:` | C2 cmd-mode; filter narrows lanes via `useFleetModel` predicate |
+| `e` | Trace pane (unchanged) |
+| `Esc` | Collapse panel → unpin selection → cancel quit |
+
+Help overlay (`?`) gains a "Supervision" section listing the new shortcuts.
+
+## Data flow
+
+```
+provider (informer / Nexus SSE push)
+  ├─ claims watch ───────────────┐
+  ├─ contributions watch ────────┤
+  ├─ handoffs watch ─────────────┤
+  └─ permissions/IPC via eventBus┤
+                                 ▼
+   useAgentMonitor (existing)  ─→ outputs / permissions / IPC / spinner
+                                 │
+                                 ▼
+   useFleetModel  ────────────→ FleetAgent[] (memoized join + health derive)
+                                 │
+                                 ▼
+   <Supervision>  ──→ <FleetRail> + <DetailRail>
+```
+
+- `useFleetModel` consumes `useEntities` watches; no new polling loops.
+- Health derivation runs in the same `useMemo` as the join; recomputed only when source data changes.
+- `useAgentMonitor` gets an additive extension: alongside `agentOutputs: Map<role, string[]>` it also exposes `agentOutputTimestamps: Map<role, string>` — the ISO timestamp of the most recent update per role, written whenever `setAgentOutputs` runs. This is the source for `FleetAgent.lastOutputAt`. The extension is pure additive: existing consumers (Trace pane, etc.) keep working.
+- `silent` detection compares `now - lastOutputAt` against `SILENT_MS`; because `setAgentOutputs` runs on push, the timestamp inherits push semantics. The `silent` threshold itself is a wall-clock comparison, which the existing braille spinner re-render at ~80 ms covers — no new timer.
+- Wall-clock badge refresh ("STUCK 3m" → "STUCK 4m") rides the same spinner re-render.
+
+### Action dispatch
+
+| Action | Implementation |
+|---|---|
+| `approve` / `deny` / `always` | `tmux.sendKeys(session, "y" / "n" / "a")` — existing `handlePermissionResponse` path |
+| `kill` | `provider.revokeClaim(claimId)` via `useConfirmAndMutate` |
+| `message` | Existing `onSendToAgent(role, msg)` prop on `RunningView` |
+| `reroute` | `provider.rerouteHandoff(handoffId)` — disabled with tooltip "Reroute lands with #163" until that backend ships |
+
+## Rollout
+
+- Ship behind env flag `GROVE_SUPERVISION=1`. Default off in the first PR; supervision-body code lives alongside today's feed-default branch.
+- Flip the default in a follow-up PR once stable. Keep `GROVE_SUPERVISION=0` as an escape hatch for one release cycle, then remove the feed-default branch.
+- C2 cmd-mode, screen-stack, pagesTop sync untouched until the flag flips.
+
+## Testing strategy
+
+### Pure modules (Vitest, no React)
+
+| File | Coverage |
+|---|---|
+| `agent-health.test.ts` | Every health kind across a `(claim, monitor outputs, handoffs, permissions, now, thresholds)` matrix. Priority ordering: error beats blocked beats stuck. Threshold edges (`SILENT_MS - 1` vs `SILENT_MS + 1`). |
+| `supervision-actions.test.ts` | Action enablement per health kind: `reroute` only when `blocked`; `kill` always except `expired`; `approve/deny/always` only when `approval`. |
+| `use-fleet-model.test.ts` | Join correctness: claim without tmux session leaves `session` undefined; cost rollup matches by `agentId`; handoff `blockedOn` aggregation; sort order with mixed-health input; C2 filter narrows result. |
+| `use-agent-monitor.test.ts` (existing) | New assertion: each `setAgentOutputs` write also updates `agentOutputTimestamps` for the affected role. |
+
+### Components (OpenTUI react-test renderer, mirroring `running-view.c2.test.tsx`)
+
+| File | Coverage |
+|---|---|
+| `fleet-rail.test.tsx` | Render snapshot per health kind. Cursor movement on `j/k`. Filter prop narrows visible lanes. Empty state. |
+| `detail-rail.test.tsx` | Each section renders for the selected agent. Approval section shows command + key hints. Placeholder when no selection. |
+| `supervision.test.tsx` | Auto-select-highest-priority on mount. Auto-select on new approval (when not pinned). Pinned selection survives data refresh. Action dispatch routes to provider/tmux mocks. |
+
+### Integration smoke (`tests/tui/`)
+
+- `supervision-e2e.ts` — spawn nexus + 2 ACPX agents via `grove up`, force one into a stalled state, assert TUI capture frame contains lane with health badge and detail-rail shows tail. Hit Nexus stores, not local SQLite.
+
+### Regression guards
+
+- Keyboard test: `j/k` move cursor in supervision body (not feed scroll).
+- Keyboard test: `Esc` from expanded panel returns to supervision with selection intact.
+- Snapshot test: floating `Permission Request` box no longer rendered by `running-view.tsx` when supervision body is active.
+
+## Out of scope (tracked separately)
+
+- Reroute action — depends on issue #163 backend.
+- Contribution-history sub-panel in detail rail — follow-up.
+- Per-agent IPC message filtering — follow-up.
+- Collapsible detail-rail sections — v1 is fixed stacked layout.
+
+## Open questions
+
+None blocking. Threshold defaults (`SILENT_MS = 5m`, `STUCK_MS = 8m`, `THRASH_RETRIES = 3`) are starting points; tune after first dogfood pass.

--- a/src/tui/hooks/use-agent-monitor.test.ts
+++ b/src/tui/hooks/use-agent-monitor.test.ts
@@ -260,4 +260,29 @@ describe("mergeOutputs", () => {
     );
     expect(timestamps.get("coder")).toBe(prior);
   });
+
+  test("assigns now to a brand-new role with no prior output or timestamp", () => {
+    const now = new Date("2026-05-18T12:00:00Z").toISOString();
+    const { outputs, timestamps } = mergeOutputs(
+      new Map(),
+      new Map(),
+      new Map([["planner", ["first line"]]]),
+      now,
+    );
+    expect(outputs.get("planner")).toEqual(["first line"]);
+    expect(timestamps.get("planner")).toBe(now);
+  });
+
+  test("drops timestamp entries for roles absent from next outputs", () => {
+    const prior = new Date("2026-05-18T11:00:00Z").toISOString();
+    const now = new Date("2026-05-18T12:00:00Z").toISOString();
+    const { timestamps } = mergeOutputs(
+      new Map([["gone", ["x"]]]),
+      new Map([["gone", prior]]),
+      new Map([["coder", ["y"]]]),
+      now,
+    );
+    expect(timestamps.has("gone")).toBe(false);
+    expect(timestamps.get("coder")).toBe(now);
+  });
 });

--- a/src/tui/hooks/use-agent-monitor.test.ts
+++ b/src/tui/hooks/use-agent-monitor.test.ts
@@ -14,6 +14,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   isLogLineKept,
+  mergeOutputs,
   parseLogContent,
   parsePermissionPrompt,
   roleFromLogFilename,
@@ -228,5 +229,35 @@ describe("parseLogContent", () => {
     const content = "\x1b]0;my-terminal\x07Actual output\n";
     const lines = parseLogContent(content, 8);
     expect(lines).toEqual(["Actual output"]);
+  });
+});
+
+// ===========================================================================
+// mergeOutputs
+// ===========================================================================
+
+describe("mergeOutputs", () => {
+  test("returns next outputs and a parallel timestamp map keyed by role", () => {
+    const now = new Date("2026-05-18T12:00:00Z").toISOString();
+    const { outputs, timestamps } = mergeOutputs(
+      new Map([["coder", ["old"]]]),
+      new Map(),
+      new Map([["coder", ["old", "new"]]]),
+      now,
+    );
+    expect(outputs.get("coder")).toEqual(["old", "new"]);
+    expect(timestamps.get("coder")).toBe(now);
+  });
+
+  test("preserves prior timestamps for roles whose outputs did not change", () => {
+    const prior = new Date("2026-05-18T11:00:00Z").toISOString();
+    const now = new Date("2026-05-18T12:00:00Z").toISOString();
+    const { timestamps } = mergeOutputs(
+      new Map([["coder", ["x"]]]),
+      new Map([["coder", prior]]),
+      new Map([["coder", ["x"]]]),
+      now,
+    );
+    expect(timestamps.get("coder")).toBe(prior);
   });
 });

--- a/src/tui/hooks/use-agent-monitor.ts
+++ b/src/tui/hooks/use-agent-monitor.ts
@@ -174,9 +174,14 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
   const [agentOutputs, setAgentOutputs] = useState<ReadonlyMap<string, readonly string[]>>(
     new Map(),
   );
-  const [agentOutputTimestamps, setAgentOutputTimestamps] = useState<ReadonlyMap<string, string>>(
-    new Map(),
-  );
+  const [agentOutputTimestamps, setAgentOutputTimestampsRaw] = useState<
+    ReadonlyMap<string, string>
+  >(new Map());
+  const agentOutputTimestampsRef = useRef<ReadonlyMap<string, string>>(new Map());
+  const setAgentOutputTimestamps = useCallback((next: ReadonlyMap<string, string>) => {
+    agentOutputTimestampsRef.current = next;
+    setAgentOutputTimestampsRaw(next);
+  }, []);
   const [pendingPermissions, setPendingPermissions] = useState<readonly PermissionPrompt[]>([]);
   const [ipcMessages, setIpcMessages] = useState<readonly IpcMessage[]>([]);
   const [spinnerFrame, setSpinnerFrame] = useState(0);
@@ -260,7 +265,7 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
       if (mountedRef.current && outputs.size > 0) {
         const now = new Date().toISOString();
         setAgentOutputs((prior) => {
-          const merged = mergeOutputs(prior, agentOutputTimestamps, outputs, now);
+          const merged = mergeOutputs(prior, agentOutputTimestampsRef.current, outputs, now);
           setAgentOutputTimestamps(merged.timestamps);
           return merged.outputs;
         });
@@ -268,7 +273,7 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
     } catch {
       // Non-fatal
     }
-  }, [groveDir, maxOutputLines, agentOutputTimestamps]);
+  }, [groveDir, maxOutputLines, setAgentOutputTimestamps]);
 
   useEffect(() => {
     void logPoll();
@@ -292,7 +297,7 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
       if (mountedRef.current) {
         const now = new Date().toISOString();
         setAgentOutputs((prior) => {
-          const merged = mergeOutputs(prior, agentOutputTimestamps, outputs, now);
+          const merged = mergeOutputs(prior, agentOutputTimestampsRef.current, outputs, now);
           setAgentOutputTimestamps(merged.timestamps);
           return merged.outputs;
         });
@@ -300,7 +305,7 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
     } catch {
       // Non-fatal
     }
-  }, [tmux, groveDir, maxOutputLines, agentOutputTimestamps]);
+  }, [tmux, groveDir, maxOutputLines, setAgentOutputTimestamps]);
 
   useInterval(() => void tmuxPoll(), POLL_INTERVAL_MS, Boolean(tmux) && !groveDir);
 

--- a/src/tui/hooks/use-agent-monitor.ts
+++ b/src/tui/hooks/use-agent-monitor.ts
@@ -153,12 +153,12 @@ export function mergeOutputs(
   readonly outputs: ReadonlyMap<string, readonly string[]>;
   readonly timestamps: ReadonlyMap<string, string>;
 } {
-  const timestamps = new Map<string, string>(priorTimestamps);
+  const timestamps = new Map<string, string>();
   for (const [role, lines] of nextOutputs) {
     const prior = priorOutputs.get(role);
     const changed =
       !prior || prior.length !== lines.length || prior.some((line, i) => line !== lines[i]);
-    if (changed) timestamps.set(role, now);
+    timestamps.set(role, changed ? now : (priorTimestamps.get(role) ?? now));
   }
   return { outputs: nextOutputs, timestamps };
 }

--- a/src/tui/hooks/use-agent-monitor.ts
+++ b/src/tui/hooks/use-agent-monitor.ts
@@ -51,6 +51,9 @@ export interface AgentMonitorOptions {
 export interface AgentMonitorState {
   /** Per-role output lines (last N lines from logs or tmux capture). */
   readonly agentOutputs: ReadonlyMap<string, readonly string[]>;
+  /** ISO timestamp of the most recent change per role. Updated only when the
+   *  role's line array differs from its prior value. */
+  readonly agentOutputTimestamps: ReadonlyMap<string, string>;
   /** Pending permission prompts detected in tmux panes. */
   readonly pendingPermissions: readonly PermissionPrompt[];
   /** Recent IPC messages from the EventBus. */
@@ -136,6 +139,30 @@ export function parseLogContent(content: string, maxLines: number): readonly str
   return lines.slice(-maxLines);
 }
 
+/**
+ * Merge a fresh outputs snapshot with the prior state and produce a parallel
+ * timestamp map. A role's timestamp is bumped to `now` only when its line
+ * array changed. Pure — exported for testing.
+ */
+export function mergeOutputs(
+  priorOutputs: ReadonlyMap<string, readonly string[]>,
+  priorTimestamps: ReadonlyMap<string, string>,
+  nextOutputs: ReadonlyMap<string, readonly string[]>,
+  now: string,
+): {
+  readonly outputs: ReadonlyMap<string, readonly string[]>;
+  readonly timestamps: ReadonlyMap<string, string>;
+} {
+  const timestamps = new Map<string, string>(priorTimestamps);
+  for (const [role, lines] of nextOutputs) {
+    const prior = priorOutputs.get(role);
+    const changed =
+      !prior || prior.length !== lines.length || prior.some((line, i) => line !== lines[i]);
+    if (changed) timestamps.set(role, now);
+  }
+  return { outputs: nextOutputs, timestamps };
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -145,6 +172,9 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
   const { groveDir, tmux, eventBus, topology, maxOutputLines = 8 } = options;
 
   const [agentOutputs, setAgentOutputs] = useState<ReadonlyMap<string, readonly string[]>>(
+    new Map(),
+  );
+  const [agentOutputTimestamps, setAgentOutputTimestamps] = useState<ReadonlyMap<string, string>>(
     new Map(),
   );
   const [pendingPermissions, setPendingPermissions] = useState<readonly PermissionPrompt[]>([]);
@@ -228,12 +258,17 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
         outputs.set(role, lines.slice(-maxOutputLines));
       }
       if (mountedRef.current && outputs.size > 0) {
-        setAgentOutputs(outputs);
+        const now = new Date().toISOString();
+        setAgentOutputs((prior) => {
+          const merged = mergeOutputs(prior, agentOutputTimestamps, outputs, now);
+          setAgentOutputTimestamps(merged.timestamps);
+          return merged.outputs;
+        });
       }
     } catch {
       // Non-fatal
     }
-  }, [groveDir, maxOutputLines]);
+  }, [groveDir, maxOutputLines, agentOutputTimestamps]);
 
   useEffect(() => {
     void logPoll();
@@ -255,12 +290,17 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
         outputs.set(role, lines.slice(-maxOutputLines).map(stripAnsi));
       }
       if (mountedRef.current) {
-        setAgentOutputs(outputs);
+        const now = new Date().toISOString();
+        setAgentOutputs((prior) => {
+          const merged = mergeOutputs(prior, agentOutputTimestamps, outputs, now);
+          setAgentOutputTimestamps(merged.timestamps);
+          return merged.outputs;
+        });
       }
     } catch {
       // Non-fatal
     }
-  }, [tmux, groveDir, maxOutputLines]);
+  }, [tmux, groveDir, maxOutputLines, agentOutputTimestamps]);
 
   useInterval(() => void tmuxPoll(), POLL_INTERVAL_MS, Boolean(tmux) && !groveDir);
 
@@ -289,5 +329,5 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
 
   useInterval(() => void permissionPoll(), POLL_INTERVAL_MS, Boolean(tmux));
 
-  return { agentOutputs, pendingPermissions, ipcMessages, spinnerFrame };
+  return { agentOutputs, agentOutputTimestamps, pendingPermissions, ipcMessages, spinnerFrame };
 }

--- a/src/tui/screens/running-view-supervision-wiring.test.ts
+++ b/src/tui/screens/running-view-supervision-wiring.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { Supervision } from "./supervision/supervision.js";
+import { supervisionInputActive } from "./supervision/supervision-input-guard.js";
+import { routeSupervisionKey } from "./supervision/supervision-keyboard.js";
+import { useFleetModel } from "./supervision/use-fleet-model.js";
+
+// Task 10: GROVE_SUPERVISION flag wiring. We deliberately do NOT mount the
+// heavy RunningView component (it transitively pulls config-watcher →
+// chokidar, opentui, etc.). Instead we unit-test the extracted guard
+// predicate `supervisionInputActive` — the SAME function the running-view
+// keyboard owner calls (imported, not duplicated) — plus assert the three
+// supervision modules are importable with the expected symbols.
+// routeSupervisionKey itself is fully covered by its own test; not duplicated.
+
+const clear = {
+  useSupervision: true,
+  expandedPanelNull: true,
+  cmdMode: "none",
+  promptMode: false,
+  showHelp: false,
+  showVfs: false,
+  filterQuery: "",
+} as const;
+
+describe("supervisionInputActive guard predicate", () => {
+  test("true when flag on and nothing else owns the keyboard", () => {
+    expect(supervisionInputActive(clear)).toBe(true);
+  });
+
+  test("false when GROVE_SUPERVISION flag is off", () => {
+    expect(supervisionInputActive({ ...clear, useSupervision: false })).toBe(false);
+  });
+
+  test("false when a panel is expanded (not the visible body)", () => {
+    expect(supervisionInputActive({ ...clear, expandedPanelNull: false })).toBe(false);
+  });
+
+  test("false when cmd-mode owns input (filter/goto)", () => {
+    expect(supervisionInputActive({ ...clear, cmdMode: "filter" })).toBe(false);
+  });
+
+  test("false when prompt mode, help, or vfs overlay is active", () => {
+    expect(supervisionInputActive({ ...clear, promptMode: true })).toBe(false);
+    expect(supervisionInputActive({ ...clear, showHelp: true })).toBe(false);
+    expect(supervisionInputActive({ ...clear, showVfs: true })).toBe(false);
+  });
+
+  test("false when a live filter query is set", () => {
+    expect(supervisionInputActive({ ...clear, filterQuery: "agent-x" })).toBe(false);
+  });
+});
+
+describe("supervision modules are wired into running-view", () => {
+  test("exports the expected symbols", () => {
+    expect(typeof Supervision).toBe("object"); // React.memo component
+    expect(typeof routeSupervisionKey).toBe("function");
+    expect(typeof useFleetModel).toBe("function");
+  });
+});

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -2134,6 +2134,18 @@ function renderHelpOverlay(): React.ReactNode {
       <text color={theme.text}> ? Toggle this help</text>
       <text color={theme.text}> Esc Collapse panel / close overlay</text>
       <text color={theme.text}> q Quit (with confirmation)</text>
+      <text> </text>
+      <text color={theme.focus} bold>
+        Supervision (GROVE_SUPERVISION=1)
+      </text>
+      <text color={theme.text}> j/k Move fleet cursor · g/G top/bottom</text>
+      <text color={theme.text}> Enter Pin selection</text>
+      <text color={theme.text}> y/n/a Approve / deny / always-allow</text>
+      <text color={theme.text}> t Open Terminal (scoped to selected)</text>
+      <text color={theme.text}> d Open DAG (scoped to selected)</text>
+      <text color={theme.text}> r Reroute blocked handoff</text>
+      <text color={theme.text}> K Kill / revoke claim</text>
+      <text color={theme.text}> m Message the selected agent</text>
       <text color={theme.secondary}> Esc to close</text>
     </box>
   );

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -74,6 +74,7 @@ import {
   routeRunningKey,
   toggleFullscreen as toggleFullscreenTransition,
 } from "./running-keyboard.js";
+import { permissionBoxVisible } from "./supervision/permission-box-visibility.js";
 import { Supervision } from "./supervision/supervision.js";
 import { supervisionInputActive } from "./supervision/supervision-input-guard.js";
 import { routeSupervisionKey } from "./supervision/supervision-keyboard.js";
@@ -1496,6 +1497,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             cmdState,
             gotoSuggestions,
             flashError,
+            useSupervision,
           )}
           {renderStatusBar(
             expandedPanel,
@@ -1584,6 +1586,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           cmdState,
           gotoSuggestions,
           flashError,
+          useSupervision,
         )}
 
         {/* Help overlay */}
@@ -2013,11 +2016,12 @@ function renderBottomChrome(
   cmdState: CmdModeState,
   gotoSuggestions: readonly string[],
   flashError: string | null,
+  supervisionOn: boolean,
 ): React.ReactNode {
   return (
     <>
       {/* Permission prompts from agents */}
-      {monitor.pendingPermissions.length > 0 ? (
+      {permissionBoxVisible(supervisionOn, monitor.pendingPermissions.length) ? (
         <box
           flexDirection="column"
           marginX={2}

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -74,6 +74,10 @@ import {
   routeRunningKey,
   toggleFullscreen as toggleFullscreenTransition,
 } from "./running-keyboard.js";
+import { Supervision } from "./supervision/supervision.js";
+import { supervisionInputActive } from "./supervision/supervision-input-guard.js";
+import { routeSupervisionKey } from "./supervision/supervision-keyboard.js";
+import { useFleetModel } from "./supervision/use-fleet-model.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -112,6 +116,11 @@ const RUNNING_PANEL_PARAM: Readonly<Record<RunningPanel, string | undefined>> = 
 // per-role: useLogView = session?.runtime === "acpx". Tracked as a
 // follow-up of issue #310.
 const useLogView = process.env.GROVE_LOGVIEW === "1";
+
+// #193: supervision body gate. STRICTLY ADDITIVE — unset → byte-for-byte
+// identical RunningView. Read once at module load (env vars are static at
+// runtime) so it never churns useMemo/useCallback deps.
+const useSupervision = process.env.GROVE_SUPERVISION === "1";
 
 /** Props for the RunningView screen. */
 export interface RunningViewProps {
@@ -533,6 +542,38 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     }, [eventBus, topology, provider, dashboardPoll.refresh, contributionsPoll.refresh]);
 
     const dashboard = dashboardPoll.data ?? undefined;
+
+    // ─── Supervision fleet model (#193, gated by GROVE_SUPERVISION) ───
+    // `active` is only true when the supervision body is the visible body
+    // (flag on AND no panel expanded) so the fetchers stay idle otherwise.
+    const fleet = useFleetModel({
+      provider,
+      monitor,
+      agentFailures,
+      tmux,
+      filterText: filterQuery,
+      active: useSupervision && expandedPanel === null,
+    });
+    const [selectedSupervisionAgent, setSelectedSupervisionAgent] = useState<string | undefined>(
+      undefined,
+    );
+    const [supervisionCursor, setSupervisionCursor] = useState(0);
+    const selectedFleetAgent = useMemo(
+      () =>
+        fleet.find((a) => a.agentId === selectedSupervisionAgent) ??
+        fleet[supervisionCursor] ??
+        fleet[0],
+      [fleet, selectedSupervisionAgent, supervisionCursor],
+    );
+    const selectedFleetRole = selectedFleetAgent?.role;
+    const selectedFleetTail = useMemo<readonly string[]>(
+      () => (selectedFleetRole ? (monitor.agentOutputs.get(selectedFleetRole) ?? []) : []),
+      [selectedFleetRole, monitor.agentOutputs],
+    );
+    const handleSupervisionSelect = useCallback(
+      (id: string | undefined) => setSelectedSupervisionAgent(id),
+      [],
+    );
     const contributions = useMemo<readonly Contribution[] | undefined>(() => {
       if (!contribInformerReady) return contributionsPoll.data ?? undefined;
       // Time-based session scope. The watch protocol does not yet filter
@@ -1117,6 +1158,69 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             confirmModalOpen,
             logFilterMode: logFilterModeRef.current,
           };
+          // #193: supervision body owns the keyboard when the flag is on and
+          // it is the visible body with no modal / overlay / input mode
+          // active. Guard predicate is the exported `supervisionInputActive`
+          // (unit-tested) so the risky condition is covered without mounting
+          // RunningView. Falls through to routeRunningKey if not consumed.
+          if (
+            supervisionInputActive({
+              useSupervision,
+              expandedPanelNull: expandedPanel === null,
+              cmdMode: cmdStateRef.current.mode,
+              promptMode,
+              showHelp,
+              showVfs,
+              filterQuery: filterQueryRef.current,
+            })
+          ) {
+            const handled = routeSupervisionKey(
+              { name: key.name },
+              { selectedHealth: selectedFleetAgent?.health },
+              {
+                moveCursor: (delta) => {
+                  setSupervisionCursor((c) => {
+                    const next = Math.max(0, Math.min(fleet.length - 1, c + delta));
+                    setSelectedSupervisionAgent(fleet[next]?.agentId);
+                    return next;
+                  });
+                },
+                pinSelection: () => setSelectedSupervisionAgent(selectedFleetAgent?.agentId),
+                jumpTop: () => {
+                  setSupervisionCursor(0);
+                  setSelectedSupervisionAgent(fleet[0]?.agentId);
+                },
+                jumpBottom: () => {
+                  const last = Math.max(0, fleet.length - 1);
+                  setSupervisionCursor(last);
+                  setSelectedSupervisionAgent(fleet[last]?.agentId);
+                },
+                approve: () => {
+                  const p = selectedFleetAgent?.pendingApproval;
+                  if (p && tmux) void tmux.sendKeys(p.sessionName, "y");
+                },
+                deny: () => {
+                  const p = selectedFleetAgent?.pendingApproval;
+                  if (p && tmux) void tmux.sendKeys(p.sessionName, "n");
+                },
+                always: () => {
+                  const p = selectedFleetAgent?.pendingApproval;
+                  if (p && tmux) void tmux.sendKeys(p.sessionName, "a");
+                },
+                openTail: () => keyboardActions.expandPanel(RunningPanel.Terminal),
+                openDag: () => keyboardActions.expandPanel(RunningPanel.Dag),
+                reroute: () => flash("Reroute lands with #163"),
+                kill: () => flash("Kill action lands with claim-revoke provider API"),
+                openMessage: () => {
+                  if (selectedFleetRole) {
+                    setPromptMode(true);
+                    setPromptTarget((activeRoles ?? []).indexOf(selectedFleetRole));
+                  }
+                },
+              },
+            );
+            if (handled) return;
+          }
           routeRunningKey(key, liveState, keyboardActions);
         },
         [
@@ -1128,6 +1232,18 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           promptMode,
           showHelp,
           confirmModalOpen,
+          // #193: supervision keyboard owner deps. expandedPanel/fleet/
+          // selectedFleetAgent/selectedFleetRole change the consumed keys'
+          // behavior; tmux/activeRoles/flash are stable refs/callbacks but
+          // listed for closure correctness. useSupervision is a module-scope
+          // env constant (not a dep), same as useLogView above.
+          expandedPanel,
+          fleet,
+          selectedFleetAgent,
+          selectedFleetRole,
+          tmux,
+          activeRoles,
+          flash,
           // #310: logFilterMode read via logFilterModeRef (synchronous) so a
           // same-tick burst sees the latest mode. keyboardState already lists
           // logFilterMode in its memo deps for rendering, so committed state
@@ -1402,27 +1518,44 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           showUnderline={true}
         />
 
-        {/* Agent status with live output */}
-        {renderAgentSection(
-          topology,
-          dashboard,
-          monitor,
-          agentFailures,
-          sessionStartedAt,
-          feed.length,
-        )}
+        {/* Default body: agent status + feed. #193: GROVE_SUPERVISION swaps
+            in the fleet/detail rail. Flag unset → byte-for-byte identical. */}
+        {useSupervision ? (
+          <Supervision
+            agents={fleet}
+            tail={selectedFleetTail}
+            cursor={supervisionCursor}
+            // exactOptionalPropertyTypes: only pass pinnedAgentId when set
+            {...(selectedSupervisionAgent !== undefined
+              ? { pinnedAgentId: selectedSupervisionAgent }
+              : {})}
+            onSelect={handleSupervisionSelect}
+          />
+        ) : (
+          <>
+            {/* Agent status with live output */}
+            {renderAgentSection(
+              topology,
+              dashboard,
+              monitor,
+              agentFailures,
+              sessionStartedAt,
+              feed.length,
+            )}
 
-        {/* Main feed area */}
-        {renderFeedSection(
-          feed,
-          cursor,
-          goal,
-          pendingAskUser,
-          frontier,
-          autoFollow,
-          newSinceFreeze,
-          activeRoles,
-          agentFailures,
+            {/* Main feed area */}
+            {renderFeedSection(
+              feed,
+              cursor,
+              goal,
+              pendingAskUser,
+              frontier,
+              autoFollow,
+              newSinceFreeze,
+              activeRoles,
+              agentFailures,
+            )}
+          </>
         )}
 
         {/* Bottom chrome: permissions, IPC, quit confirm, progress, prompt */}

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -2139,12 +2139,12 @@ function renderHelpOverlay(): React.ReactNode {
         Supervision (GROVE_SUPERVISION=1)
       </text>
       <text color={theme.text}> j/k Move fleet cursor · g/G top/bottom</text>
-      <text color={theme.text}> Enter Pin selection</text>
+      <text color={theme.text}> Enter Pin hovered agent as selected</text>
       <text color={theme.text}> y/n/a Approve / deny / always-allow</text>
-      <text color={theme.text}> t Open Terminal (scoped to selected)</text>
-      <text color={theme.text}> d Open DAG (scoped to selected)</text>
-      <text color={theme.text}> r Reroute blocked handoff</text>
-      <text color={theme.text}> K Kill / revoke claim</text>
+      <text color={theme.text}> t Open Terminal panel</text>
+      <text color={theme.text}> d Open DAG panel</text>
+      <text color={theme.text}> r Reroute blocked handoff (placeholder)</text>
+      <text color={theme.text}> K Kill / revoke claim (placeholder)</text>
       <text color={theme.text}> m Message the selected agent</text>
       <text color={theme.secondary}> Esc to close</text>
     </box>

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -1179,11 +1179,9 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
               { selectedHealth: selectedFleetAgent?.health },
               {
                 moveCursor: (delta) => {
-                  setSupervisionCursor((c) => {
-                    const next = Math.max(0, Math.min(fleet.length - 1, c + delta));
-                    setSelectedSupervisionAgent(fleet[next]?.agentId);
-                    return next;
-                  });
+                  const next = Math.max(0, Math.min(fleet.length - 1, supervisionCursor + delta));
+                  setSupervisionCursor(next);
+                  setSelectedSupervisionAgent(fleet[next]?.agentId);
                 },
                 pinSelection: () => setSelectedSupervisionAgent(selectedFleetAgent?.agentId),
                 jumpTop: () => {
@@ -1212,10 +1210,11 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
                 reroute: () => flash("Reroute lands with #163"),
                 kill: () => flash("Kill action lands with claim-revoke provider API"),
                 openMessage: () => {
-                  if (selectedFleetRole) {
-                    setPromptMode(true);
-                    setPromptTarget((activeRoles ?? []).indexOf(selectedFleetRole));
-                  }
+                  if (!selectedFleetRole) return;
+                  const idx = (activeRoles ?? []).indexOf(selectedFleetRole);
+                  if (idx < 0) return;
+                  setPromptMode(true);
+                  setPromptTarget(idx);
                 },
               },
             );
@@ -1234,13 +1233,19 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           confirmModalOpen,
           // #193: supervision keyboard owner deps. expandedPanel/fleet/
           // selectedFleetAgent/selectedFleetRole change the consumed keys'
-          // behavior; tmux/activeRoles/flash are stable refs/callbacks but
-          // listed for closure correctness. useSupervision is a module-scope
-          // env constant (not a dep), same as useLogView above.
+          // behavior; supervisionCursor is read directly by moveCursor (flat
+          // setState, not the prior functional-update form). selectedFleetRole
+          // is still referenced directly inside openMessage, so it stays
+          // listed to satisfy biome's useExhaustiveDependencies (matching this
+          // file's list-everything discipline above). tmux/activeRoles/flash
+          // are stable refs/callbacks but listed for closure correctness.
+          // useSupervision is a module-scope env constant (not a dep), same as
+          // useLogView above.
           expandedPanel,
           fleet,
           selectedFleetAgent,
           selectedFleetRole,
+          supervisionCursor,
           tmux,
           activeRoles,
           flash,
@@ -1525,9 +1530,17 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             agents={fleet}
             tail={selectedFleetTail}
             cursor={supervisionCursor}
-            // exactOptionalPropertyTypes: only pass pinnedAgentId when set
-            {...(selectedSupervisionAgent !== undefined
-              ? { pinnedAgentId: selectedSupervisionAgent }
+            // Single selection authority: drive the pin from the already
+            // RESOLVED agent (selectedFleetAgent), not raw
+            // selectedSupervisionAgent. If we passed the raw pin and it left
+            // the fleet, running-view's memo falls back to fleet[cursor] while
+            // Supervision still re-resolves the stale pin, fires onSelect, and
+            // converge-by-setState churns every fleet refresh. Deriving from
+            // the resolved memo means Supervision's find() always hits and can
+            // never disagree with running-view's fallback.
+            // exactOptionalPropertyTypes: only pass pinnedAgentId when set.
+            {...(selectedFleetAgent?.agentId !== undefined
+              ? { pinnedAgentId: selectedFleetAgent.agentId }
               : {})}
             onSelect={handleSupervisionSelect}
           />

--- a/src/tui/screens/supervision/agent-health.test.ts
+++ b/src/tui/screens/supervision/agent-health.test.ts
@@ -143,7 +143,12 @@ describe("deriveAgentHealth", () => {
     ] as const;
     const weights = kinds.map((kind) => healthPriority({ kind } as AgentHealth));
     for (let i = 0; i < weights.length - 1; i++) {
-      expect(weights[i]).toBeLessThan(weights[i + 1]);
+      const current = weights[i];
+      const next = weights[i + 1];
+      if (current === undefined || next === undefined) {
+        throw new Error(`weights gap at index ${i}`);
+      }
+      expect(current).toBeLessThan(next);
     }
   });
 });

--- a/src/tui/screens/supervision/agent-health.test.ts
+++ b/src/tui/screens/supervision/agent-health.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { deriveAgentHealth, HEALTH_THRESHOLDS, type HealthInput } from "./agent-health.js";
+import {
+  type AgentHealth,
+  deriveAgentHealth,
+  HEALTH_THRESHOLDS,
+  type HealthInput,
+  healthPriority,
+} from "./agent-health.js";
 
 const NOW = new Date("2026-05-18T12:00:00Z").getTime();
 const minutesAgo = (m: number): string => new Date(NOW - m * 60_000).toISOString();
@@ -121,5 +127,23 @@ describe("deriveAgentHealth", () => {
       HEALTH_THRESHOLDS,
     );
     expect(out.kind).not.toBe("silent");
+  });
+
+  test("healthPriority orders error < approval < blocked < stuck < thrashing < silent < running < idle < expired", () => {
+    const kinds = [
+      "error",
+      "approval",
+      "blocked",
+      "stuck",
+      "thrashing",
+      "silent",
+      "running",
+      "idle",
+      "expired",
+    ] as const;
+    const weights = kinds.map((kind) => healthPriority({ kind } as AgentHealth));
+    for (let i = 0; i < weights.length - 1; i++) {
+      expect(weights[i]).toBeLessThan(weights[i + 1]);
+    }
   });
 });

--- a/src/tui/screens/supervision/agent-health.test.ts
+++ b/src/tui/screens/supervision/agent-health.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { deriveAgentHealth, HEALTH_THRESHOLDS, type HealthInput } from "./agent-health.js";
+
+const NOW = new Date("2026-05-18T12:00:00Z").getTime();
+const minutesAgo = (m: number): string => new Date(NOW - m * 60_000).toISOString();
+
+function baseInput(over: Partial<HealthInput> = {}): HealthInput {
+  return {
+    role: "coder",
+    leaseExpiresAt: new Date(NOW + 60_000).toISOString(),
+    heartbeatAt: minutesAgo(0),
+    attemptCount: 0,
+    lastRetryAt: undefined,
+    lastOutputAt: minutesAgo(0),
+    currentTask: "task-a",
+    currentTaskSinceMs: 1_000,
+    pendingApproval: undefined,
+    blockedOn: undefined,
+    blockedSinceMs: 0,
+    agentFailure: undefined,
+    ...over,
+  };
+}
+
+describe("deriveAgentHealth", () => {
+  test("agentFailure → error (highest priority)", () => {
+    const out = deriveAgentHealth(
+      baseInput({
+        agentFailure: "auth failed",
+        pendingApproval: { sessionName: "grove-coder-x", agentRole: "coder", command: "ls" },
+      }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out).toEqual({ kind: "error", reason: "auth failed" });
+  });
+
+  test("pendingApproval beats blocked beats stuck", () => {
+    const out = deriveAgentHealth(
+      baseInput({
+        pendingApproval: { sessionName: "s", agentRole: "coder", command: "rm" },
+      }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out).toEqual({ kind: "approval", cmd: "rm" });
+  });
+
+  test("lease expired → expired", () => {
+    const out = deriveAgentHealth(
+      baseInput({ leaseExpiresAt: new Date(NOW - 1).toISOString() }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).toBe("expired");
+  });
+
+  test("attemptCount >= threshold and recent retry → thrashing", () => {
+    const out = deriveAgentHealth(
+      baseInput({ attemptCount: 4, lastRetryAt: new Date(NOW - 10_000).toISOString() }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out).toEqual({ kind: "thrashing", retries: 4 });
+  });
+
+  test("blockedOn set and past min duration → blocked", () => {
+    const out = deriveAgentHealth(
+      baseInput({ blockedOn: "coordinator", blockedSinceMs: 120_000 }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out).toEqual({ kind: "blocked", on: "coordinator", sinceMs: 120_000 });
+  });
+
+  test("no output for > SILENT_MS → silent", () => {
+    const out = deriveAgentHealth(
+      baseInput({ lastOutputAt: minutesAgo(6) }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).toBe("silent");
+  });
+
+  test("task unchanged longer than STUCK_MS but output recent → stuck", () => {
+    const out = deriveAgentHealth(
+      baseInput({ currentTaskSinceMs: 9 * 60_000, lastOutputAt: minutesAgo(0) }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).toBe("stuck");
+  });
+
+  test("heartbeat lapse > 60s → silent (heartbeat path)", () => {
+    const out = deriveAgentHealth(
+      baseInput({ heartbeatAt: minutesAgo(2), lastOutputAt: minutesAgo(0) }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).toBe("silent");
+  });
+
+  test("recent output + recent heartbeat → running", () => {
+    const out = deriveAgentHealth(baseInput(), NOW, HEALTH_THRESHOLDS);
+    expect(out.kind).toBe("running");
+  });
+
+  test("no output ever + no task → idle", () => {
+    const out = deriveAgentHealth(
+      baseInput({ lastOutputAt: undefined, currentTask: undefined }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).toBe("idle");
+  });
+
+  test("threshold edge: SILENT_MS - 1 → not silent", () => {
+    const out = deriveAgentHealth(
+      baseInput({ lastOutputAt: new Date(NOW - HEALTH_THRESHOLDS.silentMs + 1).toISOString() }),
+      NOW,
+      HEALTH_THRESHOLDS,
+    );
+    expect(out.kind).not.toBe("silent");
+  });
+});

--- a/src/tui/screens/supervision/agent-health.ts
+++ b/src/tui/screens/supervision/agent-health.ts
@@ -43,6 +43,8 @@ export type AgentHealth =
   | { kind: "expired" };
 
 export interface HealthInput {
+  /** Carried for caller correlation (fleet join / logging); not used by
+   *  deriveAgentHealth itself. */
   readonly role: string;
   readonly leaseExpiresAt: string;
   readonly heartbeatAt: string;
@@ -91,6 +93,7 @@ export function deriveAgentHealth(i: HealthInput, nowMs: number, t: HealthThresh
   if (
     i.attemptCount >= t.thrashRetries &&
     i.lastRetryAt !== undefined &&
+    // <= : lastRetryAt must be *within* the window, not older than it
     nowMs - new Date(i.lastRetryAt).getTime() <= t.thrashWindowMs
   ) {
     return { kind: "thrashing", retries: i.attemptCount };

--- a/src/tui/screens/supervision/agent-health.ts
+++ b/src/tui/screens/supervision/agent-health.ts
@@ -1,0 +1,119 @@
+/**
+ * Pure derivation of agent supervision health (issue #193).
+ *
+ * Inputs come from the fleet model (claim + monitor output timestamps +
+ * handoffs + permissions). The first matching rule wins.
+ */
+
+import type { PermissionPrompt } from "../../hooks/use-agent-monitor.js";
+
+export interface HealthThresholds {
+  /** No output for longer than this → silent. */
+  readonly silentMs: number;
+  /** currentTask unchanged for longer than this (with recent output) → stuck. */
+  readonly stuckMs: number;
+  /** attemptCount >= this with a recent retry → thrashing. */
+  readonly thrashRetries: number;
+  /** "Recent retry" window: lastRetryAt within this from now. */
+  readonly thrashWindowMs: number;
+  /** Minimum blocked age before health flips to "blocked". */
+  readonly blockedMinMs: number;
+  /** Heartbeat lapse beyond this counts as silent. */
+  readonly heartbeatLapseMs: number;
+}
+
+export const HEALTH_THRESHOLDS: HealthThresholds = {
+  silentMs: 5 * 60_000,
+  stuckMs: 8 * 60_000,
+  thrashRetries: 3,
+  thrashWindowMs: 30_000,
+  blockedMinMs: 60_000,
+  heartbeatLapseMs: 60_000,
+};
+
+export type AgentHealth =
+  | { kind: "running" }
+  | { kind: "idle" }
+  | { kind: "approval"; cmd: string }
+  | { kind: "blocked"; on: string; sinceMs: number }
+  | { kind: "stuck"; sinceMs: number }
+  | { kind: "thrashing"; retries: number }
+  | { kind: "silent"; sinceMs: number }
+  | { kind: "error"; reason: string }
+  | { kind: "expired" };
+
+export interface HealthInput {
+  readonly role: string;
+  readonly leaseExpiresAt: string;
+  readonly heartbeatAt: string;
+  readonly attemptCount: number;
+  readonly lastRetryAt: string | undefined;
+  readonly lastOutputAt: string | undefined;
+  readonly currentTask: string | undefined;
+  readonly currentTaskSinceMs: number;
+  readonly pendingApproval: PermissionPrompt | undefined;
+  readonly blockedOn: string | undefined;
+  readonly blockedSinceMs: number;
+  readonly agentFailure: string | undefined;
+}
+
+/** Sort weight — lower = surfaced first. */
+export function healthPriority(h: AgentHealth): number {
+  switch (h.kind) {
+    case "error":
+      return 0;
+    case "approval":
+      return 1;
+    case "blocked":
+      return 2;
+    case "stuck":
+      return 3;
+    case "thrashing":
+      return 4;
+    case "silent":
+      return 5;
+    case "running":
+      return 6;
+    case "idle":
+      return 7;
+    case "expired":
+      return 8;
+  }
+}
+
+export function deriveAgentHealth(i: HealthInput, nowMs: number, t: HealthThresholds): AgentHealth {
+  if (i.agentFailure) return { kind: "error", reason: i.agentFailure };
+  if (i.pendingApproval) return { kind: "approval", cmd: i.pendingApproval.command };
+
+  const leaseMs = new Date(i.leaseExpiresAt).getTime();
+  if (leaseMs <= nowMs) return { kind: "expired" };
+
+  if (
+    i.attemptCount >= t.thrashRetries &&
+    i.lastRetryAt !== undefined &&
+    nowMs - new Date(i.lastRetryAt).getTime() <= t.thrashWindowMs
+  ) {
+    return { kind: "thrashing", retries: i.attemptCount };
+  }
+
+  if (i.blockedOn !== undefined && i.blockedSinceMs > t.blockedMinMs) {
+    return { kind: "blocked", on: i.blockedOn, sinceMs: i.blockedSinceMs };
+  }
+
+  const lastOutMs = i.lastOutputAt ? new Date(i.lastOutputAt).getTime() : undefined;
+  if (lastOutMs !== undefined && nowMs - lastOutMs > t.silentMs) {
+    return { kind: "silent", sinceMs: nowMs - lastOutMs };
+  }
+
+  if (i.currentTask !== undefined && i.currentTaskSinceMs > t.stuckMs && lastOutMs !== undefined) {
+    return { kind: "stuck", sinceMs: i.currentTaskSinceMs };
+  }
+
+  const heartMs = new Date(i.heartbeatAt).getTime();
+  if (nowMs - heartMs > t.heartbeatLapseMs) {
+    return { kind: "silent", sinceMs: nowMs - heartMs };
+  }
+
+  if (lastOutMs !== undefined) return { kind: "running" };
+  return { kind: "idle" };
+}

--- a/src/tui/screens/supervision/detail-rail.test.tsx
+++ b/src/tui/screens/supervision/detail-rail.test.tsx
@@ -100,7 +100,7 @@ describe("DetailRail", () => {
     });
     const flat = JSON.stringify(renderer.toJSON());
     expect(flat).toContain("target: ");
-    expect(flat).toContain('","-"');
+    expect(flat).toContain('"-"');
     renderer.unmount();
   });
 
@@ -116,6 +116,42 @@ describe("DetailRail", () => {
     const flat = JSON.stringify(renderer.toJSON());
     expect(flat).toContain("rm -rf foo");
     expect(flat).toContain("[y]allow");
+    expect(flat).toContain("[a]always");
+    expect(flat).toContain("[n]deny");
+    renderer.unmount();
+  });
+
+  test("overdueIn branch shows overdue count", async () => {
+    const a = agent({ handoffs: { pendingOut: 0, overdueIn: 2 } });
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create((<DetailRail agent={a} tail={[]} />) as React.ReactElement);
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("2 overdue in");
+    renderer.unmount();
+  });
+
+  test("cost undefined branch renders dash", async () => {
+    const a = agent({ cost: undefined });
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create((<DetailRail agent={a} tail={[]} />) as React.ReactElement);
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("Cost");
+    expect(flat).toContain('"-"');
+    renderer.unmount();
+  });
+
+  test("blockedOn branch shows blocked-on label", async () => {
+    const a = agent({ handoffs: { pendingOut: 0, overdueIn: 0, blockedOn: "coordinator" } });
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create((<DetailRail agent={a} tail={[]} />) as React.ReactElement);
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("blocked on coordinator");
     renderer.unmount();
   });
 });

--- a/src/tui/screens/supervision/detail-rail.test.tsx
+++ b/src/tui/screens/supervision/detail-rail.test.tsx
@@ -90,6 +90,20 @@ describe("DetailRail", () => {
     renderer.unmount();
   });
 
+  test("base agent with no targetRef shows 'target: -'", async () => {
+    const a = agent({
+      claim: { spec: {} } as FleetAgent["claim"],
+    });
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create((<DetailRail agent={a} tail={[]} />) as React.ReactElement);
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("target: ");
+    expect(flat).toContain('","-"');
+    renderer.unmount();
+  });
+
   test("approval agent shows command and [y]allow prompt", async () => {
     const a = agent({
       health: { kind: "approval", cmd: "rm -rf foo" } as AgentHealth,

--- a/src/tui/screens/supervision/detail-rail.test.tsx
+++ b/src/tui/screens/supervision/detail-rail.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Component-level tests for the DetailRail selected-agent context (#193 Task 6).
+ *
+ * Covers:
+ *   - agent={undefined} → shows "Select an agent"
+ *   - base agent with tail → shows name, task, cost, pending handoffs, tail line
+ *   - approval agent → shows command and [y]allow prompt
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type React from "react";
+import type * as TestRendererTypes from "react-test-renderer";
+import type { AgentHealth } from "./agent-health.js";
+import type { FleetAgent } from "./use-fleet-model.js";
+
+mock.module("@opentui/react", () => ({
+  useKeyboard: (): void => undefined,
+  useRenderer: (): { destroy: () => void } => ({ destroy: () => undefined }),
+  useTerminalDimensions: (): { width: number; height: number } => ({ width: 120, height: 40 }),
+  useTimeline: (): unknown => ({}),
+  useOnResize: (): void => undefined,
+  useAppContext: (): unknown => ({}),
+  createPortal: (children: unknown): unknown => children,
+  createRoot: (): unknown => ({}),
+  createElement: (): unknown => null,
+  flushSync: (fn: () => void): void => fn(),
+  extend: (): void => undefined,
+  getComponentCatalogue: (): unknown => ({}),
+  componentCatalogue: {},
+  baseComponents: {},
+  TimeToFirstDraw: (): null => null,
+  AppContext: {},
+}));
+
+const TestRendererModule = await import("react-test-renderer");
+const TestRenderer = (TestRendererModule as unknown as { default: typeof TestRendererTypes })
+  .default;
+const { act } = TestRendererModule;
+const { DetailRail } = await import("./detail-rail.js");
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function agent(over: Partial<FleetAgent>): FleetAgent {
+  return {
+    agentId: "a1",
+    agentName: "alpha",
+    role: "coder",
+    platform: "claude",
+    session: "grove-coder-x",
+    claim: { spec: { targetRef: "t" } } as FleetAgent["claim"],
+    health: { kind: "running" } as AgentHealth,
+    currentTask: "edit login.ts",
+    lastAction: undefined,
+    lastOutputAt: undefined,
+    cost: { usd: 1.18, tokens: 42000 },
+    handoffs: { pendingOut: 1, overdueIn: 0 },
+    pendingApproval: undefined,
+    attemptCount: 0,
+    ...over,
+  };
+}
+
+describe("DetailRail", () => {
+  test("agent=undefined shows Select an agent prompt", async () => {
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (<DetailRail agent={undefined} tail={[]} />) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("Select an agent");
+    renderer.unmount();
+  });
+
+  test("base agent with tail shows name, task, cost, handoffs, and tail lines", async () => {
+    const a = agent({});
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (<DetailRail agent={a} tail={["line 1", "line 2"]} />) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("alpha");
+    expect(flat).toContain("edit login.ts");
+    expect(flat).toContain("$1.18");
+    expect(flat).toContain("1 pending out");
+    expect(flat).toContain("line 2");
+    renderer.unmount();
+  });
+
+  test("approval agent shows command and [y]allow prompt", async () => {
+    const a = agent({
+      health: { kind: "approval", cmd: "rm -rf foo" } as AgentHealth,
+      pendingApproval: { sessionName: "s", agentRole: "coder", command: "rm -rf foo" },
+    });
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create((<DetailRail agent={a} tail={[]} />) as React.ReactElement);
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("rm -rf foo");
+    expect(flat).toContain("[y]allow");
+    renderer.unmount();
+  });
+});

--- a/src/tui/screens/supervision/detail-rail.tsx
+++ b/src/tui/screens/supervision/detail-rail.tsx
@@ -1,0 +1,134 @@
+/**
+ * Detail rail — selected-agent context (issue #193).
+ *
+ * Stacked sections: header, approval (when present), task, tail, handoffs,
+ * cost, action footer.
+ */
+
+import React from "react";
+import { theme } from "../../theme.js";
+import type { AgentHealth } from "./agent-health.js";
+import type { FleetAgent } from "./use-fleet-model.js";
+
+export interface DetailRailProps {
+  readonly agent: FleetAgent | undefined;
+  readonly tail: readonly string[];
+}
+
+const mins = (ms: number): string => {
+  const m = Math.floor(ms / 60_000);
+  if (m < 60) return `${m}m`;
+  return `${Math.floor(m / 60)}h`;
+};
+
+function healthHeader(h: AgentHealth): { text: string; color: string } {
+  switch (h.kind) {
+    case "running":
+      return { text: "RUNNING", color: theme.running };
+    case "idle":
+      return { text: "IDLE", color: theme.idle };
+    case "approval":
+      return { text: "APPROVAL PENDING", color: theme.warning };
+    case "blocked":
+      return { text: `BLOCKED ${mins(h.sinceMs)} on ${h.on}`, color: theme.error };
+    case "stuck":
+      return { text: `STUCK ${mins(h.sinceMs)}`, color: theme.warning };
+    case "thrashing":
+      return { text: `THRASHING (${h.retries} retries)`, color: theme.warning };
+    case "silent":
+      return { text: `SILENT ${mins(h.sinceMs)}`, color: theme.warning };
+    case "error":
+      return { text: `ERROR: ${h.reason}`, color: theme.error };
+    case "expired":
+      return { text: "EXPIRED", color: theme.idle };
+  }
+}
+
+export const DetailRail = React.memo(function DetailRail({
+  agent,
+  tail,
+}: DetailRailProps): React.ReactNode {
+  if (!agent) {
+    return (
+      <box flexDirection="column" paddingX={1}>
+        <text opacity={0.5}>Select an agent (j/k) to view context</text>
+      </box>
+    );
+  }
+
+  const hdr = healthHeader(agent.health);
+
+  return (
+    <box flexDirection="column" paddingX={1}>
+      <box flexDirection="row" marginBottom={1}>
+        <text bold>{agent.agentName}</text>
+        <text color={theme.secondary}>{`  (${agent.role}/${agent.platform})  `}</text>
+        <text color={hdr.color} bold>
+          {hdr.text}
+        </text>
+      </box>
+
+      {agent.health.kind === "approval" ? (
+        <box
+          flexDirection="column"
+          marginBottom={1}
+          borderStyle="round"
+          borderColor={theme.warning}
+          paddingX={1}
+        >
+          <text color={theme.warning} bold>
+            Wants to run:
+          </text>
+          <text>{agent.health.cmd}</text>
+          <text color={theme.secondary}>[y]allow [n]deny [a]always</text>
+        </box>
+      ) : null}
+
+      <box flexDirection="column" marginBottom={1}>
+        <text color={theme.secondary} bold>
+          Task
+        </text>
+        <text>{agent.currentTask ?? "(no task)"}</text>
+        <text color={theme.secondary}>target: {agent.claim.spec.targetRef}</text>
+      </box>
+
+      <box flexDirection="column" marginBottom={1}>
+        <text color={theme.secondary} bold>
+          Tail
+        </text>
+        {tail.length === 0 ? (
+          <text opacity={0.4}>(no output)</text>
+        ) : (
+          tail.slice(-8).map((line, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: ephemeral lines
+            <text key={i}>{line}</text>
+          ))
+        )}
+      </box>
+
+      <box flexDirection="row" marginBottom={1}>
+        <text color={theme.secondary}>Handoffs: </text>
+        <text>{`${agent.handoffs.pendingOut} pending out`}</text>
+        {agent.handoffs.overdueIn > 0 ? (
+          <text color={theme.error}>{`  ${agent.handoffs.overdueIn} overdue in`}</text>
+        ) : null}
+        {agent.handoffs.blockedOn ? (
+          <text color={theme.error}>{`  blocked on ${agent.handoffs.blockedOn}`}</text>
+        ) : null}
+      </box>
+
+      <box flexDirection="row" marginBottom={1}>
+        <text color={theme.secondary}>Cost: </text>
+        <text>
+          {agent.cost
+            ? `$${agent.cost.usd.toFixed(2)} · ${agent.cost.tokens.toLocaleString()} tok`
+            : "-"}
+        </text>
+      </box>
+
+      <box flexDirection="row">
+        <text color={theme.secondary}>[t]ail [d]ag [r]eroute [K]ill [m]essage</text>
+      </box>
+    </box>
+  );
+});

--- a/src/tui/screens/supervision/detail-rail.tsx
+++ b/src/tui/screens/supervision/detail-rail.tsx
@@ -89,7 +89,7 @@ export const DetailRail = React.memo(function DetailRail({
           Task
         </text>
         <text>{agent.currentTask ?? "(no task)"}</text>
-        <text color={theme.secondary}>target: {agent.claim.spec.targetRef}</text>
+        <text color={theme.secondary}>target: {agent.claim.spec.targetRef ?? "-"}</text>
       </box>
 
       <box flexDirection="column" marginBottom={1}>

--- a/src/tui/screens/supervision/detail-rail.tsx
+++ b/src/tui/screens/supervision/detail-rail.tsx
@@ -45,91 +45,90 @@ function healthHeader(h: AgentHealth): { text: string; color: string } {
   }
 }
 
-export const DetailRail = React.memo(function DetailRail({
-  agent,
-  tail,
-}: DetailRailProps): React.ReactNode {
-  if (!agent) {
+export const DetailRail: React.NamedExoticComponent<DetailRailProps> = React.memo(
+  function DetailRail({ agent, tail }: DetailRailProps): React.ReactNode {
+    if (!agent) {
+      return (
+        <box flexDirection="column" paddingX={1}>
+          <text opacity={0.5}>Select an agent (j/k) to view context</text>
+        </box>
+      );
+    }
+
+    const hdr = healthHeader(agent.health);
+
     return (
       <box flexDirection="column" paddingX={1}>
-        <text opacity={0.5}>Select an agent (j/k) to view context</text>
+        <box flexDirection="row" marginBottom={1}>
+          <text bold>{agent.agentName}</text>
+          <text color={theme.secondary}>{`  (${agent.role}/${agent.platform})  `}</text>
+          <text color={hdr.color} bold>
+            {hdr.text}
+          </text>
+        </box>
+
+        {agent.health.kind === "approval" ? (
+          <box
+            flexDirection="column"
+            marginBottom={1}
+            borderStyle="round"
+            borderColor={theme.warning}
+            paddingX={1}
+          >
+            <text color={theme.warning} bold>
+              Wants to run:
+            </text>
+            <text>{agent.health.cmd}</text>
+            <text color={theme.secondary}>[y]allow [n]deny [a]always</text>
+          </box>
+        ) : null}
+
+        <box flexDirection="column" marginBottom={1}>
+          <text color={theme.secondary} bold>
+            Task
+          </text>
+          <text>{agent.currentTask ?? "(no task)"}</text>
+          <text color={theme.secondary}>target: {agent.claim.spec.targetRef ?? "-"}</text>
+        </box>
+
+        <box flexDirection="column" marginBottom={1}>
+          <text color={theme.secondary} bold>
+            Tail
+          </text>
+          {tail.length === 0 ? (
+            <text opacity={0.4}>(no output)</text>
+          ) : (
+            tail.slice(-8).map((line, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: ephemeral lines
+              <text key={i}>{line}</text>
+            ))
+          )}
+        </box>
+
+        <box flexDirection="row" marginBottom={1}>
+          <text color={theme.secondary}>Handoffs: </text>
+          <text>{`${agent.handoffs.pendingOut} pending out`}</text>
+          {agent.handoffs.overdueIn > 0 ? (
+            <text color={theme.error}>{`  ${agent.handoffs.overdueIn} overdue in`}</text>
+          ) : null}
+          {agent.handoffs.blockedOn ? (
+            <text color={theme.error}>{`  blocked on ${agent.handoffs.blockedOn}`}</text>
+          ) : null}
+        </box>
+
+        <box flexDirection="row" marginBottom={1}>
+          <text color={theme.secondary}>Cost: </text>
+          <text>
+            {agent.cost
+              ? `$${agent.cost.usd.toFixed(2)} · ${agent.cost.tokens.toLocaleString()} tok`
+              : "-"}
+          </text>
+        </box>
+
+        <box flexDirection="row">
+          <text color={theme.secondary}>[t]ail [d]ag [r]eroute [K]ill [m]essage</text>
+        </box>
       </box>
     );
-  }
-
-  const hdr = healthHeader(agent.health);
-
-  return (
-    <box flexDirection="column" paddingX={1}>
-      <box flexDirection="row" marginBottom={1}>
-        <text bold>{agent.agentName}</text>
-        <text color={theme.secondary}>{`  (${agent.role}/${agent.platform})  `}</text>
-        <text color={hdr.color} bold>
-          {hdr.text}
-        </text>
-      </box>
-
-      {agent.health.kind === "approval" ? (
-        <box
-          flexDirection="column"
-          marginBottom={1}
-          borderStyle="round"
-          borderColor={theme.warning}
-          paddingX={1}
-        >
-          <text color={theme.warning} bold>
-            Wants to run:
-          </text>
-          <text>{agent.health.cmd}</text>
-          <text color={theme.secondary}>[y]allow [n]deny [a]always</text>
-        </box>
-      ) : null}
-
-      <box flexDirection="column" marginBottom={1}>
-        <text color={theme.secondary} bold>
-          Task
-        </text>
-        <text>{agent.currentTask ?? "(no task)"}</text>
-        <text color={theme.secondary}>target: {agent.claim.spec.targetRef ?? "-"}</text>
-      </box>
-
-      <box flexDirection="column" marginBottom={1}>
-        <text color={theme.secondary} bold>
-          Tail
-        </text>
-        {tail.length === 0 ? (
-          <text opacity={0.4}>(no output)</text>
-        ) : (
-          tail.slice(-8).map((line, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: ephemeral lines
-            <text key={i}>{line}</text>
-          ))
-        )}
-      </box>
-
-      <box flexDirection="row" marginBottom={1}>
-        <text color={theme.secondary}>Handoffs: </text>
-        <text>{`${agent.handoffs.pendingOut} pending out`}</text>
-        {agent.handoffs.overdueIn > 0 ? (
-          <text color={theme.error}>{`  ${agent.handoffs.overdueIn} overdue in`}</text>
-        ) : null}
-        {agent.handoffs.blockedOn ? (
-          <text color={theme.error}>{`  blocked on ${agent.handoffs.blockedOn}`}</text>
-        ) : null}
-      </box>
-
-      <box flexDirection="row" marginBottom={1}>
-        <text color={theme.secondary}>Cost: </text>
-        <text>
-          {agent.cost
-            ? `$${agent.cost.usd.toFixed(2)} · ${agent.cost.tokens.toLocaleString()} tok`
-            : "-"}
-        </text>
-      </box>
-
-      <box flexDirection="row">
-        <text color={theme.secondary}>[t]ail [d]ag [r]eroute [K]ill [m]essage</text>
-      </box>
-    </box>
-  );
-});
+  },
+);

--- a/src/tui/screens/supervision/detail-rail.tsx
+++ b/src/tui/screens/supervision/detail-rail.tsx
@@ -15,6 +15,7 @@ export interface DetailRailProps {
   readonly tail: readonly string[];
 }
 
+// duplicated in fleet-rail.tsx; extract to a shared util on the 3rd consumer
 const mins = (ms: number): string => {
   const m = Math.floor(ms / 60_000);
   if (m < 60) return `${m}m`;

--- a/src/tui/screens/supervision/fleet-rail.test.tsx
+++ b/src/tui/screens/supervision/fleet-rail.test.tsx
@@ -119,7 +119,7 @@ describe("FleetRail", () => {
     renderer.unmount();
   });
 
-  test("header with 2 agents where 1 is a problem shows count and 1 problem", async () => {
+  test("header with 2 agents where 1 is a problem shows count and 1 problem (singular)", async () => {
     const agents = [
       agent({ agentId: "b1", agentName: "b1", health: { kind: "running" } }),
       agent({ agentId: "b2", agentName: "b2", health: { kind: "stuck", sinceMs: 540_000 } }),
@@ -135,6 +135,65 @@ describe("FleetRail", () => {
     const flat = JSON.stringify(renderer.toJSON());
     expect(flat).toContain("2");
     expect(flat).toContain("1 problem");
+    renderer.unmount();
+  });
+
+  test("header with 3 agents where 2 are problems shows 2 problems (plural)", async () => {
+    const agents = [
+      agent({ agentId: "c1", agentName: "c1", health: { kind: "running" } }),
+      agent({ agentId: "c2", agentName: "c2", health: { kind: "stuck", sinceMs: 540_000 } }),
+      agent({ agentId: "c3", agentName: "c3", health: { kind: "error", reason: "crash" } }),
+    ];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <FleetRail agents={agents} cursor={0} selectedAgentId={undefined} />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("3");
+    expect(flat).toContain("2 problems");
+    renderer.unmount();
+  });
+
+  test("error health agent renders with ERROR label", async () => {
+    const agents = [
+      agent({ agentId: "e1", agentName: "e1", health: { kind: "error", reason: "boom" } }),
+    ];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <FleetRail agents={agents} cursor={0} selectedAgentId={undefined} />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("ERROR");
+    renderer.unmount();
+  });
+
+  test("expired health agent renders its row and is excluded from problem count", async () => {
+    const agents = [
+      agent({ agentId: "x1", agentName: "x1", health: { kind: "running" } }),
+      agent({ agentId: "x2", agentName: "x2", health: { kind: "expired" } }),
+    ];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <FleetRail agents={agents} cursor={0} selectedAgentId={undefined} />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    // expired row should appear
+    expect(flat).toContain("x2");
+    // header should show "Fleet (2)" with no problem suffix
+    expect(flat).toContain("Fleet (2)");
+    expect(flat).not.toContain("problem");
     renderer.unmount();
   });
 });

--- a/src/tui/screens/supervision/fleet-rail.test.tsx
+++ b/src/tui/screens/supervision/fleet-rail.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Component-level tests for the FleetRail dense lane list (#193 Task 5).
+ *
+ * Covers:
+ *   - renders one row per fleet agent, both running and blocked appear
+ *   - approval agent row contains "[y/n]"
+ *   - empty agents array shows "No agents registered"
+ *   - header shows agent count and problem count
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type React from "react";
+import type * as TestRendererTypes from "react-test-renderer";
+import type { AgentHealth } from "./agent-health.js";
+import type { FleetAgent } from "./use-fleet-model.js";
+
+mock.module("@opentui/react", () => ({
+  useKeyboard: (): void => undefined,
+  useRenderer: (): { destroy: () => void } => ({ destroy: () => undefined }),
+  useTerminalDimensions: (): { width: number; height: number } => ({ width: 120, height: 40 }),
+  useTimeline: (): unknown => ({}),
+  useOnResize: (): void => undefined,
+  useAppContext: (): unknown => ({}),
+  createPortal: (children: unknown): unknown => children,
+  createRoot: (): unknown => ({}),
+  createElement: (): unknown => null,
+  flushSync: (fn: () => void): void => fn(),
+  extend: (): void => undefined,
+  getComponentCatalogue: (): unknown => ({}),
+  componentCatalogue: {},
+  baseComponents: {},
+  TimeToFirstDraw: (): null => null,
+  AppContext: {},
+}));
+
+const TestRendererModule = await import("react-test-renderer");
+const TestRenderer = (TestRendererModule as unknown as { default: typeof TestRendererTypes })
+  .default;
+const { act } = TestRendererModule;
+const { FleetRail } = await import("./fleet-rail.js");
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function agent(over: Partial<FleetAgent>): FleetAgent {
+  return {
+    agentId: "a",
+    agentName: "agent-a",
+    role: "coder",
+    platform: "claude",
+    session: undefined,
+    claim: {} as FleetAgent["claim"],
+    health: { kind: "running" } as AgentHealth,
+    currentTask: "do thing",
+    lastAction: undefined,
+    lastOutputAt: undefined,
+    cost: undefined,
+    handoffs: { pendingOut: 0, overdueIn: 0 },
+    pendingApproval: undefined,
+    attemptCount: 0,
+    ...over,
+  };
+}
+
+describe("FleetRail", () => {
+  test("renders one row per fleet agent; running and blocked agents appear with BLOCKED label", async () => {
+    const agents = [
+      agent({ agentId: "a1", agentName: "a1", health: { kind: "running" } }),
+      agent({
+        agentId: "a2",
+        agentName: "a2",
+        health: { kind: "blocked", on: "coord", sinceMs: 120_000 },
+      }),
+    ];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <FleetRail agents={agents} cursor={0} selectedAgentId={undefined} />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("a1");
+    expect(flat).toContain("a2");
+    expect(flat).toContain("BLOCKED");
+    renderer.unmount();
+  });
+
+  test("approval agent row contains [y/n]", async () => {
+    const agents = [
+      agent({
+        agentId: "a3",
+        agentName: "a3",
+        health: { kind: "approval", cmd: "rm" },
+      }),
+    ];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <FleetRail agents={agents} cursor={0} selectedAgentId={undefined} />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("[y/n]");
+    renderer.unmount();
+  });
+
+  test("empty agents array shows No agents registered", async () => {
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (<FleetRail agents={[]} cursor={0} selectedAgentId={undefined} />) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("No agents registered");
+    renderer.unmount();
+  });
+
+  test("header with 2 agents where 1 is a problem shows count and 1 problem", async () => {
+    const agents = [
+      agent({ agentId: "b1", agentName: "b1", health: { kind: "running" } }),
+      agent({ agentId: "b2", agentName: "b2", health: { kind: "stuck", sinceMs: 540_000 } }),
+    ];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <FleetRail agents={agents} cursor={0} selectedAgentId={undefined} />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("2");
+    expect(flat).toContain("1 problem");
+    renderer.unmount();
+  });
+});

--- a/src/tui/screens/supervision/fleet-rail.tsx
+++ b/src/tui/screens/supervision/fleet-rail.tsx
@@ -59,7 +59,7 @@ function healthLabel(h: AgentHealth): { label: string; color: string } {
   }
 }
 
-export const FleetRail = React.memo(function FleetRail({
+export const FleetRail: React.NamedExoticComponent<FleetRailProps> = React.memo(function FleetRail({
   agents,
   cursor,
   selectedAgentId,

--- a/src/tui/screens/supervision/fleet-rail.tsx
+++ b/src/tui/screens/supervision/fleet-rail.tsx
@@ -7,7 +7,7 @@
 
 import React from "react";
 import { EmptyState } from "../../components/empty-state.js";
-import { agentStatusIcon, theme } from "../../theme.js";
+import { theme } from "../../theme.js";
 import type { AgentHealth } from "./agent-health.js";
 import type { FleetAgent } from "./use-fleet-model.js";
 
@@ -17,6 +17,8 @@ export interface FleetRailProps {
   readonly selectedAgentId: string | undefined;
 }
 
+// `expired` is intentionally excluded — it is the lowest-priority terminal state
+// (mirrors healthPriority ordering in agent-health.ts where expired sorts last) and is not an actionable problem.
 const PROBLEM_KINDS = new Set<AgentHealth["kind"]>([
   "error",
   "approval",
@@ -74,7 +76,7 @@ export const FleetRail = React.memo(function FleetRail({
   }
 
   const problemCount = agents.filter((a) => PROBLEM_KINDS.has(a.health.kind)).length;
-  const header = `Fleet (${agents.length}${problemCount > 0 ? ` · ${problemCount} problem` : ""})`;
+  const header = `Fleet (${agents.length}${problemCount > 0 ? ` · ${problemCount} problem${problemCount === 1 ? "" : "s"}` : ""})`;
 
   return (
     <box flexDirection="column">
@@ -84,9 +86,6 @@ export const FleetRail = React.memo(function FleetRail({
       {agents.map((a, i) => {
         const isCursor = i === cursor;
         const isSelected = a.agentId === selectedAgentId;
-        const { icon } = agentStatusIcon(
-          a.health.kind === "running" ? "running" : a.health.kind === "idle" ? "idle" : "error",
-        );
         const lbl = healthLabel(a.health);
         const prefix = isCursor ? "►" : " ";
         const action = a.lastAction ?? a.currentTask ?? "";
@@ -97,7 +96,7 @@ export const FleetRail = React.memo(function FleetRail({
             backgroundColor={isSelected ? theme.focus : undefined}
           >
             <text>{`${prefix} `}</text>
-            <text color={lbl.color}>{`${icon} ${lbl.label.padEnd(14)}`}</text>
+            <text color={lbl.color}>{`${trunc(lbl.label, 14).padEnd(14)}`}</text>
             <text color={theme.secondary}>{` ${a.role.padEnd(10)} `}</text>
             <text>{trunc(a.agentName, 14).padEnd(14)}</text>
             <text color={theme.secondary}>{` ${trunc(action, 40)}`}</text>

--- a/src/tui/screens/supervision/fleet-rail.tsx
+++ b/src/tui/screens/supervision/fleet-rail.tsx
@@ -1,0 +1,114 @@
+/**
+ * Fleet rail — dense one-row-per-agent list (issue #193).
+ *
+ * Renders the FleetAgent[] from useFleetModel. Cursor row is highlighted;
+ * problem agents show ALL-CAPS health label and any blocked-on attribution.
+ */
+
+import React from "react";
+import { EmptyState } from "../../components/empty-state.js";
+import { agentStatusIcon, theme } from "../../theme.js";
+import type { AgentHealth } from "./agent-health.js";
+import type { FleetAgent } from "./use-fleet-model.js";
+
+export interface FleetRailProps {
+  readonly agents: readonly FleetAgent[];
+  readonly cursor: number;
+  readonly selectedAgentId: string | undefined;
+}
+
+const PROBLEM_KINDS = new Set<AgentHealth["kind"]>([
+  "error",
+  "approval",
+  "blocked",
+  "stuck",
+  "thrashing",
+  "silent",
+]);
+
+const trunc = (s: string, n: number): string => (s.length > n ? `${s.slice(0, n - 1)}…` : s);
+
+const mins = (ms: number): string => {
+  const m = Math.floor(ms / 60_000);
+  if (m < 60) return `${m}m`;
+  return `${Math.floor(m / 60)}h`;
+};
+
+function healthLabel(h: AgentHealth): { label: string; color: string } {
+  switch (h.kind) {
+    case "running":
+      return { label: "run", color: theme.running };
+    case "idle":
+      return { label: "idle", color: theme.idle };
+    case "approval":
+      return { label: "APPROVAL", color: theme.warning };
+    case "blocked":
+      return { label: `BLOCKED ${mins(h.sinceMs)}`, color: theme.error };
+    case "stuck":
+      return { label: `STUCK ${mins(h.sinceMs)}`, color: theme.warning };
+    case "thrashing":
+      return { label: `THRASH x${h.retries}`, color: theme.warning };
+    case "silent":
+      return { label: `SILENT ${mins(h.sinceMs)}`, color: theme.warning };
+    case "error":
+      return { label: "ERROR", color: theme.error };
+    case "expired":
+      return { label: "expired", color: theme.idle };
+  }
+}
+
+export const FleetRail = React.memo(function FleetRail({
+  agents,
+  cursor,
+  selectedAgentId,
+}: FleetRailProps): React.ReactNode {
+  if (agents.length === 0) {
+    return (
+      <box flexDirection="column">
+        <box marginBottom={1}>
+          <text>Fleet (0)</text>
+        </box>
+        <EmptyState title="No agents registered." hint="Press r to register, or Ctrl+P to spawn." />
+      </box>
+    );
+  }
+
+  const problemCount = agents.filter((a) => PROBLEM_KINDS.has(a.health.kind)).length;
+  const header = `Fleet (${agents.length}${problemCount > 0 ? ` · ${problemCount} problem` : ""})`;
+
+  return (
+    <box flexDirection="column">
+      <box marginBottom={1}>
+        <text bold>{header}</text>
+      </box>
+      {agents.map((a, i) => {
+        const isCursor = i === cursor;
+        const isSelected = a.agentId === selectedAgentId;
+        const { icon } = agentStatusIcon(
+          a.health.kind === "running" ? "running" : a.health.kind === "idle" ? "idle" : "error",
+        );
+        const lbl = healthLabel(a.health);
+        const prefix = isCursor ? "►" : " ";
+        const action = a.lastAction ?? a.currentTask ?? "";
+        return (
+          <box
+            key={a.agentId}
+            flexDirection="row"
+            backgroundColor={isSelected ? theme.focus : undefined}
+          >
+            <text>{`${prefix} `}</text>
+            <text color={lbl.color}>{`${icon} ${lbl.label.padEnd(14)}`}</text>
+            <text color={theme.secondary}>{` ${a.role.padEnd(10)} `}</text>
+            <text>{trunc(a.agentName, 14).padEnd(14)}</text>
+            <text color={theme.secondary}>{` ${trunc(action, 40)}`}</text>
+            {a.health.kind === "blocked" ? (
+              <text color={theme.error}>{` ← ${a.health.on}`}</text>
+            ) : null}
+            {a.health.kind === "approval" ? <text color={theme.warning}>{" [y/n]"}</text> : null}
+            {a.cost ? <text color={theme.secondary}>{`  $${a.cost.usd.toFixed(2)}`}</text> : null}
+          </box>
+        );
+      })}
+    </box>
+  );
+});

--- a/src/tui/screens/supervision/permission-box-visibility.test.ts
+++ b/src/tui/screens/supervision/permission-box-visibility.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { permissionBoxVisible } from "./permission-box-visibility.js";
+
+describe("permissionBoxVisible", () => {
+  test("visible when supervision off and there are pending permissions", () => {
+    expect(permissionBoxVisible(false, 1)).toBe(true);
+    expect(permissionBoxVisible(false, 3)).toBe(true);
+  });
+  test("hidden when supervision on, even with pending permissions", () => {
+    expect(permissionBoxVisible(true, 1)).toBe(false);
+    expect(permissionBoxVisible(true, 5)).toBe(false);
+  });
+  test("hidden when no pending permissions regardless of flag", () => {
+    expect(permissionBoxVisible(false, 0)).toBe(false);
+    expect(permissionBoxVisible(true, 0)).toBe(false);
+  });
+});

--- a/src/tui/screens/supervision/permission-box-visibility.ts
+++ b/src/tui/screens/supervision/permission-box-visibility.ts
@@ -1,0 +1,16 @@
+/**
+ * Whether the legacy floating "Permission Request" overlay should render.
+ *
+ * When supervision is the active body (GROVE_SUPERVISION=1) the supervision
+ * DetailRail owns approval display, so the floating overlay must be
+ * suppressed to avoid a duplicate prompt. Pure — extracted so the
+ * regression guard is testable without importing running-view.tsx
+ * (which transitively needs chokidar). See supervision-input-guard.ts for
+ * the same pattern (#193).
+ */
+export function permissionBoxVisible(
+  supervisionOn: boolean,
+  pendingPermissionCount: number,
+): boolean {
+  return !supervisionOn && pendingPermissionCount > 0;
+}

--- a/src/tui/screens/supervision/supervision-actions.test.ts
+++ b/src/tui/screens/supervision/supervision-actions.test.ts
@@ -15,6 +15,7 @@ describe("actionEnabled", () => {
   test("approve / deny / always require approval health", () => {
     expect(actionEnabled("approve", APPROVAL)).toBe(true);
     expect(actionEnabled("approve", RUNNING)).toBe(false);
+    expect(actionEnabled("deny", APPROVAL)).toBe(true);
     expect(actionEnabled("deny", BLOCKED)).toBe(false);
     expect(actionEnabled("always", APPROVAL)).toBe(true);
   });
@@ -27,17 +28,21 @@ describe("actionEnabled", () => {
   test("kill enabled for everything except expired", () => {
     expect(actionEnabled("kill", RUNNING)).toBe(true);
     expect(actionEnabled("kill", APPROVAL)).toBe(true);
+    expect(actionEnabled("kill", BLOCKED)).toBe(true);
     expect(actionEnabled("kill", EXPIRED)).toBe(false);
   });
 
   test("tail / dag / message always enabled", () => {
     for (const action of ["tail", "dag", "message"] as SupervisionAction[]) {
-      expect(actionEnabled(action, EXPIRED)).toBe(true);
+      for (const h of [RUNNING, APPROVAL, BLOCKED, EXPIRED]) {
+        expect(actionEnabled(action, h)).toBe(true);
+      }
     }
   });
 
   test("SUPERVISION_ACTIONS lists each action exactly once", () => {
     const set = new Set(SUPERVISION_ACTIONS);
     expect(set.size).toBe(SUPERVISION_ACTIONS.length);
+    expect(SUPERVISION_ACTIONS).toHaveLength(8);
   });
 });

--- a/src/tui/screens/supervision/supervision-actions.test.ts
+++ b/src/tui/screens/supervision/supervision-actions.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentHealth } from "./agent-health.js";
+import {
+  actionEnabled,
+  SUPERVISION_ACTIONS,
+  type SupervisionAction,
+} from "./supervision-actions.js";
+
+const RUNNING: AgentHealth = { kind: "running" };
+const APPROVAL: AgentHealth = { kind: "approval", cmd: "rm -rf /" };
+const BLOCKED: AgentHealth = { kind: "blocked", on: "coordinator", sinceMs: 120_000 };
+const EXPIRED: AgentHealth = { kind: "expired" };
+
+describe("actionEnabled", () => {
+  test("approve / deny / always require approval health", () => {
+    expect(actionEnabled("approve", APPROVAL)).toBe(true);
+    expect(actionEnabled("approve", RUNNING)).toBe(false);
+    expect(actionEnabled("deny", BLOCKED)).toBe(false);
+    expect(actionEnabled("always", APPROVAL)).toBe(true);
+  });
+
+  test("reroute requires blocked health", () => {
+    expect(actionEnabled("reroute", BLOCKED)).toBe(true);
+    expect(actionEnabled("reroute", RUNNING)).toBe(false);
+  });
+
+  test("kill enabled for everything except expired", () => {
+    expect(actionEnabled("kill", RUNNING)).toBe(true);
+    expect(actionEnabled("kill", APPROVAL)).toBe(true);
+    expect(actionEnabled("kill", EXPIRED)).toBe(false);
+  });
+
+  test("tail / dag / message always enabled", () => {
+    for (const action of ["tail", "dag", "message"] as SupervisionAction[]) {
+      expect(actionEnabled(action, EXPIRED)).toBe(true);
+    }
+  });
+
+  test("SUPERVISION_ACTIONS lists each action exactly once", () => {
+    const set = new Set(SUPERVISION_ACTIONS);
+    expect(set.size).toBe(SUPERVISION_ACTIONS.length);
+  });
+});

--- a/src/tui/screens/supervision/supervision-actions.ts
+++ b/src/tui/screens/supervision/supervision-actions.ts
@@ -1,0 +1,44 @@
+/**
+ * Supervision action descriptors. Pure module — pairs an action key with an
+ * enablement predicate based on the selected agent's health.
+ */
+
+import type { AgentHealth } from "./agent-health.js";
+
+export type SupervisionAction =
+  | "approve"
+  | "deny"
+  | "always"
+  | "reroute"
+  | "kill"
+  | "tail"
+  | "dag"
+  | "message";
+
+export const SUPERVISION_ACTIONS: readonly SupervisionAction[] = [
+  "approve",
+  "deny",
+  "always",
+  "reroute",
+  "kill",
+  "tail",
+  "dag",
+  "message",
+];
+
+export function actionEnabled(action: SupervisionAction, health: AgentHealth): boolean {
+  switch (action) {
+    case "approve":
+    case "deny":
+    case "always":
+      return health.kind === "approval";
+    case "reroute":
+      return health.kind === "blocked";
+    case "kill":
+      return health.kind !== "expired";
+    case "tail":
+    case "dag":
+    case "message":
+      return true;
+  }
+}

--- a/src/tui/screens/supervision/supervision-input-guard.ts
+++ b/src/tui/screens/supervision/supervision-input-guard.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure guard predicate for the supervision keyboard owner (#193 Task 10).
+ *
+ * Supervision only consumes keys when GROVE_SUPERVISION is on, it is the
+ * visible body (no panel expanded), and no modal / overlay / input mode owns
+ * the keyboard. Extracted into its own leaf module (no heavy imports) so the
+ * risky guard logic can be unit-tested without pulling RunningView's full
+ * module graph (config-watcher → chokidar, opentui, etc.).
+ */
+
+export interface SupervisionInputState {
+  readonly useSupervision: boolean;
+  readonly expandedPanelNull: boolean;
+  readonly cmdMode: string;
+  readonly promptMode: boolean;
+  readonly showHelp: boolean;
+  readonly showVfs: boolean;
+  readonly filterQuery: string;
+}
+
+export function supervisionInputActive(s: SupervisionInputState): boolean {
+  return (
+    s.useSupervision &&
+    s.expandedPanelNull &&
+    s.cmdMode === "none" &&
+    !s.promptMode &&
+    !s.showHelp &&
+    !s.showVfs &&
+    s.filterQuery === ""
+  );
+}

--- a/src/tui/screens/supervision/supervision-keyboard.test.ts
+++ b/src/tui/screens/supervision/supervision-keyboard.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentHealth } from "./agent-health.js";
+import {
+  routeSupervisionKey,
+  type SupervisionKeyboardActions,
+  type SupervisionKeyboardState,
+} from "./supervision-keyboard.js";
+
+function calls() {
+  const log: string[] = [];
+  const actions: SupervisionKeyboardActions = {
+    moveCursor: (delta) => log.push(`move:${delta}`),
+    pinSelection: () => log.push("pin"),
+    jumpTop: () => log.push("top"),
+    jumpBottom: () => log.push("bottom"),
+    approve: () => log.push("approve"),
+    deny: () => log.push("deny"),
+    always: () => log.push("always"),
+    openTail: () => log.push("tail"),
+    openDag: () => log.push("dag"),
+    reroute: () => log.push("reroute"),
+    kill: () => log.push("kill"),
+    openMessage: () => log.push("msg"),
+  };
+  return { actions, log };
+}
+
+function state(over: Partial<SupervisionKeyboardState> = {}): SupervisionKeyboardState {
+  return {
+    fleetSize: 3,
+    selectedHealth: { kind: "running" } as AgentHealth,
+    ...over,
+  };
+}
+
+describe("routeSupervisionKey", () => {
+  test("j moves cursor down, k moves up", () => {
+    const { actions, log } = calls();
+    routeSupervisionKey({ name: "j" }, state(), actions);
+    routeSupervisionKey({ name: "k" }, state(), actions);
+    expect(log).toEqual(["move:1", "move:-1"]);
+  });
+
+  test("y triggers approve only when health is approval", () => {
+    const { actions: a1, log: l1 } = calls();
+    routeSupervisionKey(
+      { name: "y" },
+      state({ selectedHealth: { kind: "approval", cmd: "rm" } }),
+      a1,
+    );
+    expect(l1).toEqual(["approve"]);
+
+    const { actions: a2, log: l2 } = calls();
+    routeSupervisionKey({ name: "y" }, state(), a2);
+    expect(l2).toEqual([]);
+  });
+
+  test("r triggers reroute only when blocked", () => {
+    const { actions, log } = calls();
+    routeSupervisionKey(
+      { name: "r" },
+      state({ selectedHealth: { kind: "blocked", on: "x", sinceMs: 9e5 } }),
+      actions,
+    );
+    expect(log).toEqual(["reroute"]);
+  });
+
+  test("returns true when handled, false otherwise", () => {
+    const { actions } = calls();
+    expect(routeSupervisionKey({ name: "j" }, state(), actions)).toBe(true);
+    expect(routeSupervisionKey({ name: "z" }, state(), actions)).toBe(false);
+  });
+});

--- a/src/tui/screens/supervision/supervision-keyboard.test.ts
+++ b/src/tui/screens/supervision/supervision-keyboard.test.ts
@@ -27,7 +27,6 @@ function calls() {
 
 function state(over: Partial<SupervisionKeyboardState> = {}): SupervisionKeyboardState {
   return {
-    fleetSize: 3,
     selectedHealth: { kind: "running" } as AgentHealth,
     ...over,
   };
@@ -69,5 +68,114 @@ describe("routeSupervisionKey", () => {
     const { actions } = calls();
     expect(routeSupervisionKey({ name: "j" }, state(), actions)).toBe(true);
     expect(routeSupervisionKey({ name: "z" }, state(), actions)).toBe(false);
+  });
+
+  test("enter and return both call pinSelection", () => {
+    const { actions, log } = calls();
+    const r1 = routeSupervisionKey({ name: "enter" }, state(), actions);
+    const r2 = routeSupervisionKey({ name: "return" }, state(), actions);
+    expect(log).toEqual(["pin", "pin"]);
+    expect(r1).toBe(true);
+    expect(r2).toBe(true);
+  });
+
+  test("g jumps to top, G jumps to bottom", () => {
+    const { actions, log } = calls();
+    expect(routeSupervisionKey({ name: "g" }, state(), actions)).toBe(true);
+    expect(routeSupervisionKey({ name: "G" }, state(), actions)).toBe(true);
+    expect(log).toEqual(["top", "bottom"]);
+  });
+
+  test("n triggers deny when approval, returns false with no log otherwise", () => {
+    const { actions: a1, log: l1 } = calls();
+    const r1 = routeSupervisionKey(
+      { name: "n" },
+      state({ selectedHealth: { kind: "approval", cmd: "rm" } }),
+      a1,
+    );
+    expect(l1).toEqual(["deny"]);
+    expect(r1).toBe(true);
+
+    const { actions: a2, log: l2 } = calls();
+    const r2 = routeSupervisionKey({ name: "n" }, state(), a2);
+    expect(l2).toEqual([]);
+    expect(r2).toBe(false);
+  });
+
+  test("a triggers always when approval, returns false with no log otherwise", () => {
+    const { actions: a1, log: l1 } = calls();
+    const r1 = routeSupervisionKey(
+      { name: "a" },
+      state({ selectedHealth: { kind: "approval", cmd: "rm" } }),
+      a1,
+    );
+    expect(l1).toEqual(["always"]);
+    expect(r1).toBe(true);
+
+    const { actions: a2, log: l2 } = calls();
+    const r2 = routeSupervisionKey({ name: "a" }, state(), a2);
+    expect(l2).toEqual([]);
+    expect(r2).toBe(false);
+  });
+
+  test("t triggers openTail for any health, false when no selection", () => {
+    const { actions: a1, log: l1 } = calls();
+    const r1 = routeSupervisionKey({ name: "t" }, state(), a1);
+    expect(l1).toEqual(["tail"]);
+    expect(r1).toBe(true);
+
+    const { actions: a2, log: l2 } = calls();
+    const r2 = routeSupervisionKey({ name: "t" }, state({ selectedHealth: undefined }), a2);
+    expect(l2).toEqual([]);
+    expect(r2).toBe(false);
+  });
+
+  test("d triggers openDag for any health, false when no selection", () => {
+    const { actions: a1, log: l1 } = calls();
+    const r1 = routeSupervisionKey({ name: "d" }, state(), a1);
+    expect(l1).toEqual(["dag"]);
+    expect(r1).toBe(true);
+
+    const { actions: a2, log: l2 } = calls();
+    const r2 = routeSupervisionKey({ name: "d" }, state({ selectedHealth: undefined }), a2);
+    expect(l2).toEqual([]);
+    expect(r2).toBe(false);
+  });
+
+  test("m triggers openMessage for any health", () => {
+    const { actions, log } = calls();
+    const r = routeSupervisionKey({ name: "m" }, state(), actions);
+    expect(log).toEqual(["msg"]);
+    expect(r).toBe(true);
+  });
+
+  test("K triggers kill when not expired, returns false when expired", () => {
+    const { actions: a1, log: l1 } = calls();
+    const r1 = routeSupervisionKey({ name: "K" }, state(), a1);
+    expect(l1).toEqual(["kill"]);
+    expect(r1).toBe(true);
+
+    const { actions: a2, log: l2 } = calls();
+    const r2 = routeSupervisionKey(
+      { name: "K" },
+      state({ selectedHealth: { kind: "expired" } }),
+      a2,
+    );
+    expect(l2).toEqual([]);
+    expect(r2).toBe(false);
+  });
+
+  test("r gated-fail: running health returns false with no log", () => {
+    const { actions, log } = calls();
+    const r = routeSupervisionKey({ name: "r" }, state(), actions);
+    expect(log).toEqual([]);
+    expect(r).toBe(false);
+  });
+
+  test("gated key with selectedHealth undefined returns false", () => {
+    const { actions, log } = calls();
+    const r = routeSupervisionKey({ name: "y" }, state({ selectedHealth: undefined }), actions);
+    expect(log).toEqual([]);
+    expect(r).toBe(false);
   });
 });

--- a/src/tui/screens/supervision/supervision-keyboard.ts
+++ b/src/tui/screens/supervision/supervision-keyboard.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure keyboard router for the supervision body (issue #193).
+ *
+ * Returns true if it consumed the key. Caller passes through to the global
+ * router otherwise.
+ */
+
+import type { AgentHealth } from "./agent-health.js";
+import { actionEnabled } from "./supervision-actions.js";
+
+export interface SupervisionKey {
+  readonly name: string;
+}
+
+export interface SupervisionKeyboardState {
+  readonly fleetSize: number;
+  readonly selectedHealth: AgentHealth | undefined;
+}
+
+export interface SupervisionKeyboardActions {
+  readonly moveCursor: (delta: number) => void;
+  readonly pinSelection: () => void;
+  readonly jumpTop: () => void;
+  readonly jumpBottom: () => void;
+  readonly approve: () => void;
+  readonly deny: () => void;
+  readonly always: () => void;
+  readonly openTail: () => void;
+  readonly openDag: () => void;
+  readonly reroute: () => void;
+  readonly kill: () => void;
+  readonly openMessage: () => void;
+}
+
+export function routeSupervisionKey(
+  key: SupervisionKey,
+  state: SupervisionKeyboardState,
+  actions: SupervisionKeyboardActions,
+): boolean {
+  const health = state.selectedHealth;
+  switch (key.name) {
+    case "j":
+      actions.moveCursor(1);
+      return true;
+    case "k":
+      actions.moveCursor(-1);
+      return true;
+    case "return":
+    case "enter":
+      actions.pinSelection();
+      return true;
+    case "g":
+      actions.jumpTop();
+      return true;
+    case "G":
+      actions.jumpBottom();
+      return true;
+    case "y":
+      if (health && actionEnabled("approve", health)) {
+        actions.approve();
+        return true;
+      }
+      return false;
+    case "n":
+      if (health && actionEnabled("deny", health)) {
+        actions.deny();
+        return true;
+      }
+      return false;
+    case "a":
+      if (health && actionEnabled("always", health)) {
+        actions.always();
+        return true;
+      }
+      return false;
+    case "t":
+      if (health && actionEnabled("tail", health)) {
+        actions.openTail();
+        return true;
+      }
+      return false;
+    case "d":
+      if (health && actionEnabled("dag", health)) {
+        actions.openDag();
+        return true;
+      }
+      return false;
+    case "r":
+      if (health && actionEnabled("reroute", health)) {
+        actions.reroute();
+        return true;
+      }
+      return false;
+    case "K":
+      if (health && actionEnabled("kill", health)) {
+        actions.kill();
+        return true;
+      }
+      return false;
+    case "m":
+      if (health && actionEnabled("message", health)) {
+        actions.openMessage();
+        return true;
+      }
+      return false;
+    default:
+      return false;
+  }
+}

--- a/src/tui/screens/supervision/supervision-keyboard.ts
+++ b/src/tui/screens/supervision/supervision-keyboard.ts
@@ -13,7 +13,6 @@ export interface SupervisionKey {
 }
 
 export interface SupervisionKeyboardState {
-  readonly fleetSize: number;
   readonly selectedHealth: AgentHealth | undefined;
 }
 

--- a/src/tui/screens/supervision/supervision.informer-render.test.tsx
+++ b/src/tui/screens/supervision/supervision.informer-render.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * Full-component mount integration: <Supervision> renders a POPULATED fleet
+ * driven entirely by the production informer data path (#193 proof boundary).
+ *
+ * Unlike use-fleet-model.mount.test.tsx (which asserts the *hook* return),
+ * this test composes useFleetModel + <Supervision> in one wrapper and
+ * asserts the rendered tree (FleetRail + DetailRail). It exercises the
+ * entire production path: hub.recordWrite → informer → EntityStore →
+ * useEntityData → useEntities → useFleetModel → buildFleet → Supervision →
+ * FleetRail/DetailRail.
+ *
+ * Harness mirrors use-fleet-model.mount.test.tsx (InformerProvider +
+ * EntityStoreProvider + RemoteReportingLocalFactory so useEntityWatchEnabled
+ * gates true; the unscoped provider stub returns [] from getClaims so the
+ * ONLY Claim source is the informer — proving the informer path, not the
+ * polling fallback).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { InformerFactory } from "../../../core/informer.js";
+import type { WatchEntity } from "../../../core/watch-events.js";
+import { WatchHub } from "../../../core/watch-hub.js";
+import { EntityStoreFactory } from "../../data/entity-store.js";
+import { EntityStoreProvider } from "../../hooks/entity-store-context.js";
+import { InformerProvider } from "../../hooks/informer-context.js";
+import type { AgentMonitorState } from "../../hooks/use-agent-monitor.js";
+import type { TuiDataProvider } from "../../provider.js";
+import { Supervision } from "./supervision.js";
+import { useFleetModel } from "./use-fleet-model.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NS = "default";
+const NOW = Date.now();
+
+/**
+ * Test-only subclass: wires the local hub (so hub.recordWrite drives
+ * events) but reports mode "remote" so useEntityWatchEnabled gates true.
+ */
+class RemoteReportingLocalFactory extends InformerFactory {
+  override get mode(): "remote" | "local" {
+    return "remote";
+  }
+}
+
+/** A valid active Claim WatchEntity (== ClaimEntity for kind "Claim"). */
+function claimEntity(agentId: string, role: string): WatchEntity {
+  return {
+    kind: "Claim",
+    id: `claim-${agentId}`,
+    namespace: NS,
+    conditions: [],
+    observedGeneration: 1,
+    resourceVersion: "1",
+    metadata: { generation: 1, creationTimestamp: new Date(NOW - 60_000).toISOString() },
+    spec: {
+      agent: { agentId, agentName: agentId, role, platform: "claude" },
+      targetRef: `target-${agentId}`,
+      intentSummary: "do thing",
+      context: {},
+    },
+    status: {
+      phase: "active",
+      persistedPhase: "active",
+      heartbeatAt: new Date(NOW).toISOString(),
+      lastHeartbeatAt: new Date(NOW).toISOString(),
+      leaseExpiresAt: new Date(NOW + 600_000).toISOString(),
+      observedGeneration: 1,
+      attemptCount: 0,
+    },
+  } as unknown as WatchEntity;
+}
+
+const monitorStub: AgentMonitorState = {
+  agentOutputs: new Map(),
+  agentOutputTimestamps: new Map(),
+  pendingPermissions: [],
+  ipcMessages: [],
+  spinnerFrame: 0,
+};
+
+/**
+ * Composition wrapper: calls the production hook then renders the full
+ * Supervision component with its result (mirrors running-view's wiring).
+ */
+function Probe({ provider }: { provider: TuiDataProvider }) {
+  const fleet = useFleetModel({
+    provider,
+    monitor: monitorStub,
+    agentFailures: undefined,
+    tmux: undefined,
+    filterText: undefined,
+    active: true,
+  });
+  return <Supervision agents={fleet} tail={[]} />;
+}
+
+async function mountProbe(
+  provider: TuiDataProvider,
+  informerFactory: RemoteReportingLocalFactory,
+  storeFactory: EntityStoreFactory,
+): Promise<TestRenderer.ReactTestRenderer> {
+  let renderer: TestRenderer.ReactTestRenderer | undefined;
+  await act(async () => {
+    renderer = TestRenderer.create(
+      (
+        <InformerProvider value={informerFactory} eager>
+          <EntityStoreProvider value={storeFactory}>
+            <Probe provider={provider} />
+          </EntityStoreProvider>
+        </InformerProvider>
+      ) as React.ReactElement,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return renderer as TestRenderer.ReactTestRenderer;
+}
+
+describe("Supervision — full-component informer render (#193)", () => {
+  test("populated fleet renders via informer path", async () => {
+    const hub = new WatchHub();
+    const informerFactory = new RemoteReportingLocalFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    // Unscoped provider — getClaims returns []; the ONLY Claim source is
+    // the informer store. Pre-fix (getClaims-only) → empty fleet → the
+    // populated assertions below would all fail.
+    const provider = {
+      hasSessionScope: () => false,
+      getClaims: async () => [],
+    } as unknown as TuiDataProvider;
+
+    const renderer = await mountProbe(provider, informerFactory, storeFactory);
+
+    await act(async () => {
+      hub.recordWrite({
+        kind: "Claim",
+        namespace: NS,
+        op: "ADDED",
+        entity: claimEntity("coder-a", "coder"),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const out = JSON.stringify(renderer.toJSON());
+
+    // FleetRail header reflects ≥1 agent (NOT the "Fleet (0)" empty header).
+    expect(out).toContain("Fleet (1");
+    expect(out).not.toContain("Fleet (0)");
+    // The agent renders as a lane.
+    expect(out).toContain("coder-a");
+    // Empty-state must be absent.
+    expect(out).not.toContain("No agents registered");
+    // DetailRail auto-selected agents[0]; the placeholder must be absent.
+    expect(out).not.toContain("Select an agent (j/k) to view context");
+    // DetailRail rendered the selected agent's identity (role/platform line
+    // is unique to the populated detail view; the placeholder has no such
+    // text). Proves the informer Claim flowed all the way to DetailRail.
+    expect(out).toContain("(coder/claude)");
+    // The active claim's intentSummary surfaces as the Task body.
+    expect(out).toContain("do thing");
+
+    renderer.unmount();
+    await informerFactory.stopAll();
+    storeFactory.dispose();
+  });
+
+  test("scope short-circuit: scoped provider yields empty even with informer Claim", async () => {
+    const hub = new WatchHub();
+    const informerFactory = new RemoteReportingLocalFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    // Scoped provider — useProviderScoped(provider) === true. Even though
+    // an informer Claim exists, the fleet must be empty (no cross-session
+    // leak), mirroring AgentListView's deliberate scoped-empty behavior.
+    const provider = {
+      hasSessionScope: () => true,
+      getClaims: async () => [],
+    } as unknown as TuiDataProvider;
+
+    const renderer = await mountProbe(provider, informerFactory, storeFactory);
+
+    await act(async () => {
+      hub.recordWrite({
+        kind: "Claim",
+        namespace: NS,
+        op: "ADDED",
+        entity: claimEntity("coder-b", "coder"),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const out = JSON.stringify(renderer.toJSON());
+
+    // Scoped guard yields empty → empty-state + Fleet (0) + placeholder.
+    expect(out).toContain("Fleet (0)");
+    expect(out).toContain("No agents registered");
+    expect(out).toContain("Select an agent (j/k) to view context");
+    expect(out).not.toContain("coder-b");
+
+    renderer.unmount();
+    await informerFactory.stopAll();
+    storeFactory.dispose();
+  });
+
+  test("two active claims render both lanes via informer path", async () => {
+    const hub = new WatchHub();
+    const informerFactory = new RemoteReportingLocalFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    const provider = {
+      hasSessionScope: () => false,
+      getClaims: async () => [],
+    } as unknown as TuiDataProvider;
+
+    const renderer = await mountProbe(provider, informerFactory, storeFactory);
+
+    await act(async () => {
+      hub.recordWrite({
+        kind: "Claim",
+        namespace: NS,
+        op: "ADDED",
+        entity: claimEntity("coder-a", "coder"),
+      });
+      hub.recordWrite({
+        kind: "Claim",
+        namespace: NS,
+        op: "ADDED",
+        entity: claimEntity("reviewer-a", "reviewer"),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const out = JSON.stringify(renderer.toJSON());
+
+    // Two agents counted in the FleetRail header.
+    expect(out).toContain("Fleet (2");
+    expect(out).not.toContain("Fleet (0)");
+    // Both agents render as lanes.
+    expect(out).toContain("coder-a");
+    expect(out).toContain("reviewer-a");
+    // Empty-state / placeholder absent (fleet is populated, agents[0] selected).
+    expect(out).not.toContain("No agents registered");
+    expect(out).not.toContain("Select an agent (j/k) to view context");
+
+    renderer.unmount();
+    await informerFactory.stopAll();
+    storeFactory.dispose();
+  });
+});

--- a/src/tui/screens/supervision/supervision.test.tsx
+++ b/src/tui/screens/supervision/supervision.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Component-level tests for the Supervision composition root (#193 Task 8).
+ *
+ * Covers:
+ *   - auto-selects highest-priority (first) agent on mount
+ *   - empty agents shows FleetRail empty state and DetailRail placeholder
+ *   - controlled pinnedAgentId prop overrides default cursor selection
+ *   - onSelect callback fires with the selected agentId on mount
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type React from "react";
+import type * as TestRendererTypes from "react-test-renderer";
+import type { AgentHealth } from "./agent-health.js";
+import type { FleetAgent } from "./use-fleet-model.js";
+
+mock.module("@opentui/react", () => ({
+  useKeyboard: (): void => undefined,
+  useRenderer: (): { destroy: () => void } => ({ destroy: () => undefined }),
+  useTerminalDimensions: (): { width: number; height: number } => ({ width: 120, height: 40 }),
+  useTimeline: (): unknown => ({}),
+  useOnResize: (): void => undefined,
+  useAppContext: (): unknown => ({}),
+  createPortal: (children: unknown): unknown => children,
+  createRoot: (): unknown => ({}),
+  createElement: (): unknown => null,
+  flushSync: (fn: () => void): void => fn(),
+  extend: (): void => undefined,
+  getComponentCatalogue: (): unknown => ({}),
+  componentCatalogue: {},
+  baseComponents: {},
+  TimeToFirstDraw: (): null => null,
+  AppContext: {},
+}));
+
+const TestRendererModule = await import("react-test-renderer");
+const TestRenderer = (TestRendererModule as unknown as { default: typeof TestRendererTypes })
+  .default;
+const { act } = TestRendererModule;
+const { Supervision } = await import("./supervision.js");
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function agent(agentId: string, over: Partial<FleetAgent> = {}): FleetAgent {
+  return {
+    agentId,
+    agentName: agentId,
+    role: "coder",
+    platform: "claude",
+    session: undefined,
+    claim: { spec: { targetRef: "t" } } as FleetAgent["claim"],
+    health: { kind: "running" } as AgentHealth,
+    currentTask: undefined,
+    lastAction: undefined,
+    lastOutputAt: undefined,
+    cost: undefined,
+    handoffs: { pendingOut: 0, overdueIn: 0 },
+    pendingApproval: undefined,
+    attemptCount: 0,
+    ...over,
+  };
+}
+
+describe("Supervision", () => {
+  test("auto-selects highest-priority agent on mount (agents[0], here 'bad')", async () => {
+    // buildFleet sorts problem-first; here we pass them already sorted, "bad" first
+    const agents = [
+      agent("bad", { agentName: "bad", health: { kind: "error", reason: "boom" } as AgentHealth }),
+      agent("ok", { agentName: "ok", health: { kind: "running" } as AgentHealth }),
+    ];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (<Supervision agents={agents} tail={[]} />) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    // "bad" is agents[0], so it should be the selected agent shown in DetailRail
+    expect(flat).toContain("bad");
+    // DetailRail health header for error shows "ERROR: boom"
+    expect(flat).toContain("ERROR: boom");
+    renderer.unmount();
+  });
+
+  test("empty agents shows FleetRail empty state and DetailRail placeholder", async () => {
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create((<Supervision agents={[]} tail={[]} />) as React.ReactElement);
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("No agents registered");
+    expect(flat).toContain("Select an agent");
+    renderer.unmount();
+  });
+
+  test("controlled pinnedAgentId prop selects 'y' even though cursor defaults to 0/'x'", async () => {
+    const agents = [agent("x", { agentName: "agent-x" }), agent("y", { agentName: "agent-y" })];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (<Supervision agents={agents} tail={[]} pinnedAgentId="y" />) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    // DetailRail shows the agent name of the pinned agent
+    expect(flat).toContain("agent-y");
+    renderer.unmount();
+  });
+
+  test("onSelect is called with the selected agentId on mount", async () => {
+    const received: Array<string | undefined> = [];
+    const onSelect = (id: string | undefined): void => {
+      received.push(id);
+    };
+    const agents = [agent("x", { agentName: "agent-x" })];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (<Supervision agents={agents} tail={[]} onSelect={onSelect} />) as React.ReactElement,
+      );
+    });
+    expect(received).toContain("x");
+    renderer.unmount();
+  });
+});

--- a/src/tui/screens/supervision/supervision.test.tsx
+++ b/src/tui/screens/supervision/supervision.test.tsx
@@ -122,4 +122,58 @@ describe("Supervision", () => {
     expect(received).toContain("x");
     renderer.unmount();
   });
+
+  test("auto-select-on-approval: approval agent becomes selected in DetailRail", async () => {
+    const runningAgents = [agent("x"), agent("y")];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (<Supervision agents={runningAgents} tail={[]} />) as React.ReactElement,
+      );
+    });
+    await act(async () => {
+      renderer.update(
+        (
+          <Supervision
+            agents={[
+              agent("x"),
+              agent("y", { health: { kind: "approval", cmd: "rm" } as AgentHealth }),
+            ]}
+            tail={[]}
+          />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("APPROVAL PENDING");
+    renderer.unmount();
+  });
+
+  test("controlled cursor prop: cursor={1} selects second agent in DetailRail", async () => {
+    const agents = [agent("x", { agentName: "agent-x" }), agent("y", { agentName: "agent-y" })];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (<Supervision agents={agents} tail={[]} cursor={1} />) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("agent-y");
+    renderer.unmount();
+  });
+
+  test("pin precedence: pinnedAgentId='y' wins over cursor={0}", async () => {
+    const agents = [agent("x", { agentName: "agent-x" }), agent("y", { agentName: "agent-y" })];
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <Supervision agents={agents} tail={[]} cursor={0} pinnedAgentId="y" />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).toContain("agent-y");
+    renderer.unmount();
+  });
 });

--- a/src/tui/screens/supervision/supervision.tsx
+++ b/src/tui/screens/supervision/supervision.tsx
@@ -20,7 +20,10 @@ export interface SupervisionProps {
   readonly tail: readonly string[];
   /** Controlled cursor (index into agents). Uncontrolled when absent. */
   readonly cursor?: number;
-  /** Controlled pinned agent id. Uncontrolled when absent. */
+  /**
+   * Controlled pinned agent id. Uncontrolled when absent.
+   * When both `cursor` and `pinnedAgentId` are provided, `pinnedAgentId` wins for selection.
+   */
   readonly pinnedAgentId?: string;
   /** Fired whenever the resolved selected agentId changes. */
   readonly onSelect?: (agentId: string | undefined) => void;
@@ -63,6 +66,7 @@ export const Supervision = React.memo(function Supervision({
 
   // ── Auto-select on approval (uncontrolled only, guarded by pin) ──────────
   const lastApprovalRef = useRef<string | undefined>(undefined);
+  const prevSelectedIdRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     if (isControlled) return; // let the controller handle this
@@ -80,18 +84,19 @@ export const Supervision = React.memo(function Supervision({
 
   // ── onSelect effect ──────────────────────────────────────────────────────
   const selectedId = selectedAgent?.agentId;
+  // guarded so an inline onSelect from the parent doesn't fire every render
   useEffect(() => {
+    if (selectedId === prevSelectedIdRef.current) return;
+    prevSelectedIdRef.current = selectedId;
     onSelect?.(selectedId);
   }, [selectedId, onSelect]);
 
   // ── Resolve cursor index for FleetRail highlight ─────────────────────────
   const resolvedCursor = useMemo((): number => {
-    if (activePinned) {
-      const idx = agents.findIndex((a) => a.agentId === activePinned);
-      return idx !== -1 ? idx : activeCursor;
-    }
-    return activeCursor;
-  }, [agents, activePinned, activeCursor]);
+    if (!selectedAgent) return activeCursor;
+    const idx = agents.indexOf(selectedAgent);
+    return idx !== -1 ? idx : activeCursor;
+  }, [agents, selectedAgent, activeCursor]);
 
   // ── Layout ───────────────────────────────────────────────────────────────
   return (

--- a/src/tui/screens/supervision/supervision.tsx
+++ b/src/tui/screens/supervision/supervision.tsx
@@ -1,0 +1,111 @@
+/**
+ * Supervision composition root — horizontal layout joining FleetRail and
+ * DetailRail (#193 Task 8).
+ *
+ * Supports controlled mode (cursor/pinnedAgentId props set by Task 10
+ * running-view) and uncontrolled mode (internal state, used by tests and
+ * standalone rendering).
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { theme } from "../../theme.js";
+import { DetailRail } from "./detail-rail.js";
+import { FleetRail } from "./fleet-rail.js";
+import type { FleetAgent } from "./use-fleet-model.js";
+
+export interface SupervisionProps {
+  /** Fleet agents, already sorted problem-first by buildFleet. */
+  readonly agents: readonly FleetAgent[];
+  /** Tail lines for the selected agent's output. */
+  readonly tail: readonly string[];
+  /** Controlled cursor (index into agents). Uncontrolled when absent. */
+  readonly cursor?: number;
+  /** Controlled pinned agent id. Uncontrolled when absent. */
+  readonly pinnedAgentId?: string;
+  /** Fired whenever the resolved selected agentId changes. */
+  readonly onSelect?: (agentId: string | undefined) => void;
+}
+
+export const Supervision = React.memo(function Supervision({
+  agents,
+  tail,
+  cursor: cursorProp,
+  pinnedAgentId: pinnedProp,
+  onSelect,
+}: SupervisionProps): React.ReactNode {
+  // ── Uncontrolled internal state ──────────────────────────────────────────
+  const [internalCursor, setInternalCursor] = useState(0);
+
+  // Clamp internal cursor when agents list shrinks
+  useEffect(() => {
+    if (agents.length === 0) {
+      setInternalCursor(0);
+      return;
+    }
+    setInternalCursor((prev) => Math.min(prev, agents.length - 1));
+  }, [agents.length]);
+
+  // ── Resolve active cursor and pinned id ──────────────────────────────────
+  // pinnedProp (controlled) acts as the pin; no uncontrolled pin state needed
+  // until a future task exposes keyboard pinning in uncontrolled mode.
+  const isControlled = cursorProp !== undefined || pinnedProp !== undefined;
+  const activeCursor = cursorProp ?? internalCursor;
+  const activePinned = pinnedProp;
+
+  // ── Resolve selected agent ───────────────────────────────────────────────
+  const selectedAgent = useMemo((): FleetAgent | undefined => {
+    if (activePinned) {
+      const pinned = agents.find((a) => a.agentId === activePinned);
+      if (pinned) return pinned;
+    }
+    return agents[activeCursor] ?? agents[0];
+  }, [agents, activeCursor, activePinned]);
+
+  // ── Auto-select on approval (uncontrolled only, guarded by pin) ──────────
+  const lastApprovalRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (isControlled) return; // let the controller handle this
+    if (activePinned) return; // pin takes precedence
+    const approvalAgent = agents.find((a) => a.health.kind === "approval");
+    if (!approvalAgent) return;
+    if (approvalAgent.agentId === lastApprovalRef.current) return; // same agent, no re-trigger
+    lastApprovalRef.current = approvalAgent.agentId;
+    const idx = agents.indexOf(approvalAgent);
+    if (idx !== -1) {
+      setInternalCursor(idx);
+      // Do not set a pin — approval auto-select is just a cursor nudge
+    }
+  }, [agents, activePinned, isControlled]);
+
+  // ── onSelect effect ──────────────────────────────────────────────────────
+  const selectedId = selectedAgent?.agentId;
+  useEffect(() => {
+    onSelect?.(selectedId);
+  }, [selectedId, onSelect]);
+
+  // ── Resolve cursor index for FleetRail highlight ─────────────────────────
+  const resolvedCursor = useMemo((): number => {
+    if (activePinned) {
+      const idx = agents.findIndex((a) => a.agentId === activePinned);
+      return idx !== -1 ? idx : activeCursor;
+    }
+    return activeCursor;
+  }, [agents, activePinned, activeCursor]);
+
+  // ── Layout ───────────────────────────────────────────────────────────────
+  return (
+    <box flexDirection="row">
+      <box flexBasis="40%" paddingX={1}>
+        <FleetRail
+          agents={agents}
+          cursor={resolvedCursor}
+          selectedAgentId={selectedAgent?.agentId}
+        />
+      </box>
+      <box flexBasis="60%" borderStyle="round" borderColor={theme.focus}>
+        <DetailRail agent={selectedAgent} tail={tail} />
+      </box>
+    </box>
+  );
+});

--- a/src/tui/screens/supervision/supervision.tsx
+++ b/src/tui/screens/supervision/supervision.tsx
@@ -29,88 +29,90 @@ export interface SupervisionProps {
   readonly onSelect?: (agentId: string | undefined) => void;
 }
 
-export const Supervision = React.memo(function Supervision({
-  agents,
-  tail,
-  cursor: cursorProp,
-  pinnedAgentId: pinnedProp,
-  onSelect,
-}: SupervisionProps): React.ReactNode {
-  // ── Uncontrolled internal state ──────────────────────────────────────────
-  const [internalCursor, setInternalCursor] = useState(0);
+export const Supervision: React.NamedExoticComponent<SupervisionProps> = React.memo(
+  function Supervision({
+    agents,
+    tail,
+    cursor: cursorProp,
+    pinnedAgentId: pinnedProp,
+    onSelect,
+  }: SupervisionProps): React.ReactNode {
+    // ── Uncontrolled internal state ──────────────────────────────────────────
+    const [internalCursor, setInternalCursor] = useState(0);
 
-  // Clamp internal cursor when agents list shrinks
-  useEffect(() => {
-    if (agents.length === 0) {
-      setInternalCursor(0);
-      return;
-    }
-    setInternalCursor((prev) => Math.min(prev, agents.length - 1));
-  }, [agents.length]);
+    // Clamp internal cursor when agents list shrinks
+    useEffect(() => {
+      if (agents.length === 0) {
+        setInternalCursor(0);
+        return;
+      }
+      setInternalCursor((prev) => Math.min(prev, agents.length - 1));
+    }, [agents.length]);
 
-  // ── Resolve active cursor and pinned id ──────────────────────────────────
-  // pinnedProp (controlled) acts as the pin; no uncontrolled pin state needed
-  // until a future task exposes keyboard pinning in uncontrolled mode.
-  const isControlled = cursorProp !== undefined || pinnedProp !== undefined;
-  const activeCursor = cursorProp ?? internalCursor;
-  const activePinned = pinnedProp;
+    // ── Resolve active cursor and pinned id ──────────────────────────────────
+    // pinnedProp (controlled) acts as the pin; no uncontrolled pin state needed
+    // until a future task exposes keyboard pinning in uncontrolled mode.
+    const isControlled = cursorProp !== undefined || pinnedProp !== undefined;
+    const activeCursor = cursorProp ?? internalCursor;
+    const activePinned = pinnedProp;
 
-  // ── Resolve selected agent ───────────────────────────────────────────────
-  const selectedAgent = useMemo((): FleetAgent | undefined => {
-    if (activePinned) {
-      const pinned = agents.find((a) => a.agentId === activePinned);
-      if (pinned) return pinned;
-    }
-    return agents[activeCursor] ?? agents[0];
-  }, [agents, activeCursor, activePinned]);
+    // ── Resolve selected agent ───────────────────────────────────────────────
+    const selectedAgent = useMemo((): FleetAgent | undefined => {
+      if (activePinned) {
+        const pinned = agents.find((a) => a.agentId === activePinned);
+        if (pinned) return pinned;
+      }
+      return agents[activeCursor] ?? agents[0];
+    }, [agents, activeCursor, activePinned]);
 
-  // ── Auto-select on approval (uncontrolled only, guarded by pin) ──────────
-  const lastApprovalRef = useRef<string | undefined>(undefined);
-  const prevSelectedIdRef = useRef<string | undefined>(undefined);
+    // ── Auto-select on approval (uncontrolled only, guarded by pin) ──────────
+    const lastApprovalRef = useRef<string | undefined>(undefined);
+    const prevSelectedIdRef = useRef<string | undefined>(undefined);
 
-  useEffect(() => {
-    if (isControlled) return; // let the controller handle this
-    if (activePinned) return; // pin takes precedence
-    const approvalAgent = agents.find((a) => a.health.kind === "approval");
-    if (!approvalAgent) return;
-    if (approvalAgent.agentId === lastApprovalRef.current) return; // same agent, no re-trigger
-    lastApprovalRef.current = approvalAgent.agentId;
-    const idx = agents.indexOf(approvalAgent);
-    if (idx !== -1) {
-      setInternalCursor(idx);
-      // Do not set a pin — approval auto-select is just a cursor nudge
-    }
-  }, [agents, activePinned, isControlled]);
+    useEffect(() => {
+      if (isControlled) return; // let the controller handle this
+      if (activePinned) return; // pin takes precedence
+      const approvalAgent = agents.find((a) => a.health.kind === "approval");
+      if (!approvalAgent) return;
+      if (approvalAgent.agentId === lastApprovalRef.current) return; // same agent, no re-trigger
+      lastApprovalRef.current = approvalAgent.agentId;
+      const idx = agents.indexOf(approvalAgent);
+      if (idx !== -1) {
+        setInternalCursor(idx);
+        // Do not set a pin — approval auto-select is just a cursor nudge
+      }
+    }, [agents, activePinned, isControlled]);
 
-  // ── onSelect effect ──────────────────────────────────────────────────────
-  const selectedId = selectedAgent?.agentId;
-  // guarded so an inline onSelect from the parent doesn't fire every render
-  useEffect(() => {
-    if (selectedId === prevSelectedIdRef.current) return;
-    prevSelectedIdRef.current = selectedId;
-    onSelect?.(selectedId);
-  }, [selectedId, onSelect]);
+    // ── onSelect effect ──────────────────────────────────────────────────────
+    const selectedId = selectedAgent?.agentId;
+    // guarded so an inline onSelect from the parent doesn't fire every render
+    useEffect(() => {
+      if (selectedId === prevSelectedIdRef.current) return;
+      prevSelectedIdRef.current = selectedId;
+      onSelect?.(selectedId);
+    }, [selectedId, onSelect]);
 
-  // ── Resolve cursor index for FleetRail highlight ─────────────────────────
-  const resolvedCursor = useMemo((): number => {
-    if (!selectedAgent) return activeCursor;
-    const idx = agents.indexOf(selectedAgent);
-    return idx !== -1 ? idx : activeCursor;
-  }, [agents, selectedAgent, activeCursor]);
+    // ── Resolve cursor index for FleetRail highlight ─────────────────────────
+    const resolvedCursor = useMemo((): number => {
+      if (!selectedAgent) return activeCursor;
+      const idx = agents.indexOf(selectedAgent);
+      return idx !== -1 ? idx : activeCursor;
+    }, [agents, selectedAgent, activeCursor]);
 
-  // ── Layout ───────────────────────────────────────────────────────────────
-  return (
-    <box flexDirection="row">
-      <box flexBasis="40%" paddingX={1}>
-        <FleetRail
-          agents={agents}
-          cursor={resolvedCursor}
-          selectedAgentId={selectedAgent?.agentId}
-        />
+    // ── Layout ───────────────────────────────────────────────────────────────
+    return (
+      <box flexDirection="row">
+        <box flexBasis="40%" paddingX={1}>
+          <FleetRail
+            agents={agents}
+            cursor={resolvedCursor}
+            selectedAgentId={selectedAgent?.agentId}
+          />
+        </box>
+        <box flexBasis="60%" borderStyle="round" borderColor={theme.focus}>
+          <DetailRail agent={selectedAgent} tail={tail} />
+        </box>
       </box>
-      <box flexBasis="60%" borderStyle="round" borderColor={theme.focus}>
-        <DetailRail agent={selectedAgent} tail={tail} />
-      </box>
-    </box>
-  );
-});
+    );
+  },
+);

--- a/src/tui/screens/supervision/use-fleet-model.mount.test.tsx
+++ b/src/tui/screens/supervision/use-fleet-model.mount.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Mount integration: useFleetModel under InformerProvider + EntityStoreProvider.
+ *
+ * Reproduces #193 — in nexus mode the live Claim source is the
+ * informer-backed EntityStore (surfaced via useEntityData → useEntities),
+ * NOT the polled `provider.getClaims` fallback. Before the fix
+ * useFleetModel only read the polling fallback, so a freshly written
+ * informer Claim never reached the FleetRail ("Fleet (0)").
+ *
+ * Harness mirrors use-entity-data.mount.test.tsx (InformerProvider +
+ * EntityStoreProvider + RemoteReportingLocalFactory so
+ * useEntityWatchEnabled gates true; hub.recordWrite pushes a Claim
+ * WatchEntity into the store).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { InformerFactory } from "../../../core/informer.js";
+import type { WatchEntity } from "../../../core/watch-events.js";
+import { WatchHub } from "../../../core/watch-hub.js";
+import { EntityStoreFactory } from "../../data/entity-store.js";
+import { EntityStoreProvider } from "../../hooks/entity-store-context.js";
+import { InformerProvider } from "../../hooks/informer-context.js";
+import type { AgentMonitorState } from "../../hooks/use-agent-monitor.js";
+import type { TuiDataProvider } from "../../provider.js";
+import { type FleetAgent, useFleetModel } from "./use-fleet-model.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NS = "default";
+const NOW = Date.now();
+
+/**
+ * Test-only subclass: wires the local hub (so hub.recordWrite drives
+ * events) but reports mode "remote" so useEntityWatchEnabled gates true.
+ */
+class RemoteReportingLocalFactory extends InformerFactory {
+  override get mode(): "remote" | "local" {
+    return "remote";
+  }
+}
+
+/** A valid active Claim WatchEntity (== ClaimEntity for kind "Claim"). */
+function claimEntity(agentId: string, role: string): WatchEntity {
+  return {
+    kind: "Claim",
+    id: `claim-${agentId}`,
+    namespace: NS,
+    conditions: [],
+    observedGeneration: 1,
+    resourceVersion: "1",
+    metadata: { generation: 1, creationTimestamp: new Date(NOW - 60_000).toISOString() },
+    spec: {
+      agent: { agentId, agentName: agentId, role, platform: "claude" },
+      targetRef: `target-${agentId}`,
+      intentSummary: "do thing",
+      context: {},
+    },
+    status: {
+      phase: "active",
+      persistedPhase: "active",
+      heartbeatAt: new Date(NOW).toISOString(),
+      lastHeartbeatAt: new Date(NOW).toISOString(),
+      leaseExpiresAt: new Date(NOW + 600_000).toISOString(),
+      observedGeneration: 1,
+      attemptCount: 0,
+    },
+  } as unknown as WatchEntity;
+}
+
+const monitorStub: AgentMonitorState = {
+  agentOutputs: new Map(),
+  agentOutputTimestamps: new Map(),
+  pendingPermissions: [],
+  ipcMessages: [],
+  spinnerFrame: 0,
+};
+
+function Probe({
+  onResult,
+  provider,
+}: {
+  onResult: (r: readonly FleetAgent[]) => void;
+  provider: TuiDataProvider;
+}) {
+  const fleet = useFleetModel({
+    provider,
+    monitor: monitorStub,
+    agentFailures: undefined,
+    tmux: undefined,
+    filterText: undefined,
+    active: true,
+  });
+  onResult(fleet);
+  return null;
+}
+
+describe("useFleetModel — mount integration (#193)", () => {
+  test("informer path: a recorded active Claim surfaces in the fleet", async () => {
+    const hub = new WatchHub();
+    const informerFactory = new RemoteReportingLocalFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    // Unscoped provider — getClaims returns []; the ONLY Claim source is
+    // the informer store. With the pre-fix code (useEventDrivenData over
+    // provider.getClaims) the fleet stays empty.
+    const provider = {
+      hasSessionScope: () => false,
+      getClaims: async () => [],
+    } as unknown as TuiDataProvider;
+
+    let last: readonly FleetAgent[] = [];
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={informerFactory} eager>
+            <EntityStoreProvider value={storeFactory}>
+              <Probe
+                provider={provider}
+                onResult={(r) => {
+                  last = r;
+                }}
+              />
+            </EntityStoreProvider>
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      hub.recordWrite({
+        kind: "Claim",
+        namespace: NS,
+        op: "ADDED",
+        entity: claimEntity("coder-1", "coder"),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(last.length).toBeGreaterThanOrEqual(1);
+    expect(last[0]?.agentId).toBe("coder-1");
+
+    renderer?.unmount();
+    await informerFactory.stopAll();
+    storeFactory.dispose();
+  });
+
+  test("scoped short-circuit: returns empty even with an informer Claim", async () => {
+    const hub = new WatchHub();
+    const informerFactory = new RemoteReportingLocalFactory({
+      mode: "local",
+      hub,
+      namespace: NS,
+      listFn: () => [],
+    });
+    const storeFactory = new EntityStoreFactory(informerFactory);
+    // Scoped provider — useProviderScoped(provider) === true. Even though
+    // an informer Claim exists, the fleet must be empty (no cross-session
+    // leak), mirroring AgentListView's deliberate scoped-empty behavior.
+    const provider = {
+      hasSessionScope: () => true,
+      getClaims: async () => [],
+    } as unknown as TuiDataProvider;
+
+    let last: readonly FleetAgent[] = [{ agentId: "sentinel" } as unknown as FleetAgent];
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <InformerProvider value={informerFactory} eager>
+            <EntityStoreProvider value={storeFactory}>
+              <Probe
+                provider={provider}
+                onResult={(r) => {
+                  last = r;
+                }}
+              />
+            </EntityStoreProvider>
+          </InformerProvider>
+        ) as React.ReactElement,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      hub.recordWrite({
+        kind: "Claim",
+        namespace: NS,
+        op: "ADDED",
+        entity: claimEntity("coder-2", "coder"),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(last).toEqual([]);
+    expect(last.length).toBe(0);
+
+    renderer?.unmount();
+    await informerFactory.stopAll();
+    storeFactory.dispose();
+  });
+});

--- a/src/tui/screens/supervision/use-fleet-model.test.ts
+++ b/src/tui/screens/supervision/use-fleet-model.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import type { ClaimEntity } from "../../../core/entity.js";
+import { type Handoff, HandoffStatus } from "../../../core/handoff.js";
+import { buildFleet, type FleetSources } from "./use-fleet-model.js";
+
+const NOW = new Date("2026-05-18T12:00:00Z").getTime();
+
+function claim(
+  agentId: string,
+  role: string,
+  over: Partial<ClaimEntity["status"]> = {},
+): ClaimEntity {
+  return {
+    kind: "Claim",
+    id: `claim-${agentId}`,
+    namespace: "default",
+    conditions: [],
+    observedGeneration: 1,
+    resourceVersion: "1",
+    metadata: { generation: 1, creationTimestamp: new Date(NOW - 60_000).toISOString() },
+    spec: {
+      agent: { agentId, agentName: agentId, role, platform: "claude" },
+      targetRef: `target-${agentId}`,
+      intentSummary: "do thing",
+      context: {},
+    },
+    status: {
+      phase: "active",
+      persistedPhase: "active",
+      heartbeatAt: new Date(NOW).toISOString(),
+      lastHeartbeatAt: new Date(NOW).toISOString(),
+      leaseExpiresAt: new Date(NOW + 60_000).toISOString(),
+      observedGeneration: 1,
+      attemptCount: 0,
+      ...over,
+    },
+  } as ClaimEntity;
+}
+
+const baseSources: FleetSources = {
+  claims: [],
+  tmuxSessions: [],
+  costs: new Map(),
+  agentOutputs: new Map(),
+  agentOutputTimestamps: new Map(),
+  pendingPermissions: [],
+  handoffs: [],
+  agentFailures: new Map(),
+  filterText: undefined,
+  nowMs: NOW,
+};
+
+describe("buildFleet", () => {
+  test("sorts problem agents before running agents", () => {
+    const fleet = buildFleet({
+      ...baseSources,
+      claims: [claim("a-run", "coder"), claim("b-fail", "coder")],
+      agentFailures: new Map([["b-fail", "ACP auth failed"]]),
+    });
+    expect(fleet[0]?.agentId).toBe("b-fail");
+    expect(fleet[0]?.health.kind).toBe("error");
+  });
+
+  test("session field undefined when no tmux session matches", () => {
+    const fleet = buildFleet({
+      ...baseSources,
+      claims: [claim("a", "coder")],
+      tmuxSessions: ["grove-other-xyz"],
+    });
+    expect(fleet[0]?.session).toBeUndefined();
+  });
+
+  test("cost rollup matches by agentId", () => {
+    const fleet = buildFleet({
+      ...baseSources,
+      claims: [claim("a", "coder")],
+      costs: new Map([["a", { usd: 1.23, tokens: 4567 }]]),
+    });
+    expect(fleet[0]?.cost?.usd).toBe(1.23);
+  });
+
+  test("filterText narrows by case-insensitive substring across role/name/target", () => {
+    const fleet = buildFleet({
+      ...baseSources,
+      claims: [claim("alpha", "coder"), claim("beta", "reviewer")],
+      filterText: "REV",
+    });
+    expect(fleet.map((f) => f.agentId)).toEqual(["beta"]);
+  });
+
+  test("handoff blockedOn aggregated from oldest pending inbound", () => {
+    const handoff = {
+      handoffId: "h1",
+      fromRole: "coordinator",
+      toRole: "coder",
+      status: HandoffStatus.PendingPickup,
+      sourceCid: "cid-1",
+      requiresReply: false,
+      createdAt: new Date(NOW - 5 * 60_000).toISOString(),
+    } as Handoff;
+    const fleet = buildFleet({
+      ...baseSources,
+      claims: [claim("a", "coder")],
+      handoffs: [handoff],
+    });
+    expect(fleet[0]?.handoffs.blockedOn).toBe("coordinator");
+  });
+});

--- a/src/tui/screens/supervision/use-fleet-model.test.ts
+++ b/src/tui/screens/supervision/use-fleet-model.test.ts
@@ -54,11 +54,12 @@ describe("buildFleet", () => {
   test("sorts problem agents before running agents", () => {
     const fleet = buildFleet({
       ...baseSources,
-      claims: [claim("a-run", "coder"), claim("b-fail", "coder")],
-      agentFailures: new Map([["b-fail", "ACP auth failed"]]),
+      claims: [claim("a-run", "coder"), claim("b-fail", "planner")],
+      agentFailures: new Map([["planner", "ACP auth failed"]]),
     });
     expect(fleet[0]?.agentId).toBe("b-fail");
     expect(fleet[0]?.health.kind).toBe("error");
+    expect(fleet[1]?.health.kind).not.toBe("error");
   });
 
   test("session field undefined when no tmux session matches", () => {

--- a/src/tui/screens/supervision/use-fleet-model.ts
+++ b/src/tui/screens/supervision/use-fleet-model.ts
@@ -113,7 +113,7 @@ export function buildFleet(s: FleetSources): readonly FleetAgent[] {
         pendingApproval,
         blockedOn,
         blockedSinceMs,
-        agentFailure: s.agentFailures.get(agentId),
+        agentFailure: s.agentFailures.get(role),
       },
       s.nowMs,
       HEALTH_THRESHOLDS,

--- a/src/tui/screens/supervision/use-fleet-model.ts
+++ b/src/tui/screens/supervision/use-fleet-model.ts
@@ -1,0 +1,260 @@
+/**
+ * Fleet model — join active claims with tmux session, cost, monitor outputs,
+ * pending permissions, handoffs, and per-role failure messages, and derive
+ * AgentHealth per agent. Sorted problem-first.
+ */
+
+import { useCallback, useMemo } from "react";
+import { type ClaimEntity, claimToEntity } from "../../../core/entity.js";
+import { type Handoff, HandoffStatus } from "../../../core/handoff.js";
+import { agentIdFromSession } from "../../agents/tmux-manager.js";
+import type { AgentMonitorState, PermissionPrompt } from "../../hooks/use-agent-monitor.js";
+import { useEventDrivenData } from "../../hooks/use-event-driven-data.js";
+import type { TuiDataProvider } from "../../provider.js";
+import { isHandoffProvider } from "../../provider.js";
+import {
+  type AgentHealth,
+  deriveAgentHealth,
+  HEALTH_THRESHOLDS,
+  healthPriority,
+} from "./agent-health.js";
+
+export interface FleetCost {
+  readonly usd: number;
+  readonly tokens: number;
+  readonly ctxPercent?: number;
+}
+
+export interface FleetAgent {
+  readonly agentId: string;
+  readonly agentName: string;
+  readonly role: string;
+  readonly platform: string;
+  readonly session: string | undefined;
+  readonly claim: ClaimEntity;
+  readonly health: AgentHealth;
+  readonly currentTask: string | undefined;
+  readonly lastAction: string | undefined;
+  readonly lastOutputAt: string | undefined;
+  readonly cost: FleetCost | undefined;
+  readonly handoffs: { pendingOut: number; overdueIn: number; blockedOn?: string };
+  readonly pendingApproval: PermissionPrompt | undefined;
+  readonly attemptCount: number;
+}
+
+export interface FleetSources {
+  readonly claims: readonly ClaimEntity[];
+  readonly tmuxSessions: readonly string[];
+  readonly costs: ReadonlyMap<string, FleetCost>;
+  readonly agentOutputs: ReadonlyMap<string, readonly string[]>;
+  readonly agentOutputTimestamps: ReadonlyMap<string, string>;
+  readonly pendingPermissions: readonly PermissionPrompt[];
+  readonly handoffs: readonly Handoff[];
+  readonly agentFailures: ReadonlyMap<string, string>;
+  readonly filterText: string | undefined;
+  readonly nowMs: number;
+}
+
+const matchesFilter = (a: FleetAgent, q: string): boolean => {
+  const haystack =
+    `${a.agentName} ${a.agentId} ${a.role} ${a.platform} ${a.claim.spec.targetRef}`.toLowerCase();
+  return haystack.includes(q);
+};
+
+/** Build a sorted FleetAgent list. Pure — exported for testing. */
+export function buildFleet(s: FleetSources): readonly FleetAgent[] {
+  const tmuxByAgent = new Map<string, string>();
+  for (const session of s.tmuxSessions) {
+    const id = agentIdFromSession(session);
+    if (id) tmuxByAgent.set(id, session);
+  }
+
+  const inboundByRole = new Map<string, Handoff[]>();
+  const outboundByRole = new Map<string, number>();
+  for (const h of s.handoffs) {
+    if (h.status !== HandoffStatus.PendingPickup) continue;
+    const list = inboundByRole.get(h.toRole) ?? [];
+    list.push(h);
+    inboundByRole.set(h.toRole, list);
+    outboundByRole.set(h.fromRole, (outboundByRole.get(h.fromRole) ?? 0) + 1);
+  }
+
+  const agents: FleetAgent[] = [];
+  for (const claim of s.claims) {
+    const role = claim.spec.agent.role ?? "worker";
+    const agentId = claim.spec.agent.agentId;
+    const session = tmuxByAgent.get(agentId);
+    const outputs = s.agentOutputs.get(role) ?? [];
+    const lastAction = outputs.length > 0 ? outputs[outputs.length - 1] : undefined;
+    const lastOutputAt = s.agentOutputTimestamps.get(role);
+    const pendingApproval = s.pendingPermissions.find((p) => p.agentRole === role);
+    const inbound = inboundByRole.get(role) ?? [];
+    const oldestInbound = inbound.slice().sort((a, b) => a.createdAt.localeCompare(b.createdAt))[0];
+    const blockedOn = oldestInbound?.fromRole;
+    const blockedSinceMs = oldestInbound
+      ? s.nowMs - new Date(oldestInbound.createdAt).getTime()
+      : 0;
+    const overdueIn = inbound.filter(
+      (h) => h.replyDueAt !== undefined && new Date(h.replyDueAt).getTime() < s.nowMs,
+    ).length;
+
+    const health = deriveAgentHealth(
+      {
+        role,
+        leaseExpiresAt: claim.status.leaseExpiresAt,
+        heartbeatAt: claim.status.heartbeatAt,
+        attemptCount: claim.status.attemptCount,
+        lastRetryAt: undefined,
+        lastOutputAt,
+        currentTask: claim.spec.intentSummary,
+        currentTaskSinceMs:
+          s.nowMs -
+          new Date(claim.metadata.creationTimestamp ?? claim.status.heartbeatAt).getTime(),
+        pendingApproval,
+        blockedOn,
+        blockedSinceMs,
+        agentFailure: s.agentFailures.get(agentId),
+      },
+      s.nowMs,
+      HEALTH_THRESHOLDS,
+    );
+
+    agents.push({
+      agentId,
+      agentName: claim.spec.agent.agentName ?? agentId,
+      role,
+      platform: claim.spec.agent.platform ?? "-",
+      session,
+      claim,
+      health,
+      currentTask: claim.spec.intentSummary,
+      lastAction,
+      lastOutputAt,
+      cost: s.costs.get(agentId),
+      handoffs: {
+        pendingOut: outboundByRole.get(role) ?? 0,
+        overdueIn,
+        ...(blockedOn ? { blockedOn } : {}),
+      },
+      pendingApproval,
+      attemptCount: claim.status.attemptCount,
+    });
+  }
+
+  const q = s.filterText?.trim().toLowerCase();
+  const filtered = q ? agents.filter((a) => matchesFilter(a, q)) : agents;
+
+  return filtered.slice().sort((a, b) => {
+    const pa = healthPriority(a.health);
+    const pb = healthPriority(b.health);
+    if (pa !== pb) return pa - pb;
+    if (a.role === "coordinator" && b.role !== "coordinator") return -1;
+    if (b.role === "coordinator" && a.role !== "coordinator") return 1;
+    return a.agentName.localeCompare(b.agentName);
+  });
+}
+
+export interface UseFleetModelArgs {
+  readonly provider: TuiDataProvider;
+  readonly monitor: AgentMonitorState;
+  readonly agentFailures: ReadonlyMap<string, string> | undefined;
+  readonly tmux: import("../../agents/tmux-manager.js").TmuxManager | undefined;
+  readonly filterText: string | undefined;
+  readonly active: boolean;
+}
+
+const NAMESPACE = "default";
+
+export function useFleetModel(args: UseFleetModelArgs): readonly FleetAgent[] {
+  const claimsFetcher = useCallback(async (): Promise<readonly ClaimEntity[]> => {
+    const flat = await args.provider.getClaims({ status: "active" });
+    return flat.map((c) => claimToEntity(c, () => Date.now(), NAMESPACE));
+  }, [args.provider]);
+  const { data: claims } = useEventDrivenData<readonly ClaimEntity[]>(
+    claimsFetcher,
+    undefined,
+    undefined,
+    args.active,
+  );
+
+  const tmuxFetcher = useCallback(async (): Promise<readonly string[]> => {
+    if (!args.tmux) return [];
+    return (await args.tmux.isAvailable()) ? args.tmux.listSessions() : [];
+  }, [args.tmux]);
+  const { data: tmuxSessions } = useEventDrivenData<readonly string[]>(
+    tmuxFetcher,
+    undefined,
+    undefined,
+    args.active && !!args.tmux,
+  );
+
+  const costsFetcher = useCallback(async (): Promise<ReadonlyMap<string, FleetCost>> => {
+    const cp = args.provider as unknown as {
+      getSessionCosts?: () => Promise<{
+        byAgent: readonly {
+          agentId: string;
+          costUsd: number;
+          tokens: number;
+          contextPercent?: number;
+        }[];
+      }>;
+    };
+    if (!cp.getSessionCosts) return new Map();
+    const out = await cp.getSessionCosts();
+    const m = new Map<string, FleetCost>();
+    for (const a of out.byAgent) {
+      m.set(a.agentId, {
+        usd: a.costUsd,
+        tokens: a.tokens,
+        ...(a.contextPercent !== undefined ? { ctxPercent: a.contextPercent } : {}),
+      });
+    }
+    return m;
+  }, [args.provider]);
+  const { data: costs } = useEventDrivenData<ReadonlyMap<string, FleetCost>>(
+    costsFetcher,
+    undefined,
+    undefined,
+    args.active,
+  );
+
+  const handoffsFetcher = useCallback(async (): Promise<readonly Handoff[]> => {
+    if (!isHandoffProvider(args.provider)) return [];
+    return args.provider.getHandoffs({ limit: 200 });
+  }, [args.provider]);
+  const { data: handoffs } = useEventDrivenData<readonly Handoff[]>(
+    handoffsFetcher,
+    undefined,
+    undefined,
+    args.active && isHandoffProvider(args.provider),
+  );
+
+  const failures = args.agentFailures ?? new Map<string, string>();
+
+  return useMemo(
+    () =>
+      buildFleet({
+        claims: claims ?? [],
+        tmuxSessions: tmuxSessions ?? [],
+        costs: costs ?? new Map(),
+        agentOutputs: args.monitor.agentOutputs,
+        agentOutputTimestamps: args.monitor.agentOutputTimestamps,
+        pendingPermissions: args.monitor.pendingPermissions,
+        handoffs: handoffs ?? [],
+        agentFailures: failures,
+        filterText: args.filterText,
+        nowMs: Date.now(),
+      }),
+    [
+      claims,
+      tmuxSessions,
+      costs,
+      args.monitor.agentOutputs,
+      args.monitor.agentOutputTimestamps,
+      args.monitor.pendingPermissions,
+      handoffs,
+      failures,
+      args.filterText,
+    ],
+  );
+}

--- a/src/tui/screens/supervision/use-fleet-model.ts
+++ b/src/tui/screens/supervision/use-fleet-model.ts
@@ -11,7 +11,7 @@ import { agentIdFromSession } from "../../agents/tmux-manager.js";
 import type { AgentMonitorState, PermissionPrompt } from "../../hooks/use-agent-monitor.js";
 import { useEventDrivenData } from "../../hooks/use-event-driven-data.js";
 import type { TuiDataProvider } from "../../provider.js";
-import { isHandoffProvider } from "../../provider.js";
+import { isCostProvider, isHandoffProvider } from "../../provider.js";
 import {
   type AgentHealth,
   deriveAgentHealth,
@@ -83,7 +83,9 @@ export function buildFleet(s: FleetSources): readonly FleetAgent[] {
   for (const claim of s.claims) {
     const role = claim.spec.agent.role ?? "worker";
     const agentId = claim.spec.agent.agentId;
+    // costs/sessions keyed by agentId
     const session = tmuxByAgent.get(agentId);
+    // outputs, timestamps, failures, permissions keyed by role
     const outputs = s.agentOutputs.get(role) ?? [];
     const lastAction = outputs.length > 0 ? outputs[outputs.length - 1] : undefined;
     const lastOutputAt = s.agentOutputTimestamps.get(role);
@@ -189,18 +191,8 @@ export function useFleetModel(args: UseFleetModelArgs): readonly FleetAgent[] {
   );
 
   const costsFetcher = useCallback(async (): Promise<ReadonlyMap<string, FleetCost>> => {
-    const cp = args.provider as unknown as {
-      getSessionCosts?: () => Promise<{
-        byAgent: readonly {
-          agentId: string;
-          costUsd: number;
-          tokens: number;
-          contextPercent?: number;
-        }[];
-      }>;
-    };
-    if (!cp.getSessionCosts) return new Map();
-    const out = await cp.getSessionCosts();
+    if (!isCostProvider(args.provider)) return new Map();
+    const out = await args.provider.getSessionCosts();
     const m = new Map<string, FleetCost>();
     for (const a of out.byAgent) {
       m.set(a.agentId, {
@@ -229,8 +221,7 @@ export function useFleetModel(args: UseFleetModelArgs): readonly FleetAgent[] {
     args.active && isHandoffProvider(args.provider),
   );
 
-  const failures = args.agentFailures ?? new Map<string, string>();
-
+  // nowMs captured at memo-eval time; health re-derives whenever any source changes
   return useMemo(
     () =>
       buildFleet({
@@ -241,7 +232,7 @@ export function useFleetModel(args: UseFleetModelArgs): readonly FleetAgent[] {
         agentOutputTimestamps: args.monitor.agentOutputTimestamps,
         pendingPermissions: args.monitor.pendingPermissions,
         handoffs: handoffs ?? [],
-        agentFailures: failures,
+        agentFailures: args.agentFailures ?? new Map(),
         filterText: args.filterText,
         nowMs: Date.now(),
       }),
@@ -253,7 +244,7 @@ export function useFleetModel(args: UseFleetModelArgs): readonly FleetAgent[] {
       args.monitor.agentOutputTimestamps,
       args.monitor.pendingPermissions,
       handoffs,
-      failures,
+      args.agentFailures,
       args.filterText,
     ],
   );

--- a/src/tui/screens/supervision/use-fleet-model.ts
+++ b/src/tui/screens/supervision/use-fleet-model.ts
@@ -8,7 +8,10 @@ import { useCallback, useMemo } from "react";
 import { type ClaimEntity, claimToEntity } from "../../../core/entity.js";
 import { type Handoff, HandoffStatus } from "../../../core/handoff.js";
 import { agentIdFromSession } from "../../agents/tmux-manager.js";
+import { isActive } from "../../components/columns/claim-columns.js";
+import { useProviderScoped } from "../../hooks/informer-context.js";
 import type { AgentMonitorState, PermissionPrompt } from "../../hooks/use-agent-monitor.js";
+import { useEntityData } from "../../hooks/use-entity-data.js";
 import { useEventDrivenData } from "../../hooks/use-event-driven-data.js";
 import type { TuiDataProvider } from "../../provider.js";
 import { isCostProvider, isHandoffProvider } from "../../provider.js";
@@ -167,17 +170,23 @@ export interface UseFleetModelArgs {
 
 const NAMESPACE = "default";
 
+/** Stable empty reference for the scoped short-circuit (no churn). */
+const EMPTY_FLEET: readonly FleetAgent[] = [];
+
 export function useFleetModel(args: UseFleetModelArgs): readonly FleetAgent[] {
-  const claimsFetcher = useCallback(async (): Promise<readonly ClaimEntity[]> => {
+  // Claims come from the informer-backed EntityStore in nexus mode
+  // (useEntityData → useEntities), with the polled getClaims path as the
+  // local-mode fallback. Reading only the fallback (#193) left the
+  // FleetRail empty in nexus mode even while agents actively claimed.
+  const claimsFallback = useCallback(async (): Promise<readonly ClaimEntity[]> => {
     const flat = await args.provider.getClaims({ status: "active" });
     return flat.map((c) => claimToEntity(c, () => Date.now(), NAMESPACE));
   }, [args.provider]);
-  const { data: claims } = useEventDrivenData<readonly ClaimEntity[]>(
-    claimsFetcher,
-    undefined,
-    undefined,
-    args.active,
-  );
+  const { data: claims } = useEntityData<"Claim">(args.provider, "Claim", {
+    active: args.active,
+    predicate: isActive,
+    fallbackFetcher: claimsFallback,
+  });
 
   const tmuxFetcher = useCallback(async (): Promise<readonly string[]> => {
     if (!args.tmux) return [];
@@ -221,8 +230,15 @@ export function useFleetModel(args: UseFleetModelArgs): readonly FleetAgent[] {
     args.active && isHandoffProvider(args.provider),
   );
 
+  // Scoped sessions: `useEntityWatchEnabled` returns false in scoped mode
+  // and `provider.getClaims` is namespace-global (no session filter), so
+  // the fallback would leak claims from OTHER sessions. Render empty until
+  // session-scoped claim filtering lands. Mirrors AgentListView. Called
+  // unconditionally with the other hooks to keep React hook order stable.
+  const isScoped = useProviderScoped(args.provider);
+
   // nowMs captured at memo-eval time; health re-derives whenever any source changes
-  return useMemo(
+  const fleet = useMemo(
     () =>
       buildFleet({
         claims: claims ?? [],
@@ -248,4 +264,6 @@ export function useFleetModel(args: UseFleetModelArgs): readonly FleetAgent[] {
       args.filterText,
     ],
   );
+
+  return isScoped ? EMPTY_FLEET : fleet;
 }

--- a/src/tui/views/dag.test.tsx
+++ b/src/tui/views/dag.test.tsx
@@ -252,7 +252,7 @@ describe("DagView (xray)", () => {
     renderer.unmount();
   });
 
-  test("accepts filterAgentId prop without crashing or changing default render", async () => {
+  test("accepts filterRole prop without crashing or changing default render", async () => {
     const root = makeContribution({ summary: "root contribution" });
     const child = makeContribution({
       summary: "child contribution",
@@ -269,7 +269,7 @@ describe("DagView (xray)", () => {
               provider={makeStubProvider([root, child]) as never}
               active
               cursor={-1}
-              filterAgentId="agent-x"
+              filterRole="agent-x"
             />
           </DagStateProvider>
         ) as React.ReactElement,

--- a/src/tui/views/dag.test.tsx
+++ b/src/tui/views/dag.test.tsx
@@ -251,4 +251,37 @@ describe("DagView (xray)", () => {
     expect(store.snapshot().collapsed.size).toBe(0);
     renderer.unmount();
   });
+
+  test("accepts filterAgentId prop without crashing or changing default render", async () => {
+    const root = makeContribution({ summary: "root contribution" });
+    const child = makeContribution({
+      summary: "child contribution",
+      createdAt: "2026-05-11T11:30:00Z",
+      relations: [makeRelation({ targetCid: root.cid, relationType: RelationType.DerivesFrom })],
+    });
+    const store = new DagStateStore();
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <DagStateProvider store={store}>
+            <DagView
+              provider={makeStubProvider([root, child]) as never}
+              active
+              cursor={-1}
+              filterAgentId="agent-x"
+            />
+          </DagStateProvider>
+        ) as React.ReactElement,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+    expect(flat).not.toBeNull();
+    expect(flat).toContain("root contribution");
+    expect(flat).toContain("child contribution");
+    renderer.unmount();
+  });
 });

--- a/src/tui/views/dag.tsx
+++ b/src/tui/views/dag.tsx
@@ -129,10 +129,8 @@ export interface DagProps {
    *  into a text field does not silently toggle the focused DAG row.
    *  Default `false`. */
   readonly keysEnabled?: boolean;
-  /** Optional: when set, the DAG biases focus toward this agent. Plumbed
-   *  for supervision drill-down (#193); narrowing behavior is a follow-up.
-   *  Default (unfiltered) behavior is preserved when omitted. */
-  readonly filterAgentId?: string | undefined;
+  /** Optional: when set, biases focus toward this role. Plumbed for supervision drill-down (#193); narrowing behavior is a follow-up. Default (unfiltered) behavior preserved when omitted. */
+  readonly filterRole?: string | undefined;
 }
 
 /** Xray-style DAG view (issue #311 C5). */

--- a/src/tui/views/dag.tsx
+++ b/src/tui/views/dag.tsx
@@ -129,6 +129,10 @@ export interface DagProps {
    *  into a text field does not silently toggle the focused DAG row.
    *  Default `false`. */
   readonly keysEnabled?: boolean;
+  /** Optional: when set, the DAG biases focus toward this agent. Plumbed
+   *  for supervision drill-down (#193); narrowing behavior is a follow-up.
+   *  Default (unfiltered) behavior is preserved when omitted. */
+  readonly filterAgentId?: string | undefined;
 }
 
 /** Xray-style DAG view (issue #311 C5). */

--- a/src/tui/views/handoffs-view.test.tsx
+++ b/src/tui/views/handoffs-view.test.tsx
@@ -55,7 +55,7 @@ describe("HandoffsView", () => {
     expect(text).toContain("met");
   });
 
-  test("filterAgentId scopes rows to touching agent; omitting prop shows all", () => {
+  test("filterRole scopes rows to touching role; omitting prop shows all", () => {
     const provider = {
       getHandoffs: async () => [],
       markHandoffDelivered: async () => undefined,
@@ -80,7 +80,7 @@ describe("HandoffsView", () => {
       createdAt: "2026-05-07T19:01:00.000Z",
     };
 
-    // --- With filterAgentId="coder": only coder-touching handoff appears ---
+    // --- With filterRole="coder": only coder-touching handoff appears ---
     let filteredRenderer: TestRenderer.ReactTestRenderer | undefined;
     act(() => {
       filteredRenderer = TestRenderer.create(
@@ -89,7 +89,7 @@ describe("HandoffsView", () => {
           active: true,
           cursor: 0,
           handoffs: [coderHandoff, plannerHandoff],
-          filterAgentId: "coder",
+          filterRole: "coder",
         }),
       );
     });
@@ -99,7 +99,7 @@ describe("HandoffsView", () => {
     expect(filteredText).not.toContain("planner");
     filteredRenderer.unmount();
 
-    // --- Without filterAgentId: both handoffs appear ---
+    // --- Without filterRole: both handoffs appear ---
     let allRenderer: TestRenderer.ReactTestRenderer | undefined;
     act(() => {
       allRenderer = TestRenderer.create(

--- a/src/tui/views/handoffs-view.test.tsx
+++ b/src/tui/views/handoffs-view.test.tsx
@@ -54,4 +54,67 @@ describe("HandoffsView", () => {
     expect(text).toContain("[done]");
     expect(text).toContain("met");
   });
+
+  test("filterAgentId scopes rows to touching agent; omitting prop shows all", () => {
+    const provider = {
+      getHandoffs: async () => [],
+      markHandoffDelivered: async () => undefined,
+    } as unknown as TuiDataProvider;
+
+    const coderHandoff: Handoff = {
+      handoffId: "handoff-coder",
+      sourceCid: "blake3:coder001",
+      fromRole: "coder",
+      toRole: "reviewer",
+      status: HandoffStatus.PendingPickup,
+      requiresReply: false,
+      createdAt: "2026-05-07T19:00:00.000Z",
+    };
+    const plannerHandoff: Handoff = {
+      handoffId: "handoff-planner",
+      sourceCid: "blake3:planner001",
+      fromRole: "planner",
+      toRole: "reviewer",
+      status: HandoffStatus.Delivered,
+      requiresReply: false,
+      createdAt: "2026-05-07T19:01:00.000Z",
+    };
+
+    // --- With filterAgentId="coder": only coder-touching handoff appears ---
+    let filteredRenderer: TestRenderer.ReactTestRenderer | undefined;
+    act(() => {
+      filteredRenderer = TestRenderer.create(
+        React.createElement(HandoffsView, {
+          provider,
+          active: true,
+          cursor: 0,
+          handoffs: [coderHandoff, plannerHandoff],
+          filterAgentId: "coder",
+        }),
+      );
+    });
+    if (!filteredRenderer) throw new Error("filteredRenderer did not mount");
+    const filteredText = collectText(filteredRenderer.toJSON());
+    expect(filteredText).toContain("coder");
+    expect(filteredText).not.toContain("planner");
+    filteredRenderer.unmount();
+
+    // --- Without filterAgentId: both handoffs appear ---
+    let allRenderer: TestRenderer.ReactTestRenderer | undefined;
+    act(() => {
+      allRenderer = TestRenderer.create(
+        React.createElement(HandoffsView, {
+          provider,
+          active: true,
+          cursor: 0,
+          handoffs: [coderHandoff, plannerHandoff],
+        }),
+      );
+    });
+    if (!allRenderer) throw new Error("allRenderer did not mount");
+    const allText = collectText(allRenderer.toJSON());
+    expect(allText).toContain("coder");
+    expect(allText).toContain("planner");
+    allRenderer.unmount();
+  });
 });

--- a/src/tui/views/handoffs-view.tsx
+++ b/src/tui/views/handoffs-view.tsx
@@ -100,9 +100,8 @@ export interface HandoffsViewProps {
   readonly sessionStartedAt?: string | undefined;
   /** Pre-fetched handoffs from parent. When provided, skips the internal fetch. */
   readonly handoffs?: readonly Handoff[] | undefined;
-  /** Optional: scope to handoffs touching this agent's role. Omitted =
-   *  no narrowing (#193). */
-  readonly filterAgentId?: string | undefined;
+  /** Optional: scope to handoffs touching this role. Omitted = no narrowing (#193). */
+  readonly filterRole?: string | undefined;
 }
 
 /** Handoffs panel component. */
@@ -115,7 +114,7 @@ export const HandoffsView: React.NamedExoticComponent<HandoffsViewProps> = React
     toRoleFilter,
     sessionStartedAt,
     handoffs: prefetched,
-    filterAgentId,
+    filterRole,
   }: HandoffsViewProps): React.ReactNode {
     // When parent provides pre-fetched handoffs, use those directly.
     const fetcher = useCallback(async () => {
@@ -157,9 +156,9 @@ export const HandoffsView: React.NamedExoticComponent<HandoffsViewProps> = React
 
     const handoffs = data ?? [];
     const scoped =
-      filterAgentId === undefined
+      filterRole === undefined
         ? handoffs
-        : handoffs.filter((h) => h.fromRole === filterAgentId || h.toRole === filterAgentId);
+        : handoffs.filter((h) => h.fromRole === filterRole || h.toRole === filterRole);
     const pending = scoped.filter((h) => h.status === HandoffStatus.PendingPickup).length;
     const overdueCount = scoped.filter(isOverdue).length;
 

--- a/src/tui/views/handoffs-view.tsx
+++ b/src/tui/views/handoffs-view.tsx
@@ -100,6 +100,9 @@ export interface HandoffsViewProps {
   readonly sessionStartedAt?: string | undefined;
   /** Pre-fetched handoffs from parent. When provided, skips the internal fetch. */
   readonly handoffs?: readonly Handoff[] | undefined;
+  /** Optional: scope to handoffs touching this agent's role. Omitted =
+   *  no narrowing (#193). */
+  readonly filterAgentId?: string | undefined;
 }
 
 /** Handoffs panel component. */
@@ -112,6 +115,7 @@ export const HandoffsView: React.NamedExoticComponent<HandoffsViewProps> = React
     toRoleFilter,
     sessionStartedAt,
     handoffs: prefetched,
+    filterAgentId,
   }: HandoffsViewProps): React.ReactNode {
     // When parent provides pre-fetched handoffs, use those directly.
     const fetcher = useCallback(async () => {
@@ -152,10 +156,14 @@ export const HandoffsView: React.NamedExoticComponent<HandoffsViewProps> = React
     }
 
     const handoffs = data ?? [];
-    const pending = handoffs.filter((h) => h.status === HandoffStatus.PendingPickup).length;
-    const overdueCount = handoffs.filter(isOverdue).length;
+    const scoped =
+      filterAgentId === undefined
+        ? handoffs
+        : handoffs.filter((h) => h.fromRole === filterAgentId || h.toRole === filterAgentId);
+    const pending = scoped.filter((h) => h.status === HandoffStatus.PendingPickup).length;
+    const overdueCount = scoped.filter(isOverdue).length;
 
-    const rows = handoffs.map((h) => ({
+    const rows = scoped.map((h) => ({
       from: h.fromRole,
       to: h.toRole,
       status: STATUS_LABELS[h.status] ?? h.status,
@@ -170,13 +178,13 @@ export const HandoffsView: React.NamedExoticComponent<HandoffsViewProps> = React
         <box marginBottom={1} flexDirection="row">
           <text>Handoffs</text>
           <text opacity={0.5}>
-            {handoffs.length > 0
-              ? `  ${handoffs.length} total, ${pending} pending`
+            {scoped.length > 0
+              ? `  ${scoped.length} total, ${pending} pending`
               : "  (no handoffs yet)"}
           </text>
           {overdueCount > 0 && <text color={theme.error}>{`  ${overdueCount} overdue`}</text>}
         </box>
-        {handoffs.length === 0 ? (
+        {scoped.length === 0 ? (
           <text opacity={0.4}>
             No handoffs yet. Handoffs appear when contributions are routed between roles.
           </text>

--- a/tests/tui/supervision-e2e.ts
+++ b/tests/tui/supervision-e2e.ts
@@ -24,21 +24,29 @@
  * DETERMINISTIC and appear immediately once the running screen with
  * GROVE_SUPERVISION=1 is active:
  *
+ *   PRIMARY pass gate (gates the exit code — both must match):
  *   1. "Fleet (" — the FleetRail header, rendered as soon as useFleetModel
  *      returns at least one agent claim.
  *   2. "coder" + "reviewer" role strings in the fleet-rail rows.
+ *
+ *   ADVISORY only (non-fatal — warns but does NOT fail the run):
  *   3. Either "Select an agent" (detail-rail empty state, no agent selected
  *      yet) or a selected agent's name / RUNNING / IDLE header — i.e. the
- *      detail-rail scaffold appeared.
+ *      detail-rail scaffold appeared. Because selection state is
+ *      indeterminate at assertion time, absence of this marker emits a
+ *      console.warn and is NOT counted as a failure.
  *
- * These three markers confirm the Supervision composition root rendered the
- * full fleet. If the --timeout budget is long enough that an agent goes idle
- * for > 5 min, the script will also look for a SILENT badge — but this is
- * opportunistic, not required.
+ * If the --timeout budget is long enough that an agent goes idle for > 5 min,
+ * the script will also look for a SILENT badge — but this is opportunistic,
+ * not required.
  *
  * Validate against the real running stack (Nexus via `grove up`), consistent
  * with this repo's e2e convention. The grove init below configures the grove
  * so that `grove up` inside the TUI's setup flow connects to Nexus.
+ *
+ * NOTE: If the TUI's 'grove up' started Nexus, a crash of the TUI (not Ctrl+C
+ * of this script) leaves docker containers running — run 'grove down' manually
+ * to clean up.
  */
 
 import { execSync, spawnSync } from "node:child_process";
@@ -133,6 +141,13 @@ process.on("SIGINT", () => {
 });
 
 async function main() {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error(
+      "[fatal] ANTHROPIC_API_KEY is not set. This e2e boots real claude-code agents and requires it. Aborting before setup.",
+    );
+    process.exit(1);
+  }
+
   const overallDeadline = Date.now() + BUDGET_MS;
 
   // 1. Kill any prior tmux server on our socket.

--- a/tests/tui/supervision-e2e.ts
+++ b/tests/tui/supervision-e2e.ts
@@ -1,0 +1,319 @@
+/**
+ * Manual tmux-driven E2E for the Supervision body (#193 Task 13).
+ *
+ * Launches the real Grove TUI in a tmux pane with GROVE_SUPERVISION=1,
+ * initialises a review-loop preset with real claude-code agents
+ * (coder + reviewer), and asserts the supervision fleet rail renders with
+ * both agents visible.
+ *
+ * NOT wired into `bun test` — this boots actual claude-code processes,
+ * requires grove up (grove-managed Nexus lifecycle), and needs:
+ *
+ *   export ANTHROPIC_API_KEY=<your key>
+ *   bun run tests/tui/supervision-e2e.ts
+ *
+ * Flags:
+ *   --keep          Leave the tmux session + work dir behind for inspection
+ *   --attach        Print `tmux attach` command and wait
+ *   --timeout <ms>  Overall budget (default 600000)
+ *
+ * ASSERTION STRATEGY
+ * ------------------
+ * The HEALTH_THRESHOLDS.silentMs default is 5 minutes, so a short-budget run
+ * cannot reliably wait for a SILENT badge. Instead the primary assertions are
+ * DETERMINISTIC and appear immediately once the running screen with
+ * GROVE_SUPERVISION=1 is active:
+ *
+ *   1. "Fleet (" — the FleetRail header, rendered as soon as useFleetModel
+ *      returns at least one agent claim.
+ *   2. "coder" + "reviewer" role strings in the fleet-rail rows.
+ *   3. Either "Select an agent" (detail-rail empty state, no agent selected
+ *      yet) or a selected agent's name / RUNNING / IDLE header — i.e. the
+ *      detail-rail scaffold appeared.
+ *
+ * These three markers confirm the Supervision composition root rendered the
+ * full fleet. If the --timeout budget is long enough that an agent goes idle
+ * for > 5 min, the script will also look for a SILENT badge — but this is
+ * opportunistic, not required.
+ *
+ * Validate against the real running stack (Nexus via `grove up`), consistent
+ * with this repo's e2e convention. The grove init below configures the grove
+ * so that `grove up` inside the TUI's setup flow connects to Nexus.
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+
+const SOCKET = "grove-supervision-e2e";
+const SESSION = "grove-supervision-e2e";
+const PROJECT_ROOT = join(import.meta.dir, "..", "..");
+
+// ─── Args ─────────────────────────────────────────────────────────────
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    keep: { type: "boolean", default: false },
+    attach: { type: "boolean", default: false },
+    timeout: { type: "string", default: "600000" },
+  },
+});
+const KEEP = values.keep;
+const ATTACH = values.attach;
+const BUDGET_MS = Number.parseInt(values.timeout as string, 10);
+
+// ─── tmux helpers ─────────────────────────────────────────────────────
+function tmux(cmd: string, opts: { check?: boolean } = {}): string {
+  const out = spawnSync("tmux", ["-L", SOCKET, ...cmd.split(" ").filter(Boolean)], {
+    encoding: "utf-8",
+  });
+  if (opts.check !== false && out.status !== 0) {
+    throw new Error(`tmux ${cmd} failed (${out.status}): ${out.stderr}`);
+  }
+  return out.stdout.trim();
+}
+
+function tmuxSendKeys(args: string[]): void {
+  const out = spawnSync("tmux", ["-L", SOCKET, "send-keys", "-t", SESSION, ...args], {
+    encoding: "utf-8",
+  });
+  if (out.status !== 0) {
+    throw new Error(`send-keys failed: ${out.stderr}`);
+  }
+}
+
+function capturePane(): string {
+  return tmux(`capture-pane -t ${SESSION} -p -S -2000`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitForPane(predicate: (pane: string) => boolean, phase: string, maxMs = 60000) {
+  const deadline = Date.now() + maxMs;
+  let last = "";
+  while (Date.now() < deadline) {
+    last = capturePane();
+    if (predicate(last)) {
+      console.log(`[${phase}] matched in ${maxMs - (deadline - Date.now())}ms`);
+      return last;
+    }
+    await sleep(1000);
+  }
+  console.error(`\n──── pane dump (${phase}) ────`);
+  console.error(last);
+  console.error("──── end pane dump ────\n");
+  throw new Error(`[${phase}] predicate did not match within ${maxMs}ms`);
+}
+
+// ─── main ─────────────────────────────────────────────────────────────
+const workDir = mkdtempSync(join(tmpdir(), "grove-supervision-e2e-"));
+const repoDir = join(workDir, "repo");
+const groveDir = join(repoDir, ".grove");
+console.log(`[setup] workDir=${workDir}`);
+
+function cleanup() {
+  try {
+    execSync(`tmux -L ${SOCKET} kill-server 2>/dev/null`, { stdio: "ignore" });
+  } catch {
+    // already dead
+  }
+  if (!KEEP && existsSync(workDir)) {
+    rmSync(workDir, { recursive: true, force: true });
+  } else if (KEEP) {
+    console.log(`[cleanup] kept workDir=${workDir} (--keep)`);
+  }
+}
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+
+async function main() {
+  const overallDeadline = Date.now() + BUDGET_MS;
+
+  // 1. Kill any prior tmux server on our socket.
+  try {
+    execSync(`tmux -L ${SOCKET} kill-server 2>/dev/null`, { stdio: "ignore" });
+  } catch {
+    /* already dead */
+  }
+
+  // 2. Create a bare repo the coder can work inside.
+  execSync(`git init -q ${repoDir} && cd ${repoDir} && git commit --allow-empty -q -m init`, {
+    stdio: "inherit",
+  });
+
+  // 3. Init a grove. Use review-loop preset (coder + reviewer).
+  console.log("[setup] grove init --preset review-loop");
+  execSync(
+    `cd ${repoDir} && GROVE_DIR=${groveDir} bun run ${PROJECT_ROOT}/src/cli/main.ts init --preset review-loop --force supervision-e2e`,
+    { stdio: "inherit" },
+  );
+
+  // 4. Launch the TUI inside tmux with GROVE_SUPERVISION=1.
+  //    grove up → TUI setup screen → Enter → running screen (supervision body).
+  //    Wrap in a subshell that keeps the pane alive after exit (via `; cat`).
+  const stdoutLog = join(workDir, "tui.stdout.log");
+  const launchCmd = [
+    `cd ${repoDir}`,
+    `GROVE_SUPERVISION=1 GROVE_DEBUG_LOG=${join(workDir, "grove-debug.log")} bun run ${PROJECT_ROOT}/src/cli/main.ts 2>&1 | tee ${stdoutLog}`,
+    `echo [EXIT $?]`,
+    `cat`,
+  ].join(" ; ");
+
+  spawnSync(
+    "tmux",
+    [
+      "-L",
+      SOCKET,
+      "new-session",
+      "-d",
+      "-s",
+      SESSION,
+      "-x",
+      "160",
+      "-y",
+      "48",
+      "sh",
+      "-c",
+      launchCmd,
+    ],
+    { stdio: "inherit" },
+  );
+  console.log(`[tmux] session started. Attach: tmux -L ${SOCKET} attach -t ${SESSION}`);
+
+  if (ATTACH) {
+    console.log(`\nAttach in another terminal:\n  tmux -L ${SOCKET} attach -t ${SESSION}\n`);
+    console.log("Press Ctrl+C here to tear down.");
+    await sleep(BUDGET_MS);
+    return;
+  }
+
+  // 5. Wait for TUI setup screen.
+  await waitForPane((p) => /Grove|Resume|Create|grove/i.test(p), "tui-setup", 60000);
+  console.log("[phase 1] TUI setup screen visible");
+
+  // 6. Press Enter on the default "New session" option. With a single preset
+  //    and an existing grove, the flow short-circuits past preset-select and
+  //    lands on the running screen with agents pre-spawned (coder + reviewer).
+  tmuxSendKeys(["Enter"]);
+  await sleep(3000);
+
+  // 7. Wait for the running screen — confirms agents spawned.
+  const running = await waitForPane(
+    (p) => /RUNNING|coder.*\[1\]|reviewer.*\[2\]|Contribution Feed|Fleet \(/i.test(p),
+    "running",
+    60000,
+  );
+  console.log("[phase 2] running screen visible");
+  console.log("──── running pane ────");
+  console.log(running);
+  console.log("──── end running pane ────");
+
+  // 8. PRIMARY ASSERTION: supervision body rendered the fleet rail.
+  //    Fleet ( appears as soon as useFleetModel returns ≥1 active claim.
+  //    Both "coder" and "reviewer" role columns must be present.
+  //    The detail rail shows either "Select an agent" (no selection yet) or
+  //    a selected agent's header (RUNNING / IDLE / ...).
+  console.log("[phase 3] asserting supervision body markers...");
+
+  const supervisionPane = await waitForPane(
+    (p) => /Fleet \(/.test(p) && /coder/.test(p) && /reviewer/.test(p),
+    "supervision-fleet-rail",
+    120000,
+  );
+
+  // Confirm the detail rail scaffold is also visible.
+  const hasDetailRail =
+    /Select an agent/.test(supervisionPane) ||
+    /RUNNING|IDLE|STUCK|SILENT|BLOCKED|APPROVAL|ERROR/.test(supervisionPane);
+
+  if (!hasDetailRail) {
+    console.warn("[phase 3] WARNING: detail-rail scaffold not yet visible in captured pane");
+    console.warn("──── supervision pane ────");
+    console.warn(supervisionPane);
+    console.warn("──── end supervision pane ────");
+  } else {
+    console.log("[phase 3] detail-rail scaffold visible — supervision body fully rendered");
+  }
+
+  console.log("\n[ASSERT] Fleet ( header:  ", /Fleet \(/.test(supervisionPane));
+  console.log('[ASSERT] "coder" row:      ', /coder/.test(supervisionPane));
+  console.log('[ASSERT] "reviewer" row:   ', /reviewer/.test(supervisionPane));
+  console.log("[ASSERT] detail-rail:      ", hasDetailRail);
+
+  if (
+    !/Fleet \(/.test(supervisionPane) ||
+    !/coder/.test(supervisionPane) ||
+    !/reviewer/.test(supervisionPane)
+  ) {
+    throw new Error(
+      "FAIL: supervision fleet rail did not render with expected Fleet ( header and both agent roles",
+    );
+  }
+
+  // 9. OPPORTUNISTIC: if budget allows, watch for a SILENT/STUCK badge.
+  //    The HEALTH_THRESHOLDS.silentMs is 5 min and cannot be overridden via
+  //    env (the constants are compile-time). Only checked if > 6 min remain.
+  const silentBudgetMs = Math.min(360_000, overallDeadline - Date.now() - 30_000);
+  if (silentBudgetMs > 60_000) {
+    console.log(
+      `\n[phase 4] watching for SILENT/STUCK badge (budget ${Math.round(silentBudgetMs / 1000)}s)...`,
+    );
+    const observeEnd = Date.now() + silentBudgetMs;
+    let lastCapture = "";
+    let silentSeen = false;
+    while (Date.now() < observeEnd) {
+      await sleep(15_000);
+      lastCapture = capturePane();
+      const headline = lastCapture.split("\n").slice(0, 3).join(" | ");
+      console.log(
+        `[observe t+${Math.round((Date.now() - (observeEnd - silentBudgetMs)) / 1000)}s] ${headline.slice(0, 120)}`,
+      );
+      if (/SILENT|STUCK/.test(lastCapture)) {
+        console.log("[phase 4] SILENT/STUCK badge observed — health degradation detection works");
+        silentSeen = true;
+        break;
+      }
+    }
+    if (!silentSeen) {
+      console.log(
+        "[phase 4] no SILENT/STUCK badge observed within budget (agents still active — expected for short runs)",
+      );
+    }
+  }
+
+  // 10. Final capture + debug log tail.
+  console.log("\n──── final pane ────");
+  console.log(capturePane());
+  console.log("──── end final pane ────");
+
+  const debugPath = join(workDir, "grove-debug.log");
+  if (existsSync(debugPath)) {
+    const debug = execSync(`tail -300 ${debugPath}`, { encoding: "utf-8" });
+    console.log("──── debug tail ────");
+    console.log(debug);
+    console.log("──── end debug tail ────");
+  }
+
+  console.log("\n[result] Supervision E2E smoke passed.");
+}
+
+main()
+  .then(() => cleanup())
+  .catch((err) => {
+    console.error("[FAIL]", err);
+    console.error("──── final pane ────");
+    try {
+      console.error(capturePane());
+    } catch {
+      /* tmux already dead */
+    }
+    console.error("──── end pane ────");
+    cleanup();
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Implements the agent supervision hero surface from #193 — a fleet-rail + detail-rail control room that surfaces problem agents at a glance, behind env flag `GROVE_SUPERVISION=1` (default off; flip in a follow-up PR per the spec's staged rollout).

- **New module** `src/tui/screens/supervision/`: pure `agent-health` (running/idle/approval/blocked/stuck/thrashing/silent/error/expired derivation + priority sort), `supervision-actions` (enablement), `use-fleet-model` (claims × tmux × cost × handoffs × permissions join), `fleet-rail` (dense problem-first lanes), `detail-rail` (selected-agent context + inline approval), `supervision` (controlled/uncontrolled composition root), `supervision-keyboard` (pure key router), plus leaf guards `supervision-input-guard` / `permission-box-visibility`.
- **Additive `useAgentMonitor` extension**: per-role `agentOutputTimestamps` (ref-mirrored, no stale-closure) powering `silent` detection.
- **`running-view.tsx` integration**: flag-gated body swap, supervision keyboard wiring (y/n/a approve, j/k/g/G nav, t/d panel, m message), floating Permission Request suppressed when supervision owns approvals, help-overlay section (accurate — placeholders marked).
- **Additive `filterRole` prop** on `DagView`/`HandoffsView` (HandoffsView scopes; DagView plumb-only).
- **Manual e2e** `tests/tui/supervision-e2e.ts` (real `grove up` + tmux capture, API-key preflight; human-run like the sibling tmux e2e).

Spec: `docs/superpowers/specs/2026-05-18-tui-agent-supervision-hero-design.md`
Plan: `docs/superpowers/plans/2026-05-18-tui-agent-supervision-hero.md`

Built via subagent-driven development: every task got spec-compliance + code-quality review with fix loops; a final holistic review verified cross-task coherence and strict additivity.

## Strict additivity

With `GROVE_SUPERVISION` unset, RunningView is byte-for-byte unchanged (body ternary, keyboard guard, permission-box predicate, `useFleetModel.active` all flag-gated; help text is static info). Verified by the unchanged legacy test suite.

## Test plan

- [x] Feature unit/component suite: 224 pass / 0 fail (supervision modules, useAgentMonitor, running-keyboard, c2, wiring guard)
- [x] `tsc --noEmit` clean; `tsup` DTS build (incl. `--isolatedDeclarations`) passes
- [x] Pre-push `build` + `typecheck` hooks pass
- [ ] Manual: `GROVE_SUPERVISION=1 bun run tests/tui/supervision-e2e.ts` (needs `ANTHROPIC_API_KEY`; boots real agents)
- [ ] Manual: `GROVE_SUPERVISION=1 grove up` visual smoke; confirm `GROVE_SUPERVISION` unset is identical to before

## Known follow-ups (non-blocking, spec-aligned; filed as issues)

1. Thread `filterRole={selectedFleetRole}` from running-view into DAG/Handoffs drill-downs + implement DagView consumption (completes #193 acceptance criterion (d)'s "drill-downs inherit selected agent").
2. `thrashing` health is unreachable in production (`use-fleet-model` hardcodes `lastRetryAt: undefined`; `ClaimEntity.status` exposes no retry timestamp) — surface a retry timestamp or document `thrashing` as deferred.

Out of scope per spec: reroute/kill backends (#163), contribution-history sub-panel, per-agent IPC filter, collapsible detail sections.