### PR TITLE
[codex] Fix Nexus session handoff routing

### DIFF
--- a/docs/superpowers/plans/2026-05-27-grove-recipes.md
+++ b/docs/superpowers/plans/2026-05-27-grove-recipes.md
@@ -1,0 +1,2086 @@
+# Grove Recipes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Grove Recipes v1 through schema validation, parser/digest helpers, recipe discovery, parameter binding, and `grove recipe run --dry-run` materialization.
+
+**Architecture:** Add a focused core recipe module that mirrors the existing `GROVE.md` contract parser style: strict Zod validation, snake_case wire format, camelCase TypeScript types, BLAKE3 canonical digests, and explicit materialization to a `GroveContract`. Add a CLI command group that delegates all behavior to the core module and stays side-effect-free for this first slice. Real agent execution and Nexus workflow compilation remain follow-up work after dry-run materialization is stable.
+
+**Tech Stack:** TypeScript strict mode, Bun test runner (`bun:test`), Zod, YAML, BLAKE3, AJV 2020 JSON Schema tests, Biome.
+
+---
+
+## File Structure
+
+- Create: `spec/GROVE-RECIPES.md`
+  - Prose contract for recipe YAML, matching the implementation and JSON Schema.
+- Create: `spec/schemas/grove-recipe.json`
+  - JSON Schema for recipe wire format.
+- Create: `spec/schemas/grove-recipe.test.ts`
+  - AJV schema tests using the same pattern as `spec/schemas/grove-contract.test.ts`.
+- Create: `src/core/recipe.ts`
+  - Zod schemas, readonly TypeScript types, YAML parser, canonical digest helpers, parameter binding, recipe discovery helpers, and materialization to a `GroveContract`.
+- Create: `src/core/recipe.test.ts`
+  - Unit tests for parser, digest, parameter binding, discovery sorting, and dry-run materialization.
+- Create: `src/cli/commands/recipe.ts`
+  - `grove recipe validate`, `grove recipe list`, and `grove recipe run --dry-run`.
+- Create: `src/cli/commands/recipe.test.ts`
+  - Command parser/runner tests with injected writers and temp directories.
+- Modify: `src/core/index.ts`
+  - Export recipe types and helpers for core consumers.
+- Modify: `src/index.ts`
+  - Export public recipe helpers from the package root.
+- Modify: `src/cli/main.ts`
+  - Register the top-level `recipe` command.
+- Modify: `src/cli/cli.integration.test.ts`
+  - Add a smoke test that `grove recipe validate <path>` works through the CLI entrypoint.
+
+Implementation commands below assume `bun` is on `PATH`. If it is not, use:
+
+```bash
+PATH="/Users/tafeng/.bun/bin:$PATH" bun <command>
+```
+
+## Scope Boundary
+
+This plan intentionally ships the first executable recipe slice:
+
+- schema
+- parser
+- stable digests
+- validation diagnostics
+- deterministic discovery
+- parameter binding
+- `run --dry-run` materialization
+
+This plan does not start agents, create sessions in persistent stores, or compile to Nexus workflow actions. Those are separate follow-up plans once the recipe contract is available to code.
+
+### Task 1: Recipe Schema And Spec Docs
+
+**Files:**
+- Create: `spec/schemas/grove-recipe.test.ts`
+- Create: `spec/schemas/grove-recipe.json`
+- Create: `spec/GROVE-RECIPES.md`
+
+- [ ] **Step 1: Write failing JSON Schema tests**
+
+Create `spec/schemas/grove-recipe.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import groveRecipeSchema from "./grove-recipe.json";
+
+function createValidator() {
+  const ajv = new Ajv2020({ allErrors: true });
+  addFormats(ajv);
+  return ajv.compile(groveRecipeSchema);
+}
+
+function validRecipe(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    kind: "recipe",
+    recipe_version: 1,
+    name: "code-review-loop",
+    version: "1.0.0",
+    ...overrides,
+  };
+}
+
+describe("grove-recipe schema", () => {
+  const validate = createValidator();
+
+  test("accepts minimal recipe", () => {
+    expect(validate(validRecipe())).toBe(true);
+  });
+
+  test("accepts parameters, activities, topology, and response schema", () => {
+    const recipe = validRecipe({
+      description: "Coder and reviewer iterate on a feature",
+      labels: ["code-review"],
+      parameters: {
+        target_path: { type: "path", required: true },
+        max_rounds: { type: "integer", default: 3 },
+      },
+      extensions: [{ type: "mcp", name: "filesystem", uri: "stdio:grove-fs-mcp" }],
+      activities: [
+        { id: "coder-drafts", label: "Coder drafts", role: "coder" },
+        {
+          id: "converge",
+          label: "Converge",
+          condition: "${parameters.max_rounds} > 0",
+        },
+      ],
+      instructions: "Work on ${parameters.target_path}.",
+      agent_topology: {
+        structure: "graph",
+        roles: [
+          { name: "coder", platform: "codex" },
+          {
+            name: "reviewer",
+            platform: "claude-code",
+            edges: [{ target: "coder", edge_type: "feedback" }],
+          },
+        ],
+      },
+      sub_recipes: [
+        {
+          name: "security-audit",
+          ref: "./recipes/security-audit.yaml",
+          when: "${parameters.target_path} matches '**/auth/**'",
+          parameters: { target_path: "${parameters.target_path}" },
+        },
+      ],
+      response: {
+        schema: {
+          type: "object",
+          properties: { approved: { type: "boolean" } },
+        },
+      },
+      run_policy: { max_iterations: 3, improvement_threshold: 0.01 },
+      library: { owner: "platform", visibility: "workspace" },
+    });
+
+    expect(validate(recipe)).toBe(true);
+  });
+
+  test("rejects unknown top-level fields", () => {
+    expect(validate(validRecipe({ unknown_field: true }))).toBe(false);
+  });
+
+  test("rejects invalid parameter defaults", () => {
+    const recipe = validRecipe({
+      parameters: {
+        max_rounds: { type: "integer", default: "three" },
+      },
+    });
+    expect(validate(recipe)).toBe(false);
+  });
+
+  test("rejects duplicate labels", () => {
+    const recipe = validRecipe({ labels: ["code-review", "code-review"] });
+    expect(validate(recipe)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify schema file is missing**
+
+Run:
+
+```bash
+bun test spec/schemas/grove-recipe.test.ts
+```
+
+Expected: FAIL with an import error for `./grove-recipe.json`.
+
+- [ ] **Step 3: Add the JSON Schema**
+
+Create `spec/schemas/grove-recipe.json` with these definitions:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grove.dev/schemas/grove-recipe.json",
+  "title": "Grove Recipe",
+  "description": "Schema for shareable Grove recipe YAML workflows.",
+  "type": "object",
+  "required": ["kind", "recipe_version", "name", "version"],
+  "properties": {
+    "kind": { "type": "string", "const": "recipe" },
+    "recipe_version": { "type": "integer", "const": 1 },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_-]*$",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$",
+      "maxLength": 64
+    },
+    "description": { "type": "string", "maxLength": 1024 },
+    "labels": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1, "maxLength": 64 },
+      "uniqueItems": true,
+      "maxItems": 50
+    },
+    "parameters": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9_]*$",
+        "maxLength": 64
+      },
+      "additionalProperties": { "$ref": "#/$defs/parameter" },
+      "maxProperties": 100
+    },
+    "extensions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/extension" },
+      "maxItems": 50
+    },
+    "activities": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/activity" },
+      "maxItems": 100
+    },
+    "instructions": { "type": "string", "maxLength": 20000 },
+    "agent_topology": { "$ref": "#/$defs/agent_topology" },
+    "context_manifests": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/context_manifest_ref" },
+      "maxItems": 50
+    },
+    "sub_recipes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/sub_recipe" },
+      "maxItems": 50
+    },
+    "response": { "$ref": "#/$defs/response" },
+    "run_policy": { "$ref": "#/$defs/run_policy" },
+    "library": { "$ref": "#/$defs/library_metadata" }
+  },
+  "unevaluatedProperties": false,
+  "$defs": {
+    "json_value": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "number" },
+        { "type": "boolean" },
+        { "type": "null" },
+        { "type": "array", "items": { "$ref": "#/$defs/json_value" } },
+        {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/json_value" }
+        }
+      ]
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["string", "integer", "number", "boolean", "enum", "path", "json"]
+        },
+        "required": { "type": "boolean" },
+        "default": { "$ref": "#/$defs/json_value" },
+        "description": { "type": "string", "maxLength": 512 },
+        "enum": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true,
+          "minItems": 1,
+          "maxItems": 100
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "integer" } } },
+          "then": {
+            "properties": { "default": { "type": "integer" } }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "number" } } },
+          "then": {
+            "properties": { "default": { "type": "number" } }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "boolean" } } },
+          "then": {
+            "properties": { "default": { "type": "boolean" } }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "enum": ["string", "path"] } } },
+          "then": {
+            "properties": { "default": { "type": "string" } }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "enum" } } },
+          "then": {
+            "required": ["enum"],
+            "properties": { "default": { "type": "string" } }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "extension": {
+      "type": "object",
+      "required": ["type", "name"],
+      "properties": {
+        "type": { "type": "string", "enum": ["mcp", "tool", "provider", "service"] },
+        "name": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "uri": { "type": "string", "maxLength": 512 },
+        "required": { "type": "boolean" }
+      },
+      "unevaluatedProperties": false
+    },
+    "activity": {
+      "type": "object",
+      "required": ["id", "label"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "label": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "role": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "maxLength": 64
+        },
+        "condition": { "type": "string", "maxLength": 512 }
+      },
+      "unevaluatedProperties": false
+    },
+    "context_manifest_ref": {
+      "type": "object",
+      "required": ["name", "ref"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "ref": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "role": { "type": "string", "maxLength": 64 }
+      },
+      "unevaluatedProperties": false
+    },
+    "sub_recipe": {
+      "type": "object",
+      "required": ["name", "ref"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "ref": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "when": { "type": "string", "maxLength": 512 },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/json_value" }
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "response": {
+      "type": "object",
+      "properties": {
+        "schema": { "type": "object" }
+      },
+      "unevaluatedProperties": false
+    },
+    "run_policy": {
+      "type": "object",
+      "properties": {
+        "max_iterations": { "type": "integer", "minimum": 1, "maximum": 1000 },
+        "max_no_improvement_rounds": { "type": "integer", "minimum": 1, "maximum": 1000 },
+        "improvement_threshold": { "type": "number", "minimum": 0 },
+        "direction": { "type": "string", "enum": ["maximize", "minimize"] }
+      },
+      "unevaluatedProperties": false
+    },
+    "library_metadata": {
+      "type": "object",
+      "properties": {
+        "owner": { "type": "string", "maxLength": 128 },
+        "license": { "type": "string", "maxLength": 128 },
+        "source": { "type": "string", "maxLength": 512 },
+        "visibility": { "type": "string", "enum": ["private", "workspace", "public"] }
+      },
+      "unevaluatedProperties": false
+    },
+    "agent_topology": {
+      "type": "object",
+      "required": ["structure", "roles"],
+      "properties": {
+        "structure": { "type": "string", "enum": ["graph", "tree", "flat"] },
+        "roles": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 50,
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9_-]*$",
+                "minLength": 1,
+                "maxLength": 64
+              },
+              "description": { "type": "string", "maxLength": 256 },
+              "max_instances": { "type": "integer", "minimum": 1, "maximum": 100 },
+              "mode": { "type": "string", "enum": ["explicit", "broadcast"] },
+              "edges": {
+                "type": "array",
+                "maxItems": 50,
+                "items": {
+                  "type": "object",
+                  "required": ["target", "edge_type"],
+                  "properties": {
+                    "target": { "type": "string", "minLength": 1, "maxLength": 64 },
+                    "edge_type": {
+                      "type": "string",
+                      "enum": [
+                        "delegates",
+                        "feedback",
+                        "monitors",
+                        "reports",
+                        "feeds",
+                        "requests",
+                        "escalates"
+                      ]
+                    },
+                    "workspace": {
+                      "type": "string",
+                      "enum": ["branch_from_source", "independent"]
+                    },
+                    "reply_timeout_seconds": {
+                      "type": "integer",
+                      "minimum": 10,
+                      "maximum": 86400
+                    }
+                  },
+                  "unevaluatedProperties": false
+                }
+              },
+              "command": { "type": "string", "maxLength": 512 },
+              "ends_session": { "type": "boolean" },
+              "platform": {
+                "type": "string",
+                "enum": ["claude-code", "codex", "gemini", "custom"]
+              },
+              "model": { "type": "string", "maxLength": 128 },
+              "color": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$" },
+              "prompt": { "type": "string", "maxLength": 4096 },
+              "goal": { "type": "string", "maxLength": 512 },
+              "skills": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+              "repo_index": { "type": "integer", "minimum": 0 }
+            },
+            "unevaluatedProperties": false
+          }
+        },
+        "spawning": {
+          "type": "object",
+          "required": ["dynamic"],
+          "properties": {
+            "dynamic": { "type": "boolean" },
+            "max_depth": { "type": "integer", "minimum": 1, "maximum": 10 },
+            "max_children_per_agent": { "type": "integer", "minimum": 1, "maximum": 20 },
+            "timeout_seconds": { "type": "integer", "minimum": 10, "maximum": 3600 }
+          },
+          "unevaluatedProperties": false
+        },
+        "edge_types": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "maxItems": 20
+        }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Add the prose contract**
+
+Create `spec/GROVE-RECIPES.md`:
+
+```markdown
+# Grove Recipes
+
+Grove Recipes are shareable YAML workflow objects. A recipe describes reusable
+workflow intent and can be validated, listed, parameter-bound, and dry-run
+materialized into a Grove session contract.
+
+Recipes do not replace `GROVE.md`. A recipe is portable library content;
+`GROVE.md` remains the session-level contract for a checkout.
+
+## File Format
+
+Recipe files are plain YAML validated against `spec/schemas/grove-recipe.json`.
+The top-level object must include:
+
+- `kind: recipe`
+- `recipe_version: 1`
+- `name`
+- `version`
+
+All wire fields use snake_case. Unknown top-level fields are rejected.
+
+## Parameters
+
+Supported parameter types are `string`, `integer`, `number`, `boolean`, `enum`,
+`path`, and `json`. Parameter defaults must match the declared type. Required
+parameters without a default must be supplied by the caller.
+
+Template references use the form `${parameters.name}`. They can only read bound
+parameters. They cannot call functions, read environment variables, run shell
+commands, or perform arbitrary evaluation.
+
+## Materialization
+
+`grove recipe run --dry-run` binds parameters and emits:
+
+- `recipeDigest`
+- `boundParameterDigest`
+- rendered instructions
+- included sub-recipes
+- extension requirements
+- a `GroveContract`-compatible session contract
+
+The first recipe implementation does not start agents. Real execution is a
+follow-up layer that will create sessions and delegate stop decisions to the
+deterministic loop runner.
+```
+
+- [ ] **Step 5: Run schema tests**
+
+Run:
+
+```bash
+bun test spec/schemas/grove-recipe.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit schema and prose docs**
+
+```bash
+git add spec/schemas/grove-recipe.test.ts spec/schemas/grove-recipe.json spec/GROVE-RECIPES.md
+git commit -m "docs: add grove recipe schema"
+```
+
+### Task 2: Core Recipe Parser And Digest
+
+**Files:**
+- Create: `src/core/recipe.test.ts`
+- Create: `src/core/recipe.ts`
+- Modify: `src/core/index.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Write failing parser and digest tests**
+
+Create `src/core/recipe.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import {
+  bindRecipeParameters,
+  computeBoundRecipeDigest,
+  computeRecipeDigest,
+  materializeRecipeContract,
+  parseGroveRecipe,
+  parseGroveRecipeObject,
+} from "./recipe.js";
+
+const MINIMAL_RECIPE = `
+kind: recipe
+recipe_version: 1
+name: code-review-loop
+version: 1.0.0
+`;
+
+const FULL_RECIPE = `
+kind: recipe
+recipe_version: 1
+name: code-review-loop
+version: 1.0.0
+description: Coder and reviewer iterate on a feature
+labels: [code-review]
+parameters:
+  target_path:
+    type: path
+    required: true
+  max_rounds:
+    type: integer
+    default: 3
+extensions:
+  - type: mcp
+    name: filesystem
+    uri: stdio:grove-fs-mcp
+activities:
+  - id: coder-drafts
+    label: Coder drafts
+    role: coder
+instructions: |
+  Work on \${parameters.target_path} for \${parameters.max_rounds} rounds.
+agent_topology:
+  structure: graph
+  roles:
+    - name: coder
+      platform: codex
+run_policy:
+  max_iterations: 3
+  improvement_threshold: 0.01
+`;
+
+describe("parseGroveRecipe", () => {
+  test("parses a minimal recipe", () => {
+    const recipe = parseGroveRecipe(MINIMAL_RECIPE);
+    expect(recipe.kind).toBe("recipe");
+    expect(recipe.recipeVersion).toBe(1);
+    expect(recipe.name).toBe("code-review-loop");
+    expect(recipe.version).toBe("1.0.0");
+  });
+
+  test("parses parameters, activities, topology, and run policy", () => {
+    const recipe = parseGroveRecipe(FULL_RECIPE);
+    expect(recipe.parameters?.target_path?.type).toBe("path");
+    expect(recipe.parameters?.max_rounds?.default).toBe(3);
+    expect(recipe.activities?.[0]?.id).toBe("coder-drafts");
+    expect(recipe.topology?.roles[0]?.name).toBe("coder");
+    expect(recipe.runPolicy?.maxIterations).toBe(3);
+  });
+
+  test("rejects unknown top-level fields", () => {
+    expect(() => parseGroveRecipe(`${MINIMAL_RECIPE}\nunknown_field: true\n`)).toThrow(
+      /unknown_field|Unrecognized key/,
+    );
+  });
+
+  test("rejects duplicate activity ids", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "duplicate-activities",
+        version: "1.0.0",
+        activities: [
+          { id: "same", label: "One" },
+          { id: "same", label: "Two" },
+        ],
+      }),
+    ).toThrow(/duplicate activity ids/);
+  });
+});
+
+describe("recipe digests", () => {
+  test("recipe digest is stable across object key order", () => {
+    const first = parseGroveRecipeObject({
+      kind: "recipe",
+      recipe_version: 1,
+      name: "digest-test",
+      version: "1.0.0",
+      description: "Stable",
+    });
+    const second = parseGroveRecipeObject({
+      description: "Stable",
+      version: "1.0.0",
+      name: "digest-test",
+      recipe_version: 1,
+      kind: "recipe",
+    });
+    expect(computeRecipeDigest(first)).toBe(computeRecipeDigest(second));
+  });
+
+  test("bound digest changes when parameters change", () => {
+    const recipe = parseGroveRecipe(FULL_RECIPE);
+    const first = bindRecipeParameters(recipe, { target_path: "src/core" });
+    const second = bindRecipeParameters(recipe, { target_path: "src/cli" });
+    expect(computeBoundRecipeDigest(first)).not.toBe(computeBoundRecipeDigest(second));
+  });
+});
+
+describe("materializeRecipeContract", () => {
+  test("creates a GroveContract-compatible dry-run contract", () => {
+    const recipe = parseGroveRecipe(FULL_RECIPE);
+    const bound = bindRecipeParameters(recipe, { target_path: "src/core" });
+    const materialized = materializeRecipeContract(bound);
+    expect(materialized.contract.contractVersion).toBe(3);
+    expect(materialized.contract.name).toBe("code-review-loop");
+    expect(materialized.contract.topology?.roles[0]?.name).toBe("coder");
+    expect(materialized.provenance.recipeName).toBe("code-review-loop");
+    expect(materialized.renderedInstructions).toContain("src/core");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify missing module failure**
+
+Run:
+
+```bash
+bun test src/core/recipe.test.ts
+```
+
+Expected: FAIL with `Cannot find module './recipe.js'`.
+
+- [ ] **Step 3: Implement core recipe module**
+
+Create `src/core/recipe.ts`:
+
+```ts
+import { hash } from "blake3";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+
+import type { GroveContract } from "./contract.js";
+import { type AgentTopology, AgentTopologySchema, wireToTopology } from "./topology.js";
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+export type RecipeParameterType = "string" | "integer" | "number" | "boolean" | "enum" | "path" | "json";
+
+export interface RecipeParameter {
+  readonly type: RecipeParameterType;
+  readonly required?: boolean | undefined;
+  readonly default?: JsonValue | undefined;
+  readonly description?: string | undefined;
+  readonly enum?: readonly string[] | undefined;
+}
+
+export interface RecipeExtension {
+  readonly type: "mcp" | "tool" | "provider" | "service";
+  readonly name: string;
+  readonly uri?: string | undefined;
+  readonly required?: boolean | undefined;
+}
+
+export interface RecipeActivity {
+  readonly id: string;
+  readonly label: string;
+  readonly role?: string | undefined;
+  readonly condition?: string | undefined;
+}
+
+export interface RecipeSubRecipe {
+  readonly name: string;
+  readonly ref: string;
+  readonly when?: string | undefined;
+  readonly parameters?: Readonly<Record<string, JsonValue>> | undefined;
+}
+
+export interface RecipeRunPolicy {
+  readonly maxIterations?: number | undefined;
+  readonly maxNoImprovementRounds?: number | undefined;
+  readonly improvementThreshold?: number | undefined;
+  readonly direction?: "maximize" | "minimize" | undefined;
+}
+
+export interface RecipeLibraryMetadata {
+  readonly owner?: string | undefined;
+  readonly license?: string | undefined;
+  readonly source?: string | undefined;
+  readonly visibility?: "private" | "workspace" | "public" | undefined;
+}
+
+export interface GroveRecipe {
+  readonly kind: "recipe";
+  readonly recipeVersion: 1;
+  readonly name: string;
+  readonly version: string;
+  readonly description?: string | undefined;
+  readonly labels?: readonly string[] | undefined;
+  readonly parameters?: Readonly<Record<string, RecipeParameter>> | undefined;
+  readonly extensions?: readonly RecipeExtension[] | undefined;
+  readonly activities?: readonly RecipeActivity[] | undefined;
+  readonly instructions?: string | undefined;
+  readonly topology?: AgentTopology | undefined;
+  readonly contextManifests?: readonly { readonly name: string; readonly ref: string; readonly role?: string | undefined }[] | undefined;
+  readonly subRecipes?: readonly RecipeSubRecipe[] | undefined;
+  readonly response?: { readonly schema?: Readonly<Record<string, JsonValue>> | undefined } | undefined;
+  readonly runPolicy?: RecipeRunPolicy | undefined;
+  readonly library?: RecipeLibraryMetadata | undefined;
+}
+
+export interface BoundRecipe {
+  readonly recipe: GroveRecipe;
+  readonly recipeDigest: string;
+  readonly parameters: Readonly<Record<string, JsonValue>>;
+  readonly renderedInstructions?: string | undefined;
+}
+
+export interface RecipeProvenance {
+  readonly recipeDigest: string;
+  readonly recipeName: string;
+  readonly recipeVersion: string;
+  readonly boundParameterDigest: string;
+  readonly subRecipeDigests: readonly string[];
+  readonly sourceRef?: string | undefined;
+}
+
+export interface MaterializedRecipe {
+  readonly contract: GroveContract;
+  readonly provenance: RecipeProvenance;
+  readonly renderedInstructions?: string | undefined;
+}
+
+const JsonValueSchema: z.ZodTypeAny = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().refine((n) => Number.isFinite(n), { message: "JSON numbers must be finite" }),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(z.string(), JsonValueSchema),
+  ]),
+);
+
+const ParameterSchema = z
+  .object({
+    type: z.enum(["string", "integer", "number", "boolean", "enum", "path", "json"]),
+    required: z.boolean().optional(),
+    default: JsonValueSchema.optional(),
+    description: z.string().max(512).optional(),
+    enum: z.array(z.string().min(1)).min(1).max(100).optional(),
+  })
+  .strict()
+  .superRefine((param, ctx) => {
+    if (param.type === "enum" && param.enum === undefined) {
+      ctx.addIssue({ code: "custom", message: "enum parameter requires enum values" });
+    }
+    if (param.default !== undefined) validateDefaultType(param, ctx);
+  });
+
+const WireRecipeSchema = z
+  .object({
+    kind: z.literal("recipe"),
+    recipe_version: z.literal(1),
+    name: z.string().regex(/^[a-z][a-z0-9_-]*$/).min(1).max(128),
+    version: z.string().regex(/^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/).max(64),
+    description: z.string().max(1024).optional(),
+    labels: z.array(z.string().min(1).max(64)).max(50).optional(),
+    parameters: z.record(z.string().regex(/^[a-z][a-z0-9_]*$/), ParameterSchema).optional(),
+    extensions: z
+      .array(
+        z
+          .object({
+            type: z.enum(["mcp", "tool", "provider", "service"]),
+            name: z.string().min(1).max(128),
+            uri: z.string().max(512).optional(),
+            required: z.boolean().optional(),
+          })
+          .strict(),
+      )
+      .max(50)
+      .optional(),
+    activities: z
+      .array(
+        z
+          .object({
+            id: z.string().regex(/^[a-z][a-z0-9_-]*$/).min(1).max(128),
+            label: z.string().min(1).max(256),
+            role: z.string().regex(/^[a-z][a-z0-9_-]*$/).max(64).optional(),
+            condition: z.string().max(512).optional(),
+          })
+          .strict(),
+      )
+      .max(100)
+      .optional(),
+    instructions: z.string().max(20000).optional(),
+    agent_topology: AgentTopologySchema.optional(),
+    context_manifests: z
+      .array(
+        z
+          .object({
+            name: z.string().min(1).max(128),
+            ref: z.string().min(1).max(512),
+            role: z.string().max(64).optional(),
+          })
+          .strict(),
+      )
+      .max(50)
+      .optional(),
+    sub_recipes: z
+      .array(
+        z
+          .object({
+            name: z.string().min(1).max(128),
+            ref: z.string().min(1).max(512),
+            when: z.string().max(512).optional(),
+            parameters: z.record(z.string(), JsonValueSchema).optional(),
+          })
+          .strict(),
+      )
+      .max(50)
+      .optional(),
+    response: z.object({ schema: z.record(z.string(), JsonValueSchema).optional() }).strict().optional(),
+    run_policy: z
+      .object({
+        max_iterations: z.number().int().min(1).max(1000).optional(),
+        max_no_improvement_rounds: z.number().int().min(1).max(1000).optional(),
+        improvement_threshold: z.number().min(0).optional(),
+        direction: z.enum(["maximize", "minimize"]).optional(),
+      })
+      .strict()
+      .optional(),
+    library: z
+      .object({
+        owner: z.string().max(128).optional(),
+        license: z.string().max(128).optional(),
+        source: z.string().max(512).optional(),
+        visibility: z.enum(["private", "workspace", "public"]).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .superRefine((recipe, ctx) => {
+    const labels = recipe.labels ?? [];
+    if (new Set(labels).size !== labels.length) {
+      ctx.addIssue({ code: "custom", message: "duplicate labels" });
+    }
+    const activityIds = (recipe.activities ?? []).map((activity) => activity.id);
+    if (new Set(activityIds).size !== activityIds.length) {
+      ctx.addIssue({ code: "custom", message: "duplicate activity ids" });
+    }
+  });
+
+function validateDefaultType(param: z.infer<typeof ParameterSchema>, ctx: z.RefinementCtx): void {
+  const value = param.default;
+  if (param.type === "integer" && (!Number.isInteger(value) || typeof value !== "number")) {
+    ctx.addIssue({ code: "custom", message: "integer parameter default must be an integer" });
+  }
+  if (param.type === "number" && typeof value !== "number") {
+    ctx.addIssue({ code: "custom", message: "number parameter default must be a number" });
+  }
+  if (param.type === "boolean" && typeof value !== "boolean") {
+    ctx.addIssue({ code: "custom", message: "boolean parameter default must be a boolean" });
+  }
+  if ((param.type === "string" || param.type === "path" || param.type === "enum") && typeof value !== "string") {
+    ctx.addIssue({ code: "custom", message: `${param.type} parameter default must be a string` });
+  }
+  if (param.type === "enum" && typeof value === "string" && !param.enum?.includes(value)) {
+    ctx.addIssue({ code: "custom", message: "enum parameter default must be in enum values" });
+  }
+}
+
+export function parseGroveRecipe(content: string): GroveRecipe {
+  const raw = parseYaml(content);
+  return parseGroveRecipeObject(raw);
+}
+
+export function parseGroveRecipeObject(raw: unknown): GroveRecipe {
+  const parsed = WireRecipeSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Invalid Grove recipe: ${parsed.error.issues.map((issue) => issue.message).join("; ")}`);
+  }
+  return wireToRecipe(parsed.data);
+}
+
+function wireToRecipe(wire: z.infer<typeof WireRecipeSchema>): GroveRecipe {
+  return {
+    kind: "recipe",
+    recipeVersion: wire.recipe_version,
+    name: wire.name,
+    version: wire.version,
+    ...(wire.description !== undefined && { description: wire.description }),
+    ...(wire.labels !== undefined && { labels: wire.labels }),
+    ...(wire.parameters !== undefined && { parameters: wire.parameters }),
+    ...(wire.extensions !== undefined && { extensions: wire.extensions }),
+    ...(wire.activities !== undefined && { activities: wire.activities }),
+    ...(wire.instructions !== undefined && { instructions: wire.instructions }),
+    ...(wire.agent_topology !== undefined && { topology: wireToTopology(wire.agent_topology) }),
+    ...(wire.context_manifests !== undefined && { contextManifests: wire.context_manifests }),
+    ...(wire.sub_recipes !== undefined && { subRecipes: wire.sub_recipes }),
+    ...(wire.response !== undefined && { response: wire.response }),
+    ...(wire.run_policy !== undefined && {
+      runPolicy: {
+        ...(wire.run_policy.max_iterations !== undefined && { maxIterations: wire.run_policy.max_iterations }),
+        ...(wire.run_policy.max_no_improvement_rounds !== undefined && {
+          maxNoImprovementRounds: wire.run_policy.max_no_improvement_rounds,
+        }),
+        ...(wire.run_policy.improvement_threshold !== undefined && {
+          improvementThreshold: wire.run_policy.improvement_threshold,
+        }),
+        ...(wire.run_policy.direction !== undefined && { direction: wire.run_policy.direction }),
+      },
+    }),
+    ...(wire.library !== undefined && { library: wire.library }),
+  };
+}
+
+function canonicalize(value: unknown): string {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error("non-finite number is not allowed");
+    return JSON.stringify(value);
+  }
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalize(item)).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  return `{${Object.keys(obj)
+    .sort()
+    .filter((key) => obj[key] !== undefined)
+    .map((key) => `${JSON.stringify(key)}:${canonicalize(obj[key])}`)
+    .join(",")}}`;
+}
+
+function digestObject(value: unknown): string {
+  return `blake3:${hash(canonicalize(value)).toString("hex")}`;
+}
+
+export function computeRecipeDigest(recipe: GroveRecipe): string {
+  return digestObject(recipe);
+}
+
+export function computeBoundRecipeDigest(bound: BoundRecipe): string {
+  return digestObject({
+    recipeDigest: bound.recipeDigest,
+    parameters: bound.parameters,
+    subRecipes: bound.recipe.subRecipes ?? [],
+  });
+}
+
+export function bindRecipeParameters(
+  recipe: GroveRecipe,
+  overrides: Readonly<Record<string, JsonValue>> = {},
+): BoundRecipe {
+  const parameters: Record<string, JsonValue> = {};
+  for (const [name, definition] of Object.entries(recipe.parameters ?? {})) {
+    const value = overrides[name] ?? definition.default;
+    if (value === undefined) {
+      if (definition.required === true) throw new Error(`Missing required parameter: ${name}`);
+      continue;
+    }
+    validateBoundParameter(name, definition, value);
+    parameters[name] = value;
+  }
+  for (const name of Object.keys(overrides)) {
+    if (recipe.parameters?.[name] === undefined) {
+      throw new Error(`Unknown parameter: ${name}`);
+    }
+  }
+  const recipeDigest = computeRecipeDigest(recipe);
+  return {
+    recipe,
+    recipeDigest,
+    parameters,
+    ...(recipe.instructions !== undefined && {
+      renderedInstructions: renderRecipeTemplate(recipe.instructions, parameters),
+    }),
+  };
+}
+
+function validateBoundParameter(name: string, definition: RecipeParameter, value: JsonValue): void {
+  if (definition.type === "integer" && (typeof value !== "number" || !Number.isInteger(value))) {
+    throw new Error(`Parameter ${name} must be an integer`);
+  }
+  if (definition.type === "number" && typeof value !== "number") {
+    throw new Error(`Parameter ${name} must be a number`);
+  }
+  if (definition.type === "boolean" && typeof value !== "boolean") {
+    throw new Error(`Parameter ${name} must be a boolean`);
+  }
+  if ((definition.type === "string" || definition.type === "path") && typeof value !== "string") {
+    throw new Error(`Parameter ${name} must be a string`);
+  }
+  if (definition.type === "enum") {
+    if (typeof value !== "string") throw new Error(`Parameter ${name} must be a string`);
+    if (!definition.enum?.includes(value)) throw new Error(`Parameter ${name} must be one of ${definition.enum?.join(", ")}`);
+  }
+}
+
+export function renderRecipeTemplate(
+  template: string,
+  parameters: Readonly<Record<string, JsonValue>>,
+): string {
+  return template.replace(/\$\{parameters\.([a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*)\}/g, (_match, path: string) => {
+    const value = resolveParameterPath(parameters, path);
+    if (typeof value === "object") {
+      return JSON.stringify(value);
+    }
+    return String(value);
+  });
+}
+
+function resolveParameterPath(parameters: Readonly<Record<string, JsonValue>>, path: string): JsonValue {
+  const parts = path.split(".");
+  let current: JsonValue | undefined = parameters[parts[0] ?? ""];
+  for (const part of parts.slice(1)) {
+    if (typeof current !== "object" || current === null || Array.isArray(current)) {
+      throw new Error(`Invalid parameter path: ${path}`);
+    }
+    current = current[part];
+  }
+  if (current === undefined) throw new Error(`Missing template parameter: ${path}`);
+  return current;
+}
+
+export function materializeRecipeContract(bound: BoundRecipe): MaterializedRecipe {
+  const recipe = bound.recipe;
+  const boundParameterDigest = computeBoundRecipeDigest(bound);
+  const contract: GroveContract = {
+    contractVersion: 3,
+    name: recipe.name,
+    ...(recipe.description !== undefined && { description: recipe.description }),
+    ...(recipe.topology !== undefined && { topology: recipe.topology }),
+    ...(recipe.runPolicy?.maxIterations !== undefined && {
+      stopConditions: {
+        budget: { maxContributions: recipe.runPolicy.maxIterations },
+      },
+    }),
+  };
+  return {
+    contract,
+    provenance: {
+      recipeDigest: bound.recipeDigest,
+      recipeName: recipe.name,
+      recipeVersion: recipe.version,
+      boundParameterDigest,
+      subRecipeDigests: [],
+    },
+    ...(bound.renderedInstructions !== undefined && { renderedInstructions: bound.renderedInstructions }),
+  };
+}
+```
+
+- [ ] **Step 4: Export recipe helpers**
+
+Append to `src/core/index.ts` near the contract exports:
+
+```ts
+export type {
+  BoundRecipe,
+  GroveRecipe,
+  MaterializedRecipe,
+  RecipeActivity,
+  RecipeExtension,
+  RecipeLibraryMetadata,
+  RecipeParameter,
+  RecipeParameterType,
+  RecipeProvenance,
+  RecipeRunPolicy,
+  RecipeSubRecipe,
+} from "./recipe.js";
+export {
+  bindRecipeParameters,
+  computeBoundRecipeDigest,
+  computeRecipeDigest,
+  materializeRecipeContract,
+  parseGroveRecipe,
+  parseGroveRecipeObject,
+  renderRecipeTemplate,
+} from "./recipe.js";
+```
+
+Append to `src/index.ts` near the contract exports:
+
+```ts
+export type {
+  BoundRecipe,
+  GroveRecipe,
+  MaterializedRecipe,
+  RecipeActivity,
+  RecipeExtension,
+  RecipeLibraryMetadata,
+  RecipeParameter,
+  RecipeParameterType,
+  RecipeProvenance,
+  RecipeRunPolicy,
+  RecipeSubRecipe,
+} from "./core/recipe.js";
+export {
+  bindRecipeParameters,
+  computeBoundRecipeDigest,
+  computeRecipeDigest,
+  materializeRecipeContract,
+  parseGroveRecipe,
+  parseGroveRecipeObject,
+  renderRecipeTemplate,
+} from "./core/recipe.js";
+```
+
+- [ ] **Step 5: Run focused core tests**
+
+Run:
+
+```bash
+bun test src/core/recipe.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run typecheck for exported API**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit core recipe parser and digest**
+
+```bash
+git add src/core/recipe.ts src/core/recipe.test.ts src/core/index.ts src/index.ts
+git commit -m "feat(core): add grove recipe parser"
+```
+
+### Task 3: Recipe Discovery
+
+**Files:**
+- Modify: `src/core/recipe.ts`
+- Modify: `src/core/recipe.test.ts`
+
+- [ ] **Step 1: Add failing discovery tests**
+
+Append to `src/core/recipe.test.ts`:
+
+```ts
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { discoverRecipes } from "./recipe.js";
+
+describe("discoverRecipes", () => {
+  test("discovers recipes from configured directories in deterministic order", async () => {
+    const root = await mkdtemp(join(tmpdir(), "grove-recipe-discovery-"));
+    try {
+      const recipesDir = join(root, "recipes");
+      const groveRecipesDir = join(root, ".grove", "recipes");
+      await mkdir(recipesDir, { recursive: true });
+      await mkdir(groveRecipesDir, { recursive: true });
+      await writeFile(
+        join(groveRecipesDir, "workspace.yaml"),
+        "kind: recipe\nrecipe_version: 1\nname: workspace-recipe\nversion: 1.0.0\n",
+      );
+      await writeFile(
+        join(recipesDir, "project.yaml"),
+        "kind: recipe\nrecipe_version: 1\nname: project-recipe\nversion: 1.0.0\n",
+      );
+
+      const discovered = await discoverRecipes({
+        cwd: root,
+        homeConfigDir: join(root, "home-recipes-missing"),
+      });
+
+      expect(discovered.map((entry) => entry.recipe.name)).toEqual([
+        "project-recipe",
+        "workspace-recipe",
+      ]);
+      expect(discovered[0]?.source).toBe("project");
+      expect(discovered[1]?.source).toBe("workspace");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test and verify missing export**
+
+Run:
+
+```bash
+bun test src/core/recipe.test.ts
+```
+
+Expected: FAIL with `discoverRecipes is not a function` or a missing export error.
+
+- [ ] **Step 3: Add discovery helpers**
+
+Update the existing import block in `src/core/recipe.ts`:
+
+```ts
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+```
+
+Then append the discovery types and helpers below `materializeRecipeContract()`:
+
+```ts
+export type RecipeSource = "project" | "workspace" | "user";
+
+export interface DiscoveredRecipe {
+  readonly path: string;
+  readonly source: RecipeSource;
+  readonly recipe: GroveRecipe;
+  readonly digest: string;
+}
+
+export interface DiscoverRecipesOptions {
+  readonly cwd: string;
+  readonly homeConfigDir?: string | undefined;
+}
+
+export async function discoverRecipes(options: DiscoverRecipesOptions): Promise<readonly DiscoveredRecipe[]> {
+  const roots: readonly { readonly source: RecipeSource; readonly dir: string }[] = [
+    { source: "project", dir: join(options.cwd, "recipes") },
+    { source: "workspace", dir: join(options.cwd, ".grove", "recipes") },
+    { source: "user", dir: options.homeConfigDir ?? join(process.env.HOME ?? "", ".config", "grove", "recipes") },
+  ];
+  const discovered: DiscoveredRecipe[] = [];
+  for (const root of roots) {
+    for (const path of await listYamlFiles(root.dir)) {
+      const content = await readFile(path, "utf-8");
+      const recipe = parseGroveRecipe(content);
+      discovered.push({
+        path,
+        source: root.source,
+        recipe,
+        digest: computeRecipeDigest(recipe),
+      });
+    }
+  }
+  return discovered.sort((a, b) => {
+    const sourceRank = sourceOrder(a.source) - sourceOrder(b.source);
+    if (sourceRank !== 0) return sourceRank;
+    return a.path.localeCompare(b.path) || a.recipe.name.localeCompare(b.recipe.name);
+  });
+}
+
+async function listYamlFiles(dir: string): Promise<readonly string[]> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const files: string[] = [];
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) files.push(...(await listYamlFiles(path)));
+      if (entry.isFile() && (entry.name.endsWith(".yaml") || entry.name.endsWith(".yml"))) {
+        files.push(path);
+      }
+    }
+    return files.sort();
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function sourceOrder(source: RecipeSource): number {
+  if (source === "project") return 0;
+  if (source === "workspace") return 1;
+  return 2;
+}
+```
+
+- [ ] **Step 4: Export discovery helpers**
+
+Append to `src/core/index.ts` and `src/index.ts` recipe type exports:
+
+```ts
+export type { DiscoveredRecipe, DiscoverRecipesOptions, RecipeSource } from "./recipe.js";
+export { discoverRecipes } from "./recipe.js";
+```
+
+For `src/index.ts`, use:
+
+```ts
+export type { DiscoveredRecipe, DiscoverRecipesOptions, RecipeSource } from "./core/recipe.js";
+export { discoverRecipes } from "./core/recipe.js";
+```
+
+- [ ] **Step 5: Run discovery tests**
+
+Run:
+
+```bash
+bun test src/core/recipe.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit discovery helpers**
+
+```bash
+git add src/core/recipe.ts src/core/recipe.test.ts src/core/index.ts src/index.ts
+git commit -m "feat(core): discover grove recipes"
+```
+
+### Task 4: Recipe Validate CLI
+
+**Files:**
+- Create: `src/cli/commands/recipe.test.ts`
+- Create: `src/cli/commands/recipe.ts`
+- Modify: `src/cli/main.ts`
+
+- [ ] **Step 1: Write failing validate command tests**
+
+Create `src/cli/commands/recipe.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { parseRecipeArgs, runRecipe } from "./recipe.js";
+
+function createWriter(): { lines: string[]; writer: (line: string) => void } {
+  const lines: string[] = [];
+  return { lines, writer: (line: string) => lines.push(line) };
+}
+
+describe("recipe command", () => {
+  test("parseRecipeArgs parses validate", () => {
+    expect(parseRecipeArgs(["validate", "recipes/review.yaml"])).toEqual({
+      command: "validate",
+      path: "recipes/review.yaml",
+      json: false,
+    });
+  });
+
+  test("validate reports a valid recipe", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-cli-"));
+    try {
+      const recipePath = join(dir, "review.yaml");
+      await writeFile(
+        recipePath,
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(parseRecipeArgs(["validate", recipePath]), { cwd: dir, writer });
+      expect(lines.join("\n")).toContain("Valid recipe: review-loop@1.0.0");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("validate --json emits parseable JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-cli-json-"));
+    try {
+      const recipePath = join(dir, "review.yaml");
+      await writeFile(
+        recipePath,
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(parseRecipeArgs(["validate", recipePath, "--json"]), { cwd: dir, writer });
+      const parsed = JSON.parse(lines.join("\n")) as { valid: boolean; name: string };
+      expect(parsed.valid).toBe(true);
+      expect(parsed.name).toBe("review-loop");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify missing module failure**
+
+Run:
+
+```bash
+bun test src/cli/commands/recipe.test.ts
+```
+
+Expected: FAIL with `Cannot find module './recipe.js'`.
+
+- [ ] **Step 3: Implement validate command**
+
+Create `src/cli/commands/recipe.ts`:
+
+```ts
+import { readFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
+
+import {
+  bindRecipeParameters,
+  computeBoundRecipeDigest,
+  computeRecipeDigest,
+  discoverRecipes,
+  materializeRecipeContract,
+  parseGroveRecipe,
+} from "../../core/recipe.js";
+import { UsageError } from "../errors.js";
+
+type RecipeCommand =
+  | { readonly command: "validate"; readonly path: string; readonly json: boolean }
+  | { readonly command: "list"; readonly dir?: string | undefined; readonly json: boolean }
+  | {
+      readonly command: "run";
+      readonly path: string;
+      readonly params: Readonly<Record<string, string>>;
+      readonly dryRun: boolean;
+      readonly json: boolean;
+    };
+
+interface RecipeDeps {
+  readonly cwd: string;
+  readonly writer: (line: string) => void;
+}
+
+export function parseRecipeArgs(argv: readonly string[]): RecipeCommand {
+  const subcommand = argv[0];
+  const rest = argv.slice(1);
+  if (subcommand === "validate") {
+    const parsed = parseArgs({
+      args: [...rest],
+      options: { json: { type: "boolean", default: false } },
+      allowPositionals: true,
+      strict: true,
+    });
+    const path = parsed.positionals[0];
+    if (path === undefined) throw new UsageError("recipe validate requires <path>");
+    return { command: "validate", path, json: parsed.values.json ?? false };
+  }
+  if (subcommand === "list") {
+    const parsed = parseArgs({
+      args: [...rest],
+      options: { dir: { type: "string" }, json: { type: "boolean", default: false } },
+      allowPositionals: false,
+      strict: true,
+    });
+    return { command: "list", dir: parsed.values.dir, json: parsed.values.json ?? false };
+  }
+  if (subcommand === "run") {
+    const parsed = parseArgs({
+      args: [...rest],
+      options: {
+        param: { type: "string", multiple: true },
+        "dry-run": { type: "boolean", default: false },
+        json: { type: "boolean", default: false },
+      },
+      allowPositionals: true,
+      strict: true,
+    });
+    const path = parsed.positionals[0];
+    if (path === undefined) throw new UsageError("recipe run requires <path>");
+    return {
+      command: "run",
+      path,
+      params: parseParamFlags(parsed.values.param ?? []),
+      dryRun: parsed.values["dry-run"] ?? false,
+      json: parsed.values.json ?? false,
+    };
+  }
+  throw new UsageError("recipe requires subcommand: validate, list, or run");
+}
+
+export async function handleRecipe(args: readonly string[], cwd = process.cwd()): Promise<void> {
+  await runRecipe(parseRecipeArgs(args), { cwd, writer: console.log });
+}
+
+export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promise<void> {
+  if (command.command === "validate") {
+    const content = await readFile(command.path, "utf-8");
+    const recipe = parseGroveRecipe(content);
+    const digest = computeRecipeDigest(recipe);
+    if (command.json) {
+      deps.writer(JSON.stringify({ valid: true, name: recipe.name, version: recipe.version, digest }, null, 2));
+      return;
+    }
+    deps.writer(`Valid recipe: ${recipe.name}@${recipe.version}`);
+    deps.writer(`Digest: ${digest}`);
+    return;
+  }
+  if (command.command === "list") {
+    const entries = await discoverRecipes({ cwd: command.dir ?? deps.cwd });
+    if (command.json) {
+      deps.writer(JSON.stringify(entries, null, 2));
+      return;
+    }
+    deps.writer(entries.length === 0 ? "No recipes found." : entries.map((entry) => `${entry.recipe.name}@${entry.recipe.version} ${entry.path}`).join("\n"));
+    return;
+  }
+  const content = await readFile(command.path, "utf-8");
+  const recipe = parseGroveRecipe(content);
+  const bound = bindRecipeParameters(recipe, command.params);
+  const materialized = materializeRecipeContract(bound);
+  if (!command.dryRun) {
+    throw new UsageError("recipe run currently requires --dry-run");
+  }
+  const payload = {
+    recipe: { name: recipe.name, version: recipe.version },
+    recipeDigest: bound.recipeDigest,
+    boundParameterDigest: computeBoundRecipeDigest(bound),
+    parameters: bound.parameters,
+    renderedInstructions: materialized.renderedInstructions,
+    contract: materialized.contract,
+    provenance: materialized.provenance,
+  };
+  deps.writer(command.json ? JSON.stringify(payload, null, 2) : formatDryRun(payload));
+}
+
+function parseParamFlags(flags: readonly string[]): Readonly<Record<string, string>> {
+  const params: Record<string, string> = {};
+  for (const flag of flags) {
+    const equals = flag.indexOf("=");
+    if (equals <= 0) throw new UsageError(`Invalid --param: ${flag}`);
+    params[flag.slice(0, equals)] = flag.slice(equals + 1);
+  }
+  return params;
+}
+
+function formatDryRun(payload: {
+  readonly recipe: { readonly name: string; readonly version: string };
+  readonly recipeDigest: string;
+  readonly boundParameterDigest: string;
+  readonly parameters: Readonly<Record<string, unknown>>;
+  readonly renderedInstructions?: string | undefined;
+}): string {
+  const lines = [
+    `Recipe dry-run: ${payload.recipe.name}@${payload.recipe.version}`,
+    `Recipe digest: ${payload.recipeDigest}`,
+    `Bound digest: ${payload.boundParameterDigest}`,
+    `Parameters: ${JSON.stringify(payload.parameters)}`,
+  ];
+  if (payload.renderedInstructions !== undefined) {
+    lines.push("Rendered instructions:");
+    lines.push(payload.renderedInstructions);
+  }
+  return lines.join("\n");
+}
+```
+
+- [ ] **Step 4: Register CLI command**
+
+Add this command object in `buildCommands()` in `src/cli/main.ts` near `goal` or `session`:
+
+```ts
+    {
+      name: "recipe",
+      description: "Validate, list, and dry-run Grove recipes",
+      needsStore: false,
+      helpText: `grove recipe — validate, list, and dry-run Grove recipes
+
+Usage:
+  grove recipe validate <path> [--json]
+  grove recipe list [--dir <path>] [--json]
+  grove recipe run <path> --dry-run [--param key=value] [--json]`,
+      handler: async (args) => {
+        const { handleRecipe } = await import("./commands/recipe.js");
+        await handleRecipe(args);
+      },
+    },
+```
+
+- [ ] **Step 5: Run validate command tests**
+
+Run:
+
+```bash
+bun test src/cli/commands/recipe.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit validate CLI**
+
+```bash
+git add src/cli/commands/recipe.ts src/cli/commands/recipe.test.ts src/cli/main.ts
+git commit -m "feat(cli): validate grove recipes"
+```
+
+### Task 5: Recipe List CLI
+
+**Files:**
+- Modify: `src/cli/commands/recipe.test.ts`
+- Modify: `src/cli/commands/recipe.ts`
+
+- [ ] **Step 1: Add failing list tests**
+
+Append to `src/cli/commands/recipe.test.ts` inside `describe("recipe command", () => { ... })`:
+
+```ts
+  test("list prints discovered recipes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-list-"));
+    try {
+      const recipesDir = join(dir, "recipes");
+      await mkdir(recipesDir, { recursive: true });
+      await writeFile(
+        join(recipesDir, "review.yaml"),
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(parseRecipeArgs(["list", "--dir", dir]), { cwd: dir, writer });
+      expect(lines.join("\n")).toContain("review-loop@1.0.0");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("list --json emits discovered recipes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-list-json-"));
+    try {
+      const recipesDir = join(dir, "recipes");
+      await mkdir(recipesDir, { recursive: true });
+      await writeFile(
+        join(recipesDir, "review.yaml"),
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(parseRecipeArgs(["list", "--dir", dir, "--json"]), { cwd: dir, writer });
+      const parsed = JSON.parse(lines.join("\n")) as Array<{ recipe: { name: string } }>;
+      expect(parsed[0]?.recipe.name).toBe("review-loop");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+```
+
+Add `mkdir` to the existing `node:fs/promises` import:
+
+```ts
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+```
+
+- [ ] **Step 2: Run tests and verify list behavior fails if not already implemented**
+
+Run:
+
+```bash
+bun test src/cli/commands/recipe.test.ts
+```
+
+Expected before implementing list: FAIL on list output. If Task 4 already included working list code, this command may PASS; in that case inspect the test output and proceed to Step 4.
+
+- [ ] **Step 3: Implement or tighten list output**
+
+In `src/cli/commands/recipe.ts`, make sure the list branch is exactly:
+
+```ts
+  if (command.command === "list") {
+    const entries = await discoverRecipes({ cwd: command.dir ?? deps.cwd });
+    if (command.json) {
+      deps.writer(JSON.stringify(entries, null, 2));
+      return;
+    }
+    if (entries.length === 0) {
+      deps.writer("No recipes found.");
+      return;
+    }
+    deps.writer(
+      entries
+        .map((entry) => `${entry.recipe.name}@${entry.recipe.version} ${entry.source} ${entry.path}`)
+        .join("\n"),
+    );
+    return;
+  }
+```
+
+- [ ] **Step 4: Run list tests**
+
+Run:
+
+```bash
+bun test src/cli/commands/recipe.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit list CLI**
+
+```bash
+git add src/cli/commands/recipe.ts src/cli/commands/recipe.test.ts
+git commit -m "feat(cli): list grove recipes"
+```
+
+### Task 6: Recipe Run Dry-Run CLI
+
+**Files:**
+- Modify: `src/cli/commands/recipe.test.ts`
+- Modify: `src/cli/commands/recipe.ts`
+- Modify: `src/core/recipe.test.ts`
+- Modify: `src/core/recipe.ts`
+
+- [ ] **Step 1: Add failing dry-run CLI tests**
+
+Append to `src/cli/commands/recipe.test.ts`:
+
+```ts
+  test("run --dry-run binds parameters and renders instructions", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-run-"));
+    try {
+      const recipePath = join(dir, "review.yaml");
+      await writeFile(
+        recipePath,
+        [
+          "kind: recipe",
+          "recipe_version: 1",
+          "name: review-loop",
+          "version: 1.0.0",
+          "parameters:",
+          "  target_path:",
+          "    type: path",
+          "    required: true",
+          "instructions: |",
+          "  Review ${parameters.target_path}.",
+          "",
+        ].join("\n"),
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(parseRecipeArgs(["run", recipePath, "--dry-run", "--param", "target_path=src/core"]), {
+        cwd: dir,
+        writer,
+      });
+      const output = lines.join("\n");
+      expect(output).toContain("Recipe dry-run: review-loop@1.0.0");
+      expect(output).toContain("src/core");
+      expect(output).toContain("Bound digest:");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("run without --dry-run is rejected in the first implementation slice", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-run-required-dry-"));
+    try {
+      const recipePath = join(dir, "review.yaml");
+      await writeFile(
+        recipePath,
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      await expect(
+        runRecipe(parseRecipeArgs(["run", recipePath]), { cwd: dir, writer: () => undefined }),
+      ).rejects.toThrow(/requires --dry-run/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+```
+
+- [ ] **Step 2: Add failing typed parameter binding tests**
+
+Append to `src/core/recipe.test.ts`:
+
+```ts
+describe("bindRecipeParameters", () => {
+  test("coerces CLI string values to declared parameter types", () => {
+    const recipe = parseGroveRecipe(`
+kind: recipe
+recipe_version: 1
+name: typed-params
+version: 1.0.0
+parameters:
+  max_rounds:
+    type: integer
+    required: true
+  enabled:
+    type: boolean
+    required: true
+`);
+    const bound = bindRecipeParameters(recipe, { max_rounds: "4", enabled: "true" });
+    expect(bound.parameters.max_rounds).toBe(4);
+    expect(bound.parameters.enabled).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests and verify type coercion fails**
+
+Run:
+
+```bash
+bun test src/core/recipe.test.ts src/cli/commands/recipe.test.ts
+```
+
+Expected before coercion: FAIL because string `"4"` is not accepted as integer.
+
+- [ ] **Step 4: Add safe CLI value coercion**
+
+In `src/core/recipe.ts`, replace the `const value = overrides[name] ?? definition.default;` line inside `bindRecipeParameters()` with:
+
+```ts
+    const rawValue = overrides[name] ?? definition.default;
+    const value = rawValue === undefined ? undefined : coerceParameterValue(name, definition, rawValue);
+```
+
+Add this helper below `bindRecipeParameters()`:
+
+```ts
+function coerceParameterValue(
+  name: string,
+  definition: RecipeParameter,
+  value: JsonValue,
+): JsonValue {
+  if (typeof value !== "string") return value;
+  if (definition.type === "integer") {
+    if (!/^-?\d+$/.test(value)) throw new Error(`Parameter ${name} must be an integer`);
+    return Number(value);
+  }
+  if (definition.type === "number") {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) throw new Error(`Parameter ${name} must be a number`);
+    return parsed;
+  }
+  if (definition.type === "boolean") {
+    if (value === "true") return true;
+    if (value === "false") return false;
+    throw new Error(`Parameter ${name} must be true or false`);
+  }
+  if (definition.type === "json") {
+    try {
+      return JSON.parse(value) as JsonValue;
+    } catch {
+      throw new Error(`Parameter ${name} must be valid JSON`);
+    }
+  }
+  return value;
+}
+```
+
+- [ ] **Step 5: Run dry-run tests**
+
+Run:
+
+```bash
+bun test src/core/recipe.test.ts src/cli/commands/recipe.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit dry-run behavior**
+
+```bash
+git add src/core/recipe.ts src/core/recipe.test.ts src/cli/commands/recipe.ts src/cli/commands/recipe.test.ts
+git commit -m "feat(cli): dry-run grove recipes"
+```
+
+### Task 7: CLI Integration And Package Verification
+
+**Files:**
+- Modify: `src/cli/cli.integration.test.ts`
+- Modify: `src/cli/main.ts`
+
+- [ ] **Step 1: Add failing CLI integration smoke test**
+
+Append to `src/cli/cli.integration.test.ts` inside the top-level `describe`:
+
+```ts
+  test("grove recipe validate works through the CLI entrypoint", async () => {
+    const recipePath = join(tempDir, "review.yaml");
+    await Bun.write(
+      recipePath,
+      "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+    );
+
+    const result = await runGrove(["recipe", "validate", recipePath]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Valid recipe: review-loop@1.0.0");
+  });
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run:
+
+```bash
+bun test src/cli/cli.integration.test.ts
+```
+
+Expected: PASS after command registration. If it fails with an unknown command, verify the `recipe` command object is inside `buildCommands()`.
+
+- [ ] **Step 3: Run focused recipe suite**
+
+Run:
+
+```bash
+bun test spec/schemas/grove-recipe.test.ts src/core/recipe.test.ts src/cli/commands/recipe.test.ts src/cli/cli.integration.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run Biome check**
+
+Run:
+
+```bash
+bun run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit integration coverage**
+
+```bash
+git add src/cli/cli.integration.test.ts src/cli/main.ts
+git commit -m "test(cli): cover recipe command entrypoint"
+```
+
+### Task 8: Final Verification
+
+**Files:**
+- No source edits unless verification finds a concrete failure.
+
+- [ ] **Step 1: Inspect changed files**
+
+Run:
+
+```bash
+git status --short
+git log --oneline --decorate -8
+```
+
+Expected: only intentional files are modified or committed.
+
+- [ ] **Step 2: Run final focused tests**
+
+Run:
+
+```bash
+bun test spec/schemas/grove-recipe.test.ts src/core/recipe.test.ts src/cli/commands/recipe.test.ts src/cli/cli.integration.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run lint/check**
+
+Run:
+
+```bash
+bun run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 6: Record follow-up boundaries in final response**
+
+Final response should state:
+
+```text
+Implemented Grove Recipes v1 through validate/list/dry-run materialization.
+Real recipe execution and Nexus workflow compilation are intentionally left for the follow-up plan named in the design.
+```
+
+## Spec Coverage Self-Review
+
+- Recipe as library object: covered by Task 1 schema/docs and Task 2 parser types.
+- Strict schema and wire/camel split: covered by Task 1 JSON Schema and Task 2 Zod parser.
+- Parameter binding and safe templates: covered by Task 2 and Task 6.
+- Sub-recipes: schema and parsed fields are covered in Task 1 and Task 2; cycle resolution is not implemented in this first dry-run slice because recipe ref loading is not part of dry-run materialization yet.
+- Materialization into sessions: covered by Task 2 `materializeRecipeContract()` and Task 6 CLI dry-run payload.
+- Digest and reproducibility: covered by Task 2 digest tests and Task 6 bound digest output.
+- CLI validate/list/run dry-run: covered by Tasks 4, 5, 6, and 7.
+- Nexus workflow brick compatibility: documented in the spec; runtime adapter is out of this first implementation slice.
+- Error handling: covered for schema, parameter, and dry-run rejection paths; extension availability and sub-recipe cycle errors need the follow-up runtime/ref-resolution slice.
+- Testing: covered by schema, core, CLI command, integration, typecheck, Biome, and whitespace checks.

--- a/docs/superpowers/specs/2026-05-26-tui-leader-key-keymaps-design.md
+++ b/docs/superpowers/specs/2026-05-26-tui-leader-key-keymaps-design.md
@@ -1,0 +1,311 @@
+# TUI Leader-Key Keymaps - Design
+
+**Issue:** [windoliver/grove#186](https://github.com/windoliver/grove/issues/186)
+**Date:** 2026-05-26
+**Status:** Approved design
+
+## Problem
+
+The inspect TUI still routes most normal-mode keys through a flat set of direct bindings in `src/tui/hooks/use-keyboard-handler.ts`. Core panels use numbers, operator panels use punctuation from `PANEL_REGISTRY`, and several global or panel-local actions are hard-coded in the router, help overlay, and status bar.
+
+This is hard to scale:
+
+- New panels consume more punctuation keys.
+- Help and status text can drift from the actual router.
+- User overrides only cover a subset of actions.
+- Existing override loading handles single keys, not leader-key sequences.
+- First-run keymap choices exist, but they are `vim` / `emacs` presets rather than the issue's `default` / `power-user` operating modes.
+
+## Goals
+
+- Introduce a leader-key grammar for normal-mode TUI actions.
+- Ship two built-in presets: `default` and `power-user`.
+- Persist user keymap choices and overrides through the existing config stack.
+- Route normal-mode actions from the active resolved keymap rather than scattered hard-coded keys.
+- Render help overlay and status bar hints from the same resolved keymap used by routing.
+- Keep modal text entry and terminal input modes protected from leader-key interception.
+- Preserve a narrow compatibility path for existing user config keys while moving the product surface to `default` / `power-user`.
+
+## Non-Goals
+
+- No change to TUI business actions, panels, provider calls, or data loading.
+- No rewrite of the command palette.
+- No global app-wide keymap for welcome screens beyond the existing first-run keymap selection UI.
+- No arbitrary multi-stroke macro system; keymaps bind sequences to existing action ids only.
+- No plugin system for external keymap packages.
+
+## Current Anchors
+
+The implementation should build on these files:
+
+| File | Current role |
+| --- | --- |
+| `src/tui/hooks/use-keyboard-handler.ts` | Main normal-mode and modal key router |
+| `src/tui/hooks/use-keybinding-overrides.ts` | Existing action-to-key override loader and default actions |
+| `src/tui/config-loader.ts` | Layered `~/.config/grove/config.json`, `.grove/config.json`, and `GROVE_CONFIG` loader |
+| `src/tui/config-watcher.ts` | Live `~/.grove/hotkeys.yaml` watcher |
+| `src/tui/panels/panel-registry.ts` | Canonical panel list and existing panel keybindings |
+| `src/tui/components/help-overlay.tsx` | Help overlay currently mixing config-derived and hard-coded entries |
+| `src/tui/components/status-bar.tsx` | Status bar currently using hard-coded panel hint strings |
+| `src/tui/views/welcome/keymap-presets.ts` | First-run keymap preset persistence |
+| `src/tui/views/welcome/customize-keyboard.ts` | First-run keymap selector routing |
+
+## Design
+
+### Keymap Model
+
+Add a pure keymap module, `src/tui/keymap/keymap.ts`, that defines the stable contract used by routing and display:
+
+```ts
+export type TuiActionId =
+  | "quit"
+  | "help"
+  | "palette"
+  | "refresh"
+  | "zoom_cycle"
+  | "zoom_reset"
+  | "layout_toggle"
+  | "view_cycle"
+  | "focus_panel"
+  | "toggle_panel"
+  | "cycle_panel_next"
+  | "cycle_panel_prev"
+  | "search_start"
+  | "terminal_input"
+  | "compare_toggle"
+  | "artifact_prev"
+  | "artifact_next"
+  | "artifact_diff"
+  | "approve"
+  | "deny"
+  | "broadcast"
+  | "direct_message";
+
+export interface KeySequence {
+  readonly keys: readonly string[];
+}
+
+export interface KeyBinding {
+  readonly action: TuiActionId;
+  readonly sequence: KeySequence;
+  readonly label: string;
+  readonly context: "global" | "panel" | "navigation";
+  readonly panel?: Panel | undefined;
+  readonly args?: Readonly<Record<string, string | number>> | undefined;
+}
+
+export interface ResolvedKeymap {
+  readonly preset: "default" | "power-user";
+  readonly bindings: readonly KeyBinding[];
+}
+```
+
+`focus_panel` and `toggle_panel` carry the target panel id in `args.panel`. Specific actions such as `artifact_prev` remain separate because their code paths are not panel registry operations.
+
+### Leader Grammar
+
+Use `Space` as the default leader key because it is common in terminal UIs and is currently not used by normal-mode routing. Escape cancels a pending leader sequence. Modal input modes continue to consume printable characters before normal-mode keymap resolution runs.
+
+Default leader groups:
+
+| Sequence | Action |
+| --- | --- |
+| `Space ?` | Help |
+| `Space q` | Quit |
+| `Space r` | Refresh |
+| `Space p 1` ... `Space p 4` | Focus core panels |
+| `Space p a` | Toggle Agents |
+| `Space p t` | Toggle Terminal |
+| `Space p f` | Toggle Frontier |
+| `Space p c` | Toggle Claims |
+| `Space p s` | Toggle Search |
+| `Space p v` | Toggle VFS |
+| `Space z` | Zoom cycle |
+| `Space Z` | Zoom reset |
+| `Space l` | Toggle layout |
+| `Space V` | Cycle grid / pipeline view |
+| `Space m b` | Broadcast |
+| `Space m @` | Direct message |
+| `Space c p` | Command palette |
+
+Direct navigation keys stay direct in both presets:
+
+- `j` / `down`: cursor down
+- `k` / `up`: cursor up
+- `Enter`: select
+- `Tab` / `Shift+Tab`: cycle focused panel
+- `Esc`: back, cancel, or zoom reset depending on current state
+
+Panel-local keys stay available when they are efficient and unlikely to conflict:
+
+- Terminal panel: `i`, `j`, `k`, `G`
+- Artifact panel: `h`, `l`, `d`
+- Frontier panel: compare action
+- Decisions panel: approve / deny
+- Search panel: `/`
+
+The keymap model can still represent those direct bindings as one-key sequences, which lets help and status rendering use one source of truth.
+
+### Built-In Presets
+
+Add `src/tui/keymaps/default.json` and `src/tui/keymaps/power-user.json`.
+
+`default` should prefer leader-key sequences for global actions and panel access. It should keep only essential navigation and panel-local keys direct.
+
+`power-user` should include the same leader sequences plus direct aliases for existing muscle memory:
+
+- `q`, `?`, `r`, `+`
+- `1` through `4` for core panels
+- existing panel registry keys for operator panel toggles
+- `b` and `@` for messaging
+- `m` and `Ctrl+P` for palette entry
+- existing panel-specific direct actions
+
+The direct aliases are additive. They should not replace leader bindings, so help can show both when useful and a user can still learn the structured grammar.
+
+### User Configuration
+
+Extend `GroveUserConfig` with a top-level `keymapPreset?: "default" | "power-user"` while preserving the existing `keymap` object for overrides.
+
+Config example:
+
+```json
+{
+  "keymapPreset": "power-user",
+  "keymap": {
+    "quit": "Space x",
+    "refresh": "F5",
+    "toggle_panel:terminal": "Space p t"
+  }
+}
+```
+
+Override keys are parsed as whitespace-separated sequences. Existing single-key override values continue to work. The loader should accept existing action ids from `REMAPPABLE_ACTIONS` and the new parameterized panel ids:
+
+- `focus_panel:dag`
+- `focus_panel:detail`
+- `focus_panel:frontier`
+- `focus_panel:claims`
+- `toggle_panel:terminal`
+- `toggle_panel:search`
+- and the rest of `PANEL_REGISTRY`
+
+Layering order:
+
+1. Built-in preset (`default` if unspecified)
+2. `config.json` `keymap`
+3. live `~/.grove/hotkeys.yaml`
+4. legacy `.grove/keybindings.json`
+
+Later layers win for the same action id. If two action ids resolve to the same sequence, the first binding in resolved order wins and the losing conflict is reported to stderr. This matches the existing first-win conflict behavior while making the final source explicit.
+
+### Sequence Resolver
+
+Replace the current single-key reverse map with a pure sequence resolver:
+
+```ts
+export type KeymapResolution =
+  | { readonly kind: "pending"; readonly prefix: readonly string[] }
+  | { readonly kind: "match"; readonly binding: KeyBinding }
+  | { readonly kind: "miss" };
+```
+
+`routeKey` owns the pending prefix state through a new `leaderPrefix` field in the app keyboard reducer, or through a small hook wrapping `routeKey`. The pure resolver should be tested without React:
+
+- leader alone returns `pending`
+- a valid prefix returns `pending`
+- a complete sequence returns `match`
+- an invalid sequence returns `miss` and clears the prefix
+- Escape clears a pending prefix before normal Escape behavior runs
+
+Routing still checks modal modes first. The resolver only runs in `InputMode.Normal`, after global hard-wired controls that must remain universal (`Ctrl+P` command palette toggle and Escape cancel/back behavior), and before legacy hard-coded normal-mode handlers. As implementation progresses, those legacy branches should be deleted once each action has a keymap binding and tests prove parity.
+
+### Action Dispatch
+
+Add an `executeKeymapAction(binding, actions)` helper near `routeKey`. It maps action ids to existing callbacks:
+
+- `quit` -> `actions.onQuit()`
+- `help` -> `panels.setMode(InputMode.Help)`
+- `focus_panel` -> `panels.focus(panel)`
+- `toggle_panel` -> `panels.toggle(panel)`
+- `palette` -> `actions.onSpawnPalette()` and command palette mode
+- `broadcast` / `direct_message` -> existing message mode callbacks
+- panel-local actions keep their current focus guards
+
+The helper should return `true` when it handled the binding and `false` when the binding is invalid for current focus. Invalid-for-context bindings should still consume the key sequence to avoid accidentally falling through into unrelated direct actions.
+
+### Help Overlay
+
+Replace local binding arrays in `help-overlay.tsx` with a presenter that receives the active `ResolvedKeymap`. The overlay groups bindings by context:
+
+- Global
+- Navigation
+- Panels
+- Focused panel
+- Messaging
+
+For panel sections, derive labels from `PANEL_REGISTRY` and `PANEL_LABELS`. If multiple bindings point to the same action, show the preferred binding first and optional aliases after it, such as `Space p t / 6`.
+
+### Status Bar
+
+Update `StatusBar` props to accept the active keymap or a precomputed hint list. The hint selection should be derived from bindings relevant to current mode, detail state, and focused panel.
+
+The status bar should stay compact. Suggested default forms:
+
+- Default preset: `Space:leader  Tab:cycle  j/k:nav  Enter:select  ?:help`
+- While a leader prefix is pending: `Space p ...  Esc:cancel`
+- Terminal panel: `Space p t:panel  i:input  j/k:scroll  ?:help`
+- Search panel: `Space p s:panel  /:search  j/k:nav  ?:help`
+
+This removes the current hard-coded punctuation ranges such as `5-\`:toggle`.
+
+### First-Run Experience
+
+Change the first-run keymap choices from `vim`, `emacs`, and `none` to `default`, `power-user`, and `none`.
+
+- Fast path should choose `default`.
+- Customize should default to `default`.
+- Selecting `power-user` writes `"keymapPreset": "power-user"` to `~/.config/grove/config.json`.
+- Selecting `default` writes `"keymapPreset": "default"` only when the config file already exists or when another first-run setting is being persisted; otherwise the implicit default is enough.
+- Existing `vim` and `emacs` JSON presets may remain in the tree temporarily, but they should not be shown in new UI copy.
+
+## Testing
+
+Use TDD for implementation. Minimum tests:
+
+- `keymap` resolver tests for pending, match, miss, conflict, and Escape cancellation.
+- Built-in preset tests proving `default` has leader panel access and `power-user` keeps direct aliases.
+- Config loader tests for `keymapPreset`, sequence parsing, and compatibility with existing single-key `keymap` values.
+- `routeKey` tests proving leader sequences call the expected existing callbacks.
+- `routeKey` tests proving modal input modes are not intercepted by leader sequences.
+- Help overlay tests proving rendered keys come from the active keymap.
+- Status bar tests proving hints change when preset, focused panel, or pending leader prefix changes.
+- First-run customize keyboard tests for `default` / `power-user` / `none` selection.
+
+Run targeted Bun tests during development, then finish with:
+
+```bash
+bun test src/tui/hooks/use-keyboard-handler.test.ts src/tui/hooks/use-keybinding-overrides.test.ts src/tui/config-loader.test.ts src/tui/components/help-overlay.test.ts src/tui/components/status-bar.test.tsx src/tui/views/welcome/customize-keyboard.test.ts src/tui/views/welcome/keymap-presets.test.ts
+bun run typecheck
+bun run check
+```
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Space conflicts with a future normal-mode action | Reserve Space as leader in the keymap module and route it before direct normal-mode actions. |
+| Users with existing `vim` or `emacs` config lose behavior | Keep existing `keymap` overrides valid; do not delete old preset files in this issue unless a migration test proves compatibility. |
+| Help gets noisy if every alias is shown | Mark one binding per action as preferred and collapse aliases to one slash-separated key cell. |
+| Leader state leaks into modal input | Resolver only runs in `InputMode.Normal`; tests cover search, message, goal, terminal, and command palette modes. |
+| Panel ids in config drift from `PANEL_REGISTRY` | Generate valid panel action ids from `PANEL_REGISTRY` instead of duplicating a list. |
+
+## Acceptance Criteria
+
+- Core actions are reachable through the leader-key grammar without relying on a growing punctuation map.
+- `default` and `power-user` presets are available and selectable from first-run customization.
+- Users can override keybindings in config without patching source.
+- Help overlay reflects the active preset and user overrides.
+- Status bar reflects the active preset, focused panel, and pending leader prefix.
+- Existing modal input behavior is unchanged.
+- Existing direct keys remain available in `power-user` where they were already part of the TUI's normal-mode workflow.

--- a/docs/superpowers/specs/2026-05-27-grove-recipes-design.md
+++ b/docs/superpowers/specs/2026-05-27-grove-recipes-design.md
@@ -1,0 +1,392 @@
+# Grove Recipes - Design
+
+**Issue:** [windoliver/grove#276](https://github.com/windoliver/grove/issues/276)
+**Date:** 2026-05-27
+**Status:** Approved design
+
+## Problem
+
+`GROVE.md` is the session-level contract for a checkout. It is good at describing
+the active grove, but it is not a portable workflow artifact:
+
+- it is edited in place inside one working tree
+- parameters are usually copied into prose or topology fields by hand
+- reusable sub-agent patterns live in presets, prompts, or local convention
+- there is no deterministic object to hash, share, search, or re-run
+
+Issue #377 broadens this into a shared library layer. Recipes should therefore
+be one library object type, not a second session format that competes with
+`GROVE.md`.
+
+## Goals
+
+- Define a versioned `GroveRecipe` YAML contract for shareable workflows.
+- Keep `GROVE.md` as the generated or attached session-level contract.
+- Make recipe execution reproducible by hashing the canonical recipe plus bound
+  parameters and recording that digest on the session.
+- Support parameters, extension requirements, activities, instructions,
+  topology, sub-recipes, context manifests, response schema, and run policy.
+- Make the schema compatible with the future library layer from #377.
+- Leave room to compile recipes into Nexus workflow brick primitives without
+  coupling the first Grove spec to Nexus internals.
+
+## Non-Goals
+
+- Replacing `GROVE.md`.
+- Building a general-purpose task runner or cache system.
+- Implementing the full recipe runtime in the first spec PR.
+- Executing arbitrary template code inside recipe files.
+- Solving publication, signing, search ranking, or permissions for every
+  library object. Those belong in the broader library-layer work.
+
+## Current Anchors
+
+| File or issue | Current role |
+| --- | --- |
+| `src/core/contract.ts` | Strict Zod parser for `GROVE.md` contracts and the model to mirror for recipe parsing. |
+| `spec/schemas/grove-contract.json` | JSON Schema pattern for wire-format validation. |
+| `src/core/manifest.ts` | Canonical JSON and BLAKE3 digest precedent for immutable identifiers. |
+| `src/core/topology.ts` | Existing `agent_topology` schema that recipes should reuse. |
+| `src/core/session-config.ts` | Session runtime lens; recipe materialization should produce this shape through a `GroveContract`. |
+| `src/core/loop-runner.ts` | Deterministic execution loop added for #340; recipe runs should delegate stop decisions to this layer. |
+| `src/nexus/nexus-workflow-store.ts` | Durable workflow-state bridge already used by loop execution. |
+| #377 | Parent library-object model that recipes must fit into. |
+| #342 | Context manifests, which recipes may reference or extend per role. |
+
+## Design
+
+### Recipe As A Library Object
+
+Add `Recipe` as a library object type whose first concrete wire format is
+`GroveRecipe` YAML. The object contract should include library metadata in a
+stable envelope so #377 can use the same ownership, versioning, import/export,
+and search model for recipes, plans, skill packs, context manifests, rubrics,
+notebooks, and autonomy profiles.
+
+Recommended top-level shape:
+
+```yaml
+kind: recipe
+recipe_version: 1
+name: code-review-loop
+version: 1.0.0
+description: Coder and reviewer iterate on a feature
+labels: [code-review]
+
+parameters:
+  target_path:
+    type: string
+    required: true
+  max_rounds:
+    type: integer
+    default: 3
+
+extensions:
+  - type: mcp
+    name: filesystem
+    uri: stdio:grove-fs-mcp
+
+activities:
+  - id: coder-drafts
+    label: Coder drafts
+    role: coder
+  - id: reviewer-reviews
+    label: Reviewer reviews
+    role: reviewer
+  - id: converge
+    label: Converge
+    condition: "${parameters.max_rounds} > 0"
+
+instructions: |
+  You are working on ${parameters.target_path}.
+
+agent_topology:
+  structure: graph
+  roles:
+    - name: coder
+      platform: codex
+    - name: reviewer
+      platform: claude-code
+      edges:
+        - target: coder
+          edge_type: feedback
+
+sub_recipes:
+  - name: security-audit
+    ref: ./recipes/security-audit.yaml
+    when: "${parameters.target_path} matches '**/auth/**'"
+
+response:
+  schema:
+    type: object
+    properties:
+      approved:
+        type: boolean
+      summary:
+        type: string
+```
+
+The parser should reject unknown top-level fields. New fields require a
+`recipe_version` bump or explicit optional schema addition.
+
+### Schema And Types
+
+Add a recipe module separate from `contract.ts`:
+
+- `src/core/recipe.ts` for Zod schemas, TypeScript types, parsing, canonical
+  digest helpers, and materialization types
+- `spec/schemas/grove-recipe.json` for JSON Schema
+- `spec/GROVE-RECIPES.md` for the prose contract
+
+The module should follow Grove's current wire/camel split:
+
+- YAML wire fields use `snake_case`.
+- TypeScript types use `camelCase`.
+- exported interfaces are readonly.
+- unknown properties are rejected.
+- `agent_topology` reuses `AgentTopologySchema`.
+
+The first schema version should be intentionally narrow enough to implement:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `kind` | Yes | Must be `recipe`. |
+| `recipe_version` | Yes | Start at `1`. |
+| `name` | Yes | Stable human-readable recipe id. |
+| `version` | Yes | Semver string for human/library versioning. |
+| `description` | No | Search and list display. |
+| `labels` | No | Search metadata. |
+| `parameters` | No | Declarative parameter definitions. |
+| `extensions` | No | Required tools, MCP servers, providers, or external systems. |
+| `activities` | No | Ordered workflow stages that can compile to execution steps. |
+| `instructions` | No | Template string injected into the materialized session. |
+| `agent_topology` | No | Existing Grove topology shape. |
+| `context_manifests` | No | References or inline manifests; compatible with #342. |
+| `sub_recipes` | No | Composable child recipes with parameter overrides. |
+| `response` | No | JSON Schema response expectations. |
+| `run_policy` | No | Max iterations, plateau thresholds, and interrupt behavior for #340. |
+| `library` | No | Owner, license, source, visibility, and search metadata for #377. |
+
+### Parameters And Template Binding
+
+Parameters are data, not executable code. Supported types:
+
+- `string`
+- `integer`
+- `number`
+- `boolean`
+- `enum`
+- `path`
+- `json`
+
+Each parameter can define `required`, `default`, `description`, and `enum`.
+Binding should produce a `BoundRecipe` object with:
+
+- the original recipe digest
+- the final parameter map
+- validation diagnostics
+- the rendered instructions string
+- the materialization input used for the session
+
+Template substitution should start with a deliberately small expression surface:
+
+- `${parameters.name}` references only bound parameters.
+- missing parameters are validation errors.
+- nested property access is allowed only for `json` parameters.
+- no functions, shell expansion, environment reads, or arbitrary evaluation.
+
+Conditions for activities and sub-recipes should use the same safe expression
+evaluator. The first implementation may validate condition syntax without
+executing conditional branches; that should be called `validate` or `dry-run`,
+not `run`.
+
+### Sub-Recipes
+
+Sub-recipes declare composition, not in-process imports. A parent recipe may
+reference another recipe by relative file path, library ref, or digest:
+
+```yaml
+sub_recipes:
+  - name: security-audit
+    ref: ./recipes/security-audit.yaml
+    when: "${parameters.target_path} matches '**/auth/**'"
+    parameters:
+      target_path: "${parameters.target_path}"
+```
+
+Validation should detect cycles after refs are resolved. The materialized run
+records the digest of every included recipe and the parameter overrides used for
+each child.
+
+### Materialization Into Sessions
+
+Recipes do not execute directly. `grove recipe run` materializes a session:
+
+1. Load and validate the recipe.
+2. Bind parameters from defaults, config, and `--param key=value` flags.
+3. Resolve extension requirements.
+4. Resolve and validate sub-recipes.
+5. Build a `GroveContract`-compatible session config.
+6. Attach recipe provenance to the session.
+7. Start the deterministic loop runner.
+
+The materialized `GroveContract` uses:
+
+- recipe `name` and `description` as the contract metadata unless overridden
+- `agent_topology` from the recipe
+- `run_policy` mapped to stop conditions and loop-runner options
+- rendered `instructions` as session prompt/context
+- context manifest refs preserved as runtime context requirements
+
+Session records should include:
+
+```ts
+interface RecipeProvenance {
+  readonly recipeDigest: string;
+  readonly recipeName: string;
+  readonly recipeVersion: string;
+  readonly boundParameterDigest: string;
+  readonly subRecipeDigests: readonly string[];
+  readonly sourceRef?: string | undefined;
+}
+```
+
+This can live in session metadata or a dedicated recipe provenance field. The
+implementation plan should choose based on the current session schema migration
+surface.
+
+### Digest And Reproducibility
+
+Use the same conceptual digest model as contribution manifests:
+
+- parse YAML into a normalized recipe object
+- render no defaults into the source digest unless the schema specifies them as
+  semantic defaults
+- canonicalize to sorted-key JSON
+- hash with BLAKE3
+- prefix with `blake3:`
+
+Two digests are useful:
+
+- `recipeDigest`: the reusable recipe object itself
+- `boundParameterDigest`: recipe digest plus the final parameter map and
+  selected sub-recipes
+
+The session should record both so users can answer different questions:
+
+- "Which recipe did this come from?"
+- "Can I re-run exactly this bound workflow?"
+
+### CLI
+
+Add a `recipe` command group:
+
+```text
+grove recipe validate <path>
+grove recipe list [--dir <path>] [--json]
+grove recipe run <path> --param key=value [--dry-run]
+```
+
+`validate` loads a recipe and reports schema, parameter, extension, and
+sub-recipe diagnostics.
+
+`list` discovers recipes from:
+
+- `./recipes/`
+- `.grove/recipes/`
+- `~/.config/grove/recipes/`
+
+Discovery should be deterministic: sort by source priority, then relative path,
+then recipe name. Duplicate names are warnings, not fatal errors, because
+multiple versions may coexist.
+
+`run --dry-run` prints the bound parameters, recipe digest, included
+sub-recipes, extension requirements, and the materialized session contract
+without starting agents.
+
+`run` without `--dry-run` should be implemented after validation and dry-run are
+stable.
+
+### Nexus Workflow Brick Compatibility
+
+Recipes should be able to compile to Nexus workflow primitives later, but Grove
+should not depend on the Python workflow brick at schema time. The recipe model
+maps cleanly:
+
+| Recipe field | Nexus workflow concept |
+| --- | --- |
+| `name`, `version`, `description` | `WorkflowDefinition` metadata |
+| `parameters` | `variables` |
+| `activities` | ordered `WorkflowAction` records |
+| `run_policy` | execution context and stop policy |
+| external triggers | `WorkflowTrigger` records |
+
+Grove-specific actions should be an adapter layer:
+
+- `spawn`
+- `claim`
+- `contribute`
+- `handoff`
+- `wait_for_condition`
+
+The adapter can emit Nexus `WorkflowAction` objects when Nexus is available and
+fall back to local Grove orchestration when it is not.
+
+### Error Handling
+
+Validation should distinguish:
+
+- schema errors
+- parameter binding errors
+- missing extension errors
+- unresolved recipe refs
+- sub-recipe cycles
+- unsafe template expressions
+- materialization errors
+- runtime errors
+
+CLI output should be human-readable by default and machine-readable under
+`--json`. Error messages should include a recipe path and a field path whenever
+possible.
+
+### Testing
+
+The implementation plan should include:
+
+- parser tests for required fields, unknown fields, type validation, and
+  topology reuse
+- digest tests proving stable key ordering and parameter digest separation
+- template binding tests for valid references, missing parameters, unsafe
+  expressions, and JSON parameter access
+- sub-recipe tests for relative refs, parameter overrides, missing refs, and
+  cycles
+- CLI tests for `validate`, `list`, and `run --dry-run`
+- materialization tests showing a recipe becomes a `GroveContract`-compatible
+  session config
+- JSON Schema tests under `spec/schemas/`
+
+## Rollout
+
+1. Land spec docs and schema/type tests only.
+2. Add parser and digest helpers.
+3. Add `grove recipe validate`.
+4. Add deterministic recipe discovery and `grove recipe list`.
+5. Add parameter binding and `run --dry-run`.
+6. Add session materialization.
+7. Add real `run` through the loop runner.
+8. Add optional Nexus workflow adapter.
+
+Each step should leave the CLI and package exports passing typecheck.
+
+## Open Questions For Implementation Planning
+
+- Whether recipe provenance should be a dedicated session field or session
+  metadata.
+- Whether context manifests are inline in recipe v1 or only references until
+  #342 lands.
+- Whether `path` parameters should normalize relative to the recipe file, the
+  current working directory, or the target grove root. The recommended default is
+  recipe-relative for defaults and caller-relative for `--param` values, with the
+  bound value recorded as a normalized path.
+- Whether `recipe run` should always create a session, or allow a pure local
+  execution mode later. The recommended v1 answer is session-only.

--- a/spec/GROVE-RECIPES.md
+++ b/spec/GROVE-RECIPES.md
@@ -1,0 +1,101 @@
+# Grove Recipes
+
+Grove Recipes are shareable YAML workflow objects. A recipe describes a portable
+workflow pattern that can be validated, hashed, shared, and materialized into a
+Grove session contract.
+
+Recipes do not replace `GROVE.md`. Recipes are portable library content:
+versioned workflow templates that may live in a local recipe directory, a shared
+workspace library, or a public catalog. `GROVE.md` remains the session-level
+contract for an active grove checkout.
+
+## Wire Format
+
+Recipe files use YAML and must validate against the Grove Recipe JSON Schema at
+`spec/schemas/grove-recipe.json`.
+
+Required top-level fields:
+
+```yaml
+kind: recipe
+recipe_version: 1
+name: code-review-loop
+version: 1.0.0
+```
+
+Wire fields use `snake_case`. Unknown top-level fields are rejected. New
+top-level fields require either an optional schema addition or a future
+`recipe_version` bump.
+
+`name` is a stable lowercase slug. `version` is a semver-like human and library
+version string.
+
+## Parameters
+
+Recipes may define declarative parameters:
+
+```yaml
+parameters:
+  target_path:
+    type: path
+    required: true
+  max_rounds:
+    type: integer
+    default: 3
+```
+
+Supported parameter types:
+
+- `string`
+- `integer`
+- `number`
+- `boolean`
+- `enum`
+- `path`
+- `json`
+
+Each parameter may define `required`, `default`, `description`, and, for
+`enum`, an `enum` value list. Defaults must match the declared parameter type.
+
+## Templates
+
+Template references use `${parameters.name}` only. Nested property access is
+reserved for bound `json` parameters. Templates do not support shell expansion,
+environment reads, functions, imports, or arbitrary code evaluation.
+
+The same restricted reference form is used in `instructions`, activity
+conditions, sub-recipe conditions, and sub-recipe parameter bindings.
+
+## Workflow Fields
+
+Recipes may include:
+
+- `description` and `labels` for discovery.
+- `extensions` for required MCP servers, tools, providers, or services.
+- `activities` for ordered workflow stages.
+- `instructions` for the rendered session prompt or context.
+- `agent_topology` using the Grove contract topology shape.
+- `context_manifests` for referenced context packs.
+- `sub_recipes` for composable child recipes.
+- `response.schema` for expected structured output.
+- `run_policy` for iteration and improvement thresholds.
+- `library` for owner, license, source, and visibility metadata.
+
+`agent_topology` is compatible with the existing Grove contract topology shape:
+`structure`, `roles`, role `edges`, `spawning`, and `edge_types`.
+
+## Dry Run Materialization
+
+`grove recipe run --dry-run` will validate the recipe, bind parameters, and
+emit:
+
+- the canonical recipe digest
+- the bound-parameter digest
+- rendered instructions
+- selected sub-recipes and their parameter bindings
+- required extensions
+- a `GroveContract`-compatible session contract
+
+The first implementation does not start agents. Real execution, persistent
+session creation, and integration with agent launchers are follow-up work after
+the dry-run contract is stable.

--- a/spec/schemas/grove-recipe.json
+++ b/spec/schemas/grove-recipe.json
@@ -1,0 +1,370 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grove.dev/schemas/grove-recipe.json",
+  "title": "Grove Recipe",
+  "description": "Schema for shareable Grove recipe YAML workflows.",
+  "type": "object",
+  "required": ["kind", "recipe_version", "name", "version"],
+  "properties": {
+    "kind": { "type": "string", "const": "recipe" },
+    "recipe_version": { "type": "integer", "const": 1 },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_-]*$",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$",
+      "maxLength": 64
+    },
+    "description": { "type": "string", "maxLength": 1024 },
+    "labels": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1, "maxLength": 64 },
+      "uniqueItems": true,
+      "maxItems": 50
+    },
+    "parameters": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9_]*$",
+        "maxLength": 64
+      },
+      "additionalProperties": { "$ref": "#/$defs/parameter" },
+      "maxProperties": 100
+    },
+    "extensions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/extension" },
+      "maxItems": 50
+    },
+    "activities": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/activity" },
+      "maxItems": 100
+    },
+    "instructions": { "type": "string", "maxLength": 20000 },
+    "agent_topology": { "$ref": "#/$defs/agent_topology" },
+    "context_manifests": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/context_manifest_ref" },
+      "maxItems": 50
+    },
+    "sub_recipes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/sub_recipe" },
+      "maxItems": 50
+    },
+    "response": { "$ref": "#/$defs/response" },
+    "run_policy": { "$ref": "#/$defs/run_policy" },
+    "library": { "$ref": "#/$defs/library_metadata" }
+  },
+  "unevaluatedProperties": false,
+  "$defs": {
+    "json_value": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "number" },
+        { "type": "boolean" },
+        { "type": "null" },
+        { "type": "array", "items": { "$ref": "#/$defs/json_value" } },
+        {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/json_value" }
+        }
+      ]
+    },
+    "parameter": {
+      "oneOf": [
+        { "$ref": "#/$defs/string_parameter" },
+        { "$ref": "#/$defs/integer_parameter" },
+        { "$ref": "#/$defs/number_parameter" },
+        { "$ref": "#/$defs/boolean_parameter" },
+        { "$ref": "#/$defs/enum_parameter" },
+        { "$ref": "#/$defs/path_parameter" },
+        { "$ref": "#/$defs/json_parameter" }
+      ]
+    },
+    "string_parameter": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "string" },
+        "required": { "type": "boolean" },
+        "description": { "type": "string", "maxLength": 1024 },
+        "default": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "integer_parameter": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "integer" },
+        "required": { "type": "boolean" },
+        "description": { "type": "string", "maxLength": 1024 },
+        "default": { "type": "integer" }
+      },
+      "additionalProperties": false
+    },
+    "number_parameter": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "number" },
+        "required": { "type": "boolean" },
+        "description": { "type": "string", "maxLength": 1024 },
+        "default": { "type": "number" }
+      },
+      "additionalProperties": false
+    },
+    "boolean_parameter": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "boolean" },
+        "required": { "type": "boolean" },
+        "description": { "type": "string", "maxLength": 1024 },
+        "default": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "enum_parameter": {
+      "type": "object",
+      "required": ["type", "enum"],
+      "properties": {
+        "type": { "const": "enum" },
+        "required": { "type": "boolean" },
+        "description": { "type": "string", "maxLength": 1024 },
+        "enum": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "maxItems": 100,
+          "uniqueItems": true
+        },
+        "default": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "path_parameter": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "path" },
+        "required": { "type": "boolean" },
+        "description": { "type": "string", "maxLength": 1024 },
+        "default": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "json_parameter": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "json" },
+        "required": { "type": "boolean" },
+        "description": { "type": "string", "maxLength": 1024 },
+        "default": { "$ref": "#/$defs/json_value" }
+      },
+      "additionalProperties": false
+    },
+    "extension": {
+      "type": "object",
+      "required": ["type", "name"],
+      "properties": {
+        "type": { "type": "string", "enum": ["mcp", "tool", "provider", "service"] },
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "uri": { "type": "string", "minLength": 1, "maxLength": 1024 },
+        "required": { "type": "boolean" }
+      },
+      "unevaluatedProperties": false
+    },
+    "activity": {
+      "type": "object",
+      "required": ["id", "label"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "label": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "role": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "condition": { "type": "string", "minLength": 1, "maxLength": 1024 }
+      },
+      "unevaluatedProperties": false
+    },
+    "context_manifest_ref": {
+      "type": "object",
+      "required": ["ref"],
+      "properties": {
+        "ref": { "type": "string", "minLength": 1, "maxLength": 1024 },
+        "role": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "required": { "type": "boolean" }
+      },
+      "unevaluatedProperties": false
+    },
+    "sub_recipe": {
+      "type": "object",
+      "required": ["name", "ref"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "ref": { "type": "string", "minLength": 1, "maxLength": 1024 },
+        "when": { "type": "string", "minLength": 1, "maxLength": 1024 },
+        "parameters": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[a-z][a-z0-9_]*$",
+            "maxLength": 64
+          },
+          "additionalProperties": { "$ref": "#/$defs/json_value" },
+          "maxProperties": 100
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "response": {
+      "type": "object",
+      "properties": {
+        "schema": { "type": "object" }
+      },
+      "unevaluatedProperties": false
+    },
+    "run_policy": {
+      "type": "object",
+      "properties": {
+        "max_iterations": { "type": "integer", "minimum": 1 },
+        "max_no_improvement_rounds": { "type": "integer", "minimum": 1 },
+        "improvement_threshold": { "type": "number", "minimum": 0 },
+        "direction": { "type": "string", "enum": ["maximize", "minimize"] }
+      },
+      "unevaluatedProperties": false
+    },
+    "library_metadata": {
+      "type": "object",
+      "properties": {
+        "owner": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "license": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "source": { "type": "string", "minLength": 1, "maxLength": 1024 },
+        "visibility": { "type": "string", "enum": ["private", "workspace", "public"] }
+      },
+      "unevaluatedProperties": false
+    },
+    "agent_topology": {
+      "type": "object",
+      "required": ["structure", "roles"],
+      "properties": {
+        "structure": {
+          "type": "string",
+          "enum": ["graph", "tree", "flat"]
+        },
+        "roles": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/topology_role" },
+          "minItems": 1,
+          "maxItems": 50
+        },
+        "spawning": { "$ref": "#/$defs/spawning_config" },
+        "edge_types": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "maxItems": 20
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "topology_role": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "description": { "type": "string", "maxLength": 256 },
+        "max_instances": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "mode": { "type": "string", "enum": ["explicit", "broadcast"] },
+        "edges": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/role_edge" },
+          "maxItems": 50
+        },
+        "command": { "type": "string", "maxLength": 512 },
+        "ends_session": { "type": "boolean" },
+        "platform": {
+          "type": "string",
+          "enum": ["claude-code", "codex", "gemini", "custom"]
+        },
+        "model": { "type": "string", "maxLength": 128 },
+        "color": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$" },
+        "prompt": { "type": "string", "maxLength": 4096 },
+        "goal": { "type": "string", "maxLength": 512 },
+        "skills": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "maxItems": 100
+        },
+        "repo_index": { "type": "integer", "minimum": 0 }
+      },
+      "unevaluatedProperties": false
+    },
+    "role_edge": {
+      "type": "object",
+      "required": ["target", "edge_type"],
+      "properties": {
+        "target": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "edge_type": {
+          "type": "string",
+          "enum": ["delegates", "feedback", "monitors", "reports", "feeds", "requests", "escalates"]
+        },
+        "workspace": {
+          "type": "string",
+          "enum": ["branch_from_source", "independent"]
+        },
+        "reply_timeout_seconds": {
+          "type": "integer",
+          "minimum": 10,
+          "maximum": 86400
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "spawning_config": {
+      "type": "object",
+      "required": ["dynamic"],
+      "properties": {
+        "dynamic": { "type": "boolean" },
+        "max_depth": { "type": "integer", "minimum": 1, "maximum": 10 },
+        "max_children_per_agent": { "type": "integer", "minimum": 1, "maximum": 20 },
+        "timeout_seconds": { "type": "integer", "minimum": 10, "maximum": 3600 }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/spec/schemas/grove-recipe.test.ts
+++ b/spec/schemas/grove-recipe.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import groveRecipeSchema from "./grove-recipe.json";
+
+function createValidator() {
+  const ajv = new Ajv2020({ allErrors: true });
+  addFormats(ajv);
+  return ajv.compile(groveRecipeSchema);
+}
+
+function validRecipe(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    kind: "recipe",
+    recipe_version: 1,
+    name: "code-review-loop",
+    version: "1.0.0",
+    ...overrides,
+  };
+}
+
+describe("grove-recipe schema", () => {
+  const validate = createValidator();
+
+  test("accepts minimal recipe", () => {
+    expect(validate(validRecipe())).toBe(true);
+  });
+
+  test("accepts parameters, activities, topology, and response schema", () => {
+    const recipe = validRecipe({
+      description: "Coder and reviewer iterate on a feature",
+      labels: ["code-review"],
+      parameters: {
+        target_path: { type: "path", required: true },
+        max_rounds: { type: "integer", default: 3 },
+      },
+      extensions: [{ type: "mcp", name: "filesystem", uri: "stdio:grove-fs-mcp" }],
+      activities: [
+        { id: "coder-drafts", label: "Coder drafts", role: "coder" },
+        {
+          id: "converge",
+          label: "Converge",
+          condition: `\${parameters.max_rounds} > 0`,
+        },
+      ],
+      instructions: `Work on \${parameters.target_path}.`,
+      agent_topology: {
+        structure: "graph",
+        roles: [
+          { name: "coder", platform: "codex" },
+          {
+            name: "reviewer",
+            platform: "claude-code",
+            edges: [{ target: "coder", edge_type: "feedback" }],
+          },
+        ],
+      },
+      sub_recipes: [
+        {
+          name: "security-audit",
+          ref: "./recipes/security-audit.yaml",
+          when: `\${parameters.target_path} matches '**/auth/**'`,
+          parameters: { target_path: `\${parameters.target_path}` },
+        },
+      ],
+      response: {
+        schema: {
+          type: "object",
+          properties: { approved: { type: "boolean" } },
+        },
+      },
+      run_policy: { max_iterations: 3, improvement_threshold: 0.01 },
+      library: { owner: "platform", visibility: "workspace" },
+    });
+
+    expect(validate(recipe)).toBe(true);
+  });
+
+  test("rejects unknown top-level fields", () => {
+    expect(validate(validRecipe({ unknown_field: true }))).toBe(false);
+  });
+
+  test("rejects invalid parameter defaults", () => {
+    const recipe = validRecipe({
+      parameters: {
+        max_rounds: { type: "integer", default: "three" },
+      },
+    });
+    expect(validate(recipe)).toBe(false);
+  });
+
+  test("rejects duplicate labels", () => {
+    const recipe = validRecipe({ labels: ["code-review", "code-review"] });
+    expect(validate(recipe)).toBe(false);
+  });
+});

--- a/src/cli/cli.integration.test.ts
+++ b/src/cli/cli.integration.test.ts
@@ -85,6 +85,19 @@ describe("grove CLI integration", () => {
     expect(stdout.trim()).toBe("grove 0.1.0");
   });
 
+  test("grove recipe validate works through the CLI entrypoint", async () => {
+    const recipePath = join(tempDir, "review.yaml");
+    await Bun.write(
+      recipePath,
+      "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+    );
+
+    const result = await runGrove(["recipe", "validate", recipePath]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Valid recipe: review-loop@1.0.0");
+  });
+
   test("grove claim + release round-trip", async () => {
     // Create a claim
     const claimResult = await runGrove(["claim", "my-target", "--lease", "30m"]);

--- a/src/cli/commands/recipe.test.ts
+++ b/src/cli/commands/recipe.test.ts
@@ -125,6 +125,67 @@ describe("recipe command", () => {
     }
   });
 
+  test("run --dry-run --json emits declared extensions and sub-recipes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-run-json-declared-"));
+    try {
+      const recipePath = join(dir, "composed.yaml");
+      await writeFile(
+        recipePath,
+        [
+          "kind: recipe",
+          "recipe_version: 1",
+          "name: composed-recipe",
+          "version: 1.0.0",
+          "parameters:",
+          "  target_path:",
+          "    type: path",
+          "    required: true",
+          "extensions:",
+          "  - type: mcp",
+          "    name: filesystem",
+          "    uri: stdio:grove-fs-mcp",
+          "sub_recipes:",
+          "  - name: child",
+          "    ref: recipe:child@1.0.0",
+          "    parameters:",
+          "      child_path: $" + "{parameters.target_path}",
+          "",
+        ].join("\n"),
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(
+        parseRecipeArgs([
+          "run",
+          recipePath,
+          "--dry-run",
+          "--json",
+          "--param",
+          "target_path=src/core",
+        ]),
+        {
+          cwd: dir,
+          writer,
+        },
+      );
+
+      const parsed = JSON.parse(lines.join("\n")) as {
+        extensions: readonly { readonly name: string; readonly type: string }[];
+        subRecipes: readonly {
+          readonly name: string;
+          readonly parameters?: Readonly<Record<string, unknown>>;
+          readonly ref: string;
+        }[];
+      };
+      expect(parsed.extensions[0]?.name).toBe("filesystem");
+      expect(parsed.extensions[0]?.type).toBe("mcp");
+      expect(parsed.subRecipes[0]?.name).toBe("child");
+      expect(parsed.subRecipes[0]?.ref).toBe("recipe:child@1.0.0");
+      expect(parsed.subRecipes[0]?.parameters?.child_path).toBe("$" + "{parameters.target_path}");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("run without --dry-run is rejected in the first implementation slice", async () => {
     const dir = await mkdtemp(join(tmpdir(), "grove-recipe-run-required-dry-"));
     try {

--- a/src/cli/commands/recipe.test.ts
+++ b/src/cli/commands/recipe.test.ts
@@ -112,4 +112,39 @@ describe("recipe command", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  test("list prints discovered recipes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-list-"));
+    try {
+      const recipesDir = join(dir, "recipes");
+      await mkdir(recipesDir, { recursive: true });
+      await writeFile(
+        join(recipesDir, "review.yaml"),
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(parseRecipeArgs(["list", "--dir", dir]), { cwd: dir, writer });
+      expect(lines.join("\n")).toContain("review-loop@1.0.0");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("list --json emits discovered recipes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-list-json-"));
+    try {
+      const recipesDir = join(dir, "recipes");
+      await mkdir(recipesDir, { recursive: true });
+      await writeFile(
+        join(recipesDir, "review.yaml"),
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(parseRecipeArgs(["list", "--dir", dir, "--json"]), { cwd: dir, writer });
+      const parsed = JSON.parse(lines.join("\n")) as Array<{ recipe: { name: string } }>;
+      expect(parsed[0]?.recipe.name).toBe("review-loop");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/commands/recipe.test.ts
+++ b/src/cli/commands/recipe.test.ts
@@ -149,6 +149,10 @@ describe("recipe command", () => {
           "    ref: recipe:child@1.0.0",
           "    parameters:",
           "      child_path: $" + "{parameters.target_path}",
+          "run_policy:",
+          "  max_no_improvement_rounds: 2",
+          "  improvement_threshold: 0.05",
+          "  direction: maximize",
           "",
         ].join("\n"),
       );
@@ -175,12 +179,22 @@ describe("recipe command", () => {
           readonly parameters?: Readonly<Record<string, unknown>>;
           readonly ref: string;
         }[];
+        runPolicy?: {
+          readonly direction?: string;
+          readonly improvementThreshold?: number;
+          readonly maxNoImprovementRounds?: number;
+        };
       };
       expect(parsed.extensions[0]?.name).toBe("filesystem");
       expect(parsed.extensions[0]?.type).toBe("mcp");
       expect(parsed.subRecipes[0]?.name).toBe("child");
       expect(parsed.subRecipes[0]?.ref).toBe("recipe:child@1.0.0");
-      expect(parsed.subRecipes[0]?.parameters?.child_path).toBe("$" + "{parameters.target_path}");
+      expect(parsed.subRecipes[0]?.parameters?.child_path).toBe("src/core");
+      expect(parsed.runPolicy).toEqual({
+        maxNoImprovementRounds: 2,
+        improvementThreshold: 0.05,
+        direction: "maximize",
+      });
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/cli/commands/recipe.test.ts
+++ b/src/cli/commands/recipe.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { parseRecipeArgs, runRecipe } from "./recipe.js";
+
+function createWriter(): { lines: string[]; writer: (line: string) => void } {
+  const lines: string[] = [];
+  return { lines, writer: (line: string) => lines.push(line) };
+}
+
+describe("recipe command", () => {
+  test("parseRecipeArgs parses validate", () => {
+    expect(parseRecipeArgs(["validate", "recipes/review.yaml"])).toEqual({
+      command: "validate",
+      path: "recipes/review.yaml",
+      json: false,
+    });
+  });
+
+  test("validate reports a valid recipe", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-cli-"));
+    try {
+      const recipePath = join(dir, "review.yaml");
+      await writeFile(
+        recipePath,
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(parseRecipeArgs(["validate", recipePath]), { cwd: dir, writer });
+      expect(lines.join("\n")).toContain("Valid recipe: review-loop@1.0.0");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("validate --json emits parseable JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-cli-json-"));
+    try {
+      const recipePath = join(dir, "review.yaml");
+      await writeFile(
+        recipePath,
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(parseRecipeArgs(["validate", recipePath, "--json"]), { cwd: dir, writer });
+      const parsed = JSON.parse(lines.join("\n")) as { valid: boolean; name: string };
+      expect(parsed.valid).toBe(true);
+      expect(parsed.name).toBe("review-loop");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/commands/recipe.test.ts
+++ b/src/cli/commands/recipe.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { UsageError } from "../errors.js";
 import { parseRecipeArgs, runRecipe } from "./recipe.js";
 
 function createWriter(): { lines: string[]; writer: (line: string) => void } {
@@ -19,6 +20,16 @@ describe("recipe command", () => {
     });
   });
 
+  test("parseRecipeArgs rejects extra validate positionals", () => {
+    expect(() => parseRecipeArgs(["validate", "recipes/review.yaml", "extra.yaml"])).toThrow(
+      UsageError,
+    );
+  });
+
+  test("parseRecipeArgs rejects extra run positionals", () => {
+    expect(() => parseRecipeArgs(["run", "recipes/review.yaml", "extra.yaml"])).toThrow(UsageError);
+  });
+
   test("validate reports a valid recipe", async () => {
     const dir = await mkdtemp(join(tmpdir(), "grove-recipe-cli-"));
     try {
@@ -29,7 +40,49 @@ describe("recipe command", () => {
       );
       const { lines, writer } = createWriter();
       await runRecipe(parseRecipeArgs(["validate", recipePath]), { cwd: dir, writer });
+      const output = lines.join("\n");
+      expect(output).toContain("Valid recipe: review-loop@1.0.0");
+      expect(output).toContain("Digest: blake3:");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("validate resolves relative recipe paths from cwd", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-cli-cwd-"));
+    try {
+      const recipesDir = join(dir, "recipes");
+      await mkdir(recipesDir);
+      await writeFile(
+        join(recipesDir, "review.yaml"),
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(parseRecipeArgs(["validate", "recipes/review.yaml"]), {
+        cwd: dir,
+        writer,
+      });
       expect(lines.join("\n")).toContain("Valid recipe: review-loop@1.0.0");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("run dry-run resolves relative recipe paths from cwd", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-cli-run-cwd-"));
+    try {
+      const recipesDir = join(dir, "recipes");
+      await mkdir(recipesDir);
+      await writeFile(
+        join(recipesDir, "review.yaml"),
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(parseRecipeArgs(["run", "recipes/review.yaml", "--dry-run"]), {
+        cwd: dir,
+        writer,
+      });
+      expect(lines.join("\n")).toContain("Recipe dry-run: review-loop@1.0.0");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -45,9 +98,16 @@ describe("recipe command", () => {
       );
       const { lines, writer } = createWriter();
       await runRecipe(parseRecipeArgs(["validate", recipePath, "--json"]), { cwd: dir, writer });
-      const parsed = JSON.parse(lines.join("\n")) as { valid: boolean; name: string };
+      const parsed = JSON.parse(lines.join("\n")) as {
+        digest: string;
+        name: string;
+        valid: boolean;
+        version: string;
+      };
       expect(parsed.valid).toBe(true);
       expect(parsed.name).toBe("review-loop");
+      expect(parsed.version).toBe("1.0.0");
+      expect(parsed.digest).toStartWith("blake3:");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/cli/commands/recipe.test.ts
+++ b/src/cli/commands/recipe.test.ts
@@ -88,6 +88,59 @@ describe("recipe command", () => {
     }
   });
 
+  test("run --dry-run binds parameters and renders instructions", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-run-"));
+    try {
+      const recipePath = join(dir, "review.yaml");
+      await writeFile(
+        recipePath,
+        [
+          "kind: recipe",
+          "recipe_version: 1",
+          "name: review-loop",
+          "version: 1.0.0",
+          "parameters:",
+          "  target_path:",
+          "    type: path",
+          "    required: true",
+          "instructions: |",
+          "  Review $" + "{parameters.target_path}.",
+          "",
+        ].join("\n"),
+      );
+      const { lines, writer } = createWriter();
+      await runRecipe(
+        parseRecipeArgs(["run", recipePath, "--dry-run", "--param", "target_path=src/core"]),
+        {
+          cwd: dir,
+          writer,
+        },
+      );
+      const output = lines.join("\n");
+      expect(output).toContain("Recipe dry-run: review-loop@1.0.0");
+      expect(output).toContain("src/core");
+      expect(output).toContain("Bound digest:");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("run without --dry-run is rejected in the first implementation slice", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-run-required-dry-"));
+    try {
+      const recipePath = join(dir, "review.yaml");
+      await writeFile(
+        recipePath,
+        "kind: recipe\nrecipe_version: 1\nname: review-loop\nversion: 1.0.0\n",
+      );
+      await expect(
+        runRecipe(parseRecipeArgs(["run", recipePath]), { cwd: dir, writer: () => undefined }),
+      ).rejects.toThrow(/requires --dry-run/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("validate --json emits parseable JSON", async () => {
     const dir = await mkdtemp(join(tmpdir(), "grove-recipe-cli-json-"));
     try {

--- a/src/cli/commands/recipe.ts
+++ b/src/cli/commands/recipe.ts
@@ -138,6 +138,7 @@ export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promi
     renderedInstructions: materialized.renderedInstructions,
     extensions: materialized.extensions,
     subRecipes: materialized.subRecipes,
+    runPolicy: materialized.runPolicy,
     contract: materialized.contract,
     provenance: materialized.provenance,
   };

--- a/src/cli/commands/recipe.ts
+++ b/src/cli/commands/recipe.ts
@@ -123,13 +123,13 @@ export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promi
     );
     return;
   }
+  if (!command.dryRun) {
+    throw new UsageError("recipe run currently requires --dry-run");
+  }
   const content = await readFile(resolveRecipePath(command.path, deps.cwd), "utf-8");
   const recipe = parseGroveRecipe(content);
   const bound = bindRecipeParameters(recipe, command.params);
   const materialized = materializeRecipeContract(bound);
-  if (!command.dryRun) {
-    throw new UsageError("recipe run currently requires --dry-run");
-  }
   const payload = {
     recipe: { name: recipe.name, version: recipe.version },
     recipeDigest: bound.recipeDigest,

--- a/src/cli/commands/recipe.ts
+++ b/src/cli/commands/recipe.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
 import { parseArgs } from "node:util";
 
 import type { JsonValue } from "../../core/models.js";
@@ -40,6 +41,7 @@ export function parseRecipeArgs(argv: readonly string[]): RecipeCommand {
     });
     const path = parsed.positionals[0];
     if (path === undefined) throw new UsageError("recipe validate requires <path>");
+    if (parsed.positionals.length > 1) throw new UsageError("recipe validate accepts one <path>");
     return { command: "validate", path, json: parsed.values.json ?? false };
   }
   if (subcommand === "list") {
@@ -64,6 +66,7 @@ export function parseRecipeArgs(argv: readonly string[]): RecipeCommand {
     });
     const path = parsed.positionals[0];
     if (path === undefined) throw new UsageError("recipe run requires <path>");
+    if (parsed.positionals.length > 1) throw new UsageError("recipe run accepts one <path>");
     return {
       command: "run",
       path,
@@ -84,7 +87,7 @@ export async function handleRecipe(
 
 export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promise<void> {
   if (command.command === "validate") {
-    const content = await readFile(command.path, "utf-8");
+    const content = await readFile(resolveRecipePath(command.path, deps.cwd), "utf-8");
     const recipe = parseGroveRecipe(content);
     const digest = computeRecipeDigest(recipe);
     if (command.json) {
@@ -116,7 +119,7 @@ export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promi
     );
     return;
   }
-  const content = await readFile(command.path, "utf-8");
+  const content = await readFile(resolveRecipePath(command.path, deps.cwd), "utf-8");
   const recipe = parseGroveRecipe(content);
   const bound = bindRecipeParameters(recipe, command.params);
   const materialized = materializeRecipeContract(bound);
@@ -133,6 +136,10 @@ export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promi
     provenance: materialized.provenance,
   };
   deps.writer(command.json ? JSON.stringify(payload, null, 2) : formatDryRun(payload));
+}
+
+function resolveRecipePath(path: string, cwd: string): string {
+  return isAbsolute(path) ? path : resolve(cwd, path);
 }
 
 function parseParamFlags(flags: readonly string[]): Readonly<Record<string, string>> {

--- a/src/cli/commands/recipe.ts
+++ b/src/cli/commands/recipe.ts
@@ -136,6 +136,8 @@ export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promi
     boundParameterDigest: computeBoundRecipeDigest(bound),
     parameters: bound.parameters,
     renderedInstructions: materialized.renderedInstructions,
+    extensions: materialized.extensions,
+    subRecipes: materialized.subRecipes,
     contract: materialized.contract,
     provenance: materialized.provenance,
   };

--- a/src/cli/commands/recipe.ts
+++ b/src/cli/commands/recipe.ts
@@ -1,0 +1,166 @@
+import { readFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
+
+import type { JsonValue } from "../../core/models.js";
+import {
+  bindRecipeParameters,
+  computeBoundRecipeDigest,
+  computeRecipeDigest,
+  discoverRecipes,
+  materializeRecipeContract,
+  parseGroveRecipe,
+} from "../../core/recipe.js";
+import { UsageError } from "../errors.js";
+
+type RecipeCommand =
+  | { readonly command: "validate"; readonly path: string; readonly json: boolean }
+  | { readonly command: "list"; readonly dir?: string | undefined; readonly json: boolean }
+  | {
+      readonly command: "run";
+      readonly path: string;
+      readonly params: Readonly<Record<string, string>>;
+      readonly dryRun: boolean;
+      readonly json: boolean;
+    };
+
+interface RecipeDeps {
+  readonly cwd: string;
+  readonly writer: (line: string) => void;
+}
+
+export function parseRecipeArgs(argv: readonly string[]): RecipeCommand {
+  const subcommand = argv[0];
+  const rest = argv.slice(1);
+  if (subcommand === "validate") {
+    const parsed = parseArgs({
+      args: [...rest],
+      options: { json: { type: "boolean", default: false } },
+      allowPositionals: true,
+      strict: true,
+    });
+    const path = parsed.positionals[0];
+    if (path === undefined) throw new UsageError("recipe validate requires <path>");
+    return { command: "validate", path, json: parsed.values.json ?? false };
+  }
+  if (subcommand === "list") {
+    const parsed = parseArgs({
+      args: [...rest],
+      options: { dir: { type: "string" }, json: { type: "boolean", default: false } },
+      allowPositionals: false,
+      strict: true,
+    });
+    return { command: "list", dir: parsed.values.dir, json: parsed.values.json ?? false };
+  }
+  if (subcommand === "run") {
+    const parsed = parseArgs({
+      args: [...rest],
+      options: {
+        param: { type: "string", multiple: true },
+        "dry-run": { type: "boolean", default: false },
+        json: { type: "boolean", default: false },
+      },
+      allowPositionals: true,
+      strict: true,
+    });
+    const path = parsed.positionals[0];
+    if (path === undefined) throw new UsageError("recipe run requires <path>");
+    return {
+      command: "run",
+      path,
+      params: parseParamFlags(parsed.values.param ?? []),
+      dryRun: parsed.values["dry-run"] ?? false,
+      json: parsed.values.json ?? false,
+    };
+  }
+  throw new UsageError("recipe requires subcommand: validate, list, or run");
+}
+
+export async function handleRecipe(
+  args: readonly string[],
+  cwd: string = process.cwd(),
+): Promise<void> {
+  await runRecipe(parseRecipeArgs(args), { cwd, writer: console.log });
+}
+
+export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promise<void> {
+  if (command.command === "validate") {
+    const content = await readFile(command.path, "utf-8");
+    const recipe = parseGroveRecipe(content);
+    const digest = computeRecipeDigest(recipe);
+    if (command.json) {
+      deps.writer(
+        JSON.stringify(
+          { valid: true, name: recipe.name, version: recipe.version, digest },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+    deps.writer(`Valid recipe: ${recipe.name}@${recipe.version}`);
+    deps.writer(`Digest: ${digest}`);
+    return;
+  }
+  if (command.command === "list") {
+    const entries = await discoverRecipes({ cwd: command.dir ?? deps.cwd });
+    if (command.json) {
+      deps.writer(JSON.stringify(entries, null, 2));
+      return;
+    }
+    deps.writer(
+      entries.length === 0
+        ? "No recipes found."
+        : entries
+            .map((entry) => `${entry.recipe.name}@${entry.recipe.version} ${entry.path}`)
+            .join("\n"),
+    );
+    return;
+  }
+  const content = await readFile(command.path, "utf-8");
+  const recipe = parseGroveRecipe(content);
+  const bound = bindRecipeParameters(recipe, command.params);
+  const materialized = materializeRecipeContract(bound);
+  if (!command.dryRun) {
+    throw new UsageError("recipe run currently requires --dry-run");
+  }
+  const payload = {
+    recipe: { name: recipe.name, version: recipe.version },
+    recipeDigest: bound.recipeDigest,
+    boundParameterDigest: computeBoundRecipeDigest(bound),
+    parameters: bound.parameters,
+    renderedInstructions: materialized.renderedInstructions,
+    contract: materialized.contract,
+    provenance: materialized.provenance,
+  };
+  deps.writer(command.json ? JSON.stringify(payload, null, 2) : formatDryRun(payload));
+}
+
+function parseParamFlags(flags: readonly string[]): Readonly<Record<string, string>> {
+  const params: Record<string, string> = {};
+  for (const flag of flags) {
+    const equals = flag.indexOf("=");
+    if (equals <= 0) throw new UsageError(`Invalid --param: ${flag}`);
+    params[flag.slice(0, equals)] = flag.slice(equals + 1);
+  }
+  return params;
+}
+
+function formatDryRun(payload: {
+  readonly recipe: { readonly name: string; readonly version: string };
+  readonly recipeDigest: string;
+  readonly boundParameterDigest: string;
+  readonly parameters: Readonly<Record<string, JsonValue>>;
+  readonly renderedInstructions?: string | undefined;
+}): string {
+  const lines = [
+    `Recipe dry-run: ${payload.recipe.name}@${payload.recipe.version}`,
+    `Recipe digest: ${payload.recipeDigest}`,
+    `Bound digest: ${payload.boundParameterDigest}`,
+    `Parameters: ${JSON.stringify(payload.parameters)}`,
+  ];
+  if (payload.renderedInstructions !== undefined) {
+    lines.push("Rendered instructions:");
+    lines.push(payload.renderedInstructions);
+  }
+  return lines.join("\n");
+}

--- a/src/cli/commands/recipe.ts
+++ b/src/cli/commands/recipe.ts
@@ -110,12 +110,16 @@ export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promi
       deps.writer(JSON.stringify(entries, null, 2));
       return;
     }
+    if (entries.length === 0) {
+      deps.writer("No recipes found.");
+      return;
+    }
     deps.writer(
-      entries.length === 0
-        ? "No recipes found."
-        : entries
-            .map((entry) => `${entry.recipe.name}@${entry.recipe.version} ${entry.path}`)
-            .join("\n"),
+      entries
+        .map(
+          (entry) => `${entry.recipe.name}@${entry.recipe.version} ${entry.source} ${entry.path}`,
+        )
+        .join("\n"),
     );
     return;
   }

--- a/src/cli/commands/session.test.ts
+++ b/src/cli/commands/session.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { writeNamespace } from "../../core/project-key.js";
+import { resolveSessionNexusZoneId } from "./session.js";
+
+const tempRoots: string[] = [];
+
+function makeGroveDir(): string {
+  const root = mkdtempSync(join(tmpdir(), "grove-session-zone-"));
+  tempRoots.push(root);
+  const groveDir = join(root, ".grove");
+  mkdirSync(groveDir);
+  return groveDir;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("resolveSessionNexusZoneId", () => {
+  test("uses the persisted grove namespace before env fallback", () => {
+    const groveDir = makeGroveDir();
+    writeNamespace(groveDir, "project-123/worktree-a");
+
+    expect(resolveSessionNexusZoneId(groveDir, { GROVE_ZONE_ID: "env-zone" })).toBe(
+      "project-123/worktree-a",
+    );
+  });
+
+  test("uses GROVE_ZONE_ID when no namespace file exists", () => {
+    const groveDir = makeGroveDir();
+
+    expect(resolveSessionNexusZoneId(groveDir, { GROVE_ZONE_ID: "env-zone" })).toBe("env-zone");
+  });
+
+  test("falls back to default when no namespace source is available", () => {
+    const groveDir = makeGroveDir();
+
+    expect(resolveSessionNexusZoneId(groveDir, {})).toBe("default");
+  });
+});

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -28,7 +28,9 @@ import {
 } from "../../core/loop-runner.js";
 import { MockRuntime } from "../../core/mock-runtime.js";
 import { lookupPresetTopology } from "../../core/presets.js";
+import { readNamespace } from "../../core/project-key.js";
 import { SessionOrchestrator } from "../../core/session-orchestrator.js";
+import type { ContributionStore } from "../../core/store.js";
 import type { AgentTopology } from "../../core/topology.js";
 import type { TopologyResolutionResult } from "../../core/topology-resolver.js";
 import { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
@@ -38,6 +40,24 @@ import { buildRepos } from "../utils/build-repos.js";
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+interface SessionNexusZoneEnv {
+  readonly GROVE_ZONE_ID?: string | undefined;
+}
+
+interface SessionCompletionUpdates {
+  readonly status: "completed" | "cancelled";
+  readonly completedAt: string;
+  readonly stopReason: string;
+  readonly stopStatus: LoopStopStatus;
+}
+
+export function resolveSessionNexusZoneId(
+  groveDir: string,
+  env: SessionNexusZoneEnv = { GROVE_ZONE_ID: process.env.GROVE_ZONE_ID },
+): string {
+  return readNamespace(groveDir) ?? env.GROVE_ZONE_ID ?? "default";
+}
 
 // ---------------------------------------------------------------------------
 // Subcommand dispatch
@@ -197,23 +217,36 @@ async function sessionStart(args: readonly string[]): Promise<void> {
   let sessionId: string | undefined;
   let orchestrator: SessionOrchestrator | undefined;
   let workflowStore: WorkflowStateStore | undefined;
+  let contributionStore: ContributionStore | undefined;
+  let updateNexusSession:
+    | ((sessionId: string, updates: SessionCompletionUpdates) => Promise<void>)
+    | undefined;
+  let addNexusContributionToSession:
+    | ((sessionId: string, cid: string) => Promise<void>)
+    | undefined;
   const goalSessionStore = new SqliteGoalSessionStore(db);
 
   const markDone = async (reason: string, stopStatus: LoopStopStatus): Promise<void> => {
     if (sessionId === undefined) return;
+    const updates: SessionCompletionUpdates = {
+      status: terminalSessionStatus(stopStatus),
+      completedAt: new Date().toISOString(),
+      stopReason: reason,
+      stopStatus,
+    };
     try {
       // C6 (#304): no ifMatch supplied — rv-mismatch is unreachable here;
       // surface as a hard error so future ifMatch wiring (T7) doesn't silently
       // skip the markDone path.
-      const result = await goalSessionStore.updateSession(sessionId, {
-        status: terminalSessionStatus(stopStatus),
-        completedAt: new Date().toISOString(),
-        stopReason: reason,
-        stopStatus,
-      });
+      const result = await goalSessionStore.updateSession(sessionId, updates);
       expectCasOk(result, `cli markDone(${sessionId})`);
     } catch {
       // Best-effort — DB may already be closed or session archived.
+    }
+    try {
+      await updateNexusSession?.(sessionId, updates);
+    } catch {
+      // Best-effort — Nexus may be unavailable during shutdown.
     }
   };
 
@@ -244,15 +277,27 @@ async function sessionStart(args: readonly string[]): Promise<void> {
     const nexusApiKey = process.env.NEXUS_API_KEY;
     if (nexusUrl) {
       const { NexusHttpClient } = await import("../../nexus/nexus-http-client.js");
+      const { NexusContributionStore } = await import("../../nexus/nexus-contribution-store.js");
       const { NexusSessionStore } = await import("../../nexus/nexus-session-store.js");
       const { NexusWorkflowStore } = await import("../../nexus/nexus-workflow-store.js");
       const nexusClient = new NexusHttpClient({
         url: nexusUrl,
         ...(nexusApiKey ? { apiKey: nexusApiKey } : {}),
       });
-      const zoneId = process.env.GROVE_ZONE_ID ?? "default";
+      const zoneId = resolveSessionNexusZoneId(groveDir);
       const nexusSessionStore = new NexusSessionStore(nexusClient, zoneId);
+      updateNexusSession = async (targetSessionId, updates) => {
+        const result = await nexusSessionStore.updateSession(targetSessionId, updates);
+        expectCasOk(result, `cli nexus markDone(${targetSessionId})`);
+      };
+      addNexusContributionToSession = (targetSessionId, cid) =>
+        nexusSessionStore.addContribution(targetSessionId, cid);
       workflowStore = new NexusWorkflowStore({ client: nexusClient, zoneId });
+      contributionStore = new NexusContributionStore({
+        client: nexusClient,
+        zoneId,
+        sessionId: session.id,
+      });
 
       const retryDelaysMs = [0, 200, 500, 1000];
       let lastErr: unknown;
@@ -282,9 +327,14 @@ async function sessionStart(args: readonly string[]): Promise<void> {
       }
     }
 
-    // Create contribution store for polling-based routing (MCP runs in child processes)
-    const { SqliteContributionStore } = await import("../../local/sqlite-store.js");
-    const contributionStore = new SqliteContributionStore(db);
+    // Create contribution store for polling-based routing (MCP runs in child processes).
+    // In Nexus mode MCP writes session-scoped contributions to Nexus, so the
+    // orchestrator must poll the same scoped store or downstream roles never
+    // receive handoffs.
+    if (!contributionStore) {
+      const { SqliteContributionStore } = await import("../../local/sqlite-store.js");
+      contributionStore = new SqliteContributionStore(db);
+    }
 
     orchestrator = new SessionOrchestrator({
       goal,
@@ -297,6 +347,14 @@ async function sessionStart(args: readonly string[]): Promise<void> {
       workspaceBaseDir: join(groveDir, "workspaces"),
       sessionId: session.id,
       contributionStore,
+      onContributionAccepted: async (cid) => {
+        const localLink = goalSessionStore.addContributionToSession(session.id, cid);
+        if (addNexusContributionToSession === undefined) {
+          await localLink;
+          return;
+        }
+        await Promise.all([localLink, addNexusContributionToSession(session.id, cid)]);
+      },
     });
 
     let status: import("../../core/session-orchestrator.js").SessionStatus;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -387,6 +387,21 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "recipe",
+      description: "Validate, list, and dry-run Grove recipes",
+      needsStore: false,
+      helpText: `grove recipe — validate, list, and dry-run Grove recipes
+
+Usage:
+  grove recipe validate <path> [--json]
+  grove recipe list [--dir <path>] [--json]
+  grove recipe run <path> --dry-run [--param key=value] [--json]`,
+      handler: async (args) => {
+        const { handleRecipe } = await import("./commands/recipe.js");
+        await handleRecipe(args);
+      },
+    },
+    {
       name: "session",
       description: "Manage agent sessions (start, list, status, stop, delete)",
       needsStore: false,

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -238,6 +238,16 @@ export const COMMANDS: readonly CommandMeta[] = [
     ],
   },
   {
+    name: "recipe",
+    description: "Validate, list, and dry-run Grove recipes",
+    flags: [],
+    subcommands: [
+      { name: "validate", description: "Validate a recipe file", flags: ["json"] },
+      { name: "list", description: "List discovered recipes", flags: ["dir", "json"] },
+      { name: "run", description: "Dry-run a recipe", flags: ["dry-run", "param", "json"] },
+    ],
+  },
+  {
     name: "session",
     description: "Manage agent sessions (start, list, status, stop, delete)",
     flags: [],

--- a/src/core/acp-runtime.spawn.test.ts
+++ b/src/core/acp-runtime.spawn.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   type Agent,
   AgentSideConnection,
+  type InitializeRequest,
   ndJsonStream,
   RequestError,
   type RequestPermissionRequest,
@@ -9,6 +13,7 @@ import {
 import { AcpRuntime, type AcpRuntimeEvent, type LaunchOverride } from "./acp-runtime.js";
 
 interface AgentStubHandlers {
+  onInitialize?: (p: InitializeRequest) => void;
   onNewSession?: (p: Parameters<Agent["newSession"]>[0]) => void;
   onCancel?: () => Promise<void> | void;
   onPrompt?: (p: {
@@ -31,7 +36,8 @@ function makeInProcessAgent(handlers: AgentStubHandlers = {}): {
     const clientStream = ndJsonStream(toAgent.writable, toClient.readable);
 
     const agent: Agent = {
-      async initialize() {
+      async initialize(p) {
+        handlers.onInitialize?.(p);
         return {
           protocolVersion: 1,
           agentCapabilities: {},
@@ -83,6 +89,26 @@ function deferred<T = void>(): {
 }
 
 describe("AcpRuntime.spawn", () => {
+  test("advertises filesystem and terminal client capabilities", async () => {
+    let captured: InitializeRequest | undefined;
+    const { launchOverride } = makeInProcessAgent({
+      onInitialize(p) {
+        captured = p;
+      },
+    });
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: process.cwd(),
+    });
+
+    expect(captured?.clientCapabilities?.fs?.readTextFile).toBe(true);
+    expect(captured?.clientCapabilities?.fs?.writeTextFile).toBe(true);
+    expect(captured?.clientCapabilities?.terminal).toBe(true);
+    await rt.close(session);
+  });
+
   test("initializes, creates a session, returns grove-formatted id", async () => {
     const { launchOverride } = makeInProcessAgent();
     const rt = new AcpRuntime({ launchOverride });
@@ -184,6 +210,44 @@ describe("AcpRuntime.spawn", () => {
 });
 
 describe("AcpRuntime.send", () => {
+  test("serves ACP filesystem and terminal requests from the client", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grove-acp-client-"));
+    const filePath = join(dir, "hello.txt");
+    const { launchOverride } = makeInProcessAgent({
+      async onPrompt({ sessionId, agentSide }) {
+        await agentSide.writeTextFile({ sessionId, path: filePath, content: "hi\nthere\n" });
+        const read = await agentSide.readTextFile({ sessionId, path: filePath, line: 2, limit: 1 });
+        expect(read.content).toBe("there\n");
+
+        const terminal = await agentSide.createTerminal({
+          sessionId,
+          command: "sh",
+          args: ["-lc", "printf terminal-ok"],
+          cwd: dir,
+        });
+        const exit = await terminal.waitForExit();
+        expect(exit.exitCode).toBe(0);
+        const output = await terminal.currentOutput();
+        expect(output.output).toBe("terminal-ok");
+        await terminal.release();
+
+        return { stopReason: "end_turn" };
+      },
+    });
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: dir,
+    });
+
+    const turn = await rt.send(session, "exercise client capabilities");
+    expect((await turn.result).stopReason).toBe("end_turn");
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath, "utf-8")).toBe("hi\nthere\n");
+    await rt.close(session);
+  });
+
   test("returns a turn; result resolves with stopReason=end_turn on successful prompt", async () => {
     const { launchOverride } = makeInProcessAgent({
       async onPrompt() {

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -4,12 +4,13 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { Readable, Writable } from "node:stream";
 import { Readable as NodeReadable, Writable as NodeWritable } from "node:stream";
 import {
@@ -69,6 +70,7 @@ interface AcpSessionEntry {
   session: AgentSession;
   connection: ClientSideConnection;
   wireSessionId: string;
+  cwd: string;
   dispose: () => Promise<void>;
   idleCallbacks: (() => void)[];
   currentTurn: AcpTurnImpl | null;
@@ -82,9 +84,20 @@ interface AcpSessionEntry {
   closed: boolean;
 }
 
+interface TerminalEntry {
+  readonly sessionId: string;
+  readonly proc: ChildProcessByStdio<null, Readable, Readable>;
+  readonly outputByteLimit: number;
+  output: string;
+  truncated: boolean;
+  exitStatus?: { readonly exitCode?: number | null; readonly signal?: string | null };
+  readonly exited: Promise<{ readonly exitCode?: number | null; readonly signal?: string | null }>;
+}
+
 const CLOSE_SEND_DRAIN_TIMEOUT_MS = 2_000;
 const CHILD_TERM_TIMEOUT_MS = 2_000;
 const CHILD_KILL_TIMEOUT_MS = 500;
+const DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT = 128 * 1024;
 
 function resolveAgentFromConfig(config: AgentConfig): string {
   if (config.platform === "claude-code") return "claude";
@@ -629,7 +642,9 @@ export class AcpRuntime implements AgentRuntime {
   private readonly launchOverride: LaunchOverride | undefined;
   private eventSink: AcpRuntimeEventSink | undefined;
   private readonly sessions: Map<string, AcpSessionEntry> = new Map();
+  private readonly terminals: Map<string, TerminalEntry> = new Map();
   private nextId = 0;
+  private nextTerminalId = 0;
 
   /**
    * Optional callback invoked after a session lifecycle transition that
@@ -708,8 +723,8 @@ export class AcpRuntime implements AgentRuntime {
       await connection.initialize({
         protocolVersion: 1,
         clientCapabilities: {
-          fs: { readTextFile: false, writeTextFile: false },
-          terminal: false,
+          fs: { readTextFile: true, writeTextFile: true },
+          terminal: true,
         },
       });
       const groveMcpEnv = Object.fromEntries(
@@ -751,6 +766,7 @@ export class AcpRuntime implements AgentRuntime {
       session,
       connection,
       wireSessionId: created.sessionId,
+      cwd: config.cwd,
       dispose: launched.dispose,
       idleCallbacks: [],
       currentTurn: null,
@@ -911,6 +927,7 @@ export class AcpRuntime implements AgentRuntime {
     } catch {
       /* ignore */
     }
+    await this.releaseSessionTerminals(entry.wireSessionId);
     try {
       await entry.dispose();
     } catch {
@@ -1000,12 +1017,109 @@ export class AcpRuntime implements AgentRuntime {
           message: msg,
         });
       },
-      async readTextFile() {
-        throw new Error("[acp-runtime] fs.readTextFile not supported; agents use local fs");
+      async readTextFile(params) {
+        const text = readFileSync(params.path, "utf-8");
+        const line = params.line ?? undefined;
+        const limit = params.limit ?? undefined;
+        if (line === undefined && limit === undefined) return { content: text };
+
+        const lines = text.split(/(?<=\n)/);
+        const start = line === undefined ? 0 : Math.max(0, line - 1);
+        const end = limit === undefined ? lines.length : start + Math.max(0, limit);
+        return { content: lines.slice(start, end).join("") };
       },
-      async writeTextFile() {
-        throw new Error("[acp-runtime] fs.writeTextFile not supported; agents use local fs");
+      async writeTextFile(params) {
+        mkdirSync(dirname(params.path), { recursive: true });
+        writeFileSync(params.path, params.content, "utf-8");
+        return {};
+      },
+      async createTerminal(params) {
+        const entry = runtime.findEntryByWireSession(params.sessionId);
+        const env = { ...process.env };
+        for (const item of params.env ?? []) {
+          env[item.name] = item.value;
+        }
+        const proc = nodeSpawn(params.command, params.args ?? [], {
+          cwd: params.cwd ?? entry?.cwd ?? process.cwd(),
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        const terminalId = `term-${++runtime.nextTerminalId}`;
+        const terminal: TerminalEntry = {
+          sessionId: params.sessionId,
+          proc,
+          outputByteLimit: params.outputByteLimit ?? DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT,
+          output: "",
+          truncated: false,
+          exited: new Promise((resolve) => {
+            proc.once("exit", (code, signal) => {
+              const exitStatus = { exitCode: code, signal };
+              terminal.exitStatus = exitStatus;
+              resolve(exitStatus);
+            });
+          }),
+        };
+        const append = (chunk: Buffer): void => {
+          terminal.output += chunk.toString("utf-8");
+          while (Buffer.byteLength(terminal.output, "utf-8") > terminal.outputByteLimit) {
+            terminal.output = terminal.output.slice(1);
+            terminal.truncated = true;
+          }
+        };
+        proc.stdout.on("data", append);
+        proc.stderr.on("data", append);
+        runtime.terminals.set(terminalId, terminal);
+        return { terminalId };
+      },
+      async terminalOutput(params) {
+        const terminal = runtime.requireTerminal(params.terminalId);
+        return {
+          output: terminal.output,
+          truncated: terminal.truncated,
+          ...(terminal.exitStatus !== undefined ? { exitStatus: terminal.exitStatus } : {}),
+        };
+      },
+      async waitForTerminalExit(params) {
+        const terminal = runtime.requireTerminal(params.terminalId);
+        return await terminal.exited;
+      },
+      async releaseTerminal(params) {
+        await runtime.releaseTerminal(params.terminalId);
+        return {};
+      },
+      async killTerminal(params) {
+        const terminal = runtime.requireTerminal(params.terminalId);
+        if (terminal.exitStatus === undefined) terminal.proc.kill("SIGTERM");
+        return {};
       },
     };
+  }
+
+  private requireTerminal(terminalId: string): TerminalEntry {
+    const terminal = this.terminals.get(terminalId);
+    if (!terminal) throw new Error(`[acp-runtime] unknown terminal: ${terminalId}`);
+    return terminal;
+  }
+
+  private async releaseTerminal(terminalId: string): Promise<void> {
+    const terminal = this.terminals.get(terminalId);
+    if (!terminal) return;
+    if (terminal.exitStatus === undefined) {
+      terminal.proc.kill("SIGTERM");
+      await Promise.race([
+        terminal.exited,
+        new Promise((resolve) => setTimeout(resolve, CHILD_TERM_TIMEOUT_MS)),
+      ]);
+    }
+    this.terminals.delete(terminalId);
+  }
+
+  private async releaseSessionTerminals(sessionId: string): Promise<void> {
+    const ids = [...this.terminals.entries()]
+      .filter(([, terminal]) => terminal.sessionId === sessionId)
+      .map(([id]) => id);
+    for (const id of ids) {
+      await this.releaseTerminal(id);
+    }
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -300,6 +300,8 @@ export type { CorePresetConfig } from "./presets.js";
 export { getPresetTopologyRegistry, listPresetNames, lookupPresetTopology } from "./presets.js";
 export type {
   BoundRecipe,
+  DiscoveredRecipe,
+  DiscoverRecipesOptions,
   GroveRecipe,
   MaterializedRecipe,
   RecipeActivity,
@@ -309,12 +311,14 @@ export type {
   RecipeParameterType,
   RecipeProvenance,
   RecipeRunPolicy,
+  RecipeSource,
   RecipeSubRecipe,
 } from "./recipe.js";
 export {
   bindRecipeParameters,
   computeBoundRecipeDigest,
   computeRecipeDigest,
+  discoverRecipes,
   materializeRecipeContract,
   parseGroveRecipe,
   parseGroveRecipeObject,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -299,6 +299,28 @@ export { PolicyEnforcer } from "./policy-enforcer.js";
 export type { CorePresetConfig } from "./presets.js";
 export { getPresetTopologyRegistry, listPresetNames, lookupPresetTopology } from "./presets.js";
 export type {
+  BoundRecipe,
+  GroveRecipe,
+  MaterializedRecipe,
+  RecipeActivity,
+  RecipeExtension,
+  RecipeLibraryMetadata,
+  RecipeParameter,
+  RecipeParameterType,
+  RecipeProvenance,
+  RecipeRunPolicy,
+  RecipeSubRecipe,
+} from "./recipe.js";
+export {
+  bindRecipeParameters,
+  computeBoundRecipeDigest,
+  computeRecipeDigest,
+  materializeRecipeContract,
+  parseGroveRecipe,
+  parseGroveRecipeObject,
+  renderRecipeTemplate,
+} from "./recipe.js";
+export type {
   ReconcileResult,
   Reconciler,
   ReconcilerConfig,

--- a/src/core/recipe.test.ts
+++ b/src/core/recipe.test.ts
@@ -303,6 +303,89 @@ parameters:
     expect(bound.parameters.enabled).toBe(true);
   });
 
+  test("preserves plain string JSON parameter defaults", () => {
+    const recipe = parseGroveRecipe(`
+kind: recipe
+recipe_version: 1
+name: json-default
+version: 1.0.0
+parameters:
+  message:
+    type: json
+    default: hello
+`);
+    const bound = bindRecipeParameters(recipe, {});
+    expect(bound.parameters.message).toBe("hello");
+  });
+
+  test("parses JSON object CLI string overrides", () => {
+    const recipe = parseGroveRecipe(`
+kind: recipe
+recipe_version: 1
+name: json-override
+version: 1.0.0
+parameters:
+  config:
+    type: json
+    required: true
+`);
+    const bound = bindRecipeParameters(recipe, { config: '{"enabled":true,"rounds":2}' });
+    expect(bound.parameters.config).toEqual({ enabled: true, rounds: 2 });
+  });
+
+  test("preserves plain string JSON CLI overrides", () => {
+    const recipe = parseGroveRecipe(`
+kind: recipe
+recipe_version: 1
+name: plain-json-override
+version: 1.0.0
+parameters:
+  message:
+    type: json
+    required: true
+`);
+    const bound = bindRecipeParameters(recipe, { message: "hello" });
+    expect(bound.parameters.message).toBe("hello");
+  });
+
+  test("rejects invalid JSON-looking CLI overrides", () => {
+    const recipe = parseGroveRecipe(`
+kind: recipe
+recipe_version: 1
+name: invalid-json-override
+version: 1.0.0
+parameters:
+  config:
+    type: json
+    required: true
+`);
+    expect(() => bindRecipeParameters(recipe, { config: "{bad" })).toThrow(
+      /Parameter config must be valid JSON/,
+    );
+  });
+
+  test("rejects empty numeric CLI string overrides", () => {
+    const recipe = parseGroveRecipe(`
+kind: recipe
+recipe_version: 1
+name: empty-numeric-overrides
+version: 1.0.0
+parameters:
+  max_rounds:
+    type: integer
+    required: true
+  threshold:
+    type: number
+    required: true
+`);
+    expect(() => bindRecipeParameters(recipe, { max_rounds: "", threshold: 0 })).toThrow(
+      /Parameter max_rounds must be an integer/,
+    );
+    expect(() => bindRecipeParameters(recipe, { max_rounds: 1, threshold: "   " })).toThrow(
+      /Parameter threshold must be a number/,
+    );
+  });
+
   test("rejects unknown parameter overrides", () => {
     const recipe = parseGroveRecipe(FULL_RECIPE);
     expect(() => bindRecipeParameters(recipe, { target_path: "src/core", extra: true })).toThrow(

--- a/src/core/recipe.test.ts
+++ b/src/core/recipe.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  bindRecipeParameters,
+  computeBoundRecipeDigest,
+  computeRecipeDigest,
+  materializeRecipeContract,
+  parseGroveRecipe,
+  parseGroveRecipeObject,
+} from "./recipe.js";
+import { resolveRoleWorkspaceStrategies, topologicalSortRoles } from "./topology.js";
+
+const MINIMAL_RECIPE = `
+kind: recipe
+recipe_version: 1
+name: code-review-loop
+version: 1.0.0
+`;
+
+const FULL_RECIPE = `
+kind: recipe
+recipe_version: 1
+name: code-review-loop
+version: 1.0.0
+description: Coder and reviewer iterate on a feature
+labels: [code-review]
+parameters:
+  target_path:
+    type: path
+    required: true
+  max_rounds:
+    type: integer
+    default: 3
+extensions:
+  - type: mcp
+    name: filesystem
+    uri: stdio:grove-fs-mcp
+activities:
+  - id: coder-drafts
+    label: Coder drafts
+    role: coder
+instructions: |
+  Work on \${parameters.target_path} for \${parameters.max_rounds} rounds.
+agent_topology:
+  structure: graph
+  roles:
+    - name: coder
+      platform: codex
+run_policy:
+  max_iterations: 3
+  improvement_threshold: 0.01
+`;
+
+describe("parseGroveRecipe", () => {
+  test("parses a minimal recipe", () => {
+    const recipe = parseGroveRecipe(MINIMAL_RECIPE);
+    expect(recipe.kind).toBe("recipe");
+    expect(recipe.recipeVersion).toBe(1);
+    expect(recipe.name).toBe("code-review-loop");
+    expect(recipe.version).toBe("1.0.0");
+  });
+
+  test("parses parameters, activities, topology, and run policy", () => {
+    const recipe = parseGroveRecipe(FULL_RECIPE);
+    expect(recipe.parameters?.target_path?.type).toBe("path");
+    expect(recipe.parameters?.max_rounds?.default).toBe(3);
+    expect(recipe.activities?.[0]?.id).toBe("coder-drafts");
+    expect(recipe.topology?.roles[0]?.name).toBe("coder");
+    expect(recipe.runPolicy?.maxIterations).toBe(3);
+  });
+
+  test("rejects unknown top-level fields", () => {
+    expect(() => parseGroveRecipe(`${MINIMAL_RECIPE}\nunknown_field: true\n`)).toThrow(
+      /unknown_field|Unrecognized key/,
+    );
+  });
+
+  test("rejects duplicate activity ids", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "duplicate-activities",
+        version: "1.0.0",
+        activities: [
+          { id: "same", label: "One" },
+          { id: "same", label: "Two" },
+        ],
+      }),
+    ).toThrow(/duplicate activity ids/);
+  });
+
+  test("rejects enum defaults outside the declared enum", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "enum-default-test",
+        version: "1.0.0",
+        parameters: {
+          mode: { type: "enum", enum: ["fast", "safe"], default: "slow" },
+        },
+      }),
+    ).toThrow(/enum parameter default must be in enum values/);
+  });
+
+  test("parses complete topology role and spawning fields", () => {
+    const recipe = parseGroveRecipeObject({
+      kind: "recipe",
+      recipe_version: 1,
+      name: "topology-fields",
+      version: "1.0.0",
+      agent_topology: {
+        structure: "graph",
+        edge_types: ["feedback"],
+        spawning: {
+          dynamic: true,
+          max_depth: 2,
+          max_children_per_agent: 3,
+          timeout_seconds: 120,
+        },
+        roles: [
+          {
+            name: "coder",
+            description: "Writes code",
+            max_instances: 2,
+            mode: "explicit",
+            command: "codex",
+            ends_session: true,
+            platform: "codex",
+            model: "gpt-5",
+            color: "#00ccff",
+            prompt: "Implement",
+            goal: "Ship",
+            skills: ["test-driven-development"],
+            repo_index: 0,
+            edges: [
+              {
+                target: "reviewer",
+                edge_type: "feedback",
+                workspace: "branch_from_source",
+                reply_timeout_seconds: 600,
+              },
+            ],
+          },
+          { name: "reviewer" },
+        ],
+      },
+    });
+
+    const topology = recipe.topology;
+    expect(topology).toBeDefined();
+    if (topology === undefined) {
+      throw new Error("expected topology");
+    }
+    expect(topology.edgeTypes).toEqual(["feedback"]);
+    expect(topology.spawning?.maxChildrenPerAgent).toBe(3);
+    expect(topology.roles[0]?.edges?.[0]?.replyTimeoutSeconds).toBe(600);
+    expect(topology.roles[0]?.repoIndex).toBe(0);
+
+    const strategies = resolveRoleWorkspaceStrategies(topology, "session-1");
+    expect(strategies.get("reviewer")).toBe("grove/session-1/coder");
+    expect(topologicalSortRoles(topology).map((role) => role.name)).toEqual(["coder", "reviewer"]);
+  });
+
+  test("rejects invalid recipe topologies", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "unknown-edge",
+        version: "1.0.0",
+        agent_topology: {
+          structure: "graph",
+          roles: [{ name: "coder", edges: [{ target: "missing", edge_type: "feedback" }] }],
+        },
+      }),
+    ).toThrow(/edge target/);
+
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "self-edge",
+        version: "1.0.0",
+        agent_topology: {
+          structure: "graph",
+          roles: [{ name: "coder", edges: [{ target: "coder", edge_type: "feedback" }] }],
+        },
+      }),
+    ).toThrow(/self-edge/);
+
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "flat-edge",
+        version: "1.0.0",
+        agent_topology: {
+          structure: "flat",
+          roles: [
+            { name: "coder", edges: [{ target: "reviewer", edge_type: "feedback" }] },
+            { name: "reviewer" },
+          ],
+        },
+      }),
+    ).toThrow(/flat topology/);
+
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "tree-roots",
+        version: "1.0.0",
+        agent_topology: {
+          structure: "tree",
+          roles: [{ name: "root" }, { name: "other" }],
+        },
+      }),
+    ).toThrow(/tree topology/);
+
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "tree-duplicate-parent",
+        version: "1.0.0",
+        agent_topology: {
+          structure: "tree",
+          roles: [
+            { name: "root", edges: [{ target: "child", edge_type: "feedback" }] },
+            { name: "other", edges: [{ target: "child", edge_type: "feedback" }] },
+            { name: "child" },
+          ],
+        },
+      }),
+    ).toThrow(/single parent/);
+  });
+});
+
+describe("recipe digests", () => {
+  test("recipe digest is stable across object key order", () => {
+    const first = parseGroveRecipeObject({
+      kind: "recipe",
+      recipe_version: 1,
+      name: "digest-test",
+      version: "1.0.0",
+      description: "Stable",
+    });
+    const second = parseGroveRecipeObject({
+      description: "Stable",
+      version: "1.0.0",
+      name: "digest-test",
+      recipe_version: 1,
+      kind: "recipe",
+    });
+    expect(computeRecipeDigest(first)).toBe(computeRecipeDigest(second));
+  });
+
+  test("bound digest changes when parameters change", () => {
+    const recipe = parseGroveRecipe(FULL_RECIPE);
+    const first = bindRecipeParameters(recipe, { target_path: "src/core" });
+    const second = bindRecipeParameters(recipe, { target_path: "src/cli" });
+    expect(computeBoundRecipeDigest(first)).not.toBe(computeBoundRecipeDigest(second));
+  });
+});
+
+describe("materializeRecipeContract", () => {
+  test("creates a GroveContract-compatible dry-run contract", () => {
+    const recipe = parseGroveRecipe(FULL_RECIPE);
+    const bound = bindRecipeParameters(recipe, { target_path: "src/core" });
+    const materialized = materializeRecipeContract(bound);
+    expect(materialized.contract.contractVersion).toBe(3);
+    expect(materialized.contract.name).toBe("code-review-loop");
+    expect(materialized.contract.topology?.roles[0]?.name).toBe("coder");
+    expect(materialized.provenance.recipeName).toBe("code-review-loop");
+    expect(materialized.renderedInstructions).toContain("src/core");
+  });
+});

--- a/src/core/recipe.test.ts
+++ b/src/core/recipe.test.ts
@@ -429,4 +429,29 @@ describe("discoverRecipes", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  test("sorts recipe paths by deterministic code-unit order", async () => {
+    const root = await mkdtemp(join(tmpdir(), "grove-recipe-discovery-"));
+    try {
+      const recipesDir = join(root, "recipes");
+      await mkdir(recipesDir, { recursive: true });
+      await writeFile(
+        join(recipesDir, "z.yaml"),
+        "kind: recipe\nrecipe_version: 1\nname: z-recipe\nversion: 1.0.0\n",
+      );
+      await writeFile(
+        join(recipesDir, `${String.fromCharCode(0xe4)}.yaml`),
+        "kind: recipe\nrecipe_version: 1\nname: accent-recipe\nversion: 1.0.0\n",
+      );
+
+      const discovered = await discoverRecipes({
+        cwd: root,
+        homeConfigDir: join(root, "home-recipes-missing"),
+      });
+
+      expect(discovered.map((entry) => entry.recipe.name)).toEqual(["z-recipe", "accent-recipe"]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/core/recipe.test.ts
+++ b/src/core/recipe.test.ts
@@ -730,8 +730,12 @@ describe("materializeRecipeContract", () => {
         {
           name: "child",
           ref: "recipe:child@1.0.0",
+          when: "$" + "{parameters.target_path} != ''",
           parameters: {
             child_path: "$" + "{parameters.target_path}",
+            child_config: {
+              mode: "review $" + "{parameters.target_path}",
+            },
           },
         },
       ],
@@ -753,12 +757,44 @@ describe("materializeRecipeContract", () => {
       {
         name: "child",
         ref: "recipe:child@1.0.0",
+        when: "src/core != ''",
         parameters: {
-          child_path: "$" + "{parameters.target_path}",
+          child_path: "src/core",
+          child_config: {
+            mode: "review src/core",
+          },
         },
       },
     ]);
     expect(materialized.provenance.subRecipeDigests).toEqual([]);
+  });
+
+  test("maps max no-improvement rounds into stop conditions", () => {
+    const recipe = parseGroveRecipeObject({
+      kind: "recipe",
+      recipe_version: 1,
+      name: "policy-recipe",
+      version: "1.0.0",
+      run_policy: {
+        max_iterations: 5,
+        max_no_improvement_rounds: 2,
+        improvement_threshold: 0.05,
+        direction: "maximize",
+      },
+    });
+
+    const materialized = materializeRecipeContract(bindRecipeParameters(recipe, {}));
+
+    expect(materialized.contract.stopConditions).toEqual({
+      maxRoundsWithoutImprovement: 2,
+      budget: { maxContributions: 5 },
+    });
+    expect(materialized.runPolicy).toEqual({
+      maxIterations: 5,
+      maxNoImprovementRounds: 2,
+      improvementThreshold: 0.05,
+      direction: "maximize",
+    });
   });
 });
 

--- a/src/core/recipe.test.ts
+++ b/src/core/recipe.test.ts
@@ -362,6 +362,22 @@ describe("bindRecipeParameters", () => {
     });
     expect(bound.renderedInstructions).toBe("Use src/core.");
   });
+
+  test("preserves literal braces outside template markers", () => {
+    const recipe = parseGroveRecipeObject({
+      kind: "recipe",
+      recipe_version: 1,
+      name: "literal-braces-template",
+      version: "1.0.0",
+      parameters: {
+        target_path: { type: "path", required: true },
+      },
+      instructions: 'Return {"ok": true} for $' + "{parameters.target_path}.",
+    });
+
+    const bound = bindRecipeParameters(recipe, { target_path: "src/core" });
+    expect(bound.renderedInstructions).toBe('Return {"ok": true} for src/core.');
+  });
 });
 
 describe("materializeRecipeContract", () => {

--- a/src/core/recipe.test.ts
+++ b/src/core/recipe.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   bindRecipeParameters,
   computeBoundRecipeDigest,
   computeRecipeDigest,
+  discoverRecipes,
   materializeRecipeContract,
   parseGroveRecipe,
   parseGroveRecipeObject,
@@ -390,5 +394,39 @@ describe("materializeRecipeContract", () => {
     expect(materialized.contract.topology?.roles[0]?.name).toBe("coder");
     expect(materialized.provenance.recipeName).toBe("code-review-loop");
     expect(materialized.renderedInstructions).toContain("src/core");
+  });
+});
+
+describe("discoverRecipes", () => {
+  test("discovers recipes from configured directories in deterministic order", async () => {
+    const root = await mkdtemp(join(tmpdir(), "grove-recipe-discovery-"));
+    try {
+      const recipesDir = join(root, "recipes");
+      const groveRecipesDir = join(root, ".grove", "recipes");
+      await mkdir(recipesDir, { recursive: true });
+      await mkdir(groveRecipesDir, { recursive: true });
+      await writeFile(
+        join(groveRecipesDir, "workspace.yaml"),
+        "kind: recipe\nrecipe_version: 1\nname: workspace-recipe\nversion: 1.0.0\n",
+      );
+      await writeFile(
+        join(recipesDir, "project.yaml"),
+        "kind: recipe\nrecipe_version: 1\nname: project-recipe\nversion: 1.0.0\n",
+      );
+
+      const discovered = await discoverRecipes({
+        cwd: root,
+        homeConfigDir: join(root, "home-recipes-missing"),
+      });
+
+      expect(discovered.map((entry) => entry.recipe.name)).toEqual([
+        "project-recipe",
+        "workspace-recipe",
+      ]);
+      expect(discovered[0]?.source).toBe("project");
+      expect(discovered[1]?.source).toBe("workspace");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/core/recipe.test.ts
+++ b/src/core/recipe.test.ts
@@ -104,6 +104,20 @@ describe("parseGroveRecipe", () => {
     ).toThrow(/enum parameter default must be in enum values/);
   });
 
+  test("rejects non-JSON response schema values", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "response-schema-json",
+        version: "1.0.0",
+        response: {
+          schema: { transform: () => undefined },
+        },
+      }),
+    ).toThrow(/JSON|Invalid input/);
+  });
+
   test("parses complete topology role and spawning fields", () => {
     const recipe = parseGroveRecipeObject({
       kind: "recipe",
@@ -262,6 +276,91 @@ describe("recipe digests", () => {
     const first = bindRecipeParameters(recipe, { target_path: "src/core" });
     const second = bindRecipeParameters(recipe, { target_path: "src/cli" });
     expect(computeBoundRecipeDigest(first)).not.toBe(computeBoundRecipeDigest(second));
+  });
+});
+
+describe("bindRecipeParameters", () => {
+  test("rejects unknown parameter overrides", () => {
+    const recipe = parseGroveRecipe(FULL_RECIPE);
+    expect(() => bindRecipeParameters(recipe, { target_path: "src/core", extra: true })).toThrow(
+      /unknown recipe parameter/,
+    );
+  });
+
+  test("rejects missing required parameters", () => {
+    const recipe = parseGroveRecipe(FULL_RECIPE);
+    expect(() => bindRecipeParameters(recipe, {})).toThrow(/missing required recipe parameter/);
+  });
+
+  test("rejects wrong bound parameter types", () => {
+    const recipe = parseGroveRecipe(FULL_RECIPE);
+    expect(() => bindRecipeParameters(recipe, { target_path: 123 })).toThrow(/must be a string/);
+  });
+
+  test("rejects enum overrides outside the declared enum", () => {
+    const recipe = parseGroveRecipeObject({
+      kind: "recipe",
+      recipe_version: 1,
+      name: "enum-override-test",
+      version: "1.0.0",
+      parameters: {
+        mode: { type: "enum", enum: ["fast", "safe"] },
+      },
+    });
+
+    expect(() => bindRecipeParameters(recipe, { mode: "slow" })).toThrow(/enum values/);
+  });
+
+  test("rejects missing template paths", () => {
+    const recipe = parseGroveRecipeObject({
+      kind: "recipe",
+      recipe_version: 1,
+      name: "missing-template-path",
+      version: "1.0.0",
+      parameters: {
+        target_path: { type: "path", required: true },
+      },
+      instructions: "Work on $" + "{parameters.other_path}.",
+    });
+
+    expect(() => bindRecipeParameters(recipe, { target_path: "src/core" })).toThrow(
+      /missing recipe template parameter/,
+    );
+  });
+
+  test("rejects malformed template syntax", () => {
+    const recipe = parseGroveRecipeObject({
+      kind: "recipe",
+      recipe_version: 1,
+      name: "malformed-template",
+      version: "1.0.0",
+      parameters: {
+        target_path: { type: "path", required: true },
+      },
+      instructions: "Work on ${parameters.target_path.",
+    });
+
+    expect(() => bindRecipeParameters(recipe, { target_path: "src/core" })).toThrow(
+      /malformed recipe template syntax/,
+    );
+  });
+
+  test("renders nested JSON parameter paths", () => {
+    const recipe = parseGroveRecipeObject({
+      kind: "recipe",
+      recipe_version: 1,
+      name: "json-template-path",
+      version: "1.0.0",
+      parameters: {
+        config: { type: "json", required: true },
+      },
+      instructions: "Use $" + "{parameters.config.paths.target}.",
+    });
+
+    const bound = bindRecipeParameters(recipe, {
+      config: { paths: { target: "src/core" } },
+    });
+    expect(bound.renderedInstructions).toBe("Use src/core.");
   });
 });
 

--- a/src/core/recipe.test.ts
+++ b/src/core/recipe.test.ts
@@ -254,6 +254,120 @@ describe("parseGroveRecipe", () => {
       }),
     ).toThrow(/single parent/);
   });
+
+  test("rejects malformed activity condition templates during parsing", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "bad-activity-condition",
+        version: "1.0.0",
+        parameters: {
+          target_path: { type: "path", required: true },
+        },
+        activities: [
+          {
+            id: "review",
+            label: "Review",
+            condition: "${parameters.target_path",
+          },
+        ],
+      }),
+    ).toThrow(/malformed recipe template syntax/);
+  });
+
+  test("rejects malformed sub-recipe when templates during parsing", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "bad-sub-recipe-when",
+        version: "1.0.0",
+        parameters: {
+          target_path: { type: "path", required: true },
+        },
+        sub_recipes: [
+          {
+            name: "child",
+            ref: "recipe:child@1.0.0",
+            when: "${parameters.target_path",
+          },
+        ],
+      }),
+    ).toThrow(/malformed recipe template syntax/);
+  });
+
+  test("rejects unsupported sub-recipe parameter templates during parsing", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "bad-sub-recipe-parameters",
+        version: "1.0.0",
+        parameters: {
+          target_path: { type: "path", required: true },
+        },
+        sub_recipes: [
+          {
+            name: "child",
+            ref: "recipe:child@1.0.0",
+            parameters: {
+              child_path: "$" + "{parameters.target_path.name}",
+            },
+          },
+        ],
+      }),
+    ).toThrow(/nested recipe template paths require json parameter/);
+  });
+
+  test("rejects undeclared template parameter references during parsing", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "bad-template-reference",
+        version: "1.0.0",
+        parameters: {},
+        activities: [
+          {
+            id: "review",
+            label: "Review",
+            condition: "$" + "{parameters.target_path}",
+          },
+        ],
+      }),
+    ).toThrow(/unknown recipe template parameter/);
+  });
+
+  test("accepts literal braces in activity and sub-recipe template fields", () => {
+    const recipe = parseGroveRecipeObject({
+      kind: "recipe",
+      recipe_version: 1,
+      name: "literal-braces-in-recipe-fields",
+      version: "1.0.0",
+      activities: [
+        {
+          id: "review",
+          label: "Review",
+          condition: 'payload == {"ok": true}',
+        },
+      ],
+      sub_recipes: [
+        {
+          name: "child",
+          ref: "recipe:child@1.0.0",
+          when: "status in {ready,pending}",
+          parameters: {
+            child_path: "literal {braces}",
+          },
+        },
+      ],
+    });
+
+    expect(recipe.activities?.[0]?.condition).toBe('payload == {"ok": true}');
+    expect(recipe.subRecipes?.[0]?.when).toBe("status in {ready,pending}");
+    expect(recipe.subRecipes?.[0]?.parameters?.child_path).toBe("literal {braces}");
+  });
 });
 
 describe("recipe digests", () => {
@@ -348,6 +462,25 @@ parameters:
     expect(bound.parameters.message).toBe("hello");
   });
 
+  test("parses JSON CLI overrides as numbers only for complete JSON number literals", () => {
+    const recipe = parseGroveRecipe(`
+kind: recipe
+recipe_version: 1
+name: json-number-overrides
+version: 1.0.0
+parameters:
+  value:
+    type: json
+    required: true
+`);
+    expect(bindRecipeParameters(recipe, { value: "2026-05-27" }).parameters.value).toBe(
+      "2026-05-27",
+    );
+    expect(bindRecipeParameters(recipe, { value: "123abc" }).parameters.value).toBe("123abc");
+    expect(bindRecipeParameters(recipe, { value: "123" }).parameters.value).toBe(123);
+    expect(bindRecipeParameters(recipe, { value: "-1.5e2" }).parameters.value).toBe(-150);
+  });
+
   test("rejects invalid JSON-looking CLI overrides", () => {
     const recipe = parseGroveRecipe(`
 kind: recipe
@@ -418,37 +551,115 @@ parameters:
   });
 
   test("rejects missing template paths", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "missing-template-path",
+        version: "1.0.0",
+        parameters: {
+          target_path: { type: "path", required: true },
+        },
+        instructions: "Work on $" + "{parameters.other_path}.",
+      }),
+    ).toThrow(/unknown recipe template parameter/);
+  });
+
+  test("rejects missing template values during binding", () => {
     const recipe = parseGroveRecipeObject({
       kind: "recipe",
       recipe_version: 1,
-      name: "missing-template-path",
+      name: "missing-template-value",
       version: "1.0.0",
       parameters: {
-        target_path: { type: "path", required: true },
+        target_path: { type: "path", required: false },
       },
-      instructions: "Work on $" + "{parameters.other_path}.",
+      instructions: "Work on $" + "{parameters.target_path}.",
     });
 
-    expect(() => bindRecipeParameters(recipe, { target_path: "src/core" })).toThrow(
-      /missing recipe template parameter/,
+    expect(() => bindRecipeParameters(recipe, {})).toThrow(
+      /missing recipe template parameter 'target_path'/,
     );
   });
 
   test("rejects malformed template syntax", () => {
-    const recipe = parseGroveRecipeObject({
-      kind: "recipe",
-      recipe_version: 1,
-      name: "malformed-template",
-      version: "1.0.0",
-      parameters: {
-        target_path: { type: "path", required: true },
-      },
-      instructions: "Work on ${parameters.target_path.",
-    });
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "malformed-template",
+        version: "1.0.0",
+        parameters: {
+          target_path: { type: "path", required: true },
+        },
+        instructions: "Work on ${parameters.target_path.",
+      }),
+    ).toThrow(/malformed recipe template syntax/);
+  });
 
-    expect(() => bindRecipeParameters(recipe, { target_path: "src/core" })).toThrow(
-      /malformed recipe template syntax/,
-    );
+  test("rejects unsupported template roots", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "unsupported-template-root",
+        version: "1.0.0",
+        parameters: {},
+        instructions: "Home is $" + "{env.HOME}.",
+      }),
+    ).toThrow(/unsupported recipe template expression/);
+  });
+
+  test("rejects empty template markers", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "empty-template-marker",
+        version: "1.0.0",
+        instructions: "Work on $" + "{}.",
+      }),
+    ).toThrow(/malformed recipe template syntax/);
+  });
+
+  test("rejects nested template paths on non-json parameters during parsing", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "non-json-template-path",
+        version: "1.0.0",
+        parameters: {
+          target_path: { type: "path", required: true },
+        },
+        instructions: "Use $" + "{parameters.target_path.name}.",
+      }),
+    ).toThrow(/nested recipe template paths require json parameter/);
+  });
+
+  test("validates nested string leaves in sub-recipe parameter objects", () => {
+    expect(() =>
+      parseGroveRecipeObject({
+        kind: "recipe",
+        recipe_version: 1,
+        name: "bad-nested-sub-recipe-parameters",
+        version: "1.0.0",
+        parameters: {
+          target_path: { type: "path", required: true },
+        },
+        sub_recipes: [
+          {
+            name: "child",
+            ref: "recipe:child@1.0.0",
+            parameters: {
+              nested: {
+                child_path: "$" + "{parameters.target_path.name}",
+              },
+            },
+          },
+        ],
+      }),
+    ).toThrow(/nested recipe template paths require json parameter/);
   });
 
   test("renders nested JSON parameter paths", () => {
@@ -496,6 +707,58 @@ describe("materializeRecipeContract", () => {
     expect(materialized.contract.topology?.roles[0]?.name).toBe("coder");
     expect(materialized.provenance.recipeName).toBe("code-review-loop");
     expect(materialized.renderedInstructions).toContain("src/core");
+  });
+
+  test("preserves declared extensions and sub-recipes in dry-run materialization", () => {
+    const recipe = parseGroveRecipeObject({
+      kind: "recipe",
+      recipe_version: 1,
+      name: "composed-recipe",
+      version: "1.0.0",
+      parameters: {
+        target_path: { type: "path", required: true },
+      },
+      extensions: [
+        {
+          type: "mcp",
+          name: "filesystem",
+          uri: "stdio:grove-fs-mcp",
+          required: true,
+        },
+      ],
+      sub_recipes: [
+        {
+          name: "child",
+          ref: "recipe:child@1.0.0",
+          parameters: {
+            child_path: "$" + "{parameters.target_path}",
+          },
+        },
+      ],
+    });
+
+    const materialized = materializeRecipeContract(
+      bindRecipeParameters(recipe, { target_path: "src/core" }),
+    );
+
+    expect(materialized.extensions).toEqual([
+      {
+        type: "mcp",
+        name: "filesystem",
+        uri: "stdio:grove-fs-mcp",
+        required: true,
+      },
+    ]);
+    expect(materialized.subRecipes).toEqual([
+      {
+        name: "child",
+        ref: "recipe:child@1.0.0",
+        parameters: {
+          child_path: "$" + "{parameters.target_path}",
+        },
+      },
+    ]);
+    expect(materialized.provenance.subRecipeDigests).toEqual([]);
   });
 });
 

--- a/src/core/recipe.test.ts
+++ b/src/core/recipe.test.ts
@@ -284,6 +284,25 @@ describe("recipe digests", () => {
 });
 
 describe("bindRecipeParameters", () => {
+  test("coerces CLI string values to declared parameter types", () => {
+    const recipe = parseGroveRecipe(`
+kind: recipe
+recipe_version: 1
+name: typed-params
+version: 1.0.0
+parameters:
+  max_rounds:
+    type: integer
+    required: true
+  enabled:
+    type: boolean
+    required: true
+`);
+    const bound = bindRecipeParameters(recipe, { max_rounds: "4", enabled: "true" });
+    expect(bound.parameters.max_rounds).toBe(4);
+    expect(bound.parameters.enabled).toBe(true);
+  });
+
   test("rejects unknown parameter overrides", () => {
     const recipe = parseGroveRecipe(FULL_RECIPE);
     expect(() => bindRecipeParameters(recipe, { target_path: "src/core", extra: true })).toThrow(

--- a/src/core/recipe.ts
+++ b/src/core/recipe.ts
@@ -641,9 +641,8 @@ export function bindRecipeParameters(
   const boundParameters: Record<string, JsonValue> = {};
   for (const [name, parameter] of Object.entries(parameterDefinitions)) {
     const override = overrides[name];
-    const rawValue = override !== undefined ? override : parameter.default;
     const value =
-      rawValue === undefined ? undefined : coerceParameterValue(name, parameter, rawValue);
+      override !== undefined ? coerceParameterValue(name, parameter, override) : parameter.default;
     if (value === undefined) {
       if (parameter.required === true) {
         throw new Error(`missing required recipe parameter '${name}'`);
@@ -674,10 +673,13 @@ function coerceParameterValue(
 ): JsonValue {
   if (typeof value !== "string") return value;
   if (definition.type === "integer") {
-    if (!/^-?\d+$/.test(value)) throw new Error(`Parameter ${name} must be an integer`);
+    if (value.trim() === "" || !/^-?\d+$/.test(value)) {
+      throw new Error(`Parameter ${name} must be an integer`);
+    }
     return Number(value);
   }
   if (definition.type === "number") {
+    if (value.trim() === "") throw new Error(`Parameter ${name} must be a number`);
     const parsed = Number(value);
     if (!Number.isFinite(parsed)) throw new Error(`Parameter ${name} must be a number`);
     return parsed;
@@ -688,6 +690,7 @@ function coerceParameterValue(
     throw new Error(`Parameter ${name} must be true or false`);
   }
   if (definition.type === "json") {
+    if (!looksLikeJsonSource(value)) return value;
     try {
       return JSON.parse(value) as JsonValue;
     } catch {
@@ -695,6 +698,19 @@ function coerceParameterValue(
     }
   }
   return value;
+}
+
+function looksLikeJsonSource(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    trimmed.startsWith("{") ||
+    trimmed.startsWith("[") ||
+    trimmed.startsWith('"') ||
+    trimmed === "true" ||
+    trimmed === "false" ||
+    trimmed === "null" ||
+    /^-?\d/.test(trimmed)
+  );
 }
 
 export function materializeRecipeContract(bound: BoundRecipe): MaterializedRecipe {

--- a/src/core/recipe.ts
+++ b/src/core/recipe.ts
@@ -1,0 +1,630 @@
+/**
+ * Grove recipe parser, digest helpers, parameter binding, and dry-run materialization.
+ *
+ * Wire format uses snake_case YAML. TypeScript types use camelCase.
+ */
+
+import { hash } from "blake3";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+
+import type { GroveContract } from "./contract.js";
+import type { JsonValue } from "./models.js";
+import { type AgentTopology, AgentTopologySchema, wireToTopology } from "./topology.js";
+
+const DIGEST_PREFIX = "blake3:";
+const NamePattern = /^[a-z][a-z0-9_-]*$/;
+const ParameterNamePattern = /^[a-z][a-z0-9_]*$/;
+const SemverPattern = /^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().refine((n) => Number.isFinite(n), { message: "JSON numbers must be finite" }),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(z.string(), JsonValueSchema),
+  ]),
+);
+
+export type RecipeParameterType =
+  | "string"
+  | "integer"
+  | "number"
+  | "boolean"
+  | "enum"
+  | "path"
+  | "json";
+
+const BaseParameterSchema = z
+  .object({
+    required: z.boolean().optional(),
+    description: z.string().max(1024).optional(),
+  })
+  .strict();
+
+const StringParameterSchema = BaseParameterSchema.extend({
+  type: z.literal("string"),
+  default: z.string().optional(),
+}).strict();
+
+const IntegerParameterSchema = BaseParameterSchema.extend({
+  type: z.literal("integer"),
+  default: z.number().int().optional(),
+}).strict();
+
+const NumberParameterSchema = BaseParameterSchema.extend({
+  type: z.literal("number"),
+  default: z
+    .number()
+    .refine((n) => Number.isFinite(n), "number default must be finite")
+    .optional(),
+}).strict();
+
+const BooleanParameterSchema = BaseParameterSchema.extend({
+  type: z.literal("boolean"),
+  default: z.boolean().optional(),
+}).strict();
+
+const EnumParameterSchema = BaseParameterSchema.extend({
+  type: z.literal("enum"),
+  enum: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(100)
+    .refine((values) => new Set(values).size === values.length, {
+      message: "duplicate enum values",
+    }),
+  default: z.string().optional(),
+})
+  .strict()
+  .superRefine((parameter, ctx) => {
+    if (parameter.default !== undefined && !parameter.enum.includes(parameter.default)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "enum parameter default must be in enum values",
+        path: ["default"],
+      });
+    }
+  });
+
+const PathParameterSchema = BaseParameterSchema.extend({
+  type: z.literal("path"),
+  default: z.string().optional(),
+}).strict();
+
+const JsonParameterSchema = BaseParameterSchema.extend({
+  type: z.literal("json"),
+  default: JsonValueSchema.optional(),
+}).strict();
+
+const RecipeParameterSchema = z.discriminatedUnion("type", [
+  StringParameterSchema,
+  IntegerParameterSchema,
+  NumberParameterSchema,
+  BooleanParameterSchema,
+  EnumParameterSchema,
+  PathParameterSchema,
+  JsonParameterSchema,
+]);
+
+const RecipeExtensionSchema = z
+  .object({
+    type: z.enum(["mcp", "tool", "provider", "service"]),
+    name: z.string().regex(NamePattern).min(1).max(128),
+    uri: z.string().min(1).max(1024).optional(),
+    required: z.boolean().optional(),
+  })
+  .strict();
+
+const RecipeActivitySchema = z
+  .object({
+    id: z.string().regex(NamePattern).min(1).max(128),
+    label: z.string().min(1).max(256),
+    role: z.string().regex(NamePattern).min(1).max(64).optional(),
+    condition: z.string().min(1).max(1024).optional(),
+  })
+  .strict();
+
+const ContextManifestRefSchema = z
+  .object({
+    ref: z.string().min(1).max(1024),
+    role: z.string().regex(NamePattern).min(1).max(64).optional(),
+    required: z.boolean().optional(),
+  })
+  .strict();
+
+const RecipeSubRecipeSchema = z
+  .object({
+    name: z.string().regex(NamePattern).min(1).max(128),
+    ref: z.string().min(1).max(1024),
+    when: z.string().min(1).max(1024).optional(),
+    parameters: z
+      .record(z.string().regex(ParameterNamePattern).max(64), JsonValueSchema)
+      .refine((value) => Object.keys(value).length <= 100, {
+        message: "max 100 sub-recipe parameters",
+      })
+      .optional(),
+  })
+  .strict();
+
+const ResponseSchema = z
+  .object({
+    schema: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+const RecipeRunPolicySchema = z
+  .object({
+    max_iterations: z.number().int().min(1).optional(),
+    max_no_improvement_rounds: z.number().int().min(1).optional(),
+    improvement_threshold: z.number().min(0).optional(),
+    direction: z.enum(["maximize", "minimize"]).optional(),
+  })
+  .strict();
+
+const RecipeLibraryMetadataSchema = z
+  .object({
+    owner: z.string().min(1).max(128).optional(),
+    license: z.string().min(1).max(128).optional(),
+    source: z.string().min(1).max(1024).optional(),
+    visibility: z.enum(["private", "workspace", "public"]).optional(),
+  })
+  .strict();
+
+const GroveRecipeWireSchema = z
+  .object({
+    kind: z.literal("recipe"),
+    recipe_version: z.literal(1),
+    name: z.string().regex(NamePattern).min(1).max(128),
+    version: z.string().regex(SemverPattern).max(64),
+    description: z.string().max(1024).optional(),
+    labels: z
+      .array(z.string().min(1).max(64))
+      .max(50)
+      .refine((labels) => new Set(labels).size === labels.length, {
+        message: "duplicate labels",
+      })
+      .optional(),
+    parameters: z
+      .record(z.string().regex(ParameterNamePattern).max(64), RecipeParameterSchema)
+      .refine((value) => Object.keys(value).length <= 100, {
+        message: "max 100 parameters",
+      })
+      .optional(),
+    extensions: z.array(RecipeExtensionSchema).max(50).optional(),
+    activities: z
+      .array(RecipeActivitySchema)
+      .max(100)
+      .superRefine((activities, ctx) => {
+        const ids = activities.map((activity) => activity.id);
+        if (new Set(ids).size !== ids.length) {
+          ctx.addIssue({ code: "custom", message: "duplicate activity ids" });
+        }
+      })
+      .optional(),
+    instructions: z.string().max(20000).optional(),
+    agent_topology: AgentTopologySchema.optional(),
+    context_manifests: z.array(ContextManifestRefSchema).max(50).optional(),
+    sub_recipes: z.array(RecipeSubRecipeSchema).max(50).optional(),
+    response: ResponseSchema.optional(),
+    run_policy: RecipeRunPolicySchema.optional(),
+    library: RecipeLibraryMetadataSchema.optional(),
+  })
+  .strict();
+
+type GroveRecipeWire = z.infer<typeof GroveRecipeWireSchema>;
+
+export type RecipeParameter = Readonly<{
+  type: RecipeParameterType;
+  required?: boolean | undefined;
+  description?: string | undefined;
+  enum?: readonly string[] | undefined;
+  default?: JsonValue | undefined;
+}>;
+
+export interface RecipeExtension {
+  readonly type: "mcp" | "tool" | "provider" | "service";
+  readonly name: string;
+  readonly uri?: string | undefined;
+  readonly required?: boolean | undefined;
+}
+
+export interface RecipeActivity {
+  readonly id: string;
+  readonly label: string;
+  readonly role?: string | undefined;
+  readonly condition?: string | undefined;
+}
+
+export interface RecipeSubRecipe {
+  readonly name: string;
+  readonly ref: string;
+  readonly when?: string | undefined;
+  readonly parameters?: Readonly<Record<string, JsonValue>> | undefined;
+}
+
+export interface RecipeRunPolicy {
+  readonly maxIterations?: number | undefined;
+  readonly maxNoImprovementRounds?: number | undefined;
+  readonly improvementThreshold?: number | undefined;
+  readonly direction?: "maximize" | "minimize" | undefined;
+}
+
+export interface RecipeLibraryMetadata {
+  readonly owner?: string | undefined;
+  readonly license?: string | undefined;
+  readonly source?: string | undefined;
+  readonly visibility?: "private" | "workspace" | "public" | undefined;
+}
+
+export interface GroveRecipe {
+  readonly kind: "recipe";
+  readonly recipeVersion: 1;
+  readonly name: string;
+  readonly version: string;
+  readonly description?: string | undefined;
+  readonly labels?: readonly string[] | undefined;
+  readonly parameters?: Readonly<Record<string, RecipeParameter>> | undefined;
+  readonly extensions?: readonly RecipeExtension[] | undefined;
+  readonly activities?: readonly RecipeActivity[] | undefined;
+  readonly instructions?: string | undefined;
+  readonly topology?: AgentTopology | undefined;
+  readonly contextManifests?:
+    | readonly {
+        readonly ref: string;
+        readonly role?: string | undefined;
+        readonly required?: boolean | undefined;
+      }[]
+    | undefined;
+  readonly subRecipes?: readonly RecipeSubRecipe[] | undefined;
+  readonly response?:
+    | { readonly schema?: Readonly<Record<string, unknown>> | undefined }
+    | undefined;
+  readonly runPolicy?: RecipeRunPolicy | undefined;
+  readonly library?: RecipeLibraryMetadata | undefined;
+}
+
+export interface BoundRecipe {
+  readonly recipe: GroveRecipe;
+  readonly recipeDigest: string;
+  readonly parameters: Readonly<Record<string, JsonValue>>;
+  readonly renderedInstructions: string;
+}
+
+export interface RecipeProvenance {
+  readonly recipeDigest: string;
+  readonly recipeName: string;
+  readonly recipeVersion: string;
+  readonly boundParameterDigest: string;
+  readonly subRecipeDigests: readonly string[];
+  readonly sourceRef?: string | undefined;
+}
+
+export interface MaterializedRecipe {
+  readonly contract: GroveContract;
+  readonly provenance: RecipeProvenance;
+  readonly renderedInstructions: string;
+}
+
+function canonicalize(value: unknown): string {
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) {
+      throw new Error("NaN is not allowed in canonical JSON");
+    }
+    if (!Number.isFinite(value)) {
+      throw new Error("Infinity is not allowed in canonical JSON");
+    }
+    return JSON.stringify(value);
+  }
+
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    const items = value.map((item) => canonicalize(item === undefined ? null : item));
+    return `[${items.join(",")}]`;
+  }
+
+  const obj = value as Record<string, unknown>;
+  const entries = Object.keys(obj)
+    .sort()
+    .reduce<string[]>((acc, key) => {
+      const v = obj[key];
+      if (v !== undefined && typeof v !== "symbol") {
+        acc.push(`${JSON.stringify(key)}:${canonicalize(v)}`);
+      }
+      return acc;
+    }, []);
+  return `{${entries.join(",")}}`;
+}
+
+function digestJson(value: unknown): string {
+  const bytes = new TextEncoder().encode(canonicalize(value));
+  return `${DIGEST_PREFIX}${hash(bytes).toString("hex")}`;
+}
+
+function formatZodIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? `${issue.path.join(".")}: ` : "";
+      return `${path}${issue.message}`;
+    })
+    .join("; ");
+}
+
+function wireToParameter(parameter: z.infer<typeof RecipeParameterSchema>): RecipeParameter {
+  return {
+    type: parameter.type,
+    ...(parameter.required !== undefined && { required: parameter.required }),
+    ...(parameter.description !== undefined && { description: parameter.description }),
+    ...("enum" in parameter && { enum: parameter.enum }),
+    ...(parameter.default !== undefined && { default: parameter.default as JsonValue }),
+  };
+}
+
+function wireToRunPolicy(wire: z.infer<typeof RecipeRunPolicySchema>): RecipeRunPolicy {
+  return {
+    ...(wire.max_iterations !== undefined && { maxIterations: wire.max_iterations }),
+    ...(wire.max_no_improvement_rounds !== undefined && {
+      maxNoImprovementRounds: wire.max_no_improvement_rounds,
+    }),
+    ...(wire.improvement_threshold !== undefined && {
+      improvementThreshold: wire.improvement_threshold,
+    }),
+    ...(wire.direction !== undefined && { direction: wire.direction }),
+  };
+}
+
+function wireToRecipe(wire: GroveRecipeWire): GroveRecipe {
+  return {
+    kind: wire.kind,
+    recipeVersion: wire.recipe_version,
+    name: wire.name,
+    version: wire.version,
+    ...(wire.description !== undefined && { description: wire.description }),
+    ...(wire.labels !== undefined && { labels: wire.labels }),
+    ...(wire.parameters !== undefined && {
+      parameters: Object.fromEntries(
+        Object.entries(wire.parameters).map(([name, parameter]) => [
+          name,
+          wireToParameter(parameter),
+        ]),
+      ),
+    }),
+    ...(wire.extensions !== undefined && { extensions: wire.extensions }),
+    ...(wire.activities !== undefined && { activities: wire.activities }),
+    ...(wire.instructions !== undefined && { instructions: wire.instructions }),
+    ...(wire.agent_topology !== undefined && { topology: wireToTopology(wire.agent_topology) }),
+    ...(wire.context_manifests !== undefined && { contextManifests: wire.context_manifests }),
+    ...(wire.sub_recipes !== undefined && {
+      subRecipes: wire.sub_recipes.map((subRecipe) => ({
+        name: subRecipe.name,
+        ref: subRecipe.ref,
+        ...(subRecipe.when !== undefined && { when: subRecipe.when }),
+        ...(subRecipe.parameters !== undefined && { parameters: subRecipe.parameters }),
+      })),
+    }),
+    ...(wire.response !== undefined && { response: wire.response }),
+    ...(wire.run_policy !== undefined && { runPolicy: wireToRunPolicy(wire.run_policy) }),
+    ...(wire.library !== undefined && { library: wire.library }),
+  };
+}
+
+function toRecipeDigestInput(recipe: GroveRecipe): Record<string, unknown> {
+  return {
+    kind: recipe.kind,
+    recipeVersion: recipe.recipeVersion,
+    name: recipe.name,
+    version: recipe.version,
+    description: recipe.description,
+    labels: recipe.labels,
+    parameters: recipe.parameters,
+    extensions: recipe.extensions,
+    activities: recipe.activities,
+    instructions: recipe.instructions,
+    topology: recipe.topology,
+    contextManifests: recipe.contextManifests,
+    subRecipes: recipe.subRecipes,
+    response: recipe.response,
+    runPolicy: recipe.runPolicy,
+    library: recipe.library,
+  };
+}
+
+function validateBoundValue(name: string, parameter: RecipeParameter, value: JsonValue): void {
+  if (parameter.type === "string" || parameter.type === "path") {
+    if (typeof value !== "string") {
+      throw new Error(`parameter '${name}' must be a string`);
+    }
+    return;
+  }
+  if (parameter.type === "integer") {
+    if (typeof value !== "number" || !Number.isInteger(value)) {
+      throw new Error(`parameter '${name}' must be an integer`);
+    }
+    return;
+  }
+  if (parameter.type === "number") {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new Error(`parameter '${name}' must be a finite number`);
+    }
+    return;
+  }
+  if (parameter.type === "boolean") {
+    if (typeof value !== "boolean") {
+      throw new Error(`parameter '${name}' must be a boolean`);
+    }
+    return;
+  }
+  if (parameter.type === "enum") {
+    if (
+      typeof value !== "string" ||
+      parameter.enum === undefined ||
+      !parameter.enum.includes(value)
+    ) {
+      throw new Error(`parameter '${name}' must be one of its enum values`);
+    }
+    return;
+  }
+  JsonValueSchema.parse(value);
+}
+
+function lookupTemplateValue(
+  parameters: Readonly<Record<string, JsonValue>>,
+  parameterDefinitions: Readonly<Record<string, RecipeParameter>> | undefined,
+  expression: string,
+): JsonValue {
+  const path = expression.trim().split(".");
+  if (path.length < 2 || path[0] !== "parameters") {
+    throw new Error(`unsupported recipe template expression '${expression}'`);
+  }
+
+  const parameterName = path[1];
+  if (parameterName === undefined || !ParameterNamePattern.test(parameterName)) {
+    throw new Error(`invalid recipe template parameter reference '${expression}'`);
+  }
+
+  const initialValue = parameters[parameterName];
+  if (initialValue === undefined) {
+    throw new Error(`missing recipe template parameter '${parameterName}'`);
+  }
+
+  if (path.length > 2 && parameterDefinitions?.[parameterName]?.type !== "json") {
+    throw new Error(`nested recipe template paths require json parameter '${parameterName}'`);
+  }
+
+  let value: JsonValue = initialValue;
+  for (const segment of path.slice(2)) {
+    if (!ParameterNamePattern.test(segment)) {
+      throw new Error(`invalid recipe template path segment '${segment}'`);
+    }
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error(`recipe template path '${expression}' does not resolve to an object`);
+    }
+    const nextValue = value[segment];
+    if (nextValue === undefined) {
+      throw new Error(`recipe template path '${expression}' is missing '${segment}'`);
+    }
+    value = nextValue;
+  }
+
+  return value;
+}
+
+function stringifyTemplateValue(value: JsonValue): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+export function parseGroveRecipe(content: string): GroveRecipe {
+  const raw: unknown = parseYaml(content);
+  if (raw === null || raw === undefined || typeof raw !== "object") {
+    throw new Error("Grove recipe YAML is not a valid object");
+  }
+  return parseGroveRecipeObject(raw);
+}
+
+export function parseGroveRecipeObject(obj: unknown): GroveRecipe {
+  const result = GroveRecipeWireSchema.safeParse(obj);
+  if (!result.success) {
+    throw new Error(`Invalid Grove recipe: ${formatZodIssues(result.error)}`);
+  }
+  return wireToRecipe(result.data);
+}
+
+export function computeRecipeDigest(recipe: GroveRecipe): string {
+  return digestJson(toRecipeDigestInput(recipe));
+}
+
+export function computeBoundRecipeDigest(bound: BoundRecipe): string {
+  return digestJson({
+    recipeDigest: bound.recipeDigest,
+    parameters: bound.parameters,
+    renderedInstructions: bound.renderedInstructions,
+  });
+}
+
+export function renderRecipeTemplate(
+  template: string,
+  parameters: Readonly<Record<string, JsonValue>>,
+  parameterDefinitions?: Readonly<Record<string, RecipeParameter>>,
+): string {
+  return template.replace(/\$\{([^}]+)\}/g, (_match, expression: string) =>
+    stringifyTemplateValue(lookupTemplateValue(parameters, parameterDefinitions, expression)),
+  );
+}
+
+export function bindRecipeParameters(
+  recipe: GroveRecipe,
+  overrides: Readonly<Record<string, JsonValue>>,
+): BoundRecipe {
+  const parameterDefinitions = recipe.parameters ?? {};
+  for (const name of Object.keys(overrides)) {
+    if (parameterDefinitions[name] === undefined) {
+      throw new Error(`unknown recipe parameter '${name}'`);
+    }
+  }
+
+  const boundParameters: Record<string, JsonValue> = {};
+  for (const [name, parameter] of Object.entries(parameterDefinitions)) {
+    const override = overrides[name];
+    const value = override !== undefined ? override : parameter.default;
+    if (value === undefined) {
+      if (parameter.required === true) {
+        throw new Error(`missing required recipe parameter '${name}'`);
+      }
+      continue;
+    }
+    validateBoundValue(name, parameter, value);
+    boundParameters[name] = value;
+  }
+
+  const renderedInstructions =
+    recipe.instructions !== undefined
+      ? renderRecipeTemplate(recipe.instructions, boundParameters, parameterDefinitions)
+      : "";
+
+  return {
+    recipe,
+    recipeDigest: computeRecipeDigest(recipe),
+    parameters: boundParameters,
+    renderedInstructions,
+  };
+}
+
+export function materializeRecipeContract(bound: BoundRecipe): MaterializedRecipe {
+  const contract: GroveContract = {
+    contractVersion: 3,
+    name: bound.recipe.name,
+    ...(bound.recipe.description !== undefined && { description: bound.recipe.description }),
+    ...(bound.recipe.topology !== undefined && { topology: bound.recipe.topology }),
+    ...(bound.recipe.runPolicy?.maxIterations !== undefined && {
+      stopConditions: {
+        budget: {
+          maxContributions: bound.recipe.runPolicy.maxIterations,
+        },
+      },
+    }),
+  };
+
+  const boundDigest = computeBoundRecipeDigest(bound);
+  return {
+    contract,
+    provenance: {
+      recipeDigest: bound.recipeDigest,
+      recipeName: bound.recipe.name,
+      recipeVersion: bound.recipe.version,
+      boundParameterDigest: boundDigest,
+      subRecipeDigests: [],
+    },
+    renderedInstructions: bound.renderedInstructions,
+  };
+}

--- a/src/core/recipe.ts
+++ b/src/core/recipe.ts
@@ -28,6 +28,11 @@ const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
   ]),
 );
 
+const JsonObjectSchema: z.ZodType<Readonly<Record<string, JsonValue>>> = z.record(
+  z.string(),
+  JsonValueSchema,
+);
+
 export type RecipeParameterType =
   | "string"
   | "integer"
@@ -151,7 +156,7 @@ const RecipeSubRecipeSchema = z
 
 const ResponseSchema = z
   .object({
-    schema: z.record(z.string(), z.unknown()).optional(),
+    schema: JsonObjectSchema.optional(),
   })
   .strict();
 
@@ -309,6 +314,15 @@ export interface MaterializedRecipe {
 }
 
 function canonicalize(value: unknown): string {
+  if (
+    value === undefined ||
+    typeof value === "function" ||
+    typeof value === "symbol" ||
+    typeof value === "bigint"
+  ) {
+    throw new Error(`Unsupported value in canonical JSON: ${typeof value}`);
+  }
+
   if (typeof value === "number") {
     if (Number.isNaN(value)) {
       throw new Error("NaN is not allowed in canonical JSON");
@@ -324,8 +338,13 @@ function canonicalize(value: unknown): string {
   }
 
   if (Array.isArray(value)) {
-    const items = value.map((item) => canonicalize(item === undefined ? null : item));
+    const items = value.map((item) => canonicalize(item));
     return `[${items.join(",")}]`;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error("Unsupported non-plain object in canonical JSON");
   }
 
   const obj = value as Record<string, unknown>;
@@ -333,7 +352,10 @@ function canonicalize(value: unknown): string {
     .sort()
     .reduce<string[]>((acc, key) => {
       const v = obj[key];
-      if (v !== undefined && typeof v !== "symbol") {
+      if (v !== undefined) {
+        if (typeof v === "function" || typeof v === "symbol" || typeof v === "bigint") {
+          throw new Error(`Unsupported value in canonical JSON at key '${key}'`);
+        }
         acc.push(`${JSON.stringify(key)}:${canonicalize(v)}`);
       }
       return acc;
@@ -557,9 +579,42 @@ export function renderRecipeTemplate(
   parameters: Readonly<Record<string, JsonValue>>,
   parameterDefinitions?: Readonly<Record<string, RecipeParameter>>,
 ): string {
-  return template.replace(/\$\{([^}]+)\}/g, (_match, expression: string) =>
-    stringifyTemplateValue(lookupTemplateValue(parameters, parameterDefinitions, expression)),
-  );
+  let rendered = "";
+  let cursor = 0;
+
+  while (cursor < template.length) {
+    const markerStart = template.indexOf("${", cursor);
+    if (markerStart === -1) {
+      const remainder = template.slice(cursor);
+      if (remainder.includes("}")) {
+        throw new Error("malformed recipe template syntax");
+      }
+      rendered += remainder;
+      break;
+    }
+
+    const literal = template.slice(cursor, markerStart);
+    if (literal.includes("}")) {
+      throw new Error("malformed recipe template syntax");
+    }
+    rendered += literal;
+
+    const markerEnd = template.indexOf("}", markerStart + 2);
+    if (markerEnd === -1) {
+      throw new Error("malformed recipe template syntax");
+    }
+
+    const expression = template.slice(markerStart + 2, markerEnd);
+    if (expression.trim() === "") {
+      throw new Error("malformed recipe template syntax");
+    }
+    rendered += stringifyTemplateValue(
+      lookupTemplateValue(parameters, parameterDefinitions, expression),
+    );
+    cursor = markerEnd + 1;
+  }
+
+  return rendered;
 }
 
 export function bindRecipeParameters(

--- a/src/core/recipe.ts
+++ b/src/core/recipe.ts
@@ -19,6 +19,7 @@ const DIGEST_PREFIX = "blake3:";
 const NamePattern = /^[a-z][a-z0-9_-]*$/;
 const ParameterNamePattern = /^[a-z][a-z0-9_]*$/;
 const SemverPattern = /^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/;
+const JsonNumberLiteralPattern = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
 
 const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
   z.union([
@@ -314,6 +315,8 @@ export interface MaterializedRecipe {
   readonly contract: GroveContract;
   readonly provenance: RecipeProvenance;
   readonly renderedInstructions: string;
+  readonly extensions: readonly RecipeExtension[];
+  readonly subRecipes: readonly RecipeSubRecipe[];
 }
 
 export type RecipeSource = "project" | "workspace" | "user";
@@ -329,6 +332,10 @@ export interface DiscoverRecipesOptions {
   readonly cwd: string;
   readonly homeConfigDir?: string | undefined;
 }
+
+type RecipeTemplateToken =
+  | Readonly<{ kind: "literal"; value: string }>
+  | Readonly<{ kind: "expression"; value: string }>;
 
 function canonicalize(value: unknown): string {
   if (
@@ -511,11 +518,7 @@ function validateBoundValue(name: string, parameter: RecipeParameter, value: Jso
   JsonValueSchema.parse(value);
 }
 
-function lookupTemplateValue(
-  parameters: Readonly<Record<string, JsonValue>>,
-  parameterDefinitions: Readonly<Record<string, RecipeParameter>> | undefined,
-  expression: string,
-): JsonValue {
+function parseTemplateExpressionPath(expression: string): readonly string[] {
   const path = expression.trim().split(".");
   if (path.length < 2 || path[0] !== "parameters") {
     throw new Error(`unsupported recipe template expression '${expression}'`);
@@ -523,6 +526,46 @@ function lookupTemplateValue(
 
   const parameterName = path[1];
   if (parameterName === undefined || !ParameterNamePattern.test(parameterName)) {
+    throw new Error(`invalid recipe template parameter reference '${expression}'`);
+  }
+
+  for (const segment of path.slice(2)) {
+    if (!ParameterNamePattern.test(segment)) {
+      throw new Error(`invalid recipe template path segment '${segment}'`);
+    }
+  }
+
+  return path;
+}
+
+function validateTemplateExpressionShape(
+  expression: string,
+  parameterDefinitions: Readonly<Record<string, RecipeParameter>>,
+): void {
+  const path = parseTemplateExpressionPath(expression);
+  const parameterName = path[1];
+  if (parameterName === undefined) {
+    throw new Error(`invalid recipe template parameter reference '${expression}'`);
+  }
+
+  const definition = parameterDefinitions[parameterName];
+  if (definition === undefined) {
+    throw new Error(`unknown recipe template parameter '${parameterName}'`);
+  }
+
+  if (path.length > 2 && definition.type !== "json") {
+    throw new Error(`nested recipe template paths require json parameter '${parameterName}'`);
+  }
+}
+
+function lookupTemplateValue(
+  parameters: Readonly<Record<string, JsonValue>>,
+  parameterDefinitions: Readonly<Record<string, RecipeParameter>> | undefined,
+  expression: string,
+): JsonValue {
+  const path = parseTemplateExpressionPath(expression);
+  const parameterName = path[1];
+  if (parameterName === undefined) {
     throw new Error(`invalid recipe template parameter reference '${expression}'`);
   }
 
@@ -537,9 +580,6 @@ function lookupTemplateValue(
 
   let value: JsonValue = initialValue;
   for (const segment of path.slice(2)) {
-    if (!ParameterNamePattern.test(segment)) {
-      throw new Error(`invalid recipe template path segment '${segment}'`);
-    }
     if (value === null || typeof value !== "object" || Array.isArray(value)) {
       throw new Error(`recipe template path '${expression}' does not resolve to an object`);
     }
@@ -563,6 +603,93 @@ function stringifyTemplateValue(value: JsonValue): string {
   return JSON.stringify(value);
 }
 
+function readRecipeTemplateTokens(template: string): readonly RecipeTemplateToken[] {
+  const tokens: RecipeTemplateToken[] = [];
+  let cursor = 0;
+
+  while (cursor < template.length) {
+    const markerStart = template.indexOf("${", cursor);
+    if (markerStart === -1) {
+      const literal = template.slice(cursor);
+      if (literal !== "") tokens.push({ kind: "literal", value: literal });
+      break;
+    }
+
+    const literal = template.slice(cursor, markerStart);
+    if (literal !== "") tokens.push({ kind: "literal", value: literal });
+
+    const markerEnd = template.indexOf("}", markerStart + 2);
+    if (markerEnd === -1) {
+      throw new Error("malformed recipe template syntax");
+    }
+
+    const expression = template.slice(markerStart + 2, markerEnd);
+    if (expression.trim() === "") {
+      throw new Error("malformed recipe template syntax");
+    }
+    tokens.push({ kind: "expression", value: expression });
+    cursor = markerEnd + 1;
+  }
+
+  return tokens;
+}
+
+function validateRecipeTemplateString(
+  template: string,
+  parameterDefinitions: Readonly<Record<string, RecipeParameter>>,
+): void {
+  for (const token of readRecipeTemplateTokens(template)) {
+    if (token.kind === "expression") {
+      validateTemplateExpressionShape(token.value, parameterDefinitions);
+    }
+  }
+}
+
+function validateRecipeTemplateJsonLeaves(
+  value: JsonValue,
+  parameterDefinitions: Readonly<Record<string, RecipeParameter>>,
+): void {
+  if (typeof value === "string") {
+    validateRecipeTemplateString(value, parameterDefinitions);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      validateRecipeTemplateJsonLeaves(item, parameterDefinitions);
+    }
+    return;
+  }
+
+  if (value !== null && typeof value === "object") {
+    for (const child of Object.values(value)) {
+      validateRecipeTemplateJsonLeaves(child, parameterDefinitions);
+    }
+  }
+}
+
+function validateRecipeTemplates(recipe: GroveRecipe): void {
+  const parameterDefinitions = recipe.parameters ?? {};
+  if (recipe.instructions !== undefined) {
+    validateRecipeTemplateString(recipe.instructions, parameterDefinitions);
+  }
+
+  for (const activity of recipe.activities ?? []) {
+    if (activity.condition !== undefined) {
+      validateRecipeTemplateString(activity.condition, parameterDefinitions);
+    }
+  }
+
+  for (const subRecipe of recipe.subRecipes ?? []) {
+    if (subRecipe.when !== undefined) {
+      validateRecipeTemplateString(subRecipe.when, parameterDefinitions);
+    }
+    if (subRecipe.parameters !== undefined) {
+      validateRecipeTemplateJsonLeaves(subRecipe.parameters, parameterDefinitions);
+    }
+  }
+}
+
 export function parseGroveRecipe(content: string): GroveRecipe {
   const raw: unknown = parseYaml(content);
   if (raw === null || raw === undefined || typeof raw !== "object") {
@@ -576,7 +703,9 @@ export function parseGroveRecipeObject(obj: unknown): GroveRecipe {
   if (!result.success) {
     throw new Error(`Invalid Grove recipe: ${formatZodIssues(result.error)}`);
   }
-  return wireToRecipe(result.data);
+  const recipe = wireToRecipe(result.data);
+  validateRecipeTemplates(recipe);
+  return recipe;
 }
 
 export function computeRecipeDigest(recipe: GroveRecipe): string {
@@ -597,31 +726,14 @@ export function renderRecipeTemplate(
   parameterDefinitions?: Readonly<Record<string, RecipeParameter>>,
 ): string {
   let rendered = "";
-  let cursor = 0;
-
-  while (cursor < template.length) {
-    const markerStart = template.indexOf("${", cursor);
-    if (markerStart === -1) {
-      rendered += template.slice(cursor);
-      break;
-    }
-
-    const literal = template.slice(cursor, markerStart);
-    rendered += literal;
-
-    const markerEnd = template.indexOf("}", markerStart + 2);
-    if (markerEnd === -1) {
-      throw new Error("malformed recipe template syntax");
-    }
-
-    const expression = template.slice(markerStart + 2, markerEnd);
-    if (expression.trim() === "") {
-      throw new Error("malformed recipe template syntax");
+  for (const token of readRecipeTemplateTokens(template)) {
+    if (token.kind === "literal") {
+      rendered += token.value;
+      continue;
     }
     rendered += stringifyTemplateValue(
-      lookupTemplateValue(parameters, parameterDefinitions, expression),
+      lookupTemplateValue(parameters, parameterDefinitions, token.value),
     );
-    cursor = markerEnd + 1;
   }
 
   return rendered;
@@ -709,7 +821,7 @@ function looksLikeJsonSource(value: string): boolean {
     trimmed === "true" ||
     trimmed === "false" ||
     trimmed === "null" ||
-    /^-?\d/.test(trimmed)
+    JsonNumberLiteralPattern.test(trimmed)
   );
 }
 
@@ -739,6 +851,8 @@ export function materializeRecipeContract(bound: BoundRecipe): MaterializedRecip
       subRecipeDigests: [],
     },
     renderedInstructions: bound.renderedInstructions,
+    extensions: bound.recipe.extensions ?? [],
+    subRecipes: bound.recipe.subRecipes ?? [],
   };
 }
 

--- a/src/core/recipe.ts
+++ b/src/core/recipe.ts
@@ -285,7 +285,7 @@ export interface GroveRecipe {
     | undefined;
   readonly subRecipes?: readonly RecipeSubRecipe[] | undefined;
   readonly response?:
-    | { readonly schema?: Readonly<Record<string, unknown>> | undefined }
+    | { readonly schema?: Readonly<Record<string, JsonValue>> | undefined }
     | undefined;
   readonly runPolicy?: RecipeRunPolicy | undefined;
   readonly library?: RecipeLibraryMetadata | undefined;
@@ -585,18 +585,11 @@ export function renderRecipeTemplate(
   while (cursor < template.length) {
     const markerStart = template.indexOf("${", cursor);
     if (markerStart === -1) {
-      const remainder = template.slice(cursor);
-      if (remainder.includes("}")) {
-        throw new Error("malformed recipe template syntax");
-      }
-      rendered += remainder;
+      rendered += template.slice(cursor);
       break;
     }
 
     const literal = template.slice(cursor, markerStart);
-    if (literal.includes("}")) {
-      throw new Error("malformed recipe template syntax");
-    }
     rendered += literal;
 
     const markerEnd = template.indexOf("}", markerStart + 2);

--- a/src/core/recipe.ts
+++ b/src/core/recipe.ts
@@ -723,7 +723,7 @@ export async function discoverRecipes(
     if (sourceRank !== 0) {
       return sourceRank;
     }
-    return a.path.localeCompare(b.path) || a.recipe.name.localeCompare(b.recipe.name);
+    return compareCodeUnits(a.path, b.path) || compareCodeUnits(a.recipe.name, b.recipe.name);
   });
 }
 
@@ -740,7 +740,7 @@ async function listYamlFiles(dir: string): Promise<readonly string[]> {
         files.push(path);
       }
     }
-    return files.sort();
+    return files.sort(compareCodeUnits);
   } catch (error) {
     const code =
       typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
@@ -759,4 +759,14 @@ function sourceOrder(source: RecipeSource): number {
     return 1;
   }
   return 2;
+}
+
+function compareCodeUnits(a: string, b: string): number {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
 }

--- a/src/core/recipe.ts
+++ b/src/core/recipe.ts
@@ -4,6 +4,9 @@
  * Wire format uses snake_case YAML. TypeScript types use camelCase.
  */
 
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
 import { hash } from "blake3";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
@@ -311,6 +314,20 @@ export interface MaterializedRecipe {
   readonly contract: GroveContract;
   readonly provenance: RecipeProvenance;
   readonly renderedInstructions: string;
+}
+
+export type RecipeSource = "project" | "workspace" | "user";
+
+export interface DiscoveredRecipe {
+  readonly path: string;
+  readonly source: RecipeSource;
+  readonly recipe: GroveRecipe;
+  readonly digest: string;
+}
+
+export interface DiscoverRecipesOptions {
+  readonly cwd: string;
+  readonly homeConfigDir?: string | undefined;
 }
 
 function canonicalize(value: unknown): string {
@@ -675,4 +692,71 @@ export function materializeRecipeContract(bound: BoundRecipe): MaterializedRecip
     },
     renderedInstructions: bound.renderedInstructions,
   };
+}
+
+export async function discoverRecipes(
+  options: DiscoverRecipesOptions,
+): Promise<readonly DiscoveredRecipe[]> {
+  const roots: readonly { readonly source: RecipeSource; readonly dir: string }[] = [
+    { source: "project", dir: join(options.cwd, "recipes") },
+    { source: "workspace", dir: join(options.cwd, ".grove", "recipes") },
+    {
+      source: "user",
+      dir: options.homeConfigDir ?? join(process.env.HOME ?? "", ".config", "grove", "recipes"),
+    },
+  ];
+  const discovered: DiscoveredRecipe[] = [];
+  for (const root of roots) {
+    for (const path of await listYamlFiles(root.dir)) {
+      const content = await readFile(path, "utf-8");
+      const recipe = parseGroveRecipe(content);
+      discovered.push({
+        path,
+        source: root.source,
+        recipe,
+        digest: computeRecipeDigest(recipe),
+      });
+    }
+  }
+  return discovered.sort((a, b) => {
+    const sourceRank = sourceOrder(a.source) - sourceOrder(b.source);
+    if (sourceRank !== 0) {
+      return sourceRank;
+    }
+    return a.path.localeCompare(b.path) || a.recipe.name.localeCompare(b.recipe.name);
+  });
+}
+
+async function listYamlFiles(dir: string): Promise<readonly string[]> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const files: string[] = [];
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...(await listYamlFiles(path)));
+      }
+      if (entry.isFile() && (entry.name.endsWith(".yaml") || entry.name.endsWith(".yml"))) {
+        files.push(path);
+      }
+    }
+    return files.sort();
+  } catch (error) {
+    const code =
+      typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+    if (code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function sourceOrder(source: RecipeSource): number {
+  if (source === "project") {
+    return 0;
+  }
+  if (source === "workspace") {
+    return 1;
+  }
+  return 2;
 }

--- a/src/core/recipe.ts
+++ b/src/core/recipe.ts
@@ -641,7 +641,9 @@ export function bindRecipeParameters(
   const boundParameters: Record<string, JsonValue> = {};
   for (const [name, parameter] of Object.entries(parameterDefinitions)) {
     const override = overrides[name];
-    const value = override !== undefined ? override : parameter.default;
+    const rawValue = override !== undefined ? override : parameter.default;
+    const value =
+      rawValue === undefined ? undefined : coerceParameterValue(name, parameter, rawValue);
     if (value === undefined) {
       if (parameter.required === true) {
         throw new Error(`missing required recipe parameter '${name}'`);
@@ -663,6 +665,36 @@ export function bindRecipeParameters(
     parameters: boundParameters,
     renderedInstructions,
   };
+}
+
+function coerceParameterValue(
+  name: string,
+  definition: RecipeParameter,
+  value: JsonValue,
+): JsonValue {
+  if (typeof value !== "string") return value;
+  if (definition.type === "integer") {
+    if (!/^-?\d+$/.test(value)) throw new Error(`Parameter ${name} must be an integer`);
+    return Number(value);
+  }
+  if (definition.type === "number") {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) throw new Error(`Parameter ${name} must be a number`);
+    return parsed;
+  }
+  if (definition.type === "boolean") {
+    if (value === "true") return true;
+    if (value === "false") return false;
+    throw new Error(`Parameter ${name} must be true or false`);
+  }
+  if (definition.type === "json") {
+    try {
+      return JSON.parse(value) as JsonValue;
+    } catch {
+      throw new Error(`Parameter ${name} must be valid JSON`);
+    }
+  }
+  return value;
 }
 
 export function materializeRecipeContract(bound: BoundRecipe): MaterializedRecipe {

--- a/src/core/recipe.ts
+++ b/src/core/recipe.ts
@@ -317,6 +317,7 @@ export interface MaterializedRecipe {
   readonly renderedInstructions: string;
   readonly extensions: readonly RecipeExtension[];
   readonly subRecipes: readonly RecipeSubRecipe[];
+  readonly runPolicy?: RecipeRunPolicy | undefined;
 }
 
 export type RecipeSource = "project" | "workspace" | "user";
@@ -739,6 +740,40 @@ export function renderRecipeTemplate(
   return rendered;
 }
 
+function renderRecipeTemplateJsonLeaves(
+  value: JsonValue,
+  parameters: Readonly<Record<string, JsonValue>>,
+  parameterDefinitions: Readonly<Record<string, RecipeParameter>>,
+): JsonValue {
+  if (typeof value === "string") {
+    return renderRecipeTemplate(value, parameters, parameterDefinitions);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      renderRecipeTemplateJsonLeaves(item, parameters, parameterDefinitions),
+    );
+  }
+
+  if (value !== null && typeof value === "object") {
+    return renderRecipeTemplateJsonObjectLeaves(value, parameters, parameterDefinitions);
+  }
+
+  return value;
+}
+
+function renderRecipeTemplateJsonObjectLeaves(
+  value: Readonly<Record<string, JsonValue>>,
+  parameters: Readonly<Record<string, JsonValue>>,
+  parameterDefinitions: Readonly<Record<string, RecipeParameter>>,
+): Record<string, JsonValue> {
+  const rendered: Record<string, JsonValue> = {};
+  for (const [key, child] of Object.entries(value)) {
+    rendered[key] = renderRecipeTemplateJsonLeaves(child, parameters, parameterDefinitions);
+  }
+  return rendered;
+}
+
 export function bindRecipeParameters(
   recipe: GroveRecipe,
   overrides: Readonly<Record<string, JsonValue>>,
@@ -826,21 +861,17 @@ function looksLikeJsonSource(value: string): boolean {
 }
 
 export function materializeRecipeContract(bound: BoundRecipe): MaterializedRecipe {
+  const stopConditions = materializeRecipeStopConditions(bound.recipe.runPolicy);
   const contract: GroveContract = {
     contractVersion: 3,
     name: bound.recipe.name,
     ...(bound.recipe.description !== undefined && { description: bound.recipe.description }),
     ...(bound.recipe.topology !== undefined && { topology: bound.recipe.topology }),
-    ...(bound.recipe.runPolicy?.maxIterations !== undefined && {
-      stopConditions: {
-        budget: {
-          maxContributions: bound.recipe.runPolicy.maxIterations,
-        },
-      },
-    }),
+    ...(stopConditions !== undefined && { stopConditions }),
   };
 
   const boundDigest = computeBoundRecipeDigest(bound);
+  const parameterDefinitions = bound.recipe.parameters ?? {};
   return {
     contract,
     provenance: {
@@ -852,8 +883,55 @@ export function materializeRecipeContract(bound: BoundRecipe): MaterializedRecip
     },
     renderedInstructions: bound.renderedInstructions,
     extensions: bound.recipe.extensions ?? [],
-    subRecipes: bound.recipe.subRecipes ?? [],
+    subRecipes: materializeSubRecipes(
+      bound.recipe.subRecipes ?? [],
+      bound.parameters,
+      parameterDefinitions,
+    ),
+    ...(bound.recipe.runPolicy !== undefined && { runPolicy: bound.recipe.runPolicy }),
   };
+}
+
+function materializeRecipeStopConditions(
+  runPolicy: RecipeRunPolicy | undefined,
+): GroveContract["stopConditions"] | undefined {
+  if (runPolicy === undefined) {
+    return undefined;
+  }
+
+  const stopConditions: NonNullable<GroveContract["stopConditions"]> = {
+    ...(runPolicy.maxNoImprovementRounds !== undefined && {
+      maxRoundsWithoutImprovement: runPolicy.maxNoImprovementRounds,
+    }),
+    ...(runPolicy.maxIterations !== undefined && {
+      budget: {
+        maxContributions: runPolicy.maxIterations,
+      },
+    }),
+  };
+
+  return Object.keys(stopConditions).length > 0 ? stopConditions : undefined;
+}
+
+function materializeSubRecipes(
+  subRecipes: readonly RecipeSubRecipe[],
+  parameters: Readonly<Record<string, JsonValue>>,
+  parameterDefinitions: Readonly<Record<string, RecipeParameter>>,
+): readonly RecipeSubRecipe[] {
+  return subRecipes.map((subRecipe) => ({
+    name: subRecipe.name,
+    ref: subRecipe.ref,
+    ...(subRecipe.when !== undefined && {
+      when: renderRecipeTemplate(subRecipe.when, parameters, parameterDefinitions),
+    }),
+    ...(subRecipe.parameters !== undefined && {
+      parameters: renderRecipeTemplateJsonObjectLeaves(
+        subRecipe.parameters,
+        parameters,
+        parameterDefinitions,
+      ),
+    }),
+  }));
 }
 
 export async function discoverRecipes(

--- a/src/core/session-orchestrator.test.ts
+++ b/src/core/session-orchestrator.test.ts
@@ -472,6 +472,7 @@ describe("SessionOrchestrator", () => {
     const bus = new LocalEventBus();
     const contract = makeContract();
     const contributions: ReturnType<typeof makeContribution>[] = [];
+    const acceptedCids: string[] = [];
     const contributionStore = {
       list: async () => contributions,
     };
@@ -487,12 +488,116 @@ describe("SessionOrchestrator", () => {
       workspaceBaseDir: "/tmp/workspaces",
       workspaceIsolationPolicy: "allow-fallback",
       contributionStore,
+      onContributionAccepted: (cid) => {
+        acceptedCids.push(cid);
+      },
     });
     const internals = orchestrator as unknown as {
       startContributionPolling: () => void;
       pollContributions: () => Promise<void>;
     };
     // Avoid a real 15s timer in test; invoke poll manually.
+    internals.startContributionPolling = () => undefined;
+
+    const started = await orchestrator.start();
+    const coderSessionId = started.agents.find((a) => a.role === "coder")?.session.id;
+    const coderToken = runtime.spawnCalls.find((c) => c.role === "coder")?.config.env
+      ?.GROVE_ROUTING_TOKEN;
+    expect(coderSessionId).toBeDefined();
+    expect(coderToken).toBeDefined();
+
+    const routedContribution = signContributionForRouting(
+      makeContribution({
+        summary: "local coder contribution",
+        agent: { agentId: coderSessionId ?? "missing", role: "coder" },
+      }),
+      coderToken ?? "missing-token",
+    );
+    contributions.push(routedContribution);
+
+    await internals.pollContributions();
+
+    // 2 initial goal sends + 1 routed handoff to reviewer.
+    expect(runtime.sendCalls).toHaveLength(3);
+    expect(runtime.sendCalls[2]!.message).toContain("local coder contribution");
+    expect(acceptedCids).toEqual([routedContribution.cid]);
+
+    await internals.pollContributions();
+    expect(acceptedCids).toEqual([routedContribution.cid]);
+    bus.close();
+  });
+
+  test("polling does not mark untrusted contributions accepted", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    const contract = makeContract();
+    const acceptedCids: string[] = [];
+    const contributions = [
+      makeContribution({
+        summary: "external coder contribution",
+        agent: { agentId: "external-session-coder", role: "coder" },
+      }),
+    ];
+    const contributionStore = {
+      list: async () => contributions,
+    };
+
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract,
+      topology: contract.topology!,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+      contributionStore,
+      onContributionAccepted: (cid) => {
+        acceptedCids.push(cid);
+      },
+    });
+    const internals = orchestrator as unknown as {
+      startContributionPolling: () => void;
+      pollContributions: () => Promise<void>;
+    };
+    internals.startContributionPolling = () => undefined;
+
+    await orchestrator.start();
+    await internals.pollContributions();
+
+    expect(acceptedCids).toEqual([]);
+    bus.close();
+  });
+
+  test("polling continues routing when session contribution linking fails", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+    const contract = makeContract();
+    const contributions: ReturnType<typeof makeContribution>[] = [];
+    const contributionStore = {
+      list: async () => contributions,
+    };
+
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract,
+      topology: contract.topology!,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+      contributionStore,
+      onContributionAccepted: () => {
+        throw new Error("link failed");
+      },
+    });
+    const internals = orchestrator as unknown as {
+      startContributionPolling: () => void;
+      pollContributions: () => Promise<void>;
+    };
     internals.startContributionPolling = () => undefined;
 
     const started = await orchestrator.start();
@@ -514,7 +619,6 @@ describe("SessionOrchestrator", () => {
 
     await internals.pollContributions();
 
-    // 2 initial goal sends + 1 routed handoff to reviewer.
     expect(runtime.sendCalls).toHaveLength(3);
     expect(runtime.sendCalls[2]!.message).toContain("local coder contribution");
     bus.close();

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -120,6 +120,12 @@ export interface SessionConfig {
         }): Promise<readonly import("./models.js").Contribution[]>;
       }
     | undefined;
+  /**
+   * Called after the orchestrator accepts a contribution for this session.
+   * Used by durable session stores to keep list/status contribution counts in
+   * sync with the routing path, including Nexus-backed session starts.
+   */
+  readonly onContributionAccepted?: ((cid: string) => void | Promise<void>) | undefined;
   /** Optional agent profiles — overlay role defaults with per-agent runtime config. */
   readonly profiles?: readonly AgentProfile[] | undefined;
 }
@@ -485,7 +491,7 @@ export class SessionOrchestrator {
         // Mark as seen only after ownership verification so transient identity
         // skew doesn't permanently suppress routing for this CID.
         this.seenCids.add(c.cid);
-        this.contributionCount++;
+        await this.recordAcceptedContribution(c.cid);
 
         // Find the source agent's workspace path — this is the handoff artifact.
         // The receiving agent reads files directly from this path, no git merge needed.
@@ -539,6 +545,17 @@ export class SessionOrchestrator {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[SessionOrchestrator] contribution poll failed: ${message}\n`);
+    }
+  }
+
+  private async recordAcceptedContribution(cid: string): Promise<void> {
+    this.contributionCount++;
+    try {
+      await this.config.onContributionAccepted?.(cid);
+    } catch (err) {
+      process.stderr.write(
+        `[SessionOrchestrator] session contribution link failed for ${cid}: ${messageFromError(err)}\n`,
+      );
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,28 @@ export type {
   Relation,
 } from "./core/models.js";
 export type {
+  BoundRecipe,
+  GroveRecipe,
+  MaterializedRecipe,
+  RecipeActivity,
+  RecipeExtension,
+  RecipeLibraryMetadata,
+  RecipeParameter,
+  RecipeParameterType,
+  RecipeProvenance,
+  RecipeRunPolicy,
+  RecipeSubRecipe,
+} from "./core/recipe.js";
+export {
+  bindRecipeParameters,
+  computeBoundRecipeDigest,
+  computeRecipeDigest,
+  materializeRecipeContract,
+  parseGroveRecipe,
+  parseGroveRecipeObject,
+  renderRecipeTemplate,
+} from "./core/recipe.js";
+export type {
   ReconcileResult,
   Reconciler,
   ReconcilerConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,8 @@ export type {
 } from "./core/models.js";
 export type {
   BoundRecipe,
+  DiscoveredRecipe,
+  DiscoverRecipesOptions,
   GroveRecipe,
   MaterializedRecipe,
   RecipeActivity,
@@ -101,12 +103,14 @@ export type {
   RecipeParameterType,
   RecipeProvenance,
   RecipeRunPolicy,
+  RecipeSource,
   RecipeSubRecipe,
 } from "./core/recipe.js";
 export {
   bindRecipeParameters,
   computeBoundRecipeDigest,
   computeRecipeDigest,
+  discoverRecipes,
   materializeRecipeContract,
   parseGroveRecipe,
   parseGroveRecipeObject,

--- a/src/mcp/serve.ts
+++ b/src/mcp/serve.ts
@@ -455,17 +455,24 @@ try {
     topologyRouter = new TopologyRouter(loadedContract.topology, eventBus);
   }
 
-  // When running with a local SQLite store and GROVE_SESSION_ID is set,
-  // tag every contribution write against the session at the MCP layer.
-  // Nexus handles this via path-scoped stores; local SQLite needs the junction table.
+  // When GROVE_SESSION_ID is set, tag every contribution write against the
+  // session at the MCP layer. Contribution stores are session-scoped in Nexus,
+  // but session rows still keep a contribution index for list/detail counts.
   const envSessionId = process.env.GROVE_SESSION_ID;
-  const onContributionWritten =
-    envSessionId && !nexusClient
-      ? (cid: string) => {
-          // biome-ignore lint/suspicious/noEmptyBlockStatements: fire-and-forget, errors intentionally swallowed
-          void runtime.goalSessionStore.addContributionToSession(envSessionId, cid).catch(() => {});
-        }
-      : undefined;
+  let onContributionWritten: ((cid: string) => void) | undefined;
+  if (envSessionId && nexusClient) {
+    const { NexusSessionStore } = await import("../nexus/nexus-session-store.js");
+    const nexusSessionStore = new NexusSessionStore(nexusClient, zoneId);
+    onContributionWritten = (cid: string) => {
+      void nexusSessionStore.addContribution(envSessionId, cid).catch(() => undefined);
+    };
+  } else if (envSessionId) {
+    onContributionWritten = (cid: string) => {
+      void runtime.goalSessionStore
+        .addContributionToSession(envSessionId, cid)
+        .catch(() => undefined);
+    };
+  }
 
   // Wire DeadlineWatcher for proactive overdue detection. Both Nexus and
   // SQLite (session-scoped via GROVE_SESSION_ID) safely support it: every


### PR DESCRIPTION
## Summary

Fixes the Nexus-backed session handoff path so Codex work can be routed to Claude reviewers and reflected accurately in session state and the TUI.

## What Changed

- Advertise and implement ACP client filesystem and terminal capabilities for spawned agents.
- Poll the Nexus session-scoped contribution store during `grove session start` when Nexus is configured.
- Resolve the Nexus zone from the persisted Grove namespace before falling back to `GROVE_ZONE_ID` or `default`.
- Link accepted routed contributions into both local and Nexus session ledgers.
- Mirror terminal session completion back to Nexus so local and Nexus session status stay aligned.
- Tag MCP-written contributions against the active session in Nexus and local modes.

## Root Cause

The headless session orchestrator mirrored the session to Nexus, but still polled local SQLite for contributions. Agent MCP servers wrote session-scoped contributions to Nexus, so downstream reviewers did not reliably receive handoffs. The session count and completion mirrors also had separate gaps, which left the TUI showing `0c` or Nexus sessions still marked active after local completion.

## Validation

- `bun --config=/dev/null test src/core/session-orchestrator.test.ts src/cli/commands/session.test.ts --timeout 30000`
- `bun --config=/dev/null test src/core/acp-runtime.spawn.test.ts --timeout 30000`
- `bun run typecheck`
- `bun run check` (passes with existing warnings)
- `timeout 180s bun run build`
- `git diff --check`
- Live tmux Nexus validation: Codex created and committed `nexus-hello-final.txt`, Claude reviewed the actual coder workspace, emitted `[DONE]`, and both local and Nexus session stores reported `completed`, `achieved`, `contributionCount: 3`. TUI capture showed the completed row as `3c · achieved`.
