### PR TITLE
feat(runtime): AcpxRuntime supervisor registry with respawn + auto-resume (#273)

### DIFF
--- a/docs/superpowers/plans/2026-05-29-acpx-supervisor-e2e-runbook.md
+++ b/docs/superpowers/plans/2026-05-29-acpx-supervisor-e2e-runbook.md
@@ -1,0 +1,84 @@
+# AcpxSupervisor respawn E2E — Runbook (#273, Phase 5.3)
+
+> **Status: the E2E script `tests/e2e/acpx-supervisor-respawn-tmux.ts` is authored but NOT-YET-RUN.**
+> It was written without executing against a live grove+Nexus stack. Treat its
+> assertions as *intended*, not *verified*, until a real run goes green. Do not
+> claim the respawn path is end-to-end validated on the strength of the script alone.
+
+## What it proves (when run green)
+
+A real acpx agent, spawned through `AcpxSupervisor` (`GROVE_SUPERVISOR=1`), is
+`kill -9`'d mid-flight and the supervisor:
+
+1. detects the death (Phase 1 `onDisconnect`),
+2. respawns a fresh session within the shared runtime (Phase 3),
+3. surfaces it on the bound `AgentTask` as a `SessionLost=True` condition while
+   keeping the task `Running` — not `Failed` (Phase 4 wiring),
+4. binds a new `status.sessionId` (respawn, not the dead session).
+
+All four are observable over `GET /api/agent-tasks/:id`.
+
+## What it deliberately does NOT assert — and why
+
+**Monotonic `seq` across the kill boundary is not wire-observable.** The
+supervisor stamps `seq` on the in-process `AcpRuntimeEvent` sink
+(`src/core/acpx-supervisor.ts` → `routeEvent`), which feeds `AcpSessionStore`
+(TUI-local) only. It is **not** exposed on any HTTP/SSE endpoint today, so a
+black-box E2E cannot see it. Seq continuity is instead covered by the unit test:
+
+```
+src/core/acpx-supervisor.respawn.test.ts
+  → "seq is strictly increasing across turns and respawn (no reset)"
+```
+
+If wire-level seq observability is ever wanted, that's a separate follow-up
+(expose `seq` on the agent-event/watch stream), out of scope for #273.
+
+## Prerequisites
+
+- Docker up with a healthy Nexus stack (this environment had several
+  `nexus-*-nexus-1 (healthy)` containers — `docker ps`), OR a local grove server
+  the script can reach on `SERVER_PORT`.
+- A real ACP adapter installed for the chosen `runtime` (default `codex` →
+  `@zed-industries/codex-acp`). Without it, spawn fails before respawn is testable.
+- `tmux` available.
+- Valid agent auth so the spawned agent can reach Nexus (per project memory on
+  per-worktree key isolation — run from a fresh dir; the script does `git init`
+  + a fresh temp workdir per run).
+
+## Run
+
+```bash
+GROVE_SUPERVISOR=1 bun run tests/e2e/acpx-supervisor-respawn-tmux.ts
+# flags: --keep (leave tmux+workdir), --attach (print attach cmd & wait), --timeout <ms>
+```
+
+## Two spots that will likely need a tweak on first real run
+
+Both are marked `TODO(verify-on-stack)` in the script:
+
+1. **acpx child-PID discovery** (`findAcpxChildPid`). The script `pgrep`s for
+   `codex-acp|claude-agent-acp|gemini .*--acp|acp` and kills the highest PID.
+   On a real box, run `pgrep -fl` once after the agent binds, confirm the exact
+   adapter argv, and pin the pattern (and ideally scope to descendants of the
+   grove server PID so a sibling test's agent isn't killed).
+
+2. **AgentTask PUT schema + readiness**. The script PUTs
+   `{ id, worktree, runtime, role, prompt, dependsOn, generation, createdAt }`.
+   Confirm against `src/server/routes/agent-tasks.ts` (`putAgentTaskSpec`) and
+   the `AgentTaskSpecRecord` shape; adjust fields if the server rejects the body.
+   Also confirm the bind actually produces `phase: "Running"` + a `sessionId`
+   (the controller must be enabled — the script sets `GROVE_TASK_CONTROLLER=1`).
+
+## Validate against Nexus, not local SQLite
+
+Per project memory (`feedback_e2e_use_nexus`): production reads/writes go to
+Nexus. Point the server at the running Nexus stack (env/keys) rather than the
+SQLite fallback, and confirm the `AgentTask` you poll is the Nexus-backed one.
+
+## Done = green + observed
+
+Per `feedback_no_workarounds` / `feedback_no_e2e_shortcuts`: the task is only
+"E2E validated" once this script runs and prints its `PASS:` line on a real
+stack, with the `SessionLost` condition + sessionId change actually observed.
+Until then this is a prepared harness, not a passing test.

--- a/docs/superpowers/plans/2026-05-29-acpx-supervisor.md
+++ b/docs/superpowers/plans/2026-05-29-acpx-supervisor.md
@@ -1,0 +1,1506 @@
+# AcpxSupervisor Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a grove-owned registry of single-child `AcpRuntime` handles with death-detection, respawn, best-effort auto-resume (respawn-as-new), and `SessionLost` surfacing on `AgentTask`, then adopt it in `selectRuntime` — closing issue [#273](https://github.com/windoliver/grove/issues/273).
+
+**Architecture:** A new `AcpxSupervisor` decorates the `AgentRuntime` interface, owning one single-child `AcpRuntime` per logical slot. `AcpRuntime` gains a death-detection seam (`onDisconnect` + `AgentDisconnectedError`) fed by a new exit signal on `LaunchResult`. The supervisor stamps a monotonic per-slot `seq` by **wrapping each child runtime's ACP event sink** (`setAcpEventSink`) — the verified production event path is `AcpRuntime.emitAcpEvent` → eventSink → `AcpSessionStore` (`src/tui/spawn-manager.ts:297`); `publishTurnToNexus` has **no production caller** today, so seq lives at the eventSink, not the publisher. A thin wiring layer translates supervisor respawn events into `AgentTask` conditions (`Resuming`/`SessionLost`). `selectRuntime` wraps the constructed runtime in the supervisor behind `GROVE_SUPERVISOR`.
+
+**Tech Stack:** Bun 1.3.x, `bun:test`, TypeScript strict (no `any`/`!`/`@ts-ignore`, `import type`, `.js` import extensions, `as const` over enums, explicit return types on exports), Biome. Design doc: `docs/superpowers/specs/2026-05-29-acpx-supervisor-design.md`.
+
+**Conventions (verified):** Tests co-located `*.test.ts`, `import { describe, expect, test } from "bun:test";`. Run a single file with `bun test path/to/file.test.ts`. Full suite: `bun test --timeout 60000`. Typecheck: `bun run typecheck`. Lint: `bun run check`. In-process ACP agents use the `makeInProcessAgent` helper pattern (`src/core/acp-runtime.spawn.test.ts:27`).
+
+---
+
+## File Structure
+
+**Create:**
+- `src/core/acpx-supervisor.ts` — `AcpxSupervisor`, `AcpxKey`, `AcpxRegistryEntry`, `AcpxRespawnEvent`, `AcpxSupervisorOptions`.
+- `src/core/acpx-supervisor.test.ts` — registry lifecycle (P2).
+- `src/core/acpx-supervisor.respawn.test.ts` — respawn + seq continuity (P3).
+- `src/core/acpx-test-support.ts` — shared in-process + disconnectable `LaunchOverride` helpers (extracted from the spawn test).
+- `src/core/runtime-adapter-matrix.ts` — shared `runRuntimeAdapterMatrix(label, factory)` (#210, P2).
+- `src/core/runtime-adapter-matrix.test.ts` — runs the matrix over Mock + Acp + Supervisor.
+- `src/core/acp-runtime.disconnect.test.ts` — death-detection seam (P1).
+- `src/server/acpx-supervisor-wiring.ts` — subscribes `onRespawn` → patches `AgentTask` (P4).
+- `src/server/acpx-supervisor-wiring.test.ts` — wiring tests (P4).
+- `tests/e2e/acpx-supervisor-respawn-tmux.ts` — real-process kill-PID E2E (P5).
+
+**Modify:**
+- `src/core/agent-runtime.ts` — export `AgentDisconnectedError`; add optional `onDisconnect?` to `AgentRuntime`.
+- `src/core/acp-runtime.ts` — extend `LaunchResult` with exit signal; wire `launchSubprocess` child `exit`; add `onDisconnect`; reject in-flight `send` on unexpected exit; add optional `seq?` to `AcpRuntimeEvent`.
+- `src/core/select-runtime.ts` — wrap the runtime in `AcpxSupervisor` behind `GROVE_SUPERVISOR` (P5).
+- `src/core/agent-task.ts` — add `Resuming`, `SessionLost` to `AgentTaskConditionType`.
+- `src/core/task-controller.ts` — export `upsertCondition` for reuse by the wiring layer.
+- `src/core/acp-runtime.spawn.test.ts` — import the extracted in-process helper from `acpx-test-support.ts`.
+
+---
+
+## Phase 1 — Death-detection seam in `AcpRuntime`
+
+**Why first:** the supervisor's respawn trigger (P3) subscribes to this. Today `launchSubprocess` keeps `child` local and returns only `{ clientStream, dispose }` (`src/core/acp-runtime.ts:34-37, 343-502`); the only exit handling is `dispose()`'s `waitForChildExit` during intentional teardown. The session entry never observes an *unexpected* exit. We add an exit signal to `LaunchResult` and a runtime-level `onDisconnect`.
+
+### Task 1.1: `AgentDisconnectedError`
+
+**Files:**
+- Modify: `src/core/agent-runtime.ts`
+- Test: `src/core/acp-runtime.disconnect.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/acp-runtime.disconnect.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { AgentDisconnectedError } from "./agent-runtime.js";
+
+describe("AgentDisconnectedError", () => {
+  test("carries session/role/exit info and a readable message", () => {
+    const err = new AgentDisconnectedError({
+      sessionId: "grove-coder-0--abc",
+      role: "coder",
+      exitCode: null,
+      signal: "SIGKILL",
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.info.sessionId).toBe("grove-coder-0--abc");
+    expect(err.info.role).toBe("coder");
+    expect(err.info.signal).toBe("SIGKILL");
+    expect(err.message).toContain("coder");
+    expect(err.message).toContain("grove-coder-0--abc");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/acp-runtime.disconnect.test.ts`
+Expected: FAIL — `AgentDisconnectedError` is not exported from `agent-runtime.js`.
+
+- [ ] **Step 3: Add the class + interface hook**
+
+Append to `src/core/agent-runtime.ts`:
+
+```ts
+/** Thrown when an agent subprocess exits unexpectedly (not via close()). */
+export class AgentDisconnectedError extends Error {
+  constructor(
+    readonly info: {
+      readonly sessionId: string;
+      readonly role: string;
+      readonly exitCode?: number | null | undefined;
+      readonly signal?: NodeJS.Signals | null | undefined;
+      readonly lastRequestId?: string | undefined;
+    },
+  ) {
+    super(`agent ${info.role} (${info.sessionId}) disconnected`);
+    this.name = "AgentDisconnectedError";
+  }
+}
+```
+
+Add the optional hook to the `AgentRuntime` interface (after `onIdle`):
+
+```ts
+  /**
+   * Register a callback for unexpected agent death (subprocess exit / connection
+   * EOF that did not originate from close()). Optional: runtimes without
+   * subprocess lifecycles (MockRuntime) may omit it.
+   */
+  onDisconnect?(session: AgentSession, callback: (err: AgentDisconnectedError) => void): void;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/acp-runtime.disconnect.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/agent-runtime.ts src/core/acp-runtime.disconnect.test.ts
+git commit -m "feat(runtime): AgentDisconnectedError + onDisconnect hook (#273)"
+```
+
+### Task 1.2: Exit signal on `LaunchResult` + disconnect detection
+
+**Files:**
+- Modify: `src/core/acp-runtime.ts` (`LaunchResult`, `launchSubprocess`, `AcpSessionEntry`, `spawn`, `send`, `onDisconnect`)
+- Test: `src/core/acp-runtime.disconnect.test.ts`
+
+**Background:** The in-process test agent (`makeInProcessAgent`, `src/core/acp-runtime.spawn.test.ts:27`) returns a `LaunchResult` with no child process. To test disconnect without real subprocesses, `LaunchResult` gains an optional `onExit(listener)` registration; `launchSubprocess` wires it to the real child's `"exit"`, and the test stub exposes a manual trigger.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/core/acp-runtime.disconnect.test.ts`:
+
+```ts
+import {
+  type Agent,
+  AgentSideConnection,
+  ndJsonStream,
+} from "@agentclientprotocol/sdk";
+import { AcpRuntime, type LaunchOverride, type LaunchResult } from "./acp-runtime.js";
+
+function makeDisconnectableAgent(): {
+  launchOverride: LaunchOverride;
+  triggerExit: (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void;
+} {
+  const exitListeners: Array<
+    (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void
+  > = [];
+  const launchOverride: LaunchOverride = async () => {
+    const toAgent = new TransformStream<Uint8Array, Uint8Array>();
+    const toClient = new TransformStream<Uint8Array, Uint8Array>();
+    const agentStream = ndJsonStream(toClient.writable, toAgent.readable);
+    const clientStream = ndJsonStream(toAgent.writable, toClient.readable);
+    const agent: Agent = {
+      async initialize() {
+        return { protocolVersion: 1, agentCapabilities: {}, authMethods: [] };
+      },
+      async newSession() {
+        return { sessionId: `wire-${exitListeners.length}` };
+      },
+      async prompt() {
+        await new Promise(() => undefined); // never resolves until disconnect
+        return { stopReason: "end_turn" };
+      },
+      async cancel() {},
+      async authenticate() {
+        return {};
+      },
+    };
+    void new AgentSideConnection(() => agent, agentStream);
+    const result: LaunchResult = {
+      clientStream,
+      dispose: async () => {},
+      onExit: (listener) => exitListeners.push(listener),
+    };
+    return result;
+  };
+  return {
+    launchOverride,
+    triggerExit: (info) => {
+      for (const l of exitListeners) l(info);
+    },
+  };
+}
+
+describe("AcpRuntime disconnect detection", () => {
+  test("onDisconnect fires once with AgentDisconnectedError on unexpected exit", async () => {
+    const { launchOverride, triggerExit } = makeDisconnectableAgent();
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", { role: "coder", command: "codex", cwd: process.cwd() });
+
+    const seen: AgentDisconnectedError[] = [];
+    rt.onDisconnect(session, (err) => seen.push(err));
+
+    triggerExit({ exitCode: null, signal: "SIGKILL" });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBeInstanceOf(AgentDisconnectedError);
+    expect(seen[0]?.info.role).toBe("coder");
+    expect(seen[0]?.info.signal).toBe("SIGKILL");
+    expect((await rt.listSessions())[0]?.status).toBe("crashed");
+  });
+
+  test("onDisconnect does NOT fire on intentional close()", async () => {
+    const { launchOverride, triggerExit } = makeDisconnectableAgent();
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", { role: "coder", command: "codex", cwd: process.cwd() });
+    const seen: AgentDisconnectedError[] = [];
+    rt.onDisconnect(session, (err) => seen.push(err));
+
+    await rt.close(session);
+    triggerExit({ exitCode: 0, signal: null }); // exit AFTER close — must be ignored
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(seen).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/acp-runtime.disconnect.test.ts`
+Expected: FAIL — `onExit` not on `LaunchResult`; `rt.onDisconnect` not a function.
+
+- [ ] **Step 3: Extend `LaunchResult` and wire the child exit**
+
+In `src/core/acp-runtime.ts`, extend the interface (around line 34):
+
+```ts
+export interface LaunchResult {
+  readonly clientStream: Stream;
+  readonly dispose: () => Promise<void>;
+  /**
+   * Register a listener fired when the underlying agent process exits.
+   * Real subprocesses wire this to the child's "exit" event; in-process test
+   * launchers expose a manual trigger. Optional for backward compatibility.
+   */
+  readonly onExit?: (
+    listener: (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void,
+  ) => void;
+}
+```
+
+In `launchSubprocess` (just before `const dispose = async () => {` at line ~472), collect listeners and wire the child:
+
+```ts
+  const exitListeners: Array<
+    (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void
+  > = [];
+  child.once("exit", (code, signal) => {
+    for (const l of exitListeners) l({ exitCode: code, signal });
+  });
+```
+
+and change the final `return { clientStream, dispose };` (line ~501) to:
+
+```ts
+  return {
+    clientStream,
+    dispose,
+    onExit: (listener) => exitListeners.push(listener),
+  };
+```
+
+- [ ] **Step 4: Implement `onDisconnect` + crash handling in `AcpRuntime`**
+
+Add two fields to `AcpSessionEntry` (around line 84, after `closed`):
+
+```ts
+  disconnectCallbacks: ((err: AgentDisconnectedError) => void)[];
+  rejectInFlight: ((err: AgentDisconnectedError) => void) | null;
+```
+
+Merge the import at line 28: `import { AgentDisconnectedError, type AgentConfig, type AgentRuntime, type AgentSession } from "./agent-runtime.js";`
+
+Initialize the two new fields in the `this.sessions.set(id, {...})` block in `spawn()` (around line 791): add `disconnectCallbacks: [], rejectInFlight: null,`.
+
+In `spawn()`, immediately after `this.fireSessionWrite("ADDED", session);` (line ~802), register the exit handler:
+
+```ts
+    launched.onExit?.((info) => {
+      const current = this.sessions.get(id);
+      if (!current || current.closed) return; // intentional close() sets closed=true first
+      const err = new AgentDisconnectedError({
+        sessionId: id,
+        role,
+        exitCode: info.exitCode,
+        signal: info.signal,
+      });
+      current.session = withSessionStatus(current.session, "crashed", err.message);
+      this.fireSessionWrite("MODIFIED", current.session);
+      current.rejectInFlight?.(err);
+      for (const cb of current.disconnectCallbacks) {
+        try {
+          cb(err);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+```
+
+Add the public method next to `onIdle` (around line 985):
+
+```ts
+  onDisconnect(session: AgentSession, callback: (err: AgentDisconnectedError) => void): void {
+    const entry = this.sessions.get(session.id);
+    if (!entry) return;
+    entry.disconnectCallbacks.push(callback);
+  }
+```
+
+Wire `rejectInFlight` so a mid-turn death rejects the in-flight prompt. In `send()`'s `mine` IIFE (the `try` at line ~908), race the prompt against a disconnect rejecter:
+
+```ts
+      const disconnectRace = new Promise<never>((_, reject) => {
+        entry.rejectInFlight = (err) => reject(err);
+      });
+      try {
+        const ok = await Promise.race([
+          entry.connection.prompt({
+            sessionId: entry.wireSessionId,
+            prompt: [{ type: "text", text: message }],
+          }),
+          disconnectRace,
+        ]);
+        finishTurn({ turnId, stopReason: ok.stopReason });
+      } catch (err) {
+        const m = acpErrorMessage(err);
+        finishTurn({ turnId, stopReason: "error", error: { code: "prompt_rejected", message: m } });
+      } finally {
+        entry.rejectInFlight = null;
+        if (entry.currentTurn === turn) entry.currentTurn = null;
+        for (const cb of entry.idleCallbacks) {
+          try {
+            cb();
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+```
+
+(This replaces the existing `try/catch/finally` body; keep the idle-callback loop intact.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test src/core/acp-runtime.disconnect.test.ts`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Regression — existing runtime tests stay green**
+
+Run: `bun test src/core/acp-runtime.spawn.test.ts src/core/acp-runtime.test.ts`
+Expected: PASS (close() still bounded; status transitions intact; the `close cancels an in-flight prompt` test still resolves `cancelled`).
+
+- [ ] **Step 7: Typecheck + lint**
+
+Run: `bun run typecheck && bun run check`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/core/acp-runtime.ts src/core/acp-runtime.disconnect.test.ts
+git commit -m "feat(runtime): detect unexpected acpx exit, reject in-flight send (#273)"
+```
+
+---
+
+## Phase 2 — Supervisor registry core + adapter matrix
+
+### Task 2.1: Extract shared in-process launch helper
+
+**Files:**
+- Create: `src/core/acpx-test-support.ts`
+- Modify: `src/core/acp-runtime.spawn.test.ts`
+
+- [ ] **Step 1: Extract**
+
+Move the `AgentStubHandlers` type and the body of `makeInProcessAgent` (`src/core/acp-runtime.spawn.test.ts:15-76`) into `src/core/acpx-test-support.ts`, exported as:
+
+```ts
+export interface AgentStubHandlers { /* ...verbatim from the spawn test... */ }
+export function makeInProcessAgent(handlers?: AgentStubHandlers): {
+  launchOverride: LaunchOverride;
+  ref: { agentSide: AgentSideConnection | null };
+};
+/** Convenience: just the override, for tests that don't need the agent ref. */
+export function makeInProcessLaunchOverride(handlers?: AgentStubHandlers): LaunchOverride {
+  return makeInProcessAgent(handlers).launchOverride;
+}
+```
+
+In `acp-runtime.spawn.test.ts`, delete the moved code and `import { makeInProcessAgent } from "./acpx-test-support.js";`.
+
+- [ ] **Step 2: Run the moved tests**
+
+Run: `bun test src/core/acp-runtime.spawn.test.ts`
+Expected: PASS (unchanged behavior, now importing the helper).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/acpx-test-support.ts src/core/acp-runtime.spawn.test.ts
+git commit -m "test(runtime): extract in-process ACP launch helper (#273)"
+```
+
+### Task 2.2: Shared runtime adapter matrix (#210)
+
+**Files:**
+- Create: `src/core/runtime-adapter-matrix.ts`
+- Create: `src/core/runtime-adapter-matrix.test.ts`
+
+- [ ] **Step 1: Write the matrix harness**
+
+Create `src/core/runtime-adapter-matrix.ts`:
+
+```ts
+import { expect, test } from "bun:test";
+import type { AgentRuntime } from "./agent-runtime.js";
+
+/**
+ * Shared conformance matrix every AgentRuntime must satisfy (#210). Call inside
+ * a describe() block. The factory must return a fresh, isolated runtime per call.
+ */
+export function runRuntimeAdapterMatrix(label: string, factory: () => AgentRuntime): void {
+  const cfg = { role: "coder", command: "codex", cwd: process.cwd() };
+
+  test(`${label}: spawn returns a running session`, async () => {
+    const rt = factory();
+    const s = await rt.spawn("coder", cfg);
+    expect(s.role).toBe("coder");
+    expect(s.status).toBe("running");
+    await rt.close(s);
+  });
+
+  test(`${label}: listSessions reflects spawn then close`, async () => {
+    const rt = factory();
+    const s = await rt.spawn("coder", cfg);
+    expect((await rt.listSessions()).some((x) => x.id === s.id)).toBe(true);
+    await rt.close(s);
+    expect((await rt.listSessions()).some((x) => x.id === s.id)).toBe(false);
+  });
+
+  test(`${label}: distinct spawns get distinct ids`, async () => {
+    const rt = factory();
+    const a = await rt.spawn("coder", cfg);
+    const b = await rt.spawn("coder", cfg);
+    expect(a.id).not.toBe(b.id);
+    await rt.close(a);
+    await rt.close(b);
+  });
+
+  test(`${label}: send returns a typed AcpxTurn that resolves`, async () => {
+    const rt = factory();
+    const s = await rt.spawn("coder", cfg);
+    const turn = await rt.send(s, "hello");
+    expect(turn.sessionId).toBeDefined();
+    for await (const _ of turn.messages) {
+      /* drain */
+    }
+    const result = await turn.result;
+    expect(typeof result.stopReason).toBe("string");
+    await rt.close(s);
+  });
+
+  test(`${label}: close is idempotent`, async () => {
+    const rt = factory();
+    const s = await rt.spawn("coder", cfg);
+    await rt.close(s);
+    await rt.close(s); // must not throw
+    expect(true).toBe(true);
+  });
+
+  test(`${label}: listSessionEntities returns AgentSession entities`, async () => {
+    const rt = factory();
+    const s = await rt.spawn("coder", cfg);
+    const entities = await rt.listSessionEntities();
+    expect(entities.every((e) => e.kind === "AgentSession")).toBe(true);
+    await rt.close(s);
+  });
+}
+```
+
+- [ ] **Step 2: Run matrix against Mock + Acp**
+
+Create `src/core/runtime-adapter-matrix.test.ts`:
+
+```ts
+import { describe } from "bun:test";
+import { AcpRuntime } from "./acp-runtime.js";
+import { makeInProcessLaunchOverride } from "./acpx-test-support.js";
+import { MockRuntime } from "./mock-runtime.js";
+import { runRuntimeAdapterMatrix } from "./runtime-adapter-matrix.js";
+
+describe("runtime adapter matrix", () => {
+  runRuntimeAdapterMatrix("MockRuntime", () => new MockRuntime());
+  runRuntimeAdapterMatrix(
+    "AcpRuntime",
+    () => new AcpRuntime({ launchOverride: makeInProcessLaunchOverride() }),
+  );
+});
+```
+
+Run: `bun test src/core/runtime-adapter-matrix.test.ts`
+Expected: PASS (all rows for Mock + Acp).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/runtime-adapter-matrix.ts src/core/runtime-adapter-matrix.test.ts
+git commit -m "test(runtime): shared runtime adapter conformance matrix (#210, #273)"
+```
+
+### Task 2.3: `AcpxSupervisor` registry core
+
+**Files:**
+- Create: `src/core/acpx-supervisor.ts`
+- Create: `src/core/acpx-supervisor.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/acpx-supervisor.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { AcpRuntime } from "./acp-runtime.js";
+import { makeInProcessLaunchOverride } from "./acpx-test-support.js";
+import { AcpxSupervisor, type AcpxKey } from "./acpx-supervisor.js";
+
+function makeSupervisor(): AcpxSupervisor {
+  return new AcpxSupervisor({
+    runtimeFactory: () => new AcpRuntime({ launchOverride: makeInProcessLaunchOverride() }),
+  });
+}
+
+const key: AcpxKey = { slotId: "task-1", backend: "codex", cwd: process.cwd() };
+const cfg = { role: "coder", command: "codex", cwd: process.cwd() };
+
+describe("AcpxSupervisor registry", () => {
+  test("ensure spawns one entry and is idempotent for the same slot", async () => {
+    const sup = makeSupervisor();
+    const a = await sup.ensure(key, cfg);
+    const b = await sup.ensure(key, cfg);
+    expect(b).toBe(a);
+    expect(sup.list()).toHaveLength(1);
+    expect(a.phase).toBe("running");
+    expect(a.acpxRecordId).toBeDefined();
+    await sup.stop(key.slotId, "test cleanup");
+  });
+
+  test("concurrent ensure for the same slot coalesces to one entry", async () => {
+    const sup = makeSupervisor();
+    const [a, b] = await Promise.all([sup.ensure(key, cfg), sup.ensure(key, cfg)]);
+    expect(a).toBe(b);
+    expect(sup.list()).toHaveLength(1);
+    await sup.stop(key.slotId, "cleanup");
+  });
+
+  test("distinct slots get distinct entries and children", async () => {
+    const sup = makeSupervisor();
+    const a = await sup.ensure(key, cfg);
+    const b = await sup.ensure({ ...key, slotId: "task-2" }, cfg);
+    expect(a.acpxRecordId).not.toBe(b.acpxRecordId);
+    expect(a.session.id).not.toBe(b.session.id);
+    expect(sup.list()).toHaveLength(2);
+    await sup.stop("task-1", "cleanup");
+    await sup.stop("task-2", "cleanup");
+  });
+
+  test("get returns the entry; stop terminates and removes it", async () => {
+    const sup = makeSupervisor();
+    await sup.ensure(key, cfg);
+    expect(sup.get(key.slotId)).toBeDefined();
+    await sup.stop(key.slotId, "done");
+    expect(sup.get(key.slotId)).toBeUndefined();
+    expect(sup.list()).toHaveLength(0);
+  });
+
+  test("AgentRuntime façade: spawn routes to ensure, listSessions reflects entries", async () => {
+    const sup = makeSupervisor();
+    const session = await sup.spawn("coder", cfg);
+    expect((await sup.listSessions()).some((s) => s.id === session.id)).toBe(true);
+    await sup.close(session);
+    expect((await sup.listSessions()).some((s) => s.id === session.id)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/acpx-supervisor.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the registry core**
+
+Create `src/core/acpx-supervisor.ts`:
+
+```ts
+import type { AcpxTurn } from "../acp/types.js";
+import { AcpRuntime, type AcpRuntimeEvent, type AcpRuntimeEventSink } from "./acp-runtime.js";
+import {
+  AgentDisconnectedError,
+  type AgentConfig,
+  type AgentRuntime,
+  type AgentSession,
+} from "./agent-runtime.js";
+import type { AgentSessionEntity } from "./entity.js";
+
+export interface AcpxKey {
+  readonly slotId: string;
+  readonly backend: "claude-code" | "codex" | "gemini";
+  readonly cwd: string;
+  readonly sessionName?: string | undefined;
+}
+
+export type AcpxPhase = "starting" | "running" | "resuming" | "dead";
+
+export interface AcpxRegistryEntry {
+  readonly key: AcpxKey;
+  handle: AcpRuntime;
+  readonly acpxRecordId: string;
+  session: AgentSession;
+  lastSeq: number;
+  lastRequestId?: string | undefined;
+  phase: AcpxPhase;
+  respawns: number;
+}
+
+export type AcpxRespawnEvent =
+  | { kind: "resuming"; key: AcpxKey; acpxRecordId: string; deadSessionId: string; respawns: number }
+  | { kind: "resumed"; key: AcpxKey; acpxRecordId: string; newSessionId: string; lastSeq: number }
+  | { kind: "dead"; key: AcpxKey; acpxRecordId: string; reason: string; respawns: number };
+
+export interface AcpxSupervisorOptions {
+  readonly runtimeFactory?: () => AcpRuntime;
+  readonly maxRespawns?: number | undefined;
+  readonly backoffBaseMs?: number | undefined;
+  readonly sleep?: ((ms: number) => Promise<void>) | undefined;
+  readonly mintRecordId?: (() => string) | undefined;
+}
+
+const DEFAULT_MAX_RESPAWNS = 5;
+const DEFAULT_BACKOFF_BASE_MS = 250;
+
+export class AcpxSupervisor implements AgentRuntime {
+  readonly sendsInitialPromptOnSpawn = true;
+
+  private readonly registry = new Map<string, AcpxRegistryEntry>();
+  private readonly inflight = new Map<string, Promise<AcpxRegistryEntry>>();
+  private readonly configs = new Map<string, AgentConfig>();
+  private readonly respawnListeners: ((e: AcpxRespawnEvent) => void)[] = [];
+  private readonly runtimeFactory: () => AcpRuntime;
+  private readonly maxRespawns: number;
+  private readonly backoffBaseMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly mintRecordId: () => string;
+  private downstreamSink: AcpRuntimeEventSink | undefined;
+  private counter = 0;
+
+  constructor(options: AcpxSupervisorOptions = {}) {
+    this.runtimeFactory = options.runtimeFactory ?? (() => new AcpRuntime());
+    this.maxRespawns = options.maxRespawns ?? DEFAULT_MAX_RESPAWNS;
+    this.backoffBaseMs = options.backoffBaseMs ?? DEFAULT_BACKOFF_BASE_MS;
+    this.sleep = options.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    this.mintRecordId = options.mintRecordId ?? (() => `acpx-rec-${this.counter++}`);
+  }
+
+  onRespawn(cb: (event: AcpxRespawnEvent) => void): void {
+    this.respawnListeners.push(cb);
+  }
+
+  private emit(event: AcpxRespawnEvent): void {
+    for (const l of this.respawnListeners) {
+      try {
+        l(event);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  async ensure(key: AcpxKey, config: AgentConfig): Promise<AcpxRegistryEntry> {
+    const existing = this.registry.get(key.slotId);
+    if (existing && existing.phase !== "dead") return existing;
+    const pending = this.inflight.get(key.slotId);
+    if (pending) return pending;
+    const promise = this.spawnEntry(key, config).finally(() => this.inflight.delete(key.slotId));
+    this.inflight.set(key.slotId, promise);
+    return promise;
+  }
+
+  private async spawnEntry(key: AcpxKey, config: AgentConfig): Promise<AcpxRegistryEntry> {
+    const handle = this.runtimeFactory();
+    const session = await handle.spawn(config.role, config);
+    const entry: AcpxRegistryEntry = {
+      key,
+      handle,
+      acpxRecordId: this.mintRecordId(),
+      session,
+      lastSeq: 0,
+      phase: "running",
+      respawns: 0,
+    };
+    this.registry.set(key.slotId, entry);
+    this.configs.set(key.slotId, config);
+    this.wireSink(entry);
+    this.attachDisconnect(entry);
+    return entry;
+  }
+
+  // seq stamping (Phase 3, Task 3.1) wraps the child sink here.
+  private wireSink(entry: AcpxRegistryEntry): void {
+    entry.handle.setAcpEventSink((event: AcpRuntimeEvent) => {
+      const seq = entry.lastSeq;
+      entry.lastSeq += 1;
+      this.downstreamSink?.({ ...event, seq });
+    });
+  }
+
+  private attachDisconnect(entry: AcpxRegistryEntry): void {
+    entry.handle.onDisconnect?.(entry.session, (err) => {
+      void this.handleDisconnect(entry, err);
+    });
+  }
+
+  // Respawn logic lands in Phase 3. For P2, a disconnect just marks the slot dead.
+  private async handleDisconnect(
+    entry: AcpxRegistryEntry,
+    _err: AgentDisconnectedError,
+  ): Promise<void> {
+    entry.phase = "dead";
+    this.emit({
+      kind: "dead",
+      key: entry.key,
+      acpxRecordId: entry.acpxRecordId,
+      reason: "disconnected",
+      respawns: entry.respawns,
+    });
+  }
+
+  get(slotId: string): AcpxRegistryEntry | undefined {
+    return this.registry.get(slotId);
+  }
+
+  list(): readonly AcpxRegistryEntry[] {
+    return [...this.registry.values()];
+  }
+
+  async stop(slotId: string, _reason: string): Promise<void> {
+    const entry = this.registry.get(slotId);
+    if (!entry) return;
+    this.registry.delete(slotId);
+    this.configs.delete(slotId);
+    await entry.handle.close(entry.session);
+  }
+
+  // --- AgentRuntime façade ---
+
+  private slotIdForSession(sessionId: string): string | undefined {
+    for (const [slotId, entry] of this.registry) {
+      if (entry.session.id === sessionId) return slotId;
+    }
+    return undefined;
+  }
+
+  setAcpEventSink(sink: AcpRuntimeEventSink | undefined): void {
+    this.downstreamSink = sink;
+  }
+
+  async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
+    const key: AcpxKey = {
+      slotId: `${role}-${this.counter++}`,
+      backend: platformToBackend(config.platform),
+      cwd: config.cwd,
+    };
+    const entry = await this.ensure(key, config);
+    return entry.session;
+  }
+
+  async send(session: AgentSession, message: string): Promise<AcpxTurn> {
+    const slotId = this.slotIdForSession(session.id);
+    const entry = slotId ? this.registry.get(slotId) : undefined;
+    if (!entry) throw new Error(`AcpxSupervisor.send: no slot for session ${session.id}`);
+    return entry.handle.send(entry.session, message);
+  }
+
+  async close(session: AgentSession): Promise<void> {
+    const slotId = this.slotIdForSession(session.id);
+    if (slotId) await this.stop(slotId, "close");
+  }
+
+  onIdle(session: AgentSession, callback: () => void): void {
+    const slotId = this.slotIdForSession(session.id);
+    const entry = slotId ? this.registry.get(slotId) : undefined;
+    entry?.handle.onIdle(entry.session, callback);
+  }
+
+  onDisconnect(session: AgentSession, callback: (err: AgentDisconnectedError) => void): void {
+    const slotId = this.slotIdForSession(session.id);
+    const entry = slotId ? this.registry.get(slotId) : undefined;
+    entry?.handle.onDisconnect?.(entry.session, callback);
+  }
+
+  async listSessions(): Promise<readonly AgentSession[]> {
+    return [...this.registry.values()].map((e) => e.session);
+  }
+
+  async listSessionEntities(): Promise<readonly AgentSessionEntity[]> {
+    const all = await Promise.all(
+      [...this.registry.values()].map((e) => e.handle.listSessionEntities()),
+    );
+    return all.flat();
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+}
+
+function platformToBackend(platform: AgentConfig["platform"]): AcpxKey["backend"] {
+  if (platform === "claude-code") return "claude-code";
+  if (platform === "gemini") return "gemini";
+  return "codex";
+}
+```
+
+> Note: `wireSink` references `entry.lastSeq` for seq (full respawn-continuity test lands in Task 3.x). It is included now so the sink is wired from the start; P2 tests don't assert seq yet.
+
+- [ ] **Step 4: Add optional `seq` to `AcpRuntimeEvent`**
+
+In `src/core/acp-runtime.ts`, add `readonly seq?: number | undefined;` to BOTH variants of the `AcpRuntimeEvent` union (the `"message"` and `"result"` objects, lines ~53-65). This lets the supervisor stamp seq without breaking existing sinks (field is optional).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test src/core/acpx-supervisor.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Add supervisor to the adapter matrix**
+
+Append to `src/core/runtime-adapter-matrix.test.ts` inside the describe, and add `import { AcpxSupervisor } from "./acpx-supervisor.js";`:
+
+```ts
+  runRuntimeAdapterMatrix(
+    "AcpxSupervisor",
+    () =>
+      new AcpxSupervisor({
+        runtimeFactory: () => new AcpRuntime({ launchOverride: makeInProcessLaunchOverride() }),
+      }),
+  );
+```
+
+Run: `bun test src/core/runtime-adapter-matrix.test.ts`
+Expected: PASS for Mock, Acp, AcpxSupervisor (#210 satisfied).
+
+- [ ] **Step 7: Typecheck + lint + commit**
+
+```bash
+bun run typecheck && bun run check
+git add src/core/acpx-supervisor.ts src/core/acpx-supervisor.test.ts src/core/runtime-adapter-matrix.test.ts src/core/acp-runtime.ts
+git commit -m "feat(runtime): AcpxSupervisor registry core + matrix row (#273)"
+```
+
+---
+
+## Phase 3 — Respawn + auto-resume + seq continuity
+
+**Seq mechanism (verified production path):** there is **no production caller of `publishTurnToNexus`**; agent output reaches consumers via `AcpRuntime.emitAcpEvent` → the eventSink set at `src/tui/spawn-manager.ts:297`. So the supervisor stamps `seq` in `wireSink` (Task 2.3) by wrapping each child's `setAcpEventSink`. Because `entry.lastSeq` lives on the registry entry and is carried across respawn, the sequence never resets. Phase 3 makes respawn real and proves seq continuity.
+
+### Task 3.1: `makeDisconnectableLaunchOverride` shared helper
+
+**Files:**
+- Modify: `src/core/acpx-test-support.ts`
+
+- [ ] **Step 1: Add the helper**
+
+Generalize Task 1.2's `makeDisconnectableAgent` into `src/core/acpx-test-support.ts`:
+
+```ts
+export function makeDisconnectableLaunchOverride(): {
+  launchOverride: LaunchOverride;
+  onTrigger: (cb: (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void) => void;
+};
+```
+
+It returns a `launchOverride` whose every spawned process registers an exit trigger, and `onTrigger(cb)` lets the test capture each trigger as runtimes are created (so the respawn tests can fire the Nth child's exit). The prompt handler never resolves (so a kill is the only way a turn ends).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/core/acpx-test-support.ts
+git commit -m "test(runtime): disconnectable launch override helper (#273)"
+```
+
+### Task 3.2: Respawn cycle + backoff + dead cap
+
+**Files:**
+- Modify: `src/core/acpx-supervisor.ts`
+- Create: `src/core/acpx-supervisor.respawn.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/acpx-supervisor.respawn.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { AcpRuntime } from "./acp-runtime.js";
+import { makeDisconnectableLaunchOverride } from "./acpx-test-support.js";
+import { AcpxSupervisor, type AcpxKey, type AcpxRespawnEvent } from "./acpx-supervisor.js";
+
+const key: AcpxKey = { slotId: "task-1", backend: "codex", cwd: process.cwd() };
+const cfg = { role: "coder", command: "codex", cwd: process.cwd() };
+
+function build(maxRespawns = 5) {
+  const triggers: Array<(info: { signal: NodeJS.Signals }) => void> = [];
+  const sup = new AcpxSupervisor({
+    maxRespawns,
+    backoffBaseMs: 0,
+    sleep: async () => {},
+    runtimeFactory: () => {
+      const { launchOverride, onTrigger } = makeDisconnectableLaunchOverride();
+      onTrigger((t) => triggers.push(t));
+      return new AcpRuntime({ launchOverride });
+    },
+  });
+  return { sup, triggers };
+}
+
+describe("AcpxSupervisor respawn", () => {
+  test("disconnect drives running -> resuming -> running with a fresh session", async () => {
+    const { sup, triggers } = build();
+    const events: AcpxRespawnEvent[] = [];
+    sup.onRespawn((e) => events.push(e));
+    const entry = await sup.ensure(key, cfg);
+    const firstSessionId = entry.session.id;
+
+    triggers[0]?.({ signal: "SIGKILL" });
+    await new Promise((r) => setTimeout(r, 30));
+
+    const after = sup.get(key.slotId);
+    expect(after?.phase).toBe("running");
+    expect(after?.session.id).not.toBe(firstSessionId);
+    expect(events.map((e) => e.kind)).toEqual(["resuming", "resumed"]);
+    await sup.stop(key.slotId, "cleanup");
+  });
+
+  test("lastSeq is preserved across respawn (no reset)", async () => {
+    const { sup, triggers } = build();
+    const entry = await sup.ensure(key, cfg);
+    entry.lastSeq = 42;
+    triggers[0]?.({ signal: "SIGKILL" });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(sup.get(key.slotId)?.lastSeq).toBe(42);
+    await sup.stop(key.slotId, "cleanup");
+  });
+
+  test("after maxRespawns the slot becomes dead", async () => {
+    const { sup, triggers } = build(2);
+    const events: AcpxRespawnEvent[] = [];
+    sup.onRespawn((e) => events.push(e));
+    await sup.ensure(key, cfg);
+    for (let i = 0; i < 3; i++) {
+      triggers[triggers.length - 1]?.({ signal: "SIGKILL" });
+      await new Promise((r) => setTimeout(r, 30));
+    }
+    expect(sup.get(key.slotId)?.phase).toBe("dead");
+    expect(events.some((e) => e.kind === "dead")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test src/core/acpx-supervisor.respawn.test.ts`
+Expected: FAIL — `handleDisconnect` only marks dead (no resume).
+
+- [ ] **Step 3: Implement respawn in `handleDisconnect`**
+
+Replace the P2 stub with:
+
+```ts
+  private async handleDisconnect(
+    entry: AcpxRegistryEntry,
+    _err: AgentDisconnectedError,
+  ): Promise<void> {
+    if (entry.phase !== "running") return;
+    const config = this.configs.get(entry.key.slotId);
+    if (!config) return;
+
+    entry.phase = "resuming";
+    this.emit({
+      kind: "resuming",
+      key: entry.key,
+      acpxRecordId: entry.acpxRecordId,
+      deadSessionId: entry.session.id,
+      respawns: entry.respawns,
+    });
+
+    try {
+      await entry.handle.close(entry.session);
+    } catch {
+      /* dead child; ignore */
+    }
+
+    if (entry.respawns >= this.maxRespawns) {
+      entry.phase = "dead";
+      this.emit({
+        kind: "dead",
+        key: entry.key,
+        acpxRecordId: entry.acpxRecordId,
+        reason: `exceeded maxRespawns=${this.maxRespawns}`,
+        respawns: entry.respawns,
+      });
+      return;
+    }
+
+    await this.sleep(this.backoffBaseMs * 2 ** entry.respawns);
+    entry.respawns += 1;
+
+    const handle = this.runtimeFactory();
+    const session = await handle.spawn(config.role, config);
+    // Carry durable identity + seq across the PID change; only the live
+    // handle and session are replaced. A fresh handle means a fresh
+    // session/new — the dead wireSessionId is never reused (#319).
+    entry.handle = handle;
+    entry.session = session;
+    entry.phase = "running";
+    this.wireSink(entry);
+    this.attachDisconnect(entry);
+    this.emit({
+      kind: "resumed",
+      key: entry.key,
+      acpxRecordId: entry.acpxRecordId,
+      newSessionId: session.id,
+      lastSeq: entry.lastSeq,
+    });
+  }
+```
+
+(Mutating `entry` in place keeps `lastSeq`/`acpxRecordId`/`respawns`; `wireSink` re-stamps from the preserved `lastSeq`.)
+
+- [ ] **Step 4: Run**
+
+Run: `bun test src/core/acpx-supervisor.respawn.test.ts`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Regression**
+
+Run: `bun test src/core/acpx-supervisor.test.ts src/core/runtime-adapter-matrix.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck + lint + commit**
+
+```bash
+bun run typecheck && bun run check
+git add src/core/acpx-supervisor.ts src/core/acpx-supervisor.respawn.test.ts
+git commit -m "feat(runtime): supervisor respawn + auto-resume + backoff (#273)"
+```
+
+### Task 3.3: Seq continuity across turns + respawn (eventSink)
+
+**Files:**
+- Test: `src/core/acpx-supervisor.respawn.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that installs a downstream sink via `sup.setAcpEventSink`, drives a turn that emits messages through the in-process agent (use `makeInProcessAgent` with an `onPrompt` that calls `agentSide.sessionUpdate(...)`), captures `event.seq`, then triggers a respawn and drives another turn — asserting seq is strictly increasing with **no reset** across the respawn boundary.
+
+```ts
+test("seq is monotonic across turns and respawns (eventSink)", async () => {
+  const seqs: number[] = [];
+  // build a supervisor whose runtimeFactory returns AcpRuntime over a
+  // disconnectable+promptable in-process agent; sup.setAcpEventSink((e) => { if (e.seq !== undefined) seqs.push(e.seq); });
+  // turn 1 emits 2 messages -> seq 0,1,2 (incl result event)
+  // trigger disconnect; await respawn
+  // turn 2 emits 1 message  -> seq continues (3,4...), never resets to 0
+  // expect(seqs).toEqual([...strictly increasing...]);
+});
+```
+
+Fill the body following Task 2.3's `wireSink` (every `AcpRuntimeEvent` forwarded carries an incrementing `seq`). The in-process agent helper must support both `onPrompt` emission and exit triggering — compose `makeInProcessAgent` handlers with the disconnect trigger, or extend `makeDisconnectableLaunchOverride` to accept an `onPrompt`.
+
+- [ ] **Step 2: Run to verify it fails, then confirm it passes**
+
+The `wireSink` from Task 2.3 already stamps seq; this test proves continuity. If it fails, the bug is that respawn replaces the entry's seq — verify `handleDisconnect` mutates in place (does not reset `lastSeq`).
+
+Run: `bun test src/core/acpx-supervisor.respawn.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/acpx-supervisor.respawn.test.ts
+git commit -m "test(runtime): seq continuity across turns + respawn (#273)"
+```
+
+---
+
+## Phase 4 — `SessionLost` condition on `AgentTask` + wiring
+
+### Task 4.1: New condition types
+
+**Files:**
+- Modify: `src/core/agent-task.ts`
+- Test: `src/core/agent-task.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { AgentTaskConditionType } from "./agent-task.js";
+test("AgentTaskConditionType includes Resuming and SessionLost", () => {
+  expect(AgentTaskConditionType.Resuming).toBe("Resuming");
+  expect(AgentTaskConditionType.SessionLost).toBe("SessionLost");
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test src/core/agent-task.test.ts`
+Expected: FAIL — properties undefined.
+
+- [ ] **Step 3: Add the types**
+
+In `src/core/agent-task.ts`, add to the `AgentTaskConditionType` const (after `DoneSignaled`, line ~26):
+
+```ts
+  Resuming: "Resuming",
+  SessionLost: "SessionLost",
+```
+
+- [ ] **Step 4: Run + commit**
+
+Run: `bun test src/core/agent-task.test.ts` → PASS.
+
+```bash
+git add src/core/agent-task.ts src/core/agent-task.test.ts
+git commit -m "feat(core): Resuming + SessionLost AgentTask conditions (#273)"
+```
+
+### Task 4.2: Export `upsertCondition` for reuse
+
+**Files:**
+- Modify: `src/core/task-controller.ts`
+
+- [ ] **Step 1:** Change `function upsertCondition(` (line ~500) to `export function upsertCondition(`. Run `bun test src/core/task-controller.test.ts` to confirm no regression.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/core/task-controller.ts
+git commit -m "refactor(core): export upsertCondition for reuse (#273)"
+```
+
+### Task 4.3: Wiring — respawn events → AgentTask conditions
+
+**Files:**
+- Create: `src/server/acpx-supervisor-wiring.ts`
+- Create: `src/server/acpx-supervisor-wiring.test.ts`
+
+Slot → task mapping: `slotId === task.spec.id`. The patch goes through `AgentTaskStore.patchAgentTaskStatus` (`task-controller.ts:144`), reusing the exported `upsertCondition`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/server/acpx-supervisor-wiring.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { AgentTaskConditionType } from "../core/agent-task.js";
+import type { AcpxRespawnEvent } from "../core/acpx-supervisor.js";
+import { wireSupervisorToTasks } from "./acpx-supervisor-wiring.js";
+
+function fakeStore() {
+  const patches: Array<{ id: string; patch: any }> = [];
+  return {
+    patches,
+    store: {
+      async patchAgentTaskStatus(id: string, patch: any) {
+        patches.push({ id, patch });
+      },
+      async getAgentTask(id: string) {
+        return {
+          spec: { id, generation: 1 },
+          status: { phase: "Running", conditions: [], observedGeneration: 1 },
+        };
+      },
+    },
+  };
+}
+
+function fakeSupervisor() {
+  const listeners: ((e: AcpxRespawnEvent) => void)[] = [];
+  return { onRespawn: (cb: (e: AcpxRespawnEvent) => void) => listeners.push(cb), fire: (e: AcpxRespawnEvent) => listeners.forEach((l) => l(e)) };
+}
+
+const baseKey = { slotId: "task-1", backend: "codex" as const, cwd: "." };
+
+describe("acpx supervisor → AgentTask wiring", () => {
+  test("resuming sets Resuming=True and keeps the task Running (no phase change)", async () => {
+    const { patches, store } = fakeStore();
+    const sup = fakeSupervisor();
+    wireSupervisorToTasks({ supervisor: sup, taskStore: store, now: () => 0 });
+    sup.fire({ kind: "resuming", key: baseKey, acpxRecordId: "r1", deadSessionId: "s0", respawns: 0 });
+    await new Promise((r) => setTimeout(r, 0));
+    const conds = patches[0]?.patch.conditions as Array<{ type: string; status: string }>;
+    expect(conds.some((c) => c.type === AgentTaskConditionType.Resuming && c.status === "True")).toBe(true);
+    expect(patches[0]?.patch.phase).toBeUndefined();
+  });
+
+  test("resumed sets SessionLost=True, clears Resuming, updates sessionId, keeps Running", async () => {
+    const { patches, store } = fakeStore();
+    const sup = fakeSupervisor();
+    wireSupervisorToTasks({ supervisor: sup, taskStore: store, now: () => 0 });
+    sup.fire({ kind: "resumed", key: baseKey, acpxRecordId: "r1", newSessionId: "s1", lastSeq: 7 });
+    await new Promise((r) => setTimeout(r, 0));
+    const p = patches[0]?.patch;
+    const conds = p.conditions as Array<{ type: string; status: string }>;
+    expect(conds.some((c) => c.type === AgentTaskConditionType.SessionLost && c.status === "True")).toBe(true);
+    expect(conds.some((c) => c.type === AgentTaskConditionType.Resuming && c.status === "False")).toBe(true);
+    expect(p.sessionId).toBe("s1");
+    expect(p.phase).toBeUndefined();
+  });
+
+  test("dead sets Failed and invokes onDead for lease release", async () => {
+    const { patches, store } = fakeStore();
+    const sup = fakeSupervisor();
+    const released: string[] = [];
+    wireSupervisorToTasks({ supervisor: sup, taskStore: store, now: () => 0, onDead: async (slotId) => { released.push(slotId); } });
+    sup.fire({ kind: "dead", key: baseKey, acpxRecordId: "r1", reason: "crash-loop", respawns: 5 });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(patches[0]?.patch.phase).toBe("Failed");
+    expect(released).toEqual(["task-1"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test src/server/acpx-supervisor-wiring.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the wiring**
+
+Create `src/server/acpx-supervisor-wiring.ts` exporting `wireSupervisorToTasks(deps)`:
+
+```ts
+import { AgentTaskConditionType } from "../core/agent-task.js";
+import type { AcpxRespawnEvent } from "../core/acpx-supervisor.js";
+import { AgentTaskPhase } from "../core/agent-task.js";
+import type { AgentTaskStore } from "../core/store.js";
+import { upsertCondition } from "../core/task-controller.js";
+
+export interface SupervisorTaskWiringDeps {
+  readonly supervisor: { onRespawn(cb: (e: AcpxRespawnEvent) => void): void };
+  readonly taskStore: Pick<AgentTaskStore, "patchAgentTaskStatus" | "getAgentTask">;
+  readonly now?: () => number;
+  readonly onDead?: (slotId: string) => Promise<void>;
+}
+
+export function wireSupervisorToTasks(deps: SupervisorTaskWiringDeps): void {
+  const now = deps.now ?? Date.now;
+  deps.supervisor.onRespawn((event) => {
+    void handle(event).catch(() => {
+      /* fire-and-forget; controller resync is the backstop */
+    });
+  });
+
+  async function handle(event: AcpxRespawnEvent): Promise<void> {
+    const slotId = event.key.slotId;
+    const task = await deps.taskStore.getAgentTask(slotId);
+    if (!task) return;
+    const gen = task.spec.generation;
+    const ts = new Date(now()).toISOString();
+    let conditions = task.status.conditions;
+
+    if (event.kind === "resuming") {
+      conditions = upsertCondition(conditions, {
+        type: AgentTaskConditionType.Resuming,
+        status: "True",
+        observedGeneration: gen,
+        lastTransitionTime: ts,
+        reason: "acpx-disconnected",
+        message: `respawn #${event.respawns + 1}`,
+      });
+      await deps.taskStore.patchAgentTaskStatus(slotId, { conditions });
+      return;
+    }
+
+    if (event.kind === "resumed") {
+      conditions = upsertCondition(
+        upsertCondition(conditions, {
+          type: AgentTaskConditionType.Resuming,
+          status: "False",
+          observedGeneration: gen,
+          lastTransitionTime: ts,
+          reason: "respawned",
+          message: "",
+        }),
+        {
+          type: AgentTaskConditionType.SessionLost,
+          status: "True",
+          observedGeneration: gen,
+          lastTransitionTime: ts,
+          reason: "respawned",
+          message: `new session ${event.newSessionId}`,
+        },
+      );
+      await deps.taskStore.patchAgentTaskStatus(slotId, {
+        conditions,
+        sessionId: event.newSessionId,
+      });
+      return;
+    }
+
+    // event.kind === "dead"
+    conditions = upsertCondition(
+      upsertCondition(conditions, {
+        type: AgentTaskConditionType.Running,
+        status: "False",
+        observedGeneration: gen,
+        lastTransitionTime: ts,
+        reason: "session-lost",
+        message: event.reason,
+      }),
+      {
+        type: AgentTaskConditionType.Failed,
+        status: "True",
+        observedGeneration: gen,
+        lastTransitionTime: ts,
+        reason: "session-lost",
+        message: event.reason,
+      },
+    );
+    await deps.taskStore.patchAgentTaskStatus(slotId, {
+      phase: AgentTaskPhase.Failed,
+      conditions,
+      lastTransitionAt: ts,
+    });
+    await deps.onDead?.(slotId);
+  }
+}
+```
+
+- [ ] **Step 4: Run + typecheck + lint + commit**
+
+Run: `bun test src/server/acpx-supervisor-wiring.test.ts` → PASS.
+
+```bash
+bun run typecheck && bun run check
+git add src/server/acpx-supervisor-wiring.ts src/server/acpx-supervisor-wiring.test.ts
+git commit -m "feat(server): wire supervisor respawn events to AgentTask conditions (#273)"
+```
+
+---
+
+## Phase 5 — Adoption in `selectRuntime` + real-process E2E
+
+### Task 5.1: Adopt the supervisor behind `GROVE_SUPERVISOR`
+
+**Files:**
+- Modify: `src/core/select-runtime.ts`
+- Test: `src/core/select-runtime.test.ts` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/select-runtime.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { AcpxSupervisor } from "./acpx-supervisor.js";
+import { selectRuntime } from "./select-runtime.js";
+
+describe("selectRuntime supervisor flag", () => {
+  test("GROVE_SUPERVISOR=1 wraps the runtime in AcpxSupervisor", () => {
+    const rt = selectRuntime({ env: { GROVE_RUNTIME: "acp" }, supervisorEnv: { GROVE_SUPERVISOR: "1" } });
+    expect(rt).toBeInstanceOf(AcpxSupervisor);
+  });
+
+  test("default (flag unset) returns a bare AcpRuntime", () => {
+    const rt = selectRuntime({ env: { GROVE_RUNTIME: "acp" }, supervisorEnv: {} });
+    expect(rt).not.toBeInstanceOf(AcpxSupervisor);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test src/core/select-runtime.test.ts`
+Expected: FAIL — no wrapping; `supervisorEnv` unknown.
+
+- [ ] **Step 3: Implement**
+
+In `src/core/select-runtime.ts`: add `readonly supervisorEnv?: { readonly GROVE_SUPERVISOR?: string | undefined };` to `SelectRuntimeOptions`. After constructing the `AcpRuntime`, wrap it when the flag is set:
+
+```ts
+export function selectRuntime(options: SelectRuntimeOptions = {}): AgentRuntime {
+  const flag = options.env?.GROVE_RUNTIME ?? process.env.GROVE_RUNTIME;
+  const normalized = flag?.trim().toLowerCase();
+  if (normalized === undefined || normalized === "" || normalized === "acp") {
+    const supervisorFlag =
+      options.supervisorEnv?.GROVE_SUPERVISOR ?? process.env.GROVE_SUPERVISOR;
+    if (supervisorFlag === "1") {
+      return new AcpxSupervisor({ runtimeFactory: () => new AcpRuntime(options.acp) });
+    }
+    return new AcpRuntime(options.acp);
+  }
+  throw new Error(
+    `[select-runtime] GROVE_RUNTIME=${flag} no longer supported; only "acp" is valid`,
+  );
+}
+```
+
+Add `import { AcpxSupervisor } from "./acpx-supervisor.js";`. Default behavior (flag unset) is unchanged — escape hatch for one release, mirroring the `GROVE_RUNTIME` cutover.
+
+- [ ] **Step 4: Run + commit**
+
+Run: `bun test src/core/select-runtime.test.ts` → PASS.
+
+```bash
+git add src/core/select-runtime.ts src/core/select-runtime.test.ts
+git commit -m "feat(runtime): adopt AcpxSupervisor behind GROVE_SUPERVISOR flag (#273)"
+```
+
+### Task 5.2: Verify eventSink re-wrap + wire respawn→task in the server
+
+**Files:**
+- Read: `src/tui/spawn-manager.ts:293-300` (production `setAcpEventSink` wiring)
+- Read: `src/server/task-controller-wiring.ts` (where `selectRuntime` feeds the TaskController)
+- Modify: `src/server/task-controller-wiring.ts` (call `wireSupervisorToTasks` when the runtime is a supervisor)
+
+**Note on drains:** `publishTurnToNexus` has no production caller; `SessionOrchestrator.watchTurn` only awaits `turn.result` (it does **not** drain `messages`). So there is **no double-drain risk** — the single production event path is the eventSink. The only requirement is that when the runtime is a supervisor, its `setAcpEventSink` (Task 2.3) is the one spawn-manager calls, so seq stamping is active. Confirm with a test.
+
+- [ ] **Step 1: Confirm spawn-manager wiring works through the façade**
+
+`spawn-manager.ts:296` checks `typeof runtime.setAcpEventSink === "function"`. The supervisor implements it (Task 2.3). Add a test in `src/core/acpx-supervisor.test.ts` asserting that after `sup.setAcpEventSink(sink)`, events emitted by a child reach `sink` **with a `seq`** field.
+
+- [ ] **Step 2: Wire respawn → AgentTask in the server**
+
+In `src/server/task-controller-wiring.ts`, after `selectRuntime(...)` returns the runtime, if it is an `AcpxSupervisor` (`instanceof`), call `wireSupervisorToTasks({ supervisor: runtime, taskStore, onDead: (slotId) => releaseLeasesForTask(slotId) })`. Use the existing claim/lease release path (`ClaimStore.release`, `store.ts:360`) for `onDead`. Add a focused test with a fake store + fake supervisor asserting the wiring is registered.
+
+- [ ] **Step 3: Run + commit**
+
+Run: `bun test src/core/acpx-supervisor.test.ts src/server/`
+Expected: PASS.
+
+```bash
+bun run typecheck && bun run check
+git add src/server/task-controller-wiring.ts src/core/acpx-supervisor.test.ts src/server/*.test.ts
+git commit -m "feat(server): activate supervisor seq sink + respawn→task wiring (#273)"
+```
+
+### Task 5.3: Real-process kill-PID E2E
+
+**Files:**
+- Create: `tests/e2e/acpx-supervisor-respawn-tmux.ts`
+
+**Pattern:** follow an existing real-process E2E under `tests/e2e/`. Launch via `grove up` (NOT `nexus up`); validate against Nexus stores (NOT local SQLite); no manual `send-keys`. Per project memory: fresh temp dir + `git init` per run (avoids stale-session IPC stall).
+
+- [ ] **Step 1: Write the E2E script**
+
+Concrete outline (no placeholders):
+1. Fresh temp dir + `git init`; `GROVE_SUPERVISOR=1`; `grove up` with one agent task.
+2. Resolve the agent's acpx child PID (from the process tree of the grove-managed runtime / the supervisor's `list()` session).
+3. `kill -9 <pid>`.
+4. Poll the Nexus `AgentTask` entity (HTTP API / watch) until a `SessionLost=True` condition appears AND `phase` stays `Running` (not `Failed`), within `maxRespawns × backoff`.
+5. Assert a new session id is bound (respawn happened) and the agent produces a subsequent contribution (continues working).
+6. Read the agent event stream; assert `seq` is monotonic with **no reset** across the kill boundary.
+7. `grove down`; clean temp dir.
+
+- [ ] **Step 2: Run the E2E**
+
+Run: `GROVE_INTEGRATION=1 bun tests/e2e/acpx-supervisor-respawn-tmux.ts`
+Expected: PASS — respawn within backoff; `SessionLost` visible on the task; monotonic seq; agent continues.
+
+> If blocked by a known infra issue (e.g. Nexus IPC brick regression — project memory), pin the working image ref + note it in the script header. Do NOT claim the E2E passed without the real run (`feedback_no_workarounds`, `feedback_e2e_use_nexus`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/acpx-supervisor-respawn-tmux.ts
+git commit -m "test(e2e): kill-PID respawn + SessionLost under grove up (#273)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full suite:** `bun test --timeout 60000` → all green.
+- [ ] **Typecheck:** `bun run typecheck` → clean.
+- [ ] **Lint:** `bun run check` → clean.
+- [ ] **Matrix (#210):** `bun test src/core/runtime-adapter-matrix.test.ts` → Mock + Acp + Supervisor green.
+- [ ] **Spec coverage:** P1–P5 each map to tasks above; OQ2 (adoption, in scope) delivered by Task 5.1–5.3.
+- [ ] **superpowers:requesting-code-review**, then **superpowers:finishing-a-development-branch** to open the PR referencing #273.
+
+## Notes / risks (carried from the spec, corrected against the code)
+
+- **Seq lives at the eventSink**, not `publishTurnToNexus` (which has no production caller). The supervisor wraps each child's `setAcpEventSink`; `entry.lastSeq` survives respawn because `handleDisconnect` mutates the entry in place.
+- **No double-drain risk:** `watchTurn` only awaits `result`; nothing else drains `messages` in production. Task 5.2 verifies the supervisor sink is the active one through `spawn-manager`.
+- **`wireSessionId` reuse prevented:** each respawn calls `runtimeFactory()` → a brand-new `AcpRuntime` → fresh `session/new`.
+- **`reconcileRunning` race** (`task-controller.ts:312`): respawn-aware `listSessions()` (the entry's live session) + the `Resuming` condition keep the controller from prematurely calling `failLostSession()`. If the TaskController runs in the E2E, assert the task stays `Running` through a respawn.
+- **Open implementation question (resolve in P5):** confirm exactly how agent events reach the durable Nexus stream so the E2E's "monotonic seq" assertion observes the supervisor-stamped `seq` (trace the live eventSink → store/EventBus path; `publishTurnToNexus` appears dead). Surface findings in the PR.
+- **Orphan reaping** across grove restarts is out of scope (design OQ4).
+```

--- a/docs/superpowers/plans/2026-05-29-acpx-supervisor.md
+++ b/docs/superpowers/plans/2026-05-29-acpx-supervisor.md
@@ -1021,15 +1021,16 @@ Replace the P2 stub with:
     await this.sleep(this.backoffBaseMs * 2 ** entry.respawns);
     entry.respawns += 1;
 
-    const handle = this.runtimeFactory();
-    const session = await handle.spawn(config.role, config);
-    // Carry durable identity + seq across the PID change; only the live
-    // handle and session are replaced. A fresh handle means a fresh
-    // session/new — the dead wireSessionId is never reused (#319).
-    entry.handle = handle;
+    // Respawn WITHIN the shared runtime (Phase 2 adopted one shared AcpRuntime
+    // for all slots — see the design doc's "Implementation note"). A fresh
+    // sharedRuntime.spawn() does a fresh session/new ⇒ a NEW wireSessionId,
+    // never the dead one (#319). The handle stays `this.sharedRuntime`; only
+    // entry.session is replaced. routeEvent() demuxes events by the new
+    // session id, so seq stamping continues from the preserved entry.lastSeq
+    // with no reset. Re-register onDisconnect for the new session.
+    const session = await this.sharedRuntime.spawn(config.role, config);
     entry.session = session;
     entry.phase = "running";
-    this.wireSink(entry);
     this.attachDisconnect(entry);
     this.emit({
       kind: "resumed",
@@ -1041,7 +1042,7 @@ Replace the P2 stub with:
   }
 ```
 
-(Mutating `entry` in place keeps `lastSeq`/`acpxRecordId`/`respawns`; `wireSink` re-stamps from the preserved `lastSeq`.)
+(Mutating `entry` in place keeps `lastSeq`/`acpxRecordId`/`respawns`. There is NO `entry.handle` swap and NO `wireSink` call — the shared runtime's single sink + `routeEvent`/`entryForSession` already re-stamp seq for the new session id from the preserved `entry.lastSeq`.)
 
 - [ ] **Step 4: Run**
 
@@ -1499,7 +1500,7 @@ git commit -m "test(e2e): kill-PID respawn + SessionLost under grove up (#273)"
 
 - **Seq lives at the eventSink**, not `publishTurnToNexus` (which has no production caller). The supervisor wraps each child's `setAcpEventSink`; `entry.lastSeq` survives respawn because `handleDisconnect` mutates the entry in place.
 - **No double-drain risk:** `watchTurn` only awaits `result`; nothing else drains `messages` in production. Task 5.2 verifies the supervisor sink is the active one through `spawn-manager`.
-- **`wireSessionId` reuse prevented:** each respawn calls `runtimeFactory()` → a brand-new `AcpRuntime` → fresh `session/new`.
+- **`wireSessionId` reuse prevented:** each respawn calls `sharedRuntime.spawn()` → a fresh `session/new` ⇒ a new `wireSessionId`, never the dead one (the shared runtime learns a distinct wire id per spawn).
 - **`reconcileRunning` race** (`task-controller.ts:312`): respawn-aware `listSessions()` (the entry's live session) + the `Resuming` condition keep the controller from prematurely calling `failLostSession()`. If the TaskController runs in the E2E, assert the task stays `Running` through a respawn.
 - **Open implementation question (resolve in P5):** confirm exactly how agent events reach the durable Nexus stream so the E2E's "monotonic seq" assertion observes the supervisor-stamped `seq` (trace the live eventSink → store/EventBus path; `publishTurnToNexus` appears dead). Surface findings in the PR.
 - **Orphan reaping** across grove restarts is out of scope (design OQ4).

--- a/docs/superpowers/specs/2026-05-29-acpx-supervisor-design.md
+++ b/docs/superpowers/specs/2026-05-29-acpx-supervisor-design.md
@@ -213,7 +213,7 @@ Dependency order: **P1 → P2 → P3 → P4 → P5.** P4 can start once P2 lands
 ## Open questions (for review)
 
 - **OQ1 — slot key source.** Confirm `AgentTask.spec.id` as the canonical `slotId` from `TaskController`, and the `grove-<role>-<n>` form from `SessionOrchestrator`. A role working N independent tasks ⇒ N slots/processes — confirm that's intended.
-- **OQ2 — orchestrator adoption scope.** Is P5 (making `SessionOrchestrator`/`TaskController` actually spawn through the supervisor) part of #273, or a follow-up once P1–P4 land behind the runtime seam?
+- **OQ2 — orchestrator adoption scope.** *Resolved 2026-05-29: in scope for #273.* P5 (making `SessionOrchestrator`/`TaskController` spawn through the supervisor) ships as part of this work, proven by the kill-PID E2E.
 - **OQ3 — `seq` placement.** Stamp `seq` in the payload of every `acp.message`/`acp.result`, or only at turn boundaries? (Plan assumes per-event.) Confirm consumers want per-event seq now vs. forward-compat only.
 - **OQ4 — registry persistence / orphan reaping** across grove restarts: in scope later, or rely on lease expiry + manual reap? (Plan defers.)
 - **OQ5 — feature flag.** Gate adoption behind a `GROVE_SUPERVISOR=1`-style flag for one release (mirroring the `GROVE_RUNTIME` cutover), defaulting off until the E2E is green?

--- a/docs/superpowers/specs/2026-05-29-acpx-supervisor-design.md
+++ b/docs/superpowers/specs/2026-05-29-acpx-supervisor-design.md
@@ -91,6 +91,8 @@ These were confirmed by reading the source, not the issue text. Several issue re
 
 The supervisor is **runtime-level and decoupled**: it knows about processes, slots, turns, and seq — not about claims, tasks, or conditions. It emits typed respawn-lifecycle events; the wiring layer translates those into `AgentTask` conditions and lease releases. This keeps the supervisor unit-testable with zero store dependencies and puts `SessionLost` where grove actually stores conditions.
 
+> **Implementation note (2026-05-29, Phase 2):** The supervisor owns **one shared `AcpRuntime`** for all slots, not a separate `AcpRuntime` per slot. Rationale: grove's current `AcpRuntime` is the in-process ACP *client* that already spawns one **agent-adapter subprocess per `spawn()` call** — so process-per-slot isolation (the issue's actual intent) is preserved even with a shared client object, exactly as `SessionOrchestrator` already shares one runtime across many agents. A shared runtime also gives a single, naturally-monotonic session-id counter (two fresh `AcpRuntime`s both start at 0 and collide on same-role/same-ms ids) and a single event sink the supervisor demuxes by `sessionId` to stamp per-slot `seq`. `AcpxRegistryEntry.handle` therefore points at the shared runtime; respawn (Phase 3) replaces the slot's **session** via `sharedRuntime.spawn()` again (a fresh `session/new` ⇒ new `wireSessionId`, never the dead one), not the runtime object. This satisfies the issue's "don't share one acpx instance across slots" at the level that matters — each slot still drives its own adapter child process.
+
 ### Types (new `src/core/acpx-supervisor.ts`)
 
 ```ts

--- a/docs/superpowers/specs/2026-05-29-acpx-supervisor-design.md
+++ b/docs/superpowers/specs/2026-05-29-acpx-supervisor-design.md
@@ -1,0 +1,219 @@
+# Design: AcpxRuntime Supervisor Registry (respawn + auto-resume)
+
+**Date:** 2026-05-29
+**Issue:** [windoliver/grove#273](https://github.com/windoliver/grove/issues/273) — `feat(runtime): AcpxRuntime supervisor registry with respawn + auto-resume`
+**Related:** [#210](https://github.com/windoliver/grove/issues/210) runtime adapter tests (supervisor is asserted against) · [#261](https://github.com/windoliver/grove/issues/261) typed `AcpxTurn` (supervisor feeds the typed stream) · [#319](https://github.com/windoliver/grove/issues/319) wire-session binding · [grove-direct-acp-runtime](2026-04-21-grove-direct-acp-runtime-design.md) (the `AcpRuntime` this wraps) · [tui-agent-supervision-hero](2026-05-18-tui-agent-supervision-hero-design.md) (#193, consumes health/respawn signals)
+**Status:** Draft — awaiting user review
+
+---
+
+## Problem
+
+Grove spawns one acpx child per agent and tracks its lifecycle ad-hoc. When a child dies, nothing detects it as a *recoverable* event: the process just stops emitting, the bound work unit eventually trips a "session lost → Failed" path, and any lease the agent held sits stranded until it expires. acpx exposes no server-side `session/list`, so grove cannot ask "what processes should be alive?" — it must own that inventory itself.
+
+We want a **supervisor**: a grove-owned registry of single-child runtime handles keyed by a stable logical slot, with three guarantees:
+
+1. **Detect** an unexpected child death as a typed, observable event (today it is a silent log line).
+2. **Respawn** the child under the same logical identity and continue the event sequence so downstream consumers (Nexus, TUI) do not replay or duplicate events.
+3. **Surface** the loss as a condition on the affected work unit instead of letting it strand — and only give up (and release leases) after a bounded retry budget.
+
+---
+
+## Current state (verified against the worktree)
+
+These were confirmed by reading the source, not the issue text. Several issue references describe an *intended* shape that does not exist yet; those deltas are called out in **Issue ↔ reality** below.
+
+- **`src/core/agent-runtime.ts`** — `AgentRuntime` interface: `spawn(role, config) → AgentSession`, `send(session, msg) → AcpxTurn`, `close(session)`, `onIdle(session, cb)`, `listSessions()`, `listSessionEntities()`, `isAvailable()`, and a `sendsInitialPromptOnSpawn` flag. `AgentSession.status` is `"running" | "idle" | "stopped" | "crashed"`.
+- **`src/core/acp-runtime.ts`** — `AcpRuntime implements AgentRuntime`. One instance owns **many** children via a private `sessions: Map`. Each child is created by `launchSubprocess()` (`nodeSpawn`, line ~387). The only exit handling is in `dispose()` (intentional teardown, lines ~472–500) via `waitForChildExit`; there is **no listener that fires on *unexpected* exit**, marks the session crashed, or rejects an in-flight `send()`. `AgentDisconnectedError` does not exist anywhere in the codebase. A turn that ends with `stopReason === "error"` flips the session to `crashed` (line ~862), but a hard PID death mid-turn is not surfaced — the turn can hang.
+- **`src/acp/types.ts`** — `AcpxTurn { sessionId; turnId; messages: AsyncIterable<Message>; result: Promise<Result>; cancel(); close() }`. `wireSessionId` (the acpx-internal UUID) is learned from the `session/new` handshake (#319) and is unique per process — a respawn MUST re-learn it and never reuse a dead child's binding.
+- **`src/nexus/nexus-agent-publisher.ts`** — `publishTurnToNexus(opts)` drains `opts.messages`, emits one `acp.message` per `Message` and a terminal `acp.result`, returns `PublishResult[]`. **There is no sequence number.** Ordering is implicit in iteration order; there is no `seq`/`startSeq` parameter and nothing persists a per-session counter across turns. A re-drain of the same turn would double-publish.
+- **`src/core/task-controller.ts`** — a Kubernetes-style reconciler. `DefaultTaskBinder.bind()` is the thing that calls `runtime.spawn()` for an `AgentTask`. `reconcileRunning()` calls `runtime.listSessions()` and, if the bound session is absent or not `running`/`idle`, runs `failLostSession()` → sets `Running=False` + `Failed=True` conditions with `reason: "session-lost"` and moves the task to `phase: Failed`. **This is the real "session lost" surface today, and it is terminal — there is no respawn.**
+- **`src/core/agent-task.ts`** — the durable agent-work entity. `AgentTaskStatusRecord` carries a real **stored** `conditions: Condition[]` array (unlike Claims, whose conditions are projected read-side). `AgentTaskConditionType` = `Admitted | Scheduled | Bound | Running | AwaitingReview | Succeeded | Failed | Blocked | Unschedulable | PermitRequired | DoneSignaled`. There is **no `SessionLost` / `Resuming`** type yet. `AgentTaskPhase` = `Pending | PendingBind | Running | AwaitingReview | Succeeded | Failed`.
+- **Two spawn paths** both go through the `AgentRuntime` interface: the older `SessionOrchestrator.spawnAgent()` (per role) and the newer `TaskController` / `DefaultTaskBinder` (per `AgentTask`). Anything that decorates `AgentRuntime` is transparent to both.
+- **Tests** — `bun test` (bun:test, co-located `*.test.ts`); integration `GROVE_INTEGRATION`/`NEXUS_URL`-gated `*.integration.test.ts`; real-process E2E via `grove up` (never `nexus up` directly — see project memory). No shared "runtime adapter matrix" harness exists yet; the closest runtime tests are `mock-runtime.test.ts`, `acp-runtime.test.ts`, `acp-runtime.spawn.test.ts`, `acp-runtime.integration.test.ts`. `docs/parity-matrix.md` is capability parity, not a runtime-adapter conformance suite.
+
+### Issue ↔ reality deltas (resolved in this design)
+
+| Issue says | Reality | Resolution |
+|---|---|---|
+| `handle: AcpxRuntime` | class is `AcpRuntime` | Registry holds `AcpRuntime`; "Acpx" kept only in supervisor type names. |
+| key includes `slotId` (a grove "slot") | grove has no agent "slot" concept (slots = gossip capacity / TUI insertion points) | `slotId` = a **caller-supplied stable logical key** (recommend the `AgentTask` id where available, else a session-role key). The supervisor treats it as opaque; it only requires stability across respawn. |
+| `acpxRecordId` "durable key, survives PID changes" via `session/load` | acpx has no server-side session record; grove-direct-acp **defers `session/load`** (fresh session per spawn) | `acpxRecordId` = **grove-minted UUID**, 1:1 with `slotId`, stable across PID changes, used as the durable handle in logs/events. No `session/load`. |
+| step 3 "Attempt `session/load` via `acpxRecordId`" | not wired; explicitly deferred upstream + in grove-direct-acp | **Respawn-as-new.** Every respawn is a fresh `session/new`; conversation state is not restored. Forward-compatible: `acpxRecordId` + seq survive if `session/load` ever lands. |
+| step 4 "mark `conditions:[{type:SessionLost…}]` on the **claim**" | Claims have no stored conditions; the real stored-condition surface is **`AgentTask`** | Add a `SessionLost` (and `Resuming`) condition to `AgentTaskConditionType` and set it on the `AgentTask`. Stranded *leases* are released only on permanent death (see Phase 4). |
+| `lastSeq` "consumers dedup via `seq`" | no seq exists anywhere | Supervisor introduces and owns a monotonic per-slot `seq`, threaded into the publisher (Phase 3). Until `session/load` exists it is ordering/boundary-marking only; the field is kept for forward-compat. |
+| "#210 tests assert against the supervisor" | no adapter-matrix harness exists | Phase 2 **creates** a small shared `runRuntimeAdapterMatrix(label, factory)` and runs `MockRuntime`, `AcpRuntime`, and `AcpxSupervisor` through it — delivering #210 as part of this work. |
+
+---
+
+## Decisions (locked; user delegated all five to "whatever you recommend")
+
+| # | Question | Decision & rationale |
+|---|---|---|
+| D1 | Deliverable | **Design doc → plan → implement (TDD), staged into sub-issues.** The work is ahead of current code in five load-bearing ways and touches the runtime hot path; a reviewed spec first is cheaper than reworking an implementation. Matches the user's `design-review → per-phase issues` preference. |
+| D2 | What is a "slot"? | **`slotId` = caller-supplied stable logical key** (opaque to the supervisor). Recommended value: `AgentTask.spec.id` via `TaskController`, or a `grove-<role>-<n>` session-role key via `SessionOrchestrator`. `acpxRecordId` = supervisor-minted durable UUID, 1:1 with the slot, surviving PID changes. |
+| D3 | Ownership model | **Supervisor decorates `AgentRuntime`; one single-child `AcpRuntime` per slot.** The supervisor constructs `new AcpRuntime()` per entry and calls `spawn` on it exactly once → effectively one process per slot, honoring "don't share one instance across slots." `AcpRuntime` internals are left intact (it merely gains a disconnect callback). The decorator multiplexes the `AgentRuntime` interface across entries, so it is a drop-in for both spawn paths and for #210. |
+| D4 | Resume semantics | **Respawn-as-new + always surface `SessionLost`.** No `session/load` (consistent with grove-direct-acp). `seq` continues monotonically across the respawn boundary so downstream ordering is unbroken. |
+| D5 | `SessionLost` surface | **On the `AgentTask`**, via a new `SessionLost` condition (and a transient `Resuming` condition), set by the **wiring layer** in response to a supervisor-emitted respawn event — the supervisor itself stays decoupled from claims/tasks. Stranded leases are proactively released only when the slot is permanently `dead`. |
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ grove process                                                         │
+│                                                                      │
+│  SessionOrchestrator.spawnAgent ─┐                                   │
+│  TaskController / DefaultBinder ─┤ both call the AgentRuntime API    │
+│                                  ▼                                   │
+│                       ┌───────────────────────────┐                 │
+│                       │ AcpxSupervisor            │ implements      │
+│                       │  (AgentRuntime decorator) │ AgentRuntime    │
+│                       │                           │                 │
+│                       │  registry: Map<slotId,    │                 │
+│                       │            AcpxRegistryEntry>               │
+│                       │  ensure / get / stop / list                 │
+│                       │  onRespawn(cb)  ──────────┼──► wiring layer  │
+│                       └───────────┬───────────────┘   (sets         │
+│                                   │ one entry per slot  SessionLost  │
+│                                   ▼                     on AgentTask)│
+│            ┌──────────────────────┴───────────────────┐            │
+│            │ AcpRuntime (single child)  × N slots      │            │
+│            │   child ⇄ ClientSideConnection ⇄ AcpxTurn │            │
+│            │   onDisconnect(cb)  ◄── NEW death seam     │            │
+│            └──────────────────────┬───────────────────┘            │
+│                                   │ send() turn drained once by      │
+│                                   ▼ supervisor, seq threaded         │
+│                          publishTurnToNexus(startSeq) ──► EventBus    │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The supervisor is **runtime-level and decoupled**: it knows about processes, slots, turns, and seq — not about claims, tasks, or conditions. It emits typed respawn-lifecycle events; the wiring layer translates those into `AgentTask` conditions and lease releases. This keeps the supervisor unit-testable with zero store dependencies and puts `SessionLost` where grove actually stores conditions.
+
+### Types (new `src/core/acpx-supervisor.ts`)
+
+```ts
+export interface AcpxKey {
+  readonly slotId: string;                 // caller-supplied, stable across respawn
+  readonly backend: "claude-code" | "codex" | "gemini";
+  readonly cwd: string;
+  readonly sessionName?: string | undefined;
+}
+
+export type AcpxPhase = "starting" | "running" | "resuming" | "dead";
+
+export interface AcpxRegistryEntry {
+  readonly key: AcpxKey;
+  readonly handle: AcpRuntime;             // owns exactly one child
+  readonly acpxRecordId: string;           // supervisor-minted; survives PID changes
+  session: AgentSession;                    // current live session (new id per respawn)
+  lastSeq: number;                          // monotonic; threaded into the publisher
+  lastRequestId?: string | undefined;
+  phase: AcpxPhase;
+  respawns: number;                         // crash-loop budget counter
+}
+
+export type AcpxRespawnEvent =
+  | { kind: "resuming"; key: AcpxKey; acpxRecordId: string; deadSessionId: string; respawns: number }
+  | { kind: "resumed";  key: AcpxKey; acpxRecordId: string; newSessionId: string; lastSeq: number }
+  | { kind: "dead";     key: AcpxKey; acpxRecordId: string; reason: string; respawns: number };
+
+export interface AcpxSupervisor extends AgentRuntime {
+  ensure(key: AcpxKey, config: AgentConfig): Promise<AcpxRegistryEntry>;
+  get(slotId: string): AcpxRegistryEntry | undefined;
+  stop(slotId: string, reason: string): Promise<void>;
+  list(): readonly AcpxRegistryEntry[];
+  onRespawn(cb: (event: AcpxRespawnEvent) => void): void;
+}
+```
+
+`extends AgentRuntime` is the decorator façade: `spawn → ensure`, `send → route to the slot's handle`, `close → stop`, `listSessions → list().map(e => e.session)`, `onIdle → delegate to the slot's handle`, `isAvailable → true`. `listSessions()` is **respawn-aware**: during `resuming` it reports the most recent live session, so `TaskController.reconcileRunning` does not spuriously trip `failLostSession`.
+
+### Death-detection seam (in `AcpRuntime`)
+
+```ts
+// agent-runtime.ts (or core/errors.ts)
+export class AgentDisconnectedError extends Error {
+  constructor(readonly info: {
+    sessionId: string; role: string;
+    exitCode?: number | null; signal?: NodeJS.Signals | null;
+    lastRequestId?: string;
+  }) { super(`agent ${info.role} (${info.sessionId}) disconnected`); }
+}
+
+// AgentRuntime gains an optional hook (no-op default on other runtimes):
+onDisconnect?(session: AgentSession, cb: (err: AgentDisconnectedError) => void): void;
+```
+
+In `AcpRuntime`, attach a child `"exit"` / connection-EOF listener that, **only when the session was not intentionally `close()`d**, marks the session `crashed`, rejects any in-flight `send()` with `AgentDisconnectedError`, and invokes registered `onDisconnect` callbacks exactly once. Intentional `dispose()`/`close()` must not fire it.
+
+---
+
+## Respawn + auto-resume + seq continuity
+
+On `onDisconnect` for a slot whose `phase === "running"`:
+
+1. `phase = "resuming"`; emit `{ kind: "resuming", deadSessionId, respawns }`.
+2. Tear down the dead handle (`handle.close` / dispose).
+3. **Crash-loop guard:** if `respawns >= MAX_RESPAWNS`, set `phase = "dead"`, emit `{ kind: "dead", reason }`, stop. Otherwise apply exponential backoff (`BACKOFF_BASE_MS * 2^respawns`, capped), `respawns++`.
+4. Construct a **fresh** `new AcpRuntime()`, `spawn` the same `AcpxKey`/config → new `session.id` and a freshly learned `wireSessionId` (never the dead one, per #319).
+5. `phase = "running"`; emit `{ kind: "resumed", newSessionId, lastSeq }`.
+
+**Seq continuity.** The supervisor is the **single owner of the turn drain** for its slots. Every `send()` turn is drained via `publishTurnToNexus({ …, startSeq: entry.lastSeq })`; the returned final seq is written back to `entry.lastSeq`. This requires (Phase 3) adding a `startSeq?: number` parameter to `publishTurnToNexus` and stamping `payload.seq` on each event. Across a respawn, `lastSeq` is preserved, so the post-respawn turn continues the sequence with no reset and no gap. An audit of existing `publishTurnToNexus` / `SessionOrchestrator.watchTurn` callers guarantees **exactly one drain per turn** (no double-publish).
+
+---
+
+## SessionLost surfacing (wiring layer)
+
+Add to `AgentTaskConditionType`: `Resuming`, `SessionLost`. The wiring layer (`src/server/task-controller-wiring.ts` and/or `SessionOrchestrator`) subscribes to `supervisor.onRespawn`:
+
+- `resuming` → patch the `AgentTask` bound to that slot: `Resuming = True (reason: "acpx-disconnected")`, keep `phase: Running` (do **not** Fail).
+- `resumed` → `Resuming = False`, `SessionLost = True (reason: "respawned", message: "<n> respawns")`, update `status.sessionId` to the new session id, keep `phase: Running`.
+- `dead` → fall through to the existing `failLostSession()` path (`Failed`, `reason: "session-lost"`) **and** release any leases the agent held (proactive de-stranding; today they wait for lease expiry).
+
+Because `listSessions()` is respawn-aware, `reconcileRunning` keeps seeing a live session during a transient blip and will not race the supervisor to `Failed`. The `AgentTask`'s stored conditions become the audit trail of respawns, which the #193 supervision surface can render (`thrashing` health already keys off retry counts).
+
+---
+
+## Phase breakdown (each → a sub-issue under #273)
+
+Dependency order: **P1 → P2 → P3 → P4 → P5.** P4 can start once P2 lands; P3 is the only one touching the Nexus publisher.
+
+- **P1 — Death-detection seam.** `AgentDisconnectedError`; `AcpRuntime` unexpected-exit listener; reject in-flight `send`; `onDisconnect` hook; optional `onDisconnect` on `AgentRuntime`. Tests via `launchOverride` / an in-process agent that force-exits. *Done when:* killing a child mid-turn rejects `send` with `AgentDisconnectedError`; `onDisconnect` fires once on crash, never on clean `close`; existing acp-runtime tests stay green.
+- **P2 — Supervisor registry core + adapter matrix.** `AcpxSupervisor` (`ensure` idempotent + single-flight, `get`/`stop`/`list`, AgentRuntime façade, respawn-aware `listSessions`). Create `runRuntimeAdapterMatrix(label, factory)` and run `MockRuntime` + `AcpRuntime` + `AcpxSupervisor` through it (delivers #210). *Done when:* same key ⇒ same entry/one child; distinct keys ⇒ distinct children; `stop` terminates + removes; matrix green for all three runtimes.
+- **P3 — Respawn + auto-resume + seq.** Subscribe to P1; `running → resuming → running`; fresh runtime per respawn; backoff + `MAX_RESPAWNS → dead`; add `startSeq` to `publishTurnToNexus` + stamp `seq`; supervisor owns the drain and threads `lastSeq`; audit callers for exactly-one-drain. *Done when:* simulated disconnect drives the phase cycle with a new `wireSessionId`; `seq` continues strictly increasing across respawn (asserted against a fake bus); no duplicate events; entry settles `dead` after the cap with backoff respected.
+- **P4 — `SessionLost` on AgentTask + wiring.** Add `Resuming`/`SessionLost` condition types; wiring subscribes to `onRespawn` and patches the task; permanent-death releases leases; ensure `reconcileRunning` does not race the supervisor. *Done when:* respawn yields `SessionLost=True` on the task while it stays `Running`; permanent death yields `Failed` + released leases; condition-projection tests updated.
+- **P5 — Orchestrator adoption + real-process E2E.** Route `SessionOrchestrator.spawnAgent` (and the TaskController binder) through `supervisor.ensure`; remove any double-drain. New `GROVE_INTEGRATION` E2E (pattern of `tests/e2e/*-tmux.ts`): launch a real agent via `grove up`, `kill -9` its acpx child, assert respawn within backoff, `SessionLost` visible on the task via the entity/TUI path (no manual probe), monotonic `seq` with no reset, agent continues. Validate against **Nexus stores, not local SQLite**; no manual `send-keys`.
+
+---
+
+## Testing strategy
+
+- **Unit (TDD, per phase):** in-process / `launchOverride` agents + a fake `EventBus`; no real subprocesses. Cover death detection, registry lifecycle, respawn + seq continuity, condition patching.
+- **Adapter conformance:** `runRuntimeAdapterMatrix` over Mock/Acp/Supervisor (#210).
+- **Integration / E2E:** kill-PID respawn under `grove up` against Nexus (P5), `GROVE_INTEGRATION`-gated.
+
+## Risks & mitigations
+
+- **Double-drain / double-publish** (seq reset, duplicated events) → supervisor is the single drain owner; thread `startSeq`; audit all `publishTurnToNexus`/`watchTurn` callers for exactly-one-drain.
+- **Reusing a dead `wireSessionId`** (#319 contamination) → respawn always builds a fresh runtime/`session/new`; never copy the dead binding.
+- **Respawn storm** on a crash-looping backend → backoff + `MAX_RESPAWNS` → `dead` + operator surface; never respawn-storm.
+- **Orphaned children** if the grove process dies (acpx has no `session/list`) → grove inventory is authoritative; persist enough of the registry to reconcile/reap on restart (follow-up; noted as OQ).
+- **`reconcileRunning` vs supervisor race** → respawn-aware `listSessions()` + `Resuming` condition keep the controller from premature `Failed`.
+- **Resource growth** (one process per slot) → note capacity implications; a concurrent-slot cap is a follow-up.
+
+## Out of scope
+
+- ACP `session/load` / `session/fork` (upstream-unsupported; explicit non-goal). Design stays forward-compatible.
+- Sharing one acpx instance across slots (non-goal).
+- Cross-host / gossip-capacity "slots" supervision (unrelated concept).
+- Persisting the registry across grove restarts (orphan reaping) — noted as an open question, not built here.
+
+## Open questions (for review)
+
+- **OQ1 — slot key source.** Confirm `AgentTask.spec.id` as the canonical `slotId` from `TaskController`, and the `grove-<role>-<n>` form from `SessionOrchestrator`. A role working N independent tasks ⇒ N slots/processes — confirm that's intended.
+- **OQ2 — orchestrator adoption scope.** Is P5 (making `SessionOrchestrator`/`TaskController` actually spawn through the supervisor) part of #273, or a follow-up once P1–P4 land behind the runtime seam?
+- **OQ3 — `seq` placement.** Stamp `seq` in the payload of every `acp.message`/`acp.result`, or only at turn boundaries? (Plan assumes per-event.) Confirm consumers want per-event seq now vs. forward-compat only.
+- **OQ4 — registry persistence / orphan reaping** across grove restarts: in scope later, or rely on lease expiry + manual reap? (Plan defers.)
+- **OQ5 — feature flag.** Gate adoption behind a `GROVE_SUPERVISOR=1`-style flag for one release (mirroring the `GROVE_RUNTIME` cutover), defaulting off until the E2E is green?

--- a/src/core/acp-runtime.disconnect.test.ts
+++ b/src/core/acp-runtime.disconnect.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { AgentDisconnectedError } from "./agent-runtime.js";
+
+describe("AgentDisconnectedError", () => {
+  test("carries session/role/exit info and a readable message", () => {
+    const err = new AgentDisconnectedError({
+      sessionId: "grove-coder-0--abc",
+      role: "coder",
+      exitCode: null,
+      signal: "SIGKILL",
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.info.sessionId).toBe("grove-coder-0--abc");
+    expect(err.info.role).toBe("coder");
+    expect(err.info.signal).toBe("SIGKILL");
+    expect(err.message).toContain("coder");
+    expect(err.message).toContain("grove-coder-0--abc");
+  });
+});

--- a/src/core/acp-runtime.disconnect.test.ts
+++ b/src/core/acp-runtime.disconnect.test.ts
@@ -104,4 +104,25 @@ describe("AcpRuntime disconnect detection", () => {
 
     expect(seen).toHaveLength(0);
   });
+
+  test("an in-flight send() settles with stopReason=error when the agent dies mid-turn", async () => {
+    const { launchOverride, triggerExit } = makeDisconnectableAgent();
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: process.cwd(),
+    });
+
+    // prompt() in the stub never resolves, so this turn stays in flight.
+    const turn = await rt.send(session, "do work");
+
+    // Let the send chain reach connection.prompt() before the process dies.
+    await new Promise((r) => setTimeout(r, 10));
+    triggerExit({ exitCode: null, signal: "SIGKILL" });
+
+    const result = await turn.result;
+    expect(result.stopReason).toBe("error");
+    expect((await rt.listSessions())[0]?.status).toBe("crashed");
+  });
 });

--- a/src/core/acp-runtime.disconnect.test.ts
+++ b/src/core/acp-runtime.disconnect.test.ts
@@ -1,5 +1,51 @@
 import { describe, expect, test } from "bun:test";
+import { type Agent, AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk";
+import { AcpRuntime, type LaunchOverride, type LaunchResult } from "./acp-runtime.js";
 import { AgentDisconnectedError } from "./agent-runtime.js";
+
+function makeDisconnectableAgent(): {
+  launchOverride: LaunchOverride;
+  triggerExit: (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void;
+} {
+  const exitListeners: Array<
+    (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void
+  > = [];
+  const launchOverride: LaunchOverride = async () => {
+    const toAgent = new TransformStream<Uint8Array, Uint8Array>();
+    const toClient = new TransformStream<Uint8Array, Uint8Array>();
+    const agentStream = ndJsonStream(toClient.writable, toAgent.readable);
+    const clientStream = ndJsonStream(toAgent.writable, toClient.readable);
+    const agent: Agent = {
+      async initialize() {
+        return { protocolVersion: 1, agentCapabilities: {}, authMethods: [] };
+      },
+      async newSession() {
+        return { sessionId: `wire-${exitListeners.length}` };
+      },
+      async prompt() {
+        await new Promise(() => undefined); // never resolves until disconnect
+        return { stopReason: "end_turn" };
+      },
+      async cancel() {},
+      async authenticate() {
+        return {};
+      },
+    };
+    void new AgentSideConnection(() => agent, agentStream);
+    const result: LaunchResult = {
+      clientStream,
+      dispose: async () => {},
+      onExit: (listener) => exitListeners.push(listener),
+    };
+    return result;
+  };
+  return {
+    launchOverride,
+    triggerExit: (info) => {
+      for (const l of exitListeners) l(info);
+    },
+  };
+}
 
 describe("AgentDisconnectedError", () => {
   test("carries session/role/exit info and a readable message", () => {
@@ -15,5 +61,47 @@ describe("AgentDisconnectedError", () => {
     expect(err.info.signal).toBe("SIGKILL");
     expect(err.message).toContain("coder");
     expect(err.message).toContain("grove-coder-0--abc");
+  });
+});
+
+describe("AcpRuntime disconnect detection", () => {
+  test("onDisconnect fires once with AgentDisconnectedError on unexpected exit", async () => {
+    const { launchOverride, triggerExit } = makeDisconnectableAgent();
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: process.cwd(),
+    });
+
+    const seen: AgentDisconnectedError[] = [];
+    rt.onDisconnect(session, (err) => seen.push(err));
+
+    triggerExit({ exitCode: null, signal: "SIGKILL" });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBeInstanceOf(AgentDisconnectedError);
+    expect(seen[0]?.info.role).toBe("coder");
+    expect(seen[0]?.info.signal).toBe("SIGKILL");
+    expect((await rt.listSessions())[0]?.status).toBe("crashed");
+  });
+
+  test("onDisconnect does NOT fire on intentional close()", async () => {
+    const { launchOverride, triggerExit } = makeDisconnectableAgent();
+    const rt = new AcpRuntime({ launchOverride });
+    const session = await rt.spawn("coder", {
+      role: "coder",
+      command: "codex",
+      cwd: process.cwd(),
+    });
+    const seen: AgentDisconnectedError[] = [];
+    rt.onDisconnect(session, (err) => seen.push(err));
+
+    await rt.close(session);
+    triggerExit({ exitCode: 0, signal: null }); // exit AFTER close — must be ignored
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(seen).toHaveLength(0);
   });
 });

--- a/src/core/acp-runtime.spawn.test.ts
+++ b/src/core/acp-runtime.spawn.test.ts
@@ -4,76 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   type Agent,
-  AgentSideConnection,
   type InitializeRequest,
-  ndJsonStream,
   RequestError,
   type RequestPermissionRequest,
 } from "@agentclientprotocol/sdk";
-import { AcpRuntime, type AcpRuntimeEvent, type LaunchOverride } from "./acp-runtime.js";
-
-interface AgentStubHandlers {
-  onInitialize?: (p: InitializeRequest) => void;
-  onNewSession?: (p: Parameters<Agent["newSession"]>[0]) => void;
-  onCancel?: () => Promise<void> | void;
-  onPrompt?: (p: {
-    sessionId: string;
-    agentSide: AgentSideConnection;
-  }) => Promise<{ stopReason: "end_turn" | "cancelled" | "error" | "max_tokens" }>;
-  onDispose?: () => Promise<void> | void;
-  capture?: (ref: { agentSide: AgentSideConnection | null }) => void;
-}
-
-function makeInProcessAgent(handlers: AgentStubHandlers = {}): {
-  launchOverride: LaunchOverride;
-  ref: { agentSide: AgentSideConnection | null };
-} {
-  const ref: { agentSide: AgentSideConnection | null } = { agentSide: null };
-  const launchOverride: LaunchOverride = async () => {
-    const toAgent = new TransformStream<Uint8Array, Uint8Array>();
-    const toClient = new TransformStream<Uint8Array, Uint8Array>();
-    const agentStream = ndJsonStream(toClient.writable, toAgent.readable);
-    const clientStream = ndJsonStream(toAgent.writable, toClient.readable);
-
-    const agent: Agent = {
-      async initialize(p) {
-        handlers.onInitialize?.(p);
-        return {
-          protocolVersion: 1,
-          agentCapabilities: {},
-          authMethods: [],
-        };
-      },
-      async newSession(p) {
-        handlers.onNewSession?.(p);
-        return { sessionId: `wire-${Date.now()}` };
-      },
-      async prompt(p) {
-        if (handlers.onPrompt && ref.agentSide) {
-          return handlers.onPrompt({ sessionId: p.sessionId, agentSide: ref.agentSide });
-        }
-        return { stopReason: "end_turn" };
-      },
-      async cancel() {
-        await handlers.onCancel?.();
-      },
-      async authenticate() {
-        return {};
-      },
-    };
-    const agentSide = new AgentSideConnection(() => agent, agentStream);
-    ref.agentSide = agentSide;
-    handlers.capture?.(ref);
-
-    return {
-      clientStream,
-      dispose: async () => {
-        await handlers.onDispose?.();
-      },
-    };
-  };
-  return { launchOverride, ref };
-}
+import { AcpRuntime, type AcpRuntimeEvent } from "./acp-runtime.js";
+import { makeInProcessAgent } from "./acpx-test-support.js";
 
 function deferred<T = void>(): {
   readonly promise: Promise<T>;

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -69,12 +69,14 @@ export type AcpRuntimeEvent =
       readonly sessionId: string;
       readonly turnId: string;
       readonly message: Message;
+      readonly seq?: number | undefined;
     }
   | {
       readonly kind: "result";
       readonly sessionId: string;
       readonly turnId: string;
       readonly result: Result;
+      readonly seq?: number | undefined;
     };
 
 export type AcpRuntimeEventSink = (event: AcpRuntimeEvent) => void;

--- a/src/core/acp-runtime.ts
+++ b/src/core/acp-runtime.ts
@@ -25,7 +25,12 @@ import { sessionUpdateToMessage } from "../acp/session-update-mapper.js";
 import { AcpTurnImpl } from "../acp/turn-direct.js";
 import type { AcpxTurn, Message, Result } from "../acp/types.js";
 import { type AcpLaunch, resolveAcpLaunch } from "./acp-launch.js";
-import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
+import {
+  type AgentConfig,
+  AgentDisconnectedError,
+  type AgentRuntime,
+  type AgentSession,
+} from "./agent-runtime.js";
 import type { AgentSessionEntity } from "./entity.js";
 import { agentSessionToEntity } from "./entity.js";
 import { DENY_ALL_RESOLVER, type PermissionResolver } from "./permission-resolver.js";
@@ -34,6 +39,14 @@ import { buildSessionId } from "./session-id.js";
 export interface LaunchResult {
   readonly clientStream: Stream;
   readonly dispose: () => Promise<void>;
+  /**
+   * Register a listener fired when the underlying agent process exits.
+   * Real subprocesses wire this to the child's "exit" event; in-process test
+   * launchers expose a manual trigger. Optional for backward compatibility.
+   */
+  readonly onExit?: (
+    listener: (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void,
+  ) => void;
 }
 
 export type LaunchOverride = (
@@ -82,6 +95,8 @@ interface AcpSessionEntry {
    */
   sendChainTail: Promise<void>;
   closed: boolean;
+  disconnectCallbacks: ((err: AgentDisconnectedError) => void)[];
+  rejectInFlight: ((err: AgentDisconnectedError) => void) | null;
 }
 
 interface TerminalEntry {
@@ -469,6 +484,13 @@ async function launchSubprocess(
     }
   });
 
+  const exitListeners: Array<
+    (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void
+  > = [];
+  child.once("exit", (code, signal) => {
+    for (const l of exitListeners) l({ exitCode: code, signal });
+  });
+
   const dispose = async () => {
     try {
       child.kill("SIGTERM");
@@ -498,7 +520,11 @@ async function launchSubprocess(
       }
     }
   };
-  return { clientStream, dispose };
+  return {
+    clientStream,
+    dispose,
+    onExit: (listener) => exitListeners.push(listener),
+  };
 }
 
 /**
@@ -798,8 +824,31 @@ export class AcpRuntime implements AgentRuntime {
       currentTurn: null,
       sendChainTail: Promise.resolve(),
       closed: false,
+      disconnectCallbacks: [],
+      rejectInFlight: null,
     });
     this.fireSessionWrite("ADDED", session);
+
+    launched.onExit?.((info) => {
+      const current = this.sessions.get(id);
+      if (!current || current.closed) return; // intentional close() sets closed=true first
+      const err = new AgentDisconnectedError({
+        sessionId: id,
+        role,
+        exitCode: info.exitCode,
+        signal: info.signal,
+      });
+      current.session = withSessionStatus(current.session, "crashed", err.message);
+      this.fireSessionWrite("MODIFIED", current.session);
+      current.rejectInFlight?.(err);
+      for (const cb of current.disconnectCallbacks) {
+        try {
+          cb(err);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
 
     const initialMessage = config.goal ?? config.prompt;
     if (!config.waitForPush && initialMessage && initialMessage.trim().length > 0) {
@@ -905,23 +954,30 @@ export class AcpRuntime implements AgentRuntime {
       entry.session = withSessionStatus(entry.session, "running");
       this.fireSessionWrite("MODIFIED", entry.session);
       entry.currentTurn = turn;
+      const disconnectRace = new Promise<never>((_, reject) => {
+        entry.rejectInFlight = (err) => reject(err);
+      });
       try {
-        const ok = await entry.connection.prompt({
-          sessionId: entry.wireSessionId,
-          prompt: [{ type: "text", text: message }],
-        });
+        const ok = await Promise.race([
+          entry.connection.prompt({
+            sessionId: entry.wireSessionId,
+            prompt: [{ type: "text", text: message }],
+          }),
+          disconnectRace,
+        ]);
         finishTurn({ turnId, stopReason: ok.stopReason });
       } catch (err) {
-        const message = acpErrorMessage(err);
+        const m = acpErrorMessage(err);
         finishTurn({
           turnId,
           stopReason: "error",
           error: {
             code: "prompt_rejected",
-            message,
+            message: m,
           },
         });
       } finally {
+        entry.rejectInFlight = null;
         if (entry.currentTurn === turn) entry.currentTurn = null;
         for (const cb of entry.idleCallbacks) {
           try {
@@ -986,6 +1042,12 @@ export class AcpRuntime implements AgentRuntime {
     const entry = this.sessions.get(session.id);
     if (!entry) return;
     entry.idleCallbacks.push(callback);
+  }
+
+  onDisconnect(session: AgentSession, callback: (err: AgentDisconnectedError) => void): void {
+    const entry = this.sessions.get(session.id);
+    if (!entry) return;
+    entry.disconnectCallbacks.push(callback);
   }
 
   async listSessions(): Promise<readonly AgentSession[]> {

--- a/src/core/acpx-supervisor.respawn.test.ts
+++ b/src/core/acpx-supervisor.respawn.test.ts
@@ -72,4 +72,52 @@ describe("AcpxSupervisor respawn", () => {
     expect(sup.get(key.slotId)?.phase).toBe("dead");
     expect(events.some((e) => e.kind === "dead")).toBe(true);
   });
+
+  test("seq is strictly increasing across turns and respawn (no reset)", async () => {
+    const onPrompt: DisconnectableHandlers["onPrompt"] = async ({ sessionId, agentSide }) => {
+      await agentSide.sessionUpdate({
+        sessionId,
+        update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "x" } },
+      });
+      return { stopReason: "end_turn" };
+    };
+    const { sup, triggers } = build(5, { onPrompt });
+    const seqs: number[] = [];
+    sup.setAcpEventSink((event) => {
+      if (event.seq !== undefined) seqs.push(event.seq);
+    });
+
+    const entry = await sup.ensure(key, cfg);
+
+    // Turn 1 on the original session — completes, emitting events.
+    const t1 = await sup.send(entry.session, "one");
+    for await (const _ of t1.messages) {
+      /* drain */
+    }
+    await t1.result;
+    const seqsBeforeRespawn = seqs.length;
+    expect(seqsBeforeRespawn).toBeGreaterThan(0);
+
+    // Kill, await respawn.
+    triggers[0]?.({ signal: "SIGKILL" });
+    await new Promise((r) => setTimeout(r, 50));
+    const resumed = sup.get(key.slotId);
+    expect(resumed?.session.id).not.toBe(entry.session.id);
+
+    // Turn 2 on the NEW session.
+    const t2 = await sup.send(resumed?.session ?? entry.session, "two");
+    for await (const _ of t2.messages) {
+      /* drain */
+    }
+    await t2.result;
+
+    // No reset: strictly increasing across the whole capture.
+    expect(seqs.length).toBeGreaterThan(seqsBeforeRespawn);
+    const strictlyIncreasing = seqs.every((v, i) => i === 0 || v > (seqs[i - 1] ?? -1));
+    expect(strictlyIncreasing).toBe(true);
+    // The first post-respawn event did not reset to 0.
+    expect(seqs[seqsBeforeRespawn]).toBeGreaterThanOrEqual(seqsBeforeRespawn);
+
+    await sup.stop(key.slotId, "cleanup");
+  });
 });

--- a/src/core/acpx-supervisor.respawn.test.ts
+++ b/src/core/acpx-supervisor.respawn.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { AcpRuntime } from "./acp-runtime.js";
+import { type AcpxKey, type AcpxRespawnEvent, AcpxSupervisor } from "./acpx-supervisor.js";
+import {
+  type DisconnectableHandlers,
+  makeDisconnectableLaunchOverride,
+} from "./acpx-test-support.js";
+
+const key: AcpxKey = { slotId: "task-1", backend: "codex", cwd: process.cwd() };
+const cfg = { role: "coder", command: "codex", cwd: process.cwd() };
+
+function build(
+  maxRespawns = 5,
+  handlers: DisconnectableHandlers = {},
+): {
+  sup: AcpxSupervisor;
+  triggers: Array<(info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void>;
+} {
+  const triggers: Array<
+    (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void
+  > = [];
+  const sup = new AcpxSupervisor({
+    maxRespawns,
+    backoffBaseMs: 0,
+    sleep: async () => {},
+    runtimeFactory: () => {
+      const { launchOverride, onTrigger } = makeDisconnectableLaunchOverride(handlers);
+      onTrigger((t) => triggers.push(t));
+      return new AcpRuntime({ launchOverride });
+    },
+  });
+  return { sup, triggers };
+}
+
+describe("AcpxSupervisor respawn", () => {
+  test("disconnect drives running -> resuming -> running with a fresh session", async () => {
+    const { sup, triggers } = build();
+    const events: AcpxRespawnEvent[] = [];
+    sup.onRespawn((e) => events.push(e));
+    const entry = await sup.ensure(key, cfg);
+    const firstSessionId = entry.session.id;
+
+    triggers[0]?.({ signal: "SIGKILL" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const after = sup.get(key.slotId);
+    expect(after?.phase).toBe("running");
+    expect(after?.session.id).not.toBe(firstSessionId);
+    expect(events.map((e) => e.kind)).toEqual(["resuming", "resumed"]);
+    await sup.stop(key.slotId, "cleanup");
+  });
+
+  test("lastSeq is preserved across respawn (no reset)", async () => {
+    const { sup, triggers } = build();
+    const entry = await sup.ensure(key, cfg);
+    entry.lastSeq = 42;
+    triggers[0]?.({ signal: "SIGKILL" });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(sup.get(key.slotId)?.lastSeq).toBe(42);
+    await sup.stop(key.slotId, "cleanup");
+  });
+
+  test("after maxRespawns the slot becomes dead", async () => {
+    const { sup, triggers } = build(2);
+    const events: AcpxRespawnEvent[] = [];
+    sup.onRespawn((e) => events.push(e));
+    await sup.ensure(key, cfg);
+    for (let i = 0; i < 3; i++) {
+      triggers[triggers.length - 1]?.({ signal: "SIGKILL" });
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(sup.get(key.slotId)?.phase).toBe("dead");
+    expect(events.some((e) => e.kind === "dead")).toBe(true);
+  });
+});

--- a/src/core/acpx-supervisor.test.ts
+++ b/src/core/acpx-supervisor.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { AcpRuntime } from "./acp-runtime.js";
+import { type AcpxKey, AcpxSupervisor } from "./acpx-supervisor.js";
+import { makeInProcessLaunchOverride } from "./acpx-test-support.js";
+
+function makeSupervisor(): AcpxSupervisor {
+  return new AcpxSupervisor({
+    runtimeFactory: () => new AcpRuntime({ launchOverride: makeInProcessLaunchOverride() }),
+  });
+}
+
+const key: AcpxKey = { slotId: "task-1", backend: "codex", cwd: process.cwd() };
+const cfg = { role: "coder", command: "codex", cwd: process.cwd() };
+
+describe("AcpxSupervisor registry", () => {
+  test("ensure spawns one entry and is idempotent for the same slot", async () => {
+    const sup = makeSupervisor();
+    const a = await sup.ensure(key, cfg);
+    const b = await sup.ensure(key, cfg);
+    expect(b).toBe(a);
+    expect(sup.list()).toHaveLength(1);
+    expect(a.phase).toBe("running");
+    expect(a.acpxRecordId).toBeDefined();
+    await sup.stop(key.slotId, "test cleanup");
+  });
+
+  test("concurrent ensure for the same slot coalesces to one entry", async () => {
+    const sup = makeSupervisor();
+    const [a, b] = await Promise.all([sup.ensure(key, cfg), sup.ensure(key, cfg)]);
+    expect(a).toBe(b);
+    expect(sup.list()).toHaveLength(1);
+    await sup.stop(key.slotId, "cleanup");
+  });
+
+  test("distinct slots get distinct entries and children", async () => {
+    const sup = makeSupervisor();
+    const a = await sup.ensure(key, cfg);
+    const b = await sup.ensure({ ...key, slotId: "task-2" }, cfg);
+    expect(a.acpxRecordId).not.toBe(b.acpxRecordId);
+    expect(a.session.id).not.toBe(b.session.id);
+    expect(sup.list()).toHaveLength(2);
+    await sup.stop("task-1", "cleanup");
+    await sup.stop("task-2", "cleanup");
+  });
+
+  test("get returns the entry; stop terminates and removes it", async () => {
+    const sup = makeSupervisor();
+    await sup.ensure(key, cfg);
+    expect(sup.get(key.slotId)).toBeDefined();
+    await sup.stop(key.slotId, "done");
+    expect(sup.get(key.slotId)).toBeUndefined();
+    expect(sup.list()).toHaveLength(0);
+  });
+
+  test("AgentRuntime facade: spawn routes to ensure, listSessions reflects entries", async () => {
+    const sup = makeSupervisor();
+    const session = await sup.spawn("coder", cfg);
+    expect((await sup.listSessions()).some((s) => s.id === session.id)).toBe(true);
+    await sup.close(session);
+    expect((await sup.listSessions()).some((s) => s.id === session.id)).toBe(false);
+  });
+
+  test("setAcpEventSink: child events reach the downstream sink with a seq", async () => {
+    const seqs: number[] = [];
+    const sup = makeSupervisor();
+    sup.setAcpEventSink((event) => {
+      if (event.seq !== undefined) seqs.push(event.seq);
+    });
+    const session = await sup.spawn("coder", cfg);
+    // The default in-process agent completes a turn (no streamed messages) but
+    // emits a terminal "result" event through the runtime's eventSink.
+    const turn = await sup.send(session, "hi");
+    for await (const _ of turn.messages) {
+      /* drain */
+    }
+    await turn.result;
+    await new Promise((r) => setTimeout(r, 5));
+    expect(seqs.length).toBeGreaterThan(0);
+    expect(seqs).toEqual([...seqs].sort((x, y) => x - y));
+    expect(seqs[0]).toBe(0);
+    await sup.close(session);
+  });
+});

--- a/src/core/acpx-supervisor.test.ts
+++ b/src/core/acpx-supervisor.test.ts
@@ -60,6 +60,18 @@ describe("AcpxSupervisor registry", () => {
     expect((await sup.listSessions()).some((s) => s.id === session.id)).toBe(false);
   });
 
+  test("listSessionEntities returns one entity per slot (no duplicates)", async () => {
+    const sup = makeSupervisor();
+    await sup.ensure(key, cfg);
+    await sup.ensure({ ...key, slotId: "task-2" }, cfg);
+    const entities = await sup.listSessionEntities();
+    expect(entities).toHaveLength(2);
+    const ids = entities.map((e) => e.id).sort();
+    expect(new Set(ids).size).toBe(2); // no duplicate ids
+    await sup.stop("task-1", "cleanup");
+    await sup.stop("task-2", "cleanup");
+  });
+
   test("setAcpEventSink: child events reach the downstream sink with a seq", async () => {
     const seqs: number[] = [];
     const sup = makeSupervisor();

--- a/src/core/acpx-supervisor.ts
+++ b/src/core/acpx-supervisor.ts
@@ -162,18 +162,60 @@ export class AcpxSupervisor implements AgentRuntime {
     });
   }
 
-  // Respawn logic lands in Phase 3. For now a disconnect marks the slot dead.
   private async handleDisconnect(
     entry: AcpxRegistryEntry,
     _err: AgentDisconnectedError,
   ): Promise<void> {
-    entry.phase = "dead";
+    if (entry.phase !== "running") return;
+    const config = this.configs.get(entry.key.slotId);
+    if (!config) return;
+
+    entry.phase = "resuming";
     this.emit({
-      kind: "dead",
+      kind: "resuming",
       key: entry.key,
       acpxRecordId: entry.acpxRecordId,
-      reason: "disconnected",
+      deadSessionId: entry.session.id,
       respawns: entry.respawns,
+    });
+
+    try {
+      await entry.handle.close(entry.session);
+    } catch {
+      /* dead child; ignore */
+    }
+
+    if (entry.respawns >= this.maxRespawns) {
+      entry.phase = "dead";
+      this.emit({
+        kind: "dead",
+        key: entry.key,
+        acpxRecordId: entry.acpxRecordId,
+        reason: `exceeded maxRespawns=${this.maxRespawns}`,
+        respawns: entry.respawns,
+      });
+      return;
+    }
+
+    await this.sleep(this.backoffBaseMs * 2 ** entry.respawns);
+    entry.respawns += 1;
+
+    // Respawn WITHIN the shared runtime: a fresh sharedRuntime.spawn() does a
+    // fresh session/new => a NEW wireSessionId (never the dead one, #319). The
+    // handle stays this.sharedRuntime; only entry.session is replaced.
+    // routeEvent() demuxes by the new session id, so seq stamping continues
+    // from the preserved entry.lastSeq with no reset. Re-register onDisconnect
+    // for the new session.
+    const session = await this.sharedRuntime.spawn(config.role, config);
+    entry.session = session;
+    entry.phase = "running";
+    this.attachDisconnect(entry);
+    this.emit({
+      kind: "resumed",
+      key: entry.key,
+      acpxRecordId: entry.acpxRecordId,
+      newSessionId: session.id,
+      lastSeq: entry.lastSeq,
     });
   }
 

--- a/src/core/acpx-supervisor.ts
+++ b/src/core/acpx-supervisor.ts
@@ -7,6 +7,7 @@ import type {
   AgentSession,
 } from "./agent-runtime.js";
 import type { AgentSessionEntity } from "./entity.js";
+import { agentSessionToEntity } from "./entity.js";
 
 export interface AcpxKey {
   readonly slotId: string;
@@ -77,6 +78,7 @@ export class AcpxSupervisor implements AgentRuntime {
   private readonly mintRecordId: () => string;
   private downstreamSink: AcpRuntimeEventSink | undefined;
   private counter = 0;
+  private recordCounter = 0;
 
   constructor(options: AcpxSupervisorOptions = {}) {
     const factory = options.runtimeFactory ?? ((): AcpRuntime => new AcpRuntime());
@@ -84,7 +86,7 @@ export class AcpxSupervisor implements AgentRuntime {
     this.maxRespawns = options.maxRespawns ?? DEFAULT_MAX_RESPAWNS;
     this.backoffBaseMs = options.backoffBaseMs ?? DEFAULT_BACKOFF_BASE_MS;
     this.sleep = options.sleep ?? ((ms): Promise<void> => new Promise((r) => setTimeout(r, ms)));
-    this.mintRecordId = options.mintRecordId ?? ((): string => `acpx-rec-${this.counter++}`);
+    this.mintRecordId = options.mintRecordId ?? ((): string => `acpx-rec-${this.recordCounter++}`);
     // Wire a single aggregated event sink on the shared runtime.
     this.sharedRuntime.setAcpEventSink((event: AcpRuntimeEvent) => {
       this.routeEvent(event);
@@ -243,10 +245,8 @@ export class AcpxSupervisor implements AgentRuntime {
   }
 
   async listSessionEntities(): Promise<readonly AgentSessionEntity[]> {
-    const all = await Promise.all(
-      [...this.registry.values()].map((e) => e.handle.listSessionEntities()),
-    );
-    return all.flat();
+    const sessions = await this.listSessions();
+    return sessions.map((s) => agentSessionToEntity(s));
   }
 
   async isAvailable(): Promise<boolean> {

--- a/src/core/acpx-supervisor.ts
+++ b/src/core/acpx-supervisor.ts
@@ -1,0 +1,261 @@
+import type { AcpxTurn } from "../acp/types.js";
+import { AcpRuntime, type AcpRuntimeEvent, type AcpRuntimeEventSink } from "./acp-runtime.js";
+import type {
+  AgentConfig,
+  AgentDisconnectedError,
+  AgentRuntime,
+  AgentSession,
+} from "./agent-runtime.js";
+import type { AgentSessionEntity } from "./entity.js";
+
+export interface AcpxKey {
+  readonly slotId: string;
+  readonly backend: "claude-code" | "codex" | "gemini";
+  readonly cwd: string;
+  readonly sessionName?: string | undefined;
+}
+
+export type AcpxPhase = "starting" | "running" | "resuming" | "dead";
+
+export interface AcpxRegistryEntry {
+  readonly key: AcpxKey;
+  handle: AcpRuntime;
+  readonly acpxRecordId: string;
+  session: AgentSession;
+  lastSeq: number;
+  lastRequestId?: string | undefined;
+  phase: AcpxPhase;
+  respawns: number;
+}
+
+export type AcpxRespawnEvent =
+  | {
+      readonly kind: "resuming";
+      readonly key: AcpxKey;
+      readonly acpxRecordId: string;
+      readonly deadSessionId: string;
+      readonly respawns: number;
+    }
+  | {
+      readonly kind: "resumed";
+      readonly key: AcpxKey;
+      readonly acpxRecordId: string;
+      readonly newSessionId: string;
+      readonly lastSeq: number;
+    }
+  | {
+      readonly kind: "dead";
+      readonly key: AcpxKey;
+      readonly acpxRecordId: string;
+      readonly reason: string;
+      readonly respawns: number;
+    };
+
+export interface AcpxSupervisorOptions {
+  readonly runtimeFactory?: () => AcpRuntime;
+  readonly maxRespawns?: number | undefined;
+  readonly backoffBaseMs?: number | undefined;
+  readonly sleep?: ((ms: number) => Promise<void>) | undefined;
+  readonly mintRecordId?: (() => string) | undefined;
+}
+
+const DEFAULT_MAX_RESPAWNS = 5;
+const DEFAULT_BACKOFF_BASE_MS = 250;
+
+export class AcpxSupervisor implements AgentRuntime {
+  readonly sendsInitialPromptOnSpawn = true;
+
+  private readonly registry = new Map<string, AcpxRegistryEntry>();
+  private readonly inflight = new Map<string, Promise<AcpxRegistryEntry>>();
+  private readonly configs = new Map<string, AgentConfig>();
+  private readonly respawnListeners: ((e: AcpxRespawnEvent) => void)[] = [];
+  /** Shared runtime — all slots are sessions within this single AcpRuntime instance. */
+  private readonly sharedRuntime: AcpRuntime;
+  private readonly maxRespawns: number;
+  private readonly backoffBaseMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly mintRecordId: () => string;
+  private downstreamSink: AcpRuntimeEventSink | undefined;
+  private counter = 0;
+
+  constructor(options: AcpxSupervisorOptions = {}) {
+    const factory = options.runtimeFactory ?? ((): AcpRuntime => new AcpRuntime());
+    this.sharedRuntime = factory();
+    this.maxRespawns = options.maxRespawns ?? DEFAULT_MAX_RESPAWNS;
+    this.backoffBaseMs = options.backoffBaseMs ?? DEFAULT_BACKOFF_BASE_MS;
+    this.sleep = options.sleep ?? ((ms): Promise<void> => new Promise((r) => setTimeout(r, ms)));
+    this.mintRecordId = options.mintRecordId ?? ((): string => `acpx-rec-${this.counter++}`);
+    // Wire a single aggregated event sink on the shared runtime.
+    this.sharedRuntime.setAcpEventSink((event: AcpRuntimeEvent) => {
+      this.routeEvent(event);
+    });
+  }
+
+  onRespawn(cb: (event: AcpxRespawnEvent) => void): void {
+    this.respawnListeners.push(cb);
+  }
+
+  private emit(event: AcpxRespawnEvent): void {
+    for (const l of this.respawnListeners) {
+      try {
+        l(event);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  async ensure(key: AcpxKey, config: AgentConfig): Promise<AcpxRegistryEntry> {
+    const existing = this.registry.get(key.slotId);
+    if (existing && existing.phase !== "dead") return existing;
+    const pending = this.inflight.get(key.slotId);
+    if (pending) return pending;
+    const promise = this.spawnEntry(key, config).finally(() => {
+      this.inflight.delete(key.slotId);
+    });
+    this.inflight.set(key.slotId, promise);
+    return promise;
+  }
+
+  private async spawnEntry(key: AcpxKey, config: AgentConfig): Promise<AcpxRegistryEntry> {
+    const session = await this.sharedRuntime.spawn(config.role, config);
+    const entry: AcpxRegistryEntry = {
+      key,
+      handle: this.sharedRuntime,
+      acpxRecordId: this.mintRecordId(),
+      session,
+      lastSeq: 0,
+      phase: "running",
+      respawns: 0,
+    };
+    this.registry.set(key.slotId, entry);
+    this.configs.set(key.slotId, config);
+    this.attachDisconnect(entry);
+    return entry;
+  }
+
+  /**
+   * Route an event from the shared runtime's aggregated sink.
+   * Finds the matching entry by sessionId, stamps the per-entry seq, and
+   * forwards to the downstream sink.
+   */
+  private routeEvent(event: AcpRuntimeEvent): void {
+    const entry = this.entryForSession(event.sessionId);
+    if (!entry) return;
+    const seq = entry.lastSeq;
+    entry.lastSeq += 1;
+    this.downstreamSink?.({ ...event, seq });
+  }
+
+  private entryForSession(sessionId: string): AcpxRegistryEntry | undefined {
+    for (const entry of this.registry.values()) {
+      if (entry.session.id === sessionId) return entry;
+    }
+    return undefined;
+  }
+
+  private attachDisconnect(entry: AcpxRegistryEntry): void {
+    entry.handle.onDisconnect?.(entry.session, (err) => {
+      void this.handleDisconnect(entry, err);
+    });
+  }
+
+  // Respawn logic lands in Phase 3. For now a disconnect marks the slot dead.
+  private async handleDisconnect(
+    entry: AcpxRegistryEntry,
+    _err: AgentDisconnectedError,
+  ): Promise<void> {
+    entry.phase = "dead";
+    this.emit({
+      kind: "dead",
+      key: entry.key,
+      acpxRecordId: entry.acpxRecordId,
+      reason: "disconnected",
+      respawns: entry.respawns,
+    });
+  }
+
+  get(slotId: string): AcpxRegistryEntry | undefined {
+    return this.registry.get(slotId);
+  }
+
+  list(): readonly AcpxRegistryEntry[] {
+    return [...this.registry.values()];
+  }
+
+  async stop(slotId: string, _reason: string): Promise<void> {
+    const entry = this.registry.get(slotId);
+    if (!entry) return;
+    this.registry.delete(slotId);
+    this.configs.delete(slotId);
+    await entry.handle.close(entry.session);
+  }
+
+  // --- AgentRuntime facade ---
+
+  private slotIdForSession(sessionId: string): string | undefined {
+    for (const [slotId, entry] of this.registry) {
+      if (entry.session.id === sessionId) return slotId;
+    }
+    return undefined;
+  }
+
+  setAcpEventSink(sink: AcpRuntimeEventSink | undefined): void {
+    this.downstreamSink = sink;
+  }
+
+  async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
+    const key: AcpxKey = {
+      slotId: `${role}-${this.counter++}`,
+      backend: platformToBackend(config.platform),
+      cwd: config.cwd,
+    };
+    const entry = await this.ensure(key, config);
+    return entry.session;
+  }
+
+  async send(session: AgentSession, message: string): Promise<AcpxTurn> {
+    const slotId = this.slotIdForSession(session.id);
+    const entry = slotId ? this.registry.get(slotId) : undefined;
+    if (!entry) throw new Error(`AcpxSupervisor.send: no slot for session ${session.id}`);
+    return entry.handle.send(entry.session, message);
+  }
+
+  async close(session: AgentSession): Promise<void> {
+    const slotId = this.slotIdForSession(session.id);
+    if (slotId) await this.stop(slotId, "close");
+  }
+
+  onIdle(session: AgentSession, callback: () => void): void {
+    const slotId = this.slotIdForSession(session.id);
+    const entry = slotId ? this.registry.get(slotId) : undefined;
+    entry?.handle.onIdle(entry.session, callback);
+  }
+
+  onDisconnect(session: AgentSession, callback: (err: AgentDisconnectedError) => void): void {
+    const slotId = this.slotIdForSession(session.id);
+    const entry = slotId ? this.registry.get(slotId) : undefined;
+    entry?.handle.onDisconnect?.(entry.session, callback);
+  }
+
+  async listSessions(): Promise<readonly AgentSession[]> {
+    return [...this.registry.values()].map((e) => e.session);
+  }
+
+  async listSessionEntities(): Promise<readonly AgentSessionEntity[]> {
+    const all = await Promise.all(
+      [...this.registry.values()].map((e) => e.handle.listSessionEntities()),
+    );
+    return all.flat();
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+}
+
+function platformToBackend(platform: AgentConfig["platform"]): AcpxKey["backend"] {
+  if (platform === "claude-code") return "claude-code";
+  if (platform === "gemini") return "gemini";
+  return "codex";
+}

--- a/src/core/acpx-supervisor.ts
+++ b/src/core/acpx-supervisor.ts
@@ -198,18 +198,24 @@ export class AcpxSupervisor implements AgentRuntime {
     }
 
     await this.sleep(this.backoffBaseMs * 2 ** entry.respawns);
-    entry.respawns += 1;
+    const nextRespawns = entry.respawns + 1;
 
     // Respawn WITHIN the shared runtime: a fresh sharedRuntime.spawn() does a
     // fresh session/new => a NEW wireSessionId (never the dead one, #319). The
-    // handle stays this.sharedRuntime; only entry.session is replaced.
-    // routeEvent() demuxes by the new session id, so seq stamping continues
-    // from the preserved entry.lastSeq with no reset. Re-register onDisconnect
-    // for the new session.
+    // handle stays this.sharedRuntime; only the registry entry is replaced with
+    // a new object so callers holding the old entry reference retain the dead
+    // session.id (enables seq-continuity testing). routeEvent() demuxes by the
+    // new session id, so seq stamping continues from the preserved lastSeq with
+    // no reset. Re-register onDisconnect for the new session.
     const session = await this.sharedRuntime.spawn(config.role, config);
-    entry.session = session;
-    entry.phase = "running";
-    this.attachDisconnect(entry);
+    const newEntry: AcpxRegistryEntry = {
+      ...entry,
+      session,
+      phase: "running",
+      respawns: nextRespawns,
+    };
+    this.registry.set(entry.key.slotId, newEntry);
+    this.attachDisconnect(newEntry);
     this.emit({
       kind: "resumed",
       key: entry.key,

--- a/src/core/acpx-test-support.ts
+++ b/src/core/acpx-test-support.ts
@@ -4,7 +4,7 @@ import {
   type InitializeRequest,
   ndJsonStream,
 } from "@agentclientprotocol/sdk";
-import type { LaunchOverride } from "./acp-runtime.js";
+import type { LaunchOverride, LaunchResult } from "./acp-runtime.js";
 
 export interface AgentStubHandlers {
   onInitialize?: (p: InitializeRequest) => void;
@@ -72,4 +72,85 @@ export function makeInProcessAgent(handlers: AgentStubHandlers = {}): {
 /** Convenience: just the launchOverride, for tests that don't need the agent ref. */
 export function makeInProcessLaunchOverride(handlers?: AgentStubHandlers): LaunchOverride {
   return makeInProcessAgent(handlers).launchOverride;
+}
+
+export interface DisconnectableHandlers {
+  /**
+   * Optional prompt handler. When provided, a turn COMPLETES (used by the
+   * seq-continuity test). When omitted, prompt() never resolves so the only
+   * way a turn/session ends is an exit trigger (used by the respawn tests,
+   * which never send()).
+   */
+  readonly onPrompt?: (ctx: {
+    readonly sessionId: string;
+    readonly agentSide: AgentSideConnection;
+  }) => Promise<{ stopReason: "end_turn" | "cancelled" | "error" | "max_tokens" }>;
+}
+
+/**
+ * A LaunchOverride whose every spawned (in-process) agent exposes a manual
+ * exit trigger. `onTrigger(cb)` is invoked once per launch with that launch's
+ * trigger function, so a test can capture the Nth child's trigger as the
+ * shared runtime spawns/respawns. Each launch gets a unique wire session id.
+ */
+export function makeDisconnectableLaunchOverride(handlers: DisconnectableHandlers = {}): {
+  launchOverride: LaunchOverride;
+  onTrigger: (
+    cb: (
+      trigger: (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void,
+    ) => void,
+  ) => void;
+} {
+  const triggerListeners: Array<
+    (trigger: (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void) => void
+  > = [];
+  let wireCounter = 0;
+
+  const launchOverride: LaunchOverride = async (): Promise<LaunchResult> => {
+    const exitListeners: Array<
+      (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }) => void
+    > = [];
+    const toAgent = new TransformStream<Uint8Array, Uint8Array>();
+    const toClient = new TransformStream<Uint8Array, Uint8Array>();
+    const agentStream = ndJsonStream(toClient.writable, toAgent.readable);
+    const clientStream = ndJsonStream(toAgent.writable, toClient.readable);
+    const wireId = `wire-${wireCounter++}`;
+    let agentSideRef: AgentSideConnection | null = null;
+    const agent: Agent = {
+      async initialize() {
+        return { protocolVersion: 1, agentCapabilities: {}, authMethods: [] };
+      },
+      async newSession() {
+        return { sessionId: wireId };
+      },
+      async prompt(p) {
+        if (handlers.onPrompt && agentSideRef) {
+          return handlers.onPrompt({ sessionId: p.sessionId, agentSide: agentSideRef });
+        }
+        await new Promise(() => undefined);
+        return { stopReason: "end_turn" };
+      },
+      async cancel() {},
+      async authenticate() {
+        return {};
+      },
+    };
+    agentSideRef = new AgentSideConnection(() => agent, agentStream);
+    const trigger = (info: { exitCode?: number | null; signal?: NodeJS.Signals | null }): void => {
+      for (const l of exitListeners) l(info);
+    };
+    for (const cb of triggerListeners) cb(trigger);
+    return {
+      clientStream,
+      dispose: async () => {},
+      onExit: (listener) => exitListeners.push(listener),
+    };
+  };
+
+  return {
+    launchOverride,
+    onTrigger: (cb) => {
+      triggerListeners.push(cb);
+    },
+  };
 }

--- a/src/core/acpx-test-support.ts
+++ b/src/core/acpx-test-support.ts
@@ -1,0 +1,75 @@
+import {
+  type Agent,
+  AgentSideConnection,
+  type InitializeRequest,
+  ndJsonStream,
+} from "@agentclientprotocol/sdk";
+import type { LaunchOverride } from "./acp-runtime.js";
+
+export interface AgentStubHandlers {
+  onInitialize?: (p: InitializeRequest) => void;
+  onNewSession?: (p: Parameters<Agent["newSession"]>[0]) => void;
+  onCancel?: () => Promise<void> | void;
+  onPrompt?: (p: {
+    sessionId: string;
+    agentSide: AgentSideConnection;
+  }) => Promise<{ stopReason: "end_turn" | "cancelled" | "error" | "max_tokens" }>;
+  onDispose?: () => Promise<void> | void;
+  capture?: (ref: { agentSide: AgentSideConnection | null }) => void;
+}
+
+export function makeInProcessAgent(handlers: AgentStubHandlers = {}): {
+  launchOverride: LaunchOverride;
+  ref: { agentSide: AgentSideConnection | null };
+} {
+  const ref: { agentSide: AgentSideConnection | null } = { agentSide: null };
+  const launchOverride: LaunchOverride = async () => {
+    const toAgent = new TransformStream<Uint8Array, Uint8Array>();
+    const toClient = new TransformStream<Uint8Array, Uint8Array>();
+    const agentStream = ndJsonStream(toClient.writable, toAgent.readable);
+    const clientStream = ndJsonStream(toAgent.writable, toClient.readable);
+
+    const agent: Agent = {
+      async initialize(p) {
+        handlers.onInitialize?.(p);
+        return {
+          protocolVersion: 1,
+          agentCapabilities: {},
+          authMethods: [],
+        };
+      },
+      async newSession(p) {
+        handlers.onNewSession?.(p);
+        return { sessionId: `wire-${Date.now()}` };
+      },
+      async prompt(p) {
+        if (handlers.onPrompt && ref.agentSide) {
+          return handlers.onPrompt({ sessionId: p.sessionId, agentSide: ref.agentSide });
+        }
+        return { stopReason: "end_turn" };
+      },
+      async cancel() {
+        await handlers.onCancel?.();
+      },
+      async authenticate() {
+        return {};
+      },
+    };
+    const agentSide = new AgentSideConnection(() => agent, agentStream);
+    ref.agentSide = agentSide;
+    handlers.capture?.(ref);
+
+    return {
+      clientStream,
+      dispose: async () => {
+        await handlers.onDispose?.();
+      },
+    };
+  };
+  return { launchOverride, ref };
+}
+
+/** Convenience: just the launchOverride, for tests that don't need the agent ref. */
+export function makeInProcessLaunchOverride(handlers?: AgentStubHandlers): LaunchOverride {
+  return makeInProcessAgent(handlers).launchOverride;
+}

--- a/src/core/agent-runtime.test.ts
+++ b/src/core/agent-runtime.test.ts
@@ -32,13 +32,14 @@ describe("AgentRuntime contract (MockRuntime)", () => {
     expect(rt.sendCalls[0]!.message).toBe("implement auth");
   });
 
-  test("close marks session as stopped", async () => {
+  test("close records the call and removes session from listSessions", async () => {
     const rt = new MockRuntime();
     const session = await rt.spawn("coder", config);
     await rt.close(session);
     expect(rt.closeCalls).toHaveLength(1);
+    // Closed sessions are removed from the active list (matches AgentRuntime contract).
     const sessions = await rt.listSessions();
-    expect(sessions[0]!.status).toBe("stopped");
+    expect(sessions.some((s) => s.id === session.id)).toBe(false);
   });
 
   test("onIdle callback fires when triggered", async () => {

--- a/src/core/agent-runtime.ts
+++ b/src/core/agent-runtime.ts
@@ -88,6 +88,12 @@ export interface AgentRuntime {
   close(session: AgentSession): Promise<void>;
   /** Register a callback for when an agent becomes idle. */
   onIdle(session: AgentSession, callback: () => void): void;
+  /**
+   * Register a callback for unexpected agent death (subprocess exit / connection
+   * EOF that did not originate from close()). Optional: runtimes without
+   * subprocess lifecycles (MockRuntime) may omit it.
+   */
+  onDisconnect?(session: AgentSession, callback: (err: AgentDisconnectedError) => void): void;
   /** List all active sessions. */
   listSessions(): Promise<readonly AgentSession[]>;
   /**
@@ -97,4 +103,20 @@ export interface AgentRuntime {
   listSessionEntities(): Promise<readonly AgentSessionEntity[]>;
   /** Check if the runtime's dependencies are available. */
   isAvailable(): Promise<boolean>;
+}
+
+/** Thrown when an agent subprocess exits unexpectedly (not via close()). */
+export class AgentDisconnectedError extends Error {
+  constructor(
+    readonly info: {
+      readonly sessionId: string;
+      readonly role: string;
+      readonly exitCode?: number | null | undefined;
+      readonly signal?: NodeJS.Signals | null | undefined;
+      readonly lastRequestId?: string | undefined;
+    },
+  ) {
+    super(`agent ${info.role} (${info.sessionId}) disconnected`);
+    this.name = "AgentDisconnectedError";
+  }
 }

--- a/src/core/agent-runtime.ts
+++ b/src/core/agent-runtime.ts
@@ -107,16 +107,17 @@ export interface AgentRuntime {
 
 /** Thrown when an agent subprocess exits unexpectedly (not via close()). */
 export class AgentDisconnectedError extends Error {
-  constructor(
-    readonly info: {
-      readonly sessionId: string;
-      readonly role: string;
-      readonly exitCode?: number | null | undefined;
-      readonly signal?: NodeJS.Signals | null | undefined;
-      readonly lastRequestId?: string | undefined;
-    },
-  ) {
+  readonly info: {
+    readonly sessionId: string;
+    readonly role: string;
+    readonly exitCode?: number | null | undefined;
+    readonly signal?: NodeJS.Signals | null | undefined;
+    readonly lastRequestId?: string | undefined;
+  };
+
+  constructor(info: AgentDisconnectedError["info"]) {
     super(`agent ${info.role} (${info.sessionId}) disconnected`);
     this.name = "AgentDisconnectedError";
+    this.info = info;
   }
 }

--- a/src/core/agent-task.test.ts
+++ b/src/core/agent-task.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  AgentTaskConditionType,
   AgentTaskPhase,
   type AgentTaskView,
   agentTaskViewToEntity,
@@ -43,6 +44,13 @@ function taskView(overrides: Partial<AgentTaskView> = {}): AgentTaskView {
     ...overrides,
   };
 }
+
+describe("AgentTaskConditionType", () => {
+  test("includes Resuming and SessionLost", () => {
+    expect(AgentTaskConditionType.Resuming).toBe("Resuming");
+    expect(AgentTaskConditionType.SessionLost).toBe("SessionLost");
+  });
+});
 
 describe("AgentTask entity projection", () => {
   test("projects split spec/status into an Entity envelope", () => {

--- a/src/core/agent-task.ts
+++ b/src/core/agent-task.ts
@@ -24,6 +24,8 @@ export const AgentTaskConditionType = {
   Unschedulable: "Unschedulable",
   PermitRequired: "PermitRequired",
   DoneSignaled: "DoneSignaled",
+  Resuming: "Resuming",
+  SessionLost: "SessionLost",
 } as const;
 export type AgentTaskConditionType =
   (typeof AgentTaskConditionType)[keyof typeof AgentTaskConditionType];

--- a/src/core/mock-runtime.ts
+++ b/src/core/mock-runtime.ts
@@ -71,10 +71,7 @@ export class MockRuntime implements AgentRuntime {
 
   async close(session: AgentSession): Promise<void> {
     this.closeCalls.push({ sessionId: session.id });
-    const s = this.sessions.get(session.id);
-    if (s) {
-      this.sessions.set(session.id, { ...s, status: "stopped" });
-    }
+    this.sessions.delete(session.id);
   }
 
   onIdle(session: AgentSession, callback: () => void): void {

--- a/src/core/runtime-adapter-matrix.test.ts
+++ b/src/core/runtime-adapter-matrix.test.ts
@@ -1,5 +1,6 @@
 import { describe } from "bun:test";
 import { AcpRuntime } from "./acp-runtime.js";
+import { AcpxSupervisor } from "./acpx-supervisor.js";
 import { makeInProcessLaunchOverride } from "./acpx-test-support.js";
 import { MockRuntime } from "./mock-runtime.js";
 import { runRuntimeAdapterMatrix } from "./runtime-adapter-matrix.js";
@@ -9,5 +10,12 @@ describe("runtime adapter matrix", () => {
   runRuntimeAdapterMatrix(
     "AcpRuntime",
     () => new AcpRuntime({ launchOverride: makeInProcessLaunchOverride() }),
+  );
+  runRuntimeAdapterMatrix(
+    "AcpxSupervisor",
+    () =>
+      new AcpxSupervisor({
+        runtimeFactory: () => new AcpRuntime({ launchOverride: makeInProcessLaunchOverride() }),
+      }),
   );
 });

--- a/src/core/runtime-adapter-matrix.test.ts
+++ b/src/core/runtime-adapter-matrix.test.ts
@@ -1,0 +1,13 @@
+import { describe } from "bun:test";
+import { AcpRuntime } from "./acp-runtime.js";
+import { makeInProcessLaunchOverride } from "./acpx-test-support.js";
+import { MockRuntime } from "./mock-runtime.js";
+import { runRuntimeAdapterMatrix } from "./runtime-adapter-matrix.js";
+
+describe("runtime adapter matrix", () => {
+  runRuntimeAdapterMatrix("MockRuntime", () => new MockRuntime());
+  runRuntimeAdapterMatrix(
+    "AcpRuntime",
+    () => new AcpRuntime({ launchOverride: makeInProcessLaunchOverride() }),
+  );
+});

--- a/src/core/runtime-adapter-matrix.ts
+++ b/src/core/runtime-adapter-matrix.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import type { AgentRuntime } from "./agent-runtime.js";
+
+/**
+ * Shared conformance matrix every AgentRuntime must satisfy (#210). Call inside
+ * a describe() block. The factory must return a fresh, isolated runtime per call.
+ */
+export function runRuntimeAdapterMatrix(label: string, factory: () => AgentRuntime): void {
+  const cfg = { role: "coder", command: "codex", cwd: process.cwd() };
+
+  test(`${label}: spawn returns a running session`, async () => {
+    const rt = factory();
+    const s = await rt.spawn("coder", cfg);
+    expect(s.role).toBe("coder");
+    expect(s.status).toBe("running");
+    await rt.close(s);
+  });
+
+  test(`${label}: listSessions reflects spawn then close`, async () => {
+    const rt = factory();
+    const s = await rt.spawn("coder", cfg);
+    expect((await rt.listSessions()).some((x) => x.id === s.id)).toBe(true);
+    await rt.close(s);
+    expect((await rt.listSessions()).some((x) => x.id === s.id)).toBe(false);
+  });
+
+  test(`${label}: distinct spawns get distinct ids`, async () => {
+    const rt = factory();
+    const a = await rt.spawn("coder", cfg);
+    const b = await rt.spawn("coder", cfg);
+    expect(a.id).not.toBe(b.id);
+    await rt.close(a);
+    await rt.close(b);
+  });
+
+  test(`${label}: send returns a typed AcpxTurn that resolves`, async () => {
+    const rt = factory();
+    const s = await rt.spawn("coder", cfg);
+    const turn = await rt.send(s, "hello");
+    expect(turn.sessionId).toBeDefined();
+    for await (const _ of turn.messages) {
+      /* drain */
+    }
+    const result = await turn.result;
+    expect(typeof result.stopReason).toBe("string");
+    await rt.close(s);
+  });
+
+  test(`${label}: close is idempotent`, async () => {
+    const rt = factory();
+    const s = await rt.spawn("coder", cfg);
+    await rt.close(s);
+    await rt.close(s); // must not throw
+    expect(true).toBe(true);
+  });
+
+  test(`${label}: listSessionEntities returns AgentSession entities`, async () => {
+    const rt = factory();
+    const s = await rt.spawn("coder", cfg);
+    const entities = await rt.listSessionEntities();
+    expect(entities.every((e) => e.kind === "AgentSession")).toBe(true);
+    await rt.close(s);
+  });
+}

--- a/src/core/select-runtime.test.ts
+++ b/src/core/select-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { AcpRuntime } from "./acp-runtime.js";
+import { AcpxSupervisor } from "./acpx-supervisor.js";
 import { selectRuntime } from "./select-runtime.js";
 
 describe("selectRuntime", () => {
@@ -24,5 +25,30 @@ describe("selectRuntime", () => {
   test("forwards options to the chosen runtime", () => {
     const rt = selectRuntime({ env: { GROVE_RUNTIME: "acp" }, acp: { logDir: "/tmp/x" } });
     expect(rt).toBeInstanceOf(AcpRuntime);
+  });
+});
+
+describe("selectRuntime GROVE_SUPERVISOR flag", () => {
+  test("GROVE_SUPERVISOR=1 wraps the runtime in AcpxSupervisor", () => {
+    const rt = selectRuntime({
+      env: { GROVE_RUNTIME: "acp" },
+      supervisorEnv: { GROVE_SUPERVISOR: "1" },
+    });
+    expect(rt).toBeInstanceOf(AcpxSupervisor);
+  });
+
+  test("flag unset returns a bare AcpRuntime", () => {
+    const rt = selectRuntime({ env: { GROVE_RUNTIME: "acp" }, supervisorEnv: {} });
+    expect(rt).toBeInstanceOf(AcpRuntime);
+    expect(rt).not.toBeInstanceOf(AcpxSupervisor);
+  });
+
+  test("GROVE_SUPERVISOR other-than-1 returns a bare AcpRuntime", () => {
+    const rt = selectRuntime({
+      env: { GROVE_RUNTIME: "acp" },
+      supervisorEnv: { GROVE_SUPERVISOR: "0" },
+    });
+    expect(rt).toBeInstanceOf(AcpRuntime);
+    expect(rt).not.toBeInstanceOf(AcpxSupervisor);
   });
 });

--- a/src/core/select-runtime.ts
+++ b/src/core/select-runtime.ts
@@ -1,8 +1,10 @@
 import { AcpRuntime, type AcpRuntimeOptions } from "./acp-runtime.js";
+import { AcpxSupervisor } from "./acpx-supervisor.js";
 import type { AgentRuntime } from "./agent-runtime.js";
 
 export interface SelectRuntimeOptions {
   readonly env?: { readonly GROVE_RUNTIME?: string | undefined };
+  readonly supervisorEnv?: { readonly GROVE_SUPERVISOR?: string | undefined };
   readonly acpx?: { agent?: string; logDir?: string };
   readonly acp?: AcpRuntimeOptions;
 }
@@ -11,6 +13,10 @@ export function selectRuntime(options: SelectRuntimeOptions = {}): AgentRuntime 
   const flag = options.env?.GROVE_RUNTIME ?? process.env.GROVE_RUNTIME;
   const normalized = flag?.trim().toLowerCase();
   if (normalized === undefined || normalized === "" || normalized === "acp") {
+    const supervisorFlag = options.supervisorEnv?.GROVE_SUPERVISOR ?? process.env.GROVE_SUPERVISOR;
+    if (supervisorFlag === "1") {
+      return new AcpxSupervisor({ runtimeFactory: (): AcpRuntime => new AcpRuntime(options.acp) });
+    }
     return new AcpRuntime(options.acp);
   }
   throw new Error(

--- a/src/core/task-controller.ts
+++ b/src/core/task-controller.ts
@@ -497,7 +497,7 @@ function transition(
   };
 }
 
-function upsertCondition(
+export function upsertCondition(
   conditions: readonly Condition[],
   desired: Condition,
 ): readonly Condition[] {

--- a/src/mcp/deps.ts
+++ b/src/mcp/deps.ts
@@ -81,6 +81,13 @@ export interface McpDeps extends ServerDeps {
    * Typically the project root containing the .grove/ directory.
    */
   readonly workspaceBoundary: string;
+  /**
+   * AgentTask id that owns this MCP session, sourced from `GROVE_AGENT_TASK_ID`
+   * in the agent process environment. When set, every claim created through this
+   * MCP session stamps `context.agentTaskId` so the supervisor can release the
+   * lease when the task permanently dies (#273).
+   */
+  readonly agentTaskId?: string | undefined;
   /** Optional deadline watcher for proactive overdue detection. */
   readonly deadlineWatcher?: DeadlineWatcher | undefined;
   /**

--- a/src/mcp/serve.ts
+++ b/src/mcp/serve.ts
@@ -813,6 +813,9 @@ try {
     ...(handoffExpiryManaged ? { handoffExpiryManaged: true } : {}),
     ...(deadlineWatcher ? { deadlineWatcher } : {}),
     watchHub: new WatchHub(),
+    // Thread GROVE_AGENT_TASK_ID so the claim tool can stamp context.agentTaskId
+    // on every new claim, enabling the supervisor to release leases on task death (#273).
+    ...(process.env.GROVE_AGENT_TASK_ID ? { agentTaskId: process.env.GROVE_AGENT_TASK_ID } : {}),
   };
   // Derive MCP tool preset from contract mode — #11 MCP Tool Surface + #12 Concept Usage
   const contractMode = loadedContract?.mode ?? "exploration";

--- a/src/mcp/tools/claims.test.ts
+++ b/src/mcp/tools/claims.test.ts
@@ -229,6 +229,74 @@ describe("grove_release", () => {
   });
 });
 
+describe("grove_claim agentTaskId stamping", () => {
+  let testDeps: TestMcpDeps;
+  let deps: McpDeps;
+  let server: McpServer;
+
+  beforeEach(async () => {
+    testDeps = await createTestMcpDeps();
+    deps = testDeps.deps;
+    server = new McpServer({ name: "test", version: "0.0.1" }, { capabilities: { tools: {} } });
+    registerClaimTools(server, { ...deps, agentTaskId: "task-abc-123" });
+  });
+
+  afterEach(async () => {
+    await testDeps.cleanup();
+  });
+
+  test("stamps agentTaskId into claim context when deps.agentTaskId is set", async () => {
+    const result = await callTool(server, "grove_claim", {
+      targetRef: "task-xyz",
+      agent: { agentId: "agent-1" },
+      intentSummary: "Working on task",
+      leaseDurationMs: 300_000,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.text) as { claimId: string };
+    const stored = await testDeps.deps.claimStore.getClaim(data.claimId);
+    expect(stored?.context?.agentTaskId).toBe("task-abc-123");
+  });
+
+  test("agentTaskId is merged additively — does not clobber caller-supplied context", async () => {
+    const result = await callTool(server, "grove_claim", {
+      targetRef: "task-xyz",
+      agent: { agentId: "agent-1" },
+      intentSummary: "Working on task",
+      leaseDurationMs: 300_000,
+      context: { priority: "high" },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.text) as { claimId: string };
+    const stored = await testDeps.deps.claimStore.getClaim(data.claimId);
+    expect(stored?.context?.agentTaskId).toBe("task-abc-123");
+    expect(stored?.context?.priority).toBe("high");
+  });
+
+  test("omits agentTaskId from context when deps.agentTaskId is undefined", async () => {
+    const serverWithoutTaskId = new McpServer(
+      { name: "test2", version: "0.0.1" },
+      { capabilities: { tools: {} } },
+    );
+    registerClaimTools(serverWithoutTaskId, deps);
+
+    const result = await callTool(serverWithoutTaskId, "grove_claim", {
+      targetRef: "task-no-task-id",
+      agent: { agentId: "agent-1" },
+      intentSummary: "Working on task",
+      leaseDurationMs: 300_000,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.text) as { claimId: string };
+    const stored = await testDeps.deps.claimStore.getClaim(data.claimId);
+    expect(stored?.context?.agentTaskId).toBeUndefined();
+    expect(stored?.context).toBeUndefined();
+  });
+});
+
 describe("grove_list_claims pagination", () => {
   let testDeps: TestMcpDeps;
   let deps: McpDeps;

--- a/src/mcp/tools/claims.ts
+++ b/src/mcp/tools/claims.ts
@@ -74,6 +74,7 @@ const listClaimsInputSchema = z.object({
 
 export function registerClaimTools(server: McpServer, deps: McpDeps): void {
   const opDeps = toOperationDeps(deps);
+  const { agentTaskId } = deps;
 
   // --- grove_claim --------------------------------------------------------
   server.registerTool(
@@ -106,14 +107,23 @@ export function registerClaimTools(server: McpServer, deps: McpDeps): void {
         return toMcpResult(result);
       }
 
+      // Merge caller-supplied context with the supervisor-linkage agentTaskId.
+      // agentTaskId is additive — it does not clobber caller context fields.
+      // Both are omitted entirely when neither is present (preserves wire compat).
+      const mergedContext: Readonly<Record<string, JsonValue>> | undefined =
+        agentTaskId !== undefined || args.context !== undefined
+          ? {
+              ...(args.context as Record<string, JsonValue> | undefined),
+              ...(agentTaskId !== undefined ? { agentTaskId } : {}),
+            }
+          : undefined;
+
       const result = await claimOperation(
         {
           targetRef: args.targetRef,
           intentSummary: args.intentSummary,
           ...(args.leaseDurationMs !== undefined ? { leaseDurationMs: args.leaseDurationMs } : {}),
-          ...(args.context !== undefined
-            ? { context: args.context as Readonly<Record<string, JsonValue>> }
-            : {}),
+          ...(mergedContext !== undefined ? { context: mergedContext } : {}),
           agent: args.agent as AgentOverrides,
         },
         opDeps,

--- a/src/server/acpx-supervisor-wiring.test.ts
+++ b/src/server/acpx-supervisor-wiring.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import type { AcpxRespawnEvent } from "../core/acpx-supervisor.js";
+import { AgentTaskConditionType } from "../core/agent-task.js";
+import type { AgentTaskStatusPatch } from "../core/store.js";
+import { wireSupervisorToTasks } from "./acpx-supervisor-wiring.js";
+
+interface CapturedPatch {
+  readonly id: string;
+  readonly patch: AgentTaskStatusPatch;
+}
+
+function fakeDeps() {
+  const patches: CapturedPatch[] = [];
+  const listeners: ((e: AcpxRespawnEvent) => void)[] = [];
+  const taskStore = {
+    async patchAgentTaskStatus(id: string, patch: AgentTaskStatusPatch) {
+      patches.push({ id, patch });
+      return undefined as never; // wiring ignores the return
+    },
+    async getAgentTask(id: string) {
+      return {
+        spec: { id, generation: 1 },
+        status: { phase: "Running", conditions: [], observedGeneration: 1 },
+      } as never;
+    },
+  };
+  const supervisor = {
+    onRespawn(cb: (e: AcpxRespawnEvent) => void): void {
+      listeners.push(cb);
+    },
+  };
+  const fire = (e: AcpxRespawnEvent): void => {
+    for (const l of listeners) l(e);
+  };
+  return { patches, taskStore, supervisor, fire };
+}
+
+const baseKey = { slotId: "task-1", backend: "codex" as const, cwd: "." };
+
+describe("acpx supervisor -> AgentTask wiring", () => {
+  test("resuming sets Resuming=True and does not change phase", async () => {
+    const { patches, taskStore, supervisor, fire } = fakeDeps();
+    wireSupervisorToTasks({ supervisor, taskStore, now: () => 0 });
+    fire({ kind: "resuming", key: baseKey, acpxRecordId: "r1", deadSessionId: "s0", respawns: 0 });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(patches).toHaveLength(1);
+    const { patch } = patches[0]!;
+    expect(patch.phase).toBeUndefined();
+    expect(
+      patch.conditions?.some(
+        (c) => c.type === AgentTaskConditionType.Resuming && c.status === "True",
+      ),
+    ).toBe(true);
+  });
+
+  test("resumed sets SessionLost=True, Resuming=False, updates sessionId, keeps phase Running", async () => {
+    const { patches, taskStore, supervisor, fire } = fakeDeps();
+    wireSupervisorToTasks({ supervisor, taskStore, now: () => 0 });
+    fire({ kind: "resumed", key: baseKey, acpxRecordId: "r1", newSessionId: "s1", lastSeq: 7 });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(patches).toHaveLength(1);
+    const { patch } = patches[0]!;
+    expect(patch.phase).toBeUndefined();
+    expect(patch.sessionId).toBe("s1");
+    expect(
+      patch.conditions?.some(
+        (c) => c.type === AgentTaskConditionType.SessionLost && c.status === "True",
+      ),
+    ).toBe(true);
+    expect(
+      patch.conditions?.some(
+        (c) => c.type === AgentTaskConditionType.Resuming && c.status === "False",
+      ),
+    ).toBe(true);
+  });
+
+  test("dead sets phase Failed and invokes onDead for lease release", async () => {
+    const { patches, taskStore, supervisor, fire } = fakeDeps();
+    const released: string[] = [];
+    wireSupervisorToTasks({
+      supervisor,
+      taskStore,
+      now: () => 0,
+      onDead: async (slotId: string) => {
+        released.push(slotId);
+      },
+    });
+    fire({ kind: "dead", key: baseKey, acpxRecordId: "r1", reason: "crash-loop", respawns: 5 });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(patches).toHaveLength(1);
+    expect(patches[0]!.patch.phase).toBe("Failed");
+    expect(released).toEqual(["task-1"]);
+  });
+
+  test("ignores events whose slot has no matching task", async () => {
+    const { patches, taskStore, supervisor, fire } = fakeDeps();
+    // override getAgentTask to return undefined
+    taskStore.getAgentTask = async () => undefined as never;
+    wireSupervisorToTasks({ supervisor, taskStore, now: () => 0 });
+    fire({ kind: "resuming", key: baseKey, acpxRecordId: "r1", deadSessionId: "s0", respawns: 0 });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(patches).toHaveLength(0);
+  });
+});

--- a/src/server/acpx-supervisor-wiring.ts
+++ b/src/server/acpx-supervisor-wiring.ts
@@ -1,0 +1,96 @@
+import type { AcpxRespawnEvent } from "../core/acpx-supervisor.js";
+import { AgentTaskConditionType, AgentTaskPhase } from "../core/agent-task.js";
+import type { AgentTaskStore } from "../core/store.js";
+import { upsertCondition } from "../core/task-controller.js";
+
+export interface SupervisorTaskWiringDeps {
+  readonly supervisor: { onRespawn(cb: (e: AcpxRespawnEvent) => void): void };
+  readonly taskStore: Pick<AgentTaskStore, "patchAgentTaskStatus" | "getAgentTask">;
+  readonly now?: (() => number) | undefined;
+  readonly onDead?: ((slotId: string) => Promise<void>) | undefined;
+}
+
+/**
+ * Translate AcpxSupervisor respawn lifecycle events into AgentTask status
+ * conditions. A transient blip surfaces as Resuming; a completed respawn marks
+ * SessionLost while keeping the task Running; a permanent death fails the task
+ * and triggers lease release via onDead. Slot id maps 1:1 to AgentTask id.
+ */
+export function wireSupervisorToTasks(deps: SupervisorTaskWiringDeps): void {
+  const now = deps.now ?? Date.now;
+
+  deps.supervisor.onRespawn((event) => {
+    void handle(event).catch(() => {
+      /* fire-and-forget; the task controller's resync is the backstop */
+    });
+  });
+
+  async function handle(event: AcpxRespawnEvent): Promise<void> {
+    const slotId = event.key.slotId;
+    const task = await deps.taskStore.getAgentTask(slotId);
+    if (!task) return;
+    const gen = task.spec.generation;
+    const ts = new Date(now()).toISOString();
+    const conditions = task.status.conditions;
+
+    if (event.kind === "resuming") {
+      await deps.taskStore.patchAgentTaskStatus(slotId, {
+        conditions: upsertCondition(conditions, {
+          type: AgentTaskConditionType.Resuming,
+          status: "True",
+          observedGeneration: gen,
+          lastTransitionTime: ts,
+          reason: "acpx-disconnected",
+          message: `respawn #${event.respawns + 1}`,
+        }),
+      });
+      return;
+    }
+
+    if (event.kind === "resumed") {
+      const withResumingCleared = upsertCondition(conditions, {
+        type: AgentTaskConditionType.Resuming,
+        status: "False",
+        observedGeneration: gen,
+        lastTransitionTime: ts,
+        reason: "respawned",
+        message: "",
+      });
+      await deps.taskStore.patchAgentTaskStatus(slotId, {
+        sessionId: event.newSessionId,
+        conditions: upsertCondition(withResumingCleared, {
+          type: AgentTaskConditionType.SessionLost,
+          status: "True",
+          observedGeneration: gen,
+          lastTransitionTime: ts,
+          reason: "respawned",
+          message: `new session ${event.newSessionId}`,
+        }),
+      });
+      return;
+    }
+
+    // event.kind === "dead"
+    const withRunningCleared = upsertCondition(conditions, {
+      type: AgentTaskConditionType.Running,
+      status: "False",
+      observedGeneration: gen,
+      lastTransitionTime: ts,
+      reason: "session-lost",
+      message: event.reason,
+    });
+    await deps.taskStore.patchAgentTaskStatus(slotId, {
+      phase: AgentTaskPhase.Failed,
+      lastTransitionAt: ts,
+      conditions: upsertCondition(withRunningCleared, {
+        type: AgentTaskConditionType.Failed,
+        status: "True",
+        observedGeneration: gen,
+        lastTransitionTime: ts,
+        reason: "session-lost",
+        message: event.reason,
+      }),
+    });
+    await deps.onDead?.(slotId);
+  }
+}

--- a/src/server/task-controller-wiring.test.ts
+++ b/src/server/task-controller-wiring.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { AcpxTurn } from "../acp/types.js";
 import { AcpRuntime } from "../core/acp-runtime.js";
-import { AcpxSupervisor } from "../core/acpx-supervisor.js";
+import { type AcpxRespawnEvent, AcpxSupervisor } from "../core/acpx-supervisor.js";
 import { makeInProcessLaunchOverride } from "../core/acpx-test-support.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import { AgentTaskPhase } from "../core/agent-task.js";
@@ -97,6 +97,9 @@ function fakeTaskStore() {
   const patches: CapturedPatch[] = [];
   return {
     store: {
+      async putAgentTaskSpec() {
+        return undefined as never;
+      },
       async patchAgentTaskStatus(id: string, patch: AgentTaskStatusPatch) {
         patches.push({ id, patch });
         return undefined as never; // wiring ignores the return value
@@ -107,10 +110,15 @@ function fakeTaskStore() {
           status: { phase: AgentTaskPhase.Running, conditions: [], observedGeneration: 1 },
         } as never;
       },
+      async listAgentTasks() {
+        return [] as never;
+      },
       async listAgentTaskEntities() {
         return [] as never;
       },
-      close() {},
+      close() {
+        // no-op stub
+      },
     },
     patches,
   };
@@ -175,7 +183,9 @@ function fakeClaimStore() {
       async cleanCompleted() {
         return 0;
       },
-      close() {},
+      close() {
+        // no-op stub
+      },
     },
     released,
   };
@@ -191,7 +201,7 @@ describe("createTaskControllerWiring + AcpxSupervisor", () => {
     });
 
     // Spy on onRespawn to verify wiring is registered
-    const onRespawnCalls: Array<(e: Parameters<typeof supervisor.onRespawn>[0]) => void> = [];
+    const onRespawnCalls: Array<(e: AcpxRespawnEvent) => void> = [];
     const origOnRespawn = supervisor.onRespawn.bind(supervisor);
     supervisor.onRespawn = (cb) => {
       onRespawnCalls.push(cb);
@@ -341,7 +351,7 @@ describe("createTaskControllerWiring + AcpxSupervisor — onDead lease release",
       runtimeFactory: () => new AcpRuntime({ launchOverride: makeInProcessLaunchOverride() }),
     });
 
-    const onRespawnCalls: Array<(e: Parameters<typeof supervisor.onRespawn>[0]) => void> = [];
+    const onRespawnCalls: Array<(e: AcpxRespawnEvent) => void> = [];
     const origOnRespawn = supervisor.onRespawn.bind(supervisor);
     supervisor.onRespawn = (cb) => {
       onRespawnCalls.push(cb);

--- a/src/server/task-controller-wiring.test.ts
+++ b/src/server/task-controller-wiring.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { AcpxTurn } from "../acp/types.js";
+import { AcpRuntime } from "../core/acp-runtime.js";
+import { AcpxSupervisor } from "../core/acpx-supervisor.js";
+import { makeInProcessLaunchOverride } from "../core/acpx-test-support.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "../core/agent-runtime.js";
+import { AgentTaskPhase } from "../core/agent-task.js";
 import type { AgentSessionEntity } from "../core/entity.js";
-import { createServerAgentRuntime, taskControllerEnabled } from "./task-controller-wiring.js";
+import type { AgentTaskStatusPatch } from "../core/store.js";
+import {
+  createServerAgentRuntime,
+  createTaskControllerWiring,
+  taskControllerEnabled,
+} from "./task-controller-wiring.js";
 
 function emptyTurn(sessionId: string): AcpxTurn {
   return {
@@ -73,6 +82,157 @@ class FakeTmuxRuntime implements AgentRuntime {
     return true;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Fake helpers for createTaskControllerWiring tests
+// ---------------------------------------------------------------------------
+
+interface CapturedPatch {
+  readonly id: string;
+  readonly patch: AgentTaskStatusPatch;
+}
+
+function fakeTaskStore() {
+  const patches: CapturedPatch[] = [];
+  return {
+    store: {
+      async patchAgentTaskStatus(id: string, patch: AgentTaskStatusPatch) {
+        patches.push({ id, patch });
+        return undefined as never; // wiring ignores the return value
+      },
+      async getAgentTask(id: string) {
+        return {
+          spec: { id, generation: 1 },
+          status: { phase: AgentTaskPhase.Running, conditions: [], observedGeneration: 1 },
+        } as never;
+      },
+      async listAgentTaskEntities() {
+        return [] as never;
+      },
+      close() {},
+    },
+    patches,
+  };
+}
+
+function fakeClaimStore() {
+  const released: string[] = [];
+  return {
+    store: {
+      async activeClaims() {
+        return [] as never;
+      },
+      async listClaims() {
+        return [] as never;
+      },
+      async release(claimId: string) {
+        released.push(claimId);
+        return undefined as never;
+      },
+      async putClaimSpec() {
+        return undefined as never;
+      },
+      async getClaimView() {
+        return undefined;
+      },
+      async patchClaimStatus() {
+        return undefined as never;
+      },
+      async createClaim() {
+        return undefined as never;
+      },
+      async claimOrRenew() {
+        return undefined as never;
+      },
+      async getClaim() {
+        return undefined;
+      },
+      async heartbeat() {
+        return undefined as never;
+      },
+      async complete() {
+        return undefined as never;
+      },
+      async expireStale() {
+        return [] as never;
+      },
+      async countActiveClaims() {
+        return 0;
+      },
+      async detectStalled() {
+        return [] as never;
+      },
+      async listEntities() {
+        return [] as never;
+      },
+      async releaseOwnedBy() {
+        return 0;
+      },
+      async deleteTerminalOwnedBy() {
+        return 0;
+      },
+      async cleanCompleted() {
+        return 0;
+      },
+      close() {},
+    },
+    released,
+  };
+}
+
+describe("createTaskControllerWiring + AcpxSupervisor", () => {
+  test("registers respawn wiring when runtime is AcpxSupervisor; dead event fails the task", async () => {
+    const { store: taskStore, patches } = fakeTaskStore();
+    const { store: claimStore } = fakeClaimStore();
+
+    const supervisor = new AcpxSupervisor({
+      runtimeFactory: () => new AcpRuntime({ launchOverride: makeInProcessLaunchOverride() }),
+    });
+
+    // Spy on onRespawn to verify wiring is registered
+    const onRespawnCalls: Array<(e: Parameters<typeof supervisor.onRespawn>[0]) => void> = [];
+    const origOnRespawn = supervisor.onRespawn.bind(supervisor);
+    supervisor.onRespawn = (cb) => {
+      onRespawnCalls.push(cb);
+      origOnRespawn(cb);
+    };
+
+    createTaskControllerWiring({ taskStore, claimStore, runtime: supervisor });
+
+    // Verify wiring was registered (onRespawn was called)
+    expect(onRespawnCalls.length).toBe(1);
+
+    // Fire a dead event through the captured callback
+    const cb = onRespawnCalls[0];
+    if (cb === undefined) throw new Error("no respawn callback registered");
+
+    cb({
+      kind: "dead",
+      key: { slotId: "task-1", backend: "codex" as const, cwd: "." },
+      acpxRecordId: "r1",
+      reason: "crash-loop",
+      respawns: 5,
+    });
+
+    // Allow the async fire-and-forget to settle
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+    expect(patches.length).toBeGreaterThanOrEqual(1);
+    expect(patches[0]?.patch.phase).toBe(AgentTaskPhase.Failed);
+  });
+
+  test("does not register respawn wiring for a non-supervisor runtime", () => {
+    const { store: taskStore } = fakeTaskStore();
+    const { store: claimStore } = fakeClaimStore();
+
+    const plainRuntime = new AcpRuntime({ launchOverride: makeInProcessLaunchOverride() });
+
+    // Should not throw, and no onRespawn on plain AcpRuntime
+    expect(() => {
+      createTaskControllerWiring({ taskStore, claimStore, runtime: plainRuntime });
+    }).not.toThrow();
+  });
+});
 
 describe("task controller server wiring", () => {
   test("uses selected runtime when available", async () => {

--- a/src/server/task-controller-wiring.test.ts
+++ b/src/server/task-controller-wiring.test.ts
@@ -6,6 +6,7 @@ import { makeInProcessLaunchOverride } from "../core/acpx-test-support.js";
 import type { AgentConfig, AgentRuntime, AgentSession } from "../core/agent-runtime.js";
 import { AgentTaskPhase } from "../core/agent-task.js";
 import type { AgentSessionEntity } from "../core/entity.js";
+import type { JsonValue } from "../core/models.js";
 import type { AgentTaskStatusPatch } from "../core/store.js";
 import {
   createServerAgentRuntime,
@@ -231,6 +232,143 @@ describe("createTaskControllerWiring + AcpxSupervisor", () => {
     expect(() => {
       createTaskControllerWiring({ taskStore, claimStore, runtime: plainRuntime });
     }).not.toThrow();
+  });
+});
+
+describe("createTaskControllerWiring + AcpxSupervisor — onDead lease release", () => {
+  test("releases only active claims whose context.agentTaskId matches the dead slotId", async () => {
+    const { store: taskStore } = fakeTaskStore();
+    const releasedIds: string[] = [];
+
+    // Two active claims — one with matching agentTaskId, one without.
+    const matchingClaim = {
+      claimId: "claim-match",
+      targetRef: "target-1",
+      status: "active" as const,
+      agent: { agentId: "agent-1", agentName: "Coder" },
+      intentSummary: "Doing work",
+      createdAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      leaseExpiresAt: new Date(Date.now() + 300_000).toISOString(),
+      context: { agentTaskId: "slot-dead" } as Record<string, JsonValue>,
+    };
+    const otherClaim = {
+      claimId: "claim-other",
+      targetRef: "target-2",
+      status: "active" as const,
+      agent: { agentId: "agent-2", agentName: "Reviewer" },
+      intentSummary: "Other work",
+      createdAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      leaseExpiresAt: new Date(Date.now() + 300_000).toISOString(),
+      context: { agentTaskId: "slot-other" } as Record<string, JsonValue>,
+    };
+    const noContextClaim = {
+      claimId: "claim-nocontext",
+      targetRef: "target-3",
+      status: "active" as const,
+      agent: { agentId: "agent-3", agentName: "Bot" },
+      intentSummary: "No context",
+      createdAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      leaseExpiresAt: new Date(Date.now() + 300_000).toISOString(),
+    };
+
+    const claimStoreWithData = {
+      store: {
+        async activeClaims() {
+          return [] as never;
+        },
+        async listClaims() {
+          return [matchingClaim, otherClaim, noContextClaim] as never;
+        },
+        async release(claimId: string) {
+          releasedIds.push(claimId);
+          return undefined as never;
+        },
+        async putClaimSpec() {
+          return undefined as never;
+        },
+        async getClaimView() {
+          return undefined;
+        },
+        async patchClaimStatus() {
+          return undefined as never;
+        },
+        async createClaim() {
+          return undefined as never;
+        },
+        async claimOrRenew() {
+          return undefined as never;
+        },
+        async getClaim() {
+          return undefined;
+        },
+        async heartbeat() {
+          return undefined as never;
+        },
+        async complete() {
+          return undefined as never;
+        },
+        async expireStale() {
+          return [] as never;
+        },
+        async countActiveClaims() {
+          return 0;
+        },
+        async detectStalled() {
+          return [] as never;
+        },
+        async listEntities() {
+          return [] as never;
+        },
+        async releaseOwnedBy() {
+          return 0;
+        },
+        async deleteTerminalOwnedBy() {
+          return 0;
+        },
+        async cleanCompleted() {
+          return 0;
+        },
+        close() {
+          // no-op stub
+        },
+      },
+    };
+
+    const supervisor = new AcpxSupervisor({
+      runtimeFactory: () => new AcpRuntime({ launchOverride: makeInProcessLaunchOverride() }),
+    });
+
+    const onRespawnCalls: Array<(e: Parameters<typeof supervisor.onRespawn>[0]) => void> = [];
+    const origOnRespawn = supervisor.onRespawn.bind(supervisor);
+    supervisor.onRespawn = (cb) => {
+      onRespawnCalls.push(cb);
+      origOnRespawn(cb);
+    };
+
+    createTaskControllerWiring({
+      taskStore,
+      claimStore: claimStoreWithData.store,
+      runtime: supervisor,
+    });
+
+    const cb = onRespawnCalls[0];
+    if (cb === undefined) throw new Error("no respawn callback registered");
+
+    cb({
+      kind: "dead",
+      key: { slotId: "slot-dead", backend: "codex" as const, cwd: "." },
+      acpxRecordId: "r1",
+      reason: "crash-loop",
+      respawns: 5,
+    });
+
+    // Allow the async fire-and-forget to settle
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+    expect(releasedIds).toEqual(["claim-match"]);
   });
 });
 

--- a/src/server/task-controller-wiring.ts
+++ b/src/server/task-controller-wiring.ts
@@ -60,8 +60,17 @@ export function createTaskControllerWiring(
       onDead: async (slotId): Promise<void> => {
         const active = await options.claimStore.listClaims({ status: "active" });
         for (const claim of active) {
-          if (claim.context?.agentTaskId === slotId) {
+          if (claim.context?.agentTaskId !== slotId) continue;
+          try {
             await options.claimStore.release(claim.claimId);
+          } catch (err) {
+            // Isolate per-claim failures: one release error must not strand the
+            // agent's other leases. The claim reconciler expires the rest.
+            process.stderr.write(
+              `[grove] supervisor onDead: failed to release claim ${claim.claimId}: ${
+                err instanceof Error ? err.message : String(err)
+              }\n`,
+            );
           }
         }
       },

--- a/src/server/task-controller-wiring.ts
+++ b/src/server/task-controller-wiring.ts
@@ -58,13 +58,12 @@ export function createTaskControllerWiring(
       supervisor: runtime,
       taskStore: options.taskStore,
       onDead: async (slotId): Promise<void> => {
-        // TODO(#273): Claim↔task linkage not available — there is no Claim field
-        // that directly stores the AgentTask id / slotId. Lease release is
-        // deferred until the protocol establishes a stable binding (e.g. an
-        // ownerRef on the claim pointing to the task). The task-failure patch
-        // (phase=Failed) is applied by wireSupervisorToTasks; the stale lease
-        // will expire naturally via the claim reconciliation controller.
-        void slotId;
+        const active = await options.claimStore.listClaims({ status: "active" });
+        for (const claim of active) {
+          if (claim.context?.agentTaskId === slotId) {
+            await options.claimStore.release(claim.claimId);
+          }
+        }
       },
     });
   }

--- a/src/server/task-controller-wiring.ts
+++ b/src/server/task-controller-wiring.ts
@@ -1,6 +1,10 @@
+import { AcpxSupervisor } from "../core/acpx-supervisor.js";
 import type { AgentRuntime } from "../core/agent-runtime.js";
 import { selectRuntime } from "../core/select-runtime.js";
+import type { AgentTaskStore, ClaimStore } from "../core/store.js";
+import { TaskController } from "../core/task-controller.js";
 import { TmuxRuntime } from "../core/tmux-runtime.js";
+import { wireSupervisorToTasks } from "./acpx-supervisor-wiring.js";
 
 export interface ServerAgentRuntimeDeps {
   readonly selectRuntime?: typeof selectRuntime;
@@ -17,4 +21,53 @@ export async function createServerAgentRuntime(
 
 export function taskControllerEnabled(env: Readonly<Record<string, string | undefined>>): boolean {
   return env.GROVE_TASK_CONTROLLER !== "0";
+}
+
+// ---------------------------------------------------------------------------
+// createTaskControllerWiring — constructs a TaskController and, when the
+// runtime is an AcpxSupervisor, activates respawn→AgentTask wiring.
+// ---------------------------------------------------------------------------
+
+export interface TaskControllerWiringOptions {
+  readonly taskStore: AgentTaskStore;
+  readonly claimStore: ClaimStore;
+  readonly runtime?: AgentRuntime | undefined;
+  readonly workerCount?: number | undefined;
+  readonly resyncIntervalMs?: number | undefined;
+}
+
+export interface TaskControllerWiring {
+  readonly controller: TaskController;
+  readonly runtime: AgentRuntime;
+}
+
+export function createTaskControllerWiring(
+  options: TaskControllerWiringOptions,
+): TaskControllerWiring {
+  const runtime = options.runtime ?? selectRuntime();
+
+  const controller = new TaskController({
+    taskStore: options.taskStore,
+    runtime,
+    workerCount: options.workerCount,
+    resyncIntervalMs: options.resyncIntervalMs,
+  });
+
+  if (runtime instanceof AcpxSupervisor) {
+    wireSupervisorToTasks({
+      supervisor: runtime,
+      taskStore: options.taskStore,
+      onDead: async (slotId): Promise<void> => {
+        // TODO(#273): Claim↔task linkage not available — there is no Claim field
+        // that directly stores the AgentTask id / slotId. Lease release is
+        // deferred until the protocol establishes a stable binding (e.g. an
+        // ownerRef on the claim pointing to the task). The task-failure patch
+        // (phase=Failed) is applied by wireSupervisorToTasks; the stale lease
+        // will expire naturally via the claim reconciliation controller.
+        void slotId;
+      },
+    });
+  }
+
+  return { controller, runtime };
 }

--- a/tests/e2e/acpx-supervisor-respawn-tmux.ts
+++ b/tests/e2e/acpx-supervisor-respawn-tmux.ts
@@ -155,7 +155,9 @@ async function pollTask(
   while (Date.now() < deadline) {
     last = await getTask(baseUrl, token);
     if (last && predicate(last)) {
-      console.log(`[${phase}] matched: phase=${last.status.phase} session=${last.status.sessionId}`);
+      console.log(
+        `[${phase}] matched: phase=${last.status.phase} session=${last.status.sessionId}`,
+      );
       return last;
     }
     await sleep(750);
@@ -199,7 +201,13 @@ async function main(): Promise<void> {
   execSync("git init -q", { cwd: workdir });
   execSync("git commit -q --allow-empty -m init", {
     cwd: workdir,
-    env: { ...process.env, GIT_AUTHOR_NAME: "e2e", GIT_AUTHOR_EMAIL: "e2e@example.com", GIT_COMMITTER_NAME: "e2e", GIT_COMMITTER_EMAIL: "e2e@example.com" },
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "e2e",
+      GIT_AUTHOR_EMAIL: "e2e@example.com",
+      GIT_COMMITTER_NAME: "e2e",
+      GIT_COMMITTER_EMAIL: "e2e@example.com",
+    },
   });
 
   // Initialize a grove project (preset gives server keys + .grove scaffold).
@@ -222,7 +230,9 @@ async function main(): Promise<void> {
   const keysPath = join(workdir, ".grove", "server-keys.yaml");
   let token = "";
   if (existsSync(keysPath)) {
-    const parsed = parseYaml(readFileSync(keysPath, "utf-8")) as { keys?: Array<{ token?: string }> };
+    const parsed = parseYaml(readFileSync(keysPath, "utf-8")) as {
+      keys?: Array<{ token?: string }>;
+    };
     token = parsed.keys?.[0]?.token ?? "";
   }
   const baseUrl = `http://127.0.0.1:${SERVER_PORT}`;

--- a/tests/e2e/acpx-supervisor-respawn-tmux.ts
+++ b/tests/e2e/acpx-supervisor-respawn-tmux.ts
@@ -1,0 +1,308 @@
+/**
+ * Real-process E2E for the AcpxRuntime supervisor respawn path (#273, Phase 5.3).
+ *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │ ⚠️  STATUS: NOT-YET-RUN. Authored without a live grove+Nexus stack.       │
+ * │ This script encodes the INTENDED end-to-end scenario and assertions, but  │
+ * │ it has NOT been executed against a real stack. Two areas are explicitly   │
+ * │ marked TODO(verify-on-stack) below and will almost certainly need a tweak │
+ * │ on first real run: (1) acpx child-PID discovery, (2) the exact agent-task │
+ * │ id / readiness signal. Do NOT report this E2E as passing until it has been │
+ * │ run on a real stack and the assertions observed green. See the runbook at  │
+ * │ docs/superpowers/plans/2026-05-29-acpx-supervisor-e2e-runbook.md.          │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ *
+ * Scenario:
+ *   1. Start a real grove-server with GROVE_SUPERVISOR=1 (so selectRuntime wraps
+ *      the runtime in AcpxSupervisor) in a fresh temp workdir + `git init`
+ *      (fresh dir per run avoids the stale-session IPC stall — project memory).
+ *   2. Create one AgentTask (PUT /api/agent-tasks/:id) that binds a real acpx
+ *      agent; wait until its status.phase === "Running" and status.sessionId set.
+ *   3. Discover the acpx adapter child PID and `kill -9` it (simulate a crash).
+ *   4. Poll GET /api/agent-tasks/:id until a `SessionLost` condition appears
+ *      AND status.phase is still "Running" (transient blip, NOT Failed) AND
+ *      status.sessionId has CHANGED (respawn bound a fresh session).
+ *
+ * What this E2E can and cannot assert (verified against the codebase, #273):
+ *   ✅ AgentTask phase transitions (Pending → Running) and stays Running on a
+ *      recoverable respawn (does not flip to Failed).
+ *   ✅ A `SessionLost` condition (type "SessionLost", status "True") is present
+ *      after respawn — set by src/server/acpx-supervisor-wiring.ts.
+ *   ✅ status.sessionId changes across the kill boundary (fresh session/new).
+ *   ❌ Monotonic `seq` across the kill boundary is NOT externally observable.
+ *      Supervisor-stamped seq lives only on the in-process AcpRuntimeEvent sink
+ *      (→ AcpSessionStore, TUI-local). It is NOT exposed over HTTP/SSE today, so
+ *      a black-box E2E cannot assert seq continuity. Seq continuity IS covered
+ *      by the unit test src/core/acpx-supervisor.respawn.test.ts
+ *      ("seq is strictly increasing across turns and respawn (no reset)").
+ *      If wire-level seq observability is wanted, that's a separate follow-up
+ *      (expose seq on the watch/agent-event stream), tracked outside #273.
+ *
+ * NOT wired into `bun test`. Run as:
+ *   GROVE_SUPERVISOR=1 bun run tests/e2e/acpx-supervisor-respawn-tmux.ts
+ *
+ * Flags:
+ *   --keep          Leave tmux session + workdir for inspection
+ *   --attach        Print `tmux attach` command and wait
+ *   --timeout <ms>  Overall budget (default 120000)
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { parse as parseYaml } from "yaml";
+
+// ─── Paths / constants ──────────────────────────────────────────────────────
+
+const SOCKET = "grove-acpx-respawn-e2e";
+const SESSION = "grove-acpx-respawn-e2e";
+const PROJECT_ROOT = join(import.meta.dir, "..", "..");
+const SERVER_PORT = 12931;
+const TASK_ID = "e2e-respawn-task";
+const ROLE = "coder";
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    keep: { type: "boolean", default: false },
+    attach: { type: "boolean", default: false },
+    timeout: { type: "string", default: "120000" },
+  },
+});
+const KEEP = values.keep;
+const ATTACH = values.attach;
+const BUDGET_MS = Number.parseInt(values.timeout as string, 10);
+
+// ─── tmux helpers (mirrors tests/e2e/watch-relist-tmux.ts) ──────────────────
+
+function tmux(cmd: string, args: string[], opts: { check?: boolean } = {}): string {
+  const out = spawnSync("tmux", ["-L", SOCKET, cmd, ...args], { encoding: "utf-8" });
+  if (opts.check !== false && out.status !== 0) {
+    throw new Error(`tmux ${cmd} failed (${out.status}): ${out.stderr}`);
+  }
+  return out.stdout;
+}
+
+function sendKeys(line: string, enter: "C-m" | undefined, target = SESSION): void {
+  tmux("send-keys", ["-t", target, line, ...(enter ? [enter] : [])]);
+}
+
+function capturePane(target = SESSION): string {
+  const out = spawnSync("tmux", ["-L", SOCKET, "capture-pane", "-t", target, "-p", "-S", "-5000"], {
+    encoding: "utf-8",
+  });
+  return out.stdout;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitForPane(
+  predicate: (pane: string) => boolean,
+  phase: string,
+  maxMs: number,
+  target = SESSION,
+): Promise<void> {
+  const deadline = Date.now() + maxMs;
+  while (Date.now() < deadline) {
+    if (predicate(capturePane(target))) {
+      console.log(`[${phase}] matched`);
+      return;
+    }
+    await sleep(500);
+  }
+  throw new Error(`[${phase}] predicate did not match within ${maxMs}ms`);
+}
+
+// ─── HTTP helpers ───────────────────────────────────────────────────────────
+
+interface TaskCondition {
+  readonly type: string;
+  readonly status: string;
+  readonly reason: string;
+}
+interface TaskView {
+  readonly status: {
+    readonly phase: string;
+    readonly sessionId?: string;
+    readonly conditions: readonly TaskCondition[];
+  };
+}
+
+function authHeaders(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+async function getTask(baseUrl: string, token: string): Promise<TaskView | undefined> {
+  const res = await fetch(`${baseUrl}/api/agent-tasks/${TASK_ID}`, { headers: authHeaders(token) });
+  if (res.status === 404) return undefined;
+  if (!res.ok) throw new Error(`GET task failed: ${res.status}`);
+  return (await res.json()) as TaskView;
+}
+
+async function pollTask(
+  baseUrl: string,
+  token: string,
+  predicate: (t: TaskView) => boolean,
+  phase: string,
+  maxMs: number,
+): Promise<TaskView> {
+  const deadline = Date.now() + maxMs;
+  let last: TaskView | undefined;
+  while (Date.now() < deadline) {
+    last = await getTask(baseUrl, token);
+    if (last && predicate(last)) {
+      console.log(`[${phase}] matched: phase=${last.status.phase} session=${last.status.sessionId}`);
+      return last;
+    }
+    await sleep(750);
+  }
+  throw new Error(`[${phase}] not satisfied within ${maxMs}ms; last=${JSON.stringify(last)}`);
+}
+
+// ─── acpx child-PID discovery ───────────────────────────────────────────────
+// TODO(verify-on-stack): confirm the adapter process name. The supervisor's
+// shared AcpRuntime spawns the agent adapter via acp-launch (codex →
+// @zed-industries/codex-acp, claude → @agentclientprotocol/claude-agent-acp,
+// gemini → `gemini --acp`). On the real stack, inspect `pgrep -fl` output once
+// and pin the matching pattern. We match a process whose argv mentions the
+// adapter and is a descendant of our server, then return the youngest match.
+function findAcpxChildPid(): number | undefined {
+  const out = spawnSync(
+    "bash",
+    ["-lc", "pgrep -fl 'codex-acp|claude-agent-acp|gemini .*--acp|acp' || true"],
+    { encoding: "utf-8" },
+  );
+  const lines = out.stdout.split("\n").filter((l) => l.trim().length > 0);
+  // Prefer the most recently started match (highest pid is a rough proxy).
+  const pids = lines
+    .map((l) => Number.parseInt(l.trim().split(/\s+/)[0] ?? "", 10))
+    .filter((n) => Number.isInteger(n));
+  if (pids.length === 0) return undefined;
+  return Math.max(...pids);
+}
+
+// ─── main ───────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  if (process.env.GROVE_SUPERVISOR !== "1") {
+    throw new Error("GROVE_SUPERVISOR=1 is required (the supervisor must wrap the runtime)");
+  }
+  const startedAt = Date.now();
+  const budgetLeft = (): number => Math.max(1000, BUDGET_MS - (Date.now() - startedAt));
+
+  const workdir = mkdtempSync(join(tmpdir(), "grove-acpx-respawn-"));
+  // Fresh git repo per run — avoids the stale-session IPC stall (project memory).
+  execSync("git init -q", { cwd: workdir });
+  execSync("git commit -q --allow-empty -m init", {
+    cwd: workdir,
+    env: { ...process.env, GIT_AUTHOR_NAME: "e2e", GIT_AUTHOR_EMAIL: "e2e@example.com", GIT_COMMITTER_NAME: "e2e", GIT_COMMITTER_EMAIL: "e2e@example.com" },
+  });
+
+  // Initialize a grove project (preset gives server keys + .grove scaffold).
+  execSync(`bun run ${join(PROJECT_ROOT, "src/cli/main.ts")} init --preset review-loop`, {
+    cwd: workdir,
+    stdio: "inherit",
+  });
+
+  tmux("new-session", ["-d", "-s", SESSION, "-x", "220", "-y", "50"]);
+
+  const serverEntry = join(PROJECT_ROOT, "src/server/serve.ts");
+  // GROVE_SUPERVISOR=1 makes selectRuntime() wrap the runtime in AcpxSupervisor.
+  sendKeys(
+    `cd ${workdir} && GROVE_SUPERVISOR=1 GROVE_TASK_CONTROLLER=1 bun ${serverEntry} --port ${SERVER_PORT}`,
+    "C-m",
+  );
+  await waitForPane((p) => /listening|ready|Server listening/i.test(p), "server-start", 25000);
+
+  // Bearer token for the API.
+  const keysPath = join(workdir, ".grove", "server-keys.yaml");
+  let token = "";
+  if (existsSync(keysPath)) {
+    const parsed = parseYaml(readFileSync(keysPath, "utf-8")) as { keys?: Array<{ token?: string }> };
+    token = parsed.keys?.[0]?.token ?? "";
+  }
+  const baseUrl = `http://127.0.0.1:${SERVER_PORT}`;
+
+  // ─── Create the AgentTask (binds a real acpx agent via the controller) ──────
+  // TODO(verify-on-stack): confirm the AgentTask spec shape the server accepts
+  // (worktree/runtime/role/prompt/generation). Adjust to the real PUT schema.
+  const putRes = await fetch(`${baseUrl}/api/agent-tasks/${TASK_ID}`, {
+    method: "PUT",
+    headers: authHeaders(token),
+    body: JSON.stringify({
+      id: TASK_ID,
+      worktree: workdir,
+      runtime: "codex",
+      role: ROLE,
+      prompt: "Stay running; do nothing destructive. Wait for instructions.",
+      dependsOn: [],
+      generation: 1,
+      createdAt: new Date().toISOString(),
+    }),
+  });
+  if (!putRes.ok) throw new Error(`PUT agent-task failed: ${putRes.status} ${await putRes.text()}`);
+
+  // ─── Wait for the task to bind + run ───────────────────────────────────────
+  const running = await pollTask(
+    baseUrl,
+    token,
+    (t) => t.status.phase === "Running" && typeof t.status.sessionId === "string",
+    "task-running",
+    Math.min(60000, budgetLeft()),
+  );
+  const firstSessionId = running.status.sessionId;
+  console.log(`[bound] first sessionId=${firstSessionId}`);
+
+  // ─── Kill the acpx child to simulate a crash ───────────────────────────────
+  const pid = findAcpxChildPid();
+  if (pid === undefined) {
+    throw new Error(
+      "could not find an acpx adapter child PID to kill — see TODO(verify-on-stack) in findAcpxChildPid()",
+    );
+  }
+  console.log(`[kill] SIGKILL acpx child pid=${pid}`);
+  spawnSync("kill", ["-9", String(pid)]);
+
+  // ─── Assert respawn: SessionLost condition + new session + still Running ────
+  const recovered = await pollTask(
+    baseUrl,
+    token,
+    (t) =>
+      t.status.phase === "Running" &&
+      t.status.conditions.some((c) => c.type === "SessionLost" && c.status === "True") &&
+      typeof t.status.sessionId === "string" &&
+      t.status.sessionId !== firstSessionId,
+    "task-respawned",
+    Math.min(90000, budgetLeft()),
+  );
+
+  console.log(
+    `PASS: respawn observed — SessionLost set, phase still Running, sessionId ${firstSessionId} → ${recovered.status.sessionId}`,
+  );
+  console.log(
+    "NOTE: seq continuity is NOT asserted here (not wire-observable); see acpx-supervisor.respawn.test.ts.",
+  );
+
+  // ─── Teardown ───────────────────────────────────────────────────────────────
+  if (ATTACH) {
+    console.log(`Attach with: tmux -L ${SOCKET} attach -t ${SESSION}`);
+    await sleep(budgetLeft());
+  }
+  if (!KEEP) {
+    tmux("kill-session", ["-t", SESSION], { check: false });
+    rmSync(workdir, { recursive: true, force: true });
+  } else {
+    console.log(`[keep] workdir=${workdir} session=${SESSION} socket=${SOCKET}`);
+  }
+}
+
+main().catch((err) => {
+  console.error("FAIL:", err);
+  // Best-effort teardown on failure unless --keep.
+  if (!KEEP) tmux("kill-session", ["-t", SESSION], { check: false });
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #273.

Builds `AcpxSupervisor` — a grove-owned registry of acpx runtime handles with death-detection, respawn, best-effort auto-resume, and `SessionLost` surfacing on `AgentTask`, adopted behind a flag. Also delivers the #210 runtime-adapter conformance matrix.

## Phases (each TDD'd, two-stage reviewed)

- **P1 — Death-detection seam.** `AgentDisconnectedError` + optional `onDisconnect` on `AgentRuntime`; `AcpRuntime` detects an *unexpected* child exit (new `onExit` on `LaunchResult`), marks the session `crashed`, and rejects the in-flight `send()` with `stopReason: "error"`. Intentional `close()` never fires it.
- **P2 — Registry core + adapter matrix (#210).** `AcpxSupervisor` (`ensure`/`get`/`stop`/`list`, idempotent + single-flight, `AgentRuntime` façade). New shared `runRuntimeAdapterMatrix(label, factory)` runs Mock + Acp + Supervisor through one conformance suite. (Caught + fixed a real `MockRuntime.close()` contract bug along the way.)
- **P3 — Respawn + auto-resume + seq.** On disconnect: `running → resuming → running`, fresh session within the shared runtime (new `wireSessionId`, never the dead one — #319), exponential backoff + `maxRespawns → dead`. Monotonic per-slot `seq` survives the respawn boundary (no reset).
- **P4 — `SessionLost` on `AgentTask`.** New `Resuming`/`SessionLost` condition types; a thin wiring layer (`src/server/acpx-supervisor-wiring.ts`) translates respawn events into task conditions — a transient blip stays `Running`, a permanent death goes `Failed`.
- **P5 — Adoption + lease release + E2E.** `selectRuntime` wraps in the supervisor behind `GROVE_SUPERVISOR=1`; the server activates the respawn→task wiring. Claims carry `context.agentTaskId` (stamped via MCP from `GROVE_AGENT_TASK_ID`) so `onDead` releases exactly that task's leases instead of stranding them.

## Key design decisions (the issue is ahead of current code in several ways)

- **Class is `AcpRuntime`, not `AcpxRuntime`**; the registry holds it.
- **One shared `AcpRuntime` for all slots**, not one per slot. grove's `AcpRuntime` already spawns one *adapter subprocess per `spawn()`*, so process-per-slot isolation (the issue's intent) is preserved while a shared client gives a single monotonic id counter and one event sink to demux. Recorded in the design doc.
- **Respawn-as-new, not `session/load`** (upstream-unsupported; consistent with grove-direct-acp). `SessionLost` is always surfaced; `seq`/`acpxRecordId` are forward-compatible if `session/load` ever lands.
- **`seq` lives at the eventSink**, not `publishTurnToNexus` (which has no production caller today).

Design + plan: `docs/superpowers/specs/2026-05-29-acpx-supervisor-design.md`, `docs/superpowers/plans/2026-05-29-acpx-supervisor.md`.

## Verification

- **Full suite: 8426 pass / 0 fail / 7 skip.** The non-zero `bun test` exit is a pre-existing coverage threshold on `use-text-input.ts` (exists on `main`), unrelated to this branch.
- `bun run build` green (after `bun install` for the ask-user SDK); typecheck shows only the pre-existing `packages/ask-user` `@anthropic-ai/sdk` errors.

## Deferred / called out honestly

- **The real-process kill-PID E2E is authored but NOT-YET-RUN** (`tests/e2e/acpx-supervisor-respawn-tmux.ts` + runbook). It needs a live grove+Nexus stack; two spots are marked `TODO(verify-on-stack)` (acpx child-PID discovery, AgentTask PUT schema/readiness). Do not treat the respawn path as E2E-validated until it runs green on a stack.
- **`seq` is not wire-observable today** — it lives on the in-process eventSink (→ `AcpSessionStore`, TUI-local), so the E2E asserts AgentTask phase + `SessionLost` condition + sessionId-change instead. Seq continuity is covered by the unit test `acpx-supervisor.respawn.test.ts`. Exposing seq over HTTP/SSE would be a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)