### PR TITLE
[codex] TUI leader-key presets and configurable keymaps

### DIFF
--- a/docs/superpowers/specs/2026-05-26-tui-leader-key-keymaps-design.md
+++ b/docs/superpowers/specs/2026-05-26-tui-leader-key-keymaps-design.md
@@ -1,0 +1,311 @@
+# TUI Leader-Key Keymaps - Design
+
+**Issue:** [windoliver/grove#186](https://github.com/windoliver/grove/issues/186)
+**Date:** 2026-05-26
+**Status:** Approved design
+
+## Problem
+
+The inspect TUI still routes most normal-mode keys through a flat set of direct bindings in `src/tui/hooks/use-keyboard-handler.ts`. Core panels use numbers, operator panels use punctuation from `PANEL_REGISTRY`, and several global or panel-local actions are hard-coded in the router, help overlay, and status bar.
+
+This is hard to scale:
+
+- New panels consume more punctuation keys.
+- Help and status text can drift from the actual router.
+- User overrides only cover a subset of actions.
+- Existing override loading handles single keys, not leader-key sequences.
+- First-run keymap choices exist, but they are `vim` / `emacs` presets rather than the issue's `default` / `power-user` operating modes.
+
+## Goals
+
+- Introduce a leader-key grammar for normal-mode TUI actions.
+- Ship two built-in presets: `default` and `power-user`.
+- Persist user keymap choices and overrides through the existing config stack.
+- Route normal-mode actions from the active resolved keymap rather than scattered hard-coded keys.
+- Render help overlay and status bar hints from the same resolved keymap used by routing.
+- Keep modal text entry and terminal input modes protected from leader-key interception.
+- Preserve a narrow compatibility path for existing user config keys while moving the product surface to `default` / `power-user`.
+
+## Non-Goals
+
+- No change to TUI business actions, panels, provider calls, or data loading.
+- No rewrite of the command palette.
+- No global app-wide keymap for welcome screens beyond the existing first-run keymap selection UI.
+- No arbitrary multi-stroke macro system; keymaps bind sequences to existing action ids only.
+- No plugin system for external keymap packages.
+
+## Current Anchors
+
+The implementation should build on these files:
+
+| File | Current role |
+| --- | --- |
+| `src/tui/hooks/use-keyboard-handler.ts` | Main normal-mode and modal key router |
+| `src/tui/hooks/use-keybinding-overrides.ts` | Existing action-to-key override loader and default actions |
+| `src/tui/config-loader.ts` | Layered `~/.config/grove/config.json`, `.grove/config.json`, and `GROVE_CONFIG` loader |
+| `src/tui/config-watcher.ts` | Live `~/.grove/hotkeys.yaml` watcher |
+| `src/tui/panels/panel-registry.ts` | Canonical panel list and existing panel keybindings |
+| `src/tui/components/help-overlay.tsx` | Help overlay currently mixing config-derived and hard-coded entries |
+| `src/tui/components/status-bar.tsx` | Status bar currently using hard-coded panel hint strings |
+| `src/tui/views/welcome/keymap-presets.ts` | First-run keymap preset persistence |
+| `src/tui/views/welcome/customize-keyboard.ts` | First-run keymap selector routing |
+
+## Design
+
+### Keymap Model
+
+Add a pure keymap module, `src/tui/keymap/keymap.ts`, that defines the stable contract used by routing and display:
+
+```ts
+export type TuiActionId =
+  | "quit"
+  | "help"
+  | "palette"
+  | "refresh"
+  | "zoom_cycle"
+  | "zoom_reset"
+  | "layout_toggle"
+  | "view_cycle"
+  | "focus_panel"
+  | "toggle_panel"
+  | "cycle_panel_next"
+  | "cycle_panel_prev"
+  | "search_start"
+  | "terminal_input"
+  | "compare_toggle"
+  | "artifact_prev"
+  | "artifact_next"
+  | "artifact_diff"
+  | "approve"
+  | "deny"
+  | "broadcast"
+  | "direct_message";
+
+export interface KeySequence {
+  readonly keys: readonly string[];
+}
+
+export interface KeyBinding {
+  readonly action: TuiActionId;
+  readonly sequence: KeySequence;
+  readonly label: string;
+  readonly context: "global" | "panel" | "navigation";
+  readonly panel?: Panel | undefined;
+  readonly args?: Readonly<Record<string, string | number>> | undefined;
+}
+
+export interface ResolvedKeymap {
+  readonly preset: "default" | "power-user";
+  readonly bindings: readonly KeyBinding[];
+}
+```
+
+`focus_panel` and `toggle_panel` carry the target panel id in `args.panel`. Specific actions such as `artifact_prev` remain separate because their code paths are not panel registry operations.
+
+### Leader Grammar
+
+Use `Space` as the default leader key because it is common in terminal UIs and is currently not used by normal-mode routing. Escape cancels a pending leader sequence. Modal input modes continue to consume printable characters before normal-mode keymap resolution runs.
+
+Default leader groups:
+
+| Sequence | Action |
+| --- | --- |
+| `Space ?` | Help |
+| `Space q` | Quit |
+| `Space r` | Refresh |
+| `Space p 1` ... `Space p 4` | Focus core panels |
+| `Space p a` | Toggle Agents |
+| `Space p t` | Toggle Terminal |
+| `Space p f` | Toggle Frontier |
+| `Space p c` | Toggle Claims |
+| `Space p s` | Toggle Search |
+| `Space p v` | Toggle VFS |
+| `Space z` | Zoom cycle |
+| `Space Z` | Zoom reset |
+| `Space l` | Toggle layout |
+| `Space V` | Cycle grid / pipeline view |
+| `Space m b` | Broadcast |
+| `Space m @` | Direct message |
+| `Space c p` | Command palette |
+
+Direct navigation keys stay direct in both presets:
+
+- `j` / `down`: cursor down
+- `k` / `up`: cursor up
+- `Enter`: select
+- `Tab` / `Shift+Tab`: cycle focused panel
+- `Esc`: back, cancel, or zoom reset depending on current state
+
+Panel-local keys stay available when they are efficient and unlikely to conflict:
+
+- Terminal panel: `i`, `j`, `k`, `G`
+- Artifact panel: `h`, `l`, `d`
+- Frontier panel: compare action
+- Decisions panel: approve / deny
+- Search panel: `/`
+
+The keymap model can still represent those direct bindings as one-key sequences, which lets help and status rendering use one source of truth.
+
+### Built-In Presets
+
+Add `src/tui/keymaps/default.json` and `src/tui/keymaps/power-user.json`.
+
+`default` should prefer leader-key sequences for global actions and panel access. It should keep only essential navigation and panel-local keys direct.
+
+`power-user` should include the same leader sequences plus direct aliases for existing muscle memory:
+
+- `q`, `?`, `r`, `+`
+- `1` through `4` for core panels
+- existing panel registry keys for operator panel toggles
+- `b` and `@` for messaging
+- `m` and `Ctrl+P` for palette entry
+- existing panel-specific direct actions
+
+The direct aliases are additive. They should not replace leader bindings, so help can show both when useful and a user can still learn the structured grammar.
+
+### User Configuration
+
+Extend `GroveUserConfig` with a top-level `keymapPreset?: "default" | "power-user"` while preserving the existing `keymap` object for overrides.
+
+Config example:
+
+```json
+{
+  "keymapPreset": "power-user",
+  "keymap": {
+    "quit": "Space x",
+    "refresh": "F5",
+    "toggle_panel:terminal": "Space p t"
+  }
+}
+```
+
+Override keys are parsed as whitespace-separated sequences. Existing single-key override values continue to work. The loader should accept existing action ids from `REMAPPABLE_ACTIONS` and the new parameterized panel ids:
+
+- `focus_panel:dag`
+- `focus_panel:detail`
+- `focus_panel:frontier`
+- `focus_panel:claims`
+- `toggle_panel:terminal`
+- `toggle_panel:search`
+- and the rest of `PANEL_REGISTRY`
+
+Layering order:
+
+1. Built-in preset (`default` if unspecified)
+2. `config.json` `keymap`
+3. live `~/.grove/hotkeys.yaml`
+4. legacy `.grove/keybindings.json`
+
+Later layers win for the same action id. If two action ids resolve to the same sequence, the first binding in resolved order wins and the losing conflict is reported to stderr. This matches the existing first-win conflict behavior while making the final source explicit.
+
+### Sequence Resolver
+
+Replace the current single-key reverse map with a pure sequence resolver:
+
+```ts
+export type KeymapResolution =
+  | { readonly kind: "pending"; readonly prefix: readonly string[] }
+  | { readonly kind: "match"; readonly binding: KeyBinding }
+  | { readonly kind: "miss" };
+```
+
+`routeKey` owns the pending prefix state through a new `leaderPrefix` field in the app keyboard reducer, or through a small hook wrapping `routeKey`. The pure resolver should be tested without React:
+
+- leader alone returns `pending`
+- a valid prefix returns `pending`
+- a complete sequence returns `match`
+- an invalid sequence returns `miss` and clears the prefix
+- Escape clears a pending prefix before normal Escape behavior runs
+
+Routing still checks modal modes first. The resolver only runs in `InputMode.Normal`, after global hard-wired controls that must remain universal (`Ctrl+P` command palette toggle and Escape cancel/back behavior), and before legacy hard-coded normal-mode handlers. As implementation progresses, those legacy branches should be deleted once each action has a keymap binding and tests prove parity.
+
+### Action Dispatch
+
+Add an `executeKeymapAction(binding, actions)` helper near `routeKey`. It maps action ids to existing callbacks:
+
+- `quit` -> `actions.onQuit()`
+- `help` -> `panels.setMode(InputMode.Help)`
+- `focus_panel` -> `panels.focus(panel)`
+- `toggle_panel` -> `panels.toggle(panel)`
+- `palette` -> `actions.onSpawnPalette()` and command palette mode
+- `broadcast` / `direct_message` -> existing message mode callbacks
+- panel-local actions keep their current focus guards
+
+The helper should return `true` when it handled the binding and `false` when the binding is invalid for current focus. Invalid-for-context bindings should still consume the key sequence to avoid accidentally falling through into unrelated direct actions.
+
+### Help Overlay
+
+Replace local binding arrays in `help-overlay.tsx` with a presenter that receives the active `ResolvedKeymap`. The overlay groups bindings by context:
+
+- Global
+- Navigation
+- Panels
+- Focused panel
+- Messaging
+
+For panel sections, derive labels from `PANEL_REGISTRY` and `PANEL_LABELS`. If multiple bindings point to the same action, show the preferred binding first and optional aliases after it, such as `Space p t / 6`.
+
+### Status Bar
+
+Update `StatusBar` props to accept the active keymap or a precomputed hint list. The hint selection should be derived from bindings relevant to current mode, detail state, and focused panel.
+
+The status bar should stay compact. Suggested default forms:
+
+- Default preset: `Space:leader  Tab:cycle  j/k:nav  Enter:select  ?:help`
+- While a leader prefix is pending: `Space p ...  Esc:cancel`
+- Terminal panel: `Space p t:panel  i:input  j/k:scroll  ?:help`
+- Search panel: `Space p s:panel  /:search  j/k:nav  ?:help`
+
+This removes the current hard-coded punctuation ranges such as `5-\`:toggle`.
+
+### First-Run Experience
+
+Change the first-run keymap choices from `vim`, `emacs`, and `none` to `default`, `power-user`, and `none`.
+
+- Fast path should choose `default`.
+- Customize should default to `default`.
+- Selecting `power-user` writes `"keymapPreset": "power-user"` to `~/.config/grove/config.json`.
+- Selecting `default` writes `"keymapPreset": "default"` only when the config file already exists or when another first-run setting is being persisted; otherwise the implicit default is enough.
+- Existing `vim` and `emacs` JSON presets may remain in the tree temporarily, but they should not be shown in new UI copy.
+
+## Testing
+
+Use TDD for implementation. Minimum tests:
+
+- `keymap` resolver tests for pending, match, miss, conflict, and Escape cancellation.
+- Built-in preset tests proving `default` has leader panel access and `power-user` keeps direct aliases.
+- Config loader tests for `keymapPreset`, sequence parsing, and compatibility with existing single-key `keymap` values.
+- `routeKey` tests proving leader sequences call the expected existing callbacks.
+- `routeKey` tests proving modal input modes are not intercepted by leader sequences.
+- Help overlay tests proving rendered keys come from the active keymap.
+- Status bar tests proving hints change when preset, focused panel, or pending leader prefix changes.
+- First-run customize keyboard tests for `default` / `power-user` / `none` selection.
+
+Run targeted Bun tests during development, then finish with:
+
+```bash
+bun test src/tui/hooks/use-keyboard-handler.test.ts src/tui/hooks/use-keybinding-overrides.test.ts src/tui/config-loader.test.ts src/tui/components/help-overlay.test.ts src/tui/components/status-bar.test.tsx src/tui/views/welcome/customize-keyboard.test.ts src/tui/views/welcome/keymap-presets.test.ts
+bun run typecheck
+bun run check
+```
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Space conflicts with a future normal-mode action | Reserve Space as leader in the keymap module and route it before direct normal-mode actions. |
+| Users with existing `vim` or `emacs` config lose behavior | Keep existing `keymap` overrides valid; do not delete old preset files in this issue unless a migration test proves compatibility. |
+| Help gets noisy if every alias is shown | Mark one binding per action as preferred and collapse aliases to one slash-separated key cell. |
+| Leader state leaks into modal input | Resolver only runs in `InputMode.Normal`; tests cover search, message, goal, terminal, and command palette modes. |
+| Panel ids in config drift from `PANEL_REGISTRY` | Generate valid panel action ids from `PANEL_REGISTRY` instead of duplicating a list. |
+
+## Acceptance Criteria
+
+- Core actions are reachable through the leader-key grammar without relying on a growing punctuation map.
+- `default` and `power-user` presets are available and selectable from first-run customization.
+- Users can override keybindings in config without patching source.
+- Help overlay reflects the active preset and user overrides.
+- Status bar reflects the active preset, focused panel, and pending leader prefix.
+- Existing modal input behavior is unchanged.
+- Existing direct keys remain available in `power-user` where they were already part of the TUI's normal-mode workflow.

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1169,6 +1169,8 @@ export function App({
           isDetailView={nav.isDetailView}
           error={lastError}
           focusedPanel={panels.state.focused}
+          resolvedKeymap={resolvedKeymap}
+          keymapPrefix={keymapPrefix}
           agentCount={paletteSessions?.filter((s) => s.startsWith("grove-")).length}
           viewMode={panels.state.viewMode}
           costLabel={

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -36,7 +36,6 @@ import { useProviderScoped } from "./hooks/informer-context.js";
 import { useRelistTrigger } from "./hooks/refresh-context.js";
 import { useEventDrivenData } from "./hooks/use-event-driven-data.js";
 import {
-  buildKeyActionMap,
   type KeybindingOverrides,
   useKeybindingOverrides,
 } from "./hooks/use-keybinding-overrides.js";
@@ -136,7 +135,6 @@ export function App({
     () => ({ ...userConfig?.keymap, ...hotkeyOverrides, ...fileOverrides }),
     [userConfig?.keymap, hotkeyOverrides, fileOverrides],
   );
-  const keyActionMap = useMemo(() => buildKeyActionMap(keybindingOverrides), [keybindingOverrides]);
   const resolvedKeymap = useMemo(
     () => resolveKeymapWithOverrides(userConfig?.keymapPreset ?? "default", keybindingOverrides),
     [userConfig?.keymapPreset, keybindingOverrides],
@@ -991,8 +989,6 @@ export function App({
       frontierCids: () => frontierCidsRef.current,
       selectedSession,
       hasTmux: tmux !== undefined,
-      keybindingOverrides,
-      keyActionMap,
       resolvedKeymap,
       keymapPrefix,
       onKeymapPrefixChange: setKeymapPrefix,
@@ -1055,8 +1051,6 @@ export function App({
       agentProfiles,
       topology,
       paletteParentId,
-      keybindingOverrides,
-      keyActionMap,
       resolvedKeymap,
       keymapPrefix,
       refreshAll,

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -45,6 +45,7 @@ import { nextZoom, routeKey } from "./hooks/use-keyboard-handler.js";
 import { useNavigation } from "./hooks/use-navigation.js";
 import { InputMode, usePanelFocus } from "./hooks/use-panel-focus.js";
 import { useTuiStatePersistence } from "./hooks/use-session-persistence.js";
+import { resolveKeymapWithOverrides } from "./keymap/keymap.js";
 import type { ZoomLevel } from "./panels/panel-manager.js";
 import { PanelManager } from "./panels/panel-manager.js";
 import {
@@ -136,7 +137,19 @@ export function App({
     [userConfig?.keymap, hotkeyOverrides, fileOverrides],
   );
   const keyActionMap = useMemo(() => buildKeyActionMap(keybindingOverrides), [keybindingOverrides]);
+  const resolvedKeymap = useMemo(
+    () => resolveKeymapWithOverrides(userConfig?.keymapPreset ?? "default", keybindingOverrides),
+    [userConfig?.keymapPreset, keybindingOverrides],
+  );
+  const [keymapPrefix, setKeymapPrefix] = useState<readonly string[]>([]);
   const [ks, dispatch] = useReducer(tuiReducer, INITIAL_KEYBOARD_STATE);
+  const resolvedKeymapRef = useRef(resolvedKeymap);
+
+  useEffect(() => {
+    if (resolvedKeymapRef.current === resolvedKeymap) return;
+    resolvedKeymapRef.current = resolvedKeymap;
+    setKeymapPrefix([]);
+  }, [resolvedKeymap]);
 
   // Restore persisted state on first load.
   // restoredRef gates both restore AND save — save must not run before restore.
@@ -980,6 +993,9 @@ export function App({
       hasTmux: tmux !== undefined,
       keybindingOverrides,
       keyActionMap,
+      resolvedKeymap,
+      keymapPrefix,
+      onKeymapPrefixChange: setKeymapPrefix,
       // Slice nav also resets the global cursor to 0 AND synchronously
       // clears the entries/cids refs. Without the cursor reset, switching
       // from a long slice (cursor=9) to a short slice (2 rows) leaves the
@@ -1041,6 +1057,8 @@ export function App({
       paletteParentId,
       keybindingOverrides,
       keyActionMap,
+      resolvedKeymap,
+      keymapPrefix,
       refreshAll,
       provider,
       spawnManager,

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1085,7 +1085,7 @@ export function App({
           visible={panels.state.mode === InputMode.Help}
           isDetailView={nav.isDetailView}
           focusedPanel={panels.state.focused}
-          keybindingOverrides={keybindingOverrides}
+          resolvedKeymap={resolvedKeymap}
         />
         {paletteVisible && (
           <box

--- a/src/tui/components/help-overlay.test.ts
+++ b/src/tui/components/help-overlay.test.ts
@@ -6,8 +6,69 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import React from "react";
+import type * as TestRendererTypes from "react-test-renderer";
 import { Panel } from "../hooks/use-panel-focus.js";
+import { resolveBuiltinKeymap } from "../keymap/keymap.js";
 import { PANEL_REGISTRY } from "../panels/panel-registry.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type RenderNode = {
+  readonly children?: readonly RenderChild[] | null;
+};
+type RenderChild = RenderNode | string;
+
+function textOf(node: RenderChild | null): string {
+  if (node === null) return "";
+  if (typeof node === "string") return node;
+  return (node.children ?? []).map((child) => textOf(child)).join("");
+}
+
+function sectionTexts(root: RenderNode | null): ReadonlyMap<string, string> {
+  const sections = root?.children?.[1];
+  if (typeof sections === "string") return new Map();
+  const entries = (sections?.children ?? [])
+    .filter((section): section is RenderNode => typeof section !== "string")
+    .map((section) => {
+      const titleNode = section.children?.[0];
+      const title = typeof titleNode === "string" ? titleNode : textOf(titleNode ?? null);
+      return [title, textOf(section)] as const;
+    });
+  return new Map(entries);
+}
+
+async function renderHelpOverlay(
+  props: {
+    readonly isDetailView?: boolean | undefined;
+    readonly focusedPanel?: Panel | undefined;
+  } = {},
+): Promise<TestRendererTypes.ReactTestRenderer> {
+  const TestRendererModule = await import("react-test-renderer");
+  const TestRenderer = (TestRendererModule as unknown as { default: typeof TestRendererTypes })
+    .default;
+  const { act } = TestRendererModule;
+  const { HelpOverlay } = await import("./help-overlay.js");
+
+  let renderer!: TestRendererTypes.ReactTestRenderer;
+  await act(async () => {
+    renderer = TestRenderer.create(
+      React.createElement(HelpOverlay, {
+        visible: true,
+        resolvedKeymap: resolveBuiltinKeymap("default"),
+        ...props,
+      }),
+    );
+  });
+  return renderer;
+}
+
+async function unmountHelpOverlay(renderer: TestRendererTypes.ReactTestRenderer): Promise<void> {
+  const { act } = await import("react-test-renderer");
+  await act(async () => {
+    renderer.unmount();
+  });
+}
 
 // ---------------------------------------------------------------------------
 // 1. Resolved keymap rendering
@@ -57,6 +118,42 @@ describe("HelpOverlay — focused panel sections", () => {
     expect(source).toContain("bindingsForPanel");
     // Must NOT contain standalone numeric panel comparisons
     expect(source).not.toMatch(/=== \d+/);
+  });
+
+  test("Panels section excludes focused-panel action bindings", async () => {
+    const renderer = await renderHelpOverlay();
+    const sections = sectionTexts(renderer.toJSON() as RenderNode | null);
+    const panels = sections.get("Panels") ?? "";
+
+    expect(panels).toContain("Toggle Terminal panel");
+    expect(panels).not.toContain("Enter terminal input mode");
+    expect(panels).not.toContain("Previous artifact");
+    expect(panels).not.toContain("Approve pending question");
+    expect(panels).not.toContain("Browse VFS entry");
+    await unmountHelpOverlay(renderer);
+  });
+
+  test("Focused Panel section excludes panel switching binding", async () => {
+    const renderer = await renderHelpOverlay({ focusedPanel: Panel.Artifact });
+    const sections = sectionTexts(renderer.toJSON() as RenderNode | null);
+    const focused = sections.get("Focused Panel") ?? "";
+
+    expect(focused).toContain("Previous artifact");
+    expect(focused).toContain("Toggle artifact diff");
+    expect(focused).not.toContain("Toggle Artifact panel");
+    await unmountHelpOverlay(renderer);
+  });
+
+  test("Detail view keeps navigation and panel sections", async () => {
+    const renderer = await renderHelpOverlay({ isDetailView: true });
+    const sections = sectionTexts(renderer.toJSON() as RenderNode | null);
+
+    expect(sections.has("Global")).toBe(true);
+    expect(sections.has("Detail View")).toBe(true);
+    expect(sections.has("Navigation")).toBe(true);
+    expect(sections.has("Panels")).toBe(true);
+    expect(sections.has("Messaging")).toBe(true);
+    await unmountHelpOverlay(renderer);
   });
 });
 

--- a/src/tui/components/help-overlay.test.ts
+++ b/src/tui/components/help-overlay.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for HelpOverlay:
- *   1. PANEL_BINDINGS completeness — every registered panel appears
+ *   1. Resolved keymap rendering
  *   2. Context-sensitive section rendering per focusedPanel
  *   3. visible=false renders nothing
  */
@@ -10,24 +10,25 @@ import { Panel } from "../hooks/use-panel-focus.js";
 import { PANEL_REGISTRY } from "../panels/panel-registry.js";
 
 // ---------------------------------------------------------------------------
-// 1. PANEL_BINDINGS completeness
+// 1. Resolved keymap rendering
 // ---------------------------------------------------------------------------
 
-describe("HelpOverlay — PANEL_BINDINGS completeness", () => {
-  test("every PANEL_REGISTRY entry's keybinding appears in PANEL_BINDINGS", async () => {
-    // We verify this by reading the module source: PANEL_BINDINGS is derived
-    // from PANEL_REGISTRY, so every registered panel must have a keybinding entry.
-    // This test ensures the derivation covers all panels — including new ones.
+describe("HelpOverlay — resolved keymap rendering", () => {
+  test("source accepts a resolvedKeymap prop", async () => {
     const { readFileSync } = await import("node:fs");
     const { resolve } = await import("node:path");
     const source = readFileSync(resolve(import.meta.dir, "help-overlay.tsx"), "utf-8");
 
-    // The panel bindings must be derived from PANEL_REGISTRY (not a hardcoded list).
-    expect(source).toContain("PANEL_REGISTRY");
-    expect(source).toContain("PANEL_BINDINGS");
+    expect(source).toContain("resolvedKeymap");
+    expect(source).toContain("formatKeySequence");
+  });
 
-    // Verify the derivation uses registry keybinding field.
-    expect(source).toContain("def.keybinding");
+  test("source no longer renders panel bindings from def.keybinding directly", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const source = readFileSync(resolve(import.meta.dir, "help-overlay.tsx"), "utf-8");
+
+    expect(source).not.toContain("def.keybinding");
   });
 
   test("every registered panel keybinding is distinct", () => {
@@ -41,30 +42,19 @@ describe("HelpOverlay — PANEL_BINDINGS completeness", () => {
     expect(planDef).toBeDefined();
     expect(planDef!.keybinding).toBe("`");
   });
-
-  test("core panels 1-4 are assigned to Dag/Detail/Frontier/Claims", () => {
-    const byKey = new Map(PANEL_REGISTRY.map((def) => [def.keybinding, def.panel]));
-    expect(byKey.get("1")).toBe(Panel.Dag);
-    expect(byKey.get("2")).toBe(Panel.Detail);
-    expect(byKey.get("3")).toBe(Panel.Frontier);
-    expect(byKey.get("4")).toBe(Panel.Claims);
-  });
 });
 
 // ---------------------------------------------------------------------------
-// 2. Context-sensitive sections — panel comparisons use Panel enum
+// 2. Context-sensitive sections — focused panel is still typed as Panel
 // ---------------------------------------------------------------------------
 
-describe("HelpOverlay — uses Panel enum constants (not magic numbers)", () => {
-  test("source uses Panel.Artifact not magic number 7", async () => {
+describe("HelpOverlay — focused panel sections", () => {
+  test("source derives focused panel bindings from resolved keymap", async () => {
     const { readFileSync } = await import("node:fs");
     const { resolve } = await import("node:path");
     const source = readFileSync(resolve(import.meta.dir, "help-overlay.tsx"), "utf-8");
-    expect(source).toContain("Panel.Artifact");
-    expect(source).toContain("Panel.Terminal");
-    expect(source).toContain("Panel.Search");
-    expect(source).toContain("Panel.Decisions");
-    expect(source).toContain("Panel.Frontier");
+
+    expect(source).toContain("bindingsForPanel");
     // Must NOT contain standalone numeric panel comparisons
     expect(source).not.toMatch(/=== \d+/);
   });

--- a/src/tui/components/help-overlay.tsx
+++ b/src/tui/components/help-overlay.tsx
@@ -6,13 +6,8 @@
  */
 
 import React from "react";
-import {
-  DEFAULT_KEY_ACTIONS,
-  type KeybindingOverrides,
-  type RemappableAction,
-} from "../hooks/use-keybinding-overrides.js";
-import { Panel } from "../hooks/use-panel-focus.js";
-import { PANEL_REGISTRY } from "../panels/panel-registry.js";
+import type { Panel } from "../hooks/use-panel-focus.js";
+import { formatKeySequence, type KeyBinding, type ResolvedKeymap } from "../keymap/keymap.js";
 import { theme } from "../theme.js";
 
 /** Props for the HelpOverlay component. */
@@ -21,100 +16,41 @@ export interface HelpOverlayProps {
   /** Whether the user is in a detail view (affects which bindings are shown). */
   readonly isDetailView?: boolean | undefined;
   /** Which panel is focused (for panel-specific hints). */
-  readonly focusedPanel?: number | undefined;
-  /** Active keybinding overrides — merged config + file-based. Shows remapped keys. */
-  readonly keybindingOverrides?: KeybindingOverrides | undefined;
-}
-
-/** Return the active key for a remappable action (override or default). */
-function activeKey(action: RemappableAction, overrides: KeybindingOverrides | undefined): string {
-  return overrides?.[action] ?? DEFAULT_KEY_ACTIONS[action];
+  readonly focusedPanel?: Panel | undefined;
+  /** Resolved active keymap, including preset defaults and user overrides. */
+  readonly resolvedKeymap: ResolvedKeymap;
 }
 
 /** A keybinding entry for display. */
-interface KeyBinding {
+interface KeyBindingEntry {
   readonly key: string;
   readonly description: string;
 }
 
-function globalBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
-  return [
-    { key: activeKey("help", overrides), description: "Toggle this help" },
-    { key: activeKey("quit", overrides), description: "Quit" },
-    { key: activeKey("zoom_reset", overrides), description: "Back / dismiss / reduce zoom" },
-    { key: "Ctrl+G", description: "Back to Session View" },
-    { key: "Ctrl+P", description: "Command palette" },
-    { key: "Tab", description: "Cycle panel focus" },
-    { key: "Shift+Tab", description: "Cycle panel focus (reverse)" },
-    { key: activeKey("zoom_cycle", overrides), description: "Zoom cycle (Normal → Half → Full)" },
-  ];
-}
-
-/** Panel keybindings derived from the registry — single source of truth. */
-const PANEL_BINDINGS: readonly KeyBinding[] = PANEL_REGISTRY.map((def) => ({
-  key: def.keybinding,
-  description: `${def.kind === "core" ? "Focus" : "Toggle"} ${def.label} panel`,
-}));
-
-function navigationBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
-  return [
-    { key: "j / \u2193", description: "Move cursor down" },
-    { key: "k / \u2191", description: "Move cursor up" },
-    { key: "Enter", description: "Select / expand" },
-    { key: "n", description: "Next page" },
-    { key: "p", description: "Previous page" },
-    { key: activeKey("refresh", overrides), description: "Refresh" },
-  ];
-}
-
-const DETAIL_BINDINGS: readonly KeyBinding[] = [
+const DETAIL_BINDINGS: readonly KeyBindingEntry[] = [
   { key: "Esc", description: "Back to list" },
   { key: "j / k", description: "Scroll content" },
 ];
 
-function artifactBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
-  return [
-    { key: `${activeKey("artifact_prev", overrides)} / \u2190`, description: "Previous artifact" },
-    { key: `${activeKey("artifact_next", overrides)} / \u2192`, description: "Next artifact" },
-    { key: activeKey("artifact_diff", overrides), description: "Toggle diff view" },
-  ];
+function bindingsForContext(
+  keymap: ResolvedKeymap,
+  context: KeyBinding["context"],
+): readonly KeyBinding[] {
+  return keymap.bindings.filter((binding) => binding.context === context && binding.preferred);
 }
 
-function terminalBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
-  return [
-    { key: activeKey("terminal_input", overrides), description: "Enter terminal input mode" },
-    { key: "Esc", description: "Exit terminal input mode" },
-  ];
+function bindingsForPanel(keymap: ResolvedKeymap, panel: Panel | undefined): readonly KeyBinding[] {
+  if (panel === undefined) return [];
+  return keymap.bindings.filter(
+    (binding) => binding.context === "panel" && binding.panel === panel && binding.preferred,
+  );
 }
 
-function searchBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
-  return [
-    { key: activeKey("search_start", overrides), description: "Enter search input mode" },
-    { key: "Enter", description: "Submit search query" },
-    { key: "Esc", description: "Cancel search input" },
-  ];
+function toDisplayBinding(binding: KeyBinding): KeyBindingEntry {
+  return { key: formatKeySequence(binding.sequence), description: binding.label };
 }
 
-function messagingBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
-  return [
-    { key: activeKey("broadcast", overrides), description: "Broadcast message to all agents" },
-    { key: activeKey("direct_message", overrides), description: "Direct message to agent" },
-    { key: "m", description: "MCP/ask-user manager" },
-  ];
-}
-
-function decisionsBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
-  return [
-    { key: activeKey("approve", overrides), description: "Approve pending question" },
-    { key: activeKey("deny", overrides), description: "Deny pending question" },
-  ];
-}
-
-function frontierBindings(overrides: KeybindingOverrides | undefined): readonly KeyBinding[] {
-  return [{ key: activeKey("compare_toggle", overrides), description: "Compare artifacts" }];
-}
-
-function renderSection(title: string, bindings: readonly KeyBinding[]): React.ReactNode {
+function renderSection(title: string, bindings: readonly KeyBindingEntry[]): React.ReactNode {
   return (
     <box flexDirection="column" key={title}>
       <box>
@@ -140,40 +76,39 @@ export const HelpOverlay: React.NamedExoticComponent<HelpOverlayProps> = React.m
     visible,
     isDetailView,
     focusedPanel,
-    keybindingOverrides,
+    resolvedKeymap,
   }: HelpOverlayProps): React.ReactNode {
     if (!visible) return null;
 
     const sections: React.ReactNode[] = [];
 
-    sections.push(renderSection("Global", globalBindings(keybindingOverrides)));
+    sections.push(
+      renderSection("Global", bindingsForContext(resolvedKeymap, "global").map(toDisplayBinding)),
+    );
 
     if (isDetailView) {
       sections.push(renderSection("Detail View", DETAIL_BINDINGS));
     } else {
-      sections.push(renderSection("Navigation", navigationBindings(keybindingOverrides)));
-      sections.push(renderSection("Panels", PANEL_BINDINGS));
+      sections.push(
+        renderSection(
+          "Navigation",
+          bindingsForContext(resolvedKeymap, "navigation").map(toDisplayBinding),
+        ),
+      );
+      sections.push(
+        renderSection("Panels", bindingsForContext(resolvedKeymap, "panel").map(toDisplayBinding)),
+      );
     }
 
-    // Panel-specific bindings
-    if (focusedPanel === Panel.Artifact) {
-      sections.push(renderSection("Artifact Panel", artifactBindings(keybindingOverrides)));
-    }
-    if (focusedPanel === Panel.Terminal) {
-      sections.push(renderSection("Terminal Panel", terminalBindings(keybindingOverrides)));
-    }
-    if (focusedPanel === Panel.Search) {
-      sections.push(renderSection("Search Panel", searchBindings(keybindingOverrides)));
-    }
-    if (focusedPanel === Panel.Decisions) {
-      sections.push(renderSection("Decisions Panel", decisionsBindings(keybindingOverrides)));
-    }
-    if (focusedPanel === Panel.Frontier) {
-      sections.push(renderSection("Frontier Panel", frontierBindings(keybindingOverrides)));
-    }
+    const focusedBindings = bindingsForPanel(resolvedKeymap, focusedPanel).map(toDisplayBinding);
+    if (focusedBindings.length > 0) sections.push(renderSection("Focused Panel", focusedBindings));
 
-    // Messaging is always available in normal mode
-    sections.push(renderSection("Messaging", messagingBindings(keybindingOverrides)));
+    sections.push(
+      renderSection(
+        "Messaging",
+        bindingsForContext(resolvedKeymap, "messaging").map(toDisplayBinding),
+      ),
+    );
 
     return (
       <box flexDirection="column" paddingLeft={1} paddingRight={1}>

--- a/src/tui/components/help-overlay.tsx
+++ b/src/tui/components/help-overlay.tsx
@@ -39,10 +39,24 @@ function bindingsForContext(
   return keymap.bindings.filter((binding) => binding.context === context && binding.preferred);
 }
 
+function isPanelSwitchBinding(binding: KeyBinding): boolean {
+  return binding.action === "focus_panel" || binding.action === "toggle_panel";
+}
+
+function bindingsForPanelSwitches(keymap: ResolvedKeymap): readonly KeyBinding[] {
+  return keymap.bindings.filter(
+    (binding) => binding.context === "panel" && binding.preferred && isPanelSwitchBinding(binding),
+  );
+}
+
 function bindingsForPanel(keymap: ResolvedKeymap, panel: Panel | undefined): readonly KeyBinding[] {
   if (panel === undefined) return [];
   return keymap.bindings.filter(
-    (binding) => binding.context === "panel" && binding.panel === panel && binding.preferred,
+    (binding) =>
+      binding.context === "panel" &&
+      binding.panel === panel &&
+      binding.preferred &&
+      !isPanelSwitchBinding(binding),
   );
 }
 
@@ -59,7 +73,7 @@ function renderSection(title: string, bindings: readonly KeyBindingEntry[]): Rea
         </text>
       </box>
       {bindings.map((b) => (
-        <box key={b.key} paddingLeft={1} flexDirection="row">
+        <box key={`${title}:${b.key}:${b.description}`} paddingLeft={1} flexDirection="row">
           <text color={theme.text} bold>
             {b.key.padEnd(14)}
           </text>
@@ -88,17 +102,17 @@ export const HelpOverlay: React.NamedExoticComponent<HelpOverlayProps> = React.m
 
     if (isDetailView) {
       sections.push(renderSection("Detail View", DETAIL_BINDINGS));
-    } else {
-      sections.push(
-        renderSection(
-          "Navigation",
-          bindingsForContext(resolvedKeymap, "navigation").map(toDisplayBinding),
-        ),
-      );
-      sections.push(
-        renderSection("Panels", bindingsForContext(resolvedKeymap, "panel").map(toDisplayBinding)),
-      );
     }
+
+    sections.push(
+      renderSection(
+        "Navigation",
+        bindingsForContext(resolvedKeymap, "navigation").map(toDisplayBinding),
+      ),
+    );
+    sections.push(
+      renderSection("Panels", bindingsForPanelSwitches(resolvedKeymap).map(toDisplayBinding)),
+    );
 
     const focusedBindings = bindingsForPanel(resolvedKeymap, focusedPanel).map(toDisplayBinding);
     if (focusedBindings.length > 0) sections.push(renderSection("Focused Panel", focusedBindings));

--- a/src/tui/components/status-bar.test.tsx
+++ b/src/tui/components/status-bar.test.tsx
@@ -33,9 +33,16 @@ const TestRenderer = (TestRendererModule as unknown as { default: typeof TestRen
   .default;
 const { act } = TestRendererModule;
 const { StatusBar } = await import("./status-bar.js");
-const { InputMode } = await import("../hooks/use-panel-focus.js");
+const { resolveBuiltinKeymap } = await import("../keymap/keymap.js");
+const { InputMode, Panel } = await import("../hooks/use-panel-focus.js");
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function unmountStatusBar(renderer: TestRendererTypes.ReactTestRenderer): Promise<void> {
+  await act(async () => {
+    renderer.unmount();
+  });
+}
 
 describe("StatusBar screen-context chip", () => {
   test("renders [INSPECT] when screenContext is 'inspect'", async () => {
@@ -50,7 +57,7 @@ describe("StatusBar screen-context chip", () => {
     // so we assert on the unique label token (the "[INSPECT]" wrapping is
     // produced by adjacent text nodes in the same <text> element).
     expect(flat).toContain("INSPECT");
-    renderer.unmount();
+    await unmountStatusBar(renderer);
   });
 
   test("does not render [INSPECT] without screenContext", async () => {
@@ -60,7 +67,7 @@ describe("StatusBar screen-context chip", () => {
     });
     const flat = JSON.stringify(renderer.toJSON());
     expect(flat).not.toContain("INSPECT");
-    renderer.unmount();
+    await unmountStatusBar(renderer);
   });
 
   test("renders [RUNNING] when screenContext is 'running'", async () => {
@@ -72,6 +79,89 @@ describe("StatusBar screen-context chip", () => {
     });
     const flat = JSON.stringify(renderer.toJSON());
     expect(flat).toContain("RUNNING");
-    renderer.unmount();
+    await unmountStatusBar(renderer);
+  });
+});
+
+describe("StatusBar keymap-driven hints", () => {
+  test("renders compact default-preset hints from the resolved keymap", async () => {
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <StatusBar mode={InputMode.Normal} resolvedKeymap={resolveBuiltinKeymap("default")} />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+
+    expect(flat).toContain("Space:leader");
+    expect(flat).toContain("Tab:cycle");
+    expect(flat).toContain("j/k:nav");
+    expect(flat).toContain("Enter:select");
+    expect(flat).not.toContain("5-`:toggle");
+    await unmountStatusBar(renderer);
+  });
+
+  test("renders focused terminal hints from the default keymap", async () => {
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <StatusBar
+            mode={InputMode.Normal}
+            focusedPanel={Panel.Terminal}
+            resolvedKeymap={resolveBuiltinKeymap("default")}
+          />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+
+    expect(flat).toContain("Space p t:panel");
+    expect(flat).toContain("i:input");
+    expect(flat).toContain("j/k:scroll");
+    await unmountStatusBar(renderer);
+  });
+
+  test("prefers power-user direct panel aliases when that preset is active", async () => {
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <StatusBar
+            mode={InputMode.Normal}
+            focusedPanel={Panel.Terminal}
+            resolvedKeymap={resolveBuiltinKeymap("power-user")}
+          />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+
+    expect(flat).toContain("6:panel");
+    expect(flat).not.toContain("Space p t:panel");
+    await unmountStatusBar(renderer);
+  });
+
+  test("renders pending leader prefix instead of normal hints", async () => {
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <StatusBar
+            mode={InputMode.Normal}
+            resolvedKeymap={resolveBuiltinKeymap("default")}
+            keymapPrefix={["space", "p"]}
+          />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+
+    expect(flat).toContain("Space p ...");
+    expect(flat).toContain("Esc:cancel");
+    expect(flat).not.toContain("j/k:nav");
+    await unmountStatusBar(renderer);
   });
 });

--- a/src/tui/components/status-bar.test.tsx
+++ b/src/tui/components/status-bar.test.tsx
@@ -99,6 +99,7 @@ describe("StatusBar keymap-driven hints", () => {
     expect(flat).toContain("Tab:cycle");
     expect(flat).toContain("j/k:nav");
     expect(flat).toContain("Enter:select");
+    expect(flat).toContain("Space ?:help");
     expect(flat).not.toContain("5-`:toggle");
     await unmountStatusBar(renderer);
   });
@@ -162,6 +163,27 @@ describe("StatusBar keymap-driven hints", () => {
     expect(flat).toContain("Space p ...");
     expect(flat).toContain("Esc:cancel");
     expect(flat).not.toContain("j/k:nav");
+    await unmountStatusBar(renderer);
+  });
+
+  test("renders inbox messaging hints from the keymap", async () => {
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <StatusBar
+            mode={InputMode.Normal}
+            focusedPanel={Panel.Inbox}
+            resolvedKeymap={resolveBuiltinKeymap("default")}
+          />
+        ) as React.ReactElement,
+      );
+    });
+    const flat = JSON.stringify(renderer.toJSON());
+
+    expect(flat).toContain("Space m b:broadcast");
+    expect(flat).toContain("Space m @:direct");
+    expect(flat).not.toContain("Space:leader");
     await unmountStatusBar(renderer);
   });
 });

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -111,19 +111,6 @@ function actionKey(
   );
 }
 
-function normalActionKey(
-  keymap: ResolvedKeymap,
-  action: TuiActionId,
-  fallback?: string,
-): string | undefined {
-  return bindingKey(
-    compactBinding(
-      keymap.bindings.filter((binding) => binding.action === action && binding.layer === "normal"),
-    ),
-    fallback,
-  );
-}
-
 function panelKey(keymap: ResolvedKeymap, panel: Panel | undefined): string | undefined {
   if (panel === undefined) return undefined;
   return bindingKey(
@@ -168,7 +155,7 @@ function keymapHints(
     return joinHints([`${formatKeySequence(keymapPrefix)} ...`, "Esc:cancel"]);
   }
 
-  const help = normalActionKey(keymap, "help", "?");
+  const help = actionKey(keymap, "help", "?");
   const nav = actionPair(keymap, "cursor_down", "cursor_up", "j/k");
   const panelSwitch = panelKey(keymap, panel);
 
@@ -223,6 +210,14 @@ function keymapHints(
         panelSwitch === undefined ? undefined : `${panelSwitch}:panel`,
         `${actionKey(keymap, "approve", "a")}:approve`,
         `${actionKey(keymap, "deny", "d")}:deny`,
+        `${nav}:nav`,
+        `${help}:help`,
+      ]);
+    case Panel.Inbox:
+      return joinHints([
+        panelSwitch === undefined ? undefined : `${panelSwitch}:panel`,
+        `${actionKey(keymap, "broadcast", "b")}:broadcast`,
+        `${actionKey(keymap, "direct_message", "@")}:direct`,
         `${nav}:nav`,
         `${help}:help`,
       ]);

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -7,6 +7,13 @@
 
 import React from "react";
 import { type InputMode, Panel, type ViewMode } from "../hooks/use-panel-focus.js";
+import {
+  formatKeySequence,
+  type KeyBinding,
+  type KeySequence,
+  type ResolvedKeymap,
+  type TuiActionId,
+} from "../keymap/keymap.js";
 import { theme } from "../theme.js";
 
 /** Which top-level screen the user is on — shown in status bar for orientation. */
@@ -32,6 +39,10 @@ export interface StatusBarProps {
   readonly viewMode?: ViewMode | undefined;
   /** Current goal text to display in the status bar. */
   readonly goalLabel?: string | undefined;
+  /** Resolved active keymap for compact keybinding hints. */
+  readonly resolvedKeymap?: ResolvedKeymap | undefined;
+  /** Pending keymap prefix, if the user is entering a leader sequence. */
+  readonly keymapPrefix?: readonly string[] | undefined;
 }
 
 /** Mode labels for the status bar. */
@@ -66,7 +77,163 @@ function panelHints(panel: Panel | undefined, isDetailView: boolean | undefined)
     case Panel.Inbox:
       return " b:broadcast  @:direct  j/k:nav  ?:help  q:quit";
     default:
-      return " 1-4:focus  5-`:toggle  Tab:cycle  j/k:nav  Enter:select  Ctrl+P:spawn  +/Esc:zoom  ?:help  q:quit";
+      return " panel keys:focus/toggle  Tab:cycle  j/k:nav  Enter:select  Ctrl+P:spawn  +/Esc:zoom  ?:help  q:quit";
+  }
+}
+
+function joinHints(hints: readonly (string | undefined)[]): string {
+  return hints.filter((hint) => hint !== undefined && hint.length > 0).join("  ");
+}
+
+function compactBinding(bindings: readonly KeyBinding[]): KeyBinding | undefined {
+  return [...bindings].sort((a, b) => compactScore(a) - compactScore(b))[0];
+}
+
+function compactScore(binding: KeyBinding): number {
+  const layerScore = binding.layer === "normal" ? 0 : binding.layer === "leader" ? 20 : 10;
+  const preferredScore = binding.preferred ? 0 : 5;
+  return layerScore + preferredScore + binding.sequence.length;
+}
+
+function bindingKey(binding: KeyBinding | undefined, fallback?: string): string | undefined {
+  if (binding === undefined) return fallback;
+  return formatKeySequence(binding.sequence);
+}
+
+function actionKey(
+  keymap: ResolvedKeymap,
+  action: TuiActionId,
+  fallback?: string,
+): string | undefined {
+  return bindingKey(
+    compactBinding(keymap.bindings.filter((binding) => binding.action === action)),
+    fallback,
+  );
+}
+
+function normalActionKey(
+  keymap: ResolvedKeymap,
+  action: TuiActionId,
+  fallback?: string,
+): string | undefined {
+  return bindingKey(
+    compactBinding(
+      keymap.bindings.filter((binding) => binding.action === action && binding.layer === "normal"),
+    ),
+    fallback,
+  );
+}
+
+function panelKey(keymap: ResolvedKeymap, panel: Panel | undefined): string | undefined {
+  if (panel === undefined) return undefined;
+  return bindingKey(
+    compactBinding(
+      keymap.bindings.filter(
+        (binding) =>
+          binding.context === "panel" &&
+          binding.panel === panel &&
+          (binding.action === "focus_panel" || binding.action === "toggle_panel"),
+      ),
+    ),
+  );
+}
+
+function actionPair(
+  keymap: ResolvedKeymap,
+  first: TuiActionId,
+  second: TuiActionId,
+  fallback?: string,
+): string | undefined {
+  const firstKey = actionKey(keymap, first);
+  const secondKey = actionKey(keymap, second);
+  if (firstKey === undefined || secondKey === undefined) return fallback;
+  return `${firstKey}/${secondKey}`;
+}
+
+function leaderKey(keymap: ResolvedKeymap): string | undefined {
+  const leaderBinding = keymap.bindings.find(
+    (binding) => binding.layer === "leader" && binding.sequence.length > 0,
+  );
+  if (leaderBinding === undefined) return undefined;
+  return formatKeySequence([leaderBinding.sequence[0]] as KeySequence);
+}
+
+function keymapHints(
+  keymap: ResolvedKeymap,
+  panel: Panel | undefined,
+  isDetailView: boolean | undefined,
+  keymapPrefix: readonly string[] | undefined,
+): string {
+  if (keymapPrefix !== undefined && keymapPrefix.length > 0) {
+    return joinHints([`${formatKeySequence(keymapPrefix)} ...`, "Esc:cancel"]);
+  }
+
+  const help = normalActionKey(keymap, "help", "?");
+  const nav = actionPair(keymap, "cursor_down", "cursor_up", "j/k");
+  const panelSwitch = panelKey(keymap, panel);
+
+  if (isDetailView) {
+    return joinHints([
+      "Esc:back",
+      `${nav}:scroll`,
+      `${actionKey(keymap, "refresh", "r")}:refresh`,
+      `${help}:help`,
+    ]);
+  }
+
+  switch (panel) {
+    case Panel.Terminal:
+      return joinHints([
+        panelSwitch === undefined ? undefined : `${panelSwitch}:panel`,
+        `${actionKey(keymap, "terminal_input", "i")}:input`,
+        `${actionPair(keymap, "terminal_scroll_down", "terminal_scroll_up", "j/k")}:scroll`,
+        `${help}:help`,
+      ]);
+    case Panel.Search:
+      return joinHints([
+        panelSwitch === undefined ? undefined : `${panelSwitch}:panel`,
+        `${actionKey(keymap, "search_start", "/")}:search`,
+        `${nav}:nav`,
+        `${help}:help`,
+      ]);
+    case Panel.Frontier:
+      return joinHints([
+        panelSwitch === undefined ? undefined : `${panelSwitch}:panel`,
+        `${actionKey(keymap, "compare_toggle", "C")}:compare`,
+        `${nav}:nav`,
+        `${actionKey(keymap, "select", "Enter")}:select`,
+        `${help}:help`,
+      ]);
+    case Panel.Artifact:
+      return joinHints([
+        panelSwitch === undefined ? undefined : `${panelSwitch}:panel`,
+        `${actionPair(keymap, "artifact_prev", "artifact_next", "h/l")}:cycle`,
+        `${actionKey(keymap, "artifact_diff", "d")}:diff`,
+        `${help}:help`,
+      ]);
+    case Panel.Vfs:
+      return joinHints([
+        panelSwitch === undefined ? undefined : `${panelSwitch}:panel`,
+        `${nav}:nav`,
+        `${actionKey(keymap, "vfs_navigate", "Enter")}:browse`,
+        `${help}:help`,
+      ]);
+    case Panel.Decisions:
+      return joinHints([
+        panelSwitch === undefined ? undefined : `${panelSwitch}:panel`,
+        `${actionKey(keymap, "approve", "a")}:approve`,
+        `${actionKey(keymap, "deny", "d")}:deny`,
+        `${nav}:nav`,
+        `${help}:help`,
+      ]);
+    default:
+      return joinHints([
+        leaderKey(keymap) === undefined ? undefined : `${leaderKey(keymap)}:leader`,
+        `${actionKey(keymap, "cycle_panel_next", "Tab")}:cycle`,
+        `${nav}:nav`,
+        `${actionKey(keymap, "select", "Enter")}:select`,
+        `${help}:help`,
+      ]);
   }
 }
 
@@ -87,9 +254,14 @@ export const StatusBar: React.NamedExoticComponent<StatusBarProps> = React.memo(
   agentCount,
   viewMode,
   goalLabel,
+  resolvedKeymap,
+  keymapPrefix,
 }: StatusBarProps): React.ReactNode {
   const modeLabel = MODE_LABELS[mode];
-  const hints = panelHints(focusedPanel, isDetailView);
+  const hints =
+    resolvedKeymap === undefined
+      ? panelHints(focusedPanel, isDetailView)
+      : keymapHints(resolvedKeymap, focusedPanel, isDetailView, keymapPrefix);
   const agentLabel =
     agentCount !== undefined && agentCount > 0 ? `${String(agentCount)} agents` : undefined;
 

--- a/src/tui/config-loader.test.ts
+++ b/src/tui/config-loader.test.ts
@@ -78,3 +78,17 @@ describe("mergeGroveConfig — merge semantics", () => {
     expect(project.theme.focus).toBe("#00ff00"); // not mutated
   });
 });
+
+describe("mergeGroveConfig — keymapPreset", () => {
+  test("project keymapPreset overrides global", () => {
+    const result = mergeGroveConfig({ keymapPreset: "default" }, { keymapPreset: "power-user" });
+
+    expect(result.keymapPreset).toBe("power-user");
+  });
+
+  test("global keymapPreset is preserved when project omits it", () => {
+    const result = mergeGroveConfig({ keymapPreset: "power-user" }, {});
+
+    expect(result.keymapPreset).toBe("power-user");
+  });
+});

--- a/src/tui/config-loader.ts
+++ b/src/tui/config-loader.ts
@@ -18,7 +18,7 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod";
-import type { RemappableAction } from "./hooks/use-keybinding-overrides.js";
+import type { KeymapOverrides, KeymapPresetName } from "./keymap/keymap.js";
 import type { ThemeColorTokens } from "./theme.js";
 
 // ---------------------------------------------------------------------------
@@ -28,7 +28,8 @@ import type { ThemeColorTokens } from "./theme.js";
 /** User-authored grove config (all fields optional — defaults always apply). */
 export interface GroveUserConfig {
   readonly theme: Partial<ThemeColorTokens>;
-  readonly keymap: Partial<Record<RemappableAction, string>>;
+  readonly keymap: KeymapOverrides;
+  readonly keymapPreset?: KeymapPresetName | undefined;
 }
 
 /** Empty config — returned when no config files are found. */
@@ -42,6 +43,7 @@ const ConfigSchema = z
   .object({
     theme: z.record(z.string(), z.string()).optional(),
     keymap: z.record(z.string(), z.string()).optional(),
+    keymapPreset: z.enum(["default", "power-user"]).optional(),
   })
   .strip();
 
@@ -61,6 +63,7 @@ export function mergeGroveConfig(
   return {
     theme: { ...global?.theme, ...project?.theme },
     keymap: { ...global?.keymap, ...project?.keymap },
+    keymapPreset: project?.keymapPreset ?? global?.keymapPreset,
   };
 }
 
@@ -79,7 +82,8 @@ async function loadConfigFile(filePath: string): Promise<Partial<GroveUserConfig
     }
     return {
       theme: (parsed.data.theme ?? {}) as Partial<ThemeColorTokens>,
-      keymap: (parsed.data.keymap ?? {}) as Partial<Record<RemappableAction, string>>,
+      keymap: (parsed.data.keymap ?? {}) as KeymapOverrides,
+      keymapPreset: parsed.data.keymapPreset,
     };
   } catch {
     // File not found or JSON parse error — gracefully skip

--- a/src/tui/config-watcher.test.ts
+++ b/src/tui/config-watcher.test.ts
@@ -143,6 +143,20 @@ describe("createTuiConfigWatcher", () => {
     await watcher.stop();
   });
 
+  test("broadcasts parameterized panel hotkeys", async () => {
+    const { homeDir, projectRoot } = await makeFixture();
+    const hotkeysPath = join(homeDir, ".grove", "hotkeys.yaml");
+    await writeFile(hotkeysPath, '"toggle_panel:terminal": Space p x\n', "utf8");
+
+    const watcher = createTuiConfigWatcher({ homeDir, projectRoot, debounceMs: 20 });
+    await watcher.start();
+    await settleWatcher();
+
+    expect(watcher.current().hotkeys["toggle_panel:terminal"]).toBe("Space p x");
+
+    await watcher.stop();
+  });
+
   test("broadcasts theme.yaml changes as theme token overrides", async () => {
     const { homeDir, projectRoot } = await makeFixture();
     const themePath = join(homeDir, ".grove", "theme.yaml");

--- a/src/tui/config-watcher.ts
+++ b/src/tui/config-watcher.ts
@@ -6,11 +6,8 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { type AliasMap, DEFAULT_ALIASES } from "./data/aliases.js";
 import { loadAliases } from "./data/aliases-loader.js";
-import {
-  type KeybindingOverrides,
-  REMAPPABLE_ACTIONS,
-  type RemappableAction,
-} from "./hooks/use-keybinding-overrides.js";
+import type { KeybindingOverrides, RemappableAction } from "./hooks/use-keybinding-overrides.js";
+import { isKeyBindingId } from "./keymap/keymap.js";
 import type { ThemeColorTokens } from "./theme.js";
 
 export type ConfigFileKind = "aliases" | "hotkeys" | "theme";
@@ -60,7 +57,6 @@ const EMPTY_SNAPSHOT: TuiConfigSnapshot = {
 };
 
 const HOTKEY_SCHEMA = z.record(z.string(), z.string().min(1));
-const REMAPPABLE_ACTION_SET: ReadonlySet<string> = new Set(REMAPPABLE_ACTIONS);
 
 const THEME_KEYS = [
   "focus",
@@ -98,7 +94,7 @@ const THEME_KEY_SET: ReadonlySet<string> = new Set(THEME_KEYS);
 const THEME_SCHEMA = z.record(z.string(), z.string().min(1));
 
 function isRemappableAction(action: string): action is RemappableAction {
-  return REMAPPABLE_ACTION_SET.has(action);
+  return isKeyBindingId(action);
 }
 
 function isThemeKey(key: string): key is keyof ThemeColorTokens {

--- a/src/tui/hooks/use-keybinding-overrides.test.ts
+++ b/src/tui/hooks/use-keybinding-overrides.test.ts
@@ -274,6 +274,13 @@ describe("loadKeybindings", () => {
     expect(result.help).toBe("F1");
   });
 
+  test("loads parameterized panel action ids", async () => {
+    await writeKeybindings({ "toggle_panel:terminal": "Space p x" });
+    const result = await loadKeybindings();
+
+    expect(result["toggle_panel:terminal"]).toBe("Space p x");
+  });
+
   test("silently ignores unknown action names", async () => {
     await writeKeybindings({ quit: "Q", nonexistent_action: "X" });
     const result = await loadKeybindings();
@@ -322,6 +329,12 @@ describe("buildKeyActionMap", () => {
     const map = buildKeyActionMap({ quit: "Q", help: "F1" });
     expect(map.get("Q")).toBe("quit");
     expect(map.get("F1")).toBe("help");
+  });
+
+  test("builds reverse map for parameterized panel ids", () => {
+    const map = buildKeyActionMap({ "toggle_panel:terminal": "Space p x" });
+
+    expect(map.get("Space p x")).toBe("toggle_panel:terminal");
   });
 
   test("first-win semantics when two actions share the same key", () => {

--- a/src/tui/hooks/use-keybinding-overrides.test.ts
+++ b/src/tui/hooks/use-keybinding-overrides.test.ts
@@ -347,7 +347,7 @@ describe("routeKey — keybinding override integration", () => {
     expect(quitCalled).toBe(true);
   });
 
-  test("non-overridden key falls through to default handler", () => {
+  test("non-overridden legacy key does not bypass the active keymap", () => {
     let quitCalled = false;
     const actions: KeyboardActions = {
       ...mockActions(),
@@ -357,9 +357,8 @@ describe("routeKey — keybinding override integration", () => {
       resolvedKeymap: resolveKeymapWithOverrides("default", {}),
     };
 
-    // No override for "q" — the default hardcoded "q" handler runs
     const handled = routeKey(keyEvent("q"), actions);
-    expect(handled).toBe(true);
-    expect(quitCalled).toBe(true);
+    expect(handled).toBe(false);
+    expect(quitCalled).toBe(false);
   });
 });

--- a/src/tui/hooks/use-keybinding-overrides.test.ts
+++ b/src/tui/hooks/use-keybinding-overrides.test.ts
@@ -5,15 +5,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import type { KeyEvent } from "@opentui/core";
-import {
-  buildKeyActionMap,
-  loadKeybindings,
-  REMAPPABLE_ACTIONS,
-} from "./use-keybinding-overrides.js";
+import { resolveKeymapWithOverrides } from "../keymap/keymap.js";
+import { loadKeybindings, REMAPPABLE_ACTIONS } from "./use-keybinding-overrides.js";
 import type { KeyboardActions } from "./use-keyboard-handler.js";
 import { routeKey } from "./use-keyboard-handler.js";
 import type { PanelFocusState } from "./use-panel-focus.js";
@@ -316,44 +314,15 @@ describe("loadKeybindings", () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildKeyActionMap
+// legacy reverse map cleanup
 // ---------------------------------------------------------------------------
 
-describe("buildKeyActionMap", () => {
-  test("empty overrides produces empty map", () => {
-    const map = buildKeyActionMap({});
-    expect(map.size).toBe(0);
-  });
+describe("legacy reverse-map cleanup", () => {
+  test("override module no longer exports the pre-keymap reverse map", () => {
+    const source = readFileSync(resolve(import.meta.dir, "use-keybinding-overrides.ts"), "utf-8");
 
-  test("builds reverse map from action→key to key→action", () => {
-    const map = buildKeyActionMap({ quit: "Q", help: "F1" });
-    expect(map.get("Q")).toBe("quit");
-    expect(map.get("F1")).toBe("help");
-  });
-
-  test("builds reverse map for parameterized panel ids", () => {
-    const map = buildKeyActionMap({ "toggle_panel:terminal": "Space p x" });
-
-    expect(map.get("Space p x")).toBe("toggle_panel:terminal");
-  });
-
-  test("first-win semantics when two actions share the same key", () => {
-    // Object.entries iteration order is insertion order for string keys
-    const overrides: Record<string, string> = {};
-    overrides.quit = "X";
-    overrides.refresh = "X";
-    const map = buildKeyActionMap(overrides);
-    // "quit" was inserted first → "X" maps to "quit"
-    expect(map.get("X")).toBe("quit");
-    expect(map.size).toBe(1); // only one entry for "X"
-  });
-
-  test("multiple distinct keys all appear in map", () => {
-    const map = buildKeyActionMap({ quit: "Q", help: "H", refresh: "R" });
-    expect(map.size).toBe(3);
-    expect(map.get("Q")).toBe("quit");
-    expect(map.get("H")).toBe("help");
-    expect(map.get("R")).toBe("refresh");
+    expect(source).not.toContain("buildKeyActionMap");
+    expect(source).not.toContain("DEFAULT_KEY_ACTIONS");
   });
 });
 
@@ -365,14 +334,12 @@ describe("routeKey — keybinding override integration", () => {
   test("remapped quit key triggers onQuit", () => {
     let quitCalled = false;
     const overrides = { quit: "Q" };
-    const keyMap = buildKeyActionMap(overrides);
     const actions: KeyboardActions = {
       ...mockActions(),
       onQuit: () => {
         quitCalled = true;
       },
-      keybindingOverrides: overrides,
-      keyActionMap: keyMap,
+      resolvedKeymap: resolveKeymapWithOverrides("default", overrides),
     };
 
     const handled = routeKey(keyEvent("Q"), actions);
@@ -387,8 +354,7 @@ describe("routeKey — keybinding override integration", () => {
       onQuit: () => {
         quitCalled = true;
       },
-      keybindingOverrides: {},
-      keyActionMap: new Map(),
+      resolvedKeymap: resolveKeymapWithOverrides("default", {}),
     };
 
     // No override for "q" — the default hardcoded "q" handler runs

--- a/src/tui/hooks/use-keybinding-overrides.ts
+++ b/src/tui/hooks/use-keybinding-overrides.ts
@@ -20,31 +20,20 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { useEffect, useState } from "react";
 import { z } from "zod";
+import {
+  isKeyBindingId,
+  KEY_BINDING_IDS,
+  type KeyBindingId,
+  type KeymapOverrides,
+} from "../keymap/keymap.js";
 
 /** Map from action name to custom key binding. */
-export type KeybindingOverrides = Readonly<Record<string, string>>;
+export type KeybindingOverrides = KeymapOverrides;
+
+export type RemappableAction = KeyBindingId;
 
 /** Known action names that can be remapped. */
-export const REMAPPABLE_ACTIONS = [
-  "quit",
-  "help",
-  "zoom_cycle",
-  "zoom_reset",
-  "broadcast",
-  "direct_message",
-  "search_start",
-  "terminal_input",
-  "compare_toggle",
-  "artifact_prev",
-  "artifact_next",
-  "artifact_diff",
-  "approve",
-  "deny",
-  "palette",
-  "refresh",
-] as const;
-
-export type RemappableAction = (typeof REMAPPABLE_ACTIONS)[number];
+export const REMAPPABLE_ACTIONS: readonly RemappableAction[] = KEY_BINDING_IDS;
 
 const KEYBINDINGS_PATH = ".grove/keybindings.json";
 
@@ -68,7 +57,7 @@ export async function loadKeybindings(): Promise<KeybindingOverrides> {
     const keyToActions = new Map<string, string[]>();
 
     for (const [action, key] of Object.entries(parsed.data)) {
-      if (!(REMAPPABLE_ACTIONS as readonly string[]).includes(action)) {
+      if (!isKeyBindingId(action)) {
         process.stderr.write(`[grove] keybindings.json: unknown action "${action}" — ignored\n`);
         continue;
       }
@@ -112,7 +101,7 @@ export function buildKeyActionMap(
 }
 
 /** Default key → action mappings (used when no override exists). */
-export const DEFAULT_KEY_ACTIONS: Readonly<Record<RemappableAction, string>> = {
+const LEGACY_DEFAULT_KEY_ACTIONS: Readonly<Partial<Record<RemappableAction, string>>> = {
   quit: "q",
   help: "?",
   zoom_cycle: "+",
@@ -130,6 +119,12 @@ export const DEFAULT_KEY_ACTIONS: Readonly<Record<RemappableAction, string>> = {
   palette: "m",
   refresh: "r",
 };
+
+export const DEFAULT_KEY_ACTIONS: Readonly<Record<RemappableAction, string>> = Object.freeze(
+  Object.fromEntries(
+    REMAPPABLE_ACTIONS.map((action) => [action, LEGACY_DEFAULT_KEY_ACTIONS[action] ?? action]),
+  ) as Record<RemappableAction, string>,
+);
 
 /** Hook to load keybinding overrides from .grove/keybindings.json. */
 export function useKeybindingOverrides(): KeybindingOverrides {

--- a/src/tui/hooks/use-keybinding-overrides.ts
+++ b/src/tui/hooks/use-keybinding-overrides.ts
@@ -2,14 +2,14 @@
  * Customizable keybindings loader.
  *
  * Loads keybinding overrides from `.grove/keybindings.json`.
- * Format: { "action": "key" } where action is a routeKey action name
- * and key is the key name (e.g., "q", "escape", "tab").
+ * Format: { "action": "sequence" } where action is a keymap binding id
+ * and sequence is a key sequence (e.g., "Q", "Space p t", "F5").
  *
  * Example .grove/keybindings.json:
  * {
- *   "quit": "Q",
+ *   "quit": "Space x",
  *   "help": "F1",
- *   "zoom_cycle": "z",
+ *   "toggle_panel:terminal": "Space p x",
  *   "broadcast": "B"
  * }
  *
@@ -81,50 +81,6 @@ export async function loadKeybindings(): Promise<KeybindingOverrides> {
     return {};
   }
 }
-
-/**
- * Build a reverse map: key → action name (for O(1) lookup in routeKey).
- *
- * Uses first-win semantics: if two actions are mapped to the same key,
- * the first one in iteration order wins.
- */
-export function buildKeyActionMap(
-  overrides: KeybindingOverrides,
-): ReadonlyMap<string, RemappableAction> {
-  const map = new Map<string, RemappableAction>();
-  for (const [action, key] of Object.entries(overrides)) {
-    if (!map.has(key)) {
-      map.set(key, action as RemappableAction);
-    }
-  }
-  return map;
-}
-
-/** Default key → action mappings (used when no override exists). */
-const LEGACY_DEFAULT_KEY_ACTIONS: Readonly<Partial<Record<RemappableAction, string>>> = {
-  quit: "q",
-  help: "?",
-  zoom_cycle: "+",
-  zoom_reset: "escape",
-  broadcast: "b",
-  direct_message: "@",
-  search_start: "/",
-  terminal_input: "i",
-  compare_toggle: "C",
-  artifact_prev: "h",
-  artifact_next: "l",
-  artifact_diff: "d",
-  approve: "a",
-  deny: "d",
-  palette: "m",
-  refresh: "r",
-};
-
-export const DEFAULT_KEY_ACTIONS: Readonly<Record<RemappableAction, string>> = Object.freeze(
-  Object.fromEntries(
-    REMAPPABLE_ACTIONS.map((action) => [action, LEGACY_DEFAULT_KEY_ACTIONS[action] ?? action]),
-  ) as Record<RemappableAction, string>,
-);
 
 /** Hook to load keybinding overrides from .grove/keybindings.json. */
 export function useKeybindingOverrides(): KeybindingOverrides {

--- a/src/tui/hooks/use-keyboard-handler.test.ts
+++ b/src/tui/hooks/use-keyboard-handler.test.ts
@@ -222,6 +222,19 @@ describe("routeKey — leader keymap", () => {
     expect(log.calls).not.toContain("onQuit");
   });
 
+  test("pending leader sequence takes precedence over legacy override map", () => {
+    const { actions, log } = mockActions({
+      keybindingOverrides: { refresh: "x" },
+      resolvedKeymap: resolveBuiltinKeymap("default"),
+      keymapPrefix: ["space"],
+    });
+    const handled = routeKey(keyEvent("x"), actions);
+
+    expect(handled).toBe(true);
+    expect(log.args.onKeymapPrefixChange).toEqual([[]]);
+    expect(log.calls).not.toContain("onRefresh");
+  });
+
   test("Escape clears pending leader prefix before zoom reset", () => {
     const { actions, log } = mockActions({
       resolvedKeymap: resolveBuiltinKeymap("default"),
@@ -671,6 +684,21 @@ describe("routeKey — Enter key", () => {
     routeKey(keyEvent("return"), actions);
     expect(log.calls).toContain("onSelect");
     expect(log.args.onSelect).toEqual([0]);
+  });
+
+  test("Enter selects contribution in Frontier when compare mode is off", () => {
+    const { actions, log } = mockActions({
+      focused: Panel.Frontier,
+      compareMode: false,
+      resolvedKeymap: resolveBuiltinKeymap("default"),
+      rowCount: 5,
+    });
+    const handled = routeKey(keyEvent("return"), actions);
+
+    expect(handled).toBe(true);
+    expect(log.calls).toContain("onSelect");
+    expect(log.args.onSelect).toEqual([0]);
+    expect(log.calls).not.toContain("onCompareSelect");
   });
 
   test("Enter does not select in Claims panel", () => {

--- a/src/tui/hooks/use-keyboard-handler.test.ts
+++ b/src/tui/hooks/use-keyboard-handler.test.ts
@@ -261,6 +261,31 @@ describe("routeKey — leader keymap", () => {
     expect(handled).toBe(true);
     expect(log.calls).toContain("onQuit");
   });
+
+  test("default keymap does not fall through to legacy direct quit", () => {
+    const { actions, log } = mockActions({
+      resolvedKeymap: resolveBuiltinKeymap("default"),
+    });
+    const handled = routeKey(keyEvent("q"), actions);
+
+    expect(handled).toBe(false);
+    expect(log.calls).not.toContain("onQuit");
+  });
+
+  test("overridden quit key removes the old direct key", () => {
+    const keymap = resolveKeymapWithOverrides("default", { quit: "Space x" });
+    const oldKey = mockActions({ resolvedKeymap: keymap });
+    const handledOld = routeKey(keyEvent("q"), oldKey.actions);
+    const leader = mockActions({ resolvedKeymap: keymap });
+    routeKey(keyEvent("space"), leader.actions);
+    const remapped = mockActions({ resolvedKeymap: keymap, keymapPrefix: ["space"] });
+    const handledRemapped = routeKey(keyEvent("x"), remapped.actions);
+
+    expect(handledOld).toBe(false);
+    expect(oldKey.log.calls).not.toContain("onQuit");
+    expect(handledRemapped).toBe(true);
+    expect(remapped.log.calls).toContain("onQuit");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tui/hooks/use-keyboard-handler.test.ts
+++ b/src/tui/hooks/use-keyboard-handler.test.ts
@@ -8,6 +8,8 @@
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
 import { INITIAL_KEYBOARD_STATE, tuiReducer } from "../app-reducer.js";
+import type { ResolvedKeymap } from "../keymap/keymap.js";
+import { resolveBuiltinKeymap } from "../keymap/keymap.js";
 import { PANEL_REGISTRY } from "../panels/panel-registry.js";
 import { buildKeyActionMap } from "./use-keybinding-overrides.js";
 import type { KeyboardActions } from "./use-keyboard-handler.js";
@@ -59,6 +61,8 @@ function mockActions(overrides?: {
   hasTmux?: boolean;
   isDetailView?: boolean;
   keybindingOverrides?: import("./use-keybinding-overrides.js").KeybindingOverrides;
+  resolvedKeymap?: ResolvedKeymap;
+  keymapPrefix?: readonly string[];
 }): { actions: KeyboardActions; log: ActionLog } {
   const log: ActionLog = { calls: [], args: {} };
 
@@ -152,6 +156,9 @@ function mockActions(overrides?: {
     keyActionMap: overrides?.keybindingOverrides
       ? buildKeyActionMap(overrides.keybindingOverrides)
       : undefined,
+    resolvedKeymap: overrides?.resolvedKeymap,
+    keymapPrefix: overrides?.keymapPrefix ?? [],
+    onKeymapPrefixChange: (prefix) => record("onKeymapPrefixChange", prefix),
   };
 
   return { actions, log };
@@ -173,6 +180,80 @@ describe("nextZoom", () => {
     zoom = nextZoom(zoom);
     zoom = nextZoom(zoom);
     expect(zoom).toBe("normal");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Normal mode — leader keymap
+// ---------------------------------------------------------------------------
+
+describe("routeKey — leader keymap", () => {
+  test("Space starts a pending leader sequence", () => {
+    const { actions, log } = mockActions({ resolvedKeymap: resolveBuiltinKeymap("default") });
+    const handled = routeKey(keyEvent("space"), actions);
+
+    expect(handled).toBe(true);
+    expect(log.args.onKeymapPrefixChange).toEqual([["space"]]);
+  });
+
+  test("Space p t toggles the Terminal panel", () => {
+    const keymap = resolveBuiltinKeymap("default");
+    const first = mockActions({ resolvedKeymap: keymap });
+    routeKey(keyEvent("space"), first.actions);
+    const second = mockActions({ resolvedKeymap: keymap, keymapPrefix: ["space"] });
+    routeKey(keyEvent("p"), second.actions);
+    const third = mockActions({ resolvedKeymap: keymap, keymapPrefix: ["space", "p"] });
+    const handled = routeKey(keyEvent("t"), third.actions);
+
+    expect(handled).toBe(true);
+    expect(third.log.args["panels.toggle"]).toEqual([Panel.Terminal]);
+    expect(third.log.args.onKeymapPrefixChange).toEqual([[]]);
+  });
+
+  test("invalid leader sequence clears prefix and consumes the key", () => {
+    const { actions, log } = mockActions({
+      resolvedKeymap: resolveBuiltinKeymap("default"),
+      keymapPrefix: ["space"],
+    });
+    const handled = routeKey(keyEvent("x"), actions);
+
+    expect(handled).toBe(true);
+    expect(log.args.onKeymapPrefixChange).toEqual([[]]);
+    expect(log.calls).not.toContain("onQuit");
+  });
+
+  test("Escape clears pending leader prefix before zoom reset", () => {
+    const { actions, log } = mockActions({
+      resolvedKeymap: resolveBuiltinKeymap("default"),
+      keymapPrefix: ["space"],
+    });
+    const handled = routeKey(keyEvent("escape"), actions);
+
+    expect(handled).toBe(true);
+    expect(log.args.onKeymapPrefixChange).toEqual([[]]);
+    expect(log.calls).not.toContain("onZoomReset");
+  });
+
+  test("leader key is not intercepted in message input mode", () => {
+    const { actions, log } = mockActions({
+      mode: InputMode.MessageInput,
+      resolvedKeymap: resolveBuiltinKeymap("default"),
+    });
+    const handled = routeKey(keyEvent("space"), actions);
+
+    expect(handled).toBe(true);
+    expect(log.args.onMessageChar).toEqual([" "]);
+    expect(log.calls).not.toContain("onKeymapPrefixChange");
+  });
+
+  test("power-user direct q still quits", () => {
+    const { actions, log } = mockActions({
+      resolvedKeymap: resolveBuiltinKeymap("power-user"),
+    });
+    const handled = routeKey(keyEvent("q"), actions);
+
+    expect(handled).toBe(true);
+    expect(log.calls).toContain("onQuit");
   });
 });
 

--- a/src/tui/hooks/use-keyboard-handler.test.ts
+++ b/src/tui/hooks/use-keyboard-handler.test.ts
@@ -9,9 +9,8 @@ import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
 import { INITIAL_KEYBOARD_STATE, tuiReducer } from "../app-reducer.js";
 import type { ResolvedKeymap } from "../keymap/keymap.js";
-import { resolveBuiltinKeymap } from "../keymap/keymap.js";
+import { resolveBuiltinKeymap, resolveKeymapWithOverrides } from "../keymap/keymap.js";
 import { PANEL_REGISTRY } from "../panels/panel-registry.js";
-import { buildKeyActionMap } from "./use-keybinding-overrides.js";
 import type { KeyboardActions } from "./use-keyboard-handler.js";
 import { nextZoom, routeKey } from "./use-keyboard-handler.js";
 import type { PanelFocusState } from "./use-panel-focus.js";
@@ -60,7 +59,6 @@ function mockActions(overrides?: {
   selectedSession?: string;
   hasTmux?: boolean;
   isDetailView?: boolean;
-  keybindingOverrides?: import("./use-keybinding-overrides.js").KeybindingOverrides;
   resolvedKeymap?: ResolvedKeymap;
   keymapPrefix?: readonly string[];
 }): { actions: KeyboardActions; log: ActionLog } {
@@ -152,10 +150,6 @@ function mockActions(overrides?: {
     frontierCids: () => overrides?.frontierCids ?? [],
     selectedSession: overrides?.selectedSession,
     hasTmux: overrides?.hasTmux ?? false,
-    keybindingOverrides: overrides?.keybindingOverrides,
-    keyActionMap: overrides?.keybindingOverrides
-      ? buildKeyActionMap(overrides.keybindingOverrides)
-      : undefined,
     resolvedKeymap: overrides?.resolvedKeymap,
     keymapPrefix: overrides?.keymapPrefix ?? [],
     onKeymapPrefixChange: (prefix) => record("onKeymapPrefixChange", prefix),
@@ -224,8 +218,7 @@ describe("routeKey — leader keymap", () => {
 
   test("pending leader sequence takes precedence over legacy override map", () => {
     const { actions, log } = mockActions({
-      keybindingOverrides: { refresh: "x" },
-      resolvedKeymap: resolveBuiltinKeymap("default"),
+      resolvedKeymap: resolveKeymapWithOverrides("default", { refresh: "x" }),
       keymapPrefix: ["space"],
     });
     const handled = routeKey(keyEvent("x"), actions);
@@ -379,7 +372,9 @@ describe("routeKey — normal mode misc", () => {
   });
 
   test("keybinding override for 'refresh' calls onRefresh", () => {
-    const { actions, log } = mockActions({ keybindingOverrides: { refresh: "F5" } });
+    const { actions, log } = mockActions({
+      resolvedKeymap: resolveKeymapWithOverrides("default", { refresh: "F5" }),
+    });
     const handled = routeKey(keyEvent("F5"), actions);
     expect(handled).toBe(true);
     expect(log.calls).toContain("onRefresh");

--- a/src/tui/hooks/use-keyboard-handler.ts
+++ b/src/tui/hooks/use-keyboard-handler.ts
@@ -160,28 +160,36 @@ export function executeKeymapAction(binding: KeyBinding, actions: KeyboardAction
       actions.onDirectMessageMode();
       return true;
     case "search_start":
-      if (focused === Panel.Search) actions.onSearchStart();
+      if (focused !== Panel.Search) return false;
+      actions.onSearchStart();
       return true;
     case "terminal_input":
-      if (focused === Panel.Terminal) actions.panels.setMode(InputMode.TerminalInput);
+      if (focused !== Panel.Terminal) return false;
+      actions.panels.setMode(InputMode.TerminalInput);
       return true;
     case "compare_toggle":
-      if (focused === Panel.Frontier) actions.onCompareToggle();
+      if (focused !== Panel.Frontier) return false;
+      actions.onCompareToggle();
       return true;
     case "artifact_prev":
-      if (focused === Panel.Artifact) actions.onArtifactPrev();
+      if (focused !== Panel.Artifact) return false;
+      actions.onArtifactPrev();
       return true;
     case "artifact_next":
-      if (focused === Panel.Artifact) actions.onArtifactNext();
+      if (focused !== Panel.Artifact) return false;
+      actions.onArtifactNext();
       return true;
     case "artifact_diff":
-      if (focused === Panel.Artifact) actions.onArtifactDiffToggle();
+      if (focused !== Panel.Artifact) return false;
+      actions.onArtifactDiffToggle();
       return true;
     case "approve":
-      if (focused === Panel.Decisions) actions.onApproveQuestion();
+      if (focused !== Panel.Decisions) return false;
+      actions.onApproveQuestion();
       return true;
     case "deny":
-      if (focused === Panel.Decisions) actions.onDenyQuestion();
+      if (focused !== Panel.Decisions) return false;
+      actions.onDenyQuestion();
       return true;
     case "cursor_down":
       actions.nav.cursorDown(Math.max(0, actions.rowCount - 1));
@@ -206,41 +214,53 @@ export function executeKeymapAction(binding: KeyBinding, actions: KeyboardAction
       actions.nav.prevPage(actions.pageSize);
       return true;
     case "vfs_navigate":
-      if (focused === Panel.Vfs) actions.onVfsNavigate();
+      if (focused !== Panel.Vfs) return false;
+      actions.onVfsNavigate();
       return true;
     case "terminal_scroll_up":
-      if (focused === Panel.Terminal) actions.onTerminalScrollUp();
+      if (focused !== Panel.Terminal) return false;
+      actions.onTerminalScrollUp();
       return true;
     case "terminal_scroll_down":
-      if (focused === Panel.Terminal) actions.onTerminalScrollDown();
+      if (focused !== Panel.Terminal) return false;
+      actions.onTerminalScrollDown();
       return true;
     case "terminal_scroll_bottom":
-      if (focused === Panel.Terminal) actions.onTerminalScrollBottom();
+      if (focused !== Panel.Terminal) return false;
+      actions.onTerminalScrollBottom();
       return true;
     case "frontier_tab_next":
-      if (focused === Panel.Frontier) actions.onFrontierTabNext();
+      if (focused !== Panel.Frontier) return false;
+      actions.onFrontierTabNext();
       return true;
     case "frontier_tab_prev":
-      if (focused === Panel.Frontier) actions.onFrontierTabPrev();
+      if (focused !== Panel.Frontier) return false;
+      actions.onFrontierTabPrev();
       return true;
     case "frontier_adopt":
       if (focused === Panel.Frontier && !actions.compareMode) {
         const entries = actions.frontierEntries();
         const entry = entries[actions.nav.state.cursor];
         if (entry !== undefined) actions.onFrontierAdopt(entry.cid, entry.summary);
+        return entry !== undefined;
       }
-      return true;
+      return false;
     case "compare_select":
       if (focused === Panel.Frontier && actions.compareMode) {
         const cid = actions.frontierCids()[actions.nav.state.cursor];
-        if (cid !== undefined) actions.onCompareSelect(cid);
+        if (cid !== undefined) {
+          actions.onCompareSelect(cid);
+          return true;
+        }
       }
-      return true;
+      return false;
     case "compare_adopt_a":
-      if (focused === Panel.Artifact && actions.compareMode) actions.onCompareAdopt("a");
+      if (!(focused === Panel.Artifact && actions.compareMode)) return false;
+      actions.onCompareAdopt("a");
       return true;
     case "compare_adopt_b":
-      if (focused === Panel.Artifact && actions.compareMode) actions.onCompareAdopt("b");
+      if (!(focused === Panel.Artifact && actions.compareMode)) return false;
+      actions.onCompareAdopt("b");
       return true;
   }
 }
@@ -261,7 +281,7 @@ export function routeKey(key: KeyEvent, actions: KeyboardActions): boolean {
   // Keybinding overrides (item 19): O(1) lookup via pre-built reverse map.
   // Override lookup only applies in normal mode to avoid breaking modal input.
   const keyActionMap = actions.keyActionMap;
-  if (mode === InputMode.Normal && keyActionMap && input && !isCtrl) {
+  if (mode === InputMode.Normal && keymapPrefix.length === 0 && keyActionMap && input && !isCtrl) {
     const action = keyActionMap.get(input);
     if (action !== undefined) {
       switch (action) {
@@ -474,8 +494,9 @@ export function routeKey(key: KeyEvent, actions: KeyboardActions): boolean {
           return true;
         case "match":
           actions.onKeymapPrefixChange?.([]);
-          executeKeymapAction(result.binding, actions);
-          return true;
+          if (executeKeymapAction(result.binding, actions)) return true;
+          if (keymapPrefix.length > 0) return true;
+          break;
         case "miss":
           if (keymapPrefix.length > 0) {
             actions.onKeymapPrefixChange?.([]);

--- a/src/tui/hooks/use-keyboard-handler.ts
+++ b/src/tui/hooks/use-keyboard-handler.ts
@@ -434,7 +434,7 @@ export function routeKey(key: KeyEvent, actions: KeyboardActions): boolean {
             actions.onKeymapPrefixChange?.([]);
             return true;
           }
-          break;
+          return false;
       }
     }
   }

--- a/src/tui/hooks/use-keyboard-handler.ts
+++ b/src/tui/hooks/use-keyboard-handler.ts
@@ -6,6 +6,12 @@
  */
 
 import type { KeyEvent } from "@opentui/core";
+import {
+  type KeyBinding,
+  keyEventToToken,
+  type ResolvedKeymap,
+  resolveKeySequence,
+} from "../keymap/keymap.js";
 import type { ZoomLevel } from "../panels/panel-manager.js";
 import { PANEL_REGISTRY } from "../panels/panel-registry.js";
 import { isHelpToggleKey } from "./shared-keyboard-core.js";
@@ -86,6 +92,9 @@ export interface KeyboardActions {
    * Use buildKeyActionMap() to construct. Enables O(1) lookup vs O(n) scan.
    */
   readonly keyActionMap?: ReadonlyMap<string, RemappableAction> | undefined;
+  readonly resolvedKeymap?: ResolvedKeymap | undefined;
+  readonly keymapPrefix?: readonly string[] | undefined;
+  readonly onKeymapPrefixChange?: (prefix: readonly string[]) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -104,6 +113,138 @@ export function nextZoom(current: ZoomLevel): ZoomLevel {
   }
 }
 
+export function executeKeymapAction(binding: KeyBinding, actions: KeyboardActions): boolean {
+  const focused = actions.panels.state.focused;
+  switch (binding.action) {
+    case "quit":
+      actions.onQuit();
+      return true;
+    case "help":
+      actions.panels.setMode(InputMode.Help);
+      return true;
+    case "palette":
+      actions.onSpawnPalette();
+      actions.panels.setMode(InputMode.CommandPalette);
+      return true;
+    case "refresh":
+      actions.onRefresh();
+      return true;
+    case "zoom_cycle":
+      actions.onZoomCycle();
+      return true;
+    case "zoom_reset":
+      actions.onZoomReset();
+      return true;
+    case "layout_toggle":
+      actions.onLayoutToggle();
+      return true;
+    case "view_cycle":
+      actions.panels.cycleViewMode();
+      return true;
+    case "cycle_panel_next":
+      actions.panels.cycleNext();
+      return true;
+    case "cycle_panel_prev":
+      actions.panels.cyclePrev();
+      return true;
+    case "focus_panel":
+      actions.panels.focus(binding.panel);
+      return true;
+    case "toggle_panel":
+      actions.panels.toggle(binding.panel);
+      return true;
+    case "broadcast":
+      actions.onBroadcastMode();
+      return true;
+    case "direct_message":
+      actions.onDirectMessageMode();
+      return true;
+    case "search_start":
+      if (focused === Panel.Search) actions.onSearchStart();
+      return true;
+    case "terminal_input":
+      if (focused === Panel.Terminal) actions.panels.setMode(InputMode.TerminalInput);
+      return true;
+    case "compare_toggle":
+      if (focused === Panel.Frontier) actions.onCompareToggle();
+      return true;
+    case "artifact_prev":
+      if (focused === Panel.Artifact) actions.onArtifactPrev();
+      return true;
+    case "artifact_next":
+      if (focused === Panel.Artifact) actions.onArtifactNext();
+      return true;
+    case "artifact_diff":
+      if (focused === Panel.Artifact) actions.onArtifactDiffToggle();
+      return true;
+    case "approve":
+      if (focused === Panel.Decisions) actions.onApproveQuestion();
+      return true;
+    case "deny":
+      if (focused === Panel.Decisions) actions.onDenyQuestion();
+      return true;
+    case "cursor_down":
+      actions.nav.cursorDown(Math.max(0, actions.rowCount - 1));
+      return true;
+    case "cursor_up":
+      actions.nav.cursorUp();
+      return true;
+    case "select":
+      if (!actions.nav.isDetailView && focused !== Panel.Claims && actions.rowCount > 0) {
+        actions.onSelect(actions.nav.state.cursor);
+      }
+      return true;
+    case "page_next": {
+      const hasFullPage = actions.rowCount >= actions.pageSize;
+      const totalItems = hasFullPage
+        ? actions.nav.state.pageOffset + actions.rowCount + 1
+        : actions.nav.state.pageOffset + actions.rowCount;
+      actions.nav.nextPage(actions.pageSize, totalItems);
+      return true;
+    }
+    case "page_prev":
+      actions.nav.prevPage(actions.pageSize);
+      return true;
+    case "vfs_navigate":
+      if (focused === Panel.Vfs) actions.onVfsNavigate();
+      return true;
+    case "terminal_scroll_up":
+      if (focused === Panel.Terminal) actions.onTerminalScrollUp();
+      return true;
+    case "terminal_scroll_down":
+      if (focused === Panel.Terminal) actions.onTerminalScrollDown();
+      return true;
+    case "terminal_scroll_bottom":
+      if (focused === Panel.Terminal) actions.onTerminalScrollBottom();
+      return true;
+    case "frontier_tab_next":
+      if (focused === Panel.Frontier) actions.onFrontierTabNext();
+      return true;
+    case "frontier_tab_prev":
+      if (focused === Panel.Frontier) actions.onFrontierTabPrev();
+      return true;
+    case "frontier_adopt":
+      if (focused === Panel.Frontier && !actions.compareMode) {
+        const entries = actions.frontierEntries();
+        const entry = entries[actions.nav.state.cursor];
+        if (entry !== undefined) actions.onFrontierAdopt(entry.cid, entry.summary);
+      }
+      return true;
+    case "compare_select":
+      if (focused === Panel.Frontier && actions.compareMode) {
+        const cid = actions.frontierCids()[actions.nav.state.cursor];
+        if (cid !== undefined) actions.onCompareSelect(cid);
+      }
+      return true;
+    case "compare_adopt_a":
+      if (focused === Panel.Artifact && actions.compareMode) actions.onCompareAdopt("a");
+      return true;
+    case "compare_adopt_b":
+      if (focused === Panel.Artifact && actions.compareMode) actions.onCompareAdopt("b");
+      return true;
+  }
+}
+
 /**
  * Route a key event to the appropriate action.
  *
@@ -115,6 +256,7 @@ export function routeKey(key: KeyEvent, actions: KeyboardActions): boolean {
   const isCtrl = key.ctrl;
   const mode = actions.panels.state.mode;
   const focused = actions.panels.state.focused;
+  const keymapPrefix = actions.keymapPrefix ?? [];
 
   // Keybinding overrides (item 19): O(1) lookup via pre-built reverse map.
   // Override lookup only applies in normal mode to avoid breaking modal input.
@@ -194,6 +336,10 @@ export function routeKey(key: KeyEvent, actions: KeyboardActions): boolean {
   // Escape: one effect per keypress, highest-priority first.
   // Priority: (1) exit mode → (2) pop detail → (3) reset zoom
   if (input === "escape") {
+    if (mode === InputMode.Normal && keymapPrefix.length > 0) {
+      actions.onKeymapPrefixChange?.([]);
+      return true;
+    }
     if (mode !== InputMode.Normal) {
       // Leaving CommandPalette via Esc must clear adoptContext (set by the
       // 'a' Frontier-row keypress) and reset palette state — otherwise the
@@ -282,6 +428,10 @@ export function routeKey(key: KeyEvent, actions: KeyboardActions): boolean {
       actions.onMessageBackspace();
       return true;
     }
+    if (input === "space") {
+      actions.onMessageChar(" ");
+      return true;
+    }
     if (input && input.length === 1 && !isCtrl) {
       actions.onMessageChar(input);
       return true;
@@ -308,6 +458,32 @@ export function routeKey(key: KeyEvent, actions: KeyboardActions): boolean {
       return true;
     }
     return true;
+  }
+
+  const resolvedKeymap = actions.resolvedKeymap;
+  if (mode === InputMode.Normal && resolvedKeymap !== undefined) {
+    const token = keyEventToToken(key);
+    if (token !== undefined) {
+      const nextPrefix = Object.freeze([...keymapPrefix, token]);
+      const result = resolveKeySequence(resolvedKeymap.bindings, nextPrefix, {
+        focusedPanel: focused,
+      });
+      switch (result.kind) {
+        case "pending":
+          actions.onKeymapPrefixChange?.(result.prefix);
+          return true;
+        case "match":
+          actions.onKeymapPrefixChange?.([]);
+          executeKeymapAction(result.binding, actions);
+          return true;
+        case "miss":
+          if (keymapPrefix.length > 0) {
+            actions.onKeymapPrefixChange?.([]);
+            return true;
+          }
+          break;
+      }
+    }
   }
 
   // Help overlay toggle

--- a/src/tui/hooks/use-keyboard-handler.ts
+++ b/src/tui/hooks/use-keyboard-handler.ts
@@ -15,7 +15,6 @@ import {
 import type { ZoomLevel } from "../panels/panel-manager.js";
 import { PANEL_REGISTRY } from "../panels/panel-registry.js";
 import { isHelpToggleKey } from "./shared-keyboard-core.js";
-import type { KeybindingOverrides, RemappableAction } from "./use-keybinding-overrides.js";
 import type { NavigationActions } from "./use-navigation.js";
 import { InputMode, Panel, type PanelFocusActions } from "./use-panel-focus.js";
 
@@ -85,13 +84,6 @@ export interface KeyboardActions {
   readonly frontierCids: () => readonly string[];
   readonly selectedSession: string | undefined;
   readonly hasTmux: boolean;
-  /** Keybinding overrides from .grove/keybindings.json (item 19). */
-  readonly keybindingOverrides?: KeybindingOverrides | undefined;
-  /**
-   * Pre-built reverse map (key → action) derived from keybindingOverrides.
-   * Use buildKeyActionMap() to construct. Enables O(1) lookup vs O(n) scan.
-   */
-  readonly keyActionMap?: ReadonlyMap<string, RemappableAction> | undefined;
   readonly resolvedKeymap?: ResolvedKeymap | undefined;
   readonly keymapPrefix?: readonly string[] | undefined;
   readonly onKeymapPrefixChange?: (prefix: readonly string[]) => void;
@@ -277,66 +269,6 @@ export function routeKey(key: KeyEvent, actions: KeyboardActions): boolean {
   const mode = actions.panels.state.mode;
   const focused = actions.panels.state.focused;
   const keymapPrefix = actions.keymapPrefix ?? [];
-
-  // Keybinding overrides (item 19): O(1) lookup via pre-built reverse map.
-  // Override lookup only applies in normal mode to avoid breaking modal input.
-  const keyActionMap = actions.keyActionMap;
-  if (mode === InputMode.Normal && keymapPrefix.length === 0 && keyActionMap && input && !isCtrl) {
-    const action = keyActionMap.get(input);
-    if (action !== undefined) {
-      switch (action) {
-        case "quit":
-          actions.onQuit();
-          return true;
-        case "help":
-          actions.panels.setMode(InputMode.Help);
-          return true;
-        case "zoom_cycle":
-          actions.onZoomCycle();
-          return true;
-        case "zoom_reset":
-          actions.onZoomReset();
-          return true;
-        case "broadcast":
-          actions.onBroadcastMode();
-          return true;
-        case "direct_message":
-          actions.onDirectMessageMode();
-          return true;
-        case "search_start":
-          if (focused === Panel.Search) actions.onSearchStart();
-          return true;
-        case "terminal_input":
-          if (focused === Panel.Terminal) actions.panels.setMode(InputMode.TerminalInput);
-          return true;
-        case "compare_toggle":
-          if (focused === Panel.Frontier) actions.onCompareToggle();
-          return true;
-        case "artifact_prev":
-          if (focused === Panel.Artifact) actions.onArtifactPrev();
-          return true;
-        case "artifact_next":
-          if (focused === Panel.Artifact) actions.onArtifactNext();
-          return true;
-        case "artifact_diff":
-          if (focused === Panel.Artifact) actions.onArtifactDiffToggle();
-          return true;
-        case "approve":
-          if (focused === Panel.Decisions) actions.onApproveQuestion();
-          return true;
-        case "deny":
-          if (focused === Panel.Decisions) actions.onDenyQuestion();
-          return true;
-        case "refresh":
-          actions.onRefresh();
-          return true;
-        case "palette":
-          actions.onSpawnPalette();
-          actions.panels.setMode(InputMode.CommandPalette);
-          return true;
-      }
-    }
-  }
 
   // Command palette toggle (works in all modes except help). Both
   // dismissal AND opening route through onPaletteClose / onSpawnPalette

--- a/src/tui/keymap/keymap.test.ts
+++ b/src/tui/keymap/keymap.test.ts
@@ -11,6 +11,7 @@ import {
   parseKeySequence,
   resolveBuiltinKeymap,
   resolveKeyBinding,
+  resolveKeymapWithOverrides,
   resolveKeySequence,
 } from "./keymap.js";
 
@@ -294,5 +295,49 @@ describe("resolveBuiltinKeymap", () => {
       expect(seen.has(key)).toBe(false);
       seen.add(key);
     }
+  });
+});
+
+describe("resolveKeymapWithOverrides", () => {
+  test("override replaces the preferred binding for the same action id", () => {
+    const keymap = resolveKeymapWithOverrides("default", { quit: "Space x" });
+    const quit = keymap.bindings.filter((binding) => binding.id === "quit");
+
+    expect(quit.some((binding) => binding.sequence.join(" ") === "space x")).toBe(true);
+    expect(quit.some((binding) => binding.sequence.join(" ") === "space q")).toBe(false);
+  });
+
+  test("parameterized panel override maps to the target panel", () => {
+    const keymap = resolveKeymapWithOverrides("default", {
+      "toggle_panel:terminal": "Space p x",
+    });
+    const terminal = keymap.bindings.find((binding) => binding.id === "toggle_panel:terminal");
+
+    expect(terminal?.sequence).toEqual(["space", "p", "x"]);
+    expect(terminal?.panel).toBe(Panel.Terminal);
+  });
+
+  test("duplicate sequences record a conflict and keep the first binding", () => {
+    const keymap = resolveKeymapWithOverrides("default", {
+      quit: "Space r",
+    });
+    const winners = keymap.bindings.filter((binding) => binding.sequence.join(" ") === "space r");
+
+    expect(keymap.conflicts[0]).toMatchObject({
+      sequence: ["space", "r"],
+      winner: "refresh",
+      loser: "quit",
+    });
+    expect(winners.map((binding) => binding.id)).toEqual(["refresh"]);
+  });
+
+  test("unknown override ids are ignored", () => {
+    const keymap = resolveKeymapWithOverrides("default", {
+      "not_real:thing": "Space nope",
+    });
+
+    expect(keymap.bindings.some((binding) => binding.sequence.join(" ") === "space nope")).toBe(
+      false,
+    );
   });
 });

--- a/src/tui/keymap/keymap.test.ts
+++ b/src/tui/keymap/keymap.test.ts
@@ -1,16 +1,20 @@
 import { describe, expect, test } from "bun:test";
+import { Panel } from "../hooks/use-panel-focus.js";
 import {
+  createKeySequence,
   formatKeySequence,
   type KeyBinding,
   keyEventToToken,
+  matchesKeySequence,
   normalizeKeyToken,
   parseKeySequence,
+  resolveKeyBinding,
   resolveKeySequence,
 } from "./keymap.js";
 
 function binding(
-  id: string,
-  sequence: readonly string[],
+  id: KeyBinding["id"],
+  sequence: KeyBinding["sequence"],
   action: KeyBinding["action"] = "help",
 ): KeyBinding {
   return {
@@ -19,6 +23,7 @@ function binding(
     sequence,
     label: id,
     context: "global",
+    layer: "normal",
     preferred: true,
   };
 }
@@ -38,6 +43,18 @@ describe("key token normalization", () => {
     expect(formatKeySequence(["return"])).toBe("Enter");
   });
 
+  test("creates immutable normalized key sequences", () => {
+    const sequence = createKeySequence("Space p t");
+    expect(sequence).toEqual(["space", "p", "t"]);
+    expect(Object.isFrozen(sequence)).toBe(true);
+  });
+
+  test("distinguishes exact, prefix, and unmatched sequences", () => {
+    expect(matchesKeySequence(["space", "p"], ["space", "p"])).toBe("exact");
+    expect(matchesKeySequence(["space", "p", "t"], ["space", "p"])).toBe("prefix");
+    expect(matchesKeySequence(["space", "p"], ["space", "x"])).toBe("none");
+  });
+
   test("normalizes individual tokens", () => {
     expect(normalizeKeyToken("Space")).toBe("space");
     expect(normalizeKeyToken("escape")).toBe("escape");
@@ -53,8 +70,8 @@ describe("key token normalization", () => {
 
 describe("resolveKeySequence", () => {
   const bindings: readonly KeyBinding[] = [
-    binding("help", ["space", "?"]),
-    binding("toggle_panel:terminal", ["space", "p", "t"], "toggle_panel"),
+    { ...binding("help", ["space", "?"]), layer: "leader" },
+    { ...binding("toggle_panel:terminal", ["space", "p", "t"], "toggle_panel"), layer: "leader" },
     binding("refresh", ["r"], "refresh"),
   ];
 
@@ -76,6 +93,38 @@ describe("resolveKeySequence", () => {
     const result = resolveKeySequence(bindings, ["space", "p", "t"]);
     expect(result.kind).toBe("match");
     if (result.kind === "match") expect(result.binding.id).toBe("toggle_panel:terminal");
+  });
+
+  test("exact match wins over a longer prefix candidate", () => {
+    const ambiguous: readonly KeyBinding[] = [
+      { ...binding("palette", ["space", "p"], "palette"), layer: "leader" },
+      { ...binding("toggle_panel:terminal", ["space", "p", "t"], "toggle_panel"), layer: "leader" },
+    ];
+
+    const result = resolveKeyBinding(ambiguous, ["space", "p"]);
+
+    expect(result.kind).toBe("match");
+    if (result.kind === "match") expect(result.binding.id).toBe("palette");
+  });
+
+  test("panel-scoped bindings only match for the focused panel", () => {
+    const scoped: readonly KeyBinding[] = [
+      {
+        ...binding("terminal_input", ["i"], "terminal_input"),
+        context: "panel",
+        layer: "panel",
+        panel: Panel.Terminal,
+      },
+      binding("refresh", ["i"], "refresh"),
+    ];
+
+    const terminalResult = resolveKeyBinding(scoped, ["i"], { focusedPanel: Panel.Terminal });
+    const dagResult = resolveKeyBinding(scoped, ["i"], { focusedPanel: Panel.Dag });
+
+    expect(terminalResult.kind).toBe("match");
+    if (terminalResult.kind === "match") expect(terminalResult.binding.id).toBe("terminal_input");
+    expect(dagResult.kind).toBe("match");
+    if (dagResult.kind === "match") expect(dagResult.binding.id).toBe("refresh");
   });
 
   test("direct sequence returns match", () => {

--- a/src/tui/keymap/keymap.test.ts
+++ b/src/tui/keymap/keymap.test.ts
@@ -331,6 +331,19 @@ describe("resolveKeymapWithOverrides", () => {
     expect(winners.map((binding) => binding.id)).toEqual(["refresh"]);
   });
 
+  test("prefix collisions record a conflict and keep the first binding", () => {
+    const keymap = resolveKeymapWithOverrides("default", {
+      refresh: "Space p",
+    });
+
+    expect(keymap.bindings.some((binding) => binding.id === "refresh")).toBe(false);
+    expect(keymap.conflicts[0]).toMatchObject({
+      sequence: ["space", "p"],
+      winner: "focus_panel:dag",
+      loser: "refresh",
+    });
+  });
+
   test("unknown override ids are ignored", () => {
     const keymap = resolveKeymapWithOverrides("default", {
       "not_real:thing": "Space nope",

--- a/src/tui/keymap/keymap.test.ts
+++ b/src/tui/keymap/keymap.test.ts
@@ -9,6 +9,7 @@ import {
   matchesKeySequence,
   normalizeKeyToken,
   parseKeySequence,
+  resolveBuiltinKeymap,
   resolveKeyBinding,
   resolveKeySequence,
 } from "./keymap.js";
@@ -159,5 +160,139 @@ describe("resolveKeySequence", () => {
 
   test("unknown sequence returns miss", () => {
     expect(resolveKeySequence(bindings, ["space", "x"])).toEqual({ kind: "miss" });
+  });
+});
+
+describe("resolveBuiltinKeymap", () => {
+  test("default preset follows the approved leader grammar", () => {
+    const keymap = resolveBuiltinKeymap("default");
+
+    expect(
+      keymap.bindings.find((binding) => binding.id === "help" && binding.preferred)?.sequence,
+    ).toEqual(["space", "?"]);
+    expect(
+      keymap.bindings.find((binding) => binding.id === "palette" && binding.preferred)?.sequence,
+    ).toEqual(["space", "c", "p"]);
+    expect(
+      keymap.bindings.find((binding) => binding.id === "zoom_reset" && binding.preferred)?.sequence,
+    ).toEqual(["space", "Z"]);
+    expect(
+      keymap.bindings.find((binding) => binding.id === "view_cycle" && binding.preferred)?.sequence,
+    ).toEqual(["space", "V"]);
+    expect(
+      keymap.bindings.find((binding) => binding.id === "direct_message" && binding.preferred)
+        ?.sequence,
+    ).toEqual(["space", "m", "@"]);
+  });
+
+  test("default preset keeps essential direct navigation", () => {
+    const keymap = resolveBuiltinKeymap("default");
+
+    expect(keymap.bindings.find((binding) => binding.id === "cursor_down")?.sequence).toEqual([
+      "j",
+    ]);
+    expect(keymap.bindings.find((binding) => binding.id === "cursor_up")?.sequence).toEqual(["k"]);
+    expect(keymap.bindings.find((binding) => binding.id === "select")?.sequence).toEqual([
+      "return",
+    ]);
+    expect(keymap.bindings.find((binding) => binding.id === "cycle_panel_next")?.sequence).toEqual([
+      "tab",
+    ]);
+  });
+
+  test("default preset focuses core panels with leader-number sequences", () => {
+    const keymap = resolveBuiltinKeymap("default");
+
+    expect(keymap.bindings.find((binding) => binding.id === "focus_panel:dag")?.sequence).toEqual([
+      "space",
+      "p",
+      "1",
+    ]);
+    expect(
+      keymap.bindings.find((binding) => binding.id === "focus_panel:detail")?.sequence,
+    ).toEqual(["space", "p", "2"]);
+    expect(
+      keymap.bindings.find((binding) => binding.id === "focus_panel:frontier")?.sequence,
+    ).toEqual(["space", "p", "3"]);
+    expect(
+      keymap.bindings.find((binding) => binding.id === "focus_panel:claims")?.sequence,
+    ).toEqual(["space", "p", "4"]);
+  });
+
+  test("default exposes leader-key terminal toggle", () => {
+    const keymap = resolveBuiltinKeymap("default");
+    const binding = keymap.bindings.find(
+      (candidate) => candidate.id === "toggle_panel:terminal" && candidate.preferred,
+    );
+
+    expect(binding).toBeDefined();
+    expect(binding?.action).toBe("toggle_panel");
+    expect(binding?.panel).toBe(Panel.Terminal);
+    expect(binding?.sequence).toEqual(["space", "p", "t"]);
+  });
+
+  test("default does not bind terminal direct alias", () => {
+    const keymap = resolveBuiltinKeymap("default");
+    const result = resolveKeySequence(keymap.bindings, ["6"]);
+
+    expect(result).toEqual({ kind: "miss" });
+  });
+
+  test("power-user includes leader and direct terminal bindings", () => {
+    const keymap = resolveBuiltinKeymap("power-user");
+    const leader = keymap.bindings.find(
+      (candidate) => candidate.id === "toggle_panel:terminal" && candidate.preferred,
+    );
+    const direct = keymap.bindings.find(
+      (candidate) =>
+        candidate.id === "toggle_panel:terminal" &&
+        candidate.sequence.length === 1 &&
+        candidate.sequence[0] === "6",
+    );
+
+    expect(leader?.sequence).toEqual(["space", "p", "t"]);
+    expect(direct?.sequence).toEqual(["6"]);
+    expect(direct?.panel).toBe(Panel.Terminal);
+  });
+
+  test("power-user direct aliases are not preferred over leader bindings", () => {
+    const keymap = resolveBuiltinKeymap("power-user");
+    const leader = keymap.bindings.find(
+      (candidate) => candidate.id === "toggle_panel:terminal" && candidate.preferred,
+    );
+    const direct = keymap.bindings.find(
+      (candidate) =>
+        candidate.id === "toggle_panel:terminal" &&
+        candidate.sequence.length === 1 &&
+        candidate.sequence[0] === "6",
+    );
+
+    expect(leader?.preferred).toBe(true);
+    expect(direct?.preferred).toBe(false);
+  });
+
+  test("imported preset bindings use frozen normalized sequences and canonical panels", () => {
+    const keymap = resolveBuiltinKeymap("power-user");
+    const terminalBindings = keymap.bindings.filter(
+      (binding) => binding.id === "toggle_panel:terminal",
+    );
+
+    expect(keymap.conflicts).toEqual([]);
+    expect(terminalBindings.length).toBeGreaterThan(0);
+    for (const binding of keymap.bindings) {
+      expect(Object.isFrozen(binding.sequence)).toBe(true);
+    }
+    expect(terminalBindings.every((binding) => binding.panel === Panel.Terminal)).toBe(true);
+  });
+
+  test("power-user does not duplicate inherited bindings", () => {
+    const keymap = resolveBuiltinKeymap("power-user");
+    const seen = new Set<string>();
+
+    for (const binding of keymap.bindings) {
+      const key = `${binding.id}:${binding.sequence.join(" ")}`;
+      expect(seen.has(key)).toBe(false);
+      seen.add(key);
+    }
   });
 });

--- a/src/tui/keymap/keymap.test.ts
+++ b/src/tui/keymap/keymap.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatKeySequence,
+  type KeyBinding,
+  keyEventToToken,
+  normalizeKeyToken,
+  parseKeySequence,
+  resolveKeySequence,
+} from "./keymap.js";
+
+function binding(
+  id: string,
+  sequence: readonly string[],
+  action: KeyBinding["action"] = "help",
+): KeyBinding {
+  return {
+    id,
+    action,
+    sequence,
+    label: id,
+    context: "global",
+    preferred: true,
+  };
+}
+
+describe("key token normalization", () => {
+  test("parses display tokens into route tokens", () => {
+    expect(parseKeySequence("Space p t")).toEqual(["space", "p", "t"]);
+    expect(parseKeySequence("Esc")).toEqual(["escape"]);
+    expect(parseKeySequence("Enter")).toEqual(["return"]);
+    expect(parseKeySequence("Ctrl+P")).toEqual(["ctrl+p"]);
+    expect(parseKeySequence("F5")).toEqual(["F5"]);
+  });
+
+  test("formats route tokens for display", () => {
+    expect(formatKeySequence(["space", "p", "t"])).toBe("Space p t");
+    expect(formatKeySequence(["ctrl+p"])).toBe("Ctrl+P");
+    expect(formatKeySequence(["return"])).toBe("Enter");
+  });
+
+  test("normalizes individual tokens", () => {
+    expect(normalizeKeyToken("Space")).toBe("space");
+    expect(normalizeKeyToken("escape")).toBe("escape");
+    expect(normalizeKeyToken("Ctrl+p")).toBe("ctrl+p");
+  });
+
+  test("converts key events into route tokens", () => {
+    expect(keyEventToToken({ name: "space", ctrl: false })).toBe("space");
+    expect(keyEventToToken({ name: "p", ctrl: true })).toBe("ctrl+p");
+    expect(keyEventToToken({ name: "F5", ctrl: false })).toBe("F5");
+  });
+});
+
+describe("resolveKeySequence", () => {
+  const bindings: readonly KeyBinding[] = [
+    binding("help", ["space", "?"]),
+    binding("toggle_panel:terminal", ["space", "p", "t"], "toggle_panel"),
+    binding("refresh", ["r"], "refresh"),
+  ];
+
+  test("leader prefix returns pending", () => {
+    expect(resolveKeySequence(bindings, ["space"])).toEqual({
+      kind: "pending",
+      prefix: ["space"],
+    });
+  });
+
+  test("nested prefix returns pending", () => {
+    expect(resolveKeySequence(bindings, ["space", "p"])).toEqual({
+      kind: "pending",
+      prefix: ["space", "p"],
+    });
+  });
+
+  test("complete sequence returns match", () => {
+    const result = resolveKeySequence(bindings, ["space", "p", "t"]);
+    expect(result.kind).toBe("match");
+    if (result.kind === "match") expect(result.binding.id).toBe("toggle_panel:terminal");
+  });
+
+  test("direct sequence returns match", () => {
+    const result = resolveKeySequence(bindings, ["r"]);
+    expect(result.kind).toBe("match");
+    if (result.kind === "match") expect(result.binding.id).toBe("refresh");
+  });
+
+  test("unknown sequence returns miss", () => {
+    expect(resolveKeySequence(bindings, ["space", "x"])).toEqual({ kind: "miss" });
+  });
+});

--- a/src/tui/keymap/keymap.test.ts
+++ b/src/tui/keymap/keymap.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Panel } from "../hooks/use-panel-focus.js";
 import {
+  type ActionKeyBinding,
   createKeySequence,
   formatKeySequence,
   type KeyBinding,
@@ -13,10 +14,10 @@ import {
 } from "./keymap.js";
 
 function binding(
-  id: KeyBinding["id"],
+  id: ActionKeyBinding["id"],
   sequence: KeyBinding["sequence"],
-  action: KeyBinding["action"] = "help",
-): KeyBinding {
+  action: ActionKeyBinding["action"] = "help",
+): ActionKeyBinding {
   return {
     id,
     action,
@@ -65,13 +66,27 @@ describe("key token normalization", () => {
     expect(keyEventToToken({ name: "space", ctrl: false })).toBe("space");
     expect(keyEventToToken({ name: "p", ctrl: true })).toBe("ctrl+p");
     expect(keyEventToToken({ name: "F5", ctrl: false })).toBe("F5");
+    expect(keyEventToToken({ name: "space", sequence: " " })).toBe("space");
+    expect(keyEventToToken({ name: "/", sequence: "?", shift: true })).toBe("?");
+    expect(keyEventToToken({ name: "v", shift: true })).toBe("V");
+    expect(keyEventToToken({ name: "z", shift: true })).toBe("Z");
+    expect(keyEventToToken({ name: "2", shift: true })).toBe("@");
   });
 });
 
 describe("resolveKeySequence", () => {
   const bindings: readonly KeyBinding[] = [
     { ...binding("help", ["space", "?"]), layer: "leader" },
-    { ...binding("toggle_panel:terminal", ["space", "p", "t"], "toggle_panel"), layer: "leader" },
+    {
+      id: "toggle_panel:terminal",
+      action: "toggle_panel",
+      sequence: ["space", "p", "t"],
+      label: "terminal",
+      context: "panel",
+      layer: "leader",
+      panel: Panel.Terminal,
+      preferred: true,
+    },
     binding("refresh", ["r"], "refresh"),
   ];
 
@@ -98,7 +113,16 @@ describe("resolveKeySequence", () => {
   test("exact match wins over a longer prefix candidate", () => {
     const ambiguous: readonly KeyBinding[] = [
       { ...binding("palette", ["space", "p"], "palette"), layer: "leader" },
-      { ...binding("toggle_panel:terminal", ["space", "p", "t"], "toggle_panel"), layer: "leader" },
+      {
+        id: "toggle_panel:terminal",
+        action: "toggle_panel",
+        sequence: ["space", "p", "t"],
+        label: "terminal",
+        context: "panel",
+        layer: "leader",
+        panel: Panel.Terminal,
+        preferred: true,
+      },
     ];
 
     const result = resolveKeyBinding(ambiguous, ["space", "p"]);

--- a/src/tui/keymap/keymap.ts
+++ b/src/tui/keymap/keymap.ts
@@ -1,4 +1,7 @@
-import { Panel, type Panel as PanelValue } from "../hooks/use-panel-focus.js";
+import type { Panel as PanelValue } from "../hooks/use-panel-focus.js";
+import defaultKeymapRaw from "../keymaps/default.json" with { type: "json" };
+import powerUserKeymapRaw from "../keymaps/power-user.json" with { type: "json" };
+import { BUILT_IN_PANEL_IDS, type BuiltInPanelId, idToPanel } from "../panels/panel-ids.js";
 
 export type KeymapPresetName = "default" | "power-user";
 
@@ -7,25 +10,7 @@ export type KeySequence = readonly KeyToken[];
 export type KeymapLayer = "normal" | "leader" | "panel";
 export type KeySequenceMatch = "exact" | "prefix" | "none";
 
-export type PanelKeymapId =
-  | "dag"
-  | "detail"
-  | "frontier"
-  | "claims"
-  | "agents"
-  | "terminal"
-  | "artifact"
-  | "vfs"
-  | "activity"
-  | "search"
-  | "threads"
-  | "outcomes"
-  | "bounties"
-  | "gossip"
-  | "inbox"
-  | "decisions"
-  | "github"
-  | "plan";
+export type PanelKeymapId = BuiltInPanelId;
 
 export type TuiActionId =
   | "quit"
@@ -109,6 +94,22 @@ export interface KeymapConflict {
   readonly loser: string;
 }
 
+interface RawKeyBinding {
+  readonly id: string;
+  readonly action: TuiActionId;
+  readonly sequence: string | readonly string[];
+  readonly label: string;
+  readonly context: KeyBindingContext;
+  readonly layer: KeymapLayer;
+  readonly panel?: string | undefined;
+  readonly preferred?: boolean | undefined;
+}
+
+interface RawBuiltinKeymap {
+  readonly extends?: KeymapPresetName | undefined;
+  readonly bindings: readonly RawKeyBinding[];
+}
+
 export type KeymapResolution =
   | { readonly kind: "pending"; readonly prefix: KeySequence }
   | { readonly kind: "match"; readonly binding: KeyBinding }
@@ -128,26 +129,31 @@ export interface KeymapResolveOptions {
   readonly focusedPanel?: PanelValue | undefined;
 }
 
-export const PANEL_BY_KEYMAP_ID: Readonly<Record<PanelKeymapId, PanelValue>> = {
-  dag: Panel.Dag,
-  detail: Panel.Detail,
-  frontier: Panel.Frontier,
-  claims: Panel.Claims,
-  agents: Panel.AgentList,
-  terminal: Panel.Terminal,
-  artifact: Panel.Artifact,
-  vfs: Panel.Vfs,
-  activity: Panel.Activity,
-  search: Panel.Search,
-  threads: Panel.Threads,
-  outcomes: Panel.Outcomes,
-  bounties: Panel.Bounties,
-  gossip: Panel.Gossip,
-  inbox: Panel.Inbox,
-  decisions: Panel.Decisions,
-  github: Panel.GitHub,
-  plan: Panel.Plan,
+const PANEL_KEYMAP_IDS: ReadonlySet<string> = new Set(BUILT_IN_PANEL_IDS);
+
+function isPanelKeymapId(id: string): id is PanelKeymapId {
+  return PANEL_KEYMAP_IDS.has(id);
+}
+
+function panelForKeymapId(id: PanelKeymapId): PanelValue {
+  const panel = idToPanel(id);
+  if (panel === undefined) throw new Error(`Unknown built-in panel id: ${id}`);
+  return panel;
+}
+
+export const PANEL_BY_KEYMAP_ID: Readonly<Record<PanelKeymapId, PanelValue>> = Object.freeze(
+  Object.fromEntries(BUILT_IN_PANEL_IDS.map((id) => [id, panelForKeymapId(id)])) as Record<
+    PanelKeymapId,
+    PanelValue
+  >,
+);
+
+const BUILTIN_KEYMAPS: Readonly<Record<KeymapPresetName, RawBuiltinKeymap>> = {
+  default: defaultKeymapRaw as RawBuiltinKeymap,
+  "power-user": powerUserKeymapRaw as RawBuiltinKeymap,
 };
+
+const EMPTY_KEYMAP_CONFLICTS: readonly KeymapConflict[] = Object.freeze([]);
 
 const DISPLAY_BY_TOKEN: Readonly<Record<string, string>> = {
   space: "Space",
@@ -256,6 +262,87 @@ export function matchesKeySequence(sequence: KeySequence, prefix: KeySequence): 
 function bindingApplies(binding: KeyBinding, options: KeymapResolveOptions): boolean {
   if (binding.layer !== "panel") return true;
   return options.focusedPanel !== undefined && binding.panel === options.focusedPanel;
+}
+
+function rawBindingsForPreset(preset: KeymapPresetName): readonly RawKeyBinding[] {
+  const raw = BUILTIN_KEYMAPS[preset];
+  if (raw.extends === undefined) return raw.bindings;
+  return [...rawBindingsForPreset(raw.extends), ...raw.bindings];
+}
+
+function resolveRawPanel(raw: RawKeyBinding): PanelValue | undefined {
+  const panelId = raw.panel;
+  if (panelId === undefined) return undefined;
+  if (!isPanelKeymapId(panelId)) {
+    throw new Error(`Key binding "${raw.id}" references unknown panel id "${panelId}"`);
+  }
+  return PANEL_BY_KEYMAP_ID[panelId];
+}
+
+function resolvePanelTargetBinding(
+  raw: RawKeyBinding,
+  action: PanelTargetActionId,
+): PanelTargetKeyBinding {
+  const panelId = raw.panel;
+  if (panelId === undefined) {
+    throw new Error(`Panel target key binding "${raw.id}" is missing a panel`);
+  }
+  if (!isPanelKeymapId(panelId)) {
+    throw new Error(`Panel target key binding "${raw.id}" references unknown panel "${panelId}"`);
+  }
+
+  const id = `${action}:${panelId}` as PanelTargetBindingId;
+  if (raw.id !== id) {
+    throw new Error(`Panel target key binding "${raw.id}" must use id "${id}"`);
+  }
+
+  return Object.freeze({
+    id,
+    action,
+    sequence: createKeySequence(raw.sequence),
+    label: raw.label,
+    context: raw.context,
+    layer: raw.layer,
+    panel: PANEL_BY_KEYMAP_ID[panelId],
+    preferred: raw.preferred ?? true,
+  });
+}
+
+function resolveActionBinding(
+  raw: RawKeyBinding,
+  action: NonPanelTargetActionId,
+): ActionKeyBinding {
+  if (raw.id !== action) {
+    throw new Error(`Key binding "${raw.id}" must match non-panel action "${action}"`);
+  }
+
+  const panel = resolveRawPanel(raw);
+  const binding = {
+    id: action,
+    action,
+    sequence: createKeySequence(raw.sequence),
+    label: raw.label,
+    context: raw.context,
+    layer: raw.layer,
+    preferred: raw.preferred ?? true,
+    ...(panel === undefined ? {} : { panel }),
+  };
+  return Object.freeze(binding);
+}
+
+function resolveRawBinding(raw: RawKeyBinding): KeyBinding {
+  if (raw.action === "focus_panel" || raw.action === "toggle_panel") {
+    return resolvePanelTargetBinding(raw, raw.action);
+  }
+  return resolveActionBinding(raw, raw.action);
+}
+
+export function resolveBuiltinKeymap(preset: KeymapPresetName): ResolvedKeymap {
+  return Object.freeze({
+    preset,
+    bindings: Object.freeze(rawBindingsForPreset(preset).map(resolveRawBinding)),
+    conflicts: EMPTY_KEYMAP_CONFLICTS,
+  });
 }
 
 function findExactBinding(

--- a/src/tui/keymap/keymap.ts
+++ b/src/tui/keymap/keymap.ts
@@ -66,14 +66,14 @@ export type TuiActionId =
   | "compare_adopt_a"
   | "compare_adopt_b";
 
-export type KeyBindingId =
-  | TuiActionId
-  | `focus_panel:${PanelKeymapId}`
-  | `toggle_panel:${PanelKeymapId}`;
+export type PanelTargetActionId = "focus_panel" | "toggle_panel";
+export type NonPanelTargetActionId = Exclude<TuiActionId, PanelTargetActionId>;
+export type PanelTargetBindingId = `focus_panel:${PanelKeymapId}` | `toggle_panel:${PanelKeymapId}`;
+export type KeyBindingId = NonPanelTargetActionId | PanelTargetBindingId;
 
 export type KeyBindingContext = "global" | "navigation" | "panel" | "messaging";
 
-export interface KeyBinding {
+interface KeyBindingBase {
   readonly id: KeyBindingId;
   readonly action: TuiActionId;
   readonly sequence: KeySequence;
@@ -83,6 +83,19 @@ export interface KeyBinding {
   readonly panel?: PanelValue | undefined;
   readonly preferred: boolean;
 }
+
+export interface ActionKeyBinding extends KeyBindingBase {
+  readonly id: NonPanelTargetActionId;
+  readonly action: NonPanelTargetActionId;
+}
+
+export interface PanelTargetKeyBinding extends Omit<KeyBindingBase, "id" | "action" | "panel"> {
+  readonly id: PanelTargetBindingId;
+  readonly action: PanelTargetActionId;
+  readonly panel: PanelValue;
+}
+
+export type KeyBinding = ActionKeyBinding | PanelTargetKeyBinding;
 
 export interface ResolvedKeymap {
   readonly preset: KeymapPresetName;
@@ -105,7 +118,9 @@ export type KeyDispatchResult = KeymapResolution;
 
 export interface KeyTokenEvent {
   readonly name?: string | undefined;
+  readonly sequence?: string | undefined;
   readonly ctrl?: boolean | undefined;
+  readonly meta?: boolean | undefined;
   readonly shift?: boolean | undefined;
 }
 
@@ -140,6 +155,33 @@ const DISPLAY_BY_TOKEN: Readonly<Record<string, string>> = {
   return: "Enter",
   tab: "Tab",
   "shift+tab": "Shift+Tab",
+};
+
+const SHIFTED_PRINTABLE_BY_NAME: Readonly<Record<string, string>> = {
+  "/": "?",
+  "=": "+",
+  v: "V",
+  z: "Z",
+  g: "G",
+  "1": "!",
+  "2": "@",
+  "3": "#",
+  "4": "$",
+  "5": "%",
+  "6": "^",
+  "7": "&",
+  "8": "*",
+  "9": "(",
+  "0": ")",
+  "-": "_",
+  "[": "{",
+  "]": "}",
+  "\\": "|",
+  ";": ":",
+  "'": '"',
+  ",": "<",
+  ".": ">",
+  "`": "~",
 };
 
 export function normalizeKeyToken(token: string): KeyToken {
@@ -185,9 +227,16 @@ export function formatKeySequence(sequence: KeySequence): string {
 
 export function keyEventToToken(event: KeyTokenEvent): KeyToken | undefined {
   const name = event.name;
-  if (!name) return undefined;
+  const sequence = event.sequence;
+  const ctrlName = name ?? sequence;
+  if (event.ctrl === true && ctrlName !== undefined) return `ctrl+${ctrlName.toLowerCase()}`;
   if (event.shift === true && name === "tab") return "shift+tab";
-  if (event.ctrl === true) return `ctrl+${name.toLowerCase()}`;
+  if (sequence === " ") return "space";
+  if (sequence !== undefined && sequence.length === 1 && event.meta !== true) {
+    return normalizeKeyToken(sequence);
+  }
+  if (!name) return undefined;
+  if (event.shift === true) return SHIFTED_PRINTABLE_BY_NAME[name] ?? normalizeKeyToken(name);
   return normalizeKeyToken(name);
 }
 

--- a/src/tui/keymap/keymap.ts
+++ b/src/tui/keymap/keymap.ts
@@ -430,6 +430,13 @@ function conflictKey(binding: KeyBinding): string {
   return `${conflictScope(binding)}:${binding.sequence.join("\u0000")}`;
 }
 
+function bindingsConflict(a: KeyBinding, b: KeyBinding): boolean {
+  return (
+    conflictScope(a) === conflictScope(b) &&
+    (sequenceStartsWith(a.sequence, b.sequence) || sequenceStartsWith(b.sequence, a.sequence))
+  );
+}
+
 function dedupeConflicts(bindings: readonly KeyBinding[]): {
   readonly bindings: readonly KeyBinding[];
   readonly conflicts: readonly KeymapConflict[];
@@ -439,7 +446,7 @@ function dedupeConflicts(bindings: readonly KeyBinding[]): {
   const conflicts: KeymapConflict[] = [];
   for (const binding of bindings) {
     const key = conflictKey(binding);
-    const winner = seen.get(key);
+    const winner = seen.get(key) ?? kept.find((candidate) => bindingsConflict(candidate, binding));
     if (winner !== undefined) {
       conflicts.push({
         sequence: binding.sequence,

--- a/src/tui/keymap/keymap.ts
+++ b/src/tui/keymap/keymap.ts
@@ -1,6 +1,11 @@
-import { Panel } from "../hooks/use-panel-focus.js";
+import { Panel, type Panel as PanelValue } from "../hooks/use-panel-focus.js";
 
 export type KeymapPresetName = "default" | "power-user";
+
+export type KeyToken = string;
+export type KeySequence = readonly KeyToken[];
+export type KeymapLayer = "normal" | "leader" | "panel";
+export type KeySequenceMatch = "exact" | "prefix" | "none";
 
 export type PanelKeymapId =
   | "dag"
@@ -44,7 +49,22 @@ export type TuiActionId =
   | "approve"
   | "deny"
   | "broadcast"
-  | "direct_message";
+  | "direct_message"
+  | "cursor_down"
+  | "cursor_up"
+  | "select"
+  | "page_next"
+  | "page_prev"
+  | "vfs_navigate"
+  | "terminal_scroll_up"
+  | "terminal_scroll_down"
+  | "terminal_scroll_bottom"
+  | "frontier_tab_next"
+  | "frontier_tab_prev"
+  | "frontier_adopt"
+  | "compare_select"
+  | "compare_adopt_a"
+  | "compare_adopt_b";
 
 export type KeyBindingId =
   | TuiActionId
@@ -54,12 +74,13 @@ export type KeyBindingId =
 export type KeyBindingContext = "global" | "navigation" | "panel" | "messaging";
 
 export interface KeyBinding {
-  readonly id: string;
+  readonly id: KeyBindingId;
   readonly action: TuiActionId;
-  readonly sequence: readonly string[];
+  readonly sequence: KeySequence;
   readonly label: string;
   readonly context: KeyBindingContext;
-  readonly panel?: Panel | undefined;
+  readonly layer: KeymapLayer;
+  readonly panel?: PanelValue | undefined;
   readonly preferred: boolean;
 }
 
@@ -76,16 +97,23 @@ export interface KeymapConflict {
 }
 
 export type KeymapResolution =
-  | { readonly kind: "pending"; readonly prefix: readonly string[] }
+  | { readonly kind: "pending"; readonly prefix: KeySequence }
   | { readonly kind: "match"; readonly binding: KeyBinding }
   | { readonly kind: "miss" };
+
+export type KeyDispatchResult = KeymapResolution;
 
 export interface KeyTokenEvent {
   readonly name?: string | undefined;
   readonly ctrl?: boolean | undefined;
+  readonly shift?: boolean | undefined;
 }
 
-export const PANEL_BY_KEYMAP_ID: Readonly<Record<PanelKeymapId, Panel>> = {
+export interface KeymapResolveOptions {
+  readonly focusedPanel?: PanelValue | undefined;
+}
+
+export const PANEL_BY_KEYMAP_ID: Readonly<Record<PanelKeymapId, PanelValue>> = {
   dag: Panel.Dag,
   detail: Panel.Detail,
   frontier: Panel.Frontier,
@@ -111,29 +139,42 @@ const DISPLAY_BY_TOKEN: Readonly<Record<string, string>> = {
   escape: "Esc",
   return: "Enter",
   tab: "Tab",
+  "shift+tab": "Shift+Tab",
 };
 
-export function normalizeKeyToken(token: string): string {
+export function normalizeKeyToken(token: string): KeyToken {
   const trimmed = token.trim();
   const lower = trimmed.toLowerCase();
   if (lower === "space") return "space";
   if (lower === "esc" || lower === "escape") return "escape";
   if (lower === "enter" || lower === "return") return "return";
   if (lower === "tab") return "tab";
+  if (lower === "shift+tab") return "shift+tab";
   if (lower.startsWith("ctrl+")) return `ctrl+${lower.slice("ctrl+".length)}`;
   return trimmed;
 }
 
-export function parseKeySequence(sequence: string): readonly string[] {
-  const tokens = sequence
-    .trim()
-    .split(/\s+/)
-    .filter((token) => token.length > 0)
-    .map(normalizeKeyToken);
+export function createKeySequence(sequence: string | readonly string[]): KeySequence {
+  const source =
+    typeof sequence === "string"
+      ? sequence
+          .trim()
+          .split(/\s+/)
+          .filter((token) => token.length > 0)
+      : sequence;
+  const tokens = source.map(normalizeKeyToken);
   return Object.freeze(tokens);
 }
 
-export function formatKeySequence(sequence: readonly string[]): string {
+export function normalizeKeySequence(sequence: string | readonly string[]): KeySequence {
+  return createKeySequence(sequence);
+}
+
+export function parseKeySequence(sequence: string): KeySequence {
+  return createKeySequence(sequence);
+}
+
+export function formatKeySequence(sequence: KeySequence): string {
   return sequence
     .map((token) => {
       if (token.startsWith("ctrl+")) return `Ctrl+${token.slice("ctrl+".length).toUpperCase()}`;
@@ -142,31 +183,64 @@ export function formatKeySequence(sequence: readonly string[]): string {
     .join(" ");
 }
 
-export function keyEventToToken(event: KeyTokenEvent): string | undefined {
+export function keyEventToToken(event: KeyTokenEvent): KeyToken | undefined {
   const name = event.name;
   if (!name) return undefined;
+  if (event.shift === true && name === "tab") return "shift+tab";
   if (event.ctrl === true) return `ctrl+${name.toLowerCase()}`;
   return normalizeKeyToken(name);
 }
 
-function sequenceEquals(a: readonly string[], b: readonly string[]): boolean {
+function sequenceEquals(a: KeySequence, b: KeySequence): boolean {
   return a.length === b.length && a.every((token, index) => token === b[index]);
 }
 
-function sequenceStartsWith(sequence: readonly string[], prefix: readonly string[]): boolean {
+function sequenceStartsWith(sequence: KeySequence, prefix: KeySequence): boolean {
   return prefix.every((token, index) => sequence[index] === token);
+}
+
+export function matchesKeySequence(sequence: KeySequence, prefix: KeySequence): KeySequenceMatch {
+  if (!sequenceStartsWith(sequence, prefix)) return "none";
+  return sequence.length === prefix.length ? "exact" : "prefix";
+}
+
+function bindingApplies(binding: KeyBinding, options: KeymapResolveOptions): boolean {
+  if (binding.layer !== "panel") return true;
+  return options.focusedPanel !== undefined && binding.panel === options.focusedPanel;
+}
+
+function findExactBinding(
+  bindings: readonly KeyBinding[],
+  prefix: KeySequence,
+  options: KeymapResolveOptions,
+): KeyBinding | undefined {
+  const exact = bindings.filter(
+    (binding) => bindingApplies(binding, options) && sequenceEquals(binding.sequence, prefix),
+  );
+  return exact.find((binding) => binding.layer === "panel") ?? exact[0];
+}
+
+export function resolveKeyBinding(
+  bindings: readonly KeyBinding[],
+  prefix: KeySequence,
+  options: KeymapResolveOptions = {},
+): KeyDispatchResult {
+  const exact = findExactBinding(bindings, prefix, options);
+  if (exact !== undefined) return { kind: "match", binding: exact };
+  const hasChild = bindings.some(
+    (binding) =>
+      bindingApplies(binding, options) &&
+      binding.sequence.length > prefix.length &&
+      sequenceStartsWith(binding.sequence, prefix),
+  );
+  if (hasChild) return { kind: "pending", prefix: Object.freeze([...prefix]) };
+  return { kind: "miss" };
 }
 
 export function resolveKeySequence(
   bindings: readonly KeyBinding[],
-  prefix: readonly string[],
+  prefix: KeySequence,
+  options: KeymapResolveOptions = {},
 ): KeymapResolution {
-  const exact = bindings.find((binding) => sequenceEquals(binding.sequence, prefix));
-  if (exact !== undefined) return { kind: "match", binding: exact };
-  const hasChild = bindings.some(
-    (binding) =>
-      binding.sequence.length > prefix.length && sequenceStartsWith(binding.sequence, prefix),
-  );
-  if (hasChild) return { kind: "pending", prefix: Object.freeze([...prefix]) };
-  return { kind: "miss" };
+  return resolveKeyBinding(bindings, prefix, options);
 }

--- a/src/tui/keymap/keymap.ts
+++ b/src/tui/keymap/keymap.ts
@@ -1,0 +1,172 @@
+import { Panel } from "../hooks/use-panel-focus.js";
+
+export type KeymapPresetName = "default" | "power-user";
+
+export type PanelKeymapId =
+  | "dag"
+  | "detail"
+  | "frontier"
+  | "claims"
+  | "agents"
+  | "terminal"
+  | "artifact"
+  | "vfs"
+  | "activity"
+  | "search"
+  | "threads"
+  | "outcomes"
+  | "bounties"
+  | "gossip"
+  | "inbox"
+  | "decisions"
+  | "github"
+  | "plan";
+
+export type TuiActionId =
+  | "quit"
+  | "help"
+  | "palette"
+  | "refresh"
+  | "zoom_cycle"
+  | "zoom_reset"
+  | "layout_toggle"
+  | "view_cycle"
+  | "focus_panel"
+  | "toggle_panel"
+  | "cycle_panel_next"
+  | "cycle_panel_prev"
+  | "search_start"
+  | "terminal_input"
+  | "compare_toggle"
+  | "artifact_prev"
+  | "artifact_next"
+  | "artifact_diff"
+  | "approve"
+  | "deny"
+  | "broadcast"
+  | "direct_message";
+
+export type KeyBindingId =
+  | TuiActionId
+  | `focus_panel:${PanelKeymapId}`
+  | `toggle_panel:${PanelKeymapId}`;
+
+export type KeyBindingContext = "global" | "navigation" | "panel" | "messaging";
+
+export interface KeyBinding {
+  readonly id: string;
+  readonly action: TuiActionId;
+  readonly sequence: readonly string[];
+  readonly label: string;
+  readonly context: KeyBindingContext;
+  readonly panel?: Panel | undefined;
+  readonly preferred: boolean;
+}
+
+export interface ResolvedKeymap {
+  readonly preset: KeymapPresetName;
+  readonly bindings: readonly KeyBinding[];
+  readonly conflicts: readonly KeymapConflict[];
+}
+
+export interface KeymapConflict {
+  readonly sequence: readonly string[];
+  readonly winner: string;
+  readonly loser: string;
+}
+
+export type KeymapResolution =
+  | { readonly kind: "pending"; readonly prefix: readonly string[] }
+  | { readonly kind: "match"; readonly binding: KeyBinding }
+  | { readonly kind: "miss" };
+
+export interface KeyTokenEvent {
+  readonly name?: string | undefined;
+  readonly ctrl?: boolean | undefined;
+}
+
+export const PANEL_BY_KEYMAP_ID: Readonly<Record<PanelKeymapId, Panel>> = {
+  dag: Panel.Dag,
+  detail: Panel.Detail,
+  frontier: Panel.Frontier,
+  claims: Panel.Claims,
+  agents: Panel.AgentList,
+  terminal: Panel.Terminal,
+  artifact: Panel.Artifact,
+  vfs: Panel.Vfs,
+  activity: Panel.Activity,
+  search: Panel.Search,
+  threads: Panel.Threads,
+  outcomes: Panel.Outcomes,
+  bounties: Panel.Bounties,
+  gossip: Panel.Gossip,
+  inbox: Panel.Inbox,
+  decisions: Panel.Decisions,
+  github: Panel.GitHub,
+  plan: Panel.Plan,
+};
+
+const DISPLAY_BY_TOKEN: Readonly<Record<string, string>> = {
+  space: "Space",
+  escape: "Esc",
+  return: "Enter",
+  tab: "Tab",
+};
+
+export function normalizeKeyToken(token: string): string {
+  const trimmed = token.trim();
+  const lower = trimmed.toLowerCase();
+  if (lower === "space") return "space";
+  if (lower === "esc" || lower === "escape") return "escape";
+  if (lower === "enter" || lower === "return") return "return";
+  if (lower === "tab") return "tab";
+  if (lower.startsWith("ctrl+")) return `ctrl+${lower.slice("ctrl+".length)}`;
+  return trimmed;
+}
+
+export function parseKeySequence(sequence: string): readonly string[] {
+  const tokens = sequence
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0)
+    .map(normalizeKeyToken);
+  return Object.freeze(tokens);
+}
+
+export function formatKeySequence(sequence: readonly string[]): string {
+  return sequence
+    .map((token) => {
+      if (token.startsWith("ctrl+")) return `Ctrl+${token.slice("ctrl+".length).toUpperCase()}`;
+      return DISPLAY_BY_TOKEN[token] ?? token;
+    })
+    .join(" ");
+}
+
+export function keyEventToToken(event: KeyTokenEvent): string | undefined {
+  const name = event.name;
+  if (!name) return undefined;
+  if (event.ctrl === true) return `ctrl+${name.toLowerCase()}`;
+  return normalizeKeyToken(name);
+}
+
+function sequenceEquals(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((token, index) => token === b[index]);
+}
+
+function sequenceStartsWith(sequence: readonly string[], prefix: readonly string[]): boolean {
+  return prefix.every((token, index) => sequence[index] === token);
+}
+
+export function resolveKeySequence(
+  bindings: readonly KeyBinding[],
+  prefix: readonly string[],
+): KeymapResolution {
+  const exact = bindings.find((binding) => sequenceEquals(binding.sequence, prefix));
+  if (exact !== undefined) return { kind: "match", binding: exact };
+  const hasChild = bindings.some(
+    (binding) =>
+      binding.sequence.length > prefix.length && sequenceStartsWith(binding.sequence, prefix),
+  );
+  if (hasChild) return { kind: "pending", prefix: Object.freeze([...prefix]) };
+  return { kind: "miss" };
+}

--- a/src/tui/keymap/keymap.ts
+++ b/src/tui/keymap/keymap.ts
@@ -58,6 +58,62 @@ export type KeyBindingId = NonPanelTargetActionId | PanelTargetBindingId;
 
 export type KeyBindingContext = "global" | "navigation" | "panel" | "messaging";
 
+export const NON_PANEL_TARGET_ACTION_IDS: readonly NonPanelTargetActionId[] = [
+  "quit",
+  "help",
+  "palette",
+  "refresh",
+  "zoom_cycle",
+  "zoom_reset",
+  "layout_toggle",
+  "view_cycle",
+  "cycle_panel_next",
+  "cycle_panel_prev",
+  "search_start",
+  "terminal_input",
+  "compare_toggle",
+  "artifact_prev",
+  "artifact_next",
+  "artifact_diff",
+  "approve",
+  "deny",
+  "broadcast",
+  "direct_message",
+  "cursor_down",
+  "cursor_up",
+  "select",
+  "page_next",
+  "page_prev",
+  "vfs_navigate",
+  "terminal_scroll_up",
+  "terminal_scroll_down",
+  "terminal_scroll_bottom",
+  "frontier_tab_next",
+  "frontier_tab_prev",
+  "frontier_adopt",
+  "compare_select",
+  "compare_adopt_a",
+  "compare_adopt_b",
+] as const;
+
+export const KEY_BINDING_IDS: readonly KeyBindingId[] = Object.freeze([
+  ...NON_PANEL_TARGET_ACTION_IDS,
+  ...BUILT_IN_PANEL_IDS.flatMap((panelId) => [
+    `focus_panel:${panelId}` as const,
+    `toggle_panel:${panelId}` as const,
+  ]),
+]) as readonly KeyBindingId[];
+
+const KEY_BINDING_ID_SET: ReadonlySet<string> = new Set(KEY_BINDING_IDS);
+
+export function isKeyBindingId(id: string): id is KeyBindingId {
+  return KEY_BINDING_ID_SET.has(id);
+}
+
+function isPanelTargetBindingId(id: KeyBindingId): id is PanelTargetBindingId {
+  return id.startsWith("focus_panel:") || id.startsWith("toggle_panel:");
+}
+
 interface KeyBindingBase {
   readonly id: KeyBindingId;
   readonly action: TuiActionId;
@@ -93,6 +149,8 @@ export interface KeymapConflict {
   readonly winner: string;
   readonly loser: string;
 }
+
+export type KeymapOverrides = Readonly<Record<string, string>>;
 
 interface RawKeyBinding {
   readonly id: string;
@@ -342,6 +400,118 @@ export function resolveBuiltinKeymap(preset: KeymapPresetName): ResolvedKeymap {
     preset,
     bindings: Object.freeze(rawBindingsForPreset(preset).map(resolveRawBinding)),
     conflicts: EMPTY_KEYMAP_CONFLICTS,
+  });
+}
+
+function actionFromBindingId(id: KeyBindingId): TuiActionId {
+  if (id.startsWith("focus_panel:")) return "focus_panel";
+  if (id.startsWith("toggle_panel:")) return "toggle_panel";
+  return id as NonPanelTargetActionId;
+}
+
+function panelFromBindingId(id: KeyBindingId): PanelValue | undefined {
+  const [, rawPanelId] = id.split(":");
+  if (rawPanelId === undefined || !isPanelKeymapId(rawPanelId)) return undefined;
+  return PANEL_BY_KEYMAP_ID[rawPanelId];
+}
+
+function findTemplateBinding(
+  id: KeyBindingId,
+  bindings: readonly KeyBinding[],
+): KeyBinding | undefined {
+  return bindings.find((binding) => binding.id === id);
+}
+
+function conflictScope(binding: KeyBinding): string {
+  return binding.layer === "panel" ? `${binding.layer}:${binding.panel ?? ""}` : binding.layer;
+}
+
+function conflictKey(binding: KeyBinding): string {
+  return `${conflictScope(binding)}:${binding.sequence.join("\u0000")}`;
+}
+
+function dedupeConflicts(bindings: readonly KeyBinding[]): {
+  readonly bindings: readonly KeyBinding[];
+  readonly conflicts: readonly KeymapConflict[];
+} {
+  const seen = new Map<string, KeyBinding>();
+  const kept: KeyBinding[] = [];
+  const conflicts: KeymapConflict[] = [];
+  for (const binding of bindings) {
+    const key = conflictKey(binding);
+    const winner = seen.get(key);
+    if (winner !== undefined) {
+      conflicts.push({
+        sequence: binding.sequence,
+        winner: winner.id,
+        loser: binding.id,
+      });
+      continue;
+    }
+    seen.set(key, binding);
+    kept.push(binding);
+  }
+  return { bindings: Object.freeze(kept), conflicts: Object.freeze(conflicts) };
+}
+
+function resolveOverrideBinding(
+  id: KeyBindingId,
+  sequence: string,
+  base: readonly KeyBinding[],
+): KeyBinding {
+  const action = actionFromBindingId(id);
+  const template = findTemplateBinding(id, base);
+  const common = {
+    sequence: createKeySequence(sequence),
+    label: template?.label ?? id,
+    context: template?.context ?? "global",
+    layer: template?.layer ?? "normal",
+    preferred: true,
+  };
+
+  if (isPanelTargetBindingId(id)) {
+    const targetAction: PanelTargetActionId = id.startsWith("focus_panel:")
+      ? "focus_panel"
+      : "toggle_panel";
+    const panel = panelFromBindingId(id);
+    if (panel === undefined) {
+      throw new Error(`Panel target key binding "${id}" is missing a valid panel`);
+    }
+    return Object.freeze({
+      id,
+      action: targetAction,
+      ...common,
+      panel,
+    });
+  }
+
+  const panel = template?.panel;
+  const nonPanelAction = action as NonPanelTargetActionId;
+  return Object.freeze({
+    id,
+    action: nonPanelAction,
+    ...common,
+    ...(panel === undefined ? {} : { panel }),
+  });
+}
+
+export function resolveKeymapWithOverrides(
+  preset: KeymapPresetName,
+  overrides: KeymapOverrides,
+): ResolvedKeymap {
+  const base = resolveBuiltinKeymap(preset).bindings;
+  const validOverrideIds = Object.keys(overrides).filter(isKeyBindingId);
+  const overriddenIds = new Set<KeyBindingId>(validOverrideIds);
+  const retained = base.filter((binding) => !overriddenIds.has(binding.id));
+  const overrideBindings = validOverrideIds.map((id) =>
+    resolveOverrideBinding(id, overrides[id] ?? "", base),
+  );
+  const deduped = dedupeConflicts([...retained, ...overrideBindings]);
+
+  return Object.freeze({
+    preset,
+    bindings: deduped.bindings,
+    conflicts: deduped.conflicts,
   });
 }
 

--- a/src/tui/keymaps/default.json
+++ b/src/tui/keymaps/default.json
@@ -1,0 +1,480 @@
+{
+  "bindings": [
+    {
+      "id": "quit",
+      "action": "quit",
+      "sequence": "Space q",
+      "label": "Quit",
+      "context": "global",
+      "layer": "leader"
+    },
+    {
+      "id": "help",
+      "action": "help",
+      "sequence": "Space ?",
+      "label": "Help",
+      "context": "global",
+      "layer": "leader"
+    },
+    {
+      "id": "palette",
+      "action": "palette",
+      "sequence": "Space c p",
+      "label": "Command palette",
+      "context": "global",
+      "layer": "leader"
+    },
+    {
+      "id": "refresh",
+      "action": "refresh",
+      "sequence": "Space r",
+      "label": "Refresh",
+      "context": "global",
+      "layer": "leader"
+    },
+    {
+      "id": "zoom_cycle",
+      "action": "zoom_cycle",
+      "sequence": "Space z",
+      "label": "Zoom cycle",
+      "context": "global",
+      "layer": "leader"
+    },
+    {
+      "id": "zoom_reset",
+      "action": "zoom_reset",
+      "sequence": "Space Z",
+      "label": "Zoom reset",
+      "context": "global",
+      "layer": "leader"
+    },
+    {
+      "id": "layout_toggle",
+      "action": "layout_toggle",
+      "sequence": "Space l",
+      "label": "Toggle layout",
+      "context": "global",
+      "layer": "leader"
+    },
+    {
+      "id": "view_cycle",
+      "action": "view_cycle",
+      "sequence": "Space V",
+      "label": "Cycle view",
+      "context": "global",
+      "layer": "leader"
+    },
+    {
+      "id": "cycle_panel_next",
+      "action": "cycle_panel_next",
+      "sequence": "Tab",
+      "label": "Next panel",
+      "context": "navigation",
+      "layer": "normal"
+    },
+    {
+      "id": "cycle_panel_prev",
+      "action": "cycle_panel_prev",
+      "sequence": "Shift+Tab",
+      "label": "Previous panel",
+      "context": "navigation",
+      "layer": "normal"
+    },
+    {
+      "id": "cursor_down",
+      "action": "cursor_down",
+      "sequence": "j",
+      "label": "Move cursor down",
+      "context": "navigation",
+      "layer": "normal"
+    },
+    {
+      "id": "cursor_down",
+      "action": "cursor_down",
+      "sequence": "down",
+      "label": "Move cursor down",
+      "context": "navigation",
+      "layer": "normal"
+    },
+    {
+      "id": "cursor_up",
+      "action": "cursor_up",
+      "sequence": "k",
+      "label": "Move cursor up",
+      "context": "navigation",
+      "layer": "normal"
+    },
+    {
+      "id": "cursor_up",
+      "action": "cursor_up",
+      "sequence": "up",
+      "label": "Move cursor up",
+      "context": "navigation",
+      "layer": "normal"
+    },
+    {
+      "id": "select",
+      "action": "select",
+      "sequence": "Enter",
+      "label": "Select",
+      "context": "navigation",
+      "layer": "normal"
+    },
+    {
+      "id": "page_next",
+      "action": "page_next",
+      "sequence": "n",
+      "label": "Next page",
+      "context": "navigation",
+      "layer": "normal"
+    },
+    {
+      "id": "page_prev",
+      "action": "page_prev",
+      "sequence": "p",
+      "label": "Previous page",
+      "context": "navigation",
+      "layer": "normal"
+    },
+    {
+      "id": "broadcast",
+      "action": "broadcast",
+      "sequence": "Space m b",
+      "label": "Broadcast message",
+      "context": "messaging",
+      "layer": "leader"
+    },
+    {
+      "id": "direct_message",
+      "action": "direct_message",
+      "sequence": "Space m @",
+      "label": "Direct message",
+      "context": "messaging",
+      "layer": "leader"
+    },
+    {
+      "id": "focus_panel:dag",
+      "action": "focus_panel",
+      "sequence": "Space p 1",
+      "label": "Focus DAG panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "dag"
+    },
+    {
+      "id": "focus_panel:detail",
+      "action": "focus_panel",
+      "sequence": "Space p 2",
+      "label": "Focus Detail panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "detail"
+    },
+    {
+      "id": "focus_panel:frontier",
+      "action": "focus_panel",
+      "sequence": "Space p 3",
+      "label": "Focus Frontier panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "frontier"
+    },
+    {
+      "id": "focus_panel:claims",
+      "action": "focus_panel",
+      "sequence": "Space p 4",
+      "label": "Focus Claims panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "claims"
+    },
+    {
+      "id": "toggle_panel:agents",
+      "action": "toggle_panel",
+      "sequence": "Space p a",
+      "label": "Toggle Agents panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "agents"
+    },
+    {
+      "id": "toggle_panel:terminal",
+      "action": "toggle_panel",
+      "sequence": "Space p t",
+      "label": "Toggle Terminal panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "terminal"
+    },
+    {
+      "id": "toggle_panel:artifact",
+      "action": "toggle_panel",
+      "sequence": "Space p A",
+      "label": "Toggle Artifact panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "artifact"
+    },
+    {
+      "id": "toggle_panel:vfs",
+      "action": "toggle_panel",
+      "sequence": "Space p v",
+      "label": "Toggle VFS panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "vfs"
+    },
+    {
+      "id": "toggle_panel:activity",
+      "action": "toggle_panel",
+      "sequence": "Space p 9",
+      "label": "Toggle Activity panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "activity"
+    },
+    {
+      "id": "toggle_panel:search",
+      "action": "toggle_panel",
+      "sequence": "Space p s",
+      "label": "Toggle Search panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "search"
+    },
+    {
+      "id": "toggle_panel:threads",
+      "action": "toggle_panel",
+      "sequence": "Space p h",
+      "label": "Toggle Threads panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "threads"
+    },
+    {
+      "id": "toggle_panel:outcomes",
+      "action": "toggle_panel",
+      "sequence": "Space p o",
+      "label": "Toggle Outcomes panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "outcomes"
+    },
+    {
+      "id": "toggle_panel:bounties",
+      "action": "toggle_panel",
+      "sequence": "Space p b",
+      "label": "Toggle Bounties panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "bounties"
+    },
+    {
+      "id": "toggle_panel:gossip",
+      "action": "toggle_panel",
+      "sequence": "Space p g",
+      "label": "Toggle Gossip panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "gossip"
+    },
+    {
+      "id": "toggle_panel:inbox",
+      "action": "toggle_panel",
+      "sequence": "Space p i",
+      "label": "Toggle Inbox panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "inbox"
+    },
+    {
+      "id": "toggle_panel:decisions",
+      "action": "toggle_panel",
+      "sequence": "Space p d",
+      "label": "Toggle Decisions panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "decisions"
+    },
+    {
+      "id": "toggle_panel:github",
+      "action": "toggle_panel",
+      "sequence": "Space p H",
+      "label": "Toggle GitHub panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "github"
+    },
+    {
+      "id": "toggle_panel:plan",
+      "action": "toggle_panel",
+      "sequence": "Space p P",
+      "label": "Toggle Plan panel",
+      "context": "panel",
+      "layer": "leader",
+      "panel": "plan"
+    },
+    {
+      "id": "terminal_input",
+      "action": "terminal_input",
+      "sequence": "i",
+      "label": "Enter terminal input mode",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "terminal"
+    },
+    {
+      "id": "terminal_scroll_down",
+      "action": "terminal_scroll_down",
+      "sequence": "j",
+      "label": "Scroll terminal down",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "terminal"
+    },
+    {
+      "id": "terminal_scroll_up",
+      "action": "terminal_scroll_up",
+      "sequence": "k",
+      "label": "Scroll terminal up",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "terminal"
+    },
+    {
+      "id": "terminal_scroll_bottom",
+      "action": "terminal_scroll_bottom",
+      "sequence": "G",
+      "label": "Scroll terminal to bottom",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "terminal"
+    },
+    {
+      "id": "artifact_prev",
+      "action": "artifact_prev",
+      "sequence": "h",
+      "label": "Previous artifact",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "artifact"
+    },
+    {
+      "id": "artifact_next",
+      "action": "artifact_next",
+      "sequence": "l",
+      "label": "Next artifact",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "artifact"
+    },
+    {
+      "id": "artifact_diff",
+      "action": "artifact_diff",
+      "sequence": "d",
+      "label": "Toggle artifact diff",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "artifact"
+    },
+    {
+      "id": "compare_adopt_a",
+      "action": "compare_adopt_a",
+      "sequence": "a",
+      "label": "Adopt comparison A",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "artifact"
+    },
+    {
+      "id": "compare_adopt_b",
+      "action": "compare_adopt_b",
+      "sequence": "b",
+      "label": "Adopt comparison B",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "artifact"
+    },
+    {
+      "id": "approve",
+      "action": "approve",
+      "sequence": "a",
+      "label": "Approve pending question",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "decisions"
+    },
+    {
+      "id": "deny",
+      "action": "deny",
+      "sequence": "d",
+      "label": "Deny pending question",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "decisions"
+    },
+    {
+      "id": "compare_toggle",
+      "action": "compare_toggle",
+      "sequence": "C",
+      "label": "Compare frontier artifacts",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "frontier"
+    },
+    {
+      "id": "frontier_tab_next",
+      "action": "frontier_tab_next",
+      "sequence": "]",
+      "label": "Next frontier slice",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "frontier"
+    },
+    {
+      "id": "frontier_tab_prev",
+      "action": "frontier_tab_prev",
+      "sequence": "[",
+      "label": "Previous frontier slice",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "frontier"
+    },
+    {
+      "id": "frontier_adopt",
+      "action": "frontier_adopt",
+      "sequence": "a",
+      "label": "Adopt frontier item",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "frontier"
+    },
+    {
+      "id": "compare_select",
+      "action": "compare_select",
+      "sequence": "Enter",
+      "label": "Select comparison item",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "frontier"
+    },
+    {
+      "id": "search_start",
+      "action": "search_start",
+      "sequence": "/",
+      "label": "Search",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "search"
+    },
+    {
+      "id": "vfs_navigate",
+      "action": "vfs_navigate",
+      "sequence": "Enter",
+      "label": "Browse VFS entry",
+      "context": "panel",
+      "layer": "panel",
+      "panel": "vfs"
+    }
+  ]
+}

--- a/src/tui/keymaps/power-user.json
+++ b/src/tui/keymaps/power-user.json
@@ -1,0 +1,275 @@
+{
+  "extends": "default",
+  "bindings": [
+    {
+      "id": "quit",
+      "action": "quit",
+      "sequence": "q",
+      "label": "Quit",
+      "context": "global",
+      "layer": "normal",
+      "preferred": false
+    },
+    {
+      "id": "help",
+      "action": "help",
+      "sequence": "?",
+      "label": "Help",
+      "context": "global",
+      "layer": "normal",
+      "preferred": false
+    },
+    {
+      "id": "refresh",
+      "action": "refresh",
+      "sequence": "r",
+      "label": "Refresh",
+      "context": "global",
+      "layer": "normal",
+      "preferred": false
+    },
+    {
+      "id": "zoom_cycle",
+      "action": "zoom_cycle",
+      "sequence": "+",
+      "label": "Zoom cycle",
+      "context": "global",
+      "layer": "normal",
+      "preferred": false
+    },
+    {
+      "id": "zoom_reset",
+      "action": "zoom_reset",
+      "sequence": "Esc",
+      "label": "Zoom reset",
+      "context": "global",
+      "layer": "normal",
+      "preferred": false
+    },
+    {
+      "id": "view_cycle",
+      "action": "view_cycle",
+      "sequence": "V",
+      "label": "Cycle view",
+      "context": "global",
+      "layer": "normal",
+      "preferred": false
+    },
+    {
+      "id": "palette",
+      "action": "palette",
+      "sequence": "m",
+      "label": "Command palette",
+      "context": "global",
+      "layer": "normal",
+      "preferred": false
+    },
+    {
+      "id": "palette",
+      "action": "palette",
+      "sequence": "Ctrl+P",
+      "label": "Command palette",
+      "context": "global",
+      "layer": "normal",
+      "preferred": false
+    },
+    {
+      "id": "focus_panel:dag",
+      "action": "focus_panel",
+      "sequence": "1",
+      "label": "Focus DAG panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "dag",
+      "preferred": false
+    },
+    {
+      "id": "focus_panel:detail",
+      "action": "focus_panel",
+      "sequence": "2",
+      "label": "Focus Detail panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "detail",
+      "preferred": false
+    },
+    {
+      "id": "focus_panel:frontier",
+      "action": "focus_panel",
+      "sequence": "3",
+      "label": "Focus Frontier panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "frontier",
+      "preferred": false
+    },
+    {
+      "id": "focus_panel:claims",
+      "action": "focus_panel",
+      "sequence": "4",
+      "label": "Focus Claims panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "claims",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:agents",
+      "action": "toggle_panel",
+      "sequence": "5",
+      "label": "Toggle Agents panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "agents",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:terminal",
+      "action": "toggle_panel",
+      "sequence": "6",
+      "label": "Toggle Terminal panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "terminal",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:artifact",
+      "action": "toggle_panel",
+      "sequence": "7",
+      "label": "Toggle Artifact panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "artifact",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:vfs",
+      "action": "toggle_panel",
+      "sequence": "8",
+      "label": "Toggle VFS panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "vfs",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:activity",
+      "action": "toggle_panel",
+      "sequence": "9",
+      "label": "Toggle Activity panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "activity",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:search",
+      "action": "toggle_panel",
+      "sequence": "0",
+      "label": "Toggle Search panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "search",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:threads",
+      "action": "toggle_panel",
+      "sequence": "-",
+      "label": "Toggle Threads panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "threads",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:outcomes",
+      "action": "toggle_panel",
+      "sequence": "=",
+      "label": "Toggle Outcomes panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "outcomes",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:bounties",
+      "action": "toggle_panel",
+      "sequence": "[",
+      "label": "Toggle Bounties panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "bounties",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:gossip",
+      "action": "toggle_panel",
+      "sequence": "]",
+      "label": "Toggle Gossip panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "gossip",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:inbox",
+      "action": "toggle_panel",
+      "sequence": "\\",
+      "label": "Toggle Inbox panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "inbox",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:decisions",
+      "action": "toggle_panel",
+      "sequence": ";",
+      "label": "Toggle Decisions panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "decisions",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:github",
+      "action": "toggle_panel",
+      "sequence": "'",
+      "label": "Toggle GitHub panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "github",
+      "preferred": false
+    },
+    {
+      "id": "toggle_panel:plan",
+      "action": "toggle_panel",
+      "sequence": "`",
+      "label": "Toggle Plan panel",
+      "context": "panel",
+      "layer": "normal",
+      "panel": "plan",
+      "preferred": false
+    },
+    {
+      "id": "broadcast",
+      "action": "broadcast",
+      "sequence": "b",
+      "label": "Broadcast message",
+      "context": "messaging",
+      "layer": "normal",
+      "preferred": false
+    },
+    {
+      "id": "direct_message",
+      "action": "direct_message",
+      "sequence": "@",
+      "label": "Direct message",
+      "context": "messaging",
+      "layer": "normal",
+      "preferred": false
+    }
+  ]
+}

--- a/src/tui/screens/running-keyboard.test.ts
+++ b/src/tui/screens/running-keyboard.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
+import { resolveBuiltinKeymap, resolveKeymapWithOverrides } from "../keymap/keymap.js";
 import {
   collapsePanel,
   expandPanel,
@@ -154,6 +155,7 @@ function mockActions(overrides?: {
     feedLength: overrides?.feedLength ?? 10,
     hasAskUser: overrides?.hasAskUser ?? false,
     logViewActive: overrides?.logViewActive ?? false,
+    onKeymapPrefixChange: (prefix) => record("onKeymapPrefixChange", prefix),
   };
 
   return { actions, log };
@@ -379,6 +381,78 @@ describe("routeRunningKey — f key fullscreen", () => {
 // ===========================================================================
 
 describe("routeRunningKey — normal mode misc", () => {
+  test("Space q shows quit dialog from the default keymap", () => {
+    const keymap = resolveBuiltinKeymap("default");
+    const first = mockActions();
+    routeRunningKey(keyEvent("space"), defaultState({ resolvedKeymap: keymap }), first.actions);
+    const second = mockActions();
+    const handled = routeRunningKey(
+      keyEvent("q"),
+      defaultState({ resolvedKeymap: keymap, keymapPrefix: ["space"] }),
+      second.actions,
+    );
+
+    expect(first.log.args.onKeymapPrefixChange).toEqual([["space"]]);
+    expect(handled).toBe(true);
+    expect(second.log.calls).toContain("showQuitDialog");
+  });
+
+  test("default keymap does not fall through to direct q quit", () => {
+    const { actions, log } = mockActions();
+    const handled = routeRunningKey(
+      keyEvent("q"),
+      defaultState({ resolvedKeymap: resolveBuiltinKeymap("default") }),
+      actions,
+    );
+
+    expect(handled).toBe(false);
+    expect(log.calls).not.toContain("showQuitDialog");
+  });
+
+  test("overridden quit key removes the old direct key", () => {
+    const keymap = resolveKeymapWithOverrides("default", { quit: "Space x" });
+    const oldKey = mockActions();
+    const handledOld = routeRunningKey(
+      keyEvent("q"),
+      defaultState({ resolvedKeymap: keymap }),
+      oldKey.actions,
+    );
+    const remapped = mockActions();
+    const handledRemapped = routeRunningKey(
+      keyEvent("x"),
+      defaultState({ resolvedKeymap: keymap, keymapPrefix: ["space"] }),
+      remapped.actions,
+    );
+
+    expect(handledOld).toBe(false);
+    expect(oldKey.log.calls).not.toContain("showQuitDialog");
+    expect(handledRemapped).toBe(true);
+    expect(remapped.log.calls).toContain("showQuitDialog");
+  });
+
+  test("Space p t expands the Terminal panel from the default keymap", () => {
+    const keymap = resolveBuiltinKeymap("default");
+    const first = mockActions();
+    routeRunningKey(keyEvent("space"), defaultState({ resolvedKeymap: keymap }), first.actions);
+    const second = mockActions();
+    routeRunningKey(
+      keyEvent("p"),
+      defaultState({ resolvedKeymap: keymap, keymapPrefix: ["space"] }),
+      second.actions,
+    );
+    const third = mockActions();
+    const handled = routeRunningKey(
+      keyEvent("t"),
+      defaultState({ resolvedKeymap: keymap, keymapPrefix: ["space", "p"] }),
+      third.actions,
+    );
+
+    expect(first.log.args.onKeymapPrefixChange).toEqual([["space"]]);
+    expect(second.log.args.onKeymapPrefixChange).toEqual([["space", "p"]]);
+    expect(handled).toBe(true);
+    expect(third.log.args.expandPanel).toEqual([RunningPanel.Terminal]);
+  });
+
   test("q shows quit dialog", () => {
     const { actions, log } = mockActions();
     routeRunningKey(keyEvent("q"), defaultState(), actions);

--- a/src/tui/screens/running-keyboard.ts
+++ b/src/tui/screens/running-keyboard.ts
@@ -8,6 +8,12 @@
 
 import type { KeyEvent } from "@opentui/core";
 import { isHelpToggleKey } from "../hooks/shared-keyboard-core.js";
+import {
+  type KeyBinding,
+  keyEventToToken,
+  type ResolvedKeymap,
+  resolveKeySequence,
+} from "../keymap/keymap.js";
 import type { ZoomLevel } from "../panels/panel-registry.js";
 
 // ---------------------------------------------------------------------------
@@ -74,6 +80,10 @@ export interface RunningKeyboardState {
    * approve/deny a pending tmux permission prompt.
    */
   readonly confirmModalOpen: boolean;
+  /** Active keymap for normal-mode leader sequences. */
+  readonly resolvedKeymap?: ResolvedKeymap | undefined;
+  /** Pending keymap prefix, if the operator is entering a leader sequence. */
+  readonly keymapPrefix?: readonly string[] | undefined;
   /**
    * #310: LogView filter-input mode. When true, the dispatcher swallows
    * printable keys into the LogView filter buffer instead of routing them
@@ -160,6 +170,7 @@ export interface RunningKeyboardActions {
   readonly logCancelFilter: () => void;
   readonly logFilterAppend: (ch: string) => void;
   readonly logFilterBackspace: () => void;
+  readonly onKeymapPrefixChange?: ((prefix: readonly string[]) => void) | undefined;
   // Context flags (not actions, just state the handler needs to make decisions)
   readonly hasPermissions: boolean;
   readonly hasActiveRoles: boolean;
@@ -208,6 +219,89 @@ export function toggleFullscreen(
 /** Collapse the expanded panel back to feed-only view. */
 export function collapsePanel(): { expandedPanel: RunningPanel | null; zoomLevel: ZoomLevel } {
   return { expandedPanel: null, zoomLevel: "normal" };
+}
+
+function runningPanelForKeyBinding(binding: KeyBinding): RunningPanel | undefined {
+  const [, panelId] = binding.id.split(":");
+  switch (panelId) {
+    case "agents":
+      return RunningPanel.Agents;
+    case "dag":
+      return RunningPanel.Dag;
+    case "terminal":
+      return RunningPanel.Terminal;
+    default:
+      return undefined;
+  }
+}
+
+function executeRunningKeymapAction(
+  binding: KeyBinding,
+  state: RunningKeyboardState,
+  actions: RunningKeyboardActions,
+): boolean {
+  switch (binding.action) {
+    case "quit":
+      if (state.showVfs) actions.dismissVfs();
+      else actions.showQuitDialog();
+      return true;
+    case "help":
+      actions.toggleHelp();
+      return true;
+    case "focus_panel":
+    case "toggle_panel": {
+      if (binding.id === "toggle_panel:vfs") {
+        actions.toggleVfs();
+        return true;
+      }
+      const panel = runningPanelForKeyBinding(binding);
+      if (panel === undefined) return false;
+      actions.expandPanel(panel);
+      return true;
+    }
+    case "zoom_cycle":
+      if (state.expandedPanel === null) return false;
+      actions.toggleFullscreen();
+      return true;
+    case "cursor_down":
+      if (state.expandedPanel === RunningPanel.Trace) actions.traceSelectDown();
+      else if (state.expandedPanel === RunningPanel.Handoffs) actions.handoffCursorDown();
+      else actions.feedCursorDown();
+      return true;
+    case "cursor_up":
+      if (state.expandedPanel === RunningPanel.Trace) actions.traceSelectUp();
+      else if (state.expandedPanel === RunningPanel.Handoffs) actions.handoffCursorUp();
+      else actions.feedCursorUp();
+      return true;
+    case "search_start":
+      actions.enterFilterMode();
+      return true;
+    case "broadcast":
+    case "direct_message":
+      if (!(actions.hasSendToAgent && actions.hasActiveRoles)) return false;
+      actions.enterPromptMode();
+      return true;
+    case "approve":
+      if (!(actions.hasPermissions && !state.confirmModalOpen)) return false;
+      actions.approvePermission();
+      return true;
+    case "deny":
+      if (!(actions.hasPermissions && !state.confirmModalOpen)) return false;
+      actions.denyPermission();
+      return true;
+    default:
+      return false;
+  }
+}
+
+function shouldSuppressLegacyRunningKey(
+  key: KeyEvent,
+  token: string,
+  keymap: ResolvedKeymap,
+): boolean {
+  if (token === "q") return keymap.bindings.some((binding) => binding.action === "quit");
+  if (isHelpToggleKey(key)) return keymap.bindings.some((binding) => binding.action === "help");
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -350,6 +444,33 @@ export function routeRunningKey(
       return true;
     }
     // Unmatched keys fall through to global handlers.
+  }
+
+  const resolvedKeymap = state.resolvedKeymap;
+  const keymapPrefix = state.keymapPrefix ?? [];
+  if (resolvedKeymap !== undefined) {
+    const token = keyEventToToken(key);
+    if (token !== undefined) {
+      const nextPrefix = Object.freeze([...keymapPrefix, token]);
+      const result = resolveKeySequence(resolvedKeymap.bindings, nextPrefix);
+      switch (result.kind) {
+        case "pending":
+          actions.onKeymapPrefixChange?.(result.prefix);
+          return true;
+        case "match":
+          actions.onKeymapPrefixChange?.([]);
+          if (executeRunningKeymapAction(result.binding, state, actions)) return true;
+          if (keymapPrefix.length > 0) return true;
+          break;
+        case "miss":
+          if (keymapPrefix.length > 0) {
+            actions.onKeymapPrefixChange?.([]);
+            return true;
+          }
+          if (shouldSuppressLegacyRunningKey(key, token, resolvedKeymap)) return false;
+          break;
+      }
+    }
   }
 
   // ─── Normal mode ───

--- a/src/tui/screens/running-view.tsx
+++ b/src/tui/screens/running-view.tsx
@@ -35,6 +35,7 @@ import { EmptyState } from "../components/empty-state.js";
 import { FlashBar } from "../components/flash-bar.js";
 import { ProgressBar } from "../components/progress-bar.js";
 import { Prompt } from "../components/prompt.js";
+import type { GroveUserConfig } from "../config-loader.js";
 import { createTuiConfigWatcher } from "../config-watcher.js";
 import type { AgentLogBuffer } from "../data/agent-log-buffer.js";
 import { type AliasMap, DEFAULT_ALIASES, matchAliases, resolveAlias } from "../data/aliases.js";
@@ -45,9 +46,19 @@ import { useEntityWatchEnabled } from "../hooks/informer-context.js";
 import { useAgentMonitor } from "../hooks/use-agent-monitor.js";
 import { useEntities } from "../hooks/use-entities.js";
 import { useEventDrivenData } from "../hooks/use-event-driven-data.js";
+import {
+  type KeybindingOverrides,
+  useKeybindingOverrides,
+} from "../hooks/use-keybinding-overrides.js";
 import { InputMode } from "../hooks/use-panel-focus.js";
 import { usePagesStoreFromContext, useScreenStack } from "../hooks/use-screen-stack.js";
 import { useTuiStatePersistence } from "../hooks/use-session-persistence.js";
+import {
+  formatKeySequence,
+  type KeyBinding,
+  type ResolvedKeymap,
+  resolveKeymapWithOverrides,
+} from "../keymap/keymap.js";
 import type { DashboardData, TuiDataProvider } from "../provider.js";
 import { isHandoffProvider, isVfsProvider } from "../provider.js";
 import { useConfirmAndMutateOpen } from "../safety/index.js";
@@ -162,6 +173,7 @@ export interface RunningViewProps {
   readonly agentFailures?: ReadonlyMap<string, string> | undefined;
   /** Suppress side effects for the first loaded feed, used when resuming historical sessions. */
   readonly suppressInitialFeedSideEffects?: boolean | undefined;
+  readonly userConfig?: GroveUserConfig | undefined;
   readonly onEnterInspect: () => void;
   /** Open the Pulse dashboard page (#308). */
   readonly onOpenPulse?: (() => void) | undefined;
@@ -240,6 +252,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     logBuffers,
     agentFailures,
     suppressInitialFeedSideEffects = false,
+    userConfig,
     onEnterInspect,
     onOpenPulse,
     onComplete: _onComplete,
@@ -313,6 +326,17 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
     }, []);
 
     const [aliases, setAliases] = useState<AliasMap>(DEFAULT_ALIASES);
+    const [hotkeyOverrides, setHotkeyOverrides] = useState<KeybindingOverrides>({});
+    const fileOverrides = useKeybindingOverrides();
+    const keybindingOverrides = useMemo(
+      () => ({ ...userConfig?.keymap, ...hotkeyOverrides, ...fileOverrides }),
+      [userConfig?.keymap, hotkeyOverrides, fileOverrides],
+    );
+    const resolvedKeymap = useMemo(
+      () => resolveKeymapWithOverrides(userConfig?.keymapPreset ?? "default", keybindingOverrides),
+      [userConfig?.keymapPreset, keybindingOverrides],
+    );
+    const [keymapPrefix, setKeymapPrefix] = useState<readonly string[]>([]);
     const [flashError, setFlashError] = useState<string | null>(null);
 
     const [filterQuery, setFilterQueryRaw] = useState<string>("");
@@ -339,6 +363,10 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           setAliases(event.config.aliases);
           return;
         }
+        if (event.type === "ConfigChanged" && event.changed === "hotkeys") {
+          setHotkeyOverrides(event.config.hotkeys);
+          return;
+        }
         if (event.type === "ConfigError") {
           flash(event.message);
         }
@@ -346,7 +374,11 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
       void watcher
         .start()
         .then(() => {
-          if (!cancelled) setAliases(watcher.current().aliases);
+          if (!cancelled) {
+            const current = watcher.current();
+            setAliases(current.aliases);
+            setHotkeyOverrides(current.hotkeys);
+          }
         })
         .catch((err) => {
           if (!cancelled) flash(err instanceof Error ? err.message : "config watcher failed");
@@ -905,6 +937,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
         cmdText: cmdState.text,
         filterQuery,
         confirmModalOpen,
+        resolvedKeymap,
+        keymapPrefix,
         logFilterMode,
       }),
       [
@@ -919,6 +953,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
         cmdState.text,
         filterQuery,
         confirmModalOpen,
+        resolvedKeymap,
+        keymapPrefix,
         logFilterMode,
       ],
     );
@@ -985,6 +1021,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
         },
         toggleHelp: () => setShowHelp((v) => !v),
         dismissHelp: () => setShowHelp(false),
+        onKeymapPrefixChange: (prefix: readonly string[]) => setKeymapPrefix(prefix),
         toggleVfs: () => setShowVfs((v) => !v),
         dismissVfs: () => setShowVfs(false),
         setConfirmQuit: (v: boolean) => setConfirmQuit(v),
@@ -1282,6 +1319,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             cmdText: cmdStateRef.current.text,
             filterQuery: filterQueryRef.current,
             confirmModalOpen,
+            resolvedKeymap,
+            keymapPrefix,
             logFilterMode: logFilterModeRef.current,
           };
           // #193: supervision body owns the keyboard when the flag is on and
@@ -1375,6 +1414,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           tmux,
           activeRoles,
           flash,
+          resolvedKeymap,
+          keymapPrefix,
           // #310: logFilterMode read via logFilterModeRef (synchronous) so a
           // same-tick burst sees the latest mode. keyboardState already lists
           // logFilterMode in its memo deps for rendering, so committed state
@@ -1533,6 +1574,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             activeRoles,
             !!pendingAskUser,
             pollHealth,
+            resolvedKeymap,
+            keymapPrefix,
           )}
         </box>
       );
@@ -1637,6 +1680,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
             activeRoles,
             !!pendingAskUser,
             pollHealth,
+            resolvedKeymap,
+            keymapPrefix,
           )}
         </box>
       );
@@ -1719,7 +1764,7 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
         )}
 
         {/* Help overlay */}
-        {showHelp ? renderHelpOverlay() : null}
+        {showHelp ? renderHelpOverlay(resolvedKeymap) : null}
 
         {/* Status bar */}
         {renderStatusBar(
@@ -1731,6 +1776,8 @@ export const RunningView: React.NamedExoticComponent<RunningViewProps> = React.m
           activeRoles,
           !!pendingAskUser,
           pollHealth,
+          resolvedKeymap,
+          keymapPrefix,
         )}
       </box>
     );
@@ -2237,8 +2284,43 @@ function renderBottomChrome(
   );
 }
 
+function preferredBinding(
+  keymap: ResolvedKeymap | undefined,
+  predicate: (binding: KeyBinding) => boolean,
+): KeyBinding | undefined {
+  const matches = keymap?.bindings.filter(predicate) ?? [];
+  return matches.find((binding) => binding.preferred) ?? matches[0];
+}
+
+function keyForAction(
+  keymap: ResolvedKeymap | undefined,
+  action: KeyBinding["action"],
+): string | undefined {
+  const binding = preferredBinding(keymap, (candidate) => candidate.action === action);
+  return binding === undefined ? undefined : formatKeySequence(binding.sequence);
+}
+
+function keyForBindingId(keymap: ResolvedKeymap | undefined, id: string): string | undefined {
+  const binding = preferredBinding(keymap, (candidate) => candidate.id === id);
+  return binding === undefined ? undefined : formatKeySequence(binding.sequence);
+}
+
+function leaderHint(keymap: ResolvedKeymap | undefined): string | undefined {
+  const binding = preferredBinding(
+    keymap,
+    (candidate) => candidate.layer === "leader" && candidate.sequence.length > 0,
+  );
+  const leader = binding?.sequence[0];
+  return leader === undefined ? undefined : `${formatKeySequence([leader])}:leader`;
+}
+
 /** Render the help overlay. */
-function renderHelpOverlay(): React.ReactNode {
+function renderHelpOverlay(resolvedKeymap: ResolvedKeymap | undefined): React.ReactNode {
+  const helpKey = keyForAction(resolvedKeymap, "help") ?? "?";
+  const quitKey = keyForAction(resolvedKeymap, "quit") ?? "q";
+  const terminalKey = keyForBindingId(resolvedKeymap, "toggle_panel:terminal") ?? "4";
+  const vfsKey = keyForBindingId(resolvedKeymap, "toggle_panel:vfs") ?? "Ctrl+F";
+  const messageKey = keyForAction(resolvedKeymap, "broadcast") ?? "m";
   return (
     <box
       flexDirection="column"
@@ -2251,22 +2333,23 @@ function renderHelpOverlay(): React.ReactNode {
         Keyboard Shortcuts
       </text>
       <text color={theme.text}> 1-4 Expand panel (Feed/Agents/DAG/Terminal)</text>
+      <text color={theme.text}> {terminalKey} Open Terminal panel</text>
       <text color={theme.text}> f Toggle fullscreen (when panel expanded)</text>
       <text color={theme.text}> e Open trace viewer (split-pane agent output)</text>
       <text color={theme.text}> j/k Navigate (feed or trace agent list)</text>
       <text color={theme.text}> J/K Scroll trace output (when trace open)</text>
       <text color={theme.text}> G/g Jump to bottom/top of trace</text>
-      <text color={theme.text}> m Send message to agent</text>
+      <text color={theme.text}> {messageKey} Send message to agent</text>
       <text color={theme.text}> Handoffs: s resend, r reroute, x cancel, v resolve</text>
       <text color={theme.text}> : Goto / command (alias chain)</text>
       <text color={theme.text}> / Filter current view</text>
       <text color={theme.text}> r Jump to ask_user question</text>
-      <text color={theme.text}> Ctrl+F File browser (VFS)</text>
+      <text color={theme.text}> {vfsKey} File browser (VFS)</text>
       <text color={theme.text}> Ctrl+G Inspect overlay (Ctrl+G to return)</text>
       <text color={theme.text}> y/n Approve/deny permission</text>
-      <text color={theme.text}> ? Toggle this help</text>
+      <text color={theme.text}> {helpKey} Toggle this help</text>
       <text color={theme.text}> Esc Collapse panel / close overlay</text>
-      <text color={theme.text}> q Quit (with confirmation)</text>
+      <text color={theme.text}> {quitKey} Quit (with confirmation)</text>
       <text> </text>
       <text color={theme.focus} bold>
         Supervision (GROVE_SUPERVISION=1)
@@ -2290,8 +2373,16 @@ function contextualHints(
   zoomLevel: "normal" | "half" | "full",
   activeRoles: readonly string[] | undefined,
   hasAskUser: boolean,
+  resolvedKeymap: ResolvedKeymap | undefined,
+  keymapPrefix: readonly string[] | undefined,
 ): string {
+  if (keymapPrefix !== undefined && keymapPrefix.length > 0) {
+    return `${formatKeySequence(keymapPrefix)} ... Esc:cancel`;
+  }
+
   const hints: string[] = [];
+  const leader = leaderHint(resolvedKeymap);
+  if (leader !== undefined) hints.push(leader);
 
   if (expandedPanel === null) {
     // Default feed view
@@ -2311,9 +2402,12 @@ function contextualHints(
     hints.push("Esc:close");
   }
 
-  if ((activeRoles ?? []).length > 0) hints.push("m:msg");
+  if ((activeRoles ?? []).length > 0) {
+    hints.push(`${keyForAction(resolvedKeymap, "broadcast") ?? "m"}:msg`);
+  }
   if (hasAskUser) hints.push("r:respond");
-  hints.push("?:help", "q:quit");
+  hints.push(`${keyForAction(resolvedKeymap, "help") ?? "?"}:help`);
+  hints.push(`${keyForAction(resolvedKeymap, "quit") ?? "q"}:quit`);
 
   return hints.join(" ");
 }
@@ -2334,6 +2428,8 @@ function renderStatusBar(
   activeRoles: readonly string[] | undefined,
   hasAskUser: boolean,
   pollHealth?: PollHealth,
+  resolvedKeymap?: ResolvedKeymap | undefined,
+  keymapPrefix?: readonly string[] | undefined,
 ): React.ReactNode {
   const panelIndicator =
     expandedPanel !== null
@@ -2355,7 +2451,14 @@ function renderStatusBar(
       ) : null}
       <text color={theme.secondary}>
         {" "}
-        {contextualHints(expandedPanel, zoomLevel, activeRoles, hasAskUser)}
+        {contextualHints(
+          expandedPanel,
+          zoomLevel,
+          activeRoles,
+          hasAskUser,
+          resolvedKeymap,
+          keymapPrefix,
+        )}
       </text>
     </box>
   );

--- a/src/tui/screens/screen-manager.tsx
+++ b/src/tui/screens/screen-manager.tsx
@@ -1115,6 +1115,7 @@ export const ScreenManager: React.NamedExoticComponent<ScreenManagerProps> = Rea
             tmux={appProps.tmux}
             eventBus={appProps.eventBus}
             groveDir={appProps.groveDir}
+            userConfig={appProps.userConfig}
             logBuffers={reconcileVersion >= 0 ? spawnManager.getLogBuffers() : undefined}
             agentFailures={agentFailureVersion >= 0 ? spawnManager.getAgentFailures() : undefined}
             onNewContribution={(c) => {

--- a/src/tui/views/welcome/customize-keyboard.test.ts
+++ b/src/tui/views/welcome/customize-keyboard.test.ts
@@ -18,8 +18,8 @@ function keyEvent(name: string, seq?: string): KeyEvent {
     sequence: seq ?? name,
     raw: name,
     eventType: "keypress",
-    preventDefault: () => {},
-    stopPropagation: () => {},
+    preventDefault: () => undefined,
+    stopPropagation: () => undefined,
   } as unknown as KeyEvent;
 }
 
@@ -45,7 +45,7 @@ function state(over: Partial<CustomizeState> = {}): CustomizeState {
     presetCursor: 0,
     presetCount: 3,
     nameIsEmpty: false,
-    keymap: "vim" as KeymapChoice,
+    keymap: "default" as KeymapChoice,
     presetDetailOpen: false,
     ...over,
   };
@@ -172,10 +172,10 @@ describe("routeCustomizeKey (preset detail overlay)", () => {
 describe("routeCustomizeKey (keymap field)", () => {
   test("h/l cycles choice", () => {
     const { calls, actions } = tracker();
-    routeCustomizeKey(keyEvent("l"), state({ field: "keymap", keymap: "vim" }), actions);
-    routeCustomizeKey(keyEvent("l"), state({ field: "keymap", keymap: "emacs" }), actions);
+    routeCustomizeKey(keyEvent("l"), state({ field: "keymap", keymap: "default" }), actions);
+    routeCustomizeKey(keyEvent("l"), state({ field: "keymap", keymap: "power-user" }), actions);
     routeCustomizeKey(keyEvent("h"), state({ field: "keymap", keymap: "none" }), actions);
-    expect(calls.map((c) => c.args[0])).toEqual(["emacs", "none", "emacs"]);
+    expect(calls.map((c) => c.args[0])).toEqual(["power-user", "none", "power-user"]);
   });
 
   test("1/2/3 set choice directly", () => {
@@ -183,7 +183,7 @@ describe("routeCustomizeKey (keymap field)", () => {
     routeCustomizeKey(keyEvent("1"), state({ field: "keymap" }), actions);
     routeCustomizeKey(keyEvent("2"), state({ field: "keymap" }), actions);
     routeCustomizeKey(keyEvent("3"), state({ field: "keymap" }), actions);
-    expect(calls.map((c) => c.args[0])).toEqual(["vim", "emacs", "none"]);
+    expect(calls.map((c) => c.args[0])).toEqual(["default", "power-user", "none"]);
   });
 
   test("Enter launches", () => {
@@ -221,18 +221,30 @@ describe("routeCustomizeKey (rapid bursts)", () => {
         actions.setField(f);
       },
     };
-    routeCustomizeKey(keyEvent("tab"), state({ field: fieldHolder.value, keymap: "vim" }), wrapped);
+    routeCustomizeKey(
+      keyEvent("tab"),
+      state({ field: fieldHolder.value, keymap: "default" }),
+      wrapped,
+    );
     // Second Tab from name → keymap
-    routeCustomizeKey(keyEvent("tab"), state({ field: fieldHolder.value, keymap: "vim" }), wrapped);
-    routeCustomizeKey(keyEvent("l"), state({ field: fieldHolder.value, keymap: "vim" }), wrapped);
+    routeCustomizeKey(
+      keyEvent("tab"),
+      state({ field: fieldHolder.value, keymap: "default" }),
+      wrapped,
+    );
+    routeCustomizeKey(
+      keyEvent("l"),
+      state({ field: fieldHolder.value, keymap: "default" }),
+      wrapped,
+    );
     expect(calls.map((c) => c.name)).toEqual(["setField", "setField", "setKeymap"]);
     expect<"preset" | "name" | "keymap">(fieldHolder.value).toBe("keymap");
-    expect(calls.at(-1)?.args).toEqual(["emacs"]);
+    expect(calls.at(-1)?.args).toEqual(["power-user"]);
   });
 
   test("h then Enter in keymap: Enter reads the flipped keymap ref", () => {
     const { calls, actions } = tracker();
-    const keymapHolder: { value: KeymapChoice } = { value: "vim" };
+    const keymapHolder: { value: KeymapChoice } = { value: "default" };
     const wrapped: CustomizeActions = {
       ...actions,
       setKeymap: (c) => {
@@ -251,7 +263,7 @@ describe("routeCustomizeKey (rapid bursts)", () => {
       wrapped,
     );
     expect(calls.map((c) => c.name)).toEqual(["setKeymap", "launch"]);
-    // vim → none (h wraps left).
+    // default → none (h wraps left).
     expect<KeymapChoice>(keymapHolder.value).toBe("none");
   });
 

--- a/src/tui/views/welcome/customize-keyboard.ts
+++ b/src/tui/views/welcome/customize-keyboard.ts
@@ -2,7 +2,7 @@
 
 import type { KeyEvent } from "@opentui/core";
 
-export type KeymapChoice = "vim" | "emacs" | "none";
+export type KeymapChoice = "default" | "power-user" | "none";
 export type CustomizeField = "preset" | "name" | "keymap";
 
 export interface CustomizeState {
@@ -30,7 +30,7 @@ export interface CustomizeActions {
 }
 
 const FIELD_ORDER: readonly CustomizeField[] = ["preset", "name", "keymap"];
-const KEYMAP_ORDER: readonly KeymapChoice[] = ["vim", "emacs", "none"];
+const KEYMAP_ORDER: readonly KeymapChoice[] = ["default", "power-user", "none"];
 
 export function routeCustomizeKey(
   key: KeyEvent,
@@ -126,11 +126,11 @@ export function routeCustomizeKey(
     return true;
   }
   if (name === "1") {
-    actions.setKeymap("vim");
+    actions.setKeymap("default");
     return true;
   }
   if (name === "2") {
-    actions.setKeymap("emacs");
+    actions.setKeymap("power-user");
     return true;
   }
   if (name === "3") {

--- a/src/tui/views/welcome/customize.tsx
+++ b/src/tui/views/welcome/customize.tsx
@@ -51,7 +51,7 @@ export const Customize: React.NamedExoticComponent<CustomizeProps> = React.memo(
   );
   const [presetCursor, setPresetCursor] = useState(initialCursor);
   const [name, setName] = useState(defaultName);
-  const [keymap, setKeymap] = useState<KeymapChoice>("vim");
+  const [keymap, setKeymap] = useState<KeymapChoice>("default");
   const [presetDetailOpen, setPresetDetailOpen] = useState(false);
   // Pin the failed keymap alongside the error string so the panel text
   // doesn't drift if the operator switches keymap after the failure.
@@ -250,7 +250,7 @@ export const Customize: React.NamedExoticComponent<CustomizeProps> = React.memo(
           Keymap
         </text>
         <box flexDirection="row">
-          {(["vim", "emacs", "none"] as const).map((c) => (
+          {(["default", "power-user", "none"] as const).map((c) => (
             <text key={c} color={c === keymap ? theme.focus : theme.text} bold={c === keymap}>
               {`${c === keymap ? "(•) " : "( ) "}${c}   `}
             </text>

--- a/src/tui/views/welcome/first-run.test.tsx
+++ b/src/tui/views/welcome/first-run.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import type React from "react";
+import type * as TestRendererTypes from "react-test-renderer";
+import type { TuiPresetEntry } from "../../tui-app.js";
+import type { KeymapChoice } from "./customize-keyboard.js";
+import type { WelcomeMode } from "./router.js";
+
+let keyboardHandler: ((key: KeyEvent) => void) | undefined;
+
+mock.module("@opentui/react", () => ({
+  useKeyboard: (handler: (key: KeyEvent) => void): void => {
+    keyboardHandler = handler;
+  },
+  useRenderer: (): { destroy: () => void } => ({ destroy: () => undefined }),
+}));
+
+const TestRendererModule = await import("react-test-renderer");
+const TestRenderer = (TestRendererModule as unknown as { default: typeof TestRendererTypes })
+  .default;
+const { act } = TestRendererModule;
+const { FirstRun } = await import("./first-run.js");
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function keyEvent(name: string): KeyEvent {
+  return {
+    name,
+    ctrl: false,
+    shift: false,
+    meta: false,
+    alt: false,
+    option: false,
+    sequence: name,
+    raw: name,
+    eventType: "keypress",
+    preventDefault: () => undefined,
+    stopPropagation: () => undefined,
+  } as unknown as KeyEvent;
+}
+
+describe("FirstRun keymap defaults", () => {
+  test("fast path launches with the default keymap preset", async () => {
+    const presets: readonly TuiPresetEntry[] = [{ name: "coder", description: "Code" }];
+    let selected:
+      | {
+          readonly preset: string;
+          readonly name: string;
+          readonly mode: WelcomeMode;
+          readonly keymap: KeymapChoice;
+        }
+      | undefined;
+    let renderer!: TestRendererTypes.ReactTestRenderer;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        (
+          <FirstRun
+            presets={presets}
+            cwd="/tmp/demo-grove"
+            onSelect={(args) => {
+              selected = args;
+            }}
+            onConnect={() => undefined}
+            onQuit={() => undefined}
+          />
+        ) as React.ReactElement,
+      );
+    });
+
+    await act(async () => {
+      keyboardHandler?.(keyEvent("return"));
+    });
+
+    expect(selected).toMatchObject({
+      preset: "coder",
+      name: "demo-grove",
+      mode: "local",
+      keymap: "default",
+    });
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+});

--- a/src/tui/views/welcome/first-run.tsx
+++ b/src/tui/views/welcome/first-run.tsx
@@ -62,7 +62,7 @@ export const FirstRun: React.NamedExoticComponent<FirstRunProps> = React.memo(fu
           }
           const preset = defaultPresetByMode[mode];
           if (!preset) return;
-          onSelect({ preset, name: defaultName, mode, keymap: "none" });
+          onSelect({ preset, name: defaultName, mode, keymap: "default" });
         }}
         onCustomize={(mode) => setStep({ kind: "customize", mode })}
         onConnect={onConnect}

--- a/src/tui/views/welcome/keymap-presets.test.ts
+++ b/src/tui/views/welcome/keymap-presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -9,29 +9,49 @@ import {
 } from "./keymap-presets.js";
 
 describe("loadKeymapPreset", () => {
-  test("loads vim preset", async () => {
-    const p = await loadKeymapPreset("vim");
-    expect(p.keymap.quit).toBe("q");
-    expect(p.keymap.search_start).toBe("/");
+  test("loads default preset choice", async () => {
+    const p = await loadKeymapPreset("default");
+    expect(p.keymapPreset).toBe("default");
+    expect(p.keymap).toEqual({});
   });
 
-  test("loads emacs preset", async () => {
-    const p = await loadKeymapPreset("emacs");
-    expect(p.keymap.help).toBe("C-h");
+  test("loads power-user preset choice", async () => {
+    const p = await loadKeymapPreset("power-user");
+    expect(p.keymapPreset).toBe("power-user");
+    expect(p.keymap).toEqual({});
   });
 });
 
 describe("applyKeymapPresetToFile", () => {
-  test("writes a fresh config.json when absent", async () => {
+  test("default preset does not create a config.json when absent", async () => {
     const dir = mkdtempSync(join(tmpdir(), "grove-keymap-"));
     const target = join(dir, "config.json");
-    await applyKeymapPresetToFile("vim" as KeymapPresetName, target);
+    await applyKeymapPresetToFile("default" as KeymapPresetName, target);
+    expect(existsSync(target)).toBe(false);
+  });
+
+  test("power-user writes a fresh config.json when absent", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grove-keymap-"));
+    const target = join(dir, "config.json");
+    await applyKeymapPresetToFile("power-user" as KeymapPresetName, target);
     const raw = JSON.parse(readFileSync(target, "utf-8"));
-    expect(raw.keymap.quit).toBe("q");
+    expect(raw.keymapPreset).toBe("power-user");
+    expect(raw.keymap ?? {}).toEqual({});
     expect(raw.theme ?? {}).toEqual({});
   });
 
-  test("merges keymap block into existing config without touching theme", async () => {
+  test("writes default keymapPreset when config already exists", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grove-keymap-"));
+    const target = join(dir, "config.json");
+    writeFileSync(target, JSON.stringify({ theme: { text: "#FFFFFF" }, keymap: { approve: "A" } }));
+    await applyKeymapPresetToFile("default", target);
+    const raw = JSON.parse(readFileSync(target, "utf-8"));
+    expect(raw.theme.text).toBe("#FFFFFF");
+    expect(raw.keymap.approve).toBe("A");
+    expect(raw.keymapPreset).toBe("default");
+  });
+
+  test("merges preset choice into existing config without touching theme or keymap", async () => {
     const dir = mkdtempSync(join(tmpdir(), "grove-keymap-"));
     const target = join(dir, "config.json");
     writeFileSync(
@@ -41,28 +61,28 @@ describe("applyKeymapPresetToFile", () => {
         keymap: { approve: "A" },
       }),
     );
-    await applyKeymapPresetToFile("emacs", target);
+    await applyKeymapPresetToFile("power-user", target);
     const raw = JSON.parse(readFileSync(target, "utf-8"));
     expect(raw.theme.text).toBe("#FFFFFF");
-    expect(raw.keymap.approve).toBe("A"); // untouched
-    expect(raw.keymap.help).toBe("C-h"); // from preset
+    expect(raw.keymap.approve).toBe("A");
+    expect(raw.keymapPreset).toBe("power-user");
   });
 
-  test("overwrites preset keys on re-apply", async () => {
+  test("overwrites keymapPreset on re-apply", async () => {
     const dir = mkdtempSync(join(tmpdir(), "grove-keymap-"));
     const target = join(dir, "config.json");
-    await applyKeymapPresetToFile("vim", target);
-    await applyKeymapPresetToFile("emacs", target);
+    await applyKeymapPresetToFile("power-user", target);
+    await applyKeymapPresetToFile("default", target);
     const raw = JSON.parse(readFileSync(target, "utf-8"));
-    expect(raw.keymap.quit).toBe("C-x C-c");
+    expect(raw.keymapPreset).toBe("default");
   });
 
   test("corrupted existing config is treated as empty", async () => {
     const dir = mkdtempSync(join(tmpdir(), "grove-keymap-"));
     const target = join(dir, "config.json");
     writeFileSync(target, "{ not valid json");
-    await applyKeymapPresetToFile("vim", target);
+    await applyKeymapPresetToFile("power-user", target);
     const raw = JSON.parse(readFileSync(target, "utf-8"));
-    expect(raw.keymap.quit).toBe("q");
+    expect(raw.keymapPreset).toBe("power-user");
   });
 });

--- a/src/tui/views/welcome/keymap-presets.ts
+++ b/src/tui/views/welcome/keymap-presets.ts
@@ -2,37 +2,25 @@
  * Keymap presets — bundled as JSON imports so the merge works under both
  * `bun run` (source) and the tsup-built output (no filesystem lookup).
  *
- * Merge semantics reuse `config-loader.ts`'s `mergeGroveConfig`: keymap
- * entries are additive, the existing theme block is preserved verbatim.
- *
- * Two named presets today: `vim` and `emacs`. The `none` sentinel exists
- * only in the UI layer (no-op; not handled here).
+ * The first-run UI writes the selected built-in keymap preset name into
+ * config.json. The `none` sentinel exists only in the UI layer (no-op; not
+ * handled here).
  */
 
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { type GroveUserConfig, mergeGroveConfig } from "../../config-loader.js";
-import emacsPresetRaw from "../../keymaps/emacs.json" with { type: "json" };
-import vimPresetRaw from "../../keymaps/vim.json" with { type: "json" };
+import type { KeymapPresetName as BuiltInKeymapPresetName } from "../../keymap/keymap.js";
 
 /** Named keymap preset identifiers bundled with the TUI. */
-export type KeymapPresetName = "vim" | "emacs";
-
-interface RawPreset {
-  readonly keymap: Record<string, string>;
-}
-
-const PRESETS: Readonly<Record<KeymapPresetName, RawPreset>> = {
-  vim: vimPresetRaw as RawPreset,
-  emacs: emacsPresetRaw as RawPreset,
-};
+export type KeymapPresetName = BuiltInKeymapPresetName;
 
 /** Load a bundled keymap preset into a `GroveUserConfig` shape. */
 export async function loadKeymapPreset(name: KeymapPresetName): Promise<GroveUserConfig> {
-  const preset = PRESETS[name];
   return {
     theme: {},
-    keymap: preset.keymap as GroveUserConfig["keymap"],
+    keymap: {},
+    keymapPreset: name,
   };
 }
 
@@ -48,28 +36,50 @@ export async function applyKeymapPresetToFile(
   name: KeymapPresetName,
   targetPath: string,
 ): Promise<void> {
-  const preset = await loadKeymapPreset(name);
-
   let existing: GroveUserConfig = { theme: {}, keymap: {} };
   try {
     const raw = await readFile(targetPath, "utf-8");
     const parsed = JSON.parse(raw) as unknown;
     if (parsed && typeof parsed === "object") {
-      const obj = parsed as { theme?: unknown; keymap?: unknown };
+      const obj = parsed as { theme?: unknown; keymap?: unknown; keymapPreset?: unknown };
       existing = {
         theme: (obj.theme ?? {}) as GroveUserConfig["theme"],
         keymap: (obj.keymap ?? {}) as GroveUserConfig["keymap"],
+        keymapPreset: isKeymapPresetName(obj.keymapPreset) ? obj.keymapPreset : undefined,
       };
     }
-  } catch {
-    // ENOENT or parse error — existing stays empty.
+  } catch (err) {
+    if (name === "default" && isErrnoException(err, "ENOENT")) return;
+    // Parse errors and non-ENOENT read failures are treated as empty.
   }
 
+  const preset = await loadKeymapPreset(name);
   const merged = mergeGroveConfig(existing, preset);
-  const out = { theme: merged.theme, keymap: merged.keymap };
+  const out: {
+    readonly theme: GroveUserConfig["theme"];
+    readonly keymap: GroveUserConfig["keymap"];
+    readonly keymapPreset?: KeymapPresetName | undefined;
+  } = {
+    theme: merged.theme,
+    keymap: merged.keymap,
+    keymapPreset: merged.keymapPreset,
+  };
 
   await mkdir(dirname(targetPath), { recursive: true });
   const tmp = `${targetPath}.tmp`;
   await writeFile(tmp, JSON.stringify(out, null, 2), "utf-8");
   await rename(tmp, targetPath);
+}
+
+function isKeymapPresetName(value: unknown): value is KeymapPresetName {
+  return value === "default" || value === "power-user";
+}
+
+function isErrnoException(err: unknown, code: string): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { readonly code?: unknown }).code === code
+  );
 }


### PR DESCRIPTION
## Summary

Implements #186 by replacing the TUI's flat key handling with a leader-key keymap system that supports presets, user overrides, discoverable help, and status-bar hints.

## What changed

- Added a strict keymap resolver with sequence support, preset merging, user overrides, and config reload handling.
- Added default and power-user keymap presets.
- Routed TUI keyboard handling, running-view commands, help overlay rows, and status-bar hints through the resolved keymap instead of hardcoded key labels.
- Updated first-run/customize flows so users can choose and preview keymap presets.
- Added focused test coverage for resolver behavior, override loading, help/status rendering, running-view keyboard actions, and preset selection.

## Validation

- `bun run typecheck`
- `bun run check`
- `bun run build`
- `git diff --check`
- Targeted `bun test` suite: 364 pass / 0 fail; command exits 1 because the repo coverage thresholds remain unmet by the targeted subset.
- Live tmux TUI E2E: `codex -> claude-code` review-loop handoff completed, with session completion and Nexus VFS records verified.
- Pre-push lefthook reran `typecheck` and `build` successfully.

Closes #186
