### PR TITLE
[codex] fix live handoff TUI E2E

### DIFF
--- a/src/cli/nexus-lifecycle.test.ts
+++ b/src/cli/nexus-lifecycle.test.ts
@@ -13,6 +13,7 @@ import { parse as yamlParse } from "yaml";
 
 import {
   derivePort,
+  describeNexusBuildLabel,
   generateNexusYaml,
   inferNexusPreset,
   type NexusState,
@@ -21,6 +22,7 @@ import {
   readNexusApiKey,
   readNexusState,
   readNexusUrl,
+  shouldReuseExistingNexusForUp,
   waitForNexusHealth,
 } from "./nexus-lifecycle.js";
 
@@ -132,6 +134,26 @@ describe("inferNexusPreset", () => {
 
   test('mode=remote, no flags → "local"', () => {
     expect(inferNexusPreset({ name: "t", mode: "remote" })).toBe("local");
+  });
+});
+
+describe("source-build lifecycle policy", () => {
+  test("normal starts may reuse an existing healthy Nexus", () => {
+    expect(shouldReuseExistingNexusForUp()).toBe(true);
+    expect(shouldReuseExistingNexusForUp({ build: false })).toBe(true);
+  });
+
+  test("source-build requests do not silently reuse an existing Nexus", () => {
+    expect(shouldReuseExistingNexusForUp({ build: true })).toBe(false);
+    expect(shouldReuseExistingNexusForUp({ nexusSource: "/tmp/nexus" })).toBe(false);
+  });
+
+  test("source-build progress labels include the requested source path", () => {
+    expect(describeNexusBuildLabel({ nexusSource: "/tmp/nexus" })).toBe(
+      " (source build from /tmp/nexus)",
+    );
+    expect(describeNexusBuildLabel({ build: true })).toBe(" (--build)");
+    expect(describeNexusBuildLabel()).toBe("");
   });
 });
 
@@ -620,6 +642,30 @@ describe("nexusUp fallback (--timeout not supported)", () => {
     expect(calls[0]).toContain("--timeout");
     expect(calls[1]).not.toContain("--timeout");
     expect(out).toContain("http://localhost:2026");
+  });
+
+  test("uses extended nexus up timeout for local source builds", async () => {
+    const dir = makeTempDir();
+    const sourceDir = makeTempDir();
+    const calls: string[][] = [];
+    writeFileSync(join(sourceDir, "nexus-stack.yml"), "services: {}\n");
+    try {
+      // @ts-expect-error -- mock
+      Bun.spawn = (args: string[], _opts?: unknown) => {
+        calls.push(args);
+        return fakeProc(0, "nexus  http://localhost:2026\n", "");
+      };
+      const { nexusUp } = await import("./nexus-lifecycle.js");
+      await nexusUp(dir, { nexusSource: sourceDir });
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toContain("--timeout");
+      expect(calls[0]).toContain("900");
+      expect(calls[0]).toContain("--compose-file");
+      expect(calls[0]).toContain(join(sourceDir, "nexus-stack.yml"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(sourceDir, { recursive: true, force: true });
+    }
   });
 
   test("falls back when CLI says 'unrecognized arguments'", async () => {

--- a/src/cli/nexus-lifecycle.ts
+++ b/src/cli/nexus-lifecycle.ts
@@ -43,6 +43,9 @@ const HEALTH_POLL_MS = 1_000;
 /** Default `nexus up` timeout (seconds). */
 const NEXUS_UP_TIMEOUT_S = 180;
 
+/** Local Docker builds can spend minutes compiling before health checks begin. */
+const NEXUS_SOURCE_BUILD_TIMEOUT_S = 900;
+
 const LIFECYCLE_PATH_EXTRAS = [
   join(homedir(), ".local/bin"),
   join(homedir(), ".bun/bin"),
@@ -444,6 +447,20 @@ function buildNexusUpArgs(opts: {
   return args;
 }
 
+export function shouldReuseExistingNexusForUp(
+  opts?: Pick<NexusUpOptions, "build" | "nexusSource">,
+): boolean {
+  return !(opts?.build || !!opts?.nexusSource);
+}
+
+export function describeNexusBuildLabel(
+  opts?: Pick<NexusUpOptions, "build" | "nexusSource">,
+): string {
+  if (opts?.nexusSource) return ` (source build from ${opts.nexusSource})`;
+  if (opts?.build) return " (--build)";
+  return "";
+}
+
 function coerceEnvString(value: unknown): string | undefined {
   if (typeof value === "string" && value.trim() !== "") return value;
   if (typeof value === "number" && Number.isFinite(value)) return String(value);
@@ -524,8 +541,9 @@ export async function nexusUp(_projectRoot: string, opts: NexusUpOptions = {}): 
   const report = opts.onProgress ?? ((msg: string) => process.stderr.write(`${msg}\n`));
   report(`[nexusUp] cwd=${projectRoot}`);
 
-  const timeout = opts.timeoutSeconds ?? NEXUS_UP_TIMEOUT_S;
   const wantsBuild = opts.build || !!opts.nexusSource;
+  const timeout =
+    opts.timeoutSeconds ?? (wantsBuild ? NEXUS_SOURCE_BUILD_TIMEOUT_S : NEXUS_UP_TIMEOUT_S);
 
   // Resolve source directory for --build
   let sourceDir: string | undefined;
@@ -966,6 +984,10 @@ export async function ensureNexusRunning(
   const stateFileUrl = state?.ports?.http ? `http://localhost:${state.ports.http}` : undefined;
 
   report(`[ensureNexus] derived port=${derivedPort} state url=${stateFileUrl ?? "none"}`);
+  const reuseExistingNexus = shouldReuseExistingNexusForUp(upOpts);
+  if (!reuseExistingNexus) {
+    report("[ensureNexus] source build requested; skipping existing Nexus reuse");
+  }
 
   // Discover any running container belonging to this worktree.
   let containerUrl: string | undefined;
@@ -979,16 +1001,18 @@ export async function ensureNexusRunning(
   // DEFAULT_NEXUS_URL is intentionally excluded — it could match any running
   // Nexus instance (e.g. another project via OrbStack port forwarding) and
   // would cause cross-worktree session leakage.
-  const candidateUrls = [
-    process.env.GROVE_NEXUS_URL, // explicit user override (highest priority)
-    containerUrl, // docker container on our derived port
-    config.nexusUrl, // persisted from a previous successful start
-    readNexusUrl(projectRoot), // our nexus.yaml (has our derived port)
-    stateFileUrl, // our state.json
-    // DEFAULT_NEXUS_URL intentionally excluded — it could match any running
-    // Nexus instance (e.g. another project via OrbStack port forwarding)
-    // and would cause cross-worktree session leakage.
-  ].filter((u): u is string => !!u);
+  const candidateUrls = reuseExistingNexus
+    ? [
+        process.env.GROVE_NEXUS_URL, // explicit user override (highest priority)
+        containerUrl, // docker container on our derived port
+        config.nexusUrl, // persisted from a previous successful start
+        readNexusUrl(projectRoot), // our nexus.yaml (has our derived port)
+        stateFileUrl, // our state.json
+        // DEFAULT_NEXUS_URL intentionally excluded — it could match any running
+        // Nexus instance (e.g. another project via OrbStack port forwarding)
+        // and would cause cross-worktree session leakage.
+      ].filter((u): u is string => !!u)
+    : [];
 
   const urlsToTry = [...new Set(candidateUrls)];
   report(`[ensureNexus] checking URLs in parallel: ${urlsToTry.join(", ")}`);
@@ -1027,7 +1051,7 @@ export async function ensureNexusRunning(
   //     in-flight grove-server connections; avoid it when the container
   //     is just slow to answer (Raft re-election, cold cache, etc.).
   // -----------------------------------------------------------------------
-  if (containerUrl) {
+  if (reuseExistingNexus && containerUrl) {
     report(`[ensureNexus] container running, waiting up to 15s for health at ${containerUrl}...`);
     try {
       await waitForNexusHealth(containerUrl, 15_000);
@@ -1065,38 +1089,40 @@ export async function ensureNexusRunning(
 
   if (hasYaml && !upOpts?.force) {
     let quickRestartUrl: string | undefined;
-    try {
-      const projectName = state?.project_name;
-      const httpPort = state?.ports?.http;
-      if (projectName && httpPort) {
-        report(`[ensureNexus] quick restart: project=${projectName} port=${httpPort}`);
-        const restart = Bun.spawn(["docker", "compose", "-p", projectName, "restart", "nexus"], {
-          cwd: groveHomeDir,
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const restartCode = await restart.exited;
-        if (restartCode === 0) {
-          quickRestartUrl = `http://localhost:${httpPort}`;
-          report(`[ensureNexus] quick restart done, checking health at ${quickRestartUrl}...`);
-          try {
-            await waitForNexusHealth(quickRestartUrl, 30_000);
-            const apiKey = readNexusApiKey(groveHomeDir);
-            report("Nexus is ready (quick restart)");
-            // We invoked `docker compose restart` — owned the transition this call.
-            return { url: quickRestartUrl, apiKey, startedThisCall: true };
-          } catch {
-            report("[ensureNexus] quick restart unhealthy, falling through to nexus up...");
+    if (reuseExistingNexus) {
+      try {
+        const projectName = state?.project_name;
+        const httpPort = state?.ports?.http;
+        if (projectName && httpPort) {
+          report(`[ensureNexus] quick restart: project=${projectName} port=${httpPort}`);
+          const restart = Bun.spawn(["docker", "compose", "-p", projectName, "restart", "nexus"], {
+            cwd: groveHomeDir,
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const restartCode = await restart.exited;
+          if (restartCode === 0) {
+            quickRestartUrl = `http://localhost:${httpPort}`;
+            report(`[ensureNexus] quick restart done, checking health at ${quickRestartUrl}...`);
+            try {
+              await waitForNexusHealth(quickRestartUrl, 30_000);
+              const apiKey = readNexusApiKey(groveHomeDir);
+              report("Nexus is ready (quick restart)");
+              // We invoked `docker compose restart` — owned the transition this call.
+              return { url: quickRestartUrl, apiKey, startedThisCall: true };
+            } catch {
+              report("[ensureNexus] quick restart unhealthy, falling through to nexus up...");
+            }
           }
         }
+      } catch {
+        // best-effort — fall through to nexus up
       }
-    } catch {
-      // best-effort — fall through to nexus up
     }
 
     report("[ensureNexus] warm start: nexus.yaml found, ensuring compose file...");
     await ensureNexusComposeFile(groveHomeDir);
-    report("[ensureNexus] warm start: running nexus up...");
+    report(`[ensureNexus] warm start: running nexus up${describeNexusBuildLabel(upOpts)}...`);
     const upStdout = await nexusUp(groveHomeDir, upOpts);
     const nexusUrl =
       readNexusUrl(groveHomeDir) ??
@@ -1140,12 +1166,7 @@ export async function ensureNexusRunning(
   report("[ensureNexus] cold start: ensuring compose file...");
   await ensureNexusComposeFile(groveHomeDir);
 
-  const buildLabel = upOpts?.nexusSource
-    ? ` (source build from ${upOpts.nexusSource})`
-    : upOpts?.build
-      ? " (--build)"
-      : "";
-  report(`[ensureNexus] starting Nexus${buildLabel}...`);
+  report(`[ensureNexus] starting Nexus${describeNexusBuildLabel(upOpts)}...`);
   const upStdout = await nexusUp(groveHomeDir, upOpts);
 
   const nexusUrl =

--- a/src/shared/service-lifecycle.test.ts
+++ b/src/shared/service-lifecycle.test.ts
@@ -18,6 +18,7 @@ import { stopServices } from "./service-lifecycle.js";
 const helpers = lifecycle as typeof lifecycle & {
   resolveBunExecutable?: (execPath?: string) => string;
   resolveServicePort?: (name: string, env?: NodeJS.ProcessEnv) => number;
+  resolveServiceHealthTimeoutMs?: (env?: NodeJS.ProcessEnv) => number;
   pickFreePort?: () => Promise<number>;
 };
 
@@ -193,6 +194,25 @@ describe("service startup configuration", () => {
 
     expect(resolveBunExecutable("/Users/example/.bun/bin/bun")).toBe("/Users/example/.bun/bin/bun");
     expect(resolveBunExecutable("/usr/local/bin/node")).toBe("bun");
+  });
+
+  test("service health timeout can be extended for cold managed starts", () => {
+    expect(helpers.resolveServiceHealthTimeoutMs).toBeDefined();
+    const resolveServiceHealthTimeoutMs = helpers.resolveServiceHealthTimeoutMs;
+    if (resolveServiceHealthTimeoutMs === undefined)
+      throw new Error("resolveServiceHealthTimeoutMs is not exported");
+
+    expect(resolveServiceHealthTimeoutMs({} as NodeJS.ProcessEnv)).toBe(10_000);
+    expect(
+      resolveServiceHealthTimeoutMs({
+        GROVE_SERVICE_HEALTH_TIMEOUT_MS: "30000",
+      } as NodeJS.ProcessEnv),
+    ).toBe(30_000);
+    expect(
+      resolveServiceHealthTimeoutMs({
+        GROVE_SERVICE_HEALTH_TIMEOUT_MS: "abc",
+      } as NodeJS.ProcessEnv),
+    ).toBe(10_000);
   });
 
   // Concurrent grove worktrees on the same host should not collide on the

--- a/src/shared/service-lifecycle.ts
+++ b/src/shared/service-lifecycle.ts
@@ -750,8 +750,17 @@ export async function stopServices(services: RunningServices): Promise<void> {
 /** Default service ports. */
 const DEFAULT_SERVICE_PORTS = { server: 4515, mcp: 4015 } as const;
 
-/** Service health-check timeout (ms). */
-const SERVICE_HEALTH_TIMEOUT_MS = 10_000;
+/** Default service health-check timeout (ms). */
+const DEFAULT_SERVICE_HEALTH_TIMEOUT_MS = 10_000;
+
+/** Resolve service health-check timeout (ms). */
+export function resolveServiceHealthTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.GROVE_SERVICE_HEALTH_TIMEOUT_MS;
+  if (raw === undefined || raw.trim() === "") return DEFAULT_SERVICE_HEALTH_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1_000) return DEFAULT_SERVICE_HEALTH_TIMEOUT_MS;
+  return parsed;
+}
 
 /**
  * Per-probe ceilings for adoption-path checks. Split into two tiers:
@@ -1004,7 +1013,7 @@ type ListenerProbe =
 async function probeListenerPid(port: number): Promise<ListenerProbe> {
   try {
     const { spawnSync } = await import("node:child_process");
-    const r = spawnSync("lsof", ["-tiTCP:" + port, "-sTCP:LISTEN"], {
+    const r = spawnSync("lsof", [`-tiTCP:${port}`, "-sTCP:LISTEN"], {
       encoding: "utf8",
       timeout: PROBE_TIMEOUTS.lsofMs,
     });
@@ -1677,13 +1686,14 @@ async function spawnService(
     // owned-but-unhealthy / owned-but-unresponsive distinguish dependency
     // problems from bind-races so we don't kill our own healthy child.
     if (port) {
+      const healthTimeoutMs = resolveServiceHealthTimeoutMs();
       const readiness = await waitForOwnedReadiness({
         port,
         spawnedPid: pid,
         spawnedExit: exited,
         readinessToken,
         url: `http://localhost:${port}/health`,
-        timeoutMs: SERVICE_HEALTH_TIMEOUT_MS,
+        timeoutMs: healthTimeoutMs,
       });
       if (!readiness.ok) {
         // Teardown policy (round 6): every non-ok verdict EXCEPT
@@ -1720,11 +1730,11 @@ async function spawnService(
             case "owned-but-unresponsive":
               return (
                 `${name} bound the port (PID ${pid}) but /health never responded within ` +
-                `${SERVICE_HEALTH_TIMEOUT_MS}ms — dependency stall, not a bind-race. ` +
+                `${healthTimeoutMs}ms — dependency stall, not a bind-race. ` +
                 `Last fetch error: ${readiness.lastError}`
               );
             case "no-listener":
-              return `no listener bound within ${SERVICE_HEALTH_TIMEOUT_MS}ms`;
+              return `no listener bound within ${healthTimeoutMs}ms`;
           }
         })();
         throw new Error(

--- a/src/tui/hooks/use-agent-monitor.test.ts
+++ b/src/tui/hooks/use-agent-monitor.test.ts
@@ -12,9 +12,11 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { AgentLogBuffer } from "../data/agent-log-buffer.js";
 import {
   isLogLineKept,
   mergeOutputs,
+  outputsFromLogBuffers,
   parseLogContent,
   parsePermissionPrompt,
   roleFromLogFilename,
@@ -284,5 +286,20 @@ describe("mergeOutputs", () => {
     );
     expect(timestamps.has("gone")).toBe(false);
     expect(timestamps.get("coder")).toBe(now);
+  });
+});
+
+describe("outputsFromLogBuffers", () => {
+  test("projects subscribed log buffers into output lines and latest timestamps", () => {
+    const buffer = new AgentLogBuffer("coder", "session-1", 100, 1);
+    const older = new Date("2026-05-18T11:59:59.000Z").getTime();
+    const newer = new Date("2026-05-18T12:00:00.000Z").getTime();
+    buffer.push({ ts: older, line: "older output", type: "output" });
+    buffer.push({ ts: newer, line: "new pushed output", type: "tool" });
+
+    const { outputs, timestamps } = outputsFromLogBuffers(new Map([["coder", buffer]]), 1);
+
+    expect(outputs.get("coder")).toEqual(["new pushed output"]);
+    expect(timestamps.get("coder")).toBe("2026-05-18T12:00:00.000Z");
   });
 });

--- a/src/tui/hooks/use-agent-monitor.ts
+++ b/src/tui/hooks/use-agent-monitor.ts
@@ -37,6 +37,12 @@ export interface IpcMessage {
 export interface AgentMonitorOptions {
   /** Path to .grove directory (for reading agent log files). */
   readonly groveDir?: string | undefined;
+  /**
+   * Push-fed per-agent log buffers owned by SpawnManager. When available,
+   * agent output snapshots subscribe to these buffers instead of reading
+   * log files on a timer.
+   */
+  readonly logBuffers?: ReadonlyMap<string, AgentOutputBuffer> | undefined;
   /** Tmux manager for pane capture and permission detection. */
   readonly tmux?: import("../agents/tmux-manager.js").TmuxManager | undefined;
   /** EventBus for IPC message subscription. */
@@ -60,6 +66,19 @@ export interface AgentMonitorState {
   readonly ipcMessages: readonly IpcMessage[];
   /** Current spinner frame index (braille animation). */
   readonly spinnerFrame: number;
+}
+
+export interface AgentOutputBufferLine {
+  readonly ts: number;
+  readonly line: string;
+}
+
+export interface AgentOutputBuffer {
+  readonly role: string;
+  readonly size: number;
+  slice(start: number, end: number): readonly AgentOutputBufferLine[];
+  subscribe(listener: () => void): void;
+  unsubscribe(listener: () => void): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -163,13 +182,40 @@ export function mergeOutputs(
   return { outputs: nextOutputs, timestamps };
 }
 
+export function outputsFromLogBuffers(
+  logBuffers: ReadonlyMap<string, AgentOutputBuffer>,
+  maxLines: number,
+): {
+  readonly outputs: ReadonlyMap<string, readonly string[]>;
+  readonly timestamps: ReadonlyMap<string, string>;
+} {
+  const outputs = new Map<string, readonly string[]>();
+  const timestamps = new Map<string, string>();
+  const limit = Math.max(0, maxLines);
+  for (const [key, buffer] of logBuffers) {
+    if (buffer.size <= 0 || limit === 0) continue;
+    const start = Math.max(0, buffer.size - limit);
+    const lines = buffer.slice(start, buffer.size);
+    if (lines.length === 0) continue;
+    const role = buffer.role || key;
+    outputs.set(
+      role,
+      lines.map((line) => line.line),
+    );
+    const newest = lines[lines.length - 1];
+    if (newest) timestamps.set(role, new Date(newest.ts).toISOString());
+  }
+  return { outputs, timestamps };
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
 /** Hook that monitors agent activity via log files, tmux, and IPC events. */
 export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState {
-  const { groveDir, tmux, eventBus, topology, maxOutputLines = 8 } = options;
+  const { groveDir, logBuffers, tmux, eventBus, topology, maxOutputLines = 8 } = options;
+  const hasLogBufferSource = logBuffers !== undefined && logBuffers.size > 0;
 
   const [agentOutputs, setAgentOutputs] = useState<ReadonlyMap<string, readonly string[]>>(
     new Map(),
@@ -196,6 +242,25 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
 
   // Braille spinner animation
   useInterval(() => setSpinnerFrame((f) => (f + 1) % BRAILLE_SPINNER.length), SPINNER_INTERVAL_MS);
+
+  const refreshFromLogBuffers = useCallback(() => {
+    if (!logBuffers || logBuffers.size === 0) return;
+    const snapshot = outputsFromLogBuffers(logBuffers, maxOutputLines);
+    if (!mountedRef.current) return;
+    setAgentOutputs(snapshot.outputs);
+    setAgentOutputTimestamps(snapshot.timestamps);
+  }, [logBuffers, maxOutputLines, setAgentOutputTimestamps]);
+
+  useEffect(() => {
+    if (!logBuffers || logBuffers.size === 0) return;
+    const buffers = [...logBuffers.values()];
+    const listener = () => refreshFromLogBuffers();
+    refreshFromLogBuffers();
+    for (const buffer of buffers) buffer.subscribe(listener);
+    return () => {
+      for (const buffer of buffers) buffer.unsubscribe(listener);
+    };
+  }, [logBuffers, refreshFromLogBuffers]);
 
   // Subscribe to EventBus for IPC message log.
   // Deduplicate: MCP TopologyRouter AND TUI wsBridge.send BOTH write into
@@ -276,10 +341,11 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
   }, [groveDir, maxOutputLines, setAgentOutputTimestamps]);
 
   useEffect(() => {
+    if (hasLogBufferSource) return;
     void logPoll();
-  }, [logPoll]);
+  }, [hasLogBufferSource, logPoll]);
 
-  useInterval(() => void logPoll(), POLL_INTERVAL_MS, Boolean(groveDir));
+  useInterval(() => void logPoll(), POLL_INTERVAL_MS, Boolean(groveDir) && !hasLogBufferSource);
 
   // Poll agent tmux panes for live output (fallback when no log files)
   const tmuxPoll = useCallback(async () => {
@@ -307,7 +373,11 @@ export function useAgentMonitor(options: AgentMonitorOptions): AgentMonitorState
     }
   }, [tmux, groveDir, maxOutputLines, setAgentOutputTimestamps]);
 
-  useInterval(() => void tmuxPoll(), POLL_INTERVAL_MS, Boolean(tmux) && !groveDir);
+  useInterval(
+    () => void tmuxPoll(),
+    POLL_INTERVAL_MS,
+    Boolean(tmux) && !groveDir && !hasLogBufferSource,
+  );
 
   // Poll agent tmux panes for permission prompts
   const permissionPoll = useCallback(async () => {

--- a/src/tui/main.reaper.test.ts
+++ b/src/tui/main.reaper.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const TUI_MAIN_PATH = join(import.meta.dir, "main.ts");
+
+describe("TUI MCP orphan reaper", () => {
+  test("targets stdio MCP serve.ts without matching serve-http.ts", () => {
+    const source = readFileSync(TUI_MAIN_PATH, "utf-8");
+
+    expect(source).not.toContain("mcp/serve'");
+    expect(source).not.toContain('mcp/serve"');
+    expect(source).toContain("mcp/serve\\\\.(ts|js)");
+  });
+});

--- a/src/tui/main.ts
+++ b/src/tui/main.ts
@@ -25,6 +25,7 @@ import {
 
 /** Default polling interval: 30s safety net. Primary updates are via Nexus SSE (instant). */
 const DEFAULT_INTERVAL_MS = 30_000;
+const MCP_STDIO_REAPER_PATTERN = "bun.*mcp/serve\\.(ts|js)";
 
 /** Parse TUI command-line arguments. */
 export function parseTuiArgs(args: readonly string[]): {
@@ -749,7 +750,10 @@ export async function handleTui(
     // TUI session leaks MCP server processes that accumulate memory.
     try {
       const { execSync } = await import("node:child_process");
-      execSync("pkill -f 'bun.*mcp/serve' 2>/dev/null || true", { stdio: "pipe", timeout: 5000 });
+      execSync(`pkill -f '${MCP_STDIO_REAPER_PATTERN}' 2>/dev/null || true`, {
+        stdio: "pipe",
+        timeout: 5000,
+      });
     } catch {
       // best-effort
     }
@@ -771,12 +775,15 @@ export async function handleTui(
   // survives the parent when the TUI crashes without cleanup.
   try {
     const { execSync } = await import("node:child_process");
-    const orphanCount = execSync("pgrep -f 'bun.*mcp/serve' 2>/dev/null | wc -l", {
+    const orphanCount = execSync(`pgrep -f '${MCP_STDIO_REAPER_PATTERN}' 2>/dev/null | wc -l`, {
       encoding: "utf-8",
       timeout: 3000,
     }).trim();
     if (Number(orphanCount) > 0) {
-      execSync("pkill -f 'bun.*mcp/serve' 2>/dev/null || true", { stdio: "pipe", timeout: 5000 });
+      execSync(`pkill -f '${MCP_STDIO_REAPER_PATTERN}' 2>/dev/null || true`, {
+        stdio: "pipe",
+        timeout: 5000,
+      });
       process.stderr.write(`[startup] reaped ${orphanCount} orphan MCP server process(es)\n`);
     }
   } catch {

--- a/src/tui/nexus-ws-bridge.test.ts
+++ b/src/tui/nexus-ws-bridge.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AcpxTurn } from "../acp/types.js";
 import type { AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import type { GroveEvent } from "../core/event-bus.js";
+import { HandoffStatus } from "../core/handoff.js";
 import { LocalEventBus } from "../core/local-event-bus.js";
 import { NexusWsBridge, type NexusWsBridgeOptions } from "./nexus-ws-bridge.js";
 
@@ -104,6 +105,24 @@ class TestableNexusWsBridge extends NexusWsBridge {
     await (
       this as unknown as { drainRoleInbox: (r: string, reason: string) => Promise<void> }
     ).drainRoleInbox(role, "test");
+  }
+
+  /** Expose dead-letter path for terminal-state regression tests. */
+  async testMarkHandoffDeadLettered(handoffId: string, targetRole = "reviewer"): Promise<void> {
+    await (
+      this as unknown as {
+        markHandoffDeadLettered: (id: string, role: string, reason: string) => Promise<void>;
+      }
+    ).markHandoffDeadLettered(handoffId, targetRole, "test failure");
+  }
+
+  /** Expose delivered path for delivery replay regression tests. */
+  async testMarkHandoffDelivered(handoffId: string, targetRole = "reviewer"): Promise<void> {
+    await (
+      this as unknown as {
+        markHandoffDeliveredById: (id: string, role: string) => Promise<void>;
+      }
+    ).markHandoffDeliveredById(handoffId, targetRole);
   }
 }
 
@@ -1274,6 +1293,138 @@ describe("NexusWsBridge", () => {
     // Wait for async readAndPush
     await new Promise((r) => setTimeout(r, 20));
     expect(markDelivered).not.toHaveBeenCalled();
+    bridge.close();
+  });
+
+  test("dead-letter path skips handoffs already replied before delivery failure wins race", async () => {
+    const markDeadLettered = mock(() => Promise.resolve());
+    const handoffStore = {
+      get: mock(() =>
+        Promise.resolve({
+          handoffId: "handoff-replied",
+          sourceCid: "blake3:reviewed",
+          fromRole: "coder",
+          toRole: "reviewer",
+          status: HandoffStatus.Replied,
+          requiresReply: true,
+          createdAt: new Date().toISOString(),
+          resolvedByCid: "blake3:review",
+        }),
+      ),
+      markDeadLettered,
+    };
+    const bridge = new TestableNexusWsBridge(
+      makeBridgeOpts({
+        handoffStore: handoffStore as unknown as NexusWsBridgeOptions["handoffStore"],
+      }),
+    );
+
+    await bridge.testMarkHandoffDeadLettered("handoff-replied");
+
+    expect(handoffStore.get).toHaveBeenCalledWith("handoff-replied");
+    expect(markDeadLettered).not.toHaveBeenCalled();
+    bridge.close();
+  });
+
+  test("delivery path skips handoffs already replied before duplicate delivery replay", async () => {
+    const markDelivered = mock(() => Promise.resolve());
+    const handoffStore = {
+      get: mock(() =>
+        Promise.resolve({
+          handoffId: "handoff-replied",
+          sourceCid: "blake3:reviewed",
+          fromRole: "coder",
+          toRole: "reviewer",
+          status: HandoffStatus.Replied,
+          requiresReply: true,
+          createdAt: new Date().toISOString(),
+          resolvedByCid: "blake3:review",
+        }),
+      ),
+      markDelivered,
+    };
+    const bridge = new TestableNexusWsBridge(
+      makeBridgeOpts({
+        handoffStore: handoffStore as unknown as NexusWsBridgeOptions["handoffStore"],
+      }),
+    );
+
+    await bridge.testMarkHandoffDelivered("handoff-replied");
+
+    expect(handoffStore.get).toHaveBeenCalledWith("handoff-replied");
+    expect(markDelivered).not.toHaveBeenCalled();
+    bridge.close();
+  });
+
+  test("cancelled optional notification push does not dead-letter handoff", async () => {
+    const runtime = makeMockRuntime();
+    runtime.send = mock((session: AgentSession) =>
+      Promise.resolve({
+        ...makeNoAcpTurn(session.id),
+        result: Promise.resolve({
+          turnId: `${session.id}-cancelled`,
+          stopReason: "cancelled" as const,
+        }),
+      }),
+    ) as AgentRuntime["send"];
+    const markDeadLettered = mock(() => Promise.resolve());
+    const optionalHandoff = {
+      handoffId: "handoff-optional",
+      sourceCid: "blake3:review",
+      fromRole: "reviewer",
+      toRole: "coder",
+      status: HandoffStatus.Delivered,
+      requiresReply: false,
+      createdAt: new Date().toISOString(),
+      ipcMessageId: "msg-optional",
+    };
+    const handoffStore = {
+      get: mock(() => Promise.resolve(optionalHandoff)),
+      list: mock(() => Promise.resolve([optionalHandoff])),
+      markDelivered: mock(() => Promise.resolve()),
+      markDeadLettered,
+    };
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          content: JSON.stringify({
+            message_id: "msg-optional",
+            sender: "reviewer",
+            payload: {
+              cid: "blake3:review",
+              kind: "review",
+              summary: "approved",
+            },
+          }),
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+    const bridge = new TestableNexusWsBridge(
+      makeBridgeOpts({
+        runtime,
+        handoffStore: handoffStore as unknown as NexusWsBridgeOptions["handoffStore"],
+      }),
+    );
+    bridge.registerSession("coder", makeSession("coder"));
+
+    bridge.testHandleEvent(
+      "coder",
+      "message_delivered",
+      JSON.stringify({
+        event: "message_delivered",
+        message_id: "msg-optional",
+        sender: "reviewer",
+        recipient: "coder",
+        type: "event",
+        path: "/ipc/coder/inbox/msg-optional.json",
+      }),
+    );
+
+    await waitFor(
+      () => (runtime.send as unknown as { mock: { calls: unknown[] } }).mock.calls.length === 1,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(markDeadLettered).not.toHaveBeenCalled();
     bridge.close();
   });
 

--- a/src/tui/nexus-ws-bridge.ts
+++ b/src/tui/nexus-ws-bridge.ts
@@ -25,7 +25,7 @@
 
 import type { AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import type { EventBus, GroveEvent } from "../core/event-bus.js";
-import type { HandoffStore } from "../core/handoff.js";
+import { HandoffStatus, type HandoffStore, InvalidTransitionError } from "../core/handoff.js";
 import { getProcessInstanceId } from "../core/process-instance.js";
 import type { AgentTopology } from "../core/topology.js";
 import { startInterval } from "../local/use-interval.js";
@@ -1158,6 +1158,14 @@ export class NexusWsBridge {
     try {
       const store = this.opts.handoffStore;
       if (!store) return;
+      const existing = await (store as { get?: HandoffStore["get"] }).get?.(handoffId);
+      if (existing && NexusWsBridge.hasReachedDelivery(existing.status)) {
+        debugLog(
+          "wsBridge.markHandoffDeliveredById",
+          `SKIP already-delivered handoffId=${handoffId} role=${targetRole} status=${existing.status}`,
+        );
+        return;
+      }
       await store.markDelivered(handoffId);
       debugLog(
         "wsBridge.markHandoffDeliveredById",
@@ -1166,6 +1174,17 @@ export class NexusWsBridge {
       const cacheable = store as { invalidateCache?: () => void };
       cacheable.invalidateCache?.();
     } catch (err) {
+      if (
+        err instanceof InvalidTransitionError &&
+        err.toStatus === HandoffStatus.Delivered &&
+        NexusWsBridge.hasReachedDelivery(err.fromStatus)
+      ) {
+        debugLog(
+          "wsBridge.markHandoffDeliveredById",
+          `SKIP already-delivered handoffId=${err.handoffId} role=${targetRole} status=${err.fromStatus}`,
+        );
+        return;
+      }
       debugLog(
         "wsBridge.markHandoffDeliveredById",
         `FAIL handoffId=${handoffId} err=${err instanceof Error ? err.message : String(err)}`,
@@ -1296,6 +1315,52 @@ export class NexusWsBridge {
     );
   }
 
+  private static isTerminalHandoffStatus(status: string): boolean {
+    return (
+      status === HandoffStatus.Replied ||
+      status === HandoffStatus.Expired ||
+      status === HandoffStatus.DeadLettered
+    );
+  }
+
+  private static hasReachedDelivery(status: string): boolean {
+    return (
+      status === HandoffStatus.Delivered ||
+      status === HandoffStatus.Processed ||
+      NexusWsBridge.isTerminalHandoffStatus(status)
+    );
+  }
+
+  private static isCancelledPush(reason: string): boolean {
+    return /stopReason=cancelled/i.test(reason);
+  }
+
+  private async shouldSkipDeadLetterForHandoff(
+    handoffId: string | undefined,
+    reason: string,
+  ): Promise<boolean> {
+    if (!handoffId) return false;
+    const store = this.opts.handoffStore;
+    if (!store) return false;
+    const existing = await store.get(handoffId);
+    if (!existing) return false;
+    if (NexusWsBridge.isTerminalHandoffStatus(existing.status)) {
+      debugLog(
+        "wsBridge.markHandoffDeadLettered",
+        `SKIP terminal handoffId=${handoffId} status=${existing.status}: ${reason}`,
+      );
+      return true;
+    }
+    if (!existing.requiresReply && NexusWsBridge.isCancelledPush(reason)) {
+      debugLog(
+        "wsBridge.markHandoffDeadLettered",
+        `SKIP optional cancelled handoffId=${handoffId} status=${existing.status}: ${reason}`,
+      );
+      return true;
+    }
+    return false;
+  }
+
   /**
    * Send a notification with bounded transient-retry. Retries on ACP
    * connection-closed-style errors (recipient bootstrap race) with
@@ -1383,6 +1448,7 @@ export class NexusWsBridge {
           await new Promise((r) => setTimeout(r, backoffsMs[attempt] ?? 1000));
           continue;
         }
+        if (await this.shouldSkipDeadLetterForHandoff(resolvedHandoffId, detail)) return;
         process.stderr.write(
           `[NexusWsBridge] local push failed for role=${targetRole} turn=${turn.turnId}: ${detail}\n`,
         );
@@ -1403,6 +1469,7 @@ export class NexusWsBridge {
           await new Promise((r) => setTimeout(r, backoffsMs[attempt] ?? 1000));
           continue;
         }
+        if (await this.shouldSkipDeadLetterForHandoff(resolvedHandoffId, detail)) return;
         process.stderr.write(
           `[NexusWsBridge] runtime.send rejected for role=${targetRole}: ${detail}\n`,
         );
@@ -1477,6 +1544,8 @@ export class NexusWsBridge {
         return;
       }
 
+      if (await this.shouldSkipDeadLetterForHandoff(effectiveId, reason)) return;
+
       await store.markDeadLettered(effectiveId);
       process.stderr.write(
         `[NexusWsBridge] dead-lettered handoffId=${effectiveId} role=${targetRole}: ${reason}\n`,
@@ -1485,6 +1554,17 @@ export class NexusWsBridge {
       const cacheable = store as { invalidateCache?: () => void };
       cacheable.invalidateCache?.();
     } catch (err) {
+      if (
+        err instanceof InvalidTransitionError &&
+        err.toStatus === HandoffStatus.DeadLettered &&
+        NexusWsBridge.isTerminalHandoffStatus(err.fromStatus)
+      ) {
+        debugLog(
+          "wsBridge.markHandoffDeadLettered",
+          `SKIP terminal handoffId=${err.handoffId} status=${err.fromStatus}: ${reason}`,
+        );
+        return;
+      }
       debugLog(
         "wsBridge.markHandoffDeadLettered",
         `FAIL handoffId=${handoffId} err=${err instanceof Error ? err.message : String(err)}`,

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -441,7 +441,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     useInterval(tickElapsed, 1000);
 
     // ─── Agent monitoring (extracted hook) ───
-    const monitor = useAgentMonitor({ groveDir, tmux, eventBus, topology });
+    const monitor = useAgentMonitor({ groveDir, logBuffers, tmux, eventBus, topology });
 
     // Toast for permission requests
     const prevPermCountRef = useRef(0);
@@ -463,7 +463,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     // expires on wall-clock and frontier needs server compute, neither of
     // which the watch protocol covers.
     //
-    // Honor the session scope gate: in scoped sessions we keep the polled
+    // Honor the session scope gate: in scoped sessions we keep the snapshot
     // path because /api/list and /api/watch are still namespace-global —
     // the EntityStore would seed with all sessions' rows on init and admit
     // foreign-session writes via the watch fan-out. The session-time
@@ -482,39 +482,38 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
       debugLog("feed.fetch", `total=${result?.length ?? 0}`);
       if (fetchCountRef.current <= 5 || fetchCountRef.current % 20 === 0) {
         debugLog(
-          "poll",
-          `fetch #${fetchCountRef.current} returned ${result?.length ?? 0} contributions`,
+          "feed.fetch",
+          `snapshot #${fetchCountRef.current} returned ${result?.length ?? 0} contributions`,
         );
       }
       return result;
     }, [provider]);
 
-    // Gate polling: pause contributions when panel is fullscreen and not showing feed
+    // Gate snapshot fetches when panel is fullscreen and not showing feed.
     const feedActive =
       zoomLevel !== "full" || expandedPanel === RunningPanel.Feed || expandedPanel === null;
     // Only switch to informer data after it has synced and is healthy. Cold
-    // start or terminal watch failure must keep the polled fallback alive,
+    // start or terminal watch failure must keep the event-triggered snapshot fallback alive,
     // otherwise the feed renders empty even though `getContributions()` would
     // still return data.
     const contribInformerReady =
       useContribInformer && contribEntities.hasSynced && !contribEntities.error;
-    const dashboardPoll = useEventDrivenData<DashboardData>(
+    const dashboardSnapshot = useEventDrivenData<DashboardData>(
       dashboardFetcher,
       undefined,
       undefined,
       true,
     );
-    const contributionsPoll = useEventDrivenData<readonly Contribution[]>(
+    const contributionsSnapshot = useEventDrivenData<readonly Contribution[]>(
       contributionsFetcher,
       undefined,
       undefined,
       feedActive && !contribInformerReady,
     );
 
-    // The polled fetcher is only used for UI refresh of the contributions feed display;
-    // agent-to-agent contribution delivery is done via NexusWsBridge SSE push,
-    // not via polling. The eventBus handler below drives immediate UI refresh
-    // when a push arrives.
+    // This fetcher is not a timer. It seeds the feed before the informer is
+    // ready, and the EventBus handler below refreshes it immediately when SSE
+    // push arrives.
 
     // When EventBus fires (SSE push from Nexus), trigger immediate re-fetch.
     //
@@ -522,8 +521,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     // publishes contribution events with `targetRole` set to the role that
     // received the inbox delivery (coder / reviewer / …). Subscribing to a
     // sentinel channel like "system" never receives anything, which is how
-    // the feed silently stopped refreshing on push in live sessions — the
-    // per-poll interval was the only refresh path.
+    // the feed silently stopped refreshing on push in live sessions.
     //
     // ScreenManager renders RunningView OUTSIDE App's RefreshContext
     // provider (the inspect overlay is a different screen state),
@@ -536,16 +534,16 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
       const handler = () => {
         const p = provider as { invalidateCaches?: () => void };
         p.invalidateCaches?.();
-        dashboardPoll.refresh();
-        contributionsPoll.refresh();
+        dashboardSnapshot.refresh();
+        contributionsSnapshot.refresh();
       };
       for (const role of roles) eventBus.subscribe(role, handler);
       return () => {
         for (const role of roles) eventBus.unsubscribe(role, handler);
       };
-    }, [eventBus, topology, provider, dashboardPoll.refresh, contributionsPoll.refresh]);
+    }, [eventBus, topology, provider, dashboardSnapshot.refresh, contributionsSnapshot.refresh]);
 
-    const dashboard = dashboardPoll.data ?? undefined;
+    const dashboard = dashboardSnapshot.data ?? undefined;
 
     // ─── Supervision fleet model (#193, gated by GROVE_SUPERVISION) ───
     // `active` is only true when the supervision body is the visible body
@@ -579,12 +577,12 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
       [],
     );
     const contributions = useMemo<readonly Contribution[] | undefined>(() => {
-      if (!contribInformerReady) return contributionsPoll.data ?? undefined;
+      if (!contribInformerReady) return contributionsSnapshot.data ?? undefined;
       // Time-based session scope. The watch protocol does not yet filter
       // by sessionId server-side, so the EntityStore cache may contain
       // contributions from prior/parallel sessions in the same namespace.
       // Filter to entries created at-or-after the current session start to
-      // match the polled provider.getContributions() semantics, which the
+      // match the provider.getContributions() snapshot semantics, which the
       // TUI provider scopes server-side via setSessionScope. Without this
       // filter, switching to the EntityStore path in a scoped session
       // would surface other-session contributions in the feed.
@@ -602,7 +600,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
       // every entity on each recompute, freezing the TUI even though the
       // visible feed only shows a window. Take the newest FEED_PROJECTION_CAP
       // by createdAt, then re-sort ASCENDING so the feed's auto-follow
-      // (`feed.length - 1`) lands on the newest row, matching the polled
+      // (`feed.length - 1`) lands on the newest row, matching the snapshot
       // `getContributions()` order.
       // DESC chronological for the cap (invalid-last so bad timestamps
       // don't displace real recent contributions); ASC for the final feed
@@ -621,7 +619,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
         compareTimestampsAscNewestLast(a.metadata.creationTimestamp, b.metadata.creationTimestamp),
       );
       return sorted.map(entityToContribution);
-    }, [contribInformerReady, contribEntities.data, contributionsPoll.data, sessionStartedAt]);
+    }, [contribInformerReady, contribEntities.data, contributionsSnapshot.data, sessionStartedAt]);
     // Session scoping is handled server-side (provider.setSessionScope).
     // The feed already contains only this session's contributions.
     const feed = contributions ?? [];
@@ -630,20 +628,20 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     // path is unhealthy. Informer error always surfaces (even when we're still
     // polling as fallback) so operators see watch-pipeline failures.
     const pollHealth = useMemo(() => {
-      const contribStale = contribInformerReady ? false : contributionsPoll.isStale;
+      const contribStale = contribInformerReady ? false : contributionsSnapshot.isStale;
       const contribError =
         contribEntities.error?.message ??
-        (contribInformerReady ? undefined : contributionsPoll.error?.message);
-      const isStale = dashboardPoll.isStale || contribStale;
-      const error = dashboardPoll.error?.message ?? contribError ?? undefined;
+        (contribInformerReady ? undefined : contributionsSnapshot.error?.message);
+      const isStale = dashboardSnapshot.isStale || contribStale;
+      const error = dashboardSnapshot.error?.message ?? contribError ?? undefined;
       return { isStale, error };
     }, [
-      dashboardPoll.isStale,
-      dashboardPoll.error?.message,
+      dashboardSnapshot.isStale,
+      dashboardSnapshot.error?.message,
       contribInformerReady,
       contribEntities.error?.message,
-      contributionsPoll.isStale,
-      contributionsPoll.error?.message,
+      contributionsSnapshot.isStale,
+      contributionsSnapshot.error?.message,
     ]);
 
     const [handoffs, setHandoffs] = useState<readonly Handoff[]>([]);
@@ -943,7 +941,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
         logViewActive: useLogView,
         // openDetail kept as an interface field for future detail-route work,
         // but wired to a no-op so Enter cannot accidentally enter inspect.
-        openDetail: () => {},
+        openDetail: () => undefined,
         enterInspect: () => onEnterInspect(),
         openPulse: () => onOpenPulse?.(),
         quit: () => onQuit(),

--- a/src/tui/spawn-manager.ts
+++ b/src/tui/spawn-manager.ts
@@ -1485,27 +1485,30 @@ export class SpawnManager {
     //   first pollAll() fires → read from byte 0 → old data included.
     if (seekToEnd) {
       try {
-        const { readdirSync, statSync } = require("node:fs") as typeof import("node:fs");
-        const files = readdirSync(logDir).filter((f: string) => f.endsWith(".log"));
-        for (const [role, buffer] of this.logBuffers) {
-          const roleFiles = files.filter(
-            (f: string) => f === `${role}.log` || f.startsWith(`${role}-`),
-          );
-          let seekCount = 0;
-          for (const roleFile of roleFiles) {
-            try {
-              const fileSize = statSync(`${logDir}/${roleFile}`).size;
-              buffer.recordSeekPosition(`${logDir}/${roleFile}`, fileSize);
-              seekCount++;
-            } catch {
-              // File unreadable — skip
+        const { existsSync, readdirSync, statSync } =
+          require("node:fs") as typeof import("node:fs");
+        if (existsSync(logDir)) {
+          const files = readdirSync(logDir).filter((f: string) => f.endsWith(".log"));
+          for (const [role, buffer] of this.logBuffers) {
+            const roleFiles = files.filter(
+              (f: string) => f === `${role}.log` || f.startsWith(`${role}-`),
+            );
+            let seekCount = 0;
+            for (const roleFile of roleFiles) {
+              try {
+                const fileSize = statSync(`${logDir}/${roleFile}`).size;
+                buffer.recordSeekPosition(`${logDir}/${roleFile}`, fileSize);
+                seekCount++;
+              } catch {
+                // File unreadable — skip
+              }
             }
+            buffer.clearForNewSession();
+            debugLog(
+              "seekToEnd",
+              `role=${role} seeked ${seekCount} file(s): [${roleFiles.join(",")}]`,
+            );
           }
-          buffer.clearForNewSession();
-          debugLog(
-            "seekToEnd",
-            `role=${role} seeked ${seekCount} file(s): [${roleFiles.join(",")}]`,
-          );
         }
       } catch (e) {
         debugLog("seekToEnd", `error: ${String(e)}`);
@@ -1516,7 +1519,8 @@ export class SpawnManager {
     const pollAll = () => {
       // Scan log directory for files matching each role (e.g., coder-0.log, coder-1.log)
       try {
-        const { readdirSync } = require("node:fs") as typeof import("node:fs");
+        const { existsSync, readdirSync } = require("node:fs") as typeof import("node:fs");
+        if (!existsSync(logDir)) return;
         const files = readdirSync(logDir).filter((f: string) => f.endsWith(".log"));
         if (pollCount < 3 || pollCount % 10 === 0) {
           debugLog(

--- a/src/tui/views/agent-tasks.test.tsx
+++ b/src/tui/views/agent-tasks.test.tsx
@@ -63,7 +63,7 @@ describe("agent task TUI helpers", () => {
     ).toBe("Running");
   });
 
-  test("does not refresh the active panel on interval", async () => {
+  test("refreshes the active panel on fallback interval", async () => {
     let fetches = 0;
     const provider = {
       getAgentTasks: async () => {
@@ -92,7 +92,7 @@ describe("agent task TUI helpers", () => {
       await sleep(35);
     });
 
-    expect(fetches).toBe(initialFetches);
+    expect(fetches).toBeGreaterThan(initialFetches);
 
     await act(async () => {
       renderer?.unmount();

--- a/src/tui/views/agent-tasks.test.tsx
+++ b/src/tui/views/agent-tasks.test.tsx
@@ -63,7 +63,7 @@ describe("agent task TUI helpers", () => {
     ).toBe("Running");
   });
 
-  test("refreshes the active panel on interval", async () => {
+  test("does not refresh the active panel on interval", async () => {
     let fetches = 0;
     const provider = {
       getAgentTasks: async () => {
@@ -92,7 +92,7 @@ describe("agent task TUI helpers", () => {
       await sleep(35);
     });
 
-    expect(fetches).toBeGreaterThan(initialFetches);
+    expect(fetches).toBe(initialFetches);
 
     await act(async () => {
       renderer?.unmount();

--- a/src/tui/views/agent-tasks.tsx
+++ b/src/tui/views/agent-tasks.tsx
@@ -5,7 +5,6 @@
 import React, { useCallback, useMemo } from "react";
 import type { AgentTaskEntity, AgentTaskView } from "../../core/agent-task.js";
 import { agentTaskViewToEntity, isAgentTaskSpecStale } from "../../core/agent-task.js";
-import { useInterval } from "../../local/use-interval.js";
 import { formatTimestamp } from "../../shared/format.js";
 import { ConditionChips } from "../components/condition-chips.js";
 import { EmptyState } from "../components/empty-state.js";
@@ -48,22 +47,16 @@ function viewToEntity(view: AgentTaskView): AgentTaskEntity {
 }
 
 export const AgentTasksView: React.NamedExoticComponent<AgentTasksViewProps> = React.memo(
-  function AgentTasksView({
-    provider,
-    intervalMs,
-    active,
-    cursor,
-  }: AgentTasksViewProps): React.ReactNode {
+  function AgentTasksView({ provider, active, cursor }: AgentTasksViewProps): React.ReactNode {
     const fetcher = useCallback(async (): Promise<readonly AgentTaskView[]> => {
       return provider.getAgentTasks ? provider.getAgentTasks() : [];
     }, [provider]);
-    const { data, loading, isStale, error, refresh } = useEventDrivenData<readonly AgentTaskView[]>(
+    const { data, loading, isStale, error } = useEventDrivenData<readonly AgentTaskView[]>(
       fetcher,
       undefined,
       undefined,
       active,
     );
-    useInterval(refresh, intervalMs, active && provider.getAgentTasks !== undefined);
 
     const entities = useMemo(() => (data ?? []).map(viewToEntity), [data]);
     const selected = cursor >= 0 && cursor < entities.length ? entities[cursor] : undefined;

--- a/src/tui/views/agent-tasks.tsx
+++ b/src/tui/views/agent-tasks.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useMemo } from "react";
 import type { AgentTaskEntity, AgentTaskView } from "../../core/agent-task.js";
 import { agentTaskViewToEntity, isAgentTaskSpecStale } from "../../core/agent-task.js";
+import { useInterval } from "../../local/use-interval.js";
 import { formatTimestamp } from "../../shared/format.js";
 import { ConditionChips } from "../components/condition-chips.js";
 import { EmptyState } from "../components/empty-state.js";
@@ -47,16 +48,22 @@ function viewToEntity(view: AgentTaskView): AgentTaskEntity {
 }
 
 export const AgentTasksView: React.NamedExoticComponent<AgentTasksViewProps> = React.memo(
-  function AgentTasksView({ provider, active, cursor }: AgentTasksViewProps): React.ReactNode {
+  function AgentTasksView({
+    provider,
+    intervalMs,
+    active,
+    cursor,
+  }: AgentTasksViewProps): React.ReactNode {
     const fetcher = useCallback(async (): Promise<readonly AgentTaskView[]> => {
       return provider.getAgentTasks ? provider.getAgentTasks() : [];
     }, [provider]);
-    const { data, loading, isStale, error } = useEventDrivenData<readonly AgentTaskView[]>(
+    const { data, loading, isStale, error, refresh } = useEventDrivenData<readonly AgentTaskView[]>(
       fetcher,
       undefined,
       undefined,
       active,
     );
+    useInterval(refresh, intervalMs, active && provider.getAgentTasks !== undefined);
 
     const entities = useMemo(() => (data ?? []).map(viewToEntity), [data]);
     const selected = cursor >= 0 && cursor < entities.length ? entities[cursor] : undefined;

--- a/tests/tui/codex-claude-handoff-e2e.ts
+++ b/tests/tui/codex-claude-handoff-e2e.ts
@@ -15,6 +15,8 @@
  *   --keep          Leave the tmux session + work dir behind for inspection
  *   --attach        Print `tmux attach` command and wait
  *   --timeout <ms>  Overall budget (default 600000)
+ *   --nexus-source <path>  Build/start Nexus from local source
+ *   --nexus-image <ref>    Pin Nexus image ref (for prebuilt local test images)
  */
 
 import { execSync, spawnSync } from "node:child_process";
@@ -22,8 +24,9 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
-const SOCKET = "grove-cx-cl-e2e";
+const SOCKET = process.env.GROVE_E2E_TMUX_SOCKET ?? `grove-cx-cl-e2e-${process.pid}`;
 const SESSION = "grove-cx-cl-e2e";
 const PROJECT_ROOT = join(import.meta.dir, "..", "..");
 
@@ -34,11 +37,32 @@ const { values } = parseArgs({
     keep: { type: "boolean", default: false },
     attach: { type: "boolean", default: false },
     timeout: { type: "string", default: "600000" },
+    "nexus-source": { type: "string" },
+    "nexus-image": { type: "string" },
   },
 });
 const KEEP = values.keep;
 const ATTACH = values.attach;
 const BUDGET_MS = Number.parseInt(values.timeout as string, 10);
+const NEXUS_SOURCE = values["nexus-source"] as string | undefined;
+const NEXUS_IMAGE = values["nexus-image"] as string | undefined;
+const SOURCE_SETUP_TIMEOUT_MS = (() => {
+  const parsed = Number.parseInt(process.env.GROVE_E2E_SOURCE_SETUP_TIMEOUT_MS ?? "1200000", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1_200_000;
+})();
+
+interface NexusYaml {
+  services?: unknown;
+  compose_profiles?: unknown;
+  ports?: Record<string, unknown> | undefined;
+  api_key?: unknown;
+  [key: string]: unknown;
+}
+
+interface NexusListResponse {
+  items?: Array<{ path?: string; isDirectory?: boolean }>;
+  detail?: string;
+}
 
 // ─── tmux helpers ─────────────────────────────────────────────────────
 function tmux(cmd: string, opts: { check?: boolean } = {}): string {
@@ -68,13 +92,110 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+function shQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function removeString(values: unknown, removed: string): string[] | undefined {
+  if (!Array.isArray(values)) return undefined;
+  return values.filter((value): value is string => typeof value === "string" && value !== removed);
+}
+
+function dropOptionalSearchService(nexusYamlPath: string): void {
+  const parsed = parseYaml(readFileSync(nexusYamlPath, "utf-8")) as NexusYaml | null;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`Unable to parse Nexus YAML at ${nexusYamlPath}`);
+  }
+
+  const services = removeString(parsed.services, "zoekt");
+  const profiles = removeString(parsed.compose_profiles, "search");
+  if (services) parsed.services = services;
+  if (profiles) parsed.compose_profiles = profiles;
+
+  const ports = parsed.ports;
+  if (ports && typeof ports === "object" && !Array.isArray(ports)) {
+    const nextPorts: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(ports)) {
+      if (key !== "zoekt") nextPorts[key] = value;
+    }
+    parsed.ports = nextPorts;
+  }
+
+  writeFileSync(nexusYamlPath, stringifyYaml(parsed), "utf-8");
+}
+
+function tailFileIfExists(path: string, maxChars = 200_000): string {
+  if (!existsSync(path)) return "";
+  const content = readFileSync(path, "utf-8");
+  return content.length > maxChars ? content.slice(-maxChars) : content;
+}
+
+function hasCoderWorkSignal(text: string): boolean {
+  return /\[(?:seenCids|contribution)\].*kind=work role=coder/i.test(text);
+}
+
+function hasHandoffSignal(text: string): boolean {
+  return (
+    /\[nexus-ipc\] SEND OK sender=coder recipient=reviewer/i.test(text) ||
+    /\[eventBus\] handoff event/i.test(text) ||
+    /\[nexus-handoff\].*total=[1-9]/i.test(text) ||
+    /\[NexusHandoffStore\.readModifyWrite\].*count=[1-9]/i.test(text)
+  );
+}
+
+function hasReviewSignal(text: string): boolean {
+  return (
+    /\[(?:seenCids|contribution)\].*kind=review role=reviewer/i.test(text) ||
+    /\[contribution\].*kind=discussion role=reviewer summary="\[DONE\] Approved/i.test(text)
+  );
+}
+
+function hasCompletionSignal(text: string): boolean {
+  return (
+    /Session Complete/i.test(text) ||
+    /Reason:\s*Session signaled done/i.test(text) ||
+    /review-loop[\s\S]{0,80}Complete/i.test(text)
+  );
+}
+
+function encodeSegment(value: string): string {
+  return value.replaceAll("%", "%25").replaceAll("/", "%2F");
+}
+
+function readNexusApiKey(nexusYamlPath: string): string | undefined {
+  const parsed = parseYaml(readFileSync(nexusYamlPath, "utf-8")) as NexusYaml | null;
+  return typeof parsed?.api_key === "string" && parsed.api_key.length > 0
+    ? parsed.api_key
+    : undefined;
+}
+
+async function listNexusDir(
+  nexusUrl: string,
+  apiKey: string,
+  path: string,
+): Promise<NexusListResponse> {
+  const params = new URLSearchParams({ path });
+  const res = await fetch(`${nexusUrl}/api/v2/files/list?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  const body = (await res.json()) as NexusListResponse;
+  if (!res.ok) {
+    throw new Error(`Nexus list failed for ${path}: HTTP ${res.status} ${JSON.stringify(body)}`);
+  }
+  if (body.detail) {
+    throw new Error(`Nexus list failed for ${path}: ${body.detail}`);
+  }
+  return body;
+}
+
 async function waitForPane(predicate: (pane: string) => boolean, phase: string, maxMs = 60000) {
-  const deadline = Date.now() + maxMs;
+  const started = Date.now();
+  const deadline = started + maxMs;
   let last = "";
   while (Date.now() < deadline) {
     last = capturePane();
     if (predicate(last)) {
-      console.log(`[${phase}] matched in ${60000 - (deadline - Date.now())}ms`);
+      console.log(`[${phase}] matched in ${Date.now() - started}ms`);
       return last;
     }
     await sleep(1000);
@@ -163,18 +284,27 @@ async function main() {
     "[setup] patched GROVE.md: coder=codex (first occurrence), reviewer stays claude-code",
   );
 
+  const nexusYamlPath = join(repoDir, "nexus.yaml");
+  if (!existsSync(nexusYamlPath)) throw new Error(`nexus.yaml missing at ${nexusYamlPath}`);
+  dropOptionalSearchService(nexusYamlPath);
+  console.log("[setup] patched nexus.yaml: disabled optional search/zoekt service");
+
   // 5. Launch the TUI inside tmux. GROVE_DIR points at our temp grove.
   //    Use `--url` is not what we want — we want the interactive flow.
   // Wrap the TUI launch in a subshell that captures the exit code and
   // writes it to a file — the `; cat` at the end keeps the pane alive
   // so we can see the output even on crash.
   const stdoutLog = join(workDir, "tui.stdout.log");
+  const debugPath = join(workDir, "grove-debug.log");
+  const nexusSourceArgs = NEXUS_SOURCE ? ` --nexus-source ${shQuote(NEXUS_SOURCE)}` : "";
+  const nexusImageEnv = NEXUS_IMAGE ? `NEXUS_IMAGE_REF=${shQuote(NEXUS_IMAGE)} ` : "";
+  const healthTimeoutMs = NEXUS_SOURCE ? 120000 : 30000;
   // GROVE_ALLOW_ALL_PERMISSIONS=1 disables the RulesResolver gate so codex/claude
   // child processes are actually allowed to Edit + execute + fetch — otherwise
   // the coder cannot write hello.txt and the loop never produces a contribution.
   const launchCmd = [
     `cd ${repoDir}`,
-    `GROVE_ALLOW_ALL_PERMISSIONS=1 GROVE_DEBUG_LOG=${join(workDir, "grove-debug.log")} bun run ${PROJECT_ROOT}/src/cli/main.ts 2>&1 | tee ${stdoutLog}`,
+    `${nexusImageEnv}GROVE_SERVICE_HEALTH_TIMEOUT_MS=${healthTimeoutMs} GROVE_ALLOW_ALL_PERMISSIONS=1 GROVE_DEBUG_LOG=${debugPath} bun run ${PROJECT_ROOT}/src/cli/main.ts up --grove ${groveDir}${nexusSourceArgs} 2>&1 | tee ${stdoutLog}`,
     `echo [EXIT $?]`,
     `cat`, // keep pane alive
   ].join(" ; ");
@@ -228,12 +358,13 @@ async function main() {
   // 8. Default cursor is on first preset (review-loop). Pick it.
   tmuxSendKeys(["Enter"]);
 
-  // 9. Wait for goal-input screen — Nexus boot + service spawn can take a while,
-  //    but the goal screen renders before any of that is required.
+  // 9. Wait for goal-input screen. Source-backed Nexus builds can take several
+  //    minutes before the TUI can advance past setup.
+  const goalInputTimeoutMs = NEXUS_SOURCE ? SOURCE_SETUP_TIMEOUT_MS : 240_000;
   await waitForPane(
     (p) => /Goal|goal/.test(p) && /Continue|Esc:back|continue/i.test(p),
     "goal-input",
-    240000,
+    goalInputTimeoutMs,
   );
   console.log("[phase 2] goal-input screen visible");
 
@@ -279,75 +410,111 @@ async function main() {
   let sawCoderWork = false;
   let sawHandoff = false;
   let sawReview = false;
+  let sawComplete = false;
   let lastCapture = "";
   while (Date.now() < observeEnd) {
     await sleep(15000);
     lastCapture = capturePane();
+    const evidence = tailFileIfExists(debugPath);
     const headline = lastCapture.split("\n").slice(0, 5).join(" | ");
     const elapsed = Math.round((Date.now() - (observeEnd - OBSERVE_MS)) / 1000);
     console.log(`[observe t+${elapsed}s] ${headline.slice(0, 120)}`);
-    if (!sawCoderWork && /submit_work|coder.*contribution|kind.?work/i.test(lastCapture)) {
+    if (!sawCoderWork && hasCoderWorkSignal(evidence)) {
       sawCoderWork = true;
       console.log("[phase 5] coder work submission detected");
     }
-    if (!sawHandoff && /handoff/i.test(lastCapture)) {
+    if (!sawHandoff && hasHandoffSignal(evidence)) {
       sawHandoff = true;
       console.log("[phase 5] handoff event detected");
     }
-    if (!sawReview && /submit_review|reviewer.*contribution|kind.?review/i.test(lastCapture)) {
+    if (!sawReview && hasReviewSignal(evidence)) {
       sawReview = true;
       console.log("[phase 5] reviewer submission detected");
     }
-    if (sawHandoff && sawReview) break;
+    if (!sawComplete && hasCompletionSignal(lastCapture)) {
+      sawComplete = true;
+      console.log("[phase 5] session completion detected in tmux pane");
+    }
+    if (sawCoderWork && sawHandoff && sawReview && sawComplete) break;
   }
 
   // 15. Final capture + debug log tail.
+  const finalPane = capturePane();
+  sawComplete ||= hasCompletionSignal(finalPane);
   console.log("\n──── final pane ────");
-  console.log(capturePane());
+  console.log(finalPane);
   console.log("──── end final pane ────");
 
-  const debugPath = join(workDir, "grove-debug.log");
   if (existsSync(debugPath)) {
-    const debug = execSync(`tail -300 ${debugPath}`, { encoding: "utf-8" });
+    const debug = tailFileIfExists(debugPath).split("\n").slice(-300).join("\n");
     console.log("──── debug tail ────");
     console.log(debug);
     console.log("──── end debug tail ────");
+
+    const finalEvidence = debug;
+    sawCoderWork ||= hasCoderWorkSignal(finalEvidence);
+    sawHandoff ||= hasHandoffSignal(finalEvidence);
+    sawReview ||= hasReviewSignal(finalEvidence);
+  }
+
+  if (NEXUS_SOURCE) {
+    const stdout = existsSync(stdoutLog) ? readFileSync(stdoutLog, "utf-8") : "";
+    const sourceLabel = `source build from ${NEXUS_SOURCE}`;
+    if (!stdout.includes(sourceLabel)) {
+      throw new Error(`Source-backed Nexus validation failed — missing "${sourceLabel}"`);
+    }
+    console.log(`[nexus] source build validated: ${NEXUS_SOURCE}`);
   }
 
   // 16. Validate via Nexus VFS — contributions + handoffs should be there.
   console.log("\n[phase 6] querying Nexus VFS for contributions + handoffs");
-  try {
-    const groveJsonPath = join(groveDir, "grove.json");
-    const apiKeyPath = join(groveDir, "api-key");
-    const groveJson = JSON.parse(readFileSync(groveJsonPath, "utf-8")) as {
-      nexusUrl?: string;
-    };
-    const nexusUrl = groveJson.nexusUrl;
-    if (nexusUrl && existsSync(apiKeyPath)) {
-      const apiKey = readFileSync(apiKeyPath, "utf-8").trim();
-      for (const dir of [
-        "/zones/default/contributions",
-        "/zones/default/handoffs",
-        "/zones/default/sessions",
-      ]) {
-        const res = execSync(
-          `curl -s -X POST '${nexusUrl}/api/nfs/sys_readdir' ` +
-            `-H 'Authorization: Bearer ${apiKey}' -H 'Content-Type: application/json' ` +
-            `-d '${JSON.stringify({ path: dir })}'`,
-          { encoding: "utf-8" },
-        );
-        console.log(`[nexus] ${dir}: ${res.slice(0, 400)}`);
-      }
-    } else {
-      console.log("[nexus] no nexusUrl/api-key — skipping VFS validation");
-    }
-  } catch (err) {
-    console.log(`[nexus] validation failed: ${(err as Error).message}`);
+  const groveJsonPath = join(groveDir, "grove.json");
+  const namespacePath = join(groveDir, "namespace");
+  const currentSessionPath = join(groveDir, "current-session.json");
+  const groveJson = JSON.parse(readFileSync(groveJsonPath, "utf-8")) as {
+    nexusUrl?: string;
+  };
+  const nexusUrl = groveJson.nexusUrl;
+  const nexusApiKey = readNexusApiKey(nexusYamlPath);
+  if (!nexusUrl || !nexusApiKey) {
+    throw new Error("Nexus VFS validation unavailable — missing nexusUrl or nexus.yaml api_key");
+  }
+  const zoneId = readFileSync(namespacePath, "utf-8").trim();
+  const currentSession = JSON.parse(readFileSync(currentSessionPath, "utf-8")) as {
+    sessionId?: string;
+  };
+  const sessionId = currentSession.sessionId;
+  if (!sessionId) throw new Error("Nexus VFS validation unavailable — missing sessionId");
+
+  const encodedZoneRoot = `/zones/${encodeSegment(zoneId)}`;
+  const rawZoneRoot = `/zones/${zoneId}`;
+  const contributionList = await listNexusDir(
+    nexusUrl,
+    nexusApiKey,
+    `${encodedZoneRoot}/sessions/${encodeSegment(sessionId)}/contributions`,
+  );
+  const handoffList = await listNexusDir(nexusUrl, nexusApiKey, `${rawZoneRoot}/handoffs`);
+  const sessionList = await listNexusDir(nexusUrl, nexusApiKey, `${rawZoneRoot}/sessions`);
+  console.log(
+    `[nexus] contributions=${contributionList.items?.length ?? 0} handoffs=${handoffList.items?.length ?? 0} sessions=${sessionList.items?.length ?? 0}`,
+  );
+  if ((contributionList.items?.length ?? 0) < 2) {
+    throw new Error("Nexus VFS validation failed — expected at least work + review contributions");
+  }
+  if ((handoffList.items?.length ?? 0) < 1) {
+    throw new Error("Nexus VFS validation failed — expected at least one handoff record");
+  }
+  if ((sessionList.items?.length ?? 0) < 1) {
+    throw new Error("Nexus VFS validation failed — expected at least one session record");
   }
 
-  console.log(`\n[result] coderWork=${sawCoderWork} handoff=${sawHandoff} review=${sawReview}`);
-  if (!sawHandoff || !sawReview) {
-    throw new Error(`E2E incomplete — handoff=${sawHandoff} review=${sawReview}`);
+  console.log(
+    `\n[result] coderWork=${sawCoderWork} handoff=${sawHandoff} review=${sawReview} complete=${sawComplete}`,
+  );
+  if (!sawCoderWork || !sawHandoff || !sawReview || !sawComplete) {
+    throw new Error(
+      `E2E incomplete — coderWork=${sawCoderWork} handoff=${sawHandoff} review=${sawReview} complete=${sawComplete}`,
+    );
   }
   console.log("[result] E2E PASSED — codex → claude handoff completed");
 }


### PR DESCRIPTION
## Summary

Fixes #188 by tightening the live TUI handoff path and validating it through the real tmux-driven Codex -> Claude operator flow.

- Make Nexus source builds explicit and avoid accidentally reusing an existing Nexus install for E2E runs.
- Harden the Nexus websocket bridge against duplicate/out-of-order handoff delivery events after replies or terminal states.
- Update the running TUI surface terminology and detail lifecycle so the live contribution feed reflects event/snapshot semantics instead of implying stale polling.
- Add regression coverage for service lifecycle shutdown, monitor updates, MCP reaper targeting, websocket handoff transitions, and the tmux E2E harness.

## Root Cause

The live handoff path could still fail under realistic event ordering: duplicate delivery events could be processed after a handoff was already replied to, which produced invalid handoff transition errors and kept the end-to-end TUI path from being fully reliable. The E2E harness also needed to prove the feature against a source-built Nexus instead of silently falling back to an already-running service.

## Validation

- `bunx biome check ...` on touched files: passed
- `git diff --check`: passed
- `bun run typecheck`: passed
- `bun run build`: passed
- `bun test src/cli/nexus-lifecycle.test.ts`: 61 pass, 0 fail
- `bun test src/tui/nexus-ws-bridge.test.ts`: 46 pass, 0 fail; command exits non-zero only because repo-wide coverage thresholds are enforced on the focused subset
- `bun run test`: 8066 pass, 7 skip, 0 fail; command exits non-zero because the existing repo-wide coverage gate is below 80%
- `PATH="$HOME/.bun/bin:$PATH" git push -u origin codex/grove-e2e-handoff`: pre-push `typecheck` and `build` hooks passed
- Real tmux E2E source-backed run passed:
  `PATH="$HOME/.bun/bin:$PATH" bun run tests/tui/codex-claude-handoff-e2e.ts --nexus-source /Users/tafeng/nexus --timeout 1800000 --keep`

E2E result included source build validation, 4 contributions, 1 handoff, 1 session, reviewer submission, completion pane, and Nexus VFS validation.
