### PR TITLE
feat(eval): grove eval harness — CLI, eval-loop preset, hooks.eval, Nexus-aware (#211)

### DIFF
--- a/docs/parity-matrix.md
+++ b/docs/parity-matrix.md
@@ -21,6 +21,7 @@ and their classification. All `shared` capabilities use the operations layer in
 | contribute | Y | Y | Y | - | shared |
 | review | Y | Y | Y | - | shared |
 | reproduce | Y | Y | Y | - | shared |
+| eval | Y | Y | - | - | shared |
 | discuss | Y | Y | Y | - | shared |
 | claim | Y | Y | Y | Y | shared |
 | release/complete | Y | Y | Y | Y | shared |

--- a/docs/superpowers/specs/2026-05-30-eval-harness-211-design.md
+++ b/docs/superpowers/specs/2026-05-30-eval-harness-211-design.md
@@ -1,0 +1,182 @@
+# Eval harness completion — `grove eval` + `hooks.eval` (#211)
+
+**Date:** 2026-05-30
+**Issue:** [#211](https://github.com/windoliver/grove/issues/211)
+**Status:** Design approved (user delegated: "whatever you recommend")
+
+## Context
+
+Issue #211 asks for a first-class eval harness: `modify → eval → score → leaderboard`.
+Three commits already shipped part of it:
+
+- `src/core/operations/eval.ts` — `evalOperation`
+- `src/mcp/tools/eval.ts` — `grove_eval` MCP tool (opt-in, disabled by default)
+- export from `src/core/operations/index.ts`
+
+The shipped implementation **diverged** from the issue's prose spec:
+
+| Aspect | Issue prose | Shipped `evalOperation` |
+|---|---|---|
+| Score protocol | JSON stdout `{"scores":{...}}` | `GROVE_SCORE name=value` lines (stdout/stderr) |
+| Env passed to script | `GROVE_EVAL_DIR` + `GROVE_EVAL_CID` | `GROVE_TARGET_CID` only |
+| Artifact checkout | yes (workspace dir) | no |
+| Resolve cmd from `contract.hooks.eval` | yes | no (command required as input) |
+| `--submit` reproduction | yes | no |
+
+The two score protocols are mutually incompatible.
+
+## Decision
+
+**Extend the shipped `GROVE_SCORE`-line design. Do not rewrite the merged core op or MCP tool.**
+
+Rationale: the shipped protocol is merged, tested, and on the public MCP surface. The
+`GROVE_SCORE`-line contract is simpler than JSON-stdout (line-streamed, tolerant of progress
+output) and already works. Rewriting it discards working code and breaks the `grove_eval`
+MCP contract for no functional gain. We add the genuinely-useful, non-conflicting pieces the
+issue wants on top of the shipped foundation.
+
+## Components
+
+### 1. Contract — `src/core/hooks.ts`
+
+Add `eval` to the hooks schema:
+
+```ts
+export interface HooksConfig {
+  readonly after_checkout?: HookEntry | undefined;
+  readonly before_contribute?: HookEntry | undefined;
+  readonly after_contribute?: HookEntry | undefined;
+  readonly eval?: HookEntry | undefined;        // NEW
+}
+```
+
+Add `eval: HookEntrySchema.optional()` to `HooksConfigSchema` (still `.strict()`). Update the
+module doc comment to list the `eval` hook. `HookEntry` already supports the `{cmd, timeout}`
+object form, so per-eval timeout is free.
+
+### 2. Core op — `src/core/operations/eval.ts`
+
+When `input.evalCommand` is absent, resolve the command from `deps.contract?.hooks?.eval`:
+
+- string form → use directly
+- `{cmd, timeout}` form → use `cmd`; if `input.timeoutMs` is also absent, use the hook's
+  `timeout` (ms) as the resolved timeout
+- neither input nor contract → existing `VALIDATION_ERROR`
+
+`evalOperation` currently ignores `deps` (`_deps`). Change to read `deps.contract`. The
+`OperationDeps` type already carries an optional `contract`. No behavior change when a command
+is passed explicitly — fully backward compatible. The MCP tool keeps passing an explicit
+`evalCommand`, so its behavior is unchanged; CLI gains contract resolution.
+
+Add **`src/core/operations/eval.test.ts`** (currently zero coverage): score parsing
+(stdout + stderr, int/float/scientific/negative), non-score line tolerance, partial-final-line
+flush, timeout → `timedOut: true` + exit 124, missing command → validation error, and
+contract-resolution path (string and `{cmd,timeout}`).
+
+### 3. CLI — `src/cli/commands/eval.ts` (new)
+
+```
+grove eval <cid>                       # cmd from contract.hooks.eval
+grove eval --frontier <metric>         # target = frontier byMetric[metric][0].cid
+grove eval --latest                    # target = logOperation({limit:1}).results[0].cid
+grove eval <cid> --eval-command "..."  # override command
+grove eval <cid> --submit              # eval, then reproduceOperation with parsed scores
+grove eval <cid> --timeout <ms>
+grove eval <cid> --json
+```
+
+`parseEvalArgs` (pure, unit-tested) + `runEval` (resolves grove dir / stores / contract / agent,
+mirrors `reproduce.ts` wiring) + `handleEval`.
+
+Target-CID resolution precedence: positional `<cid>` → `--frontier <metric>` (via
+`frontierOperation`, take `byMetric[metric][0]`; error if metric absent/empty) → `--latest`
+(via `logOperation({limit:1})`; error if no contributions). Exactly one selector required.
+
+Command resolution: `--eval-command` → `contract.hooks.eval` (passed through `deps.contract`
+to the op) → validation error.
+
+`--submit`: after a successful eval, convert parsed `EvalScore[]` → `Record<string, Score>`
+using contract metric directions (`contract.metrics[name]?.direction ?? Maximize`, same as
+`reproduce.ts`), then call `reproduceOperation({ targetCid, summary, result: "confirmed",
+scores, tags, agent })`. Default summary: `"Eval of <cid>: <metric=value, ...>"`. Submit only
+when `exitCode === 0`; otherwise print scores + nonzero exit and skip submission (note it).
+
+Human output: list `metric = value` lines, exit code, timed-out flag; `--json` emits the full
+`EvalResult` (plus reproduction cid when `--submit`).
+
+Wire-up: `main.ts` dispatch block (lazy `import("./commands/eval.js")`), `printUsage` help
+line, `registry.ts` `COMMANDS` entry with flags
+`["frontier","latest","eval-command","submit","timeout","json"]`.
+
+### 4. Preset — `src/cli/presets/eval-loop.ts` (new)
+
+Hive-style competitive benchmark:
+
+```ts
+{
+  name: "eval-loop",
+  description: "Competitive benchmark loop with score:maximize",
+  mode: "evaluation",
+  metrics: [{ name: "score", direction: "maximize", description: "Benchmark score" }],
+  topology: {
+    structure: "graph",
+    roles: [{
+      name: "competitor",
+      description: "Iterates to improve the benchmark score",
+      maxInstances: 8,
+      edges: [],
+      command: "claude --role competitor",
+    }],
+    spawning: { dynamic: true, maxDepth: 1 },
+  },
+  gates: [{ type: "metric_improves", metric: "score" }],
+  stopConditions: {
+    maxRoundsWithoutImprovement: 20,
+    targetMetric: { metric: "score", value: 1.0 },
+    budget: { maxContributions: 2000, maxWallClockSeconds: 86400 },
+  },
+  hooks: { eval: "bash eval/eval.sh" },   // placeholder, emitted into GROVE.md
+  // concurrency/execution/services/backend/features mirror research-loop
+}
+```
+
+Register in `presets/index.ts` (`getPresetRegistry`, the `export {}` block). The preset declares
+`hooks.eval`, so `grove init --preset eval-loop` writes a GROVE.md whose eval hook a benchmark
+script fills in.
+
+`renderHooks` in `src/cli/grove-md-builder.ts` currently emits only
+`after_checkout/before_contribute/after_contribute` — add an `eval:` line so the placeholder
+reaches the generated GROVE.md. (`HooksConfig` in the builder uses camelCase `afterCheckout`
+etc.; add `evalCmd`/`eval` field accordingly and thread it through `presetToGroveMdConfig`.)
+
+### 5. Surfaces / parity
+
+- `docs/parity-matrix.md`: add row `| eval | Y | Y | - | - | shared |`.
+- `parity-matrix.test.ts`: add `evalOperation` to the index-export list, `{operation:
+  "evalOperation", cliCommand: "eval"}` to the CLI list, and `{operation: "evalOperation",
+  mcpTool: "grove_eval"}` to the MCP list. This is the CI gate that keeps surfaces in sync.
+
+## Deliberate non-goals (this iteration)
+
+- **JSON-stdout protocol / `GROVE_EVAL_DIR` / `GROVE_EVAL_CID`** — superseded by the shipped
+  `GROVE_SCORE` + `GROVE_TARGET_CID` design.
+- **Artifact checkout into a workspace** — eval runs against the agent's current working tree
+  (which already holds the modified artifacts); `targetCid` is the link/reference, passed as
+  `GROVE_TARGET_CID`. Evaluating a non-working-tree CID requires a prior `grove checkout <cid>`.
+- **MCP `--submit`** — `grove_eval` returns scores; agents call `grove_reproduce` separately.
+  Keeps the MCP tool a pure, side-effect-free scorer.
+
+These are recorded so a future iteration can revisit JSON-stdout / checkout if real eval
+scripts need them.
+
+## Testing
+
+- `src/core/operations/eval.test.ts` — parsing, timeout, validation, contract resolution.
+- `src/cli/commands/eval.test.ts` — arg parsing (selectors mutually exclusive, score/flag
+  validation), and `runEval` against in-memory SQLite stores (frontier/latest resolution,
+  `--submit` creates a reproduction).
+- `src/cli/presets/preset-integration.test.ts` — picks up `eval-loop` registration; assert it
+  builds a valid GROVE.md with the eval hook.
+- `parity-matrix.test.ts` — CI gate (CLI + MCP + export coverage).
+
+Full suite + typecheck + biome must pass before PR.

--- a/src/cli/commands/eval.test.ts
+++ b/src/cli/commands/eval.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for grove eval command.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { GroveContract } from "../../core/contract.js";
+import { DefaultFrontierCalculator } from "../../core/frontier.js";
+import { ContributionKind, ScoreDirection } from "../../core/models.js";
+import type { OperationDeps } from "../../core/operations/deps.js";
+import { makeContribution } from "../../core/test-helpers.js";
+import { FsCas } from "../../local/fs-cas.js";
+import {
+  initSqliteDb,
+  SqliteClaimStore,
+  SqliteContributionStore,
+} from "../../local/sqlite-store.js";
+import { parseEvalArgs, runEval } from "./eval.js";
+
+// ---------------------------------------------------------------------------
+// parseEvalArgs
+// ---------------------------------------------------------------------------
+
+describe("parseEvalArgs", () => {
+  test("parses a positional cid as the target", () => {
+    const opts = parseEvalArgs(["blake3:abc"]);
+    expect(opts.targetCid).toBe("blake3:abc");
+    expect(opts.latest).toBe(false);
+    expect(opts.frontierMetric).toBeUndefined();
+    expect(opts.submit).toBe(false);
+    expect(opts.json).toBe(false);
+  });
+
+  test("parses --frontier <metric>", () => {
+    const opts = parseEvalArgs(["--frontier", "acc"]);
+    expect(opts.frontierMetric).toBe("acc");
+    expect(opts.targetCid).toBeUndefined();
+  });
+
+  test("parses --latest", () => {
+    const opts = parseEvalArgs(["--latest"]);
+    expect(opts.latest).toBe(true);
+  });
+
+  test("parses --eval-command, --submit, --timeout, --json", () => {
+    const opts = parseEvalArgs([
+      "blake3:abc",
+      "--eval-command",
+      "python eval.py",
+      "--submit",
+      "--timeout",
+      "5000",
+      "--json",
+    ]);
+    expect(opts.evalCommand).toBe("python eval.py");
+    expect(opts.submit).toBe(true);
+    expect(opts.timeoutMs).toBe(5000);
+    expect(opts.json).toBe(true);
+  });
+
+  test("throws when no target selector is given", () => {
+    expect(() => parseEvalArgs([])).toThrow();
+  });
+
+  test("throws when more than one target selector is given", () => {
+    expect(() => parseEvalArgs(["blake3:abc", "--latest"])).toThrow();
+    expect(() => parseEvalArgs(["--frontier", "acc", "--latest"])).toThrow();
+  });
+
+  test("throws on a non-numeric --timeout", () => {
+    expect(() => parseEvalArgs(["blake3:abc", "--timeout", "soon"])).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runEval
+// ---------------------------------------------------------------------------
+
+describe("runEval", () => {
+  let tmpDir: string;
+  let store: SqliteContributionStore;
+  let claimStore: SqliteClaimStore;
+  let cas: FsCas;
+  let baseDeps: OperationDeps;
+  const agent = { agentId: "agent-eval" };
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "grove-eval-test-"));
+    const db = initSqliteDb(join(tmpDir, "grove.db"));
+    store = new SqliteContributionStore(db);
+    claimStore = new SqliteClaimStore(db);
+    cas = new FsCas(join(tmpDir, "cas"));
+    baseDeps = {
+      contributionStore: store,
+      claimStore,
+      cas,
+      frontier: new DefaultFrontierCalculator(store),
+    };
+  });
+
+  afterEach(async () => {
+    store.close();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("evaluates an explicit cid with --eval-command and prints scores", async () => {
+    const c = makeContribution({ summary: "target" });
+    await store.put(c);
+    const out: string[] = [];
+
+    await runEval(
+      {
+        targetCid: c.cid,
+        evalCommand: "echo GROVE_SCORE acc=0.9",
+        latest: false,
+        submit: false,
+        json: false,
+      },
+      baseDeps,
+      agent,
+      (s) => out.push(s),
+    );
+
+    const text = out.join("\n");
+    expect(text).toContain("acc");
+    expect(text).toContain("0.9");
+  });
+
+  test("resolves --latest to the newest contribution", async () => {
+    const older = makeContribution({ summary: "older", createdAt: "2026-01-01T00:00:00Z" });
+    const newer = makeContribution({ summary: "newer", createdAt: "2026-02-01T00:00:00Z" });
+    await store.put(older);
+    await store.put(newer);
+    const out: string[] = [];
+
+    await runEval(
+      { evalCommand: "echo GROVE_SCORE x=1", latest: true, submit: false, json: false },
+      baseDeps,
+      agent,
+      (s) => out.push(s),
+    );
+
+    expect(out.join("\n")).toContain(newer.cid);
+  });
+
+  test("resolves --frontier <metric> to the leader", async () => {
+    const weak = makeContribution({
+      summary: "weak",
+      scores: { acc: { value: 0.5, direction: ScoreDirection.Maximize } },
+    });
+    const strong = makeContribution({
+      summary: "strong",
+      scores: { acc: { value: 0.9, direction: ScoreDirection.Maximize } },
+    });
+    await store.put(weak);
+    await store.put(strong);
+    const out: string[] = [];
+
+    await runEval(
+      {
+        frontierMetric: "acc",
+        evalCommand: "echo GROVE_SCORE x=1",
+        latest: false,
+        submit: false,
+        json: false,
+      },
+      baseDeps,
+      agent,
+      (s) => out.push(s),
+    );
+
+    expect(out.join("\n")).toContain(strong.cid);
+  });
+
+  test("--submit creates a reproduction carrying the parsed scores", async () => {
+    const c = makeContribution({ summary: "target" });
+    await store.put(c);
+    const contract: GroveContract = {
+      contractVersion: 2,
+      name: "eval-grove",
+      metrics: { acc: { direction: ScoreDirection.Maximize } },
+    };
+    const out: string[] = [];
+
+    await runEval(
+      {
+        targetCid: c.cid,
+        evalCommand: "echo GROVE_SCORE acc=0.95",
+        latest: false,
+        submit: true,
+        json: false,
+      },
+      { ...baseDeps, contract },
+      agent,
+      (s) => out.push(s),
+    );
+
+    const all = await store.list();
+    const repro = all.find((x) => x.kind === ContributionKind.Reproduction);
+    expect(repro).toBeDefined();
+    expect(repro?.scores?.acc?.value).toBe(0.95);
+  });
+
+  test("resolves the command from contract.hooks.eval when no --eval-command", async () => {
+    const c = makeContribution({ summary: "target" });
+    await store.put(c);
+    const contract: GroveContract = {
+      contractVersion: 2,
+      name: "eval-grove",
+      hooks: { eval: "echo GROVE_SCORE acc=0.7" },
+    };
+    const out: string[] = [];
+
+    await runEval(
+      { targetCid: c.cid, latest: false, submit: false, json: false },
+      { ...baseDeps, contract },
+      agent,
+      (s) => out.push(s),
+    );
+
+    const text = out.join("\n");
+    expect(text).toContain("acc");
+    expect(text).toContain("0.7");
+  });
+});

--- a/src/cli/commands/eval.ts
+++ b/src/cli/commands/eval.ts
@@ -181,6 +181,8 @@ export async function runEval(
         writer(`eval exited ${evalResult.exitCode}; skipping --submit`);
       }
     } else {
+      // A zero-score but exit-0 eval still records a `confirmed` reproduction
+      // (scores omitted below) — the run succeeded; it just reported no metrics.
       const scores: Record<string, Score> = {};
       for (const s of evalResult.scores) {
         const direction = deps.contract?.metrics?.[s.metric]?.direction ?? ScoreDirection.Maximize;

--- a/src/cli/commands/eval.ts
+++ b/src/cli/commands/eval.ts
@@ -19,6 +19,7 @@
 
 import { join } from "node:path";
 import { parseArgs } from "node:util";
+import type { ContentStore } from "../../core/cas.js";
 import { EnforcingContributionStore } from "../../core/enforcing-store.js";
 import { DefaultFrontierCalculator } from "../../core/frontier.js";
 import type { Score } from "../../core/models.js";
@@ -32,12 +33,14 @@ import {
   logOperation,
   reproduceOperation,
 } from "../../core/operations/index.js";
+import type { ClaimStore, ContributionStore } from "../../core/store.js";
 import { FsCas } from "../../local/fs-cas.js";
 import { createSqliteStores } from "../../local/sqlite-store.js";
 import { resolveAgent } from "../agent.js";
 import type { Writer } from "../context.js";
 import { outputJson, outputJsonError } from "../format.js";
 import { resolveGroveDir } from "../utils/grove-dir.js";
+import { openNexusStores, resolveNexusParams } from "../utils/nexus-stores.js";
 import { resolveContract } from "../utils/resolve-contract.js";
 
 export interface EvalOptions {
@@ -227,25 +230,47 @@ export async function runEval(
 export async function handleEval(args: readonly string[], groveOverride?: string): Promise<void> {
   const options = parseEvalArgs(args);
   const { dbPath, groveDir } = resolveGroveDir(groveOverride);
+  const groveRoot = join(groveDir, "..");
+  // Local stores are always opened — they back contract/goal resolution and
+  // are the fallback when the grove is not Nexus-managed.
   const stores = createSqliteStores(dbPath);
-  const cas = new FsCas(join(groveDir, "cas"));
-  const frontier = new DefaultFrontierCalculator(stores.contributionStore);
 
   try {
     const contract = await resolveContract({
       goalSessionStore: stores.goalSessionStore,
-      groveRoot: join(groveDir, ".."),
+      groveRoot,
       envSessionId: process.env.GROVE_SESSION_ID,
     });
 
+    // Prefer Nexus-backed stores so `--latest` / `--frontier` / `--submit` see
+    // live session contributions (which live in the Nexus VFS, not local
+    // SQLite). Fall back to local stores when the grove is not Nexus-managed.
+    const nexusParams = resolveNexusParams(groveDir, groveRoot);
+    let baseStore: ContributionStore;
+    let claimStore: ClaimStore;
+    let cas: ContentStore;
+    if (nexusParams) {
+      const nexus = await openNexusStores(nexusParams);
+      baseStore = nexus.contributionStore;
+      claimStore = nexus.claimStore;
+      cas = nexus.cas;
+      const scope = nexus.sessionId ? `session ${nexus.sessionId}` : "zone-wide";
+      process.stderr.write(`grove eval: using Nexus stores at ${nexusParams.url} (${scope})\n`);
+    } else {
+      baseStore = stores.contributionStore;
+      claimStore = stores.claimStore;
+      cas = new FsCas(join(groveDir, "cas"));
+    }
+
     const contributionStore = contract
-      ? new EnforcingContributionStore(stores.contributionStore, contract, { cas })
-      : stores.contributionStore;
+      ? new EnforcingContributionStore(baseStore, contract, { cas })
+      : baseStore;
+    const frontier = new DefaultFrontierCalculator(baseStore);
 
     const agent = resolveAgent();
     const deps: OperationDeps = {
       contributionStore,
-      claimStore: stores.claimStore,
+      claimStore,
       cas,
       frontier,
       ...(contract !== undefined ? { contract } : {}),

--- a/src/cli/commands/eval.ts
+++ b/src/cli/commands/eval.ts
@@ -1,0 +1,258 @@
+/**
+ * grove eval — run the contract's eval harness against a target contribution
+ * and report structured metric scores.
+ *
+ * Usage:
+ *   grove eval <cid>                       # cmd from GROVE.md hooks.eval
+ *   grove eval --frontier <metric>         # eval the frontier leader for <metric>
+ *   grove eval --latest                    # eval the most recent contribution
+ *   grove eval <cid> --eval-command "..."  # override the eval command
+ *   grove eval <cid> --submit              # eval, then submit a scored reproduction
+ *   grove eval <cid> --timeout 600000      # subprocess timeout (ms)
+ *   grove eval <cid> --json
+ *
+ * The eval command is spawned via `sh -c` with GROVE_TARGET_CID set to the
+ * resolved target. It must print score lines in the form
+ *   GROVE_SCORE <metric>=<value>
+ * to stdout or stderr (other output is ignored).
+ */
+
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { EnforcingContributionStore } from "../../core/enforcing-store.js";
+import { DefaultFrontierCalculator } from "../../core/frontier.js";
+import type { Score } from "../../core/models.js";
+import { ScoreDirection } from "../../core/models.js";
+import type { AgentOverrides } from "../../core/operations/agent.js";
+import type { OperationDeps } from "../../core/operations/deps.js";
+import type { EvalScore } from "../../core/operations/index.js";
+import {
+  evalOperation,
+  frontierOperation,
+  logOperation,
+  reproduceOperation,
+} from "../../core/operations/index.js";
+import { FsCas } from "../../local/fs-cas.js";
+import { createSqliteStores } from "../../local/sqlite-store.js";
+import { resolveAgent } from "../agent.js";
+import type { Writer } from "../context.js";
+import { outputJson, outputJsonError } from "../format.js";
+import { resolveGroveDir } from "../utils/grove-dir.js";
+import { resolveContract } from "../utils/resolve-contract.js";
+
+export interface EvalOptions {
+  /** Positional target CID. Mutually exclusive with --frontier / --latest. */
+  readonly targetCid?: string | undefined;
+  /** Resolve the target as the frontier leader for this metric. */
+  readonly frontierMetric?: string | undefined;
+  /** Resolve the target as the most recent contribution. */
+  readonly latest: boolean;
+  /** Override the eval command (otherwise resolved from contract.hooks.eval). */
+  readonly evalCommand?: string | undefined;
+  /** Submit a scored reproduction contribution after a successful eval. */
+  readonly submit: boolean;
+  /** Summary for the reproduction created by --submit. */
+  readonly summary?: string | undefined;
+  /** Subprocess timeout in milliseconds. */
+  readonly timeoutMs?: number | undefined;
+  readonly json: boolean;
+}
+
+/**
+ * Parse `grove eval` arguments.
+ *
+ * Positional: <cid> (optional — alternative to --frontier / --latest)
+ * Flags: --frontier, --latest, --eval-command, --submit, --summary, --timeout, --json
+ */
+export function parseEvalArgs(args: readonly string[]): EvalOptions {
+  const { values, positionals } = parseArgs({
+    args: args as string[],
+    options: {
+      frontier: { type: "string" },
+      latest: { type: "boolean", default: false },
+      "eval-command": { type: "string" },
+      submit: { type: "boolean", default: false },
+      summary: { type: "string" },
+      timeout: { type: "string" },
+      json: { type: "boolean", default: false },
+    },
+    strict: true,
+    allowPositionals: true,
+  });
+
+  const targetCid = positionals[0];
+  const frontierMetric = values.frontier as string | undefined;
+  const latest = values.latest as boolean;
+
+  // Exactly one target selector must be supplied.
+  const selectorCount = (targetCid ? 1 : 0) + (frontierMetric ? 1 : 0) + (latest ? 1 : 0);
+  if (selectorCount === 0) {
+    throw new Error(
+      "Usage: grove eval <cid> | --frontier <metric> | --latest [--eval-command <cmd>] [--submit] [--json]",
+    );
+  }
+  if (selectorCount > 1) {
+    throw new Error("Specify exactly one target: <cid>, --frontier <metric>, or --latest");
+  }
+
+  let timeoutMs: number | undefined;
+  if (values.timeout !== undefined) {
+    timeoutMs = Number.parseInt(values.timeout as string, 10);
+    if (Number.isNaN(timeoutMs) || timeoutMs <= 0) {
+      throw new Error(`Invalid --timeout '${values.timeout}': expected a positive integer (ms)`);
+    }
+  }
+
+  return {
+    ...(targetCid !== undefined ? { targetCid } : {}),
+    ...(frontierMetric !== undefined ? { frontierMetric } : {}),
+    latest,
+    ...(values["eval-command"] !== undefined
+      ? { evalCommand: values["eval-command"] as string }
+      : {}),
+    submit: values.submit as boolean,
+    ...(values.summary !== undefined ? { summary: values.summary as string } : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    json: values.json as boolean,
+  };
+}
+
+/** Resolve the target CID from the option selectors. */
+async function resolveTargetCid(options: EvalOptions, deps: OperationDeps): Promise<string> {
+  if (options.targetCid) return options.targetCid;
+
+  if (options.frontierMetric) {
+    const result = await frontierOperation({ metric: options.frontierMetric, limit: 1 }, deps);
+    if (!result.ok) throw new Error(result.error.message);
+    const leader = result.value.byMetric[options.frontierMetric]?.[0];
+    if (!leader) {
+      throw new Error(`No frontier leader found for metric '${options.frontierMetric}'`);
+    }
+    return leader.cid;
+  }
+
+  // --latest
+  const result = await logOperation({ limit: 1 }, deps);
+  if (!result.ok) throw new Error(result.error.message);
+  const latest = result.value.results[0];
+  if (!latest) throw new Error("No contributions found to evaluate");
+  return latest.cid;
+}
+
+/** Build a default reproduction summary from the parsed scores. */
+function defaultSummary(targetCid: string, scores: readonly EvalScore[]): string {
+  const parts = scores.map((s) => `${s.metric}=${s.value}`).join(", ");
+  return parts ? `Eval of ${targetCid}: ${parts}` : `Eval of ${targetCid}`;
+}
+
+/** Execute `grove eval` against injected operation dependencies. */
+export async function runEval(
+  options: EvalOptions,
+  deps: OperationDeps,
+  agent: AgentOverrides,
+  writer: Writer = console.log,
+): Promise<void> {
+  const targetCid = await resolveTargetCid(options, deps);
+
+  const result = await evalOperation(deps, {
+    targetCid,
+    ...(options.evalCommand !== undefined ? { evalCommand: options.evalCommand } : {}),
+    ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+  });
+
+  if (!result.ok) {
+    if (options.json) {
+      outputJsonError(result.error);
+      return;
+    }
+    throw new Error(result.error.message);
+  }
+
+  const evalResult = result.value;
+
+  // --submit: record a scored reproduction (only when the eval succeeded).
+  let reproductionCid: string | undefined;
+  if (options.submit) {
+    if (evalResult.exitCode !== 0) {
+      if (!options.json) {
+        writer(`eval exited ${evalResult.exitCode}; skipping --submit`);
+      }
+    } else {
+      const scores: Record<string, Score> = {};
+      for (const s of evalResult.scores) {
+        const direction = deps.contract?.metrics?.[s.metric]?.direction ?? ScoreDirection.Maximize;
+        scores[s.metric] = { value: s.value, direction };
+      }
+      const repro = await reproduceOperation(
+        {
+          targetCid,
+          summary: options.summary ?? defaultSummary(targetCid, evalResult.scores),
+          result: "confirmed",
+          ...(Object.keys(scores).length > 0 ? { scores } : {}),
+          agent,
+        },
+        deps,
+      );
+      if (!repro.ok) {
+        if (options.json) {
+          outputJsonError(repro.error);
+          return;
+        }
+        throw new Error(repro.error.message);
+      }
+      reproductionCid = repro.value.cid;
+    }
+  }
+
+  if (options.json) {
+    outputJson({ targetCid, ...evalResult, ...(reproductionCid ? { reproductionCid } : {}) });
+    return;
+  }
+
+  writer(`Eval target: ${targetCid}`);
+  if (evalResult.scores.length === 0) {
+    writer("  (no scores parsed)");
+  } else {
+    for (const s of evalResult.scores) {
+      writer(`  ${s.metric} = ${s.value}`);
+    }
+  }
+  writer(`exit code: ${evalResult.exitCode}${evalResult.timedOut ? " (timed out)" : ""}`);
+  if (reproductionCid) {
+    writer(`Reproduction submitted: ${reproductionCid}`);
+  }
+}
+
+/** Handle the `grove eval` CLI command. */
+export async function handleEval(args: readonly string[], groveOverride?: string): Promise<void> {
+  const options = parseEvalArgs(args);
+  const { dbPath, groveDir } = resolveGroveDir(groveOverride);
+  const stores = createSqliteStores(dbPath);
+  const cas = new FsCas(join(groveDir, "cas"));
+  const frontier = new DefaultFrontierCalculator(stores.contributionStore);
+
+  try {
+    const contract = await resolveContract({
+      goalSessionStore: stores.goalSessionStore,
+      groveRoot: join(groveDir, ".."),
+      envSessionId: process.env.GROVE_SESSION_ID,
+    });
+
+    const contributionStore = contract
+      ? new EnforcingContributionStore(stores.contributionStore, contract, { cas })
+      : stores.contributionStore;
+
+    const agent = resolveAgent();
+    const deps: OperationDeps = {
+      contributionStore,
+      claimStore: stores.claimStore,
+      cas,
+      frontier,
+      ...(contract !== undefined ? { contract } : {}),
+    };
+
+    await runEval(options, deps, { agentId: agent.agentId });
+  } finally {
+    stores.close();
+  }
+}

--- a/src/cli/grove-md-builder.ts
+++ b/src/cli/grove-md-builder.ts
@@ -74,6 +74,7 @@ export interface HooksConfig {
   readonly afterCheckout?: string | undefined;
   readonly beforeContribute?: string | undefined;
   readonly afterContribute?: string | undefined;
+  readonly eval?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -269,6 +270,7 @@ function renderHooks(hooks: HooksConfig | undefined): string {
   if (hooks.afterCheckout) lines.push(`  after_checkout: "${hooks.afterCheckout}"`);
   if (hooks.beforeContribute) lines.push(`  before_contribute: "${hooks.beforeContribute}"`);
   if (hooks.afterContribute) lines.push(`  after_contribute: "${hooks.afterContribute}"`);
+  if (hooks.eval) lines.push(`  eval: "${hooks.eval}"`);
   return lines.join("\n");
 }
 
@@ -366,6 +368,7 @@ export interface PresetMdInput {
   readonly concurrency?: ConcurrencyConfig | undefined;
   readonly execution?: ExecutionConfig | undefined;
   readonly topology?: AgentTopology | undefined;
+  readonly hooks?: HooksConfig | undefined;
   readonly presetDescription?: string | undefined;
 }
 
@@ -385,6 +388,7 @@ export function presetToGroveMdConfig(
     stopConditions: preset.stopConditions,
     concurrency: preset.concurrency,
     execution: preset.execution,
+    hooks: preset.hooks,
     body:
       `# ${context.name}\n\n${description}\n\n` +
       `> The topology above is the **default** for this grove. ` +

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -167,6 +167,15 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
       },
     },
     {
+      name: "eval",
+      description: "Run the eval harness against a contribution and report scores",
+      needsStore: false,
+      handler: async (args) => {
+        const { handleEval } = await import("./commands/eval.js");
+        await handleEval(args, groveOverride);
+      },
+    },
+    {
       name: "thread",
       description: "View a discussion thread",
       needsStore: false,
@@ -647,6 +656,7 @@ Contributions:
   grove review <cid>                   Review a contribution
   grove discuss [cid] <msg>            Post a discussion or reply
   grove reproduce <cid>                Submit a reproduction attempt
+  grove eval <cid> [--submit]          Run the eval harness and report scores
 
 Navigation:
   grove log [-n <count>]               Recent contributions

--- a/src/cli/presets/eval-loop.test.ts
+++ b/src/cli/presets/eval-loop.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for the eval-loop preset (Hive-style competitive benchmark).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { getPreset, presetToSessionConfig } from "./index.js";
+
+describe("eval-loop preset", () => {
+  test("is registered with a flat, 8-instance competitor topology", () => {
+    const preset = getPreset("eval-loop")!;
+    expect(preset).toBeDefined();
+    expect(preset.mode).toBe("evaluation");
+    expect(preset.topology?.structure).toBe("flat");
+    expect(preset.topology?.roles).toHaveLength(1);
+    expect(preset.topology?.roles[0]?.name).toBe("competitor");
+    expect(preset.topology?.roles[0]?.maxInstances).toBe(8);
+  });
+
+  test("declares a score:maximize metric with a metric_improves gate", () => {
+    const preset = getPreset("eval-loop")!;
+    expect(preset.metrics).toContainEqual(
+      expect.objectContaining({ name: "score", direction: "maximize" }),
+    );
+    expect(preset.gates).toContainEqual({ type: "metric_improves", metric: "score" });
+  });
+
+  test("declares an eval hook placeholder", () => {
+    const preset = getPreset("eval-loop")!;
+    expect(preset.hooks?.eval).toBeTruthy();
+  });
+
+  test("round-trips through GROVE.md with hooks.eval and the score metric", () => {
+    const preset = getPreset("eval-loop")!;
+    const contract = presetToSessionConfig(preset, "My Benchmark");
+
+    expect(contract.name).toBe("My Benchmark");
+    expect(contract.mode).toBe("evaluation");
+    expect(contract.hooks?.eval).toBeTruthy();
+    expect(contract.metrics?.score?.direction).toBe("maximize");
+    expect(contract.gates?.some((g) => g.type === "metric_improves" && g.metric === "score")).toBe(
+      true,
+    );
+  });
+});

--- a/src/cli/presets/eval-loop.ts
+++ b/src/cli/presets/eval-loop.ts
@@ -1,0 +1,61 @@
+/**
+ * Eval-loop preset — Hive-style competitive benchmark.
+ *
+ * A flat topology of up to 8 competitors that each iterate to improve a
+ * single `score` metric. The `hooks.eval` placeholder is filled in by a
+ * benchmark script; `grove eval --submit` records scored reproductions that
+ * feed the frontier leaderboard. Tuned for long-running benchmarks with a
+ * high contribution/wall-clock budget.
+ */
+
+import type { PresetConfig } from "./index.js";
+
+export const evalLoopPreset: PresetConfig = {
+  name: "eval-loop",
+  description: "Competitive benchmark loop with score:maximize and an eval hook",
+  mode: "evaluation",
+  metrics: [
+    {
+      name: "score",
+      direction: "maximize",
+      description: "Benchmark score reported by the eval harness",
+    },
+  ],
+  topology: {
+    structure: "flat",
+    roles: [
+      {
+        name: "competitor",
+        description: "Iterates on the artifact to improve the benchmark score",
+        maxInstances: 8,
+        command: "claude --role competitor",
+        platform: "claude-code",
+      },
+    ],
+    spawning: { dynamic: true, maxDepth: 1 },
+  },
+  gates: [{ type: "metric_improves", metric: "score" }],
+  stopConditions: {
+    maxRoundsWithoutImprovement: 20,
+    targetMetric: { metric: "score", value: 1.0 },
+    budget: { maxContributions: 2000, maxWallClockSeconds: 86400 },
+  },
+  concurrency: {
+    maxActiveClaims: 8,
+    maxClaimsPerAgent: 1,
+  },
+  execution: {
+    defaultLeaseSeconds: 600,
+    maxLeaseSeconds: 3600,
+  },
+  // Placeholder benchmark harness — replace eval/eval.sh with a script that
+  // prints `GROVE_SCORE score=<value>` to stdout.
+  hooks: { eval: "bash eval/eval.sh" },
+  seedContributions: [],
+  services: { server: true, mcp: true },
+  backend: "nexus",
+  features: {
+    costTracking: true,
+    messaging: true,
+  },
+};

--- a/src/cli/presets/index.ts
+++ b/src/cli/presets/index.ts
@@ -12,10 +12,12 @@ import type {
   ConcurrencyConfig,
   ExecutionConfig,
   GateEntry,
+  HooksConfig,
   MetricEntry,
   StopConditionsConfig,
 } from "../grove-md-builder.js";
 import { buildGroveMd, presetToGroveMdConfig } from "../grove-md-builder.js";
+import { evalLoopPreset } from "./eval-loop.js";
 import { explorationPreset } from "./exploration.js";
 import { federatedSwarmPreset } from "./federated-swarm.js";
 import { prReviewPreset } from "./pr-review.js";
@@ -55,6 +57,7 @@ export interface PresetConfig extends CorePresetConfig {
   readonly stopConditions?: StopConditionsConfig | undefined;
   readonly concurrency?: ConcurrencyConfig | undefined;
   readonly execution?: ExecutionConfig | undefined;
+  readonly hooks?: HooksConfig | undefined;
   readonly seedContributions?: readonly SeedContribution[] | undefined;
   readonly services: { readonly server: boolean; readonly mcp: boolean };
   /**
@@ -73,6 +76,7 @@ export interface PresetConfig extends CorePresetConfig {
 // ---------------------------------------------------------------------------
 
 export {
+  evalLoopPreset,
   explorationPreset,
   federatedSwarmPreset,
   prReviewPreset,
@@ -94,6 +98,7 @@ export function getPresetRegistry(): Readonly<Record<string, PresetConfig>> {
     "research-loop": researchLoopPreset,
     "pr-review": prReviewPreset,
     "federated-swarm": federatedSwarmPreset,
+    "eval-loop": evalLoopPreset,
   };
 
   return _registry;

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -99,6 +99,11 @@ export const COMMANDS: readonly CommandMeta[] = [
     flags: ["summary", "description", "result", "score", "tag", "json"],
   },
   {
+    name: "eval",
+    description: "Run the eval harness against a contribution and report scores",
+    flags: ["frontier", "latest", "eval-command", "submit", "summary", "timeout", "json"],
+  },
+  {
     name: "claim",
     description: "Claim work to prevent duplication",
     flags: ["lease", "intent", "agent-id", "json"],

--- a/src/cli/utils/nexus-stores.test.ts
+++ b/src/cli/utils/nexus-stores.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the CLI Nexus store resolver.
+ *
+ * resolveNexusParams decides whether a grove dir has reachable Nexus-backed
+ * stores. Driven here purely via env vars + a nonexistent grove dir (so no
+ * nexus.yaml / namespace file is read), which exercises the env-override paths.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resolveNexusParams } from "./nexus-stores.js";
+
+const NONEXISTENT = "/nonexistent/.grove";
+const ENV_KEYS = ["GROVE_NEXUS_URL", "NEXUS_API_KEY", "GROVE_ZONE_ID", "GROVE_SESSION_ID"] as const;
+
+describe("resolveNexusParams", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test("returns undefined when no Nexus URL is available", () => {
+    process.env.GROVE_ZONE_ID = "proj/wt";
+    expect(resolveNexusParams(NONEXISTENT, "/nonexistent")).toBeUndefined();
+  });
+
+  test("returns undefined when a URL exists but no zone can be resolved", () => {
+    process.env.GROVE_NEXUS_URL = "http://localhost:14939";
+    expect(resolveNexusParams(NONEXISTENT, "/nonexistent")).toBeUndefined();
+  });
+
+  test("returns params when URL and zone are both available", () => {
+    process.env.GROVE_NEXUS_URL = "http://localhost:14939";
+    process.env.GROVE_ZONE_ID = "proj/wt";
+    process.env.NEXUS_API_KEY = "grv_secret";
+    expect(resolveNexusParams(NONEXISTENT, "/nonexistent")).toEqual({
+      url: "http://localhost:14939",
+      apiKey: "grv_secret",
+      zoneId: "proj/wt",
+    });
+  });
+
+  test("includes sessionId when GROVE_SESSION_ID is set", () => {
+    process.env.GROVE_NEXUS_URL = "http://localhost:14939";
+    process.env.GROVE_ZONE_ID = "proj/wt";
+    process.env.GROVE_SESSION_ID = "sess-123";
+    const params = resolveNexusParams(NONEXISTENT, "/nonexistent");
+    expect(params?.sessionId).toBe("sess-123");
+  });
+
+  test("omits apiKey when none is configured", () => {
+    process.env.GROVE_NEXUS_URL = "http://localhost:14939";
+    process.env.GROVE_ZONE_ID = "proj/wt";
+    const params = resolveNexusParams(NONEXISTENT, "/nonexistent");
+    expect(params).toBeDefined();
+    expect(params).not.toHaveProperty("apiKey");
+  });
+});

--- a/src/cli/utils/nexus-stores.ts
+++ b/src/cli/utils/nexus-stores.ts
@@ -1,0 +1,120 @@
+/**
+ * CLI Nexus store resolver.
+ *
+ * Most contribution CLI commands open local SQLite stores. When a grove is
+ * Nexus-managed, the session's contributions live in the Nexus VFS, not local
+ * SQLite, so those commands read an empty local DB. This helper resolves the
+ * Nexus connection (URL + API key + namespace) from the grove dir — the same
+ * inputs `grove-server` / `grove-mcp` use — and builds Nexus-backed stores so a
+ * CLI command can see live session data.
+ *
+ * Resolution mirrors the server: env overrides first, then the project-local
+ * `nexus.yaml` / `.state.json` / namespace file. When no URL or no namespace is
+ * available, the grove is local-only and the caller falls back to SQLite.
+ */
+
+import type { ContentStore } from "../../core/cas.js";
+import { readNamespace } from "../../core/project-key.js";
+import type { ClaimStore, ContributionStore } from "../../core/store.js";
+import { readNexusApiKey, readNexusUrl } from "../nexus-lifecycle.js";
+
+/** Connection parameters for Nexus-backed CLI stores. */
+export interface NexusStoreParams {
+  readonly url: string;
+  readonly apiKey?: string | undefined;
+  readonly zoneId: string;
+  /** When set, stores are scoped to this session; otherwise zone-wide. */
+  readonly sessionId?: string | undefined;
+}
+
+/**
+ * Resolve Nexus connection params for a grove dir, or `undefined` when the
+ * grove is local-only (no Nexus URL, or no resolvable namespace to scope to).
+ *
+ * @param groveDir  the `.grove` directory (holds the namespace file)
+ * @param groveRoot the project root (holds `nexus.yaml` / `.state.json`)
+ */
+export function resolveNexusParams(
+  groveDir: string,
+  groveRoot: string,
+): NexusStoreParams | undefined {
+  const url = process.env.GROVE_NEXUS_URL ?? readNexusUrl(groveRoot);
+  if (!url) return undefined;
+
+  const zoneId = readNamespace(groveDir) ?? process.env.GROVE_ZONE_ID;
+  if (!zoneId) return undefined;
+
+  const apiKey = readNexusApiKey(groveRoot);
+  const sessionId = process.env.GROVE_SESSION_ID;
+
+  return {
+    url,
+    ...(apiKey ? { apiKey } : {}),
+    zoneId,
+    ...(sessionId ? { sessionId } : {}),
+  };
+}
+
+/** Nexus-backed stores for CLI contribution operations. */
+export interface NexusStores {
+  readonly contributionStore: ContributionStore;
+  readonly claimStore: ClaimStore;
+  readonly cas: ContentStore;
+  /**
+   * The session the contribution store is scoped to, or `undefined` for a
+   * zone-wide store. Reported by the caller so the user knows what was queried.
+   */
+  readonly sessionId?: string | undefined;
+}
+
+/**
+ * Pick the most recently created session id in the zone, or `undefined` when
+ * there are none. Contributions in Nexus mode are written at session-scoped
+ * VFS paths, so a zone-wide store sees nothing; defaulting to the latest
+ * session makes standalone `grove eval --latest` find live session data
+ * without the caller having to know GROVE_SESSION_ID.
+ */
+async function latestSessionId(
+  client: import("../../nexus/nexus-http-client.js").NexusHttpClient,
+  zoneId: string,
+): Promise<string | undefined> {
+  try {
+    const { NexusSessionStore } = await import("../../nexus/nexus-session-store.js");
+    const store = new NexusSessionStore(client, zoneId);
+    const sessions = await store.listSessions();
+    if (sessions.length === 0) return undefined;
+    return [...sessions].sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0]?.id;
+  } catch {
+    // Session store unavailable — fall back to a zone-wide store.
+    return undefined;
+  }
+}
+
+/**
+ * Build Nexus-backed contribution/claim/CAS stores from resolved params.
+ * Mirrors the construction in `src/mcp/serve.ts`. When no explicit sessionId
+ * is provided, the contribution store is scoped to the latest session.
+ */
+export async function openNexusStores(params: NexusStoreParams): Promise<NexusStores> {
+  const { NexusHttpClient } = await import("../../nexus/nexus-http-client.js");
+  const { NexusContributionStore } = await import("../../nexus/nexus-contribution-store.js");
+  const { NexusClaimStore } = await import("../../nexus/nexus-claim-store.js");
+  const { NexusCas } = await import("../../nexus/nexus-cas.js");
+
+  const client = new NexusHttpClient({
+    url: params.url,
+    ...(params.apiKey ? { apiKey: params.apiKey } : {}),
+  });
+
+  const sessionId = params.sessionId ?? (await latestSessionId(client, params.zoneId));
+
+  const contributionStore = new NexusContributionStore({
+    client,
+    zoneId: params.zoneId,
+    ...(sessionId ? { sessionId } : {}),
+  });
+  const claimStore = new NexusClaimStore({ client, zoneId: params.zoneId });
+  const cas = new NexusCas({ client, zoneId: params.zoneId });
+
+  return { contributionStore, claimStore, cas, sessionId };
+}

--- a/src/core/contract.test.ts
+++ b/src/core/contract.test.ts
@@ -1344,3 +1344,35 @@ admission:
     ).toThrow("default_lease_seconds");
   });
 });
+
+// ---------------------------------------------------------------------------
+// hooks.eval — benchmark harness hook (#211)
+// ---------------------------------------------------------------------------
+
+describe("hooks.eval contract config", () => {
+  test("parses the eval hook in string form", () => {
+    const content = `---
+contract_version: 2
+name: eval-grove
+hooks:
+  eval: bash eval/eval.sh
+---
+`;
+    const contract = parseGroveContract(content);
+    expect(contract.hooks?.eval).toBe("bash eval/eval.sh");
+  });
+
+  test("parses the eval hook in { cmd, timeout } object form", () => {
+    const content = `---
+contract_version: 2
+name: eval-grove
+hooks:
+  eval:
+    cmd: python eval.py
+    timeout: 600000
+---
+`;
+    const contract = parseGroveContract(content);
+    expect(contract.hooks?.eval).toEqual({ cmd: "python eval.py", timeout: 600000 });
+  });
+});

--- a/src/core/contract.ts
+++ b/src/core/contract.ts
@@ -422,6 +422,14 @@ const HooksSchema = z
           .strict(),
       ])
       .optional(),
+    eval: z
+      .union([
+        z.string().min(1),
+        z
+          .object({ cmd: z.string().min(1), timeout: z.number().int().positive().optional() })
+          .strict(),
+      ])
+      .optional(),
   })
   .strict();
 

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -6,6 +6,8 @@
  * - after_checkout: runs after artifacts are materialized
  * - before_contribute: validation before accepting a contribution
  * - after_contribute: cleanup after contribution is submitted
+ * - eval: benchmark harness run by `grove eval` / `grove_eval` (prints
+ *   GROVE_SCORE lines to stdout/stderr)
  *
  * Hook failure in `before_contribute` blocks the contribution.
  * GROVE.md is a trusted, repo-owned file (like GitHub Actions workflows).
@@ -40,6 +42,8 @@ export interface HooksConfig {
   readonly after_checkout?: HookEntry | undefined;
   readonly before_contribute?: HookEntry | undefined;
   readonly after_contribute?: HookEntry | undefined;
+  /** Benchmark harness for `grove eval` — prints GROVE_SCORE lines. */
+  readonly eval?: HookEntry | undefined;
 }
 
 /** Schema for the hooks section of GROVE.md. */
@@ -48,6 +52,7 @@ export const HooksConfigSchema: z.ZodType<HooksConfig> = z
     after_checkout: HookEntrySchema.optional(),
     before_contribute: HookEntrySchema.optional(),
     after_contribute: HookEntrySchema.optional(),
+    eval: HookEntrySchema.optional(),
   })
   .strict();
 

--- a/src/core/operations/eval.test.ts
+++ b/src/core/operations/eval.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for evalOperation.
+ *
+ * Covers the shipped GROVE_SCORE-line protocol (characterization) plus the
+ * new contract.hooks.eval command resolution.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { OperationDeps } from "./deps.js";
+import { evalOperation } from "./eval.js";
+
+const NO_DEPS: OperationDeps = {};
+
+describe("evalOperation — contract.hooks.eval resolution", () => {
+  test("resolves the command from contract.hooks.eval when no evalCommand input", async () => {
+    const deps: OperationDeps = {
+      contract: {
+        contractVersion: 2,
+        name: "eval-test",
+        hooks: { eval: "echo GROVE_SCORE acc=0.9" },
+      },
+    };
+
+    const result = await evalOperation(deps, { targetCid: "blake3:abc" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.exitCode).toBe(0);
+    expect(result.value.scores).toContainEqual({ metric: "acc", value: 0.9 });
+  });
+
+  test("supports the { cmd, timeout } hook object form", async () => {
+    const deps: OperationDeps = {
+      contract: {
+        contractVersion: 2,
+        name: "eval-test",
+        hooks: { eval: { cmd: "echo GROVE_SCORE acc=0.3", timeout: 60_000 } },
+      },
+    };
+
+    const result = await evalOperation(deps, { targetCid: "blake3:abc" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scores).toContainEqual({ metric: "acc", value: 0.3 });
+  });
+
+  test("explicit evalCommand input overrides the contract hook", async () => {
+    const deps: OperationDeps = {
+      contract: {
+        contractVersion: 2,
+        name: "eval-test",
+        hooks: { eval: "echo GROVE_SCORE fromcontract=1" },
+      },
+    };
+
+    const result = await evalOperation(deps, {
+      targetCid: "blake3:abc",
+      evalCommand: "echo GROVE_SCORE frominput=2",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scores).toContainEqual({ metric: "frominput", value: 2 });
+    expect(result.value.scores.find((s) => s.metric === "fromcontract")).toBeUndefined();
+  });
+});
+
+describe("evalOperation — score parsing (GROVE_SCORE protocol)", () => {
+  test("parses int, float, negative, and scientific notation from stdout", async () => {
+    const cmd =
+      "printf 'GROVE_SCORE acc=0.95\\nGROVE_SCORE latency_ms=42\\nGROVE_SCORE neg=-1.5\\nGROVE_SCORE sci=1e-3\\n'";
+
+    const result = await evalOperation(NO_DEPS, { targetCid: "blake3:x", evalCommand: cmd });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scores).toContainEqual({ metric: "acc", value: 0.95 });
+    expect(result.value.scores).toContainEqual({ metric: "latency_ms", value: 42 });
+    expect(result.value.scores).toContainEqual({ metric: "neg", value: -1.5 });
+    expect(result.value.scores).toContainEqual({ metric: "sci", value: 0.001 });
+  });
+
+  test("parses score lines emitted on stderr", async () => {
+    const result = await evalOperation(NO_DEPS, {
+      targetCid: "blake3:x",
+      evalCommand: ">&2 echo GROVE_SCORE acc=0.7",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scores).toContainEqual({ metric: "acc", value: 0.7 });
+  });
+
+  test("tolerates non-score progress output", async () => {
+    const cmd = "printf 'building...\\nrunning benchmark\\nGROVE_SCORE acc=0.5\\ndone\\n'";
+
+    const result = await evalOperation(NO_DEPS, { targetCid: "blake3:x", evalCommand: cmd });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scores).toEqual([{ metric: "acc", value: 0.5 }]);
+  });
+
+  test("flushes a final score line with no trailing newline", async () => {
+    const result = await evalOperation(NO_DEPS, {
+      targetCid: "blake3:x",
+      evalCommand: "printf 'GROVE_SCORE acc=0.88'",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scores).toContainEqual({ metric: "acc", value: 0.88 });
+  });
+
+  test("exitCode reflects a failing eval command", async () => {
+    const result = await evalOperation(NO_DEPS, {
+      targetCid: "blake3:x",
+      evalCommand: "echo GROVE_SCORE acc=0.1; exit 3",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.exitCode).toBe(3);
+    expect(result.value.scores).toContainEqual({ metric: "acc", value: 0.1 });
+  });
+});
+
+describe("evalOperation — timeout and validation", () => {
+  test("kills the subprocess on timeout and reports timedOut + exit 124", async () => {
+    const result = await evalOperation(NO_DEPS, {
+      targetCid: "blake3:x",
+      evalCommand: "sleep 10",
+      timeoutMs: 200,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.timedOut).toBe(true);
+    expect(result.value.exitCode).toBe(124);
+  });
+
+  test("returns a validation error when no command is available", async () => {
+    const result = await evalOperation(NO_DEPS, { targetCid: "blake3:x" });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain("evalCommand is required");
+  });
+
+  test("returns a validation error for an empty targetCid", async () => {
+    const result = await evalOperation(NO_DEPS, {
+      targetCid: "   ",
+      evalCommand: "echo GROVE_SCORE acc=1",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain("targetCid");
+  });
+});

--- a/src/core/operations/eval.ts
+++ b/src/core/operations/eval.ts
@@ -24,6 +24,7 @@
 
 import { spawn } from "node:child_process";
 
+import { hookCommand, hookTimeout } from "../hooks.js";
 import type { OperationDeps } from "./deps.js";
 import type { OperationResult } from "./result.js";
 import { err, OperationErrorCode, ok, validationErr } from "./result.js";
@@ -192,16 +193,18 @@ async function runEvalSubprocess(
 
 /** Run the eval harness against a target CID and return structured scores. */
 export async function evalOperation(
-  _deps: OperationDeps,
+  deps: OperationDeps,
   input: EvalInput,
 ): Promise<OperationResult<EvalResult>> {
   const { targetCid, evalCommand, timeoutMs } = input;
 
-  // Resolve the command to run.
-  const command = evalCommand;
+  // Resolve the command to run: explicit input overrides the contract's
+  // `hooks.eval` entry (string or { cmd, timeout } object form).
+  const hookEntry = deps.contract?.hooks?.eval;
+  const command = evalCommand ?? (hookEntry !== undefined ? hookCommand(hookEntry) : undefined);
   if (!command) {
     return validationErr(
-      "evalCommand is required: provide it as input or configure evaluation.eval_command in GROVE.md",
+      "evalCommand is required: provide it as input or configure hooks.eval in GROVE.md",
     );
   }
 
@@ -211,8 +214,10 @@ export async function evalOperation(
     return validationErr("targetCid must be a non-empty string");
   }
 
-  // Resolve timeout: input > contract (future) > default.
-  const resolvedTimeout = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  // Resolve timeout: input > contract hook timeout > default.
+  const resolvedTimeout =
+    timeoutMs ??
+    (hookEntry !== undefined ? hookTimeout(hookEntry, DEFAULT_TIMEOUT_MS) : DEFAULT_TIMEOUT_MS);
 
   try {
     const { scores, exitCode, timedOut, rawTail } = await runEvalSubprocess(

--- a/src/core/operations/eval.ts
+++ b/src/core/operations/eval.ts
@@ -62,14 +62,14 @@ export interface EvalInput {
   readonly targetCid: string;
   /**
    * Shell command to execute as the eval harness.
-   * Optional if the contract's evaluation config provides a default in a
-   * future protocol version. Currently required — returns VALIDATION_ERROR
-   * if omitted and no contract default is available.
+   * Optional — when omitted, the command is resolved from the contract's
+   * `hooks.eval` entry (string or `{ cmd, timeout }` form). Returns
+   * VALIDATION_ERROR if neither is available.
    */
   readonly evalCommand?: string | undefined;
   /**
    * Timeout in milliseconds before the subprocess is killed.
-   * Defaults to the contract's evaluation timeout if available, then
+   * Defaults to the contract's `hooks.eval` timeout if available, then
    * DEFAULT_TIMEOUT_MS (5 minutes).
    */
   readonly timeoutMs?: number | undefined;
@@ -136,9 +136,13 @@ async function runEvalSubprocess(
     /** Append to the rolling output tail, respecting the cap. */
     const appendOutput = (chunk: string): void => {
       if (outputSize >= MAX_OUTPUT_BYTES) return;
-      outputSize += chunk.length;
+      outputSize += Buffer.byteLength(chunk, "utf8");
       rawOutput += chunk;
     };
+
+    /** Build the diagnostic tail from the buffered output. */
+    const buildTail = (): string =>
+      rawOutput.length > TAIL_BYTES ? rawOutput.slice(-TAIL_BYTES) : rawOutput;
 
     /** Parse a single line for a GROVE_SCORE entry. */
     const parseLine = (line: string): void => {
@@ -180,9 +184,15 @@ async function runEvalSubprocess(
       stderrHandler.flush();
       clearTimeout(timer);
       const exitCode = code ?? (timedOut ? 124 : 1);
-      // Return last TAIL_BYTES for diagnostics.
-      const rawTail = rawOutput.length > TAIL_BYTES ? rawOutput.slice(-TAIL_BYTES) : rawOutput;
-      resolve({ scores, exitCode, timedOut, rawTail });
+      resolve({ scores, exitCode, timedOut, rawTail: buildTail() });
+    });
+
+    // spawn itself can fail (e.g. sh missing, EMFILE/ENOMEM) without ever
+    // emitting "close" — resolve with a command-not-found-style exit so the
+    // operation never hangs. resolve() is idempotent if "close" also fires.
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve({ scores, exitCode: 127, timedOut, rawTail: buildTail() });
     });
   });
 }

--- a/src/core/operations/parity-matrix.test.ts
+++ b/src/core/operations/parity-matrix.test.ts
@@ -29,6 +29,7 @@ const SHARED_OPERATIONS_MCP: ReadonlyArray<{
   { operation: "treeOperation", mcpTool: "grove_tree" },
   { operation: "threadOperation", mcpTool: "grove_thread" },
   { operation: "checkoutOperation", mcpTool: "grove_checkout" },
+  { operation: "evalOperation", mcpTool: "grove_eval" },
   { operation: "listClaimsOperation", mcpTool: "grove_list_claims" },
   { operation: "createBountyOperation", mcpTool: "grove_bounty_create" },
   { operation: "listBountiesOperation", mcpTool: "grove_bounty_list" },
@@ -62,6 +63,7 @@ const SHARED_OPERATIONS_CLI: ReadonlyArray<{
   { operation: "threadOperation", cliCommand: "thread" },
   { operation: "threadsOperation", cliCommand: "threads" },
   { operation: "checkoutOperation", cliCommand: "checkout" },
+  { operation: "evalOperation", cliCommand: "eval" },
   { operation: "listClaimsOperation", cliCommand: "claims" },
   { operation: "checkTrajectoryOperation", cliCommand: "check-trajectory" },
 ];
@@ -86,6 +88,7 @@ describe("parity matrix: operations layer exports", () => {
       "threadOperation",
       "threadsOperation",
       "checkoutOperation",
+      "evalOperation",
       "checkStopOperation",
       "createBountyOperation",
       "listBountiesOperation",

--- a/tests/presets/preset-integration.test.ts
+++ b/tests/presets/preset-integration.test.ts
@@ -128,7 +128,7 @@ afterEach(async () => {
 // ============================================================================
 
 describe("Preset Registry", () => {
-  test("lists all 6 presets", () => {
+  test("lists all 7 presets", () => {
     const names = listPresetNames();
     expect(names).toContain("review-loop");
     expect(names).toContain("exploration");
@@ -136,7 +136,8 @@ describe("Preset Registry", () => {
     expect(names).toContain("research-loop");
     expect(names).toContain("pr-review");
     expect(names).toContain("federated-swarm");
-    expect(names).toHaveLength(6);
+    expect(names).toContain("eval-loop");
+    expect(names).toHaveLength(7);
   });
 
   test("each preset has required fields", () => {
@@ -980,6 +981,7 @@ describe("Cross-preset comparisons", () => {
       "research-loop": 0,
       "pr-review": 0,
       "federated-swarm": 0,
+      "eval-loop": 0,
     };
 
     const registry = getPresetRegistry();


### PR DESCRIPTION
Closes #211.

Completes the eval harness on top of the already-shipped `evalOperation` + `grove_eval` MCP tool, then makes the CLI usable against live Nexus sessions.

## What's added

**Contract**
- `hooks.eval` in the GROVE.md hooks schema (string and `{ cmd, timeout }` forms). Added to **both** `src/core/hooks.ts` and the separate `HooksSchema` in `src/core/contract.ts` (the strict contract parser has its own copy).
- `evalOperation` resolves the command/timeout from `contract.hooks.eval` when no input override is given (backward compatible).

**CLI — `grove eval`**
```
grove eval <cid>                      # cmd from contract hooks.eval
grove eval --frontier <metric>        # eval the frontier leader
grove eval --latest                   # eval the most recent contribution
grove eval <cid> --eval-command "..."  # override command
grove eval <cid> --submit             # eval, then submit a scored reproduction
grove eval <cid> --timeout <ms> --json
```
- `--submit` maps parsed scores → `{value, direction}` using contract metric directions and calls `reproduceOperation`.
- **Nexus-aware**: prefers Nexus-backed stores (resolved from `nexus.yaml`/`.state.json`/namespace) so `--latest`/`--frontier`/`--submit` see live session contributions; falls back to local SQLite. Auto-scopes to the latest session when `GROVE_SESSION_ID` is unset. New reusable helper `src/cli/utils/nexus-stores.ts`.

**Preset — `eval-loop`**
- Hive-style competitive benchmark: flat topology, 8 `competitor` agents, `score:maximize` + `metric_improves` gate, `hooks.eval` placeholder, long-running budget. `renderHooks` now emits the eval hook.

**Surfaces**
- `docs/parity-matrix.md` row + `parity-matrix.test.ts` CI gate (CLI + MCP + export).

## Scope decision
Kept the **shipped `GROVE_SCORE <metric>=<value>` line protocol** (+ `GROVE_TARGET_CID`). The issue's prose sketched a JSON-stdout / `GROVE_EVAL_DIR` design, but the line protocol is already merged + tested + on the public MCP surface; rewriting it would break that contract for no functional gain. JSON-stdout and artifact-checkout are recorded as deliberate non-goals in the spec.

## Tests
`bun test src/` → **7315 pass / 0 fail / 5 skip**; tsc + biome clean. New coverage: core `evalOperation` (parsing/timeout/validation/contract-resolution), CLI parse+run, `eval-loop` preset round-trip, `resolveNexusParams`.

## Live E2E (grove TUI + tmux, real codex↔claude review-loop)
- Session `d970ac2a` → **archived, 3 contribs, 2m5s, "Session signaled done"**. Coder (claude) real fix + commit `b95a951`; reviewer (codex) workspace had `.codex`/`CODEX.md`. `eval-loop` preset showed live in the TUI picker.
- `grove eval` on the real coder workspace: fixed tree → `correctness=1.0` (via `--eval-command` **and** via `hooks.eval`), buggy root → `0.5`.
- Nexus-aware path verified: `grove eval --latest` resolved the real Nexus work CID; `grove eval <cid> --submit` created a scored reproduction **persisted in the Nexus session store**.

## Follow-up
The remaining contribution CLI commands (`reproduce`/`discuss`/`review`/`goal`/`log`/`frontier`/…) still read local SQLite only — tracked in #473, which can adopt the same `nexus-stores.ts` resolver.

Design spec: `docs/superpowers/specs/2026-05-30-eval-harness-211-design.md`.