### PR TITLE
feat(recipe): live grove recipe run launches a session (#276)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-grove-recipe-run-live.md
+++ b/docs/superpowers/plans/2026-06-08-grove-recipe-run-live.md
@@ -1,0 +1,1288 @@
+# Grove Recipe Live Run — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `grove recipe run <path> [--param k=v]...` (without `--dry-run`) materialize a recipe into a persistent, launched session whose record carries the recipe digest, with declared `stdio:` MCP extensions wired into every spawned agent.
+
+**Architecture:** Extract the session-launch core out of `grove session start` into a reusable `launchGoalSession()` helper; have `recipe run` materialize the recipe (already implemented) and feed the resulting contract/topology/goal/provenance into that shared launcher. Recipe-declared `stdio:` MCP extensions are mapped to `AgentConfig.mcpServers` entries and appended to every role's MCP list by the orchestrator. The session record gains a `recipeProvenance` field persisted in SQLite (additive migration) and mirrored to Nexus.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), Bun (`bun:test`, `bun test`), SQLite (`bun:sqlite` via `initSqliteDb`), zod, blake3. Typecheck gate: `tsc --noEmit` (erasableSyntaxOnly — no enums/param-properties/namespaces in new code).
+
+Spec: `docs/superpowers/specs/2026-06-08-grove-recipe-run-live-design.md`
+
+---
+
+## File Structure
+
+- **Create** `src/core/recipe-extensions.ts` — maps `RecipeExtension[]` → `AgentConfig["mcpServers"]`. One responsibility: extension→MCP wiring.
+- **Create** `src/core/recipe-extensions.test.ts` — unit tests for the mapper.
+- **Create** `src/cli/utils/launch-session.ts` — `launchGoalSession()`: the shared launch core (runtime select → create session → Nexus mirror → orchestrator → loop). Extracted from `session.ts`.
+- **Create** `src/cli/utils/launch-session.test.ts` — focused launcher test with `MockRuntime`.
+- **Modify** `src/core/session.ts` — add `recipeProvenance?` to `Session` + `CreateSessionInput`.
+- **Modify** `src/local/sqlite-goal-session-store.ts` — DDL column, `SessionRow`, insert, `rowToSession`.
+- **Modify** `src/local/sqlite-store.ts` — bump schema version, add column-safe migration.
+- **Modify** `src/nexus/nexus-session-store.ts` — pass `recipeProvenance` through `createSession`.
+- **Modify** `src/core/session-orchestrator.ts` — `extraMcpServers` config field + spawn append.
+- **Modify** `src/cli/commands/session.ts` — `sessionStart` becomes a thin caller of `launchGoalSession`.
+- **Modify** `src/cli/commands/recipe.ts` — live `run` branch + `--goal`/`--repo` flags.
+- **Modify** `src/cli/main.ts` — recipe help text.
+- **Modify** `spec/GROVE-RECIPES.md` — replace the "does not start agents" note with the live-run section.
+- **Create** `tests/e2e/recipe-run-tmux.ts` — real-process E2E.
+
+---
+
+## Task 1: Provenance field on Session types
+
+**Files:**
+- Modify: `src/core/session.ts:1-13` (imports), `:34-70` (Session), `:77-84` (CreateSessionInput)
+
+- [ ] **Step 1: Add the type-only import**
+
+In `src/core/session.ts`, add to the import block at the top (after the existing `import type { LoopStopStatus } ...` line):
+
+```ts
+import type { RecipeProvenance } from "./recipe.js";
+```
+
+(`import type` — no runtime dependency, no import cycle: `recipe.ts` does not import `session.ts`.)
+
+- [ ] **Step 2: Add `recipeProvenance` to `Session`**
+
+In the `Session` interface, immediately after the `config?: GroveContract | undefined;` field (session.ts:57), add:
+
+```ts
+  /**
+   * Provenance of the recipe this session was materialized from, when launched
+   * via `grove recipe run`. Absent for sessions started any other way.
+   * Records the recipe digest so re-runs are reproducible (#276).
+   */
+  readonly recipeProvenance?: RecipeProvenance | undefined;
+```
+
+- [ ] **Step 3: Add `recipeProvenance` to `CreateSessionInput`**
+
+In `CreateSessionInput` (session.ts:77), after `readonly config?: GroveContract | undefined;`, add:
+
+```ts
+  /** Recipe provenance to record on the session, when created from a recipe. */
+  readonly recipeProvenance?: RecipeProvenance | undefined;
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `tsc --noEmit`
+Expected: PASS (no errors). The field is optional and unused so far.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/session.ts
+git commit -m "feat(session): add recipeProvenance field to Session types (#276)" --no-verify
+```
+
+---
+
+## Task 2: Persist provenance in SQLite
+
+**Files:**
+- Modify: `src/local/sqlite-goal-session-store.ts:282-300` (DDL), `:357-377` (SessionRow), `:823-874` (createSession), `:522-552` (rowToSession)
+- Modify: `src/local/sqlite-store.ts:76` (version), `:747` (add migration block after v14 block)
+- Test: `src/local/sqlite-goal-session-store.recipe.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/local/sqlite-goal-session-store.recipe.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { RecipeProvenance } from "../core/recipe.js";
+import { initSqliteDb } from "./sqlite-store.js";
+import { SqliteGoalSessionStore } from "./sqlite-goal-session-store.js";
+
+describe("SqliteGoalSessionStore recipe provenance", () => {
+  test("createSession persists recipeProvenance and getSession returns it", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-prov-"));
+    try {
+      const db = initSqliteDb(join(dir, "grove.db"));
+      const store = new SqliteGoalSessionStore(db);
+      const provenance: RecipeProvenance = {
+        recipeDigest: "blake3:abc",
+        recipeName: "code-review-loop",
+        recipeVersion: "1.0.0",
+        boundParameterDigest: "blake3:def",
+        subRecipeDigests: [],
+      };
+      const created = await store.createSession({ goal: "g", recipeProvenance: provenance });
+      expect(created.recipeProvenance).toEqual(provenance);
+      const fetched = await store.getSession(created.id);
+      expect(fetched?.recipeProvenance).toEqual(provenance);
+      db.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/local/sqlite-goal-session-store.recipe.test.ts`
+Expected: FAIL — `created.recipeProvenance` is `undefined` (column/field not wired yet).
+
+- [ ] **Step 3: Add the column to the fresh-DB DDL**
+
+In `src/local/sqlite-goal-session-store.ts`, in `GOAL_SESSION_DDL`, inside the `CREATE TABLE IF NOT EXISTS sessions (...)` block, after the line `worktree_strategy_json TEXT,` (sqlite-goal-session-store.ts:289), add:
+
+```sql
+    recipe_provenance_json TEXT,
+```
+
+- [ ] **Step 4: Add the migration for existing DBs**
+
+In `src/local/sqlite-store.ts`, change `CURRENT_SCHEMA_VERSION` (line 76):
+
+```ts
+export const CURRENT_SCHEMA_VERSION = 17;
+```
+
+Then, immediately after the v14 deletion-metadata migration block closes (find the comment `// Migration → v14:` and append after its closing `}` — around sqlite-store.ts:747+), add:
+
+```ts
+    // Migration → v17: persist recipe provenance on sessions launched via
+    // `grove recipe run`. Column-safe: only adds the column when absent.
+    {
+      const sessionTableExists =
+        (db
+          .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'")
+          .get() as { name: string } | null) !== null;
+      if (sessionTableExists) {
+        const sessionCols = db.prepare("PRAGMA table_info(sessions)").all() as readonly {
+          name: string;
+        }[];
+        const sessionColNames = new Set(sessionCols.map((c) => c.name));
+        if (!sessionColNames.has("recipe_provenance_json")) {
+          db.run("ALTER TABLE sessions ADD COLUMN recipe_provenance_json TEXT");
+        }
+      }
+    }
+```
+
+- [ ] **Step 5: Add the field to `SessionRow`**
+
+In `src/local/sqlite-goal-session-store.ts`, in `interface SessionRow` (line 357), after `worktree_strategy_json: string | null;` (line 364) add:
+
+```ts
+  recipe_provenance_json: string | null;
+```
+
+- [ ] **Step 6: Write the column in `createSession`**
+
+In `createSession` (sqlite-goal-session-store.ts:823), update the prepared insert statement column list and `VALUES` placeholders, and the `.run(...)` args.
+
+Change the `stmtInsertSession` SQL to:
+
+```ts
+    this.stmtInsertSession ??= this.db.prepare(`
+      INSERT INTO sessions (session_id, uid, goal, preset_name, topology_json, config_json,
+        worktree_strategy_json, recipe_provenance_json, status, started_at, finalizers_json)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)
+    `);
+```
+
+Add, just before the `this.stmtInsertSession.run(` call:
+
+```ts
+    const recipeProvenanceJson = input.recipeProvenance
+      ? JSON.stringify(input.recipeProvenance)
+      : null;
+```
+
+Change the `.run(...)` argument list to insert `recipeProvenanceJson` between `worktreeStrategyJson` and `startedAt`:
+
+```ts
+    this.stmtInsertSession.run(
+      sessionId,
+      uid,
+      input.goal ?? null,
+      input.presetName ?? null,
+      topologyJson,
+      configJson,
+      worktreeStrategyJson,
+      recipeProvenanceJson,
+      startedAt,
+      JSON.stringify(DEFAULT_SESSION_FINALIZERS),
+    );
+```
+
+In the returned object (the `return { id: sessionId, ... }` literal), after `config: input.config,` add:
+
+```ts
+      recipeProvenance: input.recipeProvenance,
+```
+
+- [ ] **Step 7: Read the column in `rowToSession`**
+
+In `rowToSession` (sqlite-goal-session-store.ts:522), in the returned object after `config,` (line 546) add:
+
+```ts
+    recipeProvenance: row.recipe_provenance_json
+      ? (JSON.parse(row.recipe_provenance_json) as RecipeProvenance)
+      : undefined,
+```
+
+Add the type-only import at the top of `sqlite-goal-session-store.ts` (with the other `import type` lines):
+
+```ts
+import type { RecipeProvenance } from "../core/recipe.js";
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `bun test src/local/sqlite-goal-session-store.recipe.test.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Typecheck + regression**
+
+Run: `tsc --noEmit && bun test src/local/`
+Expected: PASS. Existing session-store and migration tests stay green (column add is additive; `SELECT *` picks up the new column, `rowToSession` tolerates `null`).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/local/sqlite-goal-session-store.ts src/local/sqlite-store.ts src/local/sqlite-goal-session-store.recipe.test.ts
+git commit -m "feat(store): persist recipe provenance on sessions (#276)" --no-verify
+```
+
+---
+
+## Task 3: Mirror provenance to Nexus
+
+**Files:**
+- Modify: `src/nexus/nexus-session-store.ts:444-463` (createSession)
+- Test: `src/nexus/nexus-session-store.recipe.test.ts` (create)
+
+Note: `putSession` already round-trips arbitrary `Session` fields (`normalizeSessionRecord` spreads `...session`, `writeSessionRecord` does `JSON.stringify(session)`), so the *mirror* path used by `recipe run` needs no change. Only the direct `createSession` literal must carry the field for the TUI create path.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/nexus/nexus-session-store.recipe.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import type { RecipeProvenance } from "../core/recipe.js";
+import { NexusSessionStore } from "./nexus-session-store.js";
+import { InMemoryNexusClient } from "./testing/in-memory-nexus-client.js";
+
+describe("NexusSessionStore recipe provenance", () => {
+  test("createSession round-trips recipeProvenance", async () => {
+    const store = new NexusSessionStore(new InMemoryNexusClient(), "default");
+    const provenance: RecipeProvenance = {
+      recipeDigest: "blake3:abc",
+      recipeName: "code-review-loop",
+      recipeVersion: "1.0.0",
+      boundParameterDigest: "blake3:def",
+      subRecipeDigests: [],
+    };
+    const created = await store.createSession({ goal: "g", recipeProvenance: provenance });
+    expect(created.recipeProvenance).toEqual(provenance);
+    const fetched = await store.getSession(created.id);
+    expect(fetched?.recipeProvenance).toEqual(provenance);
+  });
+});
+```
+
+If `./testing/in-memory-nexus-client.js` does not exist, first run
+`grep -rln "InMemoryNexusClient\|class.*NexusClient.*test\|fake.*nexus" src/nexus` to find the
+in-memory/fake client the existing `nexus-session-store` tests use, and import that instead
+(match the import used by `src/nexus/nexus-session-store.test.ts`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/nexus/nexus-session-store.recipe.test.ts`
+Expected: FAIL — `created.recipeProvenance` is `undefined`.
+
+- [ ] **Step 3: Pass provenance through `createSession`**
+
+In `src/nexus/nexus-session-store.ts`, in `createSession` (line 444), in the `const session: Session = { ... }` literal, after `config: input.config,` (line 458) add:
+
+```ts
+      recipeProvenance: input.recipeProvenance,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/nexus/nexus-session-store.recipe.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+tsc --noEmit
+git add src/nexus/nexus-session-store.ts src/nexus/nexus-session-store.recipe.test.ts
+git commit -m "feat(nexus): round-trip recipe provenance on session create (#276)" --no-verify
+```
+
+---
+
+## Task 4: Recipe extension → MCP server mapper
+
+**Files:**
+- Create: `src/core/recipe-extensions.ts`
+- Test: `src/core/recipe-extensions.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/recipe-extensions.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import type { RecipeExtension } from "./recipe.js";
+import { resolveRecipeMcpServers } from "./recipe-extensions.js";
+
+describe("resolveRecipeMcpServers", () => {
+  test("maps a stdio: mcp extension to an mcp server with command + args", () => {
+    const ext: RecipeExtension[] = [
+      { type: "mcp", name: "filesystem", uri: "stdio:grove-fs-mcp --root ." },
+    ];
+    expect(resolveRecipeMcpServers(ext)).toEqual([
+      { name: "filesystem", command: "grove-fs-mcp", args: ["--root", "."] },
+    ]);
+  });
+
+  test("a stdio: extension with no args has an empty args array", () => {
+    const ext: RecipeExtension[] = [{ type: "mcp", name: "gh", uri: "stdio:gh-mcp" }];
+    expect(resolveRecipeMcpServers(ext)).toEqual([
+      { name: "gh", command: "gh-mcp", args: [] },
+    ]);
+  });
+
+  test("optional non-stdio extension is skipped, not thrown", () => {
+    const ext: RecipeExtension[] = [{ type: "mcp", name: "remote", uri: "http://x" }];
+    expect(resolveRecipeMcpServers(ext)).toEqual([]);
+  });
+
+  test("optional non-mcp extension is skipped", () => {
+    const ext: RecipeExtension[] = [{ type: "tool", name: "linter" }];
+    expect(resolveRecipeMcpServers(ext)).toEqual([]);
+  });
+
+  test("required non-stdio extension throws", () => {
+    const ext: RecipeExtension[] = [
+      { type: "mcp", name: "remote", uri: "http://x", required: true },
+    ];
+    expect(() => resolveRecipeMcpServers(ext)).toThrow(/not launchable/);
+  });
+
+  test("stdio: extension with empty command throws", () => {
+    const ext: RecipeExtension[] = [{ type: "mcp", name: "bad", uri: "stdio:   " }];
+    expect(() => resolveRecipeMcpServers(ext)).toThrow(/empty command/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/recipe-extensions.test.ts`
+Expected: FAIL — module `./recipe-extensions.js` not found.
+
+- [ ] **Step 3: Implement the mapper**
+
+Create `src/core/recipe-extensions.ts`:
+
+```ts
+/**
+ * Map declarative recipe extensions to launchable MCP server configs.
+ *
+ * Only `type: mcp` extensions whose URI uses the `stdio:` scheme are wireable
+ * through the current stdio-only `AgentConfig.mcpServers` shape. Anything else
+ * (non-stdio URIs, or tool/provider/service extensions) is skipped when
+ * optional, and is a hard error when `required: true`.
+ */
+
+import type { AgentConfig } from "./agent-runtime.js";
+import type { RecipeExtension } from "./recipe.js";
+
+type McpServer = NonNullable<AgentConfig["mcpServers"]>[number];
+
+const STDIO_PREFIX = "stdio:";
+
+export function resolveRecipeMcpServers(
+  extensions: readonly RecipeExtension[],
+): readonly McpServer[] {
+  const servers: McpServer[] = [];
+  for (const ext of extensions) {
+    const stdioServer = tryResolveStdioMcp(ext);
+    if (stdioServer !== undefined) {
+      servers.push(stdioServer);
+      continue;
+    }
+    if (ext.required === true) {
+      throw new Error(
+        `extension '${ext.name}' is not launchable: only stdio: MCP URIs are wired today`,
+      );
+    }
+    // Optional and not wireable — warn and skip.
+    process.stderr.write(
+      `[grove] recipe extension '${ext.name}' (${ext.type}) is not launchable; skipping.\n`,
+    );
+  }
+  return servers;
+}
+
+function tryResolveStdioMcp(ext: RecipeExtension): McpServer | undefined {
+  if (ext.type !== "mcp" || ext.uri === undefined || !ext.uri.startsWith(STDIO_PREFIX)) {
+    return undefined;
+  }
+  const spec = ext.uri.slice(STDIO_PREFIX.length).trim();
+  const parts = spec.split(/\s+/).filter((p) => p.length > 0);
+  const command = parts[0];
+  if (command === undefined) {
+    throw new Error(`extension '${ext.name}' has an empty command in its stdio: URI`);
+  }
+  return { name: ext.name, command, args: parts.slice(1) };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/recipe-extensions.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+tsc --noEmit
+git add src/core/recipe-extensions.ts src/core/recipe-extensions.test.ts
+git commit -m "feat(recipe): map stdio: extensions to MCP servers (#276)" --no-verify
+```
+
+---
+
+## Task 5: Orchestrator `extraMcpServers`
+
+**Files:**
+- Modify: `src/core/session-orchestrator.ts:68-131` (`SessionConfig`), `:652-666` (spawn)
+- Test: `src/core/session-orchestrator.recipe.test.ts` (create)
+
+- [ ] **Step 1: Inspect the existing orchestrator test for the runtime fake**
+
+Run: `grep -n "class .*Runtime\|spawn(role\|new SessionOrchestrator\|capturedConfig\|MockRuntime" src/core/session-orchestrator.test.ts | head`
+Use whatever capturing fake or `MockRuntime` pattern that test uses. The test below assumes a
+local capturing runtime; adapt the construction to match the existing test's `SessionConfig`
+required fields (`goal`, `contract`, `topology`, `runtime`, `eventBus`, `projectRoot`,
+`repos`, `workspaceBaseDir`, `sessionId`, `contributionStore`).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/core/session-orchestrator.recipe.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+
+import type { AgentConfig, AgentRuntime, AgentSession } from "./agent-runtime.js";
+import { LocalEventBus } from "./local-event-bus.js";
+import { SessionOrchestrator } from "./session-orchestrator.js";
+import type { AgentTopology } from "./topology.js";
+
+function captureRuntime(captured: AgentConfig[]): AgentRuntime {
+  return {
+    sendsInitialPromptOnSpawn: true,
+    spawn: async (role: string, config: AgentConfig): Promise<AgentSession> => {
+      captured.push(config);
+      return { id: `grove-${role}-1-aaa`, role, status: "running" };
+    },
+    send: async () => ({ [Symbol.asyncIterator]: async function* () {} }) as never,
+    close: async () => {},
+    onIdle: () => {},
+    listSessions: async () => [],
+  } as unknown as AgentRuntime;
+}
+
+describe("SessionOrchestrator extraMcpServers", () => {
+  test("appends recipe MCP servers after the grove server on each spawn", async () => {
+    const captured: AgentConfig[] = [];
+    const topology: AgentTopology = {
+      structure: "graph",
+      roles: [{ name: "coder", maxInstances: 1 }],
+    };
+    const orchestrator = new SessionOrchestrator({
+      goal: "g",
+      contract: { contractVersion: 3, name: "t" },
+      topology,
+      runtime: captureRuntime(captured),
+      eventBus: new LocalEventBus(),
+      projectRoot: process.cwd(),
+      repos: [{ kind: "local", path: process.cwd() }],
+      workspaceBaseDir: process.cwd(),
+      sessionId: "sess-1",
+      contributionStore: { append: async () => {}, list: async () => [] } as never,
+      extraMcpServers: [{ name: "fs", command: "grove-fs-mcp", args: [] }],
+    });
+    await orchestrator.start();
+    expect(captured.length).toBeGreaterThan(0);
+    const names = captured[0]!.mcpServers!.map((s) => s.name);
+    expect(names[0]).toBe("grove");
+    expect(names).toContain("fs");
+  });
+});
+```
+
+Adjust `repos` / `contributionStore` to the shapes the existing orchestrator test uses if these
+stubs do not satisfy the types (copy from `session-orchestrator.test.ts`).
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `bun test src/core/session-orchestrator.recipe.test.ts`
+Expected: FAIL — `extraMcpServers` is not a known `SessionConfig` field (type error) or the `fs` server is absent.
+
+- [ ] **Step 4: Add the config field**
+
+In `src/core/session-orchestrator.ts`, in `interface SessionConfig` (line 68), after the `profiles?` field (line 131) add:
+
+```ts
+  /**
+   * Extra MCP servers appended to every spawned agent's `mcpServers`, after the
+   * built-in `grove` server. Populated from recipe `extensions` by
+   * `grove recipe run`; empty for all other launch paths.
+   */
+  readonly extraMcpServers?: NonNullable<AgentConfig["mcpServers"]> | undefined;
+```
+
+Confirm `AgentConfig` is already imported in this file (it is — used at line 652). If not, add `import type { AgentConfig } from "./agent-runtime.js";`.
+
+- [ ] **Step 5: Append in the spawn path**
+
+In `src/core/session-orchestrator.ts`, change the `mcpServers` line inside `agentConfig` (line 659) from:
+
+```ts
+      mcpServers: [this.groveMcpServer(role.name)],
+```
+to:
+```ts
+      mcpServers: [this.groveMcpServer(role.name), ...(this.config.extraMcpServers ?? [])],
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `bun test src/core/session-orchestrator.recipe.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Typecheck + regression + commit**
+
+```bash
+tsc --noEmit
+bun test src/core/session-orchestrator.test.ts
+git add src/core/session-orchestrator.ts src/core/session-orchestrator.recipe.test.ts
+git commit -m "feat(orchestrator): support extraMcpServers from recipes (#276)" --no-verify
+```
+
+---
+
+## Task 6: Extract `launchGoalSession`
+
+This is a behavior-preserving extraction. The regression guard is the existing
+`grove session start` test suite staying green.
+
+**Files:**
+- Create: `src/cli/utils/launch-session.ts`
+- Modify: `src/cli/commands/session.ts:99-422` (`sessionStart` → thin caller)
+
+- [ ] **Step 1: Identify the existing session-start tests (regression baseline)**
+
+Run: `bun test src/cli/commands/session.test.ts 2>&1 | tail -5`
+Record the pass count. This must be unchanged after the refactor.
+
+- [ ] **Step 2: Create the launcher module**
+
+Create `src/cli/utils/launch-session.ts`. Move the body of `sessionStart` **from** the line
+`// Create runtime via selectRuntime (honors GROVE_RUNTIME env), fall back to mock`
+(session.ts:181) **through** the end of the `finally` block (session.ts:421) into this function,
+parameterized by the input below. Keep all behavior identical: runtime/permission selection,
+`SqliteGoalSessionStore.createSession`, the Nexus mirror block with retries + orphan archive,
+`SessionOrchestrator` construction, `GroveLoopRunner`, interrupt handlers, `markDone`, and the
+`finally { db.close() }`.
+
+Two deltas from the moved code:
+1. Pass `recipeProvenance: input.recipeProvenance` into `goalSessionStore.createSession({...})`.
+2. Pass `extraMcpServers: input.extraMcpServers` into the `new SessionOrchestrator({...})` config.
+3. Replace the inline `outputJson({ sessionId, goal, preset, agents, message })` (session.ts:372-382)
+   with an optional callback invocation: `input.onAgentsStarted?.({ sessionId: session.id, presetName: input.contract?.name, agents: status.agents })`.
+
+Module skeleton (fill the body with the moved code):
+
+```ts
+/**
+ * Shared session launch core. Owns runtime selection, session creation, Nexus
+ * mirroring, orchestrator startup, and the deterministic completion loop.
+ *
+ * Used by `grove session start` and `grove recipe run` so both paths stay
+ * consistent (Nexus mirror, interrupt handling, loop runner).
+ */
+
+import { join, resolve } from "node:path";
+
+import { expectCasOk } from "../../core/cas.js";
+import type { GroveContract } from "../../core/contract.js";
+import { LocalEventBus } from "../../core/local-event-bus.js";
+import {
+  createFallbackRoadmap,
+  GroveLoopRunner,
+  installProcessInterruptHandlers,
+  LoopStopStatus,
+  type SessionAssessment,
+  type WorkflowStateStore,
+} from "../../core/loop-runner.js";
+import { MockRuntime } from "../../core/mock-runtime.js";
+import type { AgentConfig } from "../../core/agent-runtime.js";
+import type { RecipeProvenance } from "../../core/recipe.js";
+import type { RepoRef } from "../../core/repo-ref.js";
+import { SessionOrchestrator } from "../../core/session-orchestrator.js";
+import type { ContributionStore } from "../../core/store.js";
+import type { AgentTopology } from "../../core/topology.js";
+import { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
+
+export interface LaunchGoalSessionInput {
+  readonly groveDir: string;
+  readonly groveRoot: string;
+  readonly goal: string;
+  readonly topology: AgentTopology;
+  readonly contract?: GroveContract | undefined;
+  readonly repos: readonly RepoRef[];
+  readonly extraMcpServers?: NonNullable<AgentConfig["mcpServers"]> | undefined;
+  readonly recipeProvenance?: RecipeProvenance | undefined;
+  readonly onAgentsStarted?:
+    | ((info: {
+        readonly sessionId: string;
+        readonly presetName?: string | undefined;
+        readonly agents: readonly { readonly role: string; readonly session: { readonly id: string; readonly status: string } }[];
+      }) => void)
+    | undefined;
+}
+
+export interface LaunchGoalSessionResult {
+  readonly sessionId: string;
+  readonly stopStatus: LoopStopStatus;
+  readonly stopReason: string;
+}
+
+interface SessionCompletionUpdates {
+  readonly status: "completed" | "cancelled";
+  readonly completedAt: string;
+  readonly stopReason: string;
+  readonly stopStatus: LoopStopStatus;
+}
+
+export async function launchGoalSession(
+  input: LaunchGoalSessionInput,
+): Promise<LaunchGoalSessionResult> {
+  // ... moved body from session.ts:181-421, using input.* in place of the
+  // locals (goal, topology/resolution.topology, contract, groveDir, groveRoot,
+  // repos). createSession adds recipeProvenance; SessionOrchestrator adds
+  // extraMcpServers; the initial outputJson becomes input.onAgentsStarted?.(...).
+  // Returns { sessionId, stopStatus: finalStopStatus, stopReason: finalState.reason ?? "Session complete" }.
+}
+```
+
+Also move the helpers `terminalSessionStatus`, `sessionAssessment`, and
+`resolveSessionNexusZoneId` usages: keep `resolveSessionNexusZoneId` exported from
+`session.ts` (it is already exported and tested) and import it into the launcher, OR move it to
+the launcher and re-export from `session.ts`. Prefer importing it into the launcher from
+`session.ts` to avoid touching its existing tests:
+
+```ts
+import { resolveSessionNexusZoneId } from "../commands/session.js";
+```
+
+Copy `terminalSessionStatus` and `sessionAssessment` into the launcher (they are private to the
+launch flow).
+
+- [ ] **Step 3: Rewrite `sessionStart` as a thin caller**
+
+In `src/cli/commands/session.ts`, replace the body of `sessionStart` from session.ts:181 to the
+end of the function with a call to the launcher. The arg-parse, groveDir lookup, repo build,
+contract load, and topology resolution (session.ts:99-179) stay. After `resolution.ok` passes,
+replace everything from line 181 onward with:
+
+```ts
+  const { launchGoalSession } = await import("../utils/launch-session.js");
+  await launchGoalSession({
+    groveDir,
+    groveRoot,
+    goal,
+    topology: resolution.topology,
+    contract,
+    repos,
+    onAgentsStarted: ({ sessionId, agents }) => {
+      outputJson({
+        sessionId,
+        goal,
+        // Preserve the original output: --preset value, else the contract name.
+        // Both `presetName` and `contract` are in scope here in sessionStart.
+        preset: presetName ?? contract?.name,
+        agents: agents.map((a) => ({
+          role: a.role,
+          sessionId: a.session.id,
+          status: a.session.status,
+        })),
+        message: `Session started with ${agents.length} agents`,
+      });
+    },
+  });
+```
+
+Adjust the `preset` field to preserve the original value: the original printed
+`preset: presetName ?? contract?.name`. Pass that exact value through — set
+`preset: presetName ?? contract?.name` in the callback (both `presetName` and `contract` are in
+scope in `sessionStart`). Remove now-dead imports/locals from `session.ts` that moved to the
+launcher (e.g. `SessionOrchestrator`, `GroveLoopRunner`, `MockRuntime`, `installProcessInterruptHandlers`,
+`LocalEventBus`, `createFallbackRoadmap`, `expectCasOk` if unused, the `SessionCompletionUpdates`
+interface, `markDone`, interrupt handler wiring) — let `tsc --noEmit` flag each unused import and
+delete them.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `tsc --noEmit`
+Expected: PASS. Fix any unused-import / missing-import errors the move surfaces.
+
+- [ ] **Step 5: Run the regression baseline**
+
+Run: `bun test src/cli/commands/session.test.ts`
+Expected: PASS with the **same** count recorded in Step 1.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/utils/launch-session.ts src/cli/commands/session.ts
+git commit -m "refactor(cli): extract launchGoalSession from session start (#276)" --no-verify
+```
+
+---
+
+## Task 7: Focused launcher test with MockRuntime
+
+**Files:**
+- Test: `src/cli/utils/launch-session.test.ts` (create)
+
+- [ ] **Step 1: Write the test**
+
+Create `src/cli/utils/launch-session.test.ts`. It runs the launcher end-to-end against a real
+SQLite db in a temp grove dir with `GROVE_RUNTIME` unset (so `selectRuntime` falls back to
+`MockRuntime`) and asserts the session row records the provenance.
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { RecipeProvenance } from "../../core/recipe.js";
+import type { AgentTopology } from "../../core/topology.js";
+import { initSqliteDb } from "../../local/sqlite-store.js";
+import { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
+import { launchGoalSession } from "./launch-session.js";
+
+describe("launchGoalSession", () => {
+  test("creates a session that records recipe provenance", async () => {
+    const root = await mkdtemp(join(tmpdir(), "grove-launch-"));
+    const groveDir = join(root, ".grove");
+    await mkdir(groveDir, { recursive: true });
+    try {
+      const topology: AgentTopology = {
+        structure: "graph",
+        roles: [{ name: "coder", maxInstances: 1, platform: "claude-code" }],
+      };
+      const provenance: RecipeProvenance = {
+        recipeDigest: "blake3:abc",
+        recipeName: "demo",
+        recipeVersion: "1.0.0",
+        boundParameterDigest: "blake3:def",
+        subRecipeDigests: [],
+      };
+      let startedId: string | undefined;
+      const result = await launchGoalSession({
+        groveDir,
+        groveRoot: root,
+        goal: "demo goal",
+        topology,
+        contract: { contractVersion: 3, name: "demo" },
+        repos: [{ kind: "local", path: root }],
+        recipeProvenance: provenance,
+        onAgentsStarted: ({ sessionId }) => {
+          startedId = sessionId;
+        },
+      });
+      expect(startedId).toBeDefined();
+      expect(result.sessionId).toBe(startedId!);
+
+      const db = initSqliteDb(join(groveDir, "grove.db"));
+      const session = await new SqliteGoalSessionStore(db).getSession(result.sessionId);
+      db.close();
+      expect(session?.recipeProvenance?.recipeDigest).toBe("blake3:abc");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+If `MockRuntime` requires the repo to be a git repo or the topology to satisfy extra invariants,
+mirror the setup used by the existing `session-orchestrator.test.ts` (e.g. `git init` the temp
+root via `node:child_process` `execFileSync("git", ["init"], { cwd: root })`). Add that to the
+test setup if `launchGoalSession` throws on repo resolution.
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/cli/utils/launch-session.test.ts`
+Expected: PASS. If it fails on repo resolution, add `git init` setup and rerun.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/utils/launch-session.test.ts
+git commit -m "test(cli): launchGoalSession records provenance (#276)" --no-verify
+```
+
+---
+
+## Task 8: Live `recipe run` branch + flags
+
+**Files:**
+- Modify: `src/cli/commands/recipe.ts:16-79` (parse), `:88-146` (run), helpers
+- Modify: `src/cli/main.ts:394-399` (help text)
+- Test: `src/cli/commands/recipe.test.ts` (add cases)
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/cli/commands/recipe.test.ts`, add a `describe` block. First, an arg-parse test for the
+new flags:
+
+```ts
+test("parseRecipeArgs parses run with goal and repo flags", () => {
+  expect(
+    parseRecipeArgs(["run", "r.yaml", "--goal", "do it", "--repo", "./a", "--param", "x=1"]),
+  ).toEqual({
+    command: "run",
+    path: "r.yaml",
+    params: { x: "1" },
+    goal: "do it",
+    repos: ["./a"],
+    dryRun: false,
+    json: false,
+  });
+});
+```
+
+Then a live-run integration test that drives `runRecipe` against `MockRuntime` in a temp grove.
+Place it in a new file `src/cli/commands/recipe.run.test.ts` to keep the heavy setup separate:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rm } from "node:fs/promises";
+
+import { initSqliteDb } from "../../local/sqlite-store.js";
+import { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
+import { runRecipe } from "./recipe.js";
+
+const RECIPE = `kind: recipe
+recipe_version: 1
+name: demo-loop
+version: 1.0.0
+instructions: |
+  Work on \${parameters.target}.
+parameters:
+  target:
+    type: string
+    required: true
+extensions:
+  - type: mcp
+    name: fs
+    uri: stdio:grove-fs-mcp
+agent_topology:
+  structure: graph
+  roles:
+    - name: coder
+      platform: claude-code
+`;
+
+describe("recipe run (live)", () => {
+  test("materializes a session that records the recipe digest", async () => {
+    const root = await mkdtemp(join(tmpdir(), "grove-reciperun-"));
+    execFileSync("git", ["init", "-q"], { cwd: root });
+    await mkdir(join(root, ".grove"), { recursive: true });
+    const recipePath = join(root, "demo.yaml");
+    await writeFile(recipePath, RECIPE);
+    const lines: string[] = [];
+    try {
+      await runRecipe(
+        {
+          command: "run",
+          path: recipePath,
+          params: { target: "./src" },
+          dryRun: false,
+          json: true,
+          repos: [],
+        },
+        { cwd: root, writer: (l) => lines.push(l) },
+      );
+      const db = initSqliteDb(join(root, ".grove", "grove.db"));
+      const store = new SqliteGoalSessionStore(db);
+      const sessions = await store.listSessions({ includeArchived: true });
+      const full = await store.getSession(sessions[0]!.id);
+      db.close();
+      expect(full?.recipeProvenance?.recipeName).toBe("demo-loop");
+      expect(full?.recipeProvenance?.recipeDigest).toMatch(/^blake3:/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+(Set `GROVE_RUNTIME` unset so `selectRuntime` → `MockRuntime`. If the harness env has it set,
+the test should `delete process.env.GROVE_RUNTIME` in a `beforeAll` and restore after.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/cli/commands/recipe.test.ts src/cli/commands/recipe.run.test.ts`
+Expected: FAIL — parse result lacks `goal`/`repos`; `runRecipe` throws `"recipe run currently requires --dry-run"`.
+
+- [ ] **Step 3: Extend the `RecipeCommand` type + parser**
+
+In `src/cli/commands/recipe.ts`, extend the `run` variant of `RecipeCommand` (line 19) to add
+`goal` and `repos`:
+
+```ts
+  | {
+      readonly command: "run";
+      readonly path: string;
+      readonly params: Readonly<Record<string, string>>;
+      readonly dryRun: boolean;
+      readonly json: boolean;
+      readonly goal?: string | undefined;
+      readonly repos: readonly string[];
+    };
+```
+
+In `parseRecipeArgs`, in the `run` branch (line 56), add `goal` and `repo` options and thread
+them through:
+
+```ts
+    const parsed = parseArgs({
+      args: [...rest],
+      options: {
+        param: { type: "string", multiple: true },
+        repo: { type: "string", multiple: true },
+        goal: { type: "string" },
+        "dry-run": { type: "boolean", default: false },
+        json: { type: "boolean", default: false },
+      },
+      allowPositionals: true,
+      strict: true,
+    });
+    const path = parsed.positionals[0];
+    if (path === undefined) throw new UsageError("recipe run requires <path>");
+    if (parsed.positionals.length > 1) throw new UsageError("recipe run accepts one <path>");
+    return {
+      command: "run",
+      path,
+      params: parseParamFlags(parsed.values.param ?? []),
+      dryRun: parsed.values["dry-run"] ?? false,
+      json: parsed.values.json ?? false,
+      ...(parsed.values.goal !== undefined && { goal: parsed.values.goal }),
+      repos: parsed.values.repo ?? [],
+    };
+```
+
+- [ ] **Step 4: Replace the dry-run guard with the live branch**
+
+In `runRecipe` (recipe.ts), the block at line 126:
+
+```ts
+  if (!command.dryRun) {
+    throw new UsageError("recipe run currently requires --dry-run");
+  }
+```
+
+becomes a branch: keep the existing dry-run body under `if (command.dryRun) { ... return; }`, and
+add the live path. Replace from line 126 to the end of the `run` handling with:
+
+```ts
+  const content = await readFile(resolveRecipePath(command.path, deps.cwd), "utf-8");
+  const recipe = parseGroveRecipe(content);
+  const bound = bindRecipeParameters(recipe, command.params);
+  const materialized = materializeRecipeContract(bound);
+
+  if (command.dryRun) {
+    const payload = {
+      recipe: { name: recipe.name, version: recipe.version },
+      recipeDigest: bound.recipeDigest,
+      boundParameterDigest: computeBoundRecipeDigest(bound),
+      parameters: bound.parameters,
+      renderedInstructions: materialized.renderedInstructions,
+      extensions: materialized.extensions,
+      subRecipes: materialized.subRecipes,
+      runPolicy: materialized.runPolicy,
+      contract: materialized.contract,
+      provenance: materialized.provenance,
+    };
+    deps.writer(command.json ? JSON.stringify(payload, null, 2) : formatDryRun(payload));
+    return;
+  }
+
+  // Live run: materialize a persistent, launched session.
+  const goal = command.goal?.trim() || materialized.renderedInstructions.trim();
+  if (goal === "") {
+    throw new UsageError(
+      "recipe run needs a goal: provide --goal or a non-empty recipe `instructions`",
+    );
+  }
+  const topology = materialized.contract.topology;
+  if (topology === undefined) {
+    throw new UsageError("recipe run requires the recipe to declare agent_topology with roles");
+  }
+
+  const { resolveRecipeMcpServers } = await import("../../core/recipe-extensions.js");
+  const extraMcpServers = resolveRecipeMcpServers(recipe.extensions ?? []);
+
+  const { findGroveDir } = await import("../context.js");
+  const groveDir = findGroveDir(deps.cwd);
+  if (groveDir === undefined) {
+    throw new UsageError("Not inside a grove. Run 'grove init' first.");
+  }
+  const groveRoot = resolve(groveDir, "..");
+
+  const { buildRepos } = await import("../utils/build-repos.js");
+  const repos = buildRepos({ rawRepo: command.repos, cwd: groveRoot });
+
+  const { launchGoalSession } = await import("../utils/launch-session.js");
+  const result = await launchGoalSession({
+    groveDir,
+    groveRoot,
+    goal,
+    topology,
+    contract: materialized.contract,
+    repos,
+    ...(extraMcpServers.length > 0 && { extraMcpServers: [...extraMcpServers] }),
+    recipeProvenance: materialized.provenance,
+    onAgentsStarted: ({ sessionId, agents }) => {
+      deps.writer(
+        command.json
+          ? JSON.stringify(
+              {
+                sessionId,
+                recipe: { name: recipe.name, version: recipe.version },
+                recipeDigest: bound.recipeDigest,
+                agents: agents.map((a) => ({ role: a.role, status: a.session.status })),
+              },
+              null,
+              2,
+            )
+          : `Recipe session started: ${recipe.name}@${recipe.version} (${sessionId}) ` +
+              `with ${agents.length} agents`,
+      );
+    },
+  });
+  if (!command.json) {
+    deps.writer(`Recipe session ${result.sessionId} ended: ${result.stopReason}`);
+  }
+```
+
+Note: `resolve` from `node:path` is already imported at recipe.ts:2 (alongside `isAbsolute`), so
+no new import is needed for it. `buildRepos` is dynamically imported from `../utils/build-repos.js`
+as shown above. `parseGroveRecipe`, `bindRecipeParameters`, `materializeRecipeContract`, and
+`computeBoundRecipeDigest` are all already statically imported at the top of recipe.ts; `formatDryRun`
+is a local helper — all reused as-is.
+
+- [ ] **Step 5: Update main.ts help text**
+
+In `src/cli/main.ts`, change the recipe `helpText` (line 394) and `description` (line 392):
+
+```ts
+      description: "Validate, list, dry-run, and run Grove recipes",
+      needsStore: false,
+      helpText: `grove recipe — validate, list, dry-run, and run Grove recipes
+
+Usage:
+  grove recipe validate <path> [--json]
+  grove recipe list [--dir <path>] [--json]
+  grove recipe run <path> [--param key=value] [--goal "..."] [--repo <ref>] [--json]
+  grove recipe run <path> --dry-run [--param key=value] [--json]`,
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bun test src/cli/commands/recipe.test.ts src/cli/commands/recipe.run.test.ts`
+Expected: PASS. Existing dry-run tests still pass (the dry-run body is unchanged, just guarded).
+
+- [ ] **Step 7: Typecheck + commit**
+
+```bash
+tsc --noEmit
+git add src/cli/commands/recipe.ts src/cli/commands/recipe.test.ts src/cli/commands/recipe.run.test.ts src/cli/main.ts
+git commit -m "feat(cli): live grove recipe run launches a session (#276)" --no-verify
+```
+
+---
+
+## Task 9: Surface recipe digest in `session status` / `list`
+
+**Files:**
+- Modify: `src/cli/commands/session.ts:494-503` (status output), `:443-463` (list output)
+- Test: extend `src/cli/commands/session.test.ts` if it asserts status/list JSON shape; otherwise a focused assertion.
+
+- [ ] **Step 1: Add `recipeDigest` to `sessionStatus` output**
+
+In `src/cli/commands/session.ts`, in `sessionStatus`, in the `outputJson({...})` literal (line 494),
+add after `contributionCount: latest.contributionCount,`:
+
+```ts
+      ...(latest.recipeProvenance && { recipeDigest: latest.recipeProvenance.recipeDigest }),
+```
+
+- [ ] **Step 2: Verify list already carries it**
+
+`sessionList` outputs `sessions` verbatim (the `Session[]`), so `recipeProvenance` is already
+present when set. No change needed. (Note: `listRowToSession` omits heavy columns; confirm
+`recipeProvenance` survives list — it is read from the lightweight list query which does NOT
+select `recipe_provenance_json`. If surfacing the digest in `list` matters, switch `sessionList`
+to `getSession` per id, or add `recipe_provenance_json` to the list SELECT + `SessionListRow` +
+`listRowToSession`. For this task, digest-in-`status` is the requirement; leave `list` as-is and
+note the limitation in the commit body.)
+
+- [ ] **Step 3: Typecheck + manual check + commit**
+
+```bash
+tsc --noEmit
+git add src/cli/commands/session.ts
+git commit -m "feat(cli): surface recipe digest in session status (#276)" --no-verify
+```
+
+---
+
+## Task 10: Update the spec doc
+
+**Files:**
+- Modify: `spec/GROVE-RECIPES.md:87-101`
+
+- [ ] **Step 1: Replace the dry-run-only closing section**
+
+In `spec/GROVE-RECIPES.md`, replace the "Dry Run Materialization" section's closing paragraph
+(lines 99-101, the "The first implementation does not start agents..." note) with:
+
+```markdown
+## Live Run
+
+`grove recipe run <path> [--param k=v] [--goal "..."] [--repo <ref>]` materializes the
+recipe and launches a persistent session:
+
+- The rendered `instructions` becomes the session goal (overridable with `--goal`).
+- `agent_topology` roles are spawned via the shared launcher used by `grove session start`.
+- Declared `stdio:` MCP `extensions` are wired into every agent (after the built-in `grove`
+  server). Non-`stdio` extensions are skipped when optional and error when `required`.
+- `run_policy` maps to the session contract's stop conditions.
+- The session record stores the recipe digest and bound-parameter digest
+  (`recipeProvenance`) so re-runs are reproducible.
+
+Sub-recipe spawning and non-`stdio` extension wiring remain follow-up work.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add spec/GROVE-RECIPES.md
+git commit -m "docs(spec): document live grove recipe run (#276)" --no-verify
+```
+
+---
+
+## Task 11: Full suite + typecheck gate
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `bun test --timeout 60000 2>&1 | tail -15`
+Expected: all green; note the total count. No new failures vs. baseline.
+
+- [ ] **Step 2: Typecheck the whole project**
+
+Run: `tsc --noEmit`
+Expected: PASS (clean — this is the pre-push gate).
+
+- [ ] **Step 3: Targeted biome on changed files only**
+
+(Per project note: full-repo biome hangs in worktrees — lint only changed files.)
+
+Run: `bunx biome check --write src/core/recipe-extensions.ts src/cli/utils/launch-session.ts src/cli/commands/recipe.ts src/core/session.ts src/local/sqlite-goal-session-store.ts`
+Expected: clean / auto-fixed.
+
+- [ ] **Step 4: Commit any lint fixups**
+
+```bash
+git add -A
+git commit -m "chore: biome fixups for recipe run (#276)" --no-verify
+```
+
+---
+
+## Task 12: Real-process E2E (tmux + real grove + Nexus)
+
+This validates the live path end to end per the project's real-process-E2E rule. It is a script,
+not a `bun test` unit; it is run manually (and documented for CI later).
+
+**Files:**
+- Create: `tests/e2e/recipe-run-tmux.ts`
+
+- [ ] **Step 1: Study the reference harness**
+
+Read `tests/e2e/watch-relist-tmux.ts` for the established pattern (spawn real `grove` server,
+tmux pane orchestration, polling for state). Reuse its setup/teardown helpers.
+
+- [ ] **Step 2: Author the E2E script**
+
+Create `tests/e2e/recipe-run-tmux.ts` that:
+1. Creates a fresh temp dir, `git init`, `grove init` (fresh grove dir — per the stale-session
+   IPC note, always a fresh dir + git init per run).
+2. Starts a real Nexus via `grove up` (grove-managed lifecycle — never `nexus up` directly) and
+   exports `GROVE_NEXUS_URL`/`NEXUS_API_KEY`.
+3. Writes a 2-role review-loop recipe (coder=claude-code, reviewer=codex or claude) with a
+   `stdio:` MCP extension declared.
+4. Runs `grove recipe run ./recipe.yaml --param target_path=./src --json` with
+   `GROVE_RUNTIME=acpx` and real agents.
+5. Asserts: agents spawn (both roles appear), the codex↔claude handoff completes, the session
+   in Nexus carries `recipeProvenance.recipeDigest`, and the spawned agent's MCP set includes the
+   recipe extension (inspect agent logs under `<groveDir>/agent-logs`).
+6. Tears down tmux panes + `grove down`.
+
+- [ ] **Step 3: Run it**
+
+Run: `bun tests/e2e/recipe-run-tmux.ts`
+Expected: exits 0 with a summary line confirming spawn + handoff + digest recorded. Capture the
+output in the PR description.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/recipe-run-tmux.ts
+git commit -m "test(e2e): live recipe run tmux harness (#276)" --no-verify
+```
+
+---
+
+## Done criteria
+
+- `grove recipe run <path> --param k=v` (no `--dry-run`) launches a session; agents spawn.
+- The session row (SQLite) and Nexus record carry `recipeProvenance.recipeDigest` equal to
+  `grove recipe validate <path>` output.
+- Declared `stdio:` MCP extensions appear in spawned agents' MCP server list, after `grove`.
+- `grove session start` behavior is unchanged (existing suite green; same count).
+- `tsc --noEmit` clean; full `bun test` green; targeted biome clean.
+- Real-process E2E passes and is captured in the PR.

--- a/docs/superpowers/specs/2026-06-08-grove-recipe-run-live-design.md
+++ b/docs/superpowers/specs/2026-06-08-grove-recipe-run-live-design.md
@@ -1,0 +1,182 @@
+# Grove Recipe — Live Run (issue #276 follow-up)
+
+Status: approved design, pre-implementation
+Issue: windoliver/grove#276
+Prior art: `docs/superpowers/specs/2026-05-27-grove-recipes-design.md` (dry-run phase)
+
+## Goal
+
+Make `grove recipe run <path> [--param k=v]...` (without `--dry-run`) materialize the
+recipe into a **persistent, launched session**. The resulting session record carries the
+recipe digest so re-runs are reproducible, and declared `stdio:` MCP extensions are wired
+into every spawned agent.
+
+Today `recipe.ts` throws `"recipe run currently requires --dry-run"`. The dry-run pipeline
+(`parseGroveRecipe` → `bindRecipeParameters` → `materializeRecipeContract`) is complete and
+already emits a `GroveContract`, rendered instructions, topology, run policy, extensions, and
+provenance digests. This work feeds those outputs into the same launch path that
+`grove session start` uses.
+
+## Non-goals (separate #276 chunks — record-only here)
+
+- **Sub-recipe composition** — `sub_recipes` are materialized into provenance but not loaded
+  or spawned.
+- **Non-`stdio` extensions** — `type: tool|provider|service`, and `mcp` extensions whose URI
+  is not `stdio:`, are not wired. Required ones fail fast; optional ones warn and skip.
+- **Extension availability probing** — we map and attach `stdio:` MCP servers but do not
+  health-check that the command exists before launch.
+
+## Decisions (locked with user)
+
+1. **Approach A — shared launcher.** Extract the launch core from `sessionStart` into a
+   reusable helper; both `session start` and `recipe run` call it.
+2. **Goal source.** The recipe's rendered `instructions` is the session goal; `--goal`
+   overrides; error if neither yields a non-empty goal.
+3. **Wire extensions this pass.** Declared `stdio:` MCP extensions attach to every agent.
+
+## Components & data flow
+
+### 1. Shared launcher — `src/cli/utils/launch-session.ts` (new)
+
+Extract the launch core currently inlined in `sessionStart` (`src/cli/commands/session.ts`
+≈ lines 181–421) into:
+
+```ts
+export interface LaunchGoalSessionInput {
+  readonly groveDir: string;
+  readonly groveRoot: string;
+  readonly goal: string;
+  readonly topology: AgentTopology;
+  readonly contract?: GroveContract | undefined;
+  readonly repos: readonly RepoRef[];
+  readonly extraMcpServers?: NonNullable<AgentConfig["mcpServers"]> | undefined;
+  readonly recipeProvenance?: RecipeProvenance | undefined;
+}
+
+export interface LaunchGoalSessionResult {
+  readonly sessionId: string;
+  readonly stopStatus: LoopStopStatus;
+  readonly stopReason: string;
+}
+
+export async function launchGoalSession(
+  input: LaunchGoalSessionInput,
+): Promise<LaunchGoalSessionResult>;
+```
+
+The launcher owns everything `sessionStart` does after topology resolution:
+
+- runtime selection (`selectRuntime`, acpx/acp → `MockRuntime` fallback) honoring
+  `GROVE_RUNTIME` and `GROVE_ALLOW_ALL_PERMISSIONS`,
+- `SqliteGoalSessionStore.createSession` (now also persisting `recipeProvenance`),
+- Nexus mirror (`putSession` with retries; orphan archive + rethrow on failure),
+- `SessionOrchestrator.start()` (passing `extraMcpServers` through),
+- `GroveLoopRunner` wait-for-completion + `markDone`,
+- interrupt handlers + `finally` db close.
+
+`sessionStart` becomes a thin caller: parse args → resolve topology → `launchGoalSession` →
+print JSON. **No behavior change** to `session start`; its existing tests are the regression
+guard that proves the extraction is behavior-preserving.
+
+### 2. Recipe → launch inputs — `src/cli/commands/recipe.ts`
+
+The live branch of `runRecipe` (replacing the `--dry-run` guard at recipe.ts:126):
+
+1. `readFile` → `parseGroveRecipe` → `bindRecipeParameters(recipe, params)` →
+   `materializeRecipeContract(bound)`.
+2. `goal` = `--goal` value if non-empty, else `materialized.renderedInstructions`.
+   If both empty → `UsageError`.
+3. `topology` = `materialized.contract.topology`. If absent → `UsageError`
+   (cannot spawn agents with no roles).
+4. `extraMcpServers` = `resolveRecipeMcpServers(recipe.extensions ?? [])`.
+5. `repos` = `buildRepos({ rawRepo: --repo flags, cwd: groveRoot })` (same as `session start`).
+6. Resolve `groveDir` via `findGroveDir(cwd)`; error if not inside a grove.
+7. Call `launchGoalSession({ ... recipeProvenance: materialized.provenance })`.
+
+New flags on `recipe run`: `--goal <string>` and `--repo <ref>` (multiple), alongside the
+existing `--param`, `--json`. `--dry-run` keeps its current behavior.
+
+### 3. Extension wiring — `src/core/recipe-extensions.ts` (new)
+
+```ts
+export function resolveRecipeMcpServers(
+  extensions: readonly RecipeExtension[],
+): NonNullable<AgentConfig["mcpServers"]>;
+```
+
+Mapping rules:
+
+- `type: "mcp"`, `uri` starts with `stdio:` → `{ name, command, args }` where the text after
+  `stdio:` is split on whitespace into `[command, ...args]`. Empty command → error.
+- `type: "mcp"` with a non-`stdio:` URI (or no URI), or `type: "tool"|"provider"|"service"`
+  → not expressible in the current stdio-only `AgentConfig.mcpServers`. If
+  `required: true` → throw
+  (`extension '<name>' is not launchable: only stdio: MCP URIs are wired today`);
+  otherwise log a warning and skip.
+
+`SessionOrchestrator` config gains optional `extraMcpServers`. The per-role spawn
+(orchestrator.ts:659) changes from:
+
+```ts
+mcpServers: [this.groveMcpServer(role.name)],
+```
+to:
+```ts
+mcpServers: [this.groveMcpServer(role.name), ...(this.config.extraMcpServers ?? [])],
+```
+
+Backward-compatible: `session start` and the TUI pass nothing, preserving current behavior.
+The runtime already forwards `AgentConfig.mcpServers` to agents via ACP `session/new`
+(see `agent-runtime.ts` `mcpServers` doc), so no new runtime plumbing is required.
+
+### 4. Provenance persistence
+
+- `Session` and `CreateSessionInput` (`src/core/session.ts`) gain optional
+  `recipeProvenance?: RecipeProvenance` (the existing type from `src/core/recipe.ts`:
+  `recipeDigest`, `recipeName`, `recipeVersion`, `boundParameterDigest`, `subRecipeDigests`,
+  `sourceRef?`).
+- SQLite (`src/local/sqlite-goal-session-store.ts`): additive, idempotent migration
+  `ALTER TABLE sessions ADD COLUMN recipe_provenance_json TEXT` (guarded the same way other
+  back-compat column adds are), serialized on create and hydrated on read.
+- Nexus session store: include `recipeProvenance` in the JSON body (the store already
+  round-trips session fields as JSON).
+- `grove session status` / `grove session list` surface `recipeDigest` when present.
+
+## Error handling
+
+- Missing required param / unknown param → `bindRecipeParameters` throws (surfaced as
+  `UsageError`).
+- Empty goal, absent topology, or an unlaunchable **required** extension → `UsageError`
+  raised **before** any session is created → nothing persisted (fail-closed).
+- Nexus mirror failure → archive the orphan SQLite record + rethrow (reused from
+  `sessionStart`, now living in the launcher).
+
+## Testing
+
+- **Unit**
+  - `resolveRecipeMcpServers`: `stdio:` parse (command + args), required-non-stdio throws,
+    optional non-stdio warns and is skipped, empty command errors.
+  - recipe→launch-input mapping: goal precedence (`--goal` > instructions > error),
+    topology-absent error.
+- **Integration** (`GROVE_RUNTIME=mock`)
+  - `recipe run` of a 2-role recipe → asserts a session row exists with
+    `recipe_provenance_json` whose `recipeDigest` equals `grove recipe validate` output.
+  - asserts each spawned `AgentConfig.mcpServers` includes both the `grove` server and the
+    recipe's `stdio:` extension.
+- **Refactor guard**: existing `grove session start` tests stay green (behavior-preserving
+  extraction).
+- **Real-process E2E** (`tests/e2e/recipe-run-tmux.ts`): tmux + real grove server +
+  real Nexus running a 2-role review-loop recipe — confirms agents spawn, the `stdio:` MCP
+  extension attaches, codex↔claude handoff completes, and the session record carries the
+  recipe digest. Built on the `tests/e2e/watch-relist-tmux.ts` pattern.
+
+## Files touched
+
+- new: `src/cli/utils/launch-session.ts`, `src/core/recipe-extensions.ts`,
+  `tests/e2e/recipe-run-tmux.ts`
+- edit: `src/cli/commands/recipe.ts` (live branch + flags), `src/cli/main.ts` (help text),
+  `src/cli/commands/session.ts` (thin caller of launcher),
+  `src/core/session.ts` (provenance fields), `src/core/session-orchestrator.ts`
+  (`extraMcpServers`), `src/local/sqlite-goal-session-store.ts` (column + migration),
+  `src/nexus/nexus-session-store.ts` (provenance round-trip),
+  `spec/GROVE-RECIPES.md` (live-run section replacing the "does not start agents" note)

--- a/spec/GROVE-RECIPES.md
+++ b/spec/GROVE-RECIPES.md
@@ -96,6 +96,17 @@ emit:
 - required extensions
 - a `GroveContract`-compatible session contract
 
-The first implementation does not start agents. Real execution, persistent
-session creation, and integration with agent launchers are follow-up work after
-the dry-run contract is stable.
+## Live Run
+
+`grove recipe run <path> [--param k=v] [--goal "..."] [--repo <ref>]` materializes the
+recipe and launches a persistent session:
+
+- The rendered `instructions` becomes the session goal (overridable with `--goal`).
+- `agent_topology` roles are spawned via the shared launcher used by `grove session start`.
+- Declared `stdio:` MCP `extensions` are wired into every agent (after the built-in `grove`
+  server). Non-`stdio` extensions are skipped when optional and error when `required`.
+- `run_policy` maps to the session contract's stop conditions.
+- The session record stores the recipe digest and bound-parameter digest
+  (`recipeProvenance`) so re-runs are reproducible.
+
+Sub-recipe spawning and non-`stdio` extension wiring remain follow-up work.

--- a/src/cli/commands/recipe.run.test.ts
+++ b/src/cli/commands/recipe.run.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { LaunchGoalSessionInput, LaunchGoalSessionResult } from "../utils/launch-session.js";
+import { runRecipe } from "./recipe.js";
+
+type LaunchFn = (input: LaunchGoalSessionInput) => Promise<LaunchGoalSessionResult>;
+
+const RECIPE = `kind: recipe
+recipe_version: 1
+name: demo-loop
+version: 1.0.0
+instructions: |
+  Work on \${parameters.target}.
+parameters:
+  target:
+    type: string
+    required: true
+extensions:
+  - type: mcp
+    name: fs
+    uri: stdio:grove-fs-mcp
+agent_topology:
+  structure: graph
+  roles:
+    - name: coder
+      platform: claude-code
+`;
+
+describe("recipe run (live wiring)", () => {
+  test("materializes recipe into launch input with provenance + stdio extension", async () => {
+    const root = await mkdtemp(join(tmpdir(), "grove-reciperun-"));
+    execFileSync("git", ["init", "-q"], { cwd: root });
+    await mkdir(join(root, ".grove"), { recursive: true });
+    const recipePath = join(root, "demo.yaml");
+    await writeFile(recipePath, RECIPE);
+    const lines: string[] = [];
+    // capture the launch input; do not spawn anything
+    let captured: LaunchGoalSessionInput | undefined;
+    const fakeLaunch: LaunchFn = async (input) => {
+      captured = input;
+      input.onAgentsStarted?.({
+        sessionId: "sess-test",
+        agents: [{ role: "coder", session: { id: "a1", status: "running" } }],
+      });
+      return { sessionId: "sess-test", stopStatus: "achieved", stopReason: "done" };
+    };
+    try {
+      await runRecipe(
+        {
+          command: "run",
+          path: recipePath,
+          params: { target: "./src" },
+          dryRun: false,
+          json: true,
+          repos: [],
+        },
+        { cwd: root, writer: (l) => lines.push(l), launch: fakeLaunch },
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+    // goal came from rendered instructions
+    expect(captured?.goal).toContain("Work on ./src");
+    // topology threaded through
+    expect(captured?.topology.roles.map((r) => r.name)).toContain("coder");
+    // stdio extension wired
+    expect(captured?.extraMcpServers?.map((s) => s.name)).toContain("fs");
+    // provenance carries the recipe identity + a blake3 digest
+    expect(captured?.recipeProvenance?.recipeName).toBe("demo-loop");
+    expect(captured?.recipeProvenance?.recipeDigest).toMatch(/^blake3:/);
+    // output mentions the session
+    expect(lines.join("\n")).toContain("sess-test");
+  });
+
+  test("errors when no goal and no instructions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "grove-reciperun-"));
+    execFileSync("git", ["init", "-q"], { cwd: root });
+    await mkdir(join(root, ".grove"), { recursive: true });
+    const recipePath = join(root, "no-instr.yaml");
+    await writeFile(
+      recipePath,
+      `kind: recipe\nrecipe_version: 1\nname: x\nversion: 1.0.0\nagent_topology:\n  structure: graph\n  roles:\n    - name: coder\n`,
+    );
+    const fakeLaunch: LaunchFn = async () => ({
+      sessionId: "x",
+      stopStatus: "achieved",
+      stopReason: "",
+    });
+    try {
+      await expect(
+        runRecipe(
+          { command: "run", path: recipePath, params: {}, dryRun: false, json: false, repos: [] },
+          {
+            cwd: root,
+            writer: () => {
+              /* discard output */
+            },
+            launch: fakeLaunch,
+          },
+        ),
+      ).rejects.toThrow(/goal/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/commands/recipe.test.ts
+++ b/src/cli/commands/recipe.test.ts
@@ -30,6 +30,20 @@ describe("recipe command", () => {
     expect(() => parseRecipeArgs(["run", "recipes/review.yaml", "extra.yaml"])).toThrow(UsageError);
   });
 
+  test("parseRecipeArgs parses run with goal and repo flags", () => {
+    expect(
+      parseRecipeArgs(["run", "r.yaml", "--goal", "do it", "--repo", "./a", "--param", "x=1"]),
+    ).toEqual({
+      command: "run",
+      path: "r.yaml",
+      params: { x: "1" },
+      goal: "do it",
+      repos: ["./a"],
+      dryRun: false,
+      json: false,
+    });
+  });
+
   test("validate reports a valid recipe", async () => {
     const dir = await mkdtemp(join(tmpdir(), "grove-recipe-cli-"));
     try {
@@ -200,8 +214,8 @@ describe("recipe command", () => {
     }
   });
 
-  test("run without --dry-run is rejected in the first implementation slice", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-run-required-dry-"));
+  test("run without a goal or instructions is rejected", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-run-required-goal-"));
     try {
       const recipePath = join(dir, "review.yaml");
       await writeFile(
@@ -210,7 +224,7 @@ describe("recipe command", () => {
       );
       await expect(
         runRecipe(parseRecipeArgs(["run", recipePath]), { cwd: dir, writer: () => undefined }),
-      ).rejects.toThrow(/requires --dry-run/);
+      ).rejects.toThrow(/goal/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/cli/commands/recipe.ts
+++ b/src/cli/commands/recipe.ts
@@ -164,9 +164,9 @@ export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promi
     throw new UsageError("recipe run requires the recipe to declare agent_topology with roles");
   }
 
-  const { resolveRecipeMcpServers } = await import("../../core/recipe-extensions.js");
-  const extraMcpServers = resolveRecipeMcpServers(recipe.extensions ?? []);
-
+  // Resolve the grove location before extension wiring so the friendlier,
+  // cheaper "not inside a grove" error wins over an extension-launchability
+  // failure when both apply. Neither persists nor launches anything.
   const { findGroveDir } = await import("../context.js");
   const groveDir = findGroveDir(deps.cwd);
   if (groveDir === undefined) {
@@ -174,8 +174,11 @@ export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promi
   }
   const groveRoot = resolve(groveDir, "..");
 
+  const { resolveRecipeMcpServers } = await import("../../core/recipe-extensions.js");
+  const extraMcpServers = resolveRecipeMcpServers(recipe.extensions ?? []);
+
   const { buildRepos } = await import("../utils/build-repos.js");
-  const repos = buildRepos({ rawRepo: [...command.repos], cwd: groveRoot });
+  const repos = buildRepos({ rawRepo: command.repos, cwd: groveRoot });
 
   const launch = deps.launch ?? (await import("../utils/launch-session.js")).launchGoalSession;
   const result = await launch({

--- a/src/cli/commands/recipe.ts
+++ b/src/cli/commands/recipe.ts
@@ -22,11 +22,14 @@ type RecipeCommand =
       readonly params: Readonly<Record<string, string>>;
       readonly dryRun: boolean;
       readonly json: boolean;
+      readonly goal?: string | undefined;
+      readonly repos: readonly string[];
     };
 
 interface RecipeDeps {
   readonly cwd: string;
   readonly writer: (line: string) => void;
+  readonly launch?: typeof import("../utils/launch-session.js").launchGoalSession | undefined;
 }
 
 export function parseRecipeArgs(argv: readonly string[]): RecipeCommand {
@@ -60,6 +63,8 @@ export function parseRecipeArgs(argv: readonly string[]): RecipeCommand {
         param: { type: "string", multiple: true },
         "dry-run": { type: "boolean", default: false },
         json: { type: "boolean", default: false },
+        repo: { type: "string", multiple: true },
+        goal: { type: "string" },
       },
       allowPositionals: true,
       strict: true,
@@ -73,6 +78,8 @@ export function parseRecipeArgs(argv: readonly string[]): RecipeCommand {
       params: parseParamFlags(parsed.values.param ?? []),
       dryRun: parsed.values["dry-run"] ?? false,
       json: parsed.values.json ?? false,
+      ...(parsed.values.goal !== undefined && { goal: parsed.values.goal }),
+      repos: parsed.values.repo ?? [],
     };
   }
   throw new UsageError("recipe requires subcommand: validate, list, or run");
@@ -123,26 +130,84 @@ export async function runRecipe(command: RecipeCommand, deps: RecipeDeps): Promi
     );
     return;
   }
-  if (!command.dryRun) {
-    throw new UsageError("recipe run currently requires --dry-run");
-  }
   const content = await readFile(resolveRecipePath(command.path, deps.cwd), "utf-8");
   const recipe = parseGroveRecipe(content);
   const bound = bindRecipeParameters(recipe, command.params);
   const materialized = materializeRecipeContract(bound);
-  const payload = {
-    recipe: { name: recipe.name, version: recipe.version },
-    recipeDigest: bound.recipeDigest,
-    boundParameterDigest: computeBoundRecipeDigest(bound),
-    parameters: bound.parameters,
-    renderedInstructions: materialized.renderedInstructions,
-    extensions: materialized.extensions,
-    subRecipes: materialized.subRecipes,
-    runPolicy: materialized.runPolicy,
+
+  if (command.dryRun) {
+    const payload = {
+      recipe: { name: recipe.name, version: recipe.version },
+      recipeDigest: bound.recipeDigest,
+      boundParameterDigest: computeBoundRecipeDigest(bound),
+      parameters: bound.parameters,
+      renderedInstructions: materialized.renderedInstructions,
+      extensions: materialized.extensions,
+      subRecipes: materialized.subRecipes,
+      runPolicy: materialized.runPolicy,
+      contract: materialized.contract,
+      provenance: materialized.provenance,
+    };
+    deps.writer(command.json ? JSON.stringify(payload, null, 2) : formatDryRun(payload));
+    return;
+  }
+
+  // Live run.
+  const goal = command.goal?.trim() || materialized.renderedInstructions.trim();
+  if (goal === "") {
+    throw new UsageError(
+      "recipe run needs a goal: provide --goal or a non-empty recipe `instructions`",
+    );
+  }
+  const topology = materialized.contract.topology;
+  if (topology === undefined) {
+    throw new UsageError("recipe run requires the recipe to declare agent_topology with roles");
+  }
+
+  const { resolveRecipeMcpServers } = await import("../../core/recipe-extensions.js");
+  const extraMcpServers = resolveRecipeMcpServers(recipe.extensions ?? []);
+
+  const { findGroveDir } = await import("../context.js");
+  const groveDir = findGroveDir(deps.cwd);
+  if (groveDir === undefined) {
+    throw new UsageError("Not inside a grove. Run 'grove init' first.");
+  }
+  const groveRoot = resolve(groveDir, "..");
+
+  const { buildRepos } = await import("../utils/build-repos.js");
+  const repos = buildRepos({ rawRepo: [...command.repos], cwd: groveRoot });
+
+  const launch = deps.launch ?? (await import("../utils/launch-session.js")).launchGoalSession;
+  const result = await launch({
+    groveDir,
+    groveRoot,
+    goal,
+    topology,
     contract: materialized.contract,
-    provenance: materialized.provenance,
-  };
-  deps.writer(command.json ? JSON.stringify(payload, null, 2) : formatDryRun(payload));
+    repos,
+    ...(extraMcpServers.length > 0 && { extraMcpServers: [...extraMcpServers] }),
+    recipeProvenance: materialized.provenance,
+    onAgentsStarted: ({ sessionId, agents }) => {
+      deps.writer(
+        command.json
+          ? JSON.stringify(
+              {
+                sessionId,
+                recipe: { name: recipe.name, version: recipe.version },
+                recipeDigest: bound.recipeDigest,
+                agents: agents.map((a) => ({ role: a.role, status: a.session.status })),
+              },
+              null,
+              2,
+            )
+          : `Recipe session started: ${recipe.name}@${recipe.version} (${sessionId}) ` +
+              `with ${agents.length} agents`,
+      );
+    },
+  });
+  if (!command.json) {
+    deps.writer(`Recipe session ${result.sessionId} ended: ${result.stopReason}`);
+  }
 }
 
 function resolveRecipePath(path: string, cwd: string): string {

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -166,6 +166,7 @@ async function sessionStart(args: readonly string[]): Promise<void> {
     goal,
     topology: resolution.topology,
     contract,
+    presetName,
     repos,
     onAgentsStarted: ({ sessionId, agents }) => {
       outputJson({

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -254,6 +254,7 @@ async function sessionStatus(): Promise<void> {
       stopReason: latest.stopReason,
       stopStatus: latest.stopStatus,
       contributionCount: latest.contributionCount,
+      ...(latest.recipeProvenance && { recipeDigest: latest.recipeProvenance.recipeDigest }),
     });
   } catch (err) {
     outputJsonError({

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -17,21 +17,9 @@ import { parseArgs } from "node:util";
 import { expectCasOk } from "../../core/cas.js";
 import type { GroveContract } from "../../core/contract.js";
 import { parseGroveContract } from "../../core/contract.js";
-import { LocalEventBus } from "../../core/local-event-bus.js";
-import {
-  createFallbackRoadmap,
-  GroveLoopRunner,
-  installProcessInterruptHandlers,
-  LoopStopStatus,
-  type SessionAssessment,
-  type WorkflowStateStore,
-} from "../../core/loop-runner.js";
-import { MockRuntime } from "../../core/mock-runtime.js";
+import { LoopStopStatus } from "../../core/loop-runner.js";
 import { lookupPresetTopology } from "../../core/presets.js";
 import { readNamespace } from "../../core/project-key.js";
-import { SessionOrchestrator } from "../../core/session-orchestrator.js";
-import type { ContributionStore } from "../../core/store.js";
-import type { AgentTopology } from "../../core/topology.js";
 import type { TopologyResolutionResult } from "../../core/topology-resolver.js";
 import { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
 import { outputJson, outputJsonError } from "../format.js";
@@ -43,13 +31,6 @@ import { buildRepos } from "../utils/build-repos.js";
 
 interface SessionNexusZoneEnv {
   readonly GROVE_ZONE_ID?: string | undefined;
-}
-
-interface SessionCompletionUpdates {
-  readonly status: "completed" | "cancelled";
-  readonly completedAt: string;
-  readonly stopReason: string;
-  readonly stopStatus: LoopStopStatus;
 }
 
 export function resolveSessionNexusZoneId(
@@ -178,262 +159,34 @@ async function sessionStart(args: readonly string[]): Promise<void> {
     return;
   }
 
-  // Create runtime via selectRuntime (honors GROVE_RUNTIME env), fall back to mock
-  const { selectRuntime } = await import("../../core/select-runtime.js");
-  const { ALLOW_ALL_RESOLVER, ChainResolver, DENY_ALL_RESOLVER } = await import(
-    "../../core/permission-resolver.js"
-  );
-  const { RulesResolver } = await import("../../core/permission-rules.js");
-  const allowAllPermissions = process.env.GROVE_ALLOW_ALL_PERMISSIONS === "1";
-  const permissionResolver = allowAllPermissions
-    ? ALLOW_ALL_RESOLVER
-    : new ChainResolver([
-        new RulesResolver({
-          allowKinds: ["read", "search", "think"],
-          denyTitleSubstrings: ["rm -rf", "sudo", "shutdown"],
-        }),
-        DENY_ALL_RESOLVER,
-      ]);
-  if (allowAllPermissions) {
-    process.stderr.write(
-      "[grove] permission-resolver: ALLOW_ALL (GROVE_ALLOW_ALL_PERMISSIONS=1). " +
-        "Destructive tool calls are auto-approved.\n",
-    );
-  }
-  const picked = selectRuntime({
-    acpx: { logDir: join(groveDir, "agent-logs") },
-    acp: { logDir: join(groveDir, "agent-logs"), permissionResolver },
-  });
-  const runtime = (await picked.isAvailable()) ? picked : new MockRuntime();
-  const eventBus = new LocalEventBus();
-
-  // Open SQLite database and create session
-  const { initSqliteDb } = await import("../../local/sqlite-store.js");
-  const db = initSqliteDb(join(groveDir, "grove.db"));
-
-  // Everything below must run under try/finally so db.close() always fires.
-  // Signal handlers are installed early (before orchestrator.start) so a
-  // Ctrl-C during startup still records a stopReason.
-  let sessionId: string | undefined;
-  let orchestrator: SessionOrchestrator | undefined;
-  let workflowStore: WorkflowStateStore | undefined;
-  let contributionStore: ContributionStore | undefined;
-  let updateNexusSession:
-    | ((sessionId: string, updates: SessionCompletionUpdates) => Promise<void>)
-    | undefined;
-  let addNexusContributionToSession:
-    | ((sessionId: string, cid: string) => Promise<void>)
-    | undefined;
-  const goalSessionStore = new SqliteGoalSessionStore(db);
-
-  const markDone = async (reason: string, stopStatus: LoopStopStatus): Promise<void> => {
-    if (sessionId === undefined) return;
-    const updates: SessionCompletionUpdates = {
-      status: terminalSessionStatus(stopStatus),
-      completedAt: new Date().toISOString(),
-      stopReason: reason,
-      stopStatus,
-    };
-    try {
-      // C6 (#304): no ifMatch supplied — rv-mismatch is unreachable here;
-      // surface as a hard error so future ifMatch wiring (T7) doesn't silently
-      // skip the markDone path.
-      const result = await goalSessionStore.updateSession(sessionId, updates);
-      expectCasOk(result, `cli markDone(${sessionId})`);
-    } catch {
-      // Best-effort — DB may already be closed or session archived.
-    }
-    try {
-      await updateNexusSession?.(sessionId, updates);
-    } catch {
-      // Best-effort — Nexus may be unavailable during shutdown.
-    }
-  };
-
-  const interruptHandlers = installProcessInterruptHandlers(process, {
-    forceExit: (code) => process.exit(code),
-    onInterrupt: (reason) => {
-      void orchestrator?.stop(reason, LoopStopStatus.Interrupted);
-      void markDone(reason, LoopStopStatus.Interrupted);
+  const { launchGoalSession } = await import("../utils/launch-session.js");
+  await launchGoalSession({
+    groveDir,
+    groveRoot,
+    goal,
+    topology: resolution.topology,
+    contract,
+    repos,
+    onAgentsStarted: ({ sessionId, agents }) => {
+      outputJson({
+        sessionId,
+        goal,
+        preset: presetName ?? contract?.name,
+        agents: agents.map((a) => ({
+          role: a.role,
+          sessionId: a.session.id,
+          status: a.session.status,
+        })),
+        message: `Session started with ${agents.length} agents`,
+      });
     },
   });
-
-  try {
-    const session = await goalSessionStore.createSession({
-      goal,
-      presetName: presetName ?? contract?.name,
-      topology: resolution.topology,
-      config: contract,
-    });
-    sessionId = session.id;
-
-    // Mirror the session to Nexus so MCP servers spawned by agents (which set
-    // `GROVE_NEXUS_URL`) can resolve the frozen contract. Parallels the TUI
-    // path in NexusProvider.createSession — without this, grove-mcp's
-    // fail-closed check kills every agent spawned through `grove session
-    // start`. Best-effort with retries; a hard failure archives the orphan
-    // SQLite record and rethrows so the user sees the problem up front.
-    const nexusUrl = process.env.GROVE_NEXUS_URL;
-    const nexusApiKey = process.env.NEXUS_API_KEY;
-    if (nexusUrl) {
-      const { NexusHttpClient } = await import("../../nexus/nexus-http-client.js");
-      const { NexusContributionStore } = await import("../../nexus/nexus-contribution-store.js");
-      const { NexusSessionStore } = await import("../../nexus/nexus-session-store.js");
-      const { NexusWorkflowStore } = await import("../../nexus/nexus-workflow-store.js");
-      const nexusClient = new NexusHttpClient({
-        url: nexusUrl,
-        ...(nexusApiKey ? { apiKey: nexusApiKey } : {}),
-      });
-      const zoneId = resolveSessionNexusZoneId(groveDir);
-      const nexusSessionStore = new NexusSessionStore(nexusClient, zoneId);
-      updateNexusSession = async (targetSessionId, updates) => {
-        const result = await nexusSessionStore.updateSession(targetSessionId, updates);
-        expectCasOk(result, `cli nexus markDone(${targetSessionId})`);
-      };
-      addNexusContributionToSession = (targetSessionId, cid) =>
-        nexusSessionStore.addContribution(targetSessionId, cid);
-      workflowStore = new NexusWorkflowStore({ client: nexusClient, zoneId });
-      contributionStore = new NexusContributionStore({
-        client: nexusClient,
-        zoneId,
-        sessionId: session.id,
-      });
-
-      const retryDelaysMs = [0, 200, 500, 1000];
-      let lastErr: unknown;
-      for (const delay of retryDelaysMs) {
-        if (delay > 0) await new Promise((r) => setTimeout(r, delay));
-        try {
-          await nexusSessionStore.putSession(session);
-          lastErr = undefined;
-          break;
-        } catch (err) {
-          lastErr = err;
-        }
-      }
-      if (lastErr) {
-        // Best-effort archive — ignore both CAS mismatches and exceptions.
-        await goalSessionStore
-          .archiveSession(session.id)
-          .then((result) => {
-            if (result.kind === "rv-mismatch") return; // best-effort, ignore stale RV
-          })
-          .catch(() => undefined);
-        throw new Error(
-          `Failed to mirror session ${session.id} to Nexus at ${nexusUrl}: ` +
-            `${lastErr instanceof Error ? lastErr.message : String(lastErr)}. ` +
-            `The local session has been archived; please retry.`,
-        );
-      }
-    }
-
-    // Create contribution store for polling-based routing (MCP runs in child processes).
-    // In Nexus mode MCP writes session-scoped contributions to Nexus, so the
-    // orchestrator must poll the same scoped store or downstream roles never
-    // receive handoffs.
-    if (!contributionStore) {
-      const { SqliteContributionStore } = await import("../../local/sqlite-store.js");
-      contributionStore = new SqliteContributionStore(db);
-    }
-
-    orchestrator = new SessionOrchestrator({
-      goal,
-      contract: contract ?? { contractVersion: 3, name: presetName ?? "default" },
-      topology: resolution.topology,
-      runtime,
-      eventBus,
-      projectRoot: groveRoot,
-      repos,
-      workspaceBaseDir: join(groveDir, "workspaces"),
-      sessionId: session.id,
-      contributionStore,
-      onContributionAccepted: async (cid) => {
-        const localLink = goalSessionStore.addContributionToSession(session.id, cid);
-        if (addNexusContributionToSession === undefined) {
-          await localLink;
-          return;
-        }
-        await Promise.all([localLink, addNexusContributionToSession(session.id, cid)]);
-      },
-    });
-
-    let status: import("../../core/session-orchestrator.js").SessionStatus;
-    try {
-      status = await orchestrator.start();
-    } catch (err) {
-      // Mark session as cancelled on spawn failure. The outer finally still
-      // closes db and removes signal listeners.
-      const archiveResult = await goalSessionStore.archiveSession(session.id);
-      expectCasOk(archiveResult, `cli session start cleanup (${session.id})`);
-      throw err;
-    }
-
-    // Output initial status
-    outputJson({
-      sessionId: session.id,
-      goal,
-      preset: presetName ?? contract?.name,
-      agents: status.agents.map((a) => ({
-        role: a.role,
-        sessionId: a.session.id,
-        status: a.session.status,
-      })),
-      message: `Session started with ${status.agents.length} agents`,
-    });
-
-    // Wait for session completion through the deterministic external loop.
-    // The session orchestrator owns agent routing; the loop owns final status,
-    // interrupt observation, and durable workflow state.
-    const SESSION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-    const assessment = sessionAssessment(goal, resolution.topology);
-    const loop = new GroveLoopRunner({
-      workflowId: `workflow-${session.id}`,
-      sessionId: session.id,
-      assessment,
-      roadmap: createFallbackRoadmap(assessment),
-      maxIterations: 1,
-      interrupt: interruptHandlers.interrupt,
-      workflowStore,
-      executeIteration: async () => {
-        const stopReason = await orchestrator?.waitForCompletion(SESSION_TIMEOUT_MS);
-        const current = orchestrator?.getStatus();
-        return {
-          stopStatus:
-            current?.stopStatus ??
-            (interruptHandlers.interrupt.interruptRequested
-              ? LoopStopStatus.Interrupted
-              : LoopStopStatus.Achieved),
-          summary: stopReason ?? current?.stopReason ?? "Session complete",
-        };
-      },
-    });
-    const finalState = await loop.run();
-    const finalStopStatus =
-      finalState.status === "running" ? LoopStopStatus.Error : finalState.status;
-    await markDone(finalState.reason ?? "Session complete", finalStopStatus);
-  } finally {
-    interruptHandlers.dispose();
-    try {
-      db.close();
-    } catch {
-      /* already closed */
-    }
-  }
 }
 
 function terminalSessionStatus(stopStatus: LoopStopStatus): "completed" | "cancelled" {
   return stopStatus === LoopStopStatus.Interrupted || stopStatus === LoopStopStatus.Error
     ? "cancelled"
     : "completed";
-}
-
-function sessionAssessment(goal: string, topology: AgentTopology): SessionAssessment {
-  return {
-    goal,
-    roles: topology.roles.map((role) => role.name),
-    successCriteria: ["session reaches a deterministic terminal status"],
-    constraints: ["stop decisions are made by GroveLoopRunner, not by agent prose"],
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -389,13 +389,14 @@ function buildCommands(groveOverride: string | undefined): readonly Command[] {
     },
     {
       name: "recipe",
-      description: "Validate, list, and dry-run Grove recipes",
+      description: "Validate, list, dry-run, and run Grove recipes",
       needsStore: false,
       helpText: `grove recipe — validate, list, and dry-run Grove recipes
 
 Usage:
   grove recipe validate <path> [--json]
   grove recipe list [--dir <path>] [--json]
+  grove recipe run <path> [--param key=value] [--goal "..."] [--repo <ref>] [--json]
   grove recipe run <path> --dry-run [--param key=value] [--json]`,
       handler: async (args) => {
         const { handleRecipe } = await import("./commands/recipe.js");

--- a/src/cli/utils/launch-session.test.ts
+++ b/src/cli/utils/launch-session.test.ts
@@ -10,8 +10,8 @@ import type { AgentSessionEntity } from "../../core/entity.js";
 import { agentSessionToEntity } from "../../core/entity.js";
 import type { RecipeProvenance } from "../../core/recipe.js";
 import type { AgentTopology } from "../../core/topology.js";
-import { initSqliteDb } from "../../local/sqlite-store.js";
 import { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
+import { initSqliteDb } from "../../local/sqlite-store.js";
 import { launchGoalSession } from "./launch-session.js";
 
 // ---------------------------------------------------------------------------
@@ -108,70 +108,65 @@ class QuickIdleRuntime implements AgentRuntime {
 // ---------------------------------------------------------------------------
 
 describe("launchGoalSession", () => {
-  test(
-    "creates a session that records recipe provenance",
-    async () => {
-      const root = await mkdtemp(join(tmpdir(), "grove-launch-"));
-      const groveDir = join(root, ".grove");
-      await mkdir(groveDir, { recursive: true });
+  test("creates a session that records recipe provenance", async () => {
+    const root = await mkdtemp(join(tmpdir(), "grove-launch-"));
+    const groveDir = join(root, ".grove");
+    await mkdir(groveDir, { recursive: true });
 
-      // Initialize a real git repo so workspace provisioning (git worktree add)
-      // succeeds — provisionWorkspace requires a bare-clone/local git repo with
-      // at least one commit.
-      execFileSync("git", ["-c", "init.defaultBranch=main", "init", root], { stdio: "pipe" });
-      execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: root, stdio: "pipe" });
-      execFileSync("git", ["config", "user.name", "Test"], { cwd: root, stdio: "pipe" });
-      execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: root, stdio: "pipe" });
+    // Initialize a real git repo so workspace provisioning (git worktree add)
+    // succeeds — provisionWorkspace requires a bare-clone/local git repo with
+    // at least one commit.
+    execFileSync("git", ["-c", "init.defaultBranch=main", "init", root], { stdio: "pipe" });
+    execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: root, stdio: "pipe" });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: root, stdio: "pipe" });
+    execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: root, stdio: "pipe" });
 
-      try {
-        const topology: AgentTopology = {
-          structure: "graph",
-          roles: [{ name: "coder", maxInstances: 1, platform: "claude-code" }],
-        };
-        const provenance: RecipeProvenance = {
-          recipeDigest: "blake3:abc",
-          recipeName: "demo",
-          recipeVersion: "1.0.0",
-          boundParameterDigest: "blake3:def",
-          subRecipeDigests: [],
-        };
+    try {
+      const topology: AgentTopology = {
+        structure: "graph",
+        roles: [{ name: "coder", maxInstances: 1, platform: "claude-code" }],
+      };
+      const provenance: RecipeProvenance = {
+        recipeDigest: "blake3:abc",
+        recipeName: "demo",
+        recipeVersion: "1.0.0",
+        boundParameterDigest: "blake3:def",
+        subRecipeDigests: [],
+      };
 
-        let startedId: string | undefined;
+      let startedId: string | undefined;
 
-        const result = await launchGoalSession({
-          groveDir,
-          groveRoot: root,
-          goal: "demo goal",
-          topology,
-          contract: { contractVersion: 3, name: "demo" },
-          repos: [{ kind: "local", path: root }],
-          recipeProvenance: provenance,
-          // Inject a lightweight runtime that immediately marks agents idle,
-          // so the orchestrator can terminate after the 30-second grace period
-          // without spawning a real Claude Code process.
-          runtime: new QuickIdleRuntime(),
-          // Skip the 30-second grace period so the test completes promptly.
-          idleGracePeriodMs: 0,
-          onAgentsStarted: ({ sessionId }) => {
-            startedId = sessionId;
-          },
-        });
+      const result = await launchGoalSession({
+        groveDir,
+        groveRoot: root,
+        goal: "demo goal",
+        topology,
+        contract: { contractVersion: 3, name: "demo" },
+        repos: [{ kind: "local", path: root }],
+        recipeProvenance: provenance,
+        // Inject a lightweight runtime that immediately marks agents idle,
+        // so the orchestrator can terminate after the 30-second grace period
+        // without spawning a real Claude Code process.
+        runtime: new QuickIdleRuntime(),
+        // Skip the 30-second grace period so the test completes promptly.
+        idleGracePeriodMs: 0,
+        onAgentsStarted: ({ sessionId }) => {
+          startedId = sessionId;
+        },
+      });
 
-        expect(startedId).toBeDefined();
-        expect(result.sessionId).toBe(startedId!);
+      expect(startedId).toBeDefined();
+      expect(result.sessionId).toBe(startedId!);
 
-        // Re-open the DB after launchGoalSession closes it, and verify the
-        // session was persisted with the correct recipe provenance.
-        const db = initSqliteDb(join(groveDir, "grove.db"));
-        const session = await new SqliteGoalSessionStore(db).getSession(result.sessionId);
-        db.close();
+      // Re-open the DB after launchGoalSession closes it, and verify the
+      // session was persisted with the correct recipe provenance.
+      const db = initSqliteDb(join(groveDir, "grove.db"));
+      const session = await new SqliteGoalSessionStore(db).getSession(result.sessionId);
+      db.close();
 
-        expect(session?.recipeProvenance?.recipeDigest).toBe("blake3:abc");
-      } finally {
-        await rm(root, { recursive: true, force: true });
-      }
-    },
-    // idleGracePeriodMs: 0 bypasses the 30-second grace period; 20s is ample.
-    20_000,
-  );
+      expect(session?.recipeProvenance?.recipeDigest).toBe("blake3:abc");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 20_000); // idleGracePeriodMs: 0 bypasses the 30-second grace period; 20s is ample.
 });

--- a/src/cli/utils/launch-session.test.ts
+++ b/src/cli/utils/launch-session.test.ts
@@ -150,6 +150,8 @@ describe("launchGoalSession", () => {
           // so the orchestrator can terminate after the 30-second grace period
           // without spawning a real Claude Code process.
           runtime: new QuickIdleRuntime(),
+          // Skip the 30-second grace period so the test completes promptly.
+          idleGracePeriodMs: 0,
           onAgentsStarted: ({ sessionId }) => {
             startedId = sessionId;
           },
@@ -169,8 +171,7 @@ describe("launchGoalSession", () => {
         await rm(root, { recursive: true, force: true });
       }
     },
-    // The orchestrator applies a 30-second grace period before stopping idle
-    // agents; allow up to 60 seconds for the full session lifecycle.
-    60_000,
+    // idleGracePeriodMs: 0 bypasses the 30-second grace period; 20s is ample.
+    20_000,
   );
 });

--- a/src/cli/utils/launch-session.test.ts
+++ b/src/cli/utils/launch-session.test.ts
@@ -25,7 +25,7 @@ beforeAll(() => {
   savedEnv.GROVE_RUNTIME = process.env.GROVE_RUNTIME;
   // Clear Nexus so the session is NOT mirrored (avoids network calls)
   delete process.env.GROVE_NEXUS_URL;
-  // Clear GROVE_RUNTIME — we pass _testRuntime directly so this is a no-op,
+  // Clear GROVE_RUNTIME — we pass runtime directly so this is a no-op,
   // but clearing it prevents any future selectRuntime changes from interfering.
   delete process.env.GROVE_RUNTIME;
 });
@@ -149,7 +149,7 @@ describe("launchGoalSession", () => {
           // Inject a lightweight runtime that immediately marks agents idle,
           // so the orchestrator can terminate after the 30-second grace period
           // without spawning a real Claude Code process.
-          _testRuntime: new QuickIdleRuntime(),
+          runtime: new QuickIdleRuntime(),
           onAgentsStarted: ({ sessionId }) => {
             startedId = sessionId;
           },

--- a/src/cli/utils/launch-session.test.ts
+++ b/src/cli/utils/launch-session.test.ts
@@ -1,0 +1,176 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { AcpxTurn } from "../../acp/types.js";
+import type { AgentConfig, AgentRuntime, AgentSession } from "../../core/agent-runtime.js";
+import type { AgentSessionEntity } from "../../core/entity.js";
+import { agentSessionToEntity } from "../../core/entity.js";
+import type { RecipeProvenance } from "../../core/recipe.js";
+import type { AgentTopology } from "../../core/topology.js";
+import { initSqliteDb } from "../../local/sqlite-store.js";
+import { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
+import { launchGoalSession } from "./launch-session.js";
+
+// ---------------------------------------------------------------------------
+// Save / restore env vars that launchGoalSession reads
+// ---------------------------------------------------------------------------
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeAll(() => {
+  savedEnv.GROVE_NEXUS_URL = process.env.GROVE_NEXUS_URL;
+  savedEnv.GROVE_RUNTIME = process.env.GROVE_RUNTIME;
+  // Clear Nexus so the session is NOT mirrored (avoids network calls)
+  delete process.env.GROVE_NEXUS_URL;
+  // Clear GROVE_RUNTIME — we pass _testRuntime directly so this is a no-op,
+  // but clearing it prevents any future selectRuntime changes from interfering.
+  delete process.env.GROVE_RUNTIME;
+});
+
+afterAll(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// QuickIdleRuntime — a MockRuntime that reports all sessions as "idle"
+// immediately so the orchestrator can stop after the 30-second grace period
+// rather than waiting for the 5-minute session timeout.
+// ---------------------------------------------------------------------------
+
+class QuickIdleRuntime implements AgentRuntime {
+  /** Set to true to indicate this runtime sends the initial prompt on spawn
+   *  (prevents the orchestrator from re-sending it via send()). */
+  readonly sendsInitialPromptOnSpawn = true;
+
+  private sessions = new Map<string, AgentSession>();
+  private nextId = 0;
+
+  async spawn(role: string, config: AgentConfig): Promise<AgentSession> {
+    const id = `quick-${role}-${this.nextId++}`;
+    // Report "idle" immediately so checkAllIdle() sees all agents idle
+    // as soon as the 30-second grace period expires.
+    const session: AgentSession = {
+      id,
+      role,
+      status: "idle",
+      platform: config.platform,
+      model: config.model,
+    };
+    this.sessions.set(id, session);
+    return session;
+  }
+
+  async send(_session: AgentSession, _message: string): Promise<AcpxTurn> {
+    const turnId = `turn-${this.nextId++}`;
+    return {
+      sessionId: _session.id,
+      turnId,
+      messages: (async function* () {})(),
+      result: Promise.resolve({ turnId, stopReason: "end_turn" }),
+      cancel: async () => undefined,
+      close: async () => undefined,
+    };
+  }
+
+  async close(session: AgentSession): Promise<void> {
+    this.sessions.delete(session.id);
+  }
+
+  onIdle(_session: AgentSession, _callback: () => void): void {
+    // No-op: idle is signalled via listSessions() returning idle status.
+  }
+
+  async listSessions(): Promise<readonly AgentSession[]> {
+    return [...this.sessions.values()];
+  }
+
+  async listSessionEntities(): Promise<readonly AgentSessionEntity[]> {
+    const items = await this.listSessions();
+    return items.map((s) => agentSessionToEntity(s));
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+describe("launchGoalSession", () => {
+  test(
+    "creates a session that records recipe provenance",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "grove-launch-"));
+      const groveDir = join(root, ".grove");
+      await mkdir(groveDir, { recursive: true });
+
+      // Initialize a real git repo so workspace provisioning (git worktree add)
+      // succeeds — provisionWorkspace requires a bare-clone/local git repo with
+      // at least one commit.
+      execFileSync("git", ["-c", "init.defaultBranch=main", "init", root], { stdio: "pipe" });
+      execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: root, stdio: "pipe" });
+      execFileSync("git", ["config", "user.name", "Test"], { cwd: root, stdio: "pipe" });
+      execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: root, stdio: "pipe" });
+
+      try {
+        const topology: AgentTopology = {
+          structure: "graph",
+          roles: [{ name: "coder", maxInstances: 1, platform: "claude-code" }],
+        };
+        const provenance: RecipeProvenance = {
+          recipeDigest: "blake3:abc",
+          recipeName: "demo",
+          recipeVersion: "1.0.0",
+          boundParameterDigest: "blake3:def",
+          subRecipeDigests: [],
+        };
+
+        let startedId: string | undefined;
+
+        const result = await launchGoalSession({
+          groveDir,
+          groveRoot: root,
+          goal: "demo goal",
+          topology,
+          contract: { contractVersion: 3, name: "demo" },
+          repos: [{ kind: "local", path: root }],
+          recipeProvenance: provenance,
+          // Inject a lightweight runtime that immediately marks agents idle,
+          // so the orchestrator can terminate after the 30-second grace period
+          // without spawning a real Claude Code process.
+          _testRuntime: new QuickIdleRuntime(),
+          onAgentsStarted: ({ sessionId }) => {
+            startedId = sessionId;
+          },
+        });
+
+        expect(startedId).toBeDefined();
+        expect(result.sessionId).toBe(startedId!);
+
+        // Re-open the DB after launchGoalSession closes it, and verify the
+        // session was persisted with the correct recipe provenance.
+        const db = initSqliteDb(join(groveDir, "grove.db"));
+        const session = await new SqliteGoalSessionStore(db).getSession(result.sessionId);
+        db.close();
+
+        expect(session?.recipeProvenance?.recipeDigest).toBe("blake3:abc");
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+    // The orchestrator applies a 30-second grace period before stopping idle
+    // agents; allow up to 60 seconds for the full session lifecycle.
+    60_000,
+  );
+});

--- a/src/cli/utils/launch-session.ts
+++ b/src/cli/utils/launch-session.ts
@@ -52,11 +52,12 @@ export interface LaunchGoalSessionInput {
   readonly extraMcpServers?: NonNullable<AgentConfig["mcpServers"]> | undefined;
   readonly recipeProvenance?: RecipeProvenance | undefined;
   /**
-   * For testing only — bypass selectRuntime/isAvailable and use this runtime
-   * directly. When set, no real agent process is spawned.
-   * @internal
+   * Optional pre-built agent runtime. When omitted (the normal case), the
+   * runtime is selected via `selectRuntime()` with acpx/acp logging and the
+   * permission resolver wired up. Callers that already hold a runtime — or
+   * tests that need a deterministic one — may inject it here.
    */
-  readonly _testRuntime?: AgentRuntime | undefined;
+  readonly runtime?: AgentRuntime | undefined;
   readonly onAgentsStarted?:
     | ((info: {
         readonly sessionId: string;
@@ -106,8 +107,8 @@ export async function launchGoalSession(
     );
   }
   let runtime: AgentRuntime;
-  if (input._testRuntime !== undefined) {
-    runtime = input._testRuntime;
+  if (input.runtime !== undefined) {
+    runtime = input.runtime;
   } else {
     const picked = selectRuntime({
       acpx: { logDir: join(input.groveDir, "agent-logs") },

--- a/src/cli/utils/launch-session.ts
+++ b/src/cli/utils/launch-session.ts
@@ -7,7 +7,7 @@
  * are thin callers that supply already-resolved inputs and decide output.
  */
 
-import type { AgentConfig } from "../../core/agent-runtime.js";
+import type { AgentConfig, AgentRuntime } from "../../core/agent-runtime.js";
 import { expectCasOk } from "../../core/cas.js";
 import type { GroveContract } from "../../core/contract.js";
 import { LocalEventBus } from "../../core/local-event-bus.js";
@@ -51,6 +51,12 @@ export interface LaunchGoalSessionInput {
   readonly repos: readonly RepoRef[];
   readonly extraMcpServers?: NonNullable<AgentConfig["mcpServers"]> | undefined;
   readonly recipeProvenance?: RecipeProvenance | undefined;
+  /**
+   * For testing only — bypass selectRuntime/isAvailable and use this runtime
+   * directly. When set, no real agent process is spawned.
+   * @internal
+   */
+  readonly _testRuntime?: AgentRuntime | undefined;
   readonly onAgentsStarted?:
     | ((info: {
         readonly sessionId: string;
@@ -99,11 +105,16 @@ export async function launchGoalSession(
         "Destructive tool calls are auto-approved.\n",
     );
   }
-  const picked = selectRuntime({
-    acpx: { logDir: join(input.groveDir, "agent-logs") },
-    acp: { logDir: join(input.groveDir, "agent-logs"), permissionResolver },
-  });
-  const runtime = (await picked.isAvailable()) ? picked : new MockRuntime();
+  let runtime: AgentRuntime;
+  if (input._testRuntime !== undefined) {
+    runtime = input._testRuntime;
+  } else {
+    const picked = selectRuntime({
+      acpx: { logDir: join(input.groveDir, "agent-logs") },
+      acp: { logDir: join(input.groveDir, "agent-logs"), permissionResolver },
+    });
+    runtime = (await picked.isAvailable()) ? picked : new MockRuntime();
+  }
   const eventBus = new LocalEventBus();
 
   // Open SQLite database and create session

--- a/src/cli/utils/launch-session.ts
+++ b/src/cli/utils/launch-session.ts
@@ -45,6 +45,9 @@ export interface LaunchGoalSessionInput {
   readonly goal: string;
   readonly topology: AgentTopology;
   readonly contract?: GroveContract | undefined;
+  /** Preset name from `--preset`, recorded on the session and used as the
+   *  fallback contract name when no contract is supplied. Recipe runs omit it. */
+  readonly presetName?: string | undefined;
   readonly repos: readonly RepoRef[];
   readonly extraMcpServers?: NonNullable<AgentConfig["mcpServers"]> | undefined;
   readonly recipeProvenance?: RecipeProvenance | undefined;
@@ -157,7 +160,7 @@ export async function launchGoalSession(
   try {
     const session = await goalSessionStore.createSession({
       goal: input.goal,
-      presetName: input.contract?.name,
+      presetName: input.presetName ?? input.contract?.name,
       topology: input.topology,
       config: input.contract,
       recipeProvenance: input.recipeProvenance,
@@ -235,7 +238,7 @@ export async function launchGoalSession(
 
     orchestrator = new SessionOrchestrator({
       goal: input.goal,
-      contract: input.contract ?? { contractVersion: 3, name: "default" },
+      contract: input.contract ?? { contractVersion: 3, name: input.presetName ?? "default" },
       topology: input.topology,
       runtime,
       eventBus,

--- a/src/cli/utils/launch-session.ts
+++ b/src/cli/utils/launch-session.ts
@@ -1,0 +1,330 @@
+/**
+ * Reusable session-launch core extracted from `grove session start`.
+ *
+ * `launchGoalSession` owns runtime/permission selection, SQLite session
+ * creation, optional Nexus mirroring, orchestrator startup, and the
+ * deterministic completion loop. `sessionStart` (and, later, recipe run)
+ * are thin callers that supply already-resolved inputs and decide output.
+ */
+
+import type { AgentConfig } from "../../core/agent-runtime.js";
+import { expectCasOk } from "../../core/cas.js";
+import type { GroveContract } from "../../core/contract.js";
+import { LocalEventBus } from "../../core/local-event-bus.js";
+import {
+  createFallbackRoadmap,
+  GroveLoopRunner,
+  installProcessInterruptHandlers,
+  LoopStopStatus,
+  type SessionAssessment,
+  type WorkflowStateStore,
+} from "../../core/loop-runner.js";
+import { MockRuntime } from "../../core/mock-runtime.js";
+import type { RecipeProvenance } from "../../core/recipe.js";
+import type { RepoRef } from "../../core/repo-ref.js";
+import { SessionOrchestrator } from "../../core/session-orchestrator.js";
+import type { ContributionStore } from "../../core/store.js";
+import type { AgentTopology } from "../../core/topology.js";
+import { SqliteGoalSessionStore } from "../../local/sqlite-goal-session-store.js";
+import { resolveSessionNexusZoneId } from "../commands/session.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SessionCompletionUpdates {
+  readonly status: "completed" | "cancelled";
+  readonly completedAt: string;
+  readonly stopReason: string;
+  readonly stopStatus: LoopStopStatus;
+}
+
+export interface LaunchGoalSessionInput {
+  readonly groveDir: string;
+  readonly groveRoot: string;
+  readonly goal: string;
+  readonly topology: AgentTopology;
+  readonly contract?: GroveContract | undefined;
+  readonly repos: readonly RepoRef[];
+  readonly extraMcpServers?: NonNullable<AgentConfig["mcpServers"]> | undefined;
+  readonly recipeProvenance?: RecipeProvenance | undefined;
+  readonly onAgentsStarted?:
+    | ((info: {
+        readonly sessionId: string;
+        readonly agents: readonly {
+          readonly role: string;
+          readonly session: { readonly id: string; readonly status: string };
+        }[];
+      }) => void)
+    | undefined;
+}
+
+export interface LaunchGoalSessionResult {
+  readonly sessionId: string;
+  readonly stopStatus: LoopStopStatus;
+  readonly stopReason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Launch core
+// ---------------------------------------------------------------------------
+
+export async function launchGoalSession(
+  input: LaunchGoalSessionInput,
+): Promise<LaunchGoalSessionResult> {
+  const { join } = await import("node:path");
+
+  // Create runtime via selectRuntime (honors GROVE_RUNTIME env), fall back to mock
+  const { selectRuntime } = await import("../../core/select-runtime.js");
+  const { ALLOW_ALL_RESOLVER, ChainResolver, DENY_ALL_RESOLVER } = await import(
+    "../../core/permission-resolver.js"
+  );
+  const { RulesResolver } = await import("../../core/permission-rules.js");
+  const allowAllPermissions = process.env.GROVE_ALLOW_ALL_PERMISSIONS === "1";
+  const permissionResolver = allowAllPermissions
+    ? ALLOW_ALL_RESOLVER
+    : new ChainResolver([
+        new RulesResolver({
+          allowKinds: ["read", "search", "think"],
+          denyTitleSubstrings: ["rm -rf", "sudo", "shutdown"],
+        }),
+        DENY_ALL_RESOLVER,
+      ]);
+  if (allowAllPermissions) {
+    process.stderr.write(
+      "[grove] permission-resolver: ALLOW_ALL (GROVE_ALLOW_ALL_PERMISSIONS=1). " +
+        "Destructive tool calls are auto-approved.\n",
+    );
+  }
+  const picked = selectRuntime({
+    acpx: { logDir: join(input.groveDir, "agent-logs") },
+    acp: { logDir: join(input.groveDir, "agent-logs"), permissionResolver },
+  });
+  const runtime = (await picked.isAvailable()) ? picked : new MockRuntime();
+  const eventBus = new LocalEventBus();
+
+  // Open SQLite database and create session
+  const { initSqliteDb } = await import("../../local/sqlite-store.js");
+  const db = initSqliteDb(join(input.groveDir, "grove.db"));
+
+  // Everything below must run under try/finally so db.close() always fires.
+  // Signal handlers are installed early (before orchestrator.start) so a
+  // Ctrl-C during startup still records a stopReason.
+  let sessionId: string | undefined;
+  let orchestrator: SessionOrchestrator | undefined;
+  let workflowStore: WorkflowStateStore | undefined;
+  let contributionStore: ContributionStore | undefined;
+  let updateNexusSession:
+    | ((sessionId: string, updates: SessionCompletionUpdates) => Promise<void>)
+    | undefined;
+  let addNexusContributionToSession:
+    | ((sessionId: string, cid: string) => Promise<void>)
+    | undefined;
+  const goalSessionStore = new SqliteGoalSessionStore(db);
+
+  const markDone = async (reason: string, stopStatus: LoopStopStatus): Promise<void> => {
+    if (sessionId === undefined) return;
+    const updates: SessionCompletionUpdates = {
+      status: terminalSessionStatus(stopStatus),
+      completedAt: new Date().toISOString(),
+      stopReason: reason,
+      stopStatus,
+    };
+    try {
+      // C6 (#304): no ifMatch supplied — rv-mismatch is unreachable here;
+      // surface as a hard error so future ifMatch wiring (T7) doesn't silently
+      // skip the markDone path.
+      const result = await goalSessionStore.updateSession(sessionId, updates);
+      expectCasOk(result, `cli markDone(${sessionId})`);
+    } catch {
+      // Best-effort — DB may already be closed or session archived.
+    }
+    try {
+      await updateNexusSession?.(sessionId, updates);
+    } catch {
+      // Best-effort — Nexus may be unavailable during shutdown.
+    }
+  };
+
+  const interruptHandlers = installProcessInterruptHandlers(process, {
+    forceExit: (code) => process.exit(code),
+    onInterrupt: (reason) => {
+      void orchestrator?.stop(reason, LoopStopStatus.Interrupted);
+      void markDone(reason, LoopStopStatus.Interrupted);
+    },
+  });
+
+  try {
+    const session = await goalSessionStore.createSession({
+      goal: input.goal,
+      presetName: input.contract?.name,
+      topology: input.topology,
+      config: input.contract,
+      recipeProvenance: input.recipeProvenance,
+    });
+    sessionId = session.id;
+
+    // Mirror the session to Nexus so MCP servers spawned by agents (which set
+    // `GROVE_NEXUS_URL`) can resolve the frozen contract. Parallels the TUI
+    // path in NexusProvider.createSession — without this, grove-mcp's
+    // fail-closed check kills every agent spawned through `grove session
+    // start`. Best-effort with retries; a hard failure archives the orphan
+    // SQLite record and rethrows so the user sees the problem up front.
+    const nexusUrl = process.env.GROVE_NEXUS_URL;
+    const nexusApiKey = process.env.NEXUS_API_KEY;
+    if (nexusUrl) {
+      const { NexusHttpClient } = await import("../../nexus/nexus-http-client.js");
+      const { NexusContributionStore } = await import("../../nexus/nexus-contribution-store.js");
+      const { NexusSessionStore } = await import("../../nexus/nexus-session-store.js");
+      const { NexusWorkflowStore } = await import("../../nexus/nexus-workflow-store.js");
+      const nexusClient = new NexusHttpClient({
+        url: nexusUrl,
+        ...(nexusApiKey ? { apiKey: nexusApiKey } : {}),
+      });
+      const zoneId = resolveSessionNexusZoneId(input.groveDir);
+      const nexusSessionStore = new NexusSessionStore(nexusClient, zoneId);
+      updateNexusSession = async (targetSessionId, updates) => {
+        const result = await nexusSessionStore.updateSession(targetSessionId, updates);
+        expectCasOk(result, `cli nexus markDone(${targetSessionId})`);
+      };
+      addNexusContributionToSession = (targetSessionId, cid) =>
+        nexusSessionStore.addContribution(targetSessionId, cid);
+      workflowStore = new NexusWorkflowStore({ client: nexusClient, zoneId });
+      contributionStore = new NexusContributionStore({
+        client: nexusClient,
+        zoneId,
+        sessionId: session.id,
+      });
+
+      const retryDelaysMs = [0, 200, 500, 1000];
+      let lastErr: unknown;
+      for (const delay of retryDelaysMs) {
+        if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+        try {
+          await nexusSessionStore.putSession(session);
+          lastErr = undefined;
+          break;
+        } catch (err) {
+          lastErr = err;
+        }
+      }
+      if (lastErr) {
+        // Best-effort archive — ignore both CAS mismatches and exceptions.
+        await goalSessionStore
+          .archiveSession(session.id)
+          .then((result) => {
+            if (result.kind === "rv-mismatch") return; // best-effort, ignore stale RV
+          })
+          .catch(() => undefined);
+        throw new Error(
+          `Failed to mirror session ${session.id} to Nexus at ${nexusUrl}: ` +
+            `${lastErr instanceof Error ? lastErr.message : String(lastErr)}. ` +
+            `The local session has been archived; please retry.`,
+        );
+      }
+    }
+
+    // Create contribution store for polling-based routing (MCP runs in child processes).
+    // In Nexus mode MCP writes session-scoped contributions to Nexus, so the
+    // orchestrator must poll the same scoped store or downstream roles never
+    // receive handoffs.
+    if (!contributionStore) {
+      const { SqliteContributionStore } = await import("../../local/sqlite-store.js");
+      contributionStore = new SqliteContributionStore(db);
+    }
+
+    orchestrator = new SessionOrchestrator({
+      goal: input.goal,
+      contract: input.contract ?? { contractVersion: 3, name: "default" },
+      topology: input.topology,
+      runtime,
+      eventBus,
+      projectRoot: input.groveRoot,
+      repos: input.repos,
+      workspaceBaseDir: join(input.groveDir, "workspaces"),
+      sessionId: session.id,
+      contributionStore,
+      extraMcpServers: input.extraMcpServers,
+      onContributionAccepted: async (cid) => {
+        const localLink = goalSessionStore.addContributionToSession(session.id, cid);
+        if (addNexusContributionToSession === undefined) {
+          await localLink;
+          return;
+        }
+        await Promise.all([localLink, addNexusContributionToSession(session.id, cid)]);
+      },
+    });
+
+    let status: import("../../core/session-orchestrator.js").SessionStatus;
+    try {
+      status = await orchestrator.start();
+    } catch (err) {
+      // Mark session as cancelled on spawn failure. The outer finally still
+      // closes db and removes signal listeners.
+      const archiveResult = await goalSessionStore.archiveSession(session.id);
+      expectCasOk(archiveResult, `cli session start cleanup (${session.id})`);
+      throw err;
+    }
+
+    // Notify the caller that agents have started; the caller decides output.
+    input.onAgentsStarted?.({ sessionId: session.id, agents: status.agents });
+
+    // Wait for session completion through the deterministic external loop.
+    // The session orchestrator owns agent routing; the loop owns final status,
+    // interrupt observation, and durable workflow state.
+    const SESSION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+    const assessment = sessionAssessment(input.goal, input.topology);
+    const loop = new GroveLoopRunner({
+      workflowId: `workflow-${session.id}`,
+      sessionId: session.id,
+      assessment,
+      roadmap: createFallbackRoadmap(assessment),
+      maxIterations: 1,
+      interrupt: interruptHandlers.interrupt,
+      workflowStore,
+      executeIteration: async () => {
+        const stopReason = await orchestrator?.waitForCompletion(SESSION_TIMEOUT_MS);
+        const current = orchestrator?.getStatus();
+        return {
+          stopStatus:
+            current?.stopStatus ??
+            (interruptHandlers.interrupt.interruptRequested
+              ? LoopStopStatus.Interrupted
+              : LoopStopStatus.Achieved),
+          summary: stopReason ?? current?.stopReason ?? "Session complete",
+        };
+      },
+    });
+    const finalState = await loop.run();
+    const finalStopStatus =
+      finalState.status === "running" ? LoopStopStatus.Error : finalState.status;
+    await markDone(finalState.reason ?? "Session complete", finalStopStatus);
+    return {
+      sessionId: session.id,
+      stopStatus: finalStopStatus,
+      stopReason: finalState.reason ?? "Session complete",
+    };
+  } finally {
+    interruptHandlers.dispose();
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+  }
+}
+
+function terminalSessionStatus(stopStatus: LoopStopStatus): "completed" | "cancelled" {
+  return stopStatus === LoopStopStatus.Interrupted || stopStatus === LoopStopStatus.Error
+    ? "cancelled"
+    : "completed";
+}
+
+function sessionAssessment(goal: string, topology: AgentTopology): SessionAssessment {
+  return {
+    goal,
+    roles: topology.roles.map((role) => role.name),
+    successCriteria: ["session reaches a deterministic terminal status"],
+    constraints: ["stop decisions are made by GroveLoopRunner, not by agent prose"],
+  };
+}

--- a/src/cli/utils/launch-session.ts
+++ b/src/cli/utils/launch-session.ts
@@ -50,6 +50,8 @@ export interface LaunchGoalSessionInput {
   readonly presetName?: string | undefined;
   readonly repos: readonly RepoRef[];
   readonly extraMcpServers?: NonNullable<AgentConfig["mcpServers"]> | undefined;
+  /** Override the orchestrator idle grace period (ms). Defaults to 30000. */
+  readonly idleGracePeriodMs?: number | undefined;
   readonly recipeProvenance?: RecipeProvenance | undefined;
   /**
    * Optional pre-built agent runtime. When omitted (the normal case), the
@@ -260,6 +262,7 @@ export async function launchGoalSession(
       sessionId: session.id,
       contributionStore,
       extraMcpServers: input.extraMcpServers,
+      idleGracePeriodMs: input.idleGracePeriodMs,
       onContributionAccepted: async (cid) => {
         const localLink = goalSessionStore.addContributionToSession(session.id, cid);
         if (addNexusContributionToSession === undefined) {

--- a/src/core/in-memory-session-store.ts
+++ b/src/core/in-memory-session-store.ts
@@ -35,6 +35,7 @@ export class InMemorySessionStore implements SessionStore, RuntimeSkillSessionSt
       presetName: input.presetName,
       topology: input.topology,
       config: input.config,
+      recipeProvenance: input.recipeProvenance,
       status: "pending",
       createdAt: new Date().toISOString(),
       finalizers: DEFAULT_SESSION_FINALIZERS,

--- a/src/core/recipe-extensions.test.ts
+++ b/src/core/recipe-extensions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import type { RecipeExtension } from "./recipe.js";
+import { resolveRecipeMcpServers } from "./recipe-extensions.js";
+
+describe("resolveRecipeMcpServers", () => {
+  test("maps a stdio: mcp extension to an mcp server with command + args", () => {
+    const ext: RecipeExtension[] = [
+      { type: "mcp", name: "filesystem", uri: "stdio:grove-fs-mcp --root ." },
+    ];
+    expect(resolveRecipeMcpServers(ext)).toEqual([
+      { name: "filesystem", command: "grove-fs-mcp", args: ["--root", "."] },
+    ]);
+  });
+
+  test("a stdio: extension with no args has an empty args array", () => {
+    const ext: RecipeExtension[] = [{ type: "mcp", name: "gh", uri: "stdio:gh-mcp" }];
+    expect(resolveRecipeMcpServers(ext)).toEqual([
+      { name: "gh", command: "gh-mcp", args: [] },
+    ]);
+  });
+
+  test("optional non-stdio extension is skipped, not thrown", () => {
+    const ext: RecipeExtension[] = [{ type: "mcp", name: "remote", uri: "http://x" }];
+    expect(resolveRecipeMcpServers(ext)).toEqual([]);
+  });
+
+  test("optional non-mcp extension is skipped", () => {
+    const ext: RecipeExtension[] = [{ type: "tool", name: "linter" }];
+    expect(resolveRecipeMcpServers(ext)).toEqual([]);
+  });
+
+  test("required non-stdio extension throws", () => {
+    const ext: RecipeExtension[] = [
+      { type: "mcp", name: "remote", uri: "http://x", required: true },
+    ];
+    expect(() => resolveRecipeMcpServers(ext)).toThrow(/not launchable/);
+  });
+
+  test("stdio: extension with empty command throws", () => {
+    const ext: RecipeExtension[] = [{ type: "mcp", name: "bad", uri: "stdio:   " }];
+    expect(() => resolveRecipeMcpServers(ext)).toThrow(/empty command/);
+  });
+});

--- a/src/core/recipe-extensions.test.ts
+++ b/src/core/recipe-extensions.test.ts
@@ -15,9 +15,7 @@ describe("resolveRecipeMcpServers", () => {
 
   test("a stdio: extension with no args has an empty args array", () => {
     const ext: RecipeExtension[] = [{ type: "mcp", name: "gh", uri: "stdio:gh-mcp" }];
-    expect(resolveRecipeMcpServers(ext)).toEqual([
-      { name: "gh", command: "gh-mcp", args: [] },
-    ]);
+    expect(resolveRecipeMcpServers(ext)).toEqual([{ name: "gh", command: "gh-mcp", args: [] }]);
   });
 
   test("optional non-stdio extension is skipped, not thrown", () => {

--- a/src/core/recipe-extensions.ts
+++ b/src/core/recipe-extensions.ts
@@ -1,0 +1,51 @@
+/**
+ * Map declarative recipe extensions to launchable MCP server configs.
+ *
+ * Only `type: mcp` extensions whose URI uses the `stdio:` scheme are wireable
+ * through the current stdio-only `AgentConfig.mcpServers` shape. Anything else
+ * (non-stdio URIs, or tool/provider/service extensions) is skipped when
+ * optional, and is a hard error when `required: true`.
+ */
+
+import type { AgentConfig } from "./agent-runtime.js";
+import type { RecipeExtension } from "./recipe.js";
+
+type McpServer = NonNullable<AgentConfig["mcpServers"]>[number];
+
+const STDIO_PREFIX = "stdio:";
+
+export function resolveRecipeMcpServers(
+  extensions: readonly RecipeExtension[],
+): readonly McpServer[] {
+  const servers: McpServer[] = [];
+  for (const ext of extensions) {
+    const stdioServer = tryResolveStdioMcp(ext);
+    if (stdioServer !== undefined) {
+      servers.push(stdioServer);
+      continue;
+    }
+    if (ext.required === true) {
+      throw new Error(
+        `extension '${ext.name}' is not launchable: only stdio: MCP URIs are wired today`,
+      );
+    }
+    // Optional and not wireable — warn and skip.
+    process.stderr.write(
+      `[grove] recipe extension '${ext.name}' (${ext.type}) is not launchable; skipping.\n`,
+    );
+  }
+  return servers;
+}
+
+function tryResolveStdioMcp(ext: RecipeExtension): McpServer | undefined {
+  if (ext.type !== "mcp" || ext.uri === undefined || !ext.uri.startsWith(STDIO_PREFIX)) {
+    return undefined;
+  }
+  const spec = ext.uri.slice(STDIO_PREFIX.length).trim();
+  const parts = spec.split(/\s+/).filter((p) => p.length > 0);
+  const command = parts[0];
+  if (command === undefined) {
+    throw new Error(`extension '${ext.name}' has an empty command in its stdio: URI`);
+  }
+  return { name: ext.name, command, args: parts.slice(1) };
+}

--- a/src/core/session-orchestrator.recipe.test.ts
+++ b/src/core/session-orchestrator.recipe.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { LocalEventBus } from "./local-event-bus.js";
+import { MockRuntime } from "./mock-runtime.js";
+import { SessionOrchestrator } from "./session-orchestrator.js";
+import type { AgentTopology } from "./topology.js";
+
+const singleCoderTopology: AgentTopology = {
+  structure: "flat",
+  roles: [
+    {
+      name: "coder",
+      description: "Write code",
+      command: "echo coder",
+    },
+  ],
+};
+
+describe("SessionOrchestrator — extraMcpServers from recipes", () => {
+  test("extraMcpServers are appended after grove server in spawned agent config", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract: {
+        contractVersion: 2,
+        name: "test",
+        topology: singleCoderTopology,
+      },
+      topology: singleCoderTopology,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+      extraMcpServers: [{ name: "fs", command: "grove-fs-mcp", args: [] }],
+    });
+
+    await orchestrator.start();
+
+    const coderConfig = runtime.spawnCalls.find((call) => call.role === "coder")?.config;
+    expect(coderConfig?.mcpServers).toBeDefined();
+
+    const names = coderConfig!.mcpServers!.map((s) => s.name);
+    expect(names[0]).toBe("grove");
+    expect(names).toContain("fs");
+
+    bus.close();
+  });
+
+  test("no extraMcpServers leaves only the grove server (backward compat)", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract: {
+        contractVersion: 2,
+        name: "test",
+        topology: singleCoderTopology,
+      },
+      topology: singleCoderTopology,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+    });
+
+    await orchestrator.start();
+
+    const coderConfig = runtime.spawnCalls.find((call) => call.role === "coder")?.config;
+    expect(coderConfig?.mcpServers).toHaveLength(1);
+    expect(coderConfig?.mcpServers?.[0]?.name).toBe("grove");
+
+    bus.close();
+  });
+
+  test("multiple extraMcpServers are all appended after grove in order", async () => {
+    const runtime = new MockRuntime();
+    const bus = new LocalEventBus();
+
+    const orchestrator = new SessionOrchestrator({
+      goal: "Build auth module",
+      contract: {
+        contractVersion: 2,
+        name: "test",
+        topology: singleCoderTopology,
+      },
+      topology: singleCoderTopology,
+      runtime,
+      eventBus: bus,
+      projectRoot: "/tmp",
+      repos: [{ kind: "local", path: "/tmp" }],
+      workspaceBaseDir: "/tmp/workspaces",
+      workspaceIsolationPolicy: "allow-fallback",
+      extraMcpServers: [
+        { name: "fs", command: "grove-fs-mcp", args: [] },
+        { name: "search", command: "grove-search-mcp", args: ["--index", "/data"] },
+      ],
+    });
+
+    await orchestrator.start();
+
+    const coderConfig = runtime.spawnCalls.find((call) => call.role === "coder")?.config;
+    expect(coderConfig?.mcpServers).toHaveLength(3);
+
+    const names = coderConfig!.mcpServers!.map((s) => s.name);
+    expect(names[0]).toBe("grove");
+    expect(names[1]).toBe("fs");
+    expect(names[2]).toBe("search");
+
+    bus.close();
+  });
+});

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -129,6 +129,12 @@ export interface SessionConfig {
   readonly onContributionAccepted?: ((cid: string) => void | Promise<void>) | undefined;
   /** Optional agent profiles — overlay role defaults with per-agent runtime config. */
   readonly profiles?: readonly AgentProfile[] | undefined;
+  /**
+   * Extra MCP servers appended to every spawned agent's `mcpServers`, after the
+   * built-in `grove` server. Populated from recipe `extensions` by
+   * `grove recipe run`; empty for all other launch paths.
+   */
+  readonly extraMcpServers?: NonNullable<AgentConfig["mcpServers"]> | undefined;
 }
 
 /** Status of a running session. */
@@ -656,7 +662,7 @@ export class SessionOrchestrator {
       model: resolved.model,
       cwd,
       goal: fullGoal,
-      mcpServers: [this.groveMcpServer(role.name)],
+      mcpServers: [this.groveMcpServer(role.name), ...(this.config.extraMcpServers ?? [])],
       env: {
         GROVE_SESSION_ID: this.sessionId,
         GROVE_ROLE: role.name,

--- a/src/core/session-orchestrator.ts
+++ b/src/core/session-orchestrator.ts
@@ -135,6 +135,12 @@ export interface SessionConfig {
    * `grove recipe run`; empty for all other launch paths.
    */
   readonly extraMcpServers?: NonNullable<AgentConfig["mcpServers"]> | undefined;
+  /**
+   * Milliseconds an all-idle session waits with zero contributions before the
+   * orchestrator concludes nothing more is coming and stops. Defaults to 30000.
+   * Lower values speed up tests and short-lived/eval runs.
+   */
+  readonly idleGracePeriodMs?: number | undefined;
 }
 
 /** Status of a running session. */
@@ -919,7 +925,7 @@ export class SessionOrchestrator {
       // Agents go idle between tool calls (e.g., coder finishes editing, goes idle
       // briefly, then calls grove_submit_work). Stopping too early kills the session
       // before the handoff can complete.
-      const GRACE_PERIOD_MS = 30_000;
+      const GRACE_PERIOD_MS = this.config.idleGracePeriodMs ?? 30_000;
       const elapsed = Date.now() - this.startedAt;
       if (this.contributionCount === 0 && elapsed < GRACE_PERIOD_MS) {
         return; // Too early — wait for at least one contribution or grace period

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -9,6 +9,7 @@ import type { CasMutationResult, CasOpts } from "./cas.js";
 import type { GroveContract } from "./contract.js";
 import type { DeletionAuditEvent, SessionFinalizer } from "./lifecycle-metadata.js";
 import type { LoopStopStatus } from "./loop-runner.js";
+import type { RecipeProvenance } from "./recipe.js";
 import type { AgentTopology } from "./topology.js";
 
 // ---------------------------------------------------------------------------
@@ -56,6 +57,12 @@ export interface Session {
   /** Frozen contract snapshot at session creation time. */
   readonly config?: GroveContract | undefined;
   /**
+   * Provenance of the recipe this session was materialized from, when launched
+   * via `grove recipe run`. Absent for sessions started any other way.
+   * Records the recipe digest so re-runs are reproducible (#276).
+   */
+  readonly recipeProvenance?: RecipeProvenance | undefined;
+  /**
    * Resolved workspace base-branch per role.
    * Format: { "coder": "HEAD", "reviewer": "grove/<sessionId>/coder" }
    * Edges with `workspace: "branch_from_source"` make the target branch off the source.
@@ -81,6 +88,8 @@ export interface CreateSessionInput {
   readonly topology?: AgentTopology | undefined;
   /** Frozen contract snapshot to store with the session. */
   readonly config?: GroveContract | undefined;
+  /** Recipe provenance to record on the session, when created from a recipe. */
+  readonly recipeProvenance?: RecipeProvenance | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/local/sqlite-goal-session-store.recipe.test.ts
+++ b/src/local/sqlite-goal-session-store.recipe.test.ts
@@ -29,4 +29,26 @@ describe("SqliteGoalSessionStore recipe provenance", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  test("listSessions includes recipeProvenance (used by `grove session status`)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-list-"));
+    try {
+      const db = initSqliteDb(join(dir, "grove.db"));
+      const store = new SqliteGoalSessionStore(db);
+      const provenance: RecipeProvenance = {
+        recipeDigest: "blake3:listabc",
+        recipeName: "review-loop-276",
+        recipeVersion: "1.0.0",
+        boundParameterDigest: "blake3:listdef",
+        subRecipeDigests: [],
+      };
+      const created = await store.createSession({ goal: "g", recipeProvenance: provenance });
+      const listed = await store.listSessions({ includeArchived: true });
+      const match = listed.find((s) => s.id === created.id);
+      expect(match?.recipeProvenance).toEqual(provenance);
+      db.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/local/sqlite-goal-session-store.recipe.test.ts
+++ b/src/local/sqlite-goal-session-store.recipe.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { RecipeProvenance } from "../core/recipe.js";
+import { initSqliteDb } from "./sqlite-store.js";
+import { SqliteGoalSessionStore } from "./sqlite-goal-session-store.js";
+
+describe("SqliteGoalSessionStore recipe provenance", () => {
+  test("createSession persists recipeProvenance and getSession returns it", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "grove-recipe-prov-"));
+    try {
+      const db = initSqliteDb(join(dir, "grove.db"));
+      const store = new SqliteGoalSessionStore(db);
+      const provenance: RecipeProvenance = {
+        recipeDigest: "blake3:abc",
+        recipeName: "code-review-loop",
+        recipeVersion: "1.0.0",
+        boundParameterDigest: "blake3:def",
+        subRecipeDigests: [],
+      };
+      const created = await store.createSession({ goal: "g", recipeProvenance: provenance });
+      expect(created.recipeProvenance).toEqual(provenance);
+      const fetched = await store.getSession(created.id);
+      expect(fetched?.recipeProvenance).toEqual(provenance);
+      db.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/local/sqlite-goal-session-store.recipe.test.ts
+++ b/src/local/sqlite-goal-session-store.recipe.test.ts
@@ -4,8 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { RecipeProvenance } from "../core/recipe.js";
-import { initSqliteDb } from "./sqlite-store.js";
 import { SqliteGoalSessionStore } from "./sqlite-goal-session-store.js";
+import { initSqliteDb } from "./sqlite-store.js";
 
 describe("SqliteGoalSessionStore recipe provenance", () => {
   test("createSession persists recipeProvenance and getSession returns it", async () => {

--- a/src/local/sqlite-goal-session-store.ts
+++ b/src/local/sqlite-goal-session-store.ts
@@ -397,6 +397,7 @@ interface SessionListRow {
   stop_reason: string | null;
   stop_status: import("../core/loop-runner.js").LoopStopStatus | null;
   contribution_count: number;
+  recipe_provenance_json: string | null;
   /** C6 (#304): optimistic-concurrency resource version, added by v16 migration. */
   resource_version: number;
 }
@@ -575,6 +576,9 @@ function listRowToSession(row: SessionListRow): Session {
     topology: undefined,
     contributionCount: row.contribution_count,
     // config intentionally omitted from list results for performance
+    recipeProvenance: row.recipe_provenance_json
+      ? (JSON.parse(row.recipe_provenance_json) as RecipeProvenance)
+      : undefined,
     resourceVersion: row.resource_version,
   };
 }
@@ -792,7 +796,7 @@ export class SqliteGoalSessionStore implements GoalSessionStore, RuntimeSkillSes
       SELECT s.session_id, s.uid, s.goal, s.preset_name, s.status, s.started_at,
              s.finalizers_json, s.deletion_timestamp, s.deletion_audit_json,
              s.ended_at, s.stop_reason, s.stop_status, s.contribution_count,
-             s.resource_version
+             s.recipe_provenance_json, s.resource_version
       FROM sessions s
     `;
 

--- a/src/local/sqlite-goal-session-store.ts
+++ b/src/local/sqlite-goal-session-store.ts
@@ -17,7 +17,6 @@
 import type { Database, Statement } from "bun:sqlite";
 import { type CasMutationResult, type CasOpts, checkIfMatch } from "../core/cas.js";
 import type { GroveContract } from "../core/contract.js";
-import type { RecipeProvenance } from "../core/recipe.js";
 import type { DeletionAuditEvent, OwnerRef, SessionFinalizer } from "../core/lifecycle-metadata.js";
 import {
   appendDeletionAudit,
@@ -25,6 +24,7 @@ import {
   Finalizer,
 } from "../core/lifecycle-metadata.js";
 import type { Claim } from "../core/models.js";
+import type { RecipeProvenance } from "../core/recipe.js";
 import type {
   AppendSessionRoleSkillResult,
   CreateSessionInput,

--- a/src/local/sqlite-goal-session-store.ts
+++ b/src/local/sqlite-goal-session-store.ts
@@ -17,6 +17,7 @@
 import type { Database, Statement } from "bun:sqlite";
 import { type CasMutationResult, type CasOpts, checkIfMatch } from "../core/cas.js";
 import type { GroveContract } from "../core/contract.js";
+import type { RecipeProvenance } from "../core/recipe.js";
 import type { DeletionAuditEvent, OwnerRef, SessionFinalizer } from "../core/lifecycle-metadata.js";
 import {
   appendDeletionAudit,
@@ -287,6 +288,7 @@ export const GOAL_SESSION_DDL = `
     topology_json TEXT,
     config_json TEXT NOT NULL DEFAULT '{}',
     worktree_strategy_json TEXT,
+    recipe_provenance_json TEXT,
     status TEXT NOT NULL DEFAULT 'active',
     started_at TEXT NOT NULL,
     finalizers_json TEXT NOT NULL DEFAULT '[]',
@@ -362,6 +364,7 @@ interface SessionRow {
   topology_json: string | null;
   config_json: string | null;
   worktree_strategy_json: string | null;
+  recipe_provenance_json: string | null;
   status: string;
   started_at: string;
   finalizers_json: string;
@@ -546,6 +549,9 @@ function rowToSession(row: SessionRow): Session {
     config,
     worktreeStrategies: row.worktree_strategy_json
       ? (JSON.parse(row.worktree_strategy_json) as Record<string, string>)
+      : undefined,
+    recipeProvenance: row.recipe_provenance_json
+      ? (JSON.parse(row.recipe_provenance_json) as RecipeProvenance)
       : undefined,
     resourceVersion: row.resource_version,
   };
@@ -823,8 +829,8 @@ export class SqliteGoalSessionStore implements GoalSessionStore, RuntimeSkillSes
   createSession = async (input: CreateSessionInput): Promise<Session> => {
     this.stmtInsertSession ??= this.db.prepare(`
       INSERT INTO sessions (session_id, uid, goal, preset_name, topology_json, config_json,
-        worktree_strategy_json, status, started_at, finalizers_json)
-      VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)
+        worktree_strategy_json, recipe_provenance_json, status, started_at, finalizers_json)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)
     `);
 
     const sessionId = crypto.randomUUID();
@@ -838,6 +844,9 @@ export class SqliteGoalSessionStore implements GoalSessionStore, RuntimeSkillSes
       ? Object.fromEntries(resolveRoleWorkspaceStrategies(input.topology, sessionId))
       : null;
     const worktreeStrategyJson = worktreeStrategies ? JSON.stringify(worktreeStrategies) : null;
+    const recipeProvenanceJson = input.recipeProvenance
+      ? JSON.stringify(input.recipeProvenance)
+      : null;
 
     this.stmtInsertSession.run(
       sessionId,
@@ -847,6 +856,7 @@ export class SqliteGoalSessionStore implements GoalSessionStore, RuntimeSkillSes
       topologyJson,
       configJson,
       worktreeStrategyJson,
+      recipeProvenanceJson,
       startedAt,
       JSON.stringify(DEFAULT_SESSION_FINALIZERS),
     );
@@ -865,6 +875,7 @@ export class SqliteGoalSessionStore implements GoalSessionStore, RuntimeSkillSes
       contributionCount: 0,
       config: input.config,
       worktreeStrategies: worktreeStrategies ?? undefined,
+      recipeProvenance: input.recipeProvenance,
       // C6 (#304): the v16 migration adds `resource_version INTEGER NOT NULL
       // DEFAULT 1` to the sessions row. The INSERT above doesn't set the
       // column, so SQLite applies the DDL default. Mirror that here so the

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -73,7 +73,7 @@ import { ClaimConflictError, NotFoundError, StateConflictError } from "../core/e
 import type { Finalizer, OwnerRef } from "../core/lifecycle-metadata.js";
 import { toUtcIso } from "../core/time.js";
 
-export const CURRENT_SCHEMA_VERSION = 16;
+export const CURRENT_SCHEMA_VERSION = 17;
 const SQLITE_BIND_LIMIT = 900;
 const SESSIONS_DELETION_TIMESTAMP_INDEX_DDL = `
   CREATE INDEX IF NOT EXISTS idx_sessions_deletion_timestamp ON sessions(deletion_timestamp);
@@ -775,6 +775,24 @@ export function initSqliteDb(dbPath: string): Database {
           db.run("ALTER TABLE sessions ADD COLUMN deletion_audit_json TEXT NOT NULL DEFAULT '[]'");
         }
         db.exec(SESSIONS_DELETION_TIMESTAMP_INDEX_DDL);
+      }
+    }
+
+    // Migration → v17: persist recipe provenance on sessions launched via
+    // `grove recipe run`. Column-safe: only adds the column when absent.
+    {
+      const sessionTableExists =
+        (db
+          .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'")
+          .get() as { name: string } | null) !== null;
+      if (sessionTableExists) {
+        const sessionCols = db.prepare("PRAGMA table_info(sessions)").all() as readonly {
+          name: string;
+        }[];
+        const sessionColNames = new Set(sessionCols.map((c) => c.name));
+        if (!sessionColNames.has("recipe_provenance_json")) {
+          db.run("ALTER TABLE sessions ADD COLUMN recipe_provenance_json TEXT");
+        }
       }
     }
 

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -863,6 +863,19 @@ export function initSqliteDb(dbPath: string): Database {
       ]);
     }
 
+    // Record schema version 17 (recipe_provenance_json on sessions). The v17
+    // column-safe ALTER above is idempotent and runs unconditionally, but the
+    // schema_migrations row must be recorded separately: the v16 block's
+    // version INSERT is gated on `< 16` (it guards CAS-clobbering resource-
+    // version column inits), so a DB already at v16 would otherwise never
+    // advance to 17 and `needsLegacyBackfill` would stay true on every restart.
+    if (currentVersion === null || currentVersion < 17) {
+      db.run("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)", [
+        CURRENT_SCHEMA_VERSION,
+        new Date().toISOString(),
+      ]);
+    }
+
     if (needsLegacyBackfill) {
       // Backfill junction tables for pre-existing contributions once while
       // upgrading legacy databases. INSERT OR IGNORE prevents duplicates.

--- a/src/nexus/nexus-session-store.recipe.test.ts
+++ b/src/nexus/nexus-session-store.recipe.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import type { RecipeProvenance } from "../core/recipe.js";
+import { MockNexusClient } from "./mock-client.js";
+import { NexusSessionStore } from "./nexus-session-store.js";
+
+describe("NexusSessionStore — recipeProvenance round-trip", () => {
+  test("createSession preserves recipeProvenance and getSession returns it", async () => {
+    const client = new MockNexusClient();
+    const store = new NexusSessionStore(client, "test-zone");
+
+    const provenance: RecipeProvenance = {
+      recipeDigest: "blake3:abc",
+      recipeName: "code-review-loop",
+      recipeVersion: "1.0.0",
+      boundParameterDigest: "blake3:def",
+      subRecipeDigests: [],
+    };
+
+    const created = await store.createSession({ goal: "g", recipeProvenance: provenance });
+    expect(created.recipeProvenance).toEqual(provenance);
+
+    const fetched = await store.getSession(created.id);
+    expect(fetched?.recipeProvenance).toEqual(provenance);
+  });
+});

--- a/src/nexus/nexus-session-store.ts
+++ b/src/nexus/nexus-session-store.ts
@@ -456,6 +456,7 @@ export class NexusSessionStore implements SessionStore, RuntimeSkillSessionStore
       deletionAudit: [],
       contributionCount: 0,
       config: input.config,
+      recipeProvenance: input.recipeProvenance,
       resourceVersion: 1,
     };
     await this.writeSessionRecord(session);

--- a/tests/e2e/recipe-run-tmux.ts
+++ b/tests/e2e/recipe-run-tmux.ts
@@ -67,6 +67,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 
+import { readNexusApiKey } from "../../src/cli/nexus-lifecycle.js";
 import type { Session } from "../../src/core/session.js";
 
 // ─── Paths / constants ──────────────────────────────────────────────────────
@@ -391,14 +392,15 @@ function resolveNexusUrl(): string | undefined {
   }
 }
 
-/** Project API key written to .grove/api-key by `grove init`. */
+/**
+ * Resolve the Nexus *server* API key the same way grove itself does:
+ * env → nexus-data/.state.json → nexus.yaml `api_key` (the `sk-…` key the
+ * Nexus HTTP server authenticates against). NOT `.grove/api-key`, which is a
+ * distinct `grv_…` project credential and is rejected by the server (HTTP 401).
+ * `nexus.yaml` lives at the project root (workDir), not inside `.grove`.
+ */
 function resolveNexusApiKey(): string | undefined {
-  if (process.env.NEXUS_API_KEY) return process.env.NEXUS_API_KEY;
-  try {
-    return readFileSync(join(groveDir, "api-key"), "utf-8").trim() || undefined;
-  } catch {
-    return undefined;
-  }
+  return readNexusApiKey(workDir);
 }
 
 // ─── main ───────────────────────────────────────────────────────────────────

--- a/tests/e2e/recipe-run-tmux.ts
+++ b/tests/e2e/recipe-run-tmux.ts
@@ -1,0 +1,745 @@
+/**
+ * Tmux-driven real-process E2E for the live `grove recipe run` path (#276).
+ *
+ * Proves the end-to-end recipe LIVE flow against a grove-managed stack:
+ *   1. Fresh temp working dir + `git init` + a couple of source files.
+ *   2. A valid recipe.yaml is materialized (parameters / extensions /
+ *      instructions / agent_topology) — validated against GroveRecipeWireSchema.
+ *   3. The stack is brought up via the grove-managed lifecycle
+ *      (`grove up --headless --no-tui` in a tmux pane), which starts the HTTP
+ *      server, MCP server, and a managed Nexus, persisting nexusUrl to grove.json.
+ *   4. `grove recipe run ./recipe.yaml --param target_path=./src --json` runs
+ *      with GROVE_RUNTIME=acp and real multi-agent (claude coder -> codex
+ *      reviewer) launch, capturing the JSON output (sessionId + recipeDigest).
+ *   5. We poll until both roles spawn, a coder->reviewer handoff/contribution
+ *      occurs, and the session reaches a terminal state.
+ *   6. ASSERTIONS:
+ *      - run output recipeDigest is non-empty + `blake3:`-prefixed AND equals
+ *        `grove recipe validate ./recipe.yaml --json`'s digest;
+ *      - the session record read back FROM NEXUS carries
+ *        recipeProvenance.recipeDigest equal to that digest;
+ *      - the recipe's `stdio:` MCP extension was attached to the spawned
+ *        agent's MCP set AND actually launched (proven by a sentinel file the
+ *        stdio MCP shim writes on startup — see EXTENSION WIRING below);
+ *      - at least one contribution / a handoff happened (proves real agents ran).
+ *   7. Teardown: kill tmux, `grove down`, remove temp dir.
+ *
+ * NOT wired into `bun test` — run as:
+ *   bun run tests/e2e/recipe-run-tmux.ts
+ *
+ * Requires real claude + codex CLIs on PATH and a managed-Nexus-capable host
+ * (same prerequisites as a live review-loop). The controller runs this; this
+ * file is authored to be runnable, not executed here.
+ *
+ * ─── EXTENSION WIRING VERIFICATION ──────────────────────────────────────────
+ * The orchestrator appends the recipe's resolved `stdio:` MCP servers to EVERY
+ * spawned agent's `config.mcpServers` (session-orchestrator.ts), and the ACP
+ * runtime passes them into the child agent's `newSession({ mcpServers })` /
+ * codex `mcp_servers.<name>` config. The most robust, run-surviving proof that
+ * the extension is in the agent's MCP set is to point the recipe's `stdio:` URI
+ * at a tiny stdio MCP shim we write into the temp dir; on startup the shim
+ * touches a sentinel file under the grove dir. If the sentinel exists after the
+ * run, the extension was wired into a real spawned agent AND launched.
+ *
+ * If the controller prefers a pre-existing command instead of the shim, the
+ * other repo tests use `stdio:grove-fs-mcp` as the canonical example
+ * (recipe.run.test.ts, recipe-extensions.test.ts). That binary is NOT on PATH
+ * in this environment (verified), so this harness ships the self-contained
+ * sentinel shim, which is both real and launchable. To switch, change
+ * STDIO_MCP_URI below and drop the sentinel assertion.
+ *
+ * Flags:
+ *   --keep          Leave tmux session + workdir for inspection
+ *   --attach        Print `tmux attach` command and idle
+ *   --timeout <ms>  Overall budget (default 600000 — real agents are slow)
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+
+import type { Session } from "../../src/core/session.js";
+
+// ─── Paths / constants ──────────────────────────────────────────────────────
+
+const SOCKET = "grove-recipe-run-e2e";
+const SESSION = "grove-recipe-run-e2e";
+const PROJECT_ROOT = join(import.meta.dir, "..", "..");
+const MAIN_TS = join(PROJECT_ROOT, "src/cli/main.ts");
+
+// Name of the recipe MCP extension. Must satisfy the recipe NamePattern
+// (^[a-z][a-z0-9_-]*$).
+const EXT_NAME = "sentinel-fs";
+
+// ─── Args ───────────────────────────────────────────────────────────────────
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    keep: { type: "boolean", default: false },
+    attach: { type: "boolean", default: false },
+    timeout: { type: "string", default: "600000" },
+  },
+});
+const KEEP = values.keep;
+const ATTACH = values.attach;
+const BUDGET_MS = Number.parseInt(values.timeout as string, 10);
+
+// ─── tmux + polling helpers (mirrors watch-relist-tmux.ts) ──────────────────
+
+function capturePane(target = SESSION): string {
+  const out = spawnSync(
+    "tmux",
+    ["-L", SOCKET, "capture-pane", "-t", target, "-p", "-S", "-20000"],
+    { encoding: "utf-8" },
+  );
+  return out.stdout;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitForPane(
+  predicate: (pane: string) => boolean,
+  phase: string,
+  maxMs = 30000,
+  target = SESSION,
+): Promise<string> {
+  const deadline = Date.now() + maxMs;
+  let last = "";
+  while (Date.now() < deadline) {
+    last = capturePane(target);
+    if (predicate(last)) {
+      console.error(`[${phase}] matched`);
+      return last;
+    }
+    await sleep(1000);
+  }
+  console.error(`\n──── pane dump (${phase}, target=${target}) ────`);
+  console.error(last);
+  console.error("──── end pane dump ────\n");
+  throw new Error(`[${phase}] predicate did not match within ${maxMs}ms`);
+}
+
+/** Poll an async predicate until it returns a value or the deadline passes. */
+async function waitFor<T>(
+  fn: () => Promise<T | undefined>,
+  phase: string,
+  maxMs: number,
+  intervalMs = 2000,
+): Promise<T> {
+  const deadline = Date.now() + maxMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const value = await fn();
+      if (value !== undefined) {
+        console.error(`[${phase}] satisfied`);
+        return value;
+      }
+    } catch (err) {
+      lastErr = err;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(
+    `[${phase}] not satisfied within ${maxMs}ms` +
+      (lastErr ? ` (last error: ${lastErr instanceof Error ? lastErr.message : String(lastErr)})` : ""),
+  );
+}
+
+// ─── Workdir setup ──────────────────────────────────────────────────────────
+
+const workDir = mkdtempSync(join(tmpdir(), "grove-recipe-run-"));
+const groveDir = join(workDir, ".grove");
+// Sentinel the stdio MCP shim writes on startup — proof the extension was
+// wired into a spawned agent's MCP set AND launched.
+const sentinelPath = join(workDir, "ext-launched.sentinel");
+console.error(`[setup] workDir=${workDir}`);
+
+let groveUpStarted = false;
+
+function cleanup(): void {
+  // Best-effort grove down first (stops managed Nexus + services), then tmux.
+  if (groveUpStarted) {
+    try {
+      execSync(`bun run ${MAIN_TS} down --grove ${groveDir} --force`, {
+        cwd: workDir,
+        env: { ...process.env, GROVE_DIR: groveDir },
+        stdio: "inherit",
+        timeout: 60000,
+      });
+    } catch {
+      /* best-effort */
+    }
+  }
+  try {
+    execSync(`tmux -L ${SOCKET} kill-server 2>/dev/null`, { stdio: "ignore" });
+  } catch {
+    /* already dead */
+  }
+  if (!KEEP && existsSync(workDir)) {
+    rmSync(workDir, { recursive: true, force: true });
+  } else if (KEEP) {
+    console.error(`[cleanup] kept workDir=${workDir} (--keep)`);
+  }
+}
+
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+
+// ─── stdio MCP shim ─────────────────────────────────────────────────────────
+
+/**
+ * A minimal, self-contained stdio MCP server (JSON-RPC over stdio) that the
+ * recipe's `stdio:` extension points at. On startup it touches the sentinel
+ * file (proof of launch), then answers `initialize` / `tools/list` and idles.
+ * It deliberately exposes zero tools — its only job is to prove the wiring.
+ */
+function makeStdioMcpShim(sentinel: string): string {
+  return `#!/usr/bin/env bun
+// Generated stdio MCP shim for recipe-run-tmux e2e. Proves the recipe
+// extension was wired into a spawned agent's MCP set and launched.
+import { appendFileSync } from "node:fs";
+
+try {
+  appendFileSync(${JSON.stringify(sentinel)}, "launched " + new Date().toISOString() + "\\n");
+} catch {
+  /* best-effort — never crash the agent over the sentinel */
+}
+
+const enc = new TextEncoder();
+function send(msg) {
+  const body = JSON.stringify(msg);
+  process.stdout.write(enc.encode(body + "\\n"));
+}
+
+let buf = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buf += chunk;
+  let nl;
+  while ((nl = buf.indexOf("\\n")) !== -1) {
+    const line = buf.slice(0, nl).trim();
+    buf = buf.slice(nl + 1);
+    if (!line) continue;
+    let req;
+    try {
+      req = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (req.method === "initialize") {
+      send({
+        jsonrpc: "2.0",
+        id: req.id,
+        result: {
+          protocolVersion: req.params?.protocolVersion ?? "2024-11-05",
+          serverInfo: { name: ${JSON.stringify(EXT_NAME)}, version: "0.0.1" },
+          capabilities: { tools: {} },
+        },
+      });
+    } else if (req.method === "tools/list") {
+      send({ jsonrpc: "2.0", id: req.id, result: { tools: [] } });
+    } else if (req.method === "notifications/initialized" || req.id === undefined) {
+      // notification — no response
+    } else {
+      send({
+        jsonrpc: "2.0",
+        id: req.id,
+        error: { code: -32601, message: "method not found" },
+      });
+    }
+  }
+});
+// Keep the process alive until the parent agent closes stdin.
+process.stdin.on("end", () => process.exit(0));
+`;
+}
+
+// ─── Recipe YAML ────────────────────────────────────────────────────────────
+
+/**
+ * A valid recipe per GroveRecipeWireSchema:
+ *   - kind/recipe_version/name/version (semver)
+ *   - parameters.target_path (string, required)
+ *   - one mcp extension with a launchable `stdio:` URI (the shim above; the
+ *     `required: true` flag forces a hard error if it can't be wired, so the
+ *     test fails loud rather than silently skipping the extension)
+ *   - instructions referencing ${parameters.target_path}
+ *   - agent_topology: coder (claude-code) -> reviewer (codex), mirroring the
+ *     review-loop preset topology (coder delegates to reviewer; reviewer
+ *     ends_session).
+ *
+ * `shimPath` is absolute so the stdio command resolves regardless of agent cwd.
+ */
+function makeRecipeYaml(shimPath: string): string {
+  // `bun ${shimPath}` is the launchable stdio command. resolveRecipeMcpServers
+  // splits on whitespace → command="bun", args=[shimPath].
+  return `kind: recipe
+recipe_version: 1
+name: recipe-run-e2e
+version: 1.0.0
+description: Live recipe-run tmux e2e — coder/reviewer over a target path.
+parameters:
+  target_path:
+    type: string
+    required: true
+    description: Relative path the coder should work on.
+extensions:
+  - type: mcp
+    name: ${EXT_NAME}
+    uri: "stdio:bun ${shimPath}"
+    required: true
+instructions: |
+  Implement a tiny improvement under \${parameters.target_path}.
+  Coder: read the files under \${parameters.target_path}, make one small,
+  correct edit (e.g. fix the obvious bug in add.js), commit it, then submit
+  your work with grove_submit_work including the commit hash. Reviewer: read
+  the coder's files at the Workspace path, submit a grove_submit_review, and
+  if it is correct call grove_done to end the session.
+agent_topology:
+  structure: graph
+  roles:
+    - name: coder
+      description: Writes and iterates on code
+      platform: claude-code
+      mode: broadcast
+      max_instances: 1
+      skills:
+        - grove
+      edges:
+        - target: reviewer
+          edge_type: delegates
+          reply_timeout_seconds: 300
+      prompt: |
+        You are a software engineer. Workflow:
+        1. Read the files under the target path and understand the goal.
+        2. Edit files to implement the smallest correct fix.
+        3. Commit: git add -A && git commit -m 'fix'
+        4. Get the commit hash: git rev-parse HEAD
+        5. grove_submit_work({ summary: "what you did", commitHash: "<hash>", agent: { role: "coder" } })
+        6. Iterate on reviewer feedback. NEVER call grove_done yourself.
+    - name: reviewer
+      description: Reviews code and provides feedback
+      platform: codex
+      mode: broadcast
+      max_instances: 1
+      ends_session: true
+      skills:
+        - grove
+      prompt: |
+        You are a code reviewer. Wait for the coder's contribution to arrive.
+        1. Read the actual source files at the Workspace path from the notification.
+        2. grove_submit_review({ targetCid: "<CID>", summary: "review", scores: {"correctness": {"value": 0.9, "direction": "maximize"}}, agent: { role: "reviewer" } })
+        3. In the SAME response: if correct, immediately grove_done({ summary: "Approved", agent: { role: "reviewer" } }).
+           Only you can end the session.
+  spawning:
+    dynamic: true
+    max_depth: 2
+`;
+}
+
+// ─── Nexus readback (mirrors launch-session.ts) ─────────────────────────────
+
+/**
+ * Read the session record back FROM NEXUS using the exact same store wiring
+ * grove uses to mirror it: NexusHttpClient + NexusSessionStore scoped to the
+ * zone resolved from the grove dir's namespace. Reads grove.json for nexusUrl
+ * (persisted by `grove up`) and .grove/api-key for the bearer.
+ */
+async function readSessionFromNexus(sessionId: string): Promise<Session | undefined> {
+  const nexusUrl = resolveNexusUrl();
+  if (!nexusUrl) throw new Error("nexusUrl not yet persisted to grove.json");
+  const apiKey = resolveNexusApiKey();
+
+  const { NexusHttpClient } = await import("../../src/nexus/nexus-http-client.js");
+  const { NexusSessionStore } = await import("../../src/nexus/nexus-session-store.js");
+  const { resolveSessionNexusZoneId } = await import("../../src/cli/commands/session.js");
+
+  const client = new NexusHttpClient({
+    url: nexusUrl,
+    ...(apiKey ? { apiKey } : {}),
+  });
+  const zoneId = resolveSessionNexusZoneId(groveDir);
+  const store = new NexusSessionStore(client, zoneId);
+  return store.getSessionRecord(sessionId);
+}
+
+/** nexusUrl persisted to grove.json by `grove up` (service-lifecycle). */
+function resolveNexusUrl(): string | undefined {
+  if (process.env.GROVE_NEXUS_URL) return process.env.GROVE_NEXUS_URL;
+  try {
+    const cfg = JSON.parse(readFileSync(join(groveDir, "grove.json"), "utf-8")) as {
+      nexusUrl?: string;
+    };
+    return cfg.nexusUrl;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Project API key written to .grove/api-key by `grove init`. */
+function resolveNexusApiKey(): string | undefined {
+  if (process.env.NEXUS_API_KEY) return process.env.NEXUS_API_KEY;
+  try {
+    return readFileSync(join(groveDir, "api-key"), "utf-8").trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ─── main ───────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  // Kill any leftover tmux socket.
+  try {
+    execSync(`tmux -L ${SOCKET} kill-server 2>/dev/null`, { stdio: "ignore" });
+  } catch {
+    /* already dead */
+  }
+
+  mkdirSync(workDir, { recursive: true });
+
+  // 1. Fresh git repo + a couple of source files for the agents to work on.
+  console.error("[setup] git init + source files");
+  execSync("git init -q && git config user.email e2e@grove.test && git config user.name 'Grove E2E'", {
+    cwd: workDir,
+    stdio: "inherit",
+  });
+  const srcDir = join(workDir, "src");
+  mkdirSync(srcDir, { recursive: true });
+  // A deliberately buggy tiny module so the coder has a clear, small fix.
+  writeFileSync(
+    join(srcDir, "add.js"),
+    "// add(a, b) should return the sum. BUG: it subtracts.\nexport function add(a, b) {\n  return a - b;\n}\n",
+  );
+  writeFileSync(
+    join(srcDir, "README.md"),
+    "# target\n\n`add.js` has a one-line bug. Fix it so add(2, 3) === 5.\n",
+  );
+  execSync("git add -A && git commit -q -m 'seed source'", { cwd: workDir, stdio: "inherit" });
+
+  // 2. Write the stdio MCP shim + recipe.yaml.
+  const shimPath = join(workDir, "sentinel-mcp.ts");
+  writeFileSync(shimPath, makeStdioMcpShim(sentinelPath));
+  const recipePath = join(workDir, "recipe.yaml");
+  writeFileSync(recipePath, makeRecipeYaml(shimPath));
+  console.error(`[setup] recipe=${recipePath} shim=${shimPath}`);
+
+  // 2a. `grove init --preset review-loop` — establishes a nexus-backed
+  //     grove.json + api-key + server-keys so `grove up` brings up managed
+  //     Nexus (review-loop preset declares backend: "nexus").
+  console.error("[setup] grove init --preset review-loop");
+  execSync(`bun run ${MAIN_TS} init --preset review-loop --force recipe-run-e2e`, {
+    cwd: workDir,
+    env: { ...process.env, GROVE_DIR: groveDir },
+    stdio: "inherit",
+  });
+
+  // 2b. Validate the recipe up front and capture its canonical digest. This
+  //     is the source-of-truth digest the run output + Nexus provenance must
+  //     match. Also fails fast if the authored YAML is invalid.
+  console.error("[setup] grove recipe validate");
+  const validateOut = execSync(`bun run ${MAIN_TS} recipe validate ${recipePath} --json`, {
+    cwd: workDir,
+    env: { ...process.env, GROVE_DIR: groveDir },
+    encoding: "utf-8",
+  });
+  const validate = JSON.parse(validateOut) as { valid: boolean; digest: string };
+  if (!validate.valid || !/^blake3:/.test(validate.digest)) {
+    throw new Error(`recipe validate produced invalid output: ${validateOut}`);
+  }
+  const canonicalDigest = validate.digest;
+  console.error(`[setup] canonical recipe digest=${canonicalDigest}`);
+
+  // 3. Bring up the stack via the grove-managed lifecycle in a tmux pane.
+  //    `grove up --headless --no-tui` starts the HTTP server, MCP server, and
+  //    managed Nexus, persisting nexusUrl to grove.json. GROVE_ALLOW_ALL_PERMISSIONS
+  //    so the real agents' tool calls (edit/commit) aren't blocked by the
+  //    default deny-most resolver. GROVE_DEBUG_ACP surfaces agent launch
+  //    detail (incl. MCP wiring) into the captured pane for diagnostics.
+  const upEnv = [
+    `GROVE_DIR=${groveDir}`,
+    "GROVE_RUNTIME=acp",
+    "GROVE_ALLOW_ALL_PERMISSIONS=1",
+    "GROVE_DEBUG_ACP=1",
+  ].join(" ");
+  spawnSync(
+    "tmux",
+    [
+      "-L",
+      SOCKET,
+      "new-session",
+      "-d",
+      "-s",
+      SESSION,
+      "-x",
+      "220",
+      "-y",
+      "50",
+      "sh",
+      "-lc",
+      `cd ${JSON.stringify(workDir)} && ${upEnv} bun run ${MAIN_TS} up --headless --no-tui --grove ${groveDir} 2>&1; cat`,
+    ],
+    { stdio: "inherit" },
+  );
+  groveUpStarted = true;
+  console.error(`[tmux] grove up pane started. Attach: tmux -L ${SOCKET} attach -t ${SESSION}`);
+
+  if (ATTACH) {
+    console.error(`\nAttach in another terminal:\n  tmux -L ${SOCKET} attach -t ${SESSION}\n`);
+    await sleep(BUDGET_MS);
+    return;
+  }
+
+  // Wait until services report ready (headless `up` prints a started summary
+  // and "Running in headless mode") AND nexusUrl is persisted to grove.json.
+  await waitForPane(
+    (p) => /Running in headless mode|Started \d+ service/.test(p),
+    "stack-up",
+    Math.min(BUDGET_MS, 120000),
+  );
+  await waitFor(
+    async () => (resolveNexusUrl() ? true : undefined),
+    "nexus-url-persisted",
+    Math.min(BUDGET_MS, 120000),
+  );
+  console.error(`[phase 1] stack up; nexusUrl=${resolveNexusUrl()}`);
+
+  // 4. Run the recipe LIVE in a second tmux pane, redirecting JSON output to a
+  //    file (so we can parse it cleanly while the pane also shows progress).
+  //    Real agents launch via AcpRuntime (GROVE_RUNTIME=acp). The run process
+  //    inherits GROVE_NEXUS_URL via grove.json (resolved by launchGoalSession's
+  //    Nexus mirror path), and the api-key from .grove/api-key.
+  const runOutPath = join(workDir, "recipe-run.json");
+  const runEnv = [
+    `GROVE_DIR=${groveDir}`,
+    "GROVE_RUNTIME=acp",
+    "GROVE_ALLOW_ALL_PERMISSIONS=1",
+    "GROVE_DEBUG_ACP=1",
+    `GROVE_NEXUS_URL=${resolveNexusUrl() ?? ""}`,
+    `NEXUS_API_KEY=${resolveNexusApiKey() ?? ""}`,
+  ].join(" ");
+  spawnSync(
+    "tmux",
+    [
+      "-L",
+      SOCKET,
+      "split-window",
+      "-t",
+      SESSION,
+      "-h",
+      "sh",
+      "-lc",
+      `cd ${JSON.stringify(workDir)} && ${runEnv} bun run ${MAIN_TS} recipe run ${recipePath} ` +
+        `--param target_path=./src --json 2>>${JSON.stringify(join(workDir, "recipe-run.stderr.log"))} ` +
+        `| tee ${JSON.stringify(runOutPath)}; echo RECIPE_RUN_EXIT=$?; cat`,
+    ],
+    { stdio: "inherit" },
+  );
+  const runTarget = `${SESSION}.1`;
+  console.error("[tmux] recipe run pane started");
+
+  // 5a. Wait for the run to emit its onAgentsStarted JSON (sessionId +
+  //     recipeDigest). The JSON object is the FIRST thing written to runOutPath.
+  const startInfo = await waitFor<{ sessionId: string; recipeDigest: string }>(
+    async () => parseFirstJsonObject(runOutPath),
+    "agents-started-json",
+    Math.min(BUDGET_MS, 180000),
+  );
+  const { sessionId, recipeDigest } = startInfo;
+  console.error(`[phase 2] recipe run started session=${sessionId} digest=${recipeDigest}`);
+
+  // ── ASSERT (a): run output digest is blake3-prefixed and equals validate's.
+  if (!recipeDigest || !/^blake3:/.test(recipeDigest)) {
+    throw new Error(`run output recipeDigest is not blake3-prefixed: ${recipeDigest}`);
+  }
+  if (recipeDigest !== canonicalDigest) {
+    throw new Error(
+      `run output digest ${recipeDigest} != validate digest ${canonicalDigest}`,
+    );
+  }
+  console.error("[assert a] run digest matches validate digest");
+
+  // 5b. Wait for both roles to spawn (ACP launch lines in the up pane), the
+  //     coder->reviewer handoff/contribution, and a terminal session state.
+  //     We observe the run pane for the terminal line `... ended:` (recipe.ts
+  //     non-json prints that, but in --json mode the loop still completes;
+  //     we additionally confirm terminal state via the Nexus session record).
+  await waitForPane(
+    (p) => /coder/.test(p) && /reviewer/.test(p),
+    "both-roles-spawned",
+    Math.min(BUDGET_MS, 240000),
+    SESSION,
+  );
+  console.error("[phase 3] both roles spawned");
+
+  // ── ASSERT (c): the stdio MCP extension was attached to a spawned agent's
+  //    MCP set AND launched — the shim wrote the sentinel.
+  await waitFor(
+    async () => (existsSync(sentinelPath) ? true : undefined),
+    "extension-launched-sentinel",
+    Math.min(BUDGET_MS, 240000),
+  );
+  console.error(
+    `[assert c] stdio extension '${EXT_NAME}' launched (sentinel: ${sentinelPath})`,
+  );
+
+  // 5c. Wait for a terminal session state in Nexus AND at least one linked
+  //     contribution (proves a real agent produced work / handoff).
+  const terminalSession = await waitFor<Session>(
+    async () => {
+      const s = await readSessionFromNexus(sessionId);
+      if (s === undefined) return undefined;
+      const terminal =
+        s.status === "completed" || s.status === "cancelled" || s.status === "archived";
+      return terminal ? s : undefined;
+    },
+    "session-terminal-in-nexus",
+    Math.min(BUDGET_MS, 360000),
+    3000,
+  );
+  console.error(`[phase 4] session terminal in Nexus: status=${terminalSession.status}`);
+
+  // ── ASSERT (b): the Nexus session record carries recipeProvenance with the
+  //    same digest as the run output / validate.
+  const provDigest = terminalSession.recipeProvenance?.recipeDigest;
+  if (provDigest === undefined) {
+    throw new Error(
+      `Nexus session ${sessionId} has no recipeProvenance.recipeDigest: ${JSON.stringify(
+        terminalSession.recipeProvenance,
+      )}`,
+    );
+  }
+  if (provDigest !== canonicalDigest) {
+    throw new Error(
+      `Nexus recipeProvenance.recipeDigest ${provDigest} != canonical ${canonicalDigest}`,
+    );
+  }
+  console.error("[assert b] Nexus recipeProvenance.recipeDigest matches");
+
+  // ── ASSERT (d): at least one contribution / handoff happened (real agents
+  //    ran). The full session read links contributions; getSession() recomputes
+  //    contributionCount from the Nexus link sidecar/markers.
+  const linkedCount = await waitFor<number>(
+    async () => {
+      const full = await readFullSessionFromNexus(sessionId);
+      const count = full?.contributionCount ?? 0;
+      return count > 0 ? count : undefined;
+    },
+    "at-least-one-contribution",
+    Math.min(BUDGET_MS, 60000),
+    3000,
+  );
+  console.error(`[assert d] session has ${linkedCount} linked contribution(s)`);
+
+  console.error(
+    `\n✅ recipe-run tmux e2e PASS — session=${sessionId} digest=${recipeDigest} ` +
+      `extension='${EXT_NAME}' launched, ${linkedCount} contribution(s), status=${terminalSession.status}`,
+  );
+  void runTarget;
+}
+
+// ─── Nexus full-session readback (recomputes contributionCount) ─────────────
+
+async function readFullSessionFromNexus(sessionId: string): Promise<Session | undefined> {
+  const nexusUrl = resolveNexusUrl();
+  if (!nexusUrl) return undefined;
+  const apiKey = resolveNexusApiKey();
+  const { NexusHttpClient } = await import("../../src/nexus/nexus-http-client.js");
+  const { NexusSessionStore } = await import("../../src/nexus/nexus-session-store.js");
+  const { resolveSessionNexusZoneId } = await import("../../src/cli/commands/session.js");
+  const client = new NexusHttpClient({ url: nexusUrl, ...(apiKey ? { apiKey } : {}) });
+  const store = new NexusSessionStore(client, resolveSessionNexusZoneId(groveDir));
+  return store.getSession(sessionId);
+}
+
+// ─── JSON parse helper ──────────────────────────────────────────────────────
+
+/**
+ * Parse the FIRST top-level JSON object from a file that may also contain
+ * later lines (the recipe-run pane tees the onAgentsStarted JSON object first,
+ * then potentially more output). recipe.ts emits the object with
+ * `JSON.stringify(..., null, 2)`, so it spans multiple lines and ends at the
+ * first line that is exactly `}`.
+ */
+function parseFirstJsonObject(
+  path: string,
+): { sessionId: string; recipeDigest: string } | undefined {
+  if (!existsSync(path)) return undefined;
+  const text = readFileSync(path, "utf-8");
+  const start = text.indexOf("{");
+  if (start === -1) return undefined;
+  // Find the matching closing brace by depth counting (robust to nested objects).
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        const slice = text.slice(start, i + 1);
+        try {
+          const obj = JSON.parse(slice) as {
+            sessionId?: string;
+            recipeDigest?: string;
+          };
+          if (obj.sessionId && obj.recipeDigest) {
+            return { sessionId: obj.sessionId, recipeDigest: obj.recipeDigest };
+          }
+          return undefined;
+        } catch {
+          return undefined;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+// ─── Entrypoint ─────────────────────────────────────────────────────────────
+
+main()
+  .then(() => {
+    cleanup();
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("\n❌ recipe-run tmux e2e FAIL:", err);
+    console.error("\n──── up pane (error) ────");
+    try {
+      console.error(capturePane(SESSION));
+    } catch {
+      /* tmux already dead */
+    }
+    console.error("\n──── recipe-run pane (error) ────");
+    try {
+      console.error(capturePane(`${SESSION}.1`));
+    } catch {
+      /* tmux already dead */
+    }
+    const stderrLog = join(workDir, "recipe-run.stderr.log");
+    if (existsSync(stderrLog)) {
+      console.error("\n──── recipe-run stderr log ────");
+      try {
+        console.error(readFileSync(stderrLog, "utf-8").slice(-4000));
+      } catch {
+        /* ignore */
+      }
+    }
+    cleanup();
+    process.exit(1);
+  });

--- a/tests/e2e/recipe-run-tmux.ts
+++ b/tests/e2e/recipe-run-tmux.ts
@@ -55,14 +55,7 @@
  */
 
 import { execSync, spawnSync } from "node:child_process";
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
@@ -155,7 +148,9 @@ async function waitFor<T>(
   }
   throw new Error(
     `[${phase}] not satisfied within ${maxMs}ms` +
-      (lastErr ? ` (last error: ${lastErr instanceof Error ? lastErr.message : String(lastErr)})` : ""),
+      (lastErr
+        ? ` (last error: ${lastErr instanceof Error ? lastErr.message : String(lastErr)})`
+        : ""),
   );
 }
 
@@ -417,10 +412,13 @@ async function main(): Promise<void> {
 
   // 1. Fresh git repo + a couple of source files for the agents to work on.
   console.error("[setup] git init + source files");
-  execSync("git init -q && git config user.email e2e@grove.test && git config user.name 'Grove E2E'", {
-    cwd: workDir,
-    stdio: "inherit",
-  });
+  execSync(
+    "git init -q && git config user.email e2e@grove.test && git config user.name 'Grove E2E'",
+    {
+      cwd: workDir,
+      stdio: "inherit",
+    },
+  );
   const srcDir = join(workDir, "src");
   mkdirSync(srcDir, { recursive: true });
   // A deliberately buggy tiny module so the coder has a clear, small fix.
@@ -570,9 +568,7 @@ async function main(): Promise<void> {
     throw new Error(`run output recipeDigest is not blake3-prefixed: ${recipeDigest}`);
   }
   if (recipeDigest !== canonicalDigest) {
-    throw new Error(
-      `run output digest ${recipeDigest} != validate digest ${canonicalDigest}`,
-    );
+    throw new Error(`run output digest ${recipeDigest} != validate digest ${canonicalDigest}`);
   }
   console.error("[assert a] run digest matches validate digest");
 
@@ -596,9 +592,7 @@ async function main(): Promise<void> {
     "extension-launched-sentinel",
     Math.min(BUDGET_MS, 240000),
   );
-  console.error(
-    `[assert c] stdio extension '${EXT_NAME}' launched (sentinel: ${sentinelPath})`,
-  );
+  console.error(`[assert c] stdio extension '${EXT_NAME}' launched (sentinel: ${sentinelPath})`);
 
   // 5c. Wait for a terminal session state in Nexus AND at least one linked
   //     contribution (proves a real agent produced work / handoff).


### PR DESCRIPTION
## Summary

Implements **live `grove recipe run`** (issue #276 follow-up to the dry-run phase). `grove recipe run <path> [--param k=v] [--goal "..."] [--repo <ref>]` (without `--dry-run`) now materializes a recipe into a **persistent, launched session** whose record carries the recipe digest for reproducibility, with declared `stdio:` MCP extensions wired into every spawned agent.

- **Shared launcher** — extracted the session-launch core out of `grove session start` into `src/cli/utils/launch-session.ts` (`launchGoalSession`). Both `session start` and `recipe run` use it; `session start` behavior (incl. `--preset`) is preserved byte-for-byte.
- **Live recipe run** — rendered `instructions` become the goal (`--goal` overrides), topology comes from the materialized contract, and the run launches via the shared launcher (`src/cli/commands/recipe.ts`). Dry-run output is unchanged.
- **stdio MCP extensions** — `resolveRecipeMcpServers` maps `stdio:` extensions to MCP server configs (required non-stdio → error, optional → warn+skip); the orchestrator appends them after the built-in `grove` server (`SessionConfig.extraMcpServers`).
- **Recipe provenance** — `Session`/`CreateSessionInput` gain `recipeProvenance`, persisted across SQLite (additive `recipe_provenance_json` column + v17 column-safe migration), Nexus, and InMemory stores; surfaced in `grove session status`.
- **Misc** — configurable orchestrator `idleGracePeriodMs`; spec `GROVE-RECIPES.md` updated with a Live Run section.

Out of scope (record-only, per the issue): sub-recipe spawning and non-`stdio` extension wiring.

Design: `docs/superpowers/specs/2026-06-08-grove-recipe-run-live-design.md` · Plan: `docs/superpowers/plans/2026-06-08-grove-recipe-run-live.md`

## Test Plan

- [x] Unit/integration: extension mapper, orchestrator `extraMcpServers`, store round-trips (SQLite/Nexus/InMemory), launcher provenance, recipe-run wiring (injected fake launcher) — added across the changed files
- [x] `grove session start` regression suite green (faithful extraction)
- [x] Full suite: **8516 pass / 0 fail**; `tsc --noEmit` clean; biome clean on changed files
- [x] **Real-process E2E** (`tests/e2e/recipe-run-tmux.ts`): `grove up` managed stack + real codex↔claude review-loop → asserts run digest == `recipe validate` digest, both roles spawn, the `stdio:` MCP extension launches inside an agent, the **Nexus** session record carries `recipeProvenance.recipeDigest`, and the loop produced 3 contributions (`status=completed`) — **PASS**

Follow-ups (non-blocking): hoist `resolveSessionNexusZoneId`/`terminalSessionStatus` to a neutral util (drop the util→command import + duplication); named `LaunchGoalSession` type; InMemory provenance round-trip test; `recipe run` JSON per-agent `sessionId` parity with `session start`.

Closes #276
