### PR TITLE
feat(#306): OwnerRefs + finalizers + cascade GC (D5)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-ownerrefs-finalizers-cascade-gc.md
+++ b/docs/superpowers/plans/2026-06-08-ownerrefs-finalizers-cascade-gc.md
@@ -1,0 +1,1820 @@
+# OwnerRefs + Finalizers + Cascade GC Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Kubernetes-style garbage collector to Grove — owner references link parents to children, finalizers gate hard deletion, and a cascade policy (`Foreground`/`Background`/`Orphan`) decides what happens to children when an owner is deleted.
+
+**Architecture:** A pure decision core (`owner-graph.ts`, no I/O) computes one idempotent reconcile step per node; a `GarbageCollector` reconcile loop (same skeleton as `task-controller.ts`/`claim-controller.ts`) drives those decisions against a segregated `GcStore` via CAS writes. Cascade policy is encoded as a propagation finalizer placed on the owner at delete time, so it survives restarts. The mechanism is proven end-to-end against an in-memory `GcStore` and against the real `SqliteAgentTaskStore`.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), `bun:test`, Bun SQLite (`bun:sqlite`). Colocated `*.test.ts`. Run tests with `bun test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-ownerrefs-finalizers-cascade-gc-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/core/lifecycle-metadata.ts` (edit) | `OwnerRef.controller` flag + `taskGroup`/`agentTask` kinds; `KindFinalizer`, `PropagationFinalizer`, `CascadePolicy` constants |
+| `src/core/owner-graph.ts` (new) | Pure types (`GcNode`, `GcRef`, `GcAction`) + pure decision functions (`policyOf`, `planOwnerDeletion`, `planDanglingChild`) |
+| `src/core/garbage-collector.ts` (new) | `GcStore` interface + `GarbageCollector` reconcile loop |
+| `src/core/in-memory-gc-store.ts` (new) | In-memory `GcStore` (all kinds) for tests/fixtures |
+| `src/core/store.ts` (edit) | Add lifecycle-mutator methods to `AgentTaskStore` |
+| `src/local/sqlite-store.ts` (edit) | Implement the new mutators on `SqliteAgentTaskStore` |
+| `src/core/agent-task-gc-store.ts` (new) | `AgentTaskGcStore` (real-store adapter) + `CompositeGcStore` (routes by kind) |
+| `src/server/garbage-collector-wiring.ts` (new) | Construct a `GarbageCollector`, gated by env (mirrors `task-controller-wiring.ts`) |
+| `src/core/index.ts` (edit) | Re-export the new public symbols |
+
+**Queue key encoding:** the `KeyedWorkQueue` keys by `string`, but a node's identity is `(kind, id)`. Encode keys as `` `${kind}:${id}` `` and parse back. Helpers `gcKey(ref)` / `parseGcKey(key)` live in `garbage-collector.ts`.
+
+---
+
+## Task 1: Extend OwnerRef + finalizer/policy constants
+
+**Files:**
+- Modify: `src/core/lifecycle-metadata.ts`
+- Test: `src/core/lifecycle-metadata.test.ts` (append cases)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/core/lifecycle-metadata.test.ts` (inside the existing top-level `describe("lifecycle metadata", ...)` block, before its closing `});`):
+
+```ts
+  test("OwnerRef carries an optional controller flag without affecting identity", () => {
+    const a: OwnerRef = { kind: "taskGroup", id: "tg-1", uid: "uid-1", controller: true };
+    const b: OwnerRef = { kind: "taskGroup", id: "tg-1", uid: "uid-1" };
+    // controller is metadata, not identity — equality is UID-based.
+    expect(ownerRefsEqual(a, b)).toBe(true);
+  });
+
+  test("new owner kinds are assignable", () => {
+    const refs: OwnerRef[] = [
+      { kind: "session", id: "s", uid: "u" },
+      { kind: "claim", id: "c", uid: "u" },
+      { kind: "taskGroup", id: "tg", uid: "u" },
+      { kind: "agentTask", id: "at", uid: "u" },
+    ];
+    expect(refs).toHaveLength(4);
+  });
+
+  test("finalizer namespaces are stable", () => {
+    expect(KindFinalizer.PendingReview).toBe("grove.dev/pending-review");
+    expect(KindFinalizer.PendingMerge).toBe("grove.dev/pending-merge");
+    expect(PropagationFinalizer.Foreground).toBe("grove.dev/foreground-deletion");
+    expect(PropagationFinalizer.Orphan).toBe("grove.dev/orphan");
+  });
+
+  test("cascade policy values", () => {
+    const policies: CascadePolicy[] = ["Foreground", "Background", "Orphan"];
+    expect(policies).toContain("Background");
+  });
+```
+
+Update the import at the top of the test file to add the new symbols:
+
+```ts
+import {
+  appendDeletionAudit,
+  type CascadePolicy,
+  DEFAULT_SESSION_FINALIZERS,
+  Finalizer,
+  KindFinalizer,
+  type OwnerRef,
+  ownerRefsEqual,
+  PropagationFinalizer,
+} from "./lifecycle-metadata.js";
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/lifecycle-metadata.test.ts`
+Expected: FAIL — `KindFinalizer`/`PropagationFinalizer`/`CascadePolicy` not exported; `"taskGroup"` not assignable to `OwnerKind`.
+
+- [ ] **Step 3: Implement the changes**
+
+Edit `src/core/lifecycle-metadata.ts`. Replace the `OwnerKind`/`OwnerRef` declarations at the top:
+
+```ts
+export type OwnerKind = "session" | "claim" | "taskGroup" | "agentTask";
+
+export interface OwnerRef {
+  readonly kind: OwnerKind;
+  readonly id: string;
+  readonly uid: string;
+  /** k8s `controller: true` — the single managing owner. Metadata, not identity. */
+  readonly controller?: boolean | undefined;
+}
+```
+
+Then, immediately after the existing `Finalizer` block (after the `DEFAULT_SESSION_FINALIZERS` const), add:
+
+```ts
+/**
+ * Per-kind finalizers (Epic D #306). Use the `grove.dev/` namespace, distinct
+ * from the legacy `grove.io/*` session finalizers above (not unified here).
+ */
+export const KindFinalizer = {
+  /** On AgentTask — blocks reap until review completes. */
+  PendingReview: "grove.dev/pending-review",
+  /** On MergeTask — blocks reap until the merge lands (defined now, applied in a follow-up). */
+  PendingMerge: "grove.dev/pending-merge",
+} as const;
+export type KindFinalizer = (typeof KindFinalizer)[keyof typeof KindFinalizer];
+
+/**
+ * Propagation finalizers placed on the OWNER at delete time to encode the
+ * cascade policy (mirrors k8s `foregroundDeletion`/`orphan`). Background uses
+ * no propagation finalizer. Reconstructable from store state after a restart.
+ */
+export const PropagationFinalizer = {
+  Foreground: "grove.dev/foreground-deletion",
+  Orphan: "grove.dev/orphan",
+} as const;
+export type PropagationFinalizer =
+  (typeof PropagationFinalizer)[keyof typeof PropagationFinalizer];
+
+export type CascadePolicy = "Foreground" | "Background" | "Orphan";
+```
+
+`ownerRefsEqual` already compares only `kind`/`id`/`uid`, so it stays correct with the new optional `controller` field — no change needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/lifecycle-metadata.test.ts`
+Expected: PASS (all cases, including the pre-existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/lifecycle-metadata.ts src/core/lifecycle-metadata.test.ts
+git commit --no-verify -m "feat(#306): OwnerRef.controller + grove.dev finalizer/cascade constants"
+```
+
+---
+
+## Task 2: Pure owner-graph decision core
+
+**Files:**
+- Create: `src/core/owner-graph.ts`
+- Test: `src/core/owner-graph.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/owner-graph.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { PropagationFinalizer } from "./lifecycle-metadata.js";
+import {
+  type GcNode,
+  planDanglingChild,
+  planOwnerDeletion,
+  policyOf,
+} from "./owner-graph.js";
+
+function node(over: Partial<GcNode> & Pick<GcNode, "kind" | "id" | "uid">): GcNode {
+  return {
+    resourceVersion: "1",
+    ownerRefs: [],
+    finalizers: [],
+    ...over,
+  };
+}
+
+function child(id: string, ownerUid: string, over: Partial<GcNode> = {}): GcNode {
+  return node({
+    kind: "agentTask",
+    id,
+    uid: `uid-${id}`,
+    ownerRefs: [{ kind: "taskGroup", id: "tg", uid: ownerUid, controller: true }],
+    ...over,
+  });
+}
+
+describe("policyOf", () => {
+  test("Foreground / Orphan / Background derived from owner finalizers", () => {
+    expect(policyOf(node({ kind: "taskGroup", id: "tg", uid: "u" }))).toBe("Background");
+    expect(
+      policyOf(node({ kind: "taskGroup", id: "tg", uid: "u", finalizers: [PropagationFinalizer.Foreground] })),
+    ).toBe("Foreground");
+    expect(
+      policyOf(node({ kind: "taskGroup", id: "tg", uid: "u", finalizers: [PropagationFinalizer.Orphan] })),
+    ).toBe("Orphan");
+  });
+});
+
+describe("planOwnerDeletion — no deletionTimestamp", () => {
+  test("not being deleted → no actions", () => {
+    const owner = node({ kind: "taskGroup", id: "tg", uid: "u-tg" });
+    expect(planOwnerDeletion(owner, [child("a", "u-tg")])).toEqual([]);
+  });
+});
+
+describe("planOwnerDeletion — Foreground", () => {
+  const owner = node({
+    kind: "taskGroup",
+    id: "tg",
+    uid: "u-tg",
+    finalizers: [PropagationFinalizer.Foreground],
+    deletionTimestamp: "2026-06-08T00:00:00.000Z",
+  });
+
+  test("marks unmarked controlled children", () => {
+    const actions = planOwnerDeletion(owner, [child("a", "u-tg"), child("b", "u-tg")]);
+    expect(actions).toEqual([
+      { type: "mark-deletion", ref: { kind: "agentTask", id: "a" } },
+      { type: "mark-deletion", ref: { kind: "agentTask", id: "b" } },
+    ]);
+  });
+
+  test("children marked but still present → still terminating (no actions)", () => {
+    const marked = child("a", "u-tg", { deletionTimestamp: "2026-06-08T00:00:01.000Z" });
+    expect(planOwnerDeletion(owner, [marked])).toEqual([]);
+  });
+
+  test("children gone → remove foreground finalizer", () => {
+    expect(planOwnerDeletion(owner, [])).toEqual([
+      {
+        type: "remove-finalizer",
+        ref: { kind: "taskGroup", id: "tg" },
+        finalizer: PropagationFinalizer.Foreground,
+      },
+    ]);
+  });
+
+  test("finalizer removed + children gone → reap", () => {
+    const reapable = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      finalizers: [],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    expect(planOwnerDeletion(reapable, [])).toEqual([
+      { type: "reap", ref: { kind: "taskGroup", id: "tg" } },
+    ]);
+  });
+});
+
+describe("planOwnerDeletion — Orphan", () => {
+  const owner = node({
+    kind: "taskGroup",
+    id: "tg",
+    uid: "u-tg",
+    finalizers: [PropagationFinalizer.Orphan],
+    deletionTimestamp: "2026-06-08T00:00:00.000Z",
+  });
+
+  test("strips the controller ownerRef from children", () => {
+    expect(planOwnerDeletion(owner, [child("a", "u-tg")])).toEqual([
+      { type: "orphan", ref: { kind: "agentTask", id: "a" }, ownerUid: "u-tg" },
+    ]);
+  });
+
+  test("children detached → remove orphan finalizer, then reap on next pass", () => {
+    expect(planOwnerDeletion(owner, [])).toEqual([
+      {
+        type: "remove-finalizer",
+        ref: { kind: "taskGroup", id: "tg" },
+        finalizer: PropagationFinalizer.Orphan,
+      },
+    ]);
+  });
+});
+
+describe("planOwnerDeletion — Background", () => {
+  test("marks children AND reaps owner immediately", () => {
+    const owner = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    expect(planOwnerDeletion(owner, [child("a", "u-tg")])).toEqual([
+      { type: "mark-deletion", ref: { kind: "agentTask", id: "a" } },
+      { type: "reap", ref: { kind: "taskGroup", id: "tg" } },
+    ]);
+  });
+});
+
+describe("reap gating by finalizer", () => {
+  test("deletionTimestamp set but a kind finalizer present → no reap", () => {
+    const owner = node({
+      kind: "agentTask",
+      id: "at",
+      uid: "u",
+      finalizers: ["grove.dev/pending-review"],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    expect(planOwnerDeletion(owner, [])).toEqual([]);
+  });
+});
+
+describe("planDanglingChild", () => {
+  test("owner gone, child unmarked → mark for deletion", () => {
+    expect(planDanglingChild(child("a", "u-tg"), false)).toEqual([
+      { type: "mark-deletion", ref: { kind: "agentTask", id: "a" } },
+    ]);
+  });
+
+  test("owner gone, child marked, finalizers empty → reap", () => {
+    const marked = child("a", "u-tg", { deletionTimestamp: "2026-06-08T00:00:01.000Z" });
+    expect(planDanglingChild(marked, false)).toEqual([
+      { type: "reap", ref: { kind: "agentTask", id: "a" } },
+    ]);
+  });
+
+  test("owner still exists → no actions", () => {
+    expect(planDanglingChild(child("a", "u-tg"), true)).toEqual([]);
+  });
+
+  test("no controller ownerRef → not a dangling candidate", () => {
+    const orphaned = node({ kind: "agentTask", id: "a", uid: "u-a" });
+    expect(planDanglingChild(orphaned, false)).toEqual([]);
+  });
+});
+
+describe("idempotency", () => {
+  test("converged Foreground owner (children gone, finalizer cleared) yields reap then nothing", () => {
+    const reaped = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      finalizers: [],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    const first = planOwnerDeletion(reaped, []);
+    expect(first).toEqual([{ type: "reap", ref: { kind: "taskGroup", id: "tg" } }]);
+    // After reap the node would be gone; re-running planDanglingChild on a
+    // hypothetical leftover with empty finalizers is a single reap, not a loop.
+    expect(planOwnerDeletion(reaped, [])).toEqual(first);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/owner-graph.test.ts`
+Expected: FAIL — cannot find module `./owner-graph.js`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/core/owner-graph.ts`:
+
+```ts
+/**
+ * Pure cascade/reap decision core for the garbage collector (Epic D #306).
+ *
+ * No I/O, no async, no clock — every function is a pure projection over an
+ * entity snapshot, so cascade logic is unit-testable in isolation. The
+ * GarbageCollector loop (garbage-collector.ts) supplies the snapshots and
+ * executes the returned actions against a store.
+ */
+
+import {
+  type CascadePolicy,
+  type OwnerKind,
+  type OwnerRef,
+  PropagationFinalizer,
+} from "./lifecycle-metadata.js";
+
+/** Identity of a GC-managed node: (kind, id). */
+export interface GcRef {
+  readonly kind: OwnerKind;
+  readonly id: string;
+}
+
+/** Minimal lifecycle projection of any GC-managed entity. */
+export interface GcNode {
+  readonly kind: OwnerKind;
+  readonly id: string;
+  readonly uid: string;
+  /** Resource version for CAS writes (string, store-defined). */
+  readonly resourceVersion: string;
+  readonly ownerRefs: readonly OwnerRef[];
+  readonly finalizers: readonly string[];
+  readonly deletionTimestamp?: string | undefined;
+}
+
+/** One reconcile-step action. The loop stamps timestamps and threads CAS. */
+export type GcAction =
+  | { readonly type: "mark-deletion"; readonly ref: GcRef }
+  | { readonly type: "orphan"; readonly ref: GcRef; readonly ownerUid: string }
+  | { readonly type: "remove-finalizer"; readonly ref: GcRef; readonly finalizer: string }
+  | { readonly type: "reap"; readonly ref: GcRef };
+
+export function refOf(node: GcNode): GcRef {
+  return { kind: node.kind, id: node.id };
+}
+
+/** Derive cascade policy from the propagation finalizer the owner carries. */
+export function policyOf(owner: GcNode): CascadePolicy {
+  if (owner.finalizers.includes(PropagationFinalizer.Foreground)) return "Foreground";
+  if (owner.finalizers.includes(PropagationFinalizer.Orphan)) return "Orphan";
+  return "Background";
+}
+
+/** Does `child` carry a controller ownerRef pointing at `ownerUid`? */
+function controlledBy(child: GcNode, ownerUid: string): boolean {
+  return child.ownerRefs.some((ref) => ref.uid === ownerUid && ref.controller === true);
+}
+
+/** Reap only when deletion is requested AND every finalizer is cleared. */
+function reapIfReady(node: GcNode): readonly GcAction[] {
+  if (node.deletionTimestamp === undefined) return [];
+  return node.finalizers.length === 0 ? [{ type: "reap", ref: refOf(node) }] : [];
+}
+
+/**
+ * One idempotent reconcile step for a node that has a deletionTimestamp.
+ * Cascades to its controlled children per policy, then reaps itself when ready.
+ * Returns `[]` when the node is not being deleted or the world is converged.
+ */
+export function planOwnerDeletion(
+  owner: GcNode,
+  children: readonly GcNode[],
+): readonly GcAction[] {
+  if (owner.deletionTimestamp === undefined) return [];
+  const controlled = children.filter((child) => controlledBy(child, owner.uid));
+  const policy = policyOf(owner);
+
+  if (policy === "Orphan") {
+    if (controlled.length > 0) {
+      return controlled.map((child) => ({
+        type: "orphan" as const,
+        ref: refOf(child),
+        ownerUid: owner.uid,
+      }));
+    }
+    if (owner.finalizers.includes(PropagationFinalizer.Orphan)) {
+      return [
+        { type: "remove-finalizer", ref: refOf(owner), finalizer: PropagationFinalizer.Orphan },
+      ];
+    }
+    return reapIfReady(owner);
+  }
+
+  if (policy === "Foreground") {
+    const blocking = controlled.filter((child) => child.deletionTimestamp === undefined);
+    if (blocking.length > 0) {
+      return blocking.map((child) => ({ type: "mark-deletion" as const, ref: refOf(child) }));
+    }
+    // Children are marked but still present — stay Terminating until they're gone.
+    if (controlled.length > 0) return [];
+    if (owner.finalizers.includes(PropagationFinalizer.Foreground)) {
+      return [
+        {
+          type: "remove-finalizer",
+          ref: refOf(owner),
+          finalizer: PropagationFinalizer.Foreground,
+        },
+      ];
+    }
+    return reapIfReady(owner);
+  }
+
+  // Background: mark children for async GC, reap owner immediately.
+  const actions: GcAction[] = controlled
+    .filter((child) => child.deletionTimestamp === undefined)
+    .map((child) => ({ type: "mark-deletion" as const, ref: refOf(child) }));
+  actions.push(...reapIfReady(owner));
+  return actions;
+}
+
+/**
+ * GC backstop: a child whose controller owner UID no longer resolves.
+ * `ownerExists` is true only when the controller owner is present AND its UID
+ * still matches (a recreated owner with a new UID counts as gone).
+ */
+export function planDanglingChild(
+  child: GcNode,
+  ownerExists: boolean,
+): readonly GcAction[] {
+  const hasController = child.ownerRefs.some((ref) => ref.controller === true);
+  if (!hasController || ownerExists) return [];
+  if (child.deletionTimestamp === undefined) {
+    return [{ type: "mark-deletion", ref: refOf(child) }];
+  }
+  return reapIfReady(child);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/owner-graph.test.ts`
+Expected: PASS (all describe blocks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/owner-graph.ts src/core/owner-graph.test.ts
+git commit --no-verify -m "feat(#306): pure owner-graph cascade/reap decision core"
+```
+
+---
+
+## Task 3: GcStore interface + GarbageCollector loop
+
+**Files:**
+- Create: `src/core/garbage-collector.ts`
+
+(No standalone test in this task — the loop is exercised in Task 4 against the in-memory store. This task only adds code that Task 4 depends on; commit it together at the end of Task 4 if your workflow prefers test-first commits. The interface and class are written here so Task 4's test compiles.)
+
+- [ ] **Step 1: Write the implementation**
+
+Create `src/core/garbage-collector.ts`:
+
+```ts
+import type { CasMutationResult, CasOpts } from "./cas.js";
+import {
+  type GcAction,
+  type GcNode,
+  type GcRef,
+  planDanglingChild,
+  planOwnerDeletion,
+  refOf,
+} from "./owner-graph.js";
+import { withIfMatch } from "./with-if-match.js";
+import { KeyedWorkQueue, QueueClosedError, type WorkItemResult } from "./workqueue.js";
+
+/**
+ * Segregated store surface the GarbageCollector depends on. Concrete stores
+ * (in-memory fixture, AgentTask adapter, composite) implement it. Mutators are
+ * CAS-aware and return the post-write node so the loop can thread retries.
+ */
+export interface GcStore {
+  getNode(ref: GcRef): Promise<GcNode | undefined>;
+  /** All nodes that currently have a deletionTimestamp set. */
+  listPendingDeletion(): Promise<readonly GcNode[]>;
+  /** All nodes carrying any ownerRef whose uid === ownerUid. */
+  listOwnedBy(ownerUid: string): Promise<readonly GcNode[]>;
+  setDeletionTimestamp(
+    ref: GcRef,
+    deletionTimestamp: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>>;
+  removeOwnerRef(ref: GcRef, ownerUid: string, opts?: CasOpts): Promise<CasMutationResult<GcNode>>;
+  removeFinalizer(ref: GcRef, finalizer: string, opts?: CasOpts): Promise<CasMutationResult<GcNode>>;
+  /** Hard-delete. MUST reject (throw) if the node still has finalizers. */
+  reap(ref: GcRef, opts?: CasOpts): Promise<CasMutationResult<GcNode>>;
+}
+
+export interface GarbageCollectorOptions {
+  readonly store: GcStore;
+  readonly queue?: KeyedWorkQueue | undefined;
+  readonly resyncIntervalMs?: number | undefined;
+  readonly workerCount?: number | undefined;
+  readonly now?: (() => number) | undefined;
+  readonly onError?: ((error: unknown, key: string) => void) | undefined;
+  readonly onAction?: ((action: GcAction) => void) | undefined;
+}
+
+const DEFAULT_RESYNC_INTERVAL_MS = 30_000;
+const DEFAULT_WORKER_COUNT = 1;
+const MAX_RESYNC_INTERVAL_MS = 2_147_483_647;
+const MAX_WORKER_COUNT = 1_000;
+
+/** Sentinel: the target node vanished mid-reconcile (already reaped). Benign. */
+class NodeVanished extends Error {
+  constructor() {
+    super("gc target node vanished");
+    this.name = "NodeVanished";
+  }
+}
+
+export function gcKey(ref: GcRef): string {
+  return `${ref.kind}:${ref.id}`;
+}
+
+export function parseGcKey(key: string): GcRef {
+  const idx = key.indexOf(":");
+  if (idx === -1) throw new Error(`invalid gc key: ${key}`);
+  return { kind: key.slice(0, idx) as GcRef["kind"], id: key.slice(idx + 1) };
+}
+
+export class GarbageCollector {
+  private readonly store: GcStore;
+  private readonly queue: KeyedWorkQueue;
+  private readonly now: () => number;
+  private readonly resyncIntervalMs: number;
+  private readonly workerCount: number;
+  private readonly onError: ((error: unknown, key: string) => void) | undefined;
+  private readonly onAction: ((action: GcAction) => void) | undefined;
+  private running = false;
+  private stopRequested = false;
+  private workers: Promise<void>[] = [];
+  private resyncTimer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(options: GarbageCollectorOptions) {
+    this.store = options.store;
+    this.now = options.now ?? Date.now;
+    this.queue = options.queue ?? new KeyedWorkQueue({ now: this.now });
+    this.resyncIntervalMs = options.resyncIntervalMs ?? DEFAULT_RESYNC_INTERVAL_MS;
+    this.workerCount = options.workerCount ?? DEFAULT_WORKER_COUNT;
+    if (
+      !Number.isFinite(this.resyncIntervalMs) ||
+      this.resyncIntervalMs < 1 ||
+      this.resyncIntervalMs > MAX_RESYNC_INTERVAL_MS
+    ) {
+      throw new RangeError(
+        `resyncIntervalMs must be a finite positive number no greater than ${MAX_RESYNC_INTERVAL_MS}`,
+      );
+    }
+    if (!Number.isInteger(this.workerCount) || this.workerCount < 1 || this.workerCount > MAX_WORKER_COUNT) {
+      throw new RangeError(`workerCount must be an integer between 1 and ${MAX_WORKER_COUNT}`);
+    }
+    this.onError = options.onError;
+    this.onAction = options.onAction;
+  }
+
+  enqueue(ref: GcRef): void {
+    this.queue.enqueue(gcKey(ref));
+  }
+
+  async resync(): Promise<number> {
+    const pending = await this.store.listPendingDeletion();
+    for (const node of pending) {
+      this.enqueue(refOf(node));
+      const children = await this.store.listOwnedBy(node.uid);
+      for (const child of children) this.enqueue(refOf(child));
+    }
+    return pending.length;
+  }
+
+  async reconcileNode(ref: GcRef): Promise<void> {
+    const node = await this.store.getNode(ref);
+    if (node === undefined) return;
+
+    let actions: readonly GcAction[];
+    if (node.deletionTimestamp !== undefined) {
+      const children = await this.store.listOwnedBy(node.uid);
+      actions = planOwnerDeletion(node, children);
+    } else {
+      actions = planDanglingChild(node, await this.ownerExists(node));
+    }
+
+    for (const action of actions) {
+      try {
+        await this.execute(action);
+        this.onAction?.(action);
+        // Promptly re-reconcile the touched node so multi-step convergence
+        // (mark → reap, orphan → remove-finalizer → reap) does not wait for
+        // the next resync.
+        this.enqueue(action.ref);
+      } catch (error) {
+        if (error instanceof NodeVanished) continue;
+        throw error;
+      }
+    }
+  }
+
+  start(): void {
+    if (this.running) return;
+    if (this.stopRequested) throw new QueueClosedError();
+    this.running = true;
+    this.stopRequested = false;
+    for (let i = 0; i < this.workerCount; i += 1) {
+      this.workers.push(this.workerLoop());
+    }
+    this.resyncTimer = setInterval(() => {
+      void this.resync().catch((error: unknown) => this.reportError(error, "__resync__"));
+    }, this.resyncIntervalMs);
+    this.resyncTimer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running && this.stopRequested) return;
+    this.stopRequested = true;
+    if (this.resyncTimer !== undefined) {
+      clearInterval(this.resyncTimer);
+      this.resyncTimer = undefined;
+    }
+    this.queue.close();
+    const workers = this.workers;
+    this.workers = [];
+    await Promise.all(workers);
+    this.running = false;
+  }
+
+  private async workerLoop(): Promise<void> {
+    while (!this.stopRequested) {
+      let item: WorkItemResult;
+      try {
+        item = await this.queue.take();
+      } catch (error) {
+        if (this.stopRequested) return;
+        throw error;
+      }
+      try {
+        await this.reconcileNode(parseGcKey(item.key));
+        this.queue.acknowledge(item.key);
+      } catch (error) {
+        if (!this.stopRequested) this.queue.retry(item.key);
+        this.reportError(error, item.key);
+      }
+    }
+  }
+
+  private async ownerExists(node: GcNode): Promise<boolean> {
+    const controller = node.ownerRefs.find((ref) => ref.controller === true);
+    if (controller === undefined) return true; // not a dangling candidate
+    const owner = await this.store.getNode({ kind: controller.kind, id: controller.id });
+    return owner !== undefined && owner.uid === controller.uid;
+  }
+
+  private async execute(action: GcAction): Promise<void> {
+    const nowIso = new Date(this.now()).toISOString();
+    await this.casMutate(action.ref, (opts) => {
+      switch (action.type) {
+        case "mark-deletion":
+          return this.store.setDeletionTimestamp(action.ref, nowIso, opts);
+        case "orphan":
+          return this.store.removeOwnerRef(action.ref, action.ownerUid, opts);
+        case "remove-finalizer":
+          return this.store.removeFinalizer(action.ref, action.finalizer, opts);
+        case "reap":
+          return this.store.reap(action.ref, opts);
+      }
+    });
+  }
+
+  private async casMutate(
+    ref: GcRef,
+    patch: (opts: CasOpts) => Promise<CasMutationResult<GcNode>>,
+  ): Promise<void> {
+    await withIfMatch<GcNode>(
+      async () => {
+        const cur = await this.store.getNode(ref);
+        if (cur === undefined) throw new NodeVanished();
+        return { resourceVersion: cur.resourceVersion };
+      },
+      (opts) => patch({ ifMatch: opts.ifMatch }),
+    );
+  }
+
+  private reportError(error: unknown, key: string): void {
+    try {
+      this.onError?.(error, key);
+    } catch {
+      return;
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck the new module compiles**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS (no errors in `garbage-collector.ts`; the file is unused so far, which is fine).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/garbage-collector.ts
+git commit --no-verify -m "feat(#306): GcStore interface + GarbageCollector reconcile loop"
+```
+
+---
+
+## Task 4: In-memory GcStore + cascade acceptance tests
+
+**Files:**
+- Create: `src/core/in-memory-gc-store.ts`
+- Test: `src/core/garbage-collector.test.ts`
+
+- [ ] **Step 1: Write the in-memory store**
+
+Create `src/core/in-memory-gc-store.ts`:
+
+```ts
+import { type CasMismatchResult, type CasMutationResult, type CasOpts } from "./cas.js";
+import type { GcStore } from "./garbage-collector.js";
+import { gcKey } from "./garbage-collector.js";
+import type { GcNode, GcRef } from "./owner-graph.js";
+
+interface MutableNode {
+  kind: GcNode["kind"];
+  id: string;
+  uid: string;
+  rv: number;
+  ownerRefs: GcNode["ownerRefs"];
+  finalizers: string[];
+  deletionTimestamp?: string | undefined;
+}
+
+function toGcNode(n: MutableNode): GcNode {
+  return {
+    kind: n.kind,
+    id: n.id,
+    uid: n.uid,
+    resourceVersion: String(n.rv),
+    ownerRefs: n.ownerRefs,
+    finalizers: [...n.finalizers],
+    deletionTimestamp: n.deletionTimestamp,
+  };
+}
+
+/** In-memory GcStore holding nodes of every kind. For tests/fixtures only. */
+export class InMemoryGcStore implements GcStore {
+  private readonly nodes = new Map<string, MutableNode>();
+
+  /** Seed a node. Returns the key. */
+  put(node: Omit<GcNode, "resourceVersion"> & { resourceVersion?: string }): void {
+    this.nodes.set(gcKey(node), {
+      kind: node.kind,
+      id: node.id,
+      uid: node.uid,
+      rv: node.resourceVersion === undefined ? 1 : Number(node.resourceVersion),
+      ownerRefs: node.ownerRefs,
+      finalizers: [...node.finalizers],
+      deletionTimestamp: node.deletionTimestamp,
+    });
+  }
+
+  has(ref: GcRef): boolean {
+    return this.nodes.has(gcKey(ref));
+  }
+
+  async getNode(ref: GcRef): Promise<GcNode | undefined> {
+    const n = this.nodes.get(gcKey(ref));
+    return n === undefined ? undefined : toGcNode(n);
+  }
+
+  async listPendingDeletion(): Promise<readonly GcNode[]> {
+    return [...this.nodes.values()].filter((n) => n.deletionTimestamp !== undefined).map(toGcNode);
+  }
+
+  async listOwnedBy(ownerUid: string): Promise<readonly GcNode[]> {
+    return [...this.nodes.values()]
+      .filter((n) => n.ownerRefs.some((r) => r.uid === ownerUid))
+      .map(toGcNode);
+  }
+
+  async setDeletionTimestamp(
+    ref: GcRef,
+    deletionTimestamp: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>> {
+    return this.mutate(ref, opts, (n) => {
+      if (n.deletionTimestamp === undefined) n.deletionTimestamp = deletionTimestamp;
+    });
+  }
+
+  async removeOwnerRef(
+    ref: GcRef,
+    ownerUid: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>> {
+    return this.mutate(ref, opts, (n) => {
+      n.ownerRefs = n.ownerRefs.filter((r) => r.uid !== ownerUid);
+    });
+  }
+
+  async removeFinalizer(
+    ref: GcRef,
+    finalizer: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>> {
+    return this.mutate(ref, opts, (n) => {
+      n.finalizers = n.finalizers.filter((f) => f !== finalizer);
+    });
+  }
+
+  async reap(ref: GcRef, opts?: CasOpts): Promise<CasMutationResult<GcNode>> {
+    const key = gcKey(ref);
+    const n = this.nodes.get(key);
+    if (n === undefined) {
+      // Already gone — surface as a benign mismatch so the loop's getNode
+      // probe (which throws NodeVanished) handles it; never reached in practice
+      // because the loop reads first.
+      return { kind: "rv-mismatch", current: { resourceVersion: "0", generation: 0 } };
+    }
+    const mismatch = this.checkCas(n, opts);
+    if (mismatch !== null) return mismatch;
+    if (n.finalizers.length > 0) {
+      throw new Error(`reap refused: ${key} still has finalizers [${n.finalizers.join(", ")}]`);
+    }
+    const view = toGcNode(n);
+    this.nodes.delete(key);
+    return { kind: "ok", view };
+  }
+
+  private mutate(
+    ref: GcRef,
+    opts: CasOpts | undefined,
+    apply: (n: MutableNode) => void,
+  ): CasMutationResult<GcNode> {
+    const n = this.nodes.get(gcKey(ref));
+    if (n === undefined) {
+      return { kind: "rv-mismatch", current: { resourceVersion: "0", generation: 0 } };
+    }
+    const mismatch = this.checkCas(n, opts);
+    if (mismatch !== null) return mismatch;
+    apply(n);
+    n.rv += 1;
+    return { kind: "ok", view: toGcNode(n) };
+  }
+
+  private checkCas(n: MutableNode, opts: CasOpts | undefined): CasMismatchResult | null {
+    if (opts?.ifMatch === undefined) return null;
+    if (opts.ifMatch === String(n.rv)) return null;
+    return { kind: "rv-mismatch", current: { resourceVersion: String(n.rv), generation: n.rv } };
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing acceptance tests**
+
+Create `src/core/garbage-collector.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { GarbageCollector } from "./garbage-collector.js";
+import { InMemoryGcStore } from "./in-memory-gc-store.js";
+import { KindFinalizer, PropagationFinalizer } from "./lifecycle-metadata.js";
+import type { GcRef } from "./owner-graph.js";
+
+const TG: GcRef = { kind: "taskGroup", id: "tg" };
+const A: GcRef = { kind: "agentTask", id: "a" };
+const B: GcRef = { kind: "agentTask", id: "b" };
+
+function controlledByTg(id: string) {
+  return [{ kind: "taskGroup" as const, id: "tg", uid: "u-tg", controller: true }];
+}
+
+/** Drive the loop to convergence: drain the queue by reconciling until empty. */
+async function drain(gc: GarbageCollector, store: InMemoryGcStore, refs: GcRef[]): Promise<void> {
+  // Deterministic manual pump: repeatedly reconcile every still-present ref
+  // plus all pending-deletion nodes until a full pass produces no changes.
+  for (let pass = 0; pass < 50; pass += 1) {
+    const pending = await store.listPendingDeletion();
+    const toVisit = new Map<string, GcRef>();
+    for (const r of refs) toVisit.set(`${r.kind}:${r.id}`, r);
+    for (const n of pending) toVisit.set(`${n.kind}:${n.id}`, { kind: n.kind, id: n.id });
+    for (const ref of toVisit.values()) await gc.reconcileNode(ref);
+  }
+}
+
+describe("cascade: delete TaskGroup", () => {
+  test("Foreground — children marked then reaped, then owner reaped", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [PropagationFinalizer.Foreground],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
+    store.put({ kind: "agentTask", id: "b", uid: "u-b", ownerRefs: controlledByTg("b"), finalizers: [] });
+
+    const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
+    await drain(gc, store, [TG, A, B]);
+
+    expect(store.has(A)).toBe(false);
+    expect(store.has(B)).toBe(false);
+    expect(store.has(TG)).toBe(false);
+  });
+
+  test("Background — owner reaped, children GC'd", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
+
+    const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
+    await drain(gc, store, [TG, A]);
+
+    expect(store.has(TG)).toBe(false);
+    expect(store.has(A)).toBe(false);
+  });
+
+  test("Orphan — children preserved, controller ownerRef stripped, owner reaped", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [PropagationFinalizer.Orphan],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
+
+    const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
+    await drain(gc, store, [TG, A]);
+
+    expect(store.has(TG)).toBe(false);
+    expect(store.has(A)).toBe(true);
+    const a = await store.getNode(A);
+    expect(a?.ownerRefs).toEqual([]); // controller ref stripped, child orphaned
+    expect(a?.deletionTimestamp).toBeUndefined(); // NOT marked for deletion
+  });
+});
+
+describe("finalizer blocks reap", () => {
+  test("AgentTask with pending-review is not reaped until the finalizer is removed", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "agentTask",
+      id: "a",
+      uid: "u-a",
+      ownerRefs: [],
+      finalizers: [KindFinalizer.PendingReview],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+
+    const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
+    await drain(gc, store, [A]);
+    expect(store.has(A)).toBe(true); // blocked
+
+    // Reviewer clears the finalizer.
+    await store.removeFinalizer(A, KindFinalizer.PendingReview);
+    await drain(gc, store, [A]);
+    expect(store.has(A)).toBe(false); // now reaped
+  });
+});
+
+describe("crash recovery", () => {
+  test("partial cascade converges on a fresh reconcile pass", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [PropagationFinalizer.Foreground],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
+
+    // Simulate a crash after only marking the child: do ONE reconcile of TG.
+    const gc1 = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
+    await gc1.reconcileNode(TG);
+    expect((await store.getNode(A))?.deletionTimestamp).toBeDefined();
+    expect(store.has(TG)).toBe(true); // not yet reaped
+
+    // Fresh collector resumes and finishes.
+    const gc2 = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:06.000Z") });
+    await drain(gc2, store, [TG, A]);
+    expect(store.has(A)).toBe(false);
+    expect(store.has(TG)).toBe(false);
+  });
+});
+
+describe("resync enqueues pending + children", () => {
+  test("resync returns the count of pending-deletion owners", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    const gc = new GarbageCollector({ store });
+    expect(await gc.resync()).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `bun test src/core/garbage-collector.test.ts`
+Expected: FAIL — `./in-memory-gc-store.js` / `./garbage-collector.js` resolve, but assertions fail or modules are incomplete if Task 3 was skipped. If Task 3 is committed, expect PASS-or-FAIL per assertion; investigate any FAIL before continuing.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/garbage-collector.test.ts`
+Expected: PASS (all describe blocks). If the Foreground test loops without reaping, confirm `reconcileNode` re-enqueues `action.ref` and `drain` revisits both TG and children.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/in-memory-gc-store.ts src/core/garbage-collector.test.ts
+git commit --no-verify -m "feat(#306): in-memory GcStore + cascade/finalizer/crash acceptance tests"
+```
+
+---
+
+## Task 5: Real AgentTask lifecycle mutators (Sqlite)
+
+**Files:**
+- Modify: `src/core/store.ts:451-493` (`AgentTaskStore` interface)
+- Modify: `src/local/sqlite-store.ts` (`SqliteAgentTaskStore`)
+- Test: `src/local/sqlite-store.test.ts` (append) — confirm the file exists; if not, create it with the import block shown.
+
+- [ ] **Step 1: Extend the `AgentTaskStore` interface**
+
+In `src/core/store.ts`, inside `export interface AgentTaskStore { ... }`, add these methods just before `close(): void;`:
+
+```ts
+  /**
+   * Set `deletionTimestamp` (and optionally seed propagation/kind finalizers)
+   * on the spec row. Idempotent: a second call with deletion already set is a
+   * no-op write that still bumps RV. CAS-aware via `opts.ifMatch` (spec RV).
+   */
+  setAgentTaskDeletion(
+    taskId: string,
+    deletionTimestamp: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>>;
+
+  /** Remove a single finalizer from the spec row. CAS-aware (spec RV). */
+  removeAgentTaskFinalizer(
+    taskId: string,
+    finalizer: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>>;
+
+  /** Remove every ownerRef whose uid === ownerUid from the spec row (orphan). */
+  removeAgentTaskOwnerRef(
+    taskId: string,
+    ownerUid: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>>;
+
+  /**
+   * Hard-delete the spec row (status drops via the FK ON DELETE CASCADE).
+   * MUST throw if the row still has finalizers. CAS-aware (spec RV). Returns
+   * the pre-delete view on success.
+   */
+  reapAgentTask(taskId: string, opts?: CasOpts): Promise<CasMutationResult<AgentTaskView>>;
+```
+
+`CasOpts` and `CasMutationResult` are already imported in `store.ts` (used by `putAgentTaskSpec`). `OwnerRef` is not needed here.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `src/local/sqlite-store.test.ts`. If the file does not yet exist, create it with this header:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { AgentTaskPhase, type AgentTaskSpecRecord } from "../core/agent-task.js";
+import { expectOk } from "../core/cas.js";
+import { KindFinalizer } from "../core/lifecycle-metadata.js";
+import { createSqliteStores } from "./sqlite-store.js";
+```
+
+Add the test block:
+
+```ts
+describe("SqliteAgentTaskStore lifecycle mutators (#306)", () => {
+  function spec(id: string, over: Partial<AgentTaskSpecRecord> = {}): AgentTaskSpecRecord {
+    return {
+      id,
+      worktree: "/wt",
+      runtime: "claude",
+      role: "coder",
+      prompt: "go",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-06-08T00:00:00.000Z",
+      ...over,
+    };
+  }
+
+  test("setAgentTaskDeletion stamps the spec row", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      expectOk(await stores.agentTaskStore.putAgentTaskSpec(spec("t1")));
+      const r = expectOk(
+        await stores.agentTaskStore.setAgentTaskDeletion("t1", "2026-06-08T01:00:00.000Z"),
+      );
+      expect(r.spec.deletionTimestamp).toBe("2026-06-08T01:00:00.000Z");
+    } finally {
+      stores.close();
+    }
+  });
+
+  test("reapAgentTask refuses while finalizers remain, succeeds once cleared", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      expectOk(
+        await stores.agentTaskStore.putAgentTaskSpec(
+          spec("t2", { finalizers: [KindFinalizer.PendingReview] }),
+        ),
+      );
+      expectOk(await stores.agentTaskStore.setAgentTaskDeletion("t2", "2026-06-08T01:00:00.000Z"));
+
+      await expect(stores.agentTaskStore.reapAgentTask("t2")).rejects.toThrow(/finalizer/i);
+
+      expectOk(
+        await stores.agentTaskStore.removeAgentTaskFinalizer("t2", KindFinalizer.PendingReview),
+      );
+      expectOk(await stores.agentTaskStore.reapAgentTask("t2"));
+
+      expect(await stores.agentTaskStore.getAgentTask("t2")).toBeUndefined();
+    } finally {
+      stores.close();
+    }
+  });
+
+  test("removeAgentTaskOwnerRef strips matching refs (orphan)", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      expectOk(
+        await stores.agentTaskStore.putAgentTaskSpec(
+          spec("t3", { ownerRef: { kind: "taskGroup", id: "tg", uid: "u-tg", controller: true } }),
+        ),
+      );
+      const r = expectOk(await stores.agentTaskStore.removeAgentTaskOwnerRef("t3", "u-tg"));
+      expect(r.spec.ownerRef).toBeUndefined();
+    } finally {
+      stores.close();
+    }
+  });
+});
+```
+
+Note on `ownerRef` shape: `AgentTaskSpecRecord.ownerRef` is a single `OwnerRef` (see `src/core/agent-task.ts:43`). `removeAgentTaskOwnerRef` clears it when its uid matches.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `bun test src/local/sqlite-store.test.ts`
+Expected: FAIL — `setAgentTaskDeletion` etc. are not functions on the store.
+
+- [ ] **Step 4: Implement the mutators**
+
+In `src/local/sqlite-store.ts`, inside `class SqliteAgentTaskStore`, add these methods after `patchAgentTaskStatus` (before `listAgentTaskEntities`). They follow the same CAS pattern as `putAgentTaskSpec` (compare against spec `resource_version`, bump it on write):
+
+```ts
+  setAgentTaskDeletion = async (
+    taskId: string,
+    deletionTimestamp: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>> =>
+    this.mutateSpec(taskId, opts, (existing) => {
+      const next = existing.deletionTimestamp ?? deletionTimestamp;
+      this.db
+        .prepare(
+          `UPDATE agent_task_spec
+             SET deletion_timestamp = ?, generation = generation + 1, resource_version = resource_version + 1
+           WHERE id = ?`,
+        )
+        .run(next, taskId);
+    });
+
+  removeAgentTaskFinalizer = async (
+    taskId: string,
+    finalizer: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>> =>
+    this.mutateSpec(taskId, opts, (existing) => {
+      const remaining = (existing.finalizers ?? []).filter((f) => f !== finalizer);
+      this.db
+        .prepare(
+          `UPDATE agent_task_spec
+             SET finalizers_json = ?, generation = generation + 1, resource_version = resource_version + 1
+           WHERE id = ?`,
+        )
+        .run(JSON.stringify(remaining), taskId);
+    });
+
+  removeAgentTaskOwnerRef = async (
+    taskId: string,
+    ownerUid: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>> =>
+    this.mutateSpec(taskId, opts, (existing) => {
+      const cleared = existing.ownerRef !== undefined && existing.ownerRef.uid === ownerUid;
+      this.db
+        .prepare(
+          `UPDATE agent_task_spec
+             SET owner_ref_json = ?, generation = generation + 1, resource_version = resource_version + 1
+           WHERE id = ?`,
+        )
+        .run(cleared ? null : JSON.stringify(existing.ownerRef ?? null), taskId);
+    });
+
+  reapAgentTask = async (
+    taskId: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>> => {
+    let mismatch: CasMutationResult<AgentTaskView> | null = null;
+    let deleted: AgentTaskView | null = null;
+    const tx = this.db.transaction(() => {
+      const existing = this.readAgentTask(taskId);
+      if (existing === null) {
+        throw new NotFoundError({
+          resource: "AgentTask",
+          identifier: taskId,
+          message: `AgentTask '${taskId}' not found`,
+        });
+      }
+      const cas = checkIfMatch(existing.spec.resourceVersion, opts?.ifMatch, existing.spec.generation);
+      if (cas !== null) {
+        mismatch = cas;
+        return;
+      }
+      if ((existing.spec.finalizers ?? []).length > 0) {
+        throw new Error(
+          `reapAgentTask refused: '${taskId}' still has finalizers [${(existing.spec.finalizers ?? []).join(", ")}]`,
+        );
+      }
+      deleted = existing;
+      // agent_task_status drops via FK ON DELETE CASCADE.
+      this.db.prepare("DELETE FROM agent_task_spec WHERE id = ?").run(taskId);
+    });
+    tx.immediate();
+    if (mismatch !== null) return mismatch;
+    if (deleted === null) throw new Error(`reapAgentTask('${taskId}') produced no view`);
+    return { kind: "ok", view: deleted };
+  };
+
+  /** Shared CAS wrapper for spec-row lifecycle edits. */
+  private mutateSpec(
+    taskId: string,
+    opts: CasOpts | undefined,
+    apply: (existing: AgentTaskSpecRecord) => void,
+  ): CasMutationResult<AgentTaskView> {
+    let mismatch: CasMutationResult<AgentTaskView> | null = null;
+    const tx = this.db.transaction(() => {
+      const existing = this.readAgentTask(taskId);
+      if (existing === null) {
+        throw new NotFoundError({
+          resource: "AgentTask",
+          identifier: taskId,
+          message: `AgentTask '${taskId}' not found`,
+        });
+      }
+      const cas = checkIfMatch(existing.spec.resourceVersion, opts?.ifMatch, existing.spec.generation);
+      if (cas !== null) {
+        mismatch = cas;
+        return;
+      }
+      apply(existing.spec);
+    });
+    tx.immediate();
+    if (mismatch !== null) return mismatch;
+    const view = this.readAgentTask(taskId);
+    if (view === null) throw new Error(`Failed to read back agent task '${taskId}'`);
+    this.emitAgentTaskWrite("MODIFIED", view);
+    return { kind: "ok", view };
+  }
+```
+
+`mutateSpec` is synchronous and returns the result directly; the public async methods just `return this.mutateSpec(...)` (a value, auto-wrapped in the returned Promise). `checkIfMatch` and `NotFoundError` are already imported in `sqlite-store.ts` (used by the existing methods). `AgentTaskSpecRecord` is already imported.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test src/local/sqlite-store.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS. Any other `AgentTaskStore` implementor (search `implements AgentTaskStore`) must also gain the four methods; if `bunx tsc` flags one, add the same signatures. (As of this plan, `SqliteAgentTaskStore` is the only implementor.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/store.ts src/local/sqlite-store.ts src/local/sqlite-store.test.ts
+git commit --no-verify -m "feat(#306): AgentTask spec-lifecycle mutators + finalizer-guarded reap (Sqlite)"
+```
+
+---
+
+## Task 6: AgentTaskGcStore adapter + CompositeGcStore + real-store integration
+
+**Files:**
+- Create: `src/core/agent-task-gc-store.ts`
+- Test: `src/core/agent-task-gc-store.test.ts`
+
+- [ ] **Step 1: Write the adapter + composite**
+
+Create `src/core/agent-task-gc-store.ts`:
+
+```ts
+import type { AgentTaskView } from "./agent-task.js";
+import type { CasMutationResult, CasOpts } from "./cas.js";
+import type { GcStore } from "./garbage-collector.js";
+import type { GcNode, GcRef } from "./owner-graph.js";
+import type { AgentTaskStore } from "./store.js";
+
+/** Project an AgentTaskView onto the GcNode lifecycle shape. */
+function taskToGcNode(view: AgentTaskView): GcNode {
+  return {
+    kind: "agentTask",
+    id: view.spec.id,
+    // AgentTask has no separate uid column; its id is its stable identity.
+    uid: view.spec.id,
+    resourceVersion: String(view.spec.resourceVersion ?? view.spec.generation),
+    ownerRefs: view.spec.ownerRef === undefined ? [] : [view.spec.ownerRef],
+    finalizers: view.spec.finalizers ?? [],
+    deletionTimestamp: view.spec.deletionTimestamp,
+  };
+}
+
+function mapResult(r: CasMutationResult<AgentTaskView>): CasMutationResult<GcNode> {
+  return r.kind === "ok" ? { kind: "ok", view: taskToGcNode(r.view) } : r;
+}
+
+/** GcStore scoped to the `agentTask` kind, backed by a real AgentTaskStore. */
+export class AgentTaskGcStore implements GcStore {
+  constructor(private readonly store: AgentTaskStore) {}
+
+  private assertKind(ref: GcRef): void {
+    if (ref.kind !== "agentTask") {
+      throw new Error(`AgentTaskGcStore received non-agentTask ref: ${ref.kind}:${ref.id}`);
+    }
+  }
+
+  async getNode(ref: GcRef): Promise<GcNode | undefined> {
+    if (ref.kind !== "agentTask") return undefined;
+    const view = await this.store.getAgentTask(ref.id);
+    return view === undefined ? undefined : taskToGcNode(view);
+  }
+
+  async listPendingDeletion(): Promise<readonly GcNode[]> {
+    const all = await this.store.listAgentTasks();
+    return all
+      .filter((v) => v.spec.deletionTimestamp !== undefined)
+      .map(taskToGcNode);
+  }
+
+  async listOwnedBy(ownerUid: string): Promise<readonly GcNode[]> {
+    const all = await this.store.listAgentTasks();
+    return all
+      .filter((v) => v.spec.ownerRef !== undefined && v.spec.ownerRef.uid === ownerUid)
+      .map(taskToGcNode);
+  }
+
+  async setDeletionTimestamp(ref: GcRef, ts: string, opts?: CasOpts) {
+    this.assertKind(ref);
+    return mapResult(await this.store.setAgentTaskDeletion(ref.id, ts, opts));
+  }
+
+  async removeOwnerRef(ref: GcRef, ownerUid: string, opts?: CasOpts) {
+    this.assertKind(ref);
+    return mapResult(await this.store.removeAgentTaskOwnerRef(ref.id, ownerUid, opts));
+  }
+
+  async removeFinalizer(ref: GcRef, finalizer: string, opts?: CasOpts) {
+    this.assertKind(ref);
+    return mapResult(await this.store.removeAgentTaskFinalizer(ref.id, finalizer, opts));
+  }
+
+  async reap(ref: GcRef, opts?: CasOpts) {
+    this.assertKind(ref);
+    return mapResult(await this.store.reapAgentTask(ref.id, opts));
+  }
+}
+
+/**
+ * Routes GcStore calls to a per-kind backing store, and fans `listPendingDeletion`
+ * / `listOwnedBy` across all of them. Lets the GarbageCollector span a TaskGroup
+ * owner (one store) and AgentTask children (another) as one logical graph.
+ */
+export class CompositeGcStore implements GcStore {
+  constructor(private readonly byKind: ReadonlyMap<GcRef["kind"], GcStore>) {}
+
+  private route(ref: GcRef): GcStore {
+    const store = this.byKind.get(ref.kind);
+    if (store === undefined) throw new Error(`no GcStore registered for kind ${ref.kind}`);
+    return store;
+  }
+
+  getNode(ref: GcRef) {
+    return this.route(ref).getNode(ref);
+  }
+
+  async listPendingDeletion(): Promise<readonly GcNode[]> {
+    const out: GcNode[] = [];
+    for (const store of this.byKind.values()) out.push(...(await store.listPendingDeletion()));
+    return out;
+  }
+
+  async listOwnedBy(ownerUid: string): Promise<readonly GcNode[]> {
+    const out: GcNode[] = [];
+    for (const store of this.byKind.values()) out.push(...(await store.listOwnedBy(ownerUid)));
+    return out;
+  }
+
+  setDeletionTimestamp(ref: GcRef, ts: string, opts?: CasOpts) {
+    return this.route(ref).setDeletionTimestamp(ref, ts, opts);
+  }
+  removeOwnerRef(ref: GcRef, ownerUid: string, opts?: CasOpts) {
+    return this.route(ref).removeOwnerRef(ref, ownerUid, opts);
+  }
+  removeFinalizer(ref: GcRef, finalizer: string, opts?: CasOpts) {
+    return this.route(ref).removeFinalizer(ref, finalizer, opts);
+  }
+  reap(ref: GcRef, opts?: CasOpts) {
+    return this.route(ref).reap(ref, opts);
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+Create `src/core/agent-task-gc-store.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import type { AgentTaskSpecRecord } from "./agent-task.js";
+import { expectOk } from "./cas.js";
+import { GarbageCollector } from "./garbage-collector.js";
+import { InMemoryGcStore } from "./in-memory-gc-store.js";
+import { KindFinalizer, PropagationFinalizer } from "./lifecycle-metadata.js";
+import type { GcRef } from "./owner-graph.js";
+import { AgentTaskGcStore, CompositeGcStore } from "./agent-task-gc-store.js";
+import { createSqliteStores } from "../local/sqlite-store.js";
+
+function spec(id: string, over: Partial<AgentTaskSpecRecord> = {}): AgentTaskSpecRecord {
+  return {
+    id,
+    worktree: "/wt",
+    runtime: "claude",
+    role: "coder",
+    prompt: "go",
+    dependsOn: [],
+    generation: 1,
+    createdAt: "2026-06-08T00:00:00.000Z",
+    ...over,
+  };
+}
+
+async function drain(gc: GarbageCollector, refs: GcRef[], probe: () => Promise<readonly GcRef[]>) {
+  for (let pass = 0; pass < 50; pass += 1) {
+    const dynamic = await probe();
+    const all = new Map<string, GcRef>();
+    for (const r of [...refs, ...dynamic]) all.set(`${r.kind}:${r.id}`, r);
+    for (const ref of all.values()) await gc.reconcileNode(ref);
+  }
+}
+
+describe("AgentTaskGcStore over real Sqlite", () => {
+  test("pending-review finalizer blocks reap until removed", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      const store = new AgentTaskGcStore(stores.agentTaskStore);
+      expectOk(
+        await stores.agentTaskStore.putAgentTaskSpec(
+          spec("at-1", { finalizers: [KindFinalizer.PendingReview] }),
+        ),
+      );
+      expectOk(await stores.agentTaskStore.setAgentTaskDeletion("at-1", "2026-06-08T01:00:00.000Z"));
+
+      const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T02:00:00.000Z") });
+      const ref: GcRef = { kind: "agentTask", id: "at-1" };
+      await drain(gc, [ref], async () => []);
+      expect(await store.getNode(ref)).toBeDefined(); // blocked
+
+      await store.removeFinalizer(ref, KindFinalizer.PendingReview);
+      await drain(gc, [ref], async () => []);
+      expect(await store.getNode(ref)).toBeUndefined(); // reaped
+    } finally {
+      stores.close();
+    }
+  });
+
+  test("Foreground cascade: delete TaskGroup reaps real AgentTask children", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      // TaskGroup owner lives in-memory; AgentTask children live in Sqlite.
+      const tgStore = new InMemoryGcStore();
+      tgStore.put({
+        kind: "taskGroup",
+        id: "tg",
+        uid: "u-tg",
+        ownerRefs: [],
+        finalizers: [PropagationFinalizer.Foreground],
+        deletionTimestamp: "2026-06-08T00:00:00.000Z",
+      });
+      expectOk(
+        await stores.agentTaskStore.putAgentTaskSpec(
+          spec("at-c", {
+            ownerRef: { kind: "taskGroup", id: "tg", uid: "u-tg", controller: true },
+          }),
+        ),
+      );
+
+      const composite = new CompositeGcStore(
+        new Map([
+          ["taskGroup", tgStore],
+          ["agentTask", new AgentTaskGcStore(stores.agentTaskStore)],
+        ]),
+      );
+      const gc = new GarbageCollector({
+        store: composite,
+        now: () => Date.parse("2026-06-08T03:00:00.000Z"),
+      });
+
+      const tg: GcRef = { kind: "taskGroup", id: "tg" };
+      const child: GcRef = { kind: "agentTask", id: "at-c" };
+      await drain(gc, [tg, child], async () =>
+        (await composite.listPendingDeletion()).map((n) => ({ kind: n.kind, id: n.id })),
+      );
+
+      expect(await stores.agentTaskStore.getAgentTask("at-c")).toBeUndefined(); // child reaped
+      expect(tgStore.has(tg)).toBe(false); // owner reaped
+    } finally {
+      stores.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails (then passes)**
+
+Run: `bun test src/core/agent-task-gc-store.test.ts`
+Expected: FAIL first (module missing), then PASS after Step 1 is in place. If the Foreground cascade test stalls, confirm `CompositeGcStore.listOwnedBy` fans across BOTH kinds so the TaskGroup's AgentTask child is discovered by `u-tg`.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/agent-task-gc-store.ts src/core/agent-task-gc-store.test.ts
+git commit --no-verify -m "feat(#306): AgentTaskGcStore + CompositeGcStore; real-store cascade integration"
+```
+
+---
+
+## Task 7: Exports + server wiring
+
+**Files:**
+- Modify: `src/core/index.ts`
+- Create: `src/server/garbage-collector-wiring.ts`
+- Test: `src/server/garbage-collector-wiring.test.ts`
+
+- [ ] **Step 1: Add core exports**
+
+In `src/core/index.ts`, add these near the other `export ... from` lines (the import-ordering lint sorts them; run biome fix in Step 5). Update the existing `lifecycle-metadata` export line and add the new modules:
+
+```ts
+export type {
+  CascadePolicy,
+  KindFinalizer,
+  OwnerRef,
+  PropagationFinalizer,
+  SessionFinalizer,
+} from "./lifecycle-metadata.js";
+export { KindFinalizer, PropagationFinalizer } from "./lifecycle-metadata.js";
+export type { GcAction, GcNode, GcRef } from "./owner-graph.js";
+export { planDanglingChild, planOwnerDeletion, policyOf, refOf } from "./owner-graph.js";
+export type { GarbageCollectorOptions, GcStore } from "./garbage-collector.js";
+export { GarbageCollector, gcKey, parseGcKey } from "./garbage-collector.js";
+export { InMemoryGcStore } from "./in-memory-gc-store.js";
+export { AgentTaskGcStore, CompositeGcStore } from "./agent-task-gc-store.js";
+```
+
+Note: `KindFinalizer` and `PropagationFinalizer` are exported both as a type and a value (const + derived type sharing the name) — mirror the existing `Finalizer` dual export pattern already in `lifecycle-metadata.ts`. If the existing line only re-exports `OwnerRef`/`SessionFinalizer` as types, keep that and add the value re-export as a separate `export { ... }` line as shown.
+
+- [ ] **Step 2: Write the failing wiring test**
+
+Create `src/server/garbage-collector-wiring.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { GarbageCollector } from "../core/garbage-collector.js";
+import { InMemoryGcStore } from "../core/in-memory-gc-store.js";
+import {
+  createGarbageCollectorWiring,
+  garbageCollectorEnabled,
+} from "./garbage-collector-wiring.js";
+
+describe("garbage-collector-wiring", () => {
+  test("enabled by default, disabled by GROVE_GC=0", () => {
+    expect(garbageCollectorEnabled({})).toBe(true);
+    expect(garbageCollectorEnabled({ GROVE_GC: "0" })).toBe(false);
+    expect(garbageCollectorEnabled({ GROVE_GC: "1" })).toBe(true);
+  });
+
+  test("constructs a GarbageCollector over the supplied store", () => {
+    const wiring = createGarbageCollectorWiring({ store: new InMemoryGcStore(), workerCount: 2 });
+    expect(wiring.collector).toBeInstanceOf(GarbageCollector);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `bun test src/server/garbage-collector-wiring.test.ts`
+Expected: FAIL — module `./garbage-collector-wiring.js` not found.
+
+- [ ] **Step 4: Implement the wiring**
+
+Create `src/server/garbage-collector-wiring.ts`:
+
+```ts
+import { GarbageCollector, type GcStore } from "../core/garbage-collector.js";
+
+export function garbageCollectorEnabled(
+  env: Readonly<Record<string, string | undefined>>,
+): boolean {
+  return env.GROVE_GC !== "0";
+}
+
+export interface GarbageCollectorWiringOptions {
+  readonly store: GcStore;
+  readonly workerCount?: number | undefined;
+  readonly resyncIntervalMs?: number | undefined;
+  readonly onError?: ((error: unknown, key: string) => void) | undefined;
+}
+
+export interface GarbageCollectorWiring {
+  readonly collector: GarbageCollector;
+}
+
+export function createGarbageCollectorWiring(
+  options: GarbageCollectorWiringOptions,
+): GarbageCollectorWiring {
+  const collector = new GarbageCollector({
+    store: options.store,
+    workerCount: options.workerCount,
+    resyncIntervalMs: options.resyncIntervalMs,
+    onError: options.onError,
+  });
+  return { collector };
+}
+```
+
+(Live activation in `serve.ts` — constructing a `CompositeGcStore` from the server's real stores and calling `collector.start()` — is deferred with TaskGroup persistence, per the spec. This module + its test are the seam.)
+
+- [ ] **Step 5: Run tests + biome + typecheck**
+
+Run: `bun test src/server/garbage-collector-wiring.test.ts`
+Expected: PASS.
+
+Run: `bunx @biomejs/biome check --write src/core/index.ts src/server/garbage-collector-wiring.ts`
+Expected: import ordering normalized, no errors. (Targeted biome only — do NOT run repo-wide biome in a worktree; it hangs.)
+
+Run: `bunx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/index.ts src/server/garbage-collector-wiring.ts src/server/garbage-collector-wiring.test.ts
+git commit --no-verify -m "feat(#306): export GC surface + server garbage-collector wiring seam"
+```
+
+---
+
+## Task 8: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `bun test --timeout 60000`
+Expected: PASS — all pre-existing tests plus the new GC tests. If a pre-existing `AgentTaskStore` mock/fake elsewhere fails to compile because it lacks the four new methods, add the four signatures to it (the interface grew). Search: `grep -rl "implements AgentTaskStore" src tests`.
+
+- [ ] **Step 2: Typecheck the whole project**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS (0 errors). This is the `erasableSyntaxOnly` gate that `bun test` does NOT enforce — it must pass before push.
+
+- [ ] **Step 3: Targeted biome on all changed files**
+
+Run: `git diff --name-only main...HEAD -- '*.ts' | xargs bunx @biomejs/biome check --write`
+Expected: no remaining diagnostics. Re-stage any files biome rewrote.
+
+- [ ] **Step 4: Confirm acceptance criteria are demonstrated**
+
+Verify by re-reading the passing tests:
+- **Delete TaskGroup → children cascade** — `garbage-collector.test.ts` (Foreground + Background) and `agent-task-gc-store.test.ts` (Foreground over real Sqlite).
+- **Finalizer blocks deletion until removed** — `garbage-collector.test.ts` (in-memory) + `agent-task-gc-store.test.ts` (real Sqlite, `pending-review`). `MergeTask`/`pending-merge` is the documented follow-up.
+- **Orphan preserves children** — `garbage-collector.test.ts` (Orphan: child kept, ownerRef stripped, not marked).
+
+- [ ] **Step 5: Final commit (if biome restaged anything)**
+
+```bash
+git add -A
+git commit --no-verify -m "chore(#306): biome + final verification pass"
+```
+
+---
+
+## Deviations from the committed spec
+
+Two conscious simplifications vs `docs/superpowers/specs/2026-06-08-...-design.md`, both keeping the acceptance criteria intact:
+
+1. **No standalone `src/core/task-group.ts`.** The spec listed a minimal TaskGroup type + in-memory store. Since `GcNode` already models any lifecycle entity by `kind`, TaskGroup is represented as a `GcNode` of `kind: "taskGroup"` held in `InMemoryGcStore`. This is the "in-memory store as top-level owner" the spec asked for, without a redundant dedicated type. A real `TaskGroup` entity + persistence remains the deferred follow-up.
+2. **`Terminating` condition emission is deferred.** The spec mentioned the GC setting a `Terminating` condition (mirroring `claim-controller`). That requires writing to the AgentTask **status** row (conditions live there, not on the spec lifecycle fields the GC owns), expanding the `GcStore` surface. None of the issue's acceptance criteria require it, so it is moved to the follow-up. The GC's observable signal in this issue is the `deletionTimestamp` + finalizer state on the spec row.
+
+## Notes for the implementer
+
+- **Worktree hazards** (from project memory): repo-wide biome and the pre-commit lefthook hook HANG in worktrees. Use targeted biome on changed files only and `git commit --no-verify`. A fresh worktree may need `bun install` before `build` succeeds (not required for `bun test`/`tsc`).
+- **CAS pattern**: every store mutator compares `opts.ifMatch` against the spec `resource_version` and bumps it on write. The loop's `withIfMatch` reads the node's `resourceVersion`, so the value the store compares MUST equal `GcNode.resourceVersion` (the spec RV for AgentTask). Keep these consistent or CAS retries will livelock.
+- **Idempotency is the invariant**: every plan function returns `[]` on a converged snapshot. If a test loops without terminating, a plan is emitting an action that doesn't change state — fix the plan, not the loop bound.
+- **Do not** wire `collector.start()` into `serve.ts` in this issue; TaskGroup has no persistence yet, so a live GC would have no real owners to act on. The wiring seam (Task 7) is the handoff point for the follow-up.

--- a/docs/superpowers/specs/2026-06-08-ownerrefs-finalizers-cascade-gc-design.md
+++ b/docs/superpowers/specs/2026-06-08-ownerrefs-finalizers-cascade-gc-design.md
@@ -1,0 +1,233 @@
+# Design: OwnerRefs + Finalizers + Cascade GC (#306)
+
+**Issue**: [#306](https://github.com/windoliver/grove/issues/306) — D5 of Epic D (#285, Orchestration: Controllers + Scheduler + GC)
+**Depends on**: #287 (Entity envelope, CLOSED), #299 (Task controller, CLOSED)
+**Reference**: `kubernetes/pkg/controller/garbagecollector/garbagecollector.go`
+**Date**: 2026-06-08
+
+## Goal
+
+A Kubernetes-style garbage collector for Grove's entity hierarchy: owner references
+link parents to children, finalizers gate hard deletion until preconditions are met,
+and a cascade policy (`Foreground` / `Background` / `Orphan`) decides what happens to
+children when an owner is deleted.
+
+## Scope
+
+This issue builds the **GC mechanism** and proves it end-to-end on the entity types
+that already exist (`AgentTask`, `AgentSession`), plus a minimal `TaskGroup` owner.
+
+### In scope (real, tested)
+
+1. `OwnerRef` extension: `controller?: boolean` flag + new kinds `taskGroup` / `agentTask`.
+2. Finalizer + propagation-finalizer + `CascadePolicy` constants.
+3. `owner-graph.ts` — pure cascade/reap decision core (no I/O).
+4. `garbage-collector.ts` — reconcile loop + segregated `GcStore` interface.
+5. In-memory `GcStore` implementation + conformance covering all acceptance criteria.
+6. `AgentTask` real-store spec-lifecycle mutators (Sqlite) + an `AgentTaskGcStore` adapter,
+   with an integration test proving `pending-review` blocks reap and cascade marks real rows.
+7. Minimal `TaskGroup` model + in-memory store as the top-level owner.
+
+### Deferred to follow-up issues (mechanism ready, drops in trivially)
+
+- `MergeTask` entity + store + `grove.dev/pending-merge` finalizer.
+- `TaskGroup` persistence in SQLite / Nexus.
+- Live server-side GC activation in `serve.ts`.
+- TUI surfacing of the `Terminating` condition.
+
+The finalizer-blocking mechanism is fully generic. The acceptance line "MergeTask with
+`pending-merge` finalizer cannot be deleted until finalizer removed" is proven by the
+identical `AgentTask` + `pending-review` path; `MergeTask` is then one constant + one
+finalizer assignment away.
+
+## Background — current state
+
+- **Entity envelope** (`src/core/entity.ts`) already carries `metadata.ownerRefs`,
+  `metadata.finalizers`, `metadata.deletionTimestamp`.
+- **`OwnerRef`** (`src/core/lifecycle-metadata.ts`) is today `{ kind: "session" | "claim", id, uid }`
+  — no `controller` flag, no task kinds.
+- **`claim-controller.ts`** already reconciles `deletionTimestamp` + finalizers into a
+  `Terminating` condition. This is the idiom the GC loop mirrors.
+- **`SqliteAgentTaskStore`** (`src/local/sqlite-store.ts`): the `agent_task_spec` table
+  already has `owner_ref_json`, `finalizers_json`, `deletion_timestamp` columns, and
+  `agent_task_status` has `FOREIGN KEY (id) REFERENCES agent_task_spec(id) ON DELETE CASCADE`.
+  So lifecycle mutators + a reap need **no schema migration**.
+- AgentTask's only concrete store is server-side `SqliteAgentTaskStore` (TUI/CLI reach it
+  over HTTP routes), so the GC is a **server-side controller**, exactly like `task-controller`.
+- No `TaskGroup` or `MergeTask` concept exists anywhere yet.
+
+## Architecture
+
+Faithful to the Kubernetes GC split: a **GC controller** that walks owner references and
+propagates deletion per cascade policy, and **finalizers** that block hard deletion until
+the responsible party clears its precondition. Cascade policy is encoded as a propagation
+finalizer placed on the *owner* at delete time (k8s records `foregroundDeletion` / `orphan`
+the same way), so the policy survives restarts and is reconstructable from store state.
+
+### A. Data model — `src/core/lifecycle-metadata.ts`
+
+```ts
+export type OwnerKind = "session" | "claim" | "taskGroup" | "agentTask";
+export interface OwnerRef {
+  readonly kind: OwnerKind;
+  readonly id: string;
+  readonly uid: string;
+  readonly controller?: boolean | undefined;   // k8s controller:true — the managing owner
+}
+
+export const KindFinalizer = {
+  PendingReview: "grove.dev/pending-review",   // on AgentTask
+  PendingMerge:  "grove.dev/pending-merge",    // on MergeTask (defined now, applied in follow-up)
+} as const;
+
+export const PropagationFinalizer = {           // placed on the OWNER at delete time
+  Foreground: "grove.dev/foreground-deletion",
+  Orphan:     "grove.dev/orphan",
+} as const;
+
+export type CascadePolicy = "Foreground" | "Background" | "Orphan";
+```
+
+- `ownerRefsEqual` stays UID-based — the `controller` flag is metadata, not identity.
+- New finalizers use the `grove.dev/` prefix per the issue. Existing `grove.io/*` session
+  finalizers are untouched (documented divergence; not unified in this issue).
+- Simplification vs k8s: every `controller` ownerRef is treated as blocking under
+  Foreground (k8s gates on a per-ref `blockOwnerDeletion`). The flag can be added later
+  without changing the plan shape.
+
+### B. Pure core — `src/core/owner-graph.ts`
+
+No async, no store access — pure functions over snapshots, so cascade logic is
+adversarially unit-testable in isolation.
+
+```ts
+interface GcNode {
+  readonly kind: OwnerKind;
+  readonly id: string;
+  readonly uid: string;
+  readonly ownerRefs: readonly OwnerRef[];
+  readonly finalizers: readonly string[];
+  readonly deletionTimestamp?: string | undefined;
+}
+
+interface GcRef { readonly kind: OwnerKind; readonly id: string; }
+
+type GcAction =
+  | { readonly kind: "delete-child";    readonly ref: GcRef }                         // set child.deletionTimestamp
+  | { readonly kind: "orphan-child";    readonly ref: GcRef; readonly ownerUid: string } // strip controller ownerRef
+  | { readonly kind: "remove-finalizer"; readonly ref: GcRef; readonly finalizer: string } // drop owner propagation finalizer
+  | { readonly kind: "reap";            readonly ref: GcRef };                         // hard-delete (finalizers empty)
+
+// Derived from which propagation finalizer the owner carries.
+function policyOf(owner: GcNode): CascadePolicy;
+
+// One idempotent reconcile step for an owner that has a deletionTimestamp.
+function planOwnerDeletion(owner: GcNode, children: readonly GcNode[]): readonly GcAction[];
+
+// GC backstop: a child whose controller owner UID no longer exists.
+function planDanglingChild(child: GcNode, ownerExists: boolean): readonly GcAction[];
+```
+
+Policy semantics:
+
+- **Foreground**: emit `delete-child` for every blocking child not yet marked. Owner stays
+  `Terminating`. Once all blocking children are gone, emit `remove-finalizer(Foreground)`,
+  then (finalizers empty) `reap(owner)`.
+- **Background**: `reap(owner)` immediately (no blocking propagation finalizer present);
+  children are deleted asynchronously by their own dangling-child reconciles.
+- **Orphan**: emit `orphan-child` for each child still carrying the owner's controller ref.
+  Once none remain, `remove-finalizer(Orphan)`, then `reap(owner)`.
+
+`reap` is **only** emitted when `deletionTimestamp` is set **and** `finalizers` is empty —
+so `pending-review` / `pending-merge` block it regardless of cascade progress. All plans are
+idempotent: re-running against a converged snapshot yields `[]`.
+
+### C. GC loop — `src/core/garbage-collector.ts`
+
+Same skeleton as `task-controller` / `claim-controller`: `KeyedWorkQueue`, `resync()`,
+`workerLoop`, CAS writes via `withIfMatch`, `onError` / `onTransition` hooks,
+`resyncIntervalMs` / `workerCount` validation. GC depends on a **segregated** interface,
+not the full `AgentTaskStore`:
+
+```ts
+interface GcStore {
+  listPendingDeletion(): Promise<readonly GcNode[]>;          // deletionTimestamp set
+  listOwnedBy(ownerUid: string): Promise<readonly GcNode[]>;
+  getNode(ref: GcRef): Promise<GcNode | undefined>;
+  setDeletionTimestamp(ref: GcRef, ts: string, opts?: CasOpts): Promise<void>;
+  removeOwnerRef(ref: GcRef, ownerUid: string, opts?: CasOpts): Promise<void>;
+  removeFinalizer(ref: GcRef, finalizer: string, opts?: CasOpts): Promise<void>;
+  reap(ref: GcRef, opts?: CasOpts): Promise<void>;            // asserts finalizers empty
+}
+```
+
+`reconcileNode(ref)`:
+1. Read the node; if missing, done.
+2. If it has a `deletionTimestamp`: read children via `listOwnedBy(uid)`, run
+   `planOwnerDeletion`, execute each action through CAS.
+3. Else if it is a child whose controller owner is gone: run `planDanglingChild` → delete.
+4. Set/refresh a `Terminating` condition (reusing the claim-controller condition shape)
+   where applicable.
+
+`resync()` enqueues every pending-deletion node plus children of pending-deletion owners, so
+a controller killed mid-cascade converges on the next resync.
+
+### D. Store integration
+
+- **AgentTask (real):** add to `AgentTaskStore` + `SqliteAgentTaskStore`:
+  `setAgentTaskDeletion`, `removeAgentTaskFinalizer`, `removeAgentTaskOwnerRef`,
+  `reapAgentTask` (hard-delete the spec row; status drops via the existing FK cascade).
+  No schema migration. `src/core/agent-task-gc-store.ts` adapts these to `GcStore`.
+- **TaskGroup (minimal):** `src/core/task-group.ts` — a `TaskGroup` type +
+  in-memory store holding `{ id, uid, finalizers, deletionTimestamp }`, enough to own
+  AgentTasks and be deleted. A combined `GcStore` spans TaskGroup (owner) + AgentTask (children).
+
+### E. Error handling & concurrency
+
+- Every mutating action is a CAS write (`withIfMatch`); on RV mismatch the work item is
+  retried (same `KeyedWorkQueue.retry` path as the existing controllers).
+- A vanished node mid-cascade is a no-op (idempotent plans tolerate partial progress).
+- `reap` re-asserts finalizers-empty at the store layer; a concurrent finalizer add
+  between plan and execute fails CAS and re-reconciles rather than deleting a still-gated row.
+- `onError` swallows callback throws (mirrors existing controllers).
+
+### F. Testing
+
+- `owner-graph.test.ts` — pure: all three cascade policies; dangling-ref detection; reap
+  gating by finalizer; 3-level `TaskGroup → AgentTask → AgentSession`; idempotency
+  (converged snapshot → `[]`).
+- `garbage-collector.test.ts` — loop over in-memory `GcStore`:
+  - **Delete TaskGroup → children cascade** (Foreground marks-then-reaps; Background reaps
+    owner first then children; **Orphan preserves children and strips the controller ownerRef**).
+  - **Finalizer blocks reap** until removed (`pending-review`).
+  - **Kill mid-cascade → converges** on next `resync()`.
+  - **CAS-conflict retry**.
+- AgentTask integration over the real `SqliteAgentTaskStore`: `pending-review` blocks
+  `reapAgentTask`; cascade marks real rows; reap drops spec + status (FK cascade).
+
+### G. Wiring & files
+
+**New:** `src/core/owner-graph.ts` (+test), `src/core/garbage-collector.ts` (+test),
+`src/core/task-group.ts`, `src/core/agent-task-gc-store.ts` (+test),
+`src/server/garbage-collector-wiring.ts` (+test, mirrors `task-controller-wiring.ts`).
+
+**Edited:** `src/core/lifecycle-metadata.ts`, `src/core/store.ts`, `src/local/sqlite-store.ts`,
+`src/core/index.ts`.
+
+Live `serve.ts` activation is deferred together with TaskGroup persistence.
+
+## Acceptance criteria mapping
+
+| Acceptance (issue #306) | Covered by |
+| --- | --- |
+| Delete TaskGroup → children cascade | D + E (garbage-collector.test: Foreground/Background) |
+| MergeTask `pending-merge` finalizer blocks deletion until removed | Generic finalizer gate proven via AgentTask `pending-review` (E); `MergeTask`/`pending-merge` = documented follow-up |
+| Orphan mode preserves children on parent delete | owner-graph + garbage-collector.test (Orphan path) |
+
+## Out of scope / follow-ups
+
+- `MergeTask` entity, store, and `grove.dev/pending-merge` wiring.
+- `TaskGroup` persistence (SQLite/Nexus) and live server-side GC activation.
+- Per-ref `blockOwnerDeletion` granularity (all controller refs block under Foreground for now).
+- TUI rendering of `Terminating`.
+- Unifying the legacy `grove.io/*` session finalizer prefix with `grove.dev/*`.

--- a/src/core/agent-task-gc-store.test.ts
+++ b/src/core/agent-task-gc-store.test.ts
@@ -103,4 +103,48 @@ describe("AgentTaskGcStore over real Sqlite", () => {
       stores.close();
     }
   });
+
+  test("Background cascade: delete TaskGroup reaps owner immediately and GC's its real AgentTask child", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      const tgStore = new InMemoryGcStore();
+      tgStore.put({
+        kind: "taskGroup",
+        id: "tg-bg",
+        uid: "u-tg-bg",
+        ownerRefs: [],
+        finalizers: [], // no propagation finalizer → Background policy
+        deletionTimestamp: "2026-06-08T00:00:00.000Z",
+      });
+      expectOk(
+        await stores.agentTaskStore.putAgentTaskSpec(
+          spec("at-bg", {
+            ownerRef: { kind: "taskGroup", id: "tg-bg", uid: "u-tg-bg", controller: true },
+          }),
+        ),
+      );
+
+      const composite = new CompositeGcStore(
+        new Map<GcRef["kind"], GcStore>([
+          ["taskGroup", tgStore],
+          ["agentTask", new AgentTaskGcStore(stores.agentTaskStore)],
+        ]),
+      );
+      const gc = new GarbageCollector({
+        store: composite,
+        now: () => Date.parse("2026-06-08T03:00:00.000Z"),
+      });
+
+      const tg: GcRef = { kind: "taskGroup", id: "tg-bg" };
+      const child: GcRef = { kind: "agentTask", id: "at-bg" };
+      await drain(gc, [tg, child], async () =>
+        (await composite.listPendingDeletion()).map((n) => ({ kind: n.kind, id: n.id })),
+      );
+
+      expect(tgStore.has(tg)).toBe(false); // owner reaped (Background = immediate)
+      expect(await stores.agentTaskStore.getAgentTask("at-bg")).toBeUndefined(); // child GC'd
+    } finally {
+      stores.close();
+    }
+  });
 });

--- a/src/core/agent-task-gc-store.test.ts
+++ b/src/core/agent-task-gc-store.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { createSqliteStores } from "../local/sqlite-store.js";
+import type { AgentTaskSpecRecord } from "./agent-task.js";
+import { AgentTaskGcStore, CompositeGcStore } from "./agent-task-gc-store.js";
+import { expectOk } from "./cas.js";
+import type { GcStore } from "./garbage-collector.js";
+import { GarbageCollector } from "./garbage-collector.js";
+import { InMemoryGcStore } from "./in-memory-gc-store.js";
+import { KindFinalizer, PropagationFinalizer } from "./lifecycle-metadata.js";
+import type { GcRef } from "./owner-graph.js";
+
+function spec(id: string, over: Partial<AgentTaskSpecRecord> = {}): AgentTaskSpecRecord {
+  return {
+    id,
+    worktree: "/wt",
+    runtime: "claude",
+    role: "coder",
+    prompt: "go",
+    dependsOn: [],
+    generation: 1,
+    createdAt: "2026-06-08T00:00:00.000Z",
+    ...over,
+  };
+}
+
+async function drain(gc: GarbageCollector, refs: GcRef[], probe: () => Promise<readonly GcRef[]>) {
+  for (let pass = 0; pass < 50; pass += 1) {
+    const dynamic = await probe();
+    const all = new Map<string, GcRef>();
+    for (const r of [...refs, ...dynamic]) all.set(`${r.kind}:${r.id}`, r);
+    for (const ref of all.values()) await gc.reconcileNode(ref);
+  }
+}
+
+describe("AgentTaskGcStore over real Sqlite", () => {
+  test("pending-review finalizer blocks reap until removed", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      const store = new AgentTaskGcStore(stores.agentTaskStore);
+      expectOk(
+        await stores.agentTaskStore.putAgentTaskSpec(
+          spec("at-1", { finalizers: [KindFinalizer.PendingReview] }),
+        ),
+      );
+      expectOk(
+        await stores.agentTaskStore.setAgentTaskDeletion("at-1", "2026-06-08T01:00:00.000Z"),
+      );
+
+      const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T02:00:00.000Z") });
+      const ref: GcRef = { kind: "agentTask", id: "at-1" };
+      await drain(gc, [ref], async () => []);
+      expect(await store.getNode(ref)).toBeDefined(); // blocked
+
+      await store.removeFinalizer(ref, KindFinalizer.PendingReview);
+      await drain(gc, [ref], async () => []);
+      expect(await store.getNode(ref)).toBeUndefined(); // reaped
+    } finally {
+      stores.close();
+    }
+  });
+
+  test("Foreground cascade: delete TaskGroup reaps real AgentTask children", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      // TaskGroup owner lives in-memory; AgentTask children live in Sqlite.
+      const tgStore = new InMemoryGcStore();
+      tgStore.put({
+        kind: "taskGroup",
+        id: "tg",
+        uid: "u-tg",
+        ownerRefs: [],
+        finalizers: [PropagationFinalizer.Foreground],
+        deletionTimestamp: "2026-06-08T00:00:00.000Z",
+      });
+      expectOk(
+        await stores.agentTaskStore.putAgentTaskSpec(
+          spec("at-c", {
+            ownerRef: { kind: "taskGroup", id: "tg", uid: "u-tg", controller: true },
+          }),
+        ),
+      );
+
+      const composite = new CompositeGcStore(
+        new Map<GcRef["kind"], GcStore>([
+          ["taskGroup", tgStore],
+          ["agentTask", new AgentTaskGcStore(stores.agentTaskStore)],
+        ]),
+      );
+      const gc = new GarbageCollector({
+        store: composite,
+        now: () => Date.parse("2026-06-08T03:00:00.000Z"),
+      });
+
+      const tg: GcRef = { kind: "taskGroup", id: "tg" };
+      const child: GcRef = { kind: "agentTask", id: "at-c" };
+      await drain(gc, [tg, child], async () =>
+        (await composite.listPendingDeletion()).map((n) => ({ kind: n.kind, id: n.id })),
+      );
+
+      expect(await stores.agentTaskStore.getAgentTask("at-c")).toBeUndefined(); // child reaped
+      expect(tgStore.has(tg)).toBe(false); // owner reaped
+    } finally {
+      stores.close();
+    }
+  });
+});

--- a/src/core/agent-task-gc-store.ts
+++ b/src/core/agent-task-gc-store.ts
@@ -9,8 +9,16 @@ function taskToGcNode(view: AgentTaskView): GcNode {
   return {
     kind: "agentTask",
     id: view.spec.id,
-    // AgentTask has no separate uid column; its id is its stable identity.
+    // AgentTask has no separate uid column; its id is its stable, immutable primary
+    // key that is never reused — so it is safe to use as the GC identity and as the
+    // target of ownerRef.uid references.
     uid: view.spec.id,
+    // `spec.resourceVersion` is the persisted `resource_version` column, always set
+    // for rows created/touched after migration v16 — so it matches what the store's
+    // checkIfMatch compares (String(spec.resource_version)). The `generation`
+    // fallback only covers legacy pre-v16 rows, which the v16 migration initializes
+    // to MAX(generation,1), keeping the values aligned. So the GC's CAS ifMatch
+    // round-trip agrees in practice.
     resourceVersion: String(view.spec.resourceVersion ?? view.spec.generation),
     ownerRefs: view.spec.ownerRef === undefined ? [] : [view.spec.ownerRef],
     finalizers: view.spec.finalizers ?? [],
@@ -35,12 +43,14 @@ export class AgentTaskGcStore implements GcStore {
     }
   }
 
+  // Soft-return (not assertKind-throw) because the GC's ownerExists probe may getNode across kinds; CompositeGcStore.route() already gates wrong-kind mutators.
   async getNode(ref: GcRef): Promise<GcNode | undefined> {
     if (ref.kind !== "agentTask") return undefined;
     const view = await this.store.getAgentTask(ref.id);
     return view === undefined ? undefined : taskToGcNode(view);
   }
 
+  // TODO: these full-scan listAgentTasks() then filter in memory; push the filter into AgentTaskQuery (WHERE deletion_timestamp IS NOT NULL / owner uid) when the store query supports it, to avoid O(tasks) scans per resync.
   async listPendingDeletion(): Promise<readonly GcNode[]> {
     const all = await this.store.listAgentTasks();
     return all.filter((v) => v.spec.deletionTimestamp !== undefined).map(taskToGcNode);

--- a/src/core/agent-task-gc-store.ts
+++ b/src/core/agent-task-gc-store.ts
@@ -1,0 +1,138 @@
+import type { AgentTaskView } from "./agent-task.js";
+import type { CasMutationResult, CasOpts } from "./cas.js";
+import type { GcStore } from "./garbage-collector.js";
+import type { GcNode, GcRef } from "./owner-graph.js";
+import type { AgentTaskStore } from "./store.js";
+
+/** Project an AgentTaskView onto the GcNode lifecycle shape. */
+function taskToGcNode(view: AgentTaskView): GcNode {
+  return {
+    kind: "agentTask",
+    id: view.spec.id,
+    // AgentTask has no separate uid column; its id is its stable identity.
+    uid: view.spec.id,
+    resourceVersion: String(view.spec.resourceVersion ?? view.spec.generation),
+    ownerRefs: view.spec.ownerRef === undefined ? [] : [view.spec.ownerRef],
+    finalizers: view.spec.finalizers ?? [],
+    deletionTimestamp: view.spec.deletionTimestamp,
+  };
+}
+
+function mapResult(r: CasMutationResult<AgentTaskView>): CasMutationResult<GcNode> {
+  return r.kind === "ok" ? { kind: "ok", view: taskToGcNode(r.view) } : r;
+}
+
+/** GcStore scoped to the `agentTask` kind, backed by a real AgentTaskStore. */
+export class AgentTaskGcStore implements GcStore {
+  private readonly store: AgentTaskStore;
+  constructor(store: AgentTaskStore) {
+    this.store = store;
+  }
+
+  private assertKind(ref: GcRef): void {
+    if (ref.kind !== "agentTask") {
+      throw new Error(`AgentTaskGcStore received non-agentTask ref: ${ref.kind}:${ref.id}`);
+    }
+  }
+
+  async getNode(ref: GcRef): Promise<GcNode | undefined> {
+    if (ref.kind !== "agentTask") return undefined;
+    const view = await this.store.getAgentTask(ref.id);
+    return view === undefined ? undefined : taskToGcNode(view);
+  }
+
+  async listPendingDeletion(): Promise<readonly GcNode[]> {
+    const all = await this.store.listAgentTasks();
+    return all.filter((v) => v.spec.deletionTimestamp !== undefined).map(taskToGcNode);
+  }
+
+  async listOwnedBy(ownerUid: string): Promise<readonly GcNode[]> {
+    const all = await this.store.listAgentTasks();
+    return all
+      .filter((v) => v.spec.ownerRef !== undefined && v.spec.ownerRef.uid === ownerUid)
+      .map(taskToGcNode);
+  }
+
+  async setDeletionTimestamp(
+    ref: GcRef,
+    ts: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>> {
+    this.assertKind(ref);
+    return mapResult(await this.store.setAgentTaskDeletion(ref.id, ts, opts));
+  }
+
+  async removeOwnerRef(
+    ref: GcRef,
+    ownerUid: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>> {
+    this.assertKind(ref);
+    return mapResult(await this.store.removeAgentTaskOwnerRef(ref.id, ownerUid, opts));
+  }
+
+  async removeFinalizer(
+    ref: GcRef,
+    finalizer: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>> {
+    this.assertKind(ref);
+    return mapResult(await this.store.removeAgentTaskFinalizer(ref.id, finalizer, opts));
+  }
+
+  async reap(ref: GcRef, opts?: CasOpts): Promise<CasMutationResult<GcNode>> {
+    this.assertKind(ref);
+    return mapResult(await this.store.reapAgentTask(ref.id, opts));
+  }
+}
+
+/**
+ * Routes GcStore calls to a per-kind backing store, and fans `listPendingDeletion`
+ * / `listOwnedBy` across all of them. Lets the GarbageCollector span a TaskGroup
+ * owner (one store) and AgentTask children (another) as one logical graph.
+ */
+export class CompositeGcStore implements GcStore {
+  private readonly byKind: ReadonlyMap<GcRef["kind"], GcStore>;
+  constructor(byKind: ReadonlyMap<GcRef["kind"], GcStore>) {
+    this.byKind = byKind;
+  }
+
+  private route(ref: GcRef): GcStore {
+    const store = this.byKind.get(ref.kind);
+    if (store === undefined) throw new Error(`no GcStore registered for kind ${ref.kind}`);
+    return store;
+  }
+
+  getNode(ref: GcRef): Promise<GcNode | undefined> {
+    return this.route(ref).getNode(ref);
+  }
+
+  async listPendingDeletion(): Promise<readonly GcNode[]> {
+    const out: GcNode[] = [];
+    for (const store of this.byKind.values()) out.push(...(await store.listPendingDeletion()));
+    return out;
+  }
+
+  async listOwnedBy(ownerUid: string): Promise<readonly GcNode[]> {
+    const out: GcNode[] = [];
+    for (const store of this.byKind.values()) out.push(...(await store.listOwnedBy(ownerUid)));
+    return out;
+  }
+
+  setDeletionTimestamp(ref: GcRef, ts: string, opts?: CasOpts): Promise<CasMutationResult<GcNode>> {
+    return this.route(ref).setDeletionTimestamp(ref, ts, opts);
+  }
+  removeOwnerRef(ref: GcRef, ownerUid: string, opts?: CasOpts): Promise<CasMutationResult<GcNode>> {
+    return this.route(ref).removeOwnerRef(ref, ownerUid, opts);
+  }
+  removeFinalizer(
+    ref: GcRef,
+    finalizer: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>> {
+    return this.route(ref).removeFinalizer(ref, finalizer, opts);
+  }
+  reap(ref: GcRef, opts?: CasOpts): Promise<CasMutationResult<GcNode>> {
+    return this.route(ref).reap(ref, opts);
+  }
+}

--- a/src/core/agent-task.ts
+++ b/src/core/agent-task.ts
@@ -1,5 +1,10 @@
 import type { Condition, Entity } from "./entity.js";
-import type { Finalizer, OwnerRef } from "./lifecycle-metadata.js";
+import type {
+  Finalizer,
+  KindFinalizer,
+  OwnerRef,
+  PropagationFinalizer,
+} from "./lifecycle-metadata.js";
 import type { JsonValue } from "./models.js";
 
 export const AgentTaskPhase = {
@@ -41,7 +46,7 @@ export interface AgentTaskSpecRecord {
   readonly budget?: Readonly<Record<string, JsonValue>> | undefined;
   readonly generation: number;
   readonly ownerRef?: OwnerRef | undefined;
-  readonly finalizers?: readonly Finalizer[] | undefined;
+  readonly finalizers?: readonly (Finalizer | KindFinalizer | PropagationFinalizer)[] | undefined;
   readonly deletionTimestamp?: string | undefined;
   readonly createdAt: string;
   /**

--- a/src/core/entity.ts
+++ b/src/core/entity.ts
@@ -8,7 +8,12 @@
 
 import type { AgentSession } from "./agent-runtime.js";
 import { rvComposite } from "./cas.js";
-import type { Finalizer, OwnerRef } from "./lifecycle-metadata.js";
+import type {
+  Finalizer,
+  KindFinalizer,
+  OwnerRef,
+  PropagationFinalizer,
+} from "./lifecycle-metadata.js";
 import type {
   AgentIdentity,
   Claim,
@@ -50,7 +55,7 @@ export interface EntityMetadata {
   readonly creationTimestamp?: string | undefined;
   readonly labels?: Readonly<Record<string, string>> | undefined;
   readonly ownerRefs?: readonly OwnerRef[] | undefined;
-  readonly finalizers?: readonly Finalizer[] | undefined;
+  readonly finalizers?: readonly (Finalizer | KindFinalizer | PropagationFinalizer)[] | undefined;
   readonly deletionTimestamp?: string | undefined;
 }
 

--- a/src/core/garbage-collector.test.ts
+++ b/src/core/garbage-collector.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { GarbageCollector } from "./garbage-collector.js";
+import { InMemoryGcStore } from "./in-memory-gc-store.js";
+import { KindFinalizer, PropagationFinalizer } from "./lifecycle-metadata.js";
+import type { GcRef } from "./owner-graph.js";
+
+const TG: GcRef = { kind: "taskGroup", id: "tg" };
+const A: GcRef = { kind: "agentTask", id: "a" };
+const B: GcRef = { kind: "agentTask", id: "b" };
+
+function controlledByTg(id: string) {
+  return [{ kind: "taskGroup" as const, id: "tg", uid: "u-tg", controller: true }];
+}
+
+/** Drive the loop to convergence: drain the queue by reconciling until empty. */
+async function drain(gc: GarbageCollector, store: InMemoryGcStore, refs: GcRef[]): Promise<void> {
+  // Deterministic manual pump: repeatedly reconcile every still-present ref
+  // plus all pending-deletion nodes until a full pass produces no changes.
+  for (let pass = 0; pass < 50; pass += 1) {
+    const pending = await store.listPendingDeletion();
+    const toVisit = new Map<string, GcRef>();
+    for (const r of refs) toVisit.set(`${r.kind}:${r.id}`, r);
+    for (const n of pending) toVisit.set(`${n.kind}:${n.id}`, { kind: n.kind, id: n.id });
+    for (const ref of toVisit.values()) await gc.reconcileNode(ref);
+  }
+}
+
+describe("cascade: delete TaskGroup", () => {
+  test("Foreground — children marked then reaped, then owner reaped", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [PropagationFinalizer.Foreground],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
+    store.put({ kind: "agentTask", id: "b", uid: "u-b", ownerRefs: controlledByTg("b"), finalizers: [] });
+
+    const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
+    await drain(gc, store, [TG, A, B]);
+
+    expect(store.has(A)).toBe(false);
+    expect(store.has(B)).toBe(false);
+    expect(store.has(TG)).toBe(false);
+  });
+
+  test("Background — owner reaped, children GC'd", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
+
+    const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
+    await drain(gc, store, [TG, A]);
+
+    expect(store.has(TG)).toBe(false);
+    expect(store.has(A)).toBe(false);
+  });
+
+  test("Orphan — children preserved, controller ownerRef stripped, owner reaped", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [PropagationFinalizer.Orphan],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
+
+    const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
+    await drain(gc, store, [TG, A]);
+
+    expect(store.has(TG)).toBe(false);
+    expect(store.has(A)).toBe(true);
+    const a = await store.getNode(A);
+    expect(a?.ownerRefs).toEqual([]); // controller ref stripped, child orphaned
+    expect(a?.deletionTimestamp).toBeUndefined(); // NOT marked for deletion
+  });
+});
+
+describe("finalizer blocks reap", () => {
+  test("AgentTask with pending-review is not reaped until the finalizer is removed", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "agentTask",
+      id: "a",
+      uid: "u-a",
+      ownerRefs: [],
+      finalizers: [KindFinalizer.PendingReview],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+
+    const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
+    await drain(gc, store, [A]);
+    expect(store.has(A)).toBe(true); // blocked
+
+    // Reviewer clears the finalizer.
+    await store.removeFinalizer(A, KindFinalizer.PendingReview);
+    await drain(gc, store, [A]);
+    expect(store.has(A)).toBe(false); // now reaped
+  });
+});
+
+describe("crash recovery", () => {
+  test("partial cascade converges on a fresh reconcile pass", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [PropagationFinalizer.Foreground],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
+
+    // Simulate a crash after only marking the child: do ONE reconcile of TG.
+    const gc1 = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
+    await gc1.reconcileNode(TG);
+    expect((await store.getNode(A))?.deletionTimestamp).toBeDefined();
+    expect(store.has(TG)).toBe(true); // not yet reaped
+
+    // Fresh collector resumes and finishes.
+    const gc2 = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:06.000Z") });
+    await drain(gc2, store, [TG, A]);
+    expect(store.has(A)).toBe(false);
+    expect(store.has(TG)).toBe(false);
+  });
+});
+
+describe("resync enqueues pending + children", () => {
+  test("resync returns the count of pending-deletion owners", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    const gc = new GarbageCollector({ store });
+    expect(await gc.resync()).toBe(1);
+  });
+});

--- a/src/core/garbage-collector.test.ts
+++ b/src/core/garbage-collector.test.ts
@@ -187,7 +187,7 @@ describe("resync enqueues pending + children", () => {
   });
 });
 
-async function waitUntil(pred: () => boolean, timeoutMs = 5000): Promise<void> {
+async function waitUntil(pred: () => boolean, timeoutMs = 20000): Promise<void> {
   const start = Date.now();
   while (!pred()) {
     if (Date.now() - start > timeoutMs) throw new Error("waitUntil timed out");

--- a/src/core/garbage-collector.test.ts
+++ b/src/core/garbage-collector.test.ts
@@ -36,8 +36,20 @@ describe("cascade: delete TaskGroup", () => {
       finalizers: [PropagationFinalizer.Foreground],
       deletionTimestamp: "2026-06-08T00:00:00.000Z",
     });
-    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
-    store.put({ kind: "agentTask", id: "b", uid: "u-b", ownerRefs: controlledByTg("b"), finalizers: [] });
+    store.put({
+      kind: "agentTask",
+      id: "a",
+      uid: "u-a",
+      ownerRefs: controlledByTg("a"),
+      finalizers: [],
+    });
+    store.put({
+      kind: "agentTask",
+      id: "b",
+      uid: "u-b",
+      ownerRefs: controlledByTg("b"),
+      finalizers: [],
+    });
 
     const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
     await drain(gc, store, [TG, A, B]);
@@ -57,7 +69,13 @@ describe("cascade: delete TaskGroup", () => {
       finalizers: [],
       deletionTimestamp: "2026-06-08T00:00:00.000Z",
     });
-    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
+    store.put({
+      kind: "agentTask",
+      id: "a",
+      uid: "u-a",
+      ownerRefs: controlledByTg("a"),
+      finalizers: [],
+    });
 
     const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
     await drain(gc, store, [TG, A]);
@@ -76,7 +94,13 @@ describe("cascade: delete TaskGroup", () => {
       finalizers: [PropagationFinalizer.Orphan],
       deletionTimestamp: "2026-06-08T00:00:00.000Z",
     });
-    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
+    store.put({
+      kind: "agentTask",
+      id: "a",
+      uid: "u-a",
+      ownerRefs: controlledByTg("a"),
+      finalizers: [],
+    });
 
     const gc = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
     await drain(gc, store, [TG, A]);
@@ -123,7 +147,13 @@ describe("crash recovery", () => {
       finalizers: [PropagationFinalizer.Foreground],
       deletionTimestamp: "2026-06-08T00:00:00.000Z",
     });
-    store.put({ kind: "agentTask", id: "a", uid: "u-a", ownerRefs: controlledByTg("a"), finalizers: [] });
+    store.put({
+      kind: "agentTask",
+      id: "a",
+      uid: "u-a",
+      ownerRefs: controlledByTg("a"),
+      finalizers: [],
+    });
 
     // Simulate a crash after only marking the child: do ONE reconcile of TG.
     const gc1 = new GarbageCollector({ store, now: () => Date.parse("2026-06-08T00:00:05.000Z") });
@@ -152,5 +182,88 @@ describe("resync enqueues pending + children", () => {
     });
     const gc = new GarbageCollector({ store });
     expect(await gc.resync()).toBe(1);
+  });
+});
+
+async function waitUntil(pred: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitUntil timed out");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+describe("real worker loop converges without relying on resync", () => {
+  test("Foreground cascade fully reaps owner + children", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [PropagationFinalizer.Foreground],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    store.put({
+      kind: "agentTask",
+      id: "a",
+      uid: "u-a",
+      ownerRefs: controlledByTg("a"),
+      finalizers: [],
+    });
+    store.put({
+      kind: "agentTask",
+      id: "b",
+      uid: "u-b",
+      ownerRefs: controlledByTg("b"),
+      finalizers: [],
+    });
+
+    // Huge resync interval = periodic resync never fires during the test, so
+    // convergence is driven purely by reconcileNode's re-enqueue logic.
+    const gc = new GarbageCollector({ store, resyncIntervalMs: 2_000_000_000 });
+    gc.start();
+    gc.enqueue(TG);
+    try {
+      await waitUntil(() => !store.has(TG) && !store.has(A) && !store.has(B));
+    } finally {
+      await gc.stop();
+    }
+    expect(store.has(TG)).toBe(false);
+    expect(store.has(A)).toBe(false);
+    expect(store.has(B)).toBe(false);
+  });
+
+  test("Orphan cascade reaps owner, preserves + detaches child", async () => {
+    const store = new InMemoryGcStore();
+    store.put({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      ownerRefs: [],
+      finalizers: [PropagationFinalizer.Orphan],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    store.put({
+      kind: "agentTask",
+      id: "a",
+      uid: "u-a",
+      ownerRefs: controlledByTg("a"),
+      finalizers: [],
+    });
+
+    const gc = new GarbageCollector({ store, resyncIntervalMs: 2_000_000_000 });
+    gc.start();
+    gc.enqueue(TG);
+    try {
+      await waitUntil(() => !store.has(TG));
+    } finally {
+      await gc.stop();
+    }
+    expect(store.has(TG)).toBe(false);
+    expect(store.has(A)).toBe(true);
+    const a = await store.getNode(A);
+    expect(a?.ownerRefs).toEqual([]);
+    expect(a?.deletionTimestamp).toBeUndefined();
   });
 });

--- a/src/core/garbage-collector.test.ts
+++ b/src/core/garbage-collector.test.ts
@@ -8,7 +8,9 @@ const TG: GcRef = { kind: "taskGroup", id: "tg" };
 const A: GcRef = { kind: "agentTask", id: "a" };
 const B: GcRef = { kind: "agentTask", id: "b" };
 
-function controlledByTg(id: string) {
+// The arg labels which child the ownerRef belongs to at the call site; the ref
+// itself always points at the single TaskGroup owner, so the value is unused.
+function controlledByTg(_child: string) {
   return [{ kind: "taskGroup" as const, id: "tg", uid: "u-tg", controller: true }];
 }
 

--- a/src/core/garbage-collector.ts
+++ b/src/core/garbage-collector.ts
@@ -27,7 +27,11 @@ export interface GcStore {
     opts?: CasOpts,
   ): Promise<CasMutationResult<GcNode>>;
   removeOwnerRef(ref: GcRef, ownerUid: string, opts?: CasOpts): Promise<CasMutationResult<GcNode>>;
-  removeFinalizer(ref: GcRef, finalizer: string, opts?: CasOpts): Promise<CasMutationResult<GcNode>>;
+  removeFinalizer(
+    ref: GcRef,
+    finalizer: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>>;
   /** Hard-delete. MUST reject (throw) if the node still has finalizers. */
   reap(ref: GcRef, opts?: CasOpts): Promise<CasMutationResult<GcNode>>;
 }
@@ -93,7 +97,11 @@ export class GarbageCollector {
         `resyncIntervalMs must be a finite positive number no greater than ${MAX_RESYNC_INTERVAL_MS}`,
       );
     }
-    if (!Number.isInteger(this.workerCount) || this.workerCount < 1 || this.workerCount > MAX_WORKER_COUNT) {
+    if (
+      !Number.isInteger(this.workerCount) ||
+      this.workerCount < 1 ||
+      this.workerCount > MAX_WORKER_COUNT
+    ) {
       throw new RangeError(`workerCount must be an integer between 1 and ${MAX_WORKER_COUNT}`);
     }
     this.onError = options.onError;
@@ -105,6 +113,15 @@ export class GarbageCollector {
   }
 
   async resync(): Promise<number> {
+    // NOTE: resync only enqueues pending-deletion owners and their
+    // listOwnedBy children. A *pure dangling child* — controller owner UID
+    // vanished WITHOUT the child being marked for deletion — is not returned by
+    // listOwnedBy (its owner is gone) and GcStore has no list-all method, so
+    // planDanglingChild runs for such nodes only when an external caller
+    // explicitly enqueue()s them. In the normal cascade this is a non-issue:
+    // Background marks children (giving them a deletionTimestamp), so they show
+    // up in listPendingDeletion. A full dangling sweep (listAll /
+    // listDanglingCandidates) is intentionally deferred to a follow-up.
     const pending = await this.store.listPendingDeletion();
     for (const node of pending) {
       this.enqueue(refOf(node));
@@ -126,17 +143,42 @@ export class GarbageCollector {
       actions = planDanglingChild(node, await this.ownerExists(node));
     }
 
+    let actedOnChild = false;
+    let reapedSelf = false;
     for (const action of actions) {
       try {
         await this.execute(action);
         this.onAction?.(action);
-        // Promptly re-reconcile the touched node so multi-step convergence
-        // (mark → reap, orphan → remove-finalizer → reap) does not wait for
-        // the next resync.
+        // Re-drive the action's target so its own next step runs promptly.
         this.enqueue(action.ref);
+        if (action.ref.kind === ref.kind && action.ref.id === ref.id) {
+          if (action.type === "reap") reapedSelf = true;
+        } else {
+          actedOnChild = true;
+        }
       } catch (error) {
         if (error instanceof NodeVanished) continue;
         throw error;
+      }
+    }
+
+    // Cross-level convergence. The per-action re-enqueue above only re-drives the
+    // action's *target*, which is not enough for multi-level cascades:
+    //  (a) If this node (as owner) acted on a child, re-drive THIS node so it
+    //      re-evaluates once the child's state changes — e.g. Orphan: after a
+    //      child's controller ownerRef is stripped, the owner can drop its
+    //      orphan finalizer and reap. Without this, the owner would wait for the
+    //      next resync.
+    //  (b) If this node (as child) reaped itself, re-drive its controller owner
+    //      so the owner observes its shrunken child set (Foreground/Background)
+    //      and can advance to remove-finalizer / reap.
+    // Both terminate: a converged owner emits no actions (no re-enqueue), and a
+    // vanished owner is a benign no-op.
+    if (actedOnChild) this.enqueue(ref);
+    if (reapedSelf) {
+      const controller = node.ownerRefs.find((r) => r.controller === true);
+      if (controller !== undefined) {
+        this.enqueue({ kind: controller.kind, id: controller.id });
       }
     }
   }

--- a/src/core/garbage-collector.ts
+++ b/src/core/garbage-collector.ts
@@ -1,0 +1,235 @@
+import type { CasMutationResult, CasOpts } from "./cas.js";
+import {
+  type GcAction,
+  type GcNode,
+  type GcRef,
+  planDanglingChild,
+  planOwnerDeletion,
+  refOf,
+} from "./owner-graph.js";
+import { withIfMatch } from "./with-if-match.js";
+import { KeyedWorkQueue, QueueClosedError, type WorkItemResult } from "./workqueue.js";
+
+/**
+ * Segregated store surface the GarbageCollector depends on. Concrete stores
+ * (in-memory fixture, AgentTask adapter, composite) implement it. Mutators are
+ * CAS-aware and return the post-write node so the loop can thread retries.
+ */
+export interface GcStore {
+  getNode(ref: GcRef): Promise<GcNode | undefined>;
+  /** All nodes that currently have a deletionTimestamp set. */
+  listPendingDeletion(): Promise<readonly GcNode[]>;
+  /** All nodes carrying any ownerRef whose uid === ownerUid. */
+  listOwnedBy(ownerUid: string): Promise<readonly GcNode[]>;
+  setDeletionTimestamp(
+    ref: GcRef,
+    deletionTimestamp: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>>;
+  removeOwnerRef(ref: GcRef, ownerUid: string, opts?: CasOpts): Promise<CasMutationResult<GcNode>>;
+  removeFinalizer(ref: GcRef, finalizer: string, opts?: CasOpts): Promise<CasMutationResult<GcNode>>;
+  /** Hard-delete. MUST reject (throw) if the node still has finalizers. */
+  reap(ref: GcRef, opts?: CasOpts): Promise<CasMutationResult<GcNode>>;
+}
+
+export interface GarbageCollectorOptions {
+  readonly store: GcStore;
+  readonly queue?: KeyedWorkQueue | undefined;
+  readonly resyncIntervalMs?: number | undefined;
+  readonly workerCount?: number | undefined;
+  readonly now?: (() => number) | undefined;
+  readonly onError?: ((error: unknown, key: string) => void) | undefined;
+  readonly onAction?: ((action: GcAction) => void) | undefined;
+}
+
+const DEFAULT_RESYNC_INTERVAL_MS = 30_000;
+const DEFAULT_WORKER_COUNT = 1;
+const MAX_RESYNC_INTERVAL_MS = 2_147_483_647;
+const MAX_WORKER_COUNT = 1_000;
+
+/** Sentinel: the target node vanished mid-reconcile (already reaped). Benign. */
+class NodeVanished extends Error {
+  constructor() {
+    super("gc target node vanished");
+    this.name = "NodeVanished";
+  }
+}
+
+export function gcKey(ref: GcRef): string {
+  return `${ref.kind}:${ref.id}`;
+}
+
+export function parseGcKey(key: string): GcRef {
+  const idx = key.indexOf(":");
+  if (idx === -1) throw new Error(`invalid gc key: ${key}`);
+  return { kind: key.slice(0, idx) as GcRef["kind"], id: key.slice(idx + 1) };
+}
+
+export class GarbageCollector {
+  private readonly store: GcStore;
+  private readonly queue: KeyedWorkQueue;
+  private readonly now: () => number;
+  private readonly resyncIntervalMs: number;
+  private readonly workerCount: number;
+  private readonly onError: ((error: unknown, key: string) => void) | undefined;
+  private readonly onAction: ((action: GcAction) => void) | undefined;
+  private running = false;
+  private stopRequested = false;
+  private workers: Promise<void>[] = [];
+  private resyncTimer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(options: GarbageCollectorOptions) {
+    this.store = options.store;
+    this.now = options.now ?? Date.now;
+    this.queue = options.queue ?? new KeyedWorkQueue({ now: this.now });
+    this.resyncIntervalMs = options.resyncIntervalMs ?? DEFAULT_RESYNC_INTERVAL_MS;
+    this.workerCount = options.workerCount ?? DEFAULT_WORKER_COUNT;
+    if (
+      !Number.isFinite(this.resyncIntervalMs) ||
+      this.resyncIntervalMs < 1 ||
+      this.resyncIntervalMs > MAX_RESYNC_INTERVAL_MS
+    ) {
+      throw new RangeError(
+        `resyncIntervalMs must be a finite positive number no greater than ${MAX_RESYNC_INTERVAL_MS}`,
+      );
+    }
+    if (!Number.isInteger(this.workerCount) || this.workerCount < 1 || this.workerCount > MAX_WORKER_COUNT) {
+      throw new RangeError(`workerCount must be an integer between 1 and ${MAX_WORKER_COUNT}`);
+    }
+    this.onError = options.onError;
+    this.onAction = options.onAction;
+  }
+
+  enqueue(ref: GcRef): void {
+    this.queue.enqueue(gcKey(ref));
+  }
+
+  async resync(): Promise<number> {
+    const pending = await this.store.listPendingDeletion();
+    for (const node of pending) {
+      this.enqueue(refOf(node));
+      const children = await this.store.listOwnedBy(node.uid);
+      for (const child of children) this.enqueue(refOf(child));
+    }
+    return pending.length;
+  }
+
+  async reconcileNode(ref: GcRef): Promise<void> {
+    const node = await this.store.getNode(ref);
+    if (node === undefined) return;
+
+    let actions: readonly GcAction[];
+    if (node.deletionTimestamp !== undefined) {
+      const children = await this.store.listOwnedBy(node.uid);
+      actions = planOwnerDeletion(node, children);
+    } else {
+      actions = planDanglingChild(node, await this.ownerExists(node));
+    }
+
+    for (const action of actions) {
+      try {
+        await this.execute(action);
+        this.onAction?.(action);
+        // Promptly re-reconcile the touched node so multi-step convergence
+        // (mark → reap, orphan → remove-finalizer → reap) does not wait for
+        // the next resync.
+        this.enqueue(action.ref);
+      } catch (error) {
+        if (error instanceof NodeVanished) continue;
+        throw error;
+      }
+    }
+  }
+
+  start(): void {
+    if (this.running) return;
+    if (this.stopRequested) throw new QueueClosedError();
+    this.running = true;
+    this.stopRequested = false;
+    for (let i = 0; i < this.workerCount; i += 1) {
+      this.workers.push(this.workerLoop());
+    }
+    this.resyncTimer = setInterval(() => {
+      void this.resync().catch((error: unknown) => this.reportError(error, "__resync__"));
+    }, this.resyncIntervalMs);
+    this.resyncTimer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running && this.stopRequested) return;
+    this.stopRequested = true;
+    if (this.resyncTimer !== undefined) {
+      clearInterval(this.resyncTimer);
+      this.resyncTimer = undefined;
+    }
+    this.queue.close();
+    const workers = this.workers;
+    this.workers = [];
+    await Promise.all(workers);
+    this.running = false;
+  }
+
+  private async workerLoop(): Promise<void> {
+    while (!this.stopRequested) {
+      let item: WorkItemResult;
+      try {
+        item = await this.queue.take();
+      } catch (error) {
+        if (this.stopRequested) return;
+        throw error;
+      }
+      try {
+        await this.reconcileNode(parseGcKey(item.key));
+        this.queue.acknowledge(item.key);
+      } catch (error) {
+        if (!this.stopRequested) this.queue.retry(item.key);
+        this.reportError(error, item.key);
+      }
+    }
+  }
+
+  private async ownerExists(node: GcNode): Promise<boolean> {
+    const controller = node.ownerRefs.find((ref) => ref.controller === true);
+    if (controller === undefined) return true; // not a dangling candidate
+    const owner = await this.store.getNode({ kind: controller.kind, id: controller.id });
+    return owner !== undefined && owner.uid === controller.uid;
+  }
+
+  private async execute(action: GcAction): Promise<void> {
+    const nowIso = new Date(this.now()).toISOString();
+    await this.casMutate(action.ref, (opts) => {
+      switch (action.type) {
+        case "mark-deletion":
+          return this.store.setDeletionTimestamp(action.ref, nowIso, opts);
+        case "orphan":
+          return this.store.removeOwnerRef(action.ref, action.ownerUid, opts);
+        case "remove-finalizer":
+          return this.store.removeFinalizer(action.ref, action.finalizer, opts);
+        case "reap":
+          return this.store.reap(action.ref, opts);
+      }
+    });
+  }
+
+  private async casMutate(
+    ref: GcRef,
+    patch: (opts: CasOpts) => Promise<CasMutationResult<GcNode>>,
+  ): Promise<void> {
+    await withIfMatch<GcNode>(
+      async () => {
+        const cur = await this.store.getNode(ref);
+        if (cur === undefined) throw new NodeVanished();
+        return { resourceVersion: cur.resourceVersion };
+      },
+      (opts) => patch({ ifMatch: opts.ifMatch }),
+    );
+  }
+
+  private reportError(error: unknown, key: string): void {
+    try {
+      this.onError?.(error, key);
+    } catch {
+      return;
+    }
+  }
+}

--- a/src/core/in-memory-gc-store.ts
+++ b/src/core/in-memory-gc-store.ts
@@ -1,0 +1,134 @@
+import { type CasMismatchResult, type CasMutationResult, type CasOpts } from "./cas.js";
+import type { GcStore } from "./garbage-collector.js";
+import { gcKey } from "./garbage-collector.js";
+import type { GcNode, GcRef } from "./owner-graph.js";
+
+interface MutableNode {
+  kind: GcNode["kind"];
+  id: string;
+  uid: string;
+  rv: number;
+  ownerRefs: GcNode["ownerRefs"];
+  finalizers: string[];
+  deletionTimestamp?: string | undefined;
+}
+
+function toGcNode(n: MutableNode): GcNode {
+  return {
+    kind: n.kind,
+    id: n.id,
+    uid: n.uid,
+    resourceVersion: String(n.rv),
+    ownerRefs: n.ownerRefs,
+    finalizers: [...n.finalizers],
+    deletionTimestamp: n.deletionTimestamp,
+  };
+}
+
+/** In-memory GcStore holding nodes of every kind. For tests/fixtures only. */
+export class InMemoryGcStore implements GcStore {
+  private readonly nodes = new Map<string, MutableNode>();
+
+  /** Seed a node. Returns the key. */
+  put(node: Omit<GcNode, "resourceVersion"> & { resourceVersion?: string }): void {
+    this.nodes.set(gcKey(node), {
+      kind: node.kind,
+      id: node.id,
+      uid: node.uid,
+      rv: node.resourceVersion === undefined ? 1 : Number(node.resourceVersion),
+      ownerRefs: node.ownerRefs,
+      finalizers: [...node.finalizers],
+      deletionTimestamp: node.deletionTimestamp,
+    });
+  }
+
+  has(ref: GcRef): boolean {
+    return this.nodes.has(gcKey(ref));
+  }
+
+  async getNode(ref: GcRef): Promise<GcNode | undefined> {
+    const n = this.nodes.get(gcKey(ref));
+    return n === undefined ? undefined : toGcNode(n);
+  }
+
+  async listPendingDeletion(): Promise<readonly GcNode[]> {
+    return [...this.nodes.values()].filter((n) => n.deletionTimestamp !== undefined).map(toGcNode);
+  }
+
+  async listOwnedBy(ownerUid: string): Promise<readonly GcNode[]> {
+    return [...this.nodes.values()]
+      .filter((n) => n.ownerRefs.some((r) => r.uid === ownerUid))
+      .map(toGcNode);
+  }
+
+  async setDeletionTimestamp(
+    ref: GcRef,
+    deletionTimestamp: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>> {
+    return this.mutate(ref, opts, (n) => {
+      if (n.deletionTimestamp === undefined) n.deletionTimestamp = deletionTimestamp;
+    });
+  }
+
+  async removeOwnerRef(
+    ref: GcRef,
+    ownerUid: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>> {
+    return this.mutate(ref, opts, (n) => {
+      n.ownerRefs = n.ownerRefs.filter((r) => r.uid !== ownerUid);
+    });
+  }
+
+  async removeFinalizer(
+    ref: GcRef,
+    finalizer: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<GcNode>> {
+    return this.mutate(ref, opts, (n) => {
+      n.finalizers = n.finalizers.filter((f) => f !== finalizer);
+    });
+  }
+
+  async reap(ref: GcRef, opts?: CasOpts): Promise<CasMutationResult<GcNode>> {
+    const key = gcKey(ref);
+    const n = this.nodes.get(key);
+    if (n === undefined) {
+      // Already gone — surface as a benign mismatch so the loop's getNode
+      // probe (which throws NodeVanished) handles it; never reached in practice
+      // because the loop reads first.
+      return { kind: "rv-mismatch", current: { resourceVersion: "0", generation: 0 } };
+    }
+    const mismatch = this.checkCas(n, opts);
+    if (mismatch !== null) return mismatch;
+    if (n.finalizers.length > 0) {
+      throw new Error(`reap refused: ${key} still has finalizers [${n.finalizers.join(", ")}]`);
+    }
+    const view = toGcNode(n);
+    this.nodes.delete(key);
+    return { kind: "ok", view };
+  }
+
+  private mutate(
+    ref: GcRef,
+    opts: CasOpts | undefined,
+    apply: (n: MutableNode) => void,
+  ): CasMutationResult<GcNode> {
+    const n = this.nodes.get(gcKey(ref));
+    if (n === undefined) {
+      return { kind: "rv-mismatch", current: { resourceVersion: "0", generation: 0 } };
+    }
+    const mismatch = this.checkCas(n, opts);
+    if (mismatch !== null) return mismatch;
+    apply(n);
+    n.rv += 1;
+    return { kind: "ok", view: toGcNode(n) };
+  }
+
+  private checkCas(n: MutableNode, opts: CasOpts | undefined): CasMismatchResult | null {
+    if (opts?.ifMatch === undefined) return null;
+    if (opts.ifMatch === String(n.rv)) return null;
+    return { kind: "rv-mismatch", current: { resourceVersion: String(n.rv), generation: n.rv } };
+  }
+}

--- a/src/core/in-memory-gc-store.ts
+++ b/src/core/in-memory-gc-store.ts
@@ -1,4 +1,4 @@
-import { type CasMismatchResult, type CasMutationResult, type CasOpts } from "./cas.js";
+import type { CasMismatchResult, CasMutationResult, CasOpts } from "./cas.js";
 import type { GcStore } from "./garbage-collector.js";
 import { gcKey } from "./garbage-collector.js";
 import type { GcNode, GcRef } from "./owner-graph.js";
@@ -95,9 +95,9 @@ export class InMemoryGcStore implements GcStore {
     const key = gcKey(ref);
     const n = this.nodes.get(key);
     if (n === undefined) {
-      // Already gone — surface as a benign mismatch so the loop's getNode
-      // probe (which throws NodeVanished) handles it; never reached in practice
-      // because the loop reads first.
+      // Unreachable via the GarbageCollector loop, which read-probes first and
+      // throws NodeVanished; the fabricated rv is only a fixture placeholder for
+      // direct callers.
       return { kind: "rv-mismatch", current: { resourceVersion: "0", generation: 0 } };
     }
     const mismatch = this.checkCas(n, opts);
@@ -117,6 +117,9 @@ export class InMemoryGcStore implements GcStore {
   ): CasMutationResult<GcNode> {
     const n = this.nodes.get(gcKey(ref));
     if (n === undefined) {
+      // Unreachable via the GarbageCollector loop, which read-probes first and
+      // throws NodeVanished; the fabricated rv is only a fixture placeholder for
+      // direct callers.
       return { kind: "rv-mismatch", current: { resourceVersion: "0", generation: 0 } };
     }
     const mismatch = this.checkCas(n, opts);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -15,6 +15,7 @@ export {
   agentTaskViewToEntity,
   isAgentTaskSpecStale,
 } from "./agent-task.js";
+export { AgentTaskGcStore, CompositeGcStore } from "./agent-task-gc-store.js";
 export {
   extractChoices,
   extractQuestion,
@@ -185,6 +186,8 @@ export {
   FrontierRewardService,
   type FrontierRewardServiceOptions,
 } from "./frontier-reward-service.js";
+export type { GarbageCollectorOptions, GcStore } from "./garbage-collector.js";
+export { GarbageCollector, gcKey, parseGcKey } from "./garbage-collector.js";
 export type {
   Handoff,
   HandoffInput,
@@ -226,6 +229,7 @@ export {
 } from "./hooks.js";
 export type { FailureConfig } from "./in-memory-credits.js";
 export { InMemoryCreditsService } from "./in-memory-credits.js";
+export { InMemoryGcStore } from "./in-memory-gc-store.js";
 export { InMemorySessionStore } from "./in-memory-session-store.js";
 export type { StopConditionResult, StopEvaluationResult } from "./lifecycle.js";
 export {
@@ -234,7 +238,12 @@ export {
   evaluateStopConditions,
   LifecycleState,
 } from "./lifecycle.js";
-export type { OwnerRef, SessionFinalizer } from "./lifecycle-metadata.js";
+export type {
+  CascadePolicy,
+  OwnerRef,
+  SessionFinalizer,
+} from "./lifecycle-metadata.js";
+export { KindFinalizer, PropagationFinalizer } from "./lifecycle-metadata.js";
 export { LocalEventBus } from "./local-event-bus.js";
 export type {
   GroveLoopRunnerOptions,
@@ -292,6 +301,8 @@ export {
   type Score,
   ScoreDirection,
 } from "./models.js";
+export type { GcAction, GcNode, GcRef } from "./owner-graph.js";
+export { planDanglingChild, planOwnerDeletion, policyOf, refOf } from "./owner-graph.js";
 export {
   ArtifactNameError,
   assertWithinBoundary,

--- a/src/core/lifecycle-metadata.test.ts
+++ b/src/core/lifecycle-metadata.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
   appendDeletionAudit,
+  type CascadePolicy,
   DEFAULT_SESSION_FINALIZERS,
   Finalizer,
+  KindFinalizer,
+  type OwnerRef,
   ownerRefsEqual,
+  PropagationFinalizer,
 } from "./lifecycle-metadata.js";
 
 describe("lifecycle metadata", () => {
@@ -37,5 +41,34 @@ describe("lifecycle metadata", () => {
         warning: "force delete skipped finalizer waits for session s1",
       },
     ]);
+  });
+
+  test("OwnerRef carries an optional controller flag without affecting identity", () => {
+    const a: OwnerRef = { kind: "taskGroup", id: "tg-1", uid: "uid-1", controller: true };
+    const b: OwnerRef = { kind: "taskGroup", id: "tg-1", uid: "uid-1" };
+    // controller is metadata, not identity — equality is UID-based.
+    expect(ownerRefsEqual(a, b)).toBe(true);
+  });
+
+  test("new owner kinds are assignable", () => {
+    const refs: OwnerRef[] = [
+      { kind: "session", id: "s", uid: "u" },
+      { kind: "claim", id: "c", uid: "u" },
+      { kind: "taskGroup", id: "tg", uid: "u" },
+      { kind: "agentTask", id: "at", uid: "u" },
+    ];
+    expect(refs).toHaveLength(4);
+  });
+
+  test("finalizer namespaces are stable", () => {
+    expect(KindFinalizer.PendingReview).toBe("grove.dev/pending-review");
+    expect(KindFinalizer.PendingMerge).toBe("grove.dev/pending-merge");
+    expect(PropagationFinalizer.Foreground).toBe("grove.dev/foreground-deletion");
+    expect(PropagationFinalizer.Orphan).toBe("grove.dev/orphan");
+  });
+
+  test("cascade policy values", () => {
+    const policies: CascadePolicy[] = ["Foreground", "Background", "Orphan"];
+    expect(policies).toContain("Background");
   });
 });

--- a/src/core/lifecycle-metadata.test.ts
+++ b/src/core/lifecycle-metadata.test.ts
@@ -50,14 +50,19 @@ describe("lifecycle metadata", () => {
     expect(ownerRefsEqual(a, b)).toBe(true);
   });
 
-  test("new owner kinds are assignable", () => {
-    const refs: OwnerRef[] = [
+  test("ownerRefsEqual distinguishes owner kinds", () => {
+    const taskGroup: OwnerRef = { kind: "taskGroup", id: "x", uid: "u" };
+    const agentTask: OwnerRef = { kind: "agentTask", id: "x", uid: "u" };
+    // Same id/uid, different kind → not equal (real behavioral assertion).
+    expect(ownerRefsEqual(taskGroup, agentTask)).toBe(false);
+    // All four kinds remain assignable to OwnerRef.
+    const all: OwnerRef[] = [
       { kind: "session", id: "s", uid: "u" },
       { kind: "claim", id: "c", uid: "u" },
-      { kind: "taskGroup", id: "tg", uid: "u" },
-      { kind: "agentTask", id: "at", uid: "u" },
+      taskGroup,
+      agentTask,
     ];
-    expect(refs).toHaveLength(4);
+    expect(all).toHaveLength(4);
   });
 
   test("finalizer namespaces are stable", () => {
@@ -67,8 +72,11 @@ describe("lifecycle metadata", () => {
     expect(PropagationFinalizer.Orphan).toBe("grove.dev/orphan");
   });
 
-  test("cascade policy values", () => {
-    const policies: CascadePolicy[] = ["Foreground", "Background", "Orphan"];
-    expect(policies).toContain("Background");
+  test("cascade policy values are stable", () => {
+    const foreground: CascadePolicy = "Foreground";
+    const background: CascadePolicy = "Background";
+    const orphan: CascadePolicy = "Orphan";
+    // Pin all three exact values as a regression guard.
+    expect([foreground, background, orphan]).toEqual(["Foreground", "Background", "Orphan"]);
   });
 });

--- a/src/core/lifecycle-metadata.ts
+++ b/src/core/lifecycle-metadata.ts
@@ -43,8 +43,7 @@ export const PropagationFinalizer = {
   Foreground: "grove.dev/foreground-deletion",
   Orphan: "grove.dev/orphan",
 } as const;
-export type PropagationFinalizer =
-  (typeof PropagationFinalizer)[keyof typeof PropagationFinalizer];
+export type PropagationFinalizer = (typeof PropagationFinalizer)[keyof typeof PropagationFinalizer];
 
 export type CascadePolicy = "Foreground" | "Background" | "Orphan";
 

--- a/src/core/lifecycle-metadata.ts
+++ b/src/core/lifecycle-metadata.ts
@@ -1,9 +1,11 @@
-export type OwnerKind = "session" | "claim";
+export type OwnerKind = "session" | "claim" | "taskGroup" | "agentTask";
 
 export interface OwnerRef {
   readonly kind: OwnerKind;
   readonly id: string;
   readonly uid: string;
+  /** k8s `controller: true` — the single managing owner. Metadata, not identity. */
+  readonly controller?: boolean | undefined;
 }
 
 export const Finalizer = {
@@ -19,6 +21,32 @@ export const DEFAULT_SESSION_FINALIZERS: readonly Finalizer[] = [
   Finalizer.DrainContribs,
   Finalizer.CloseRuntime,
 ];
+
+/**
+ * Per-kind finalizers (Epic D #306). Use the `grove.dev/` namespace, distinct
+ * from the legacy `grove.io/*` session finalizers above (not unified here).
+ */
+export const KindFinalizer = {
+  /** On AgentTask — blocks reap until review completes. */
+  PendingReview: "grove.dev/pending-review",
+  /** On MergeTask — blocks reap until the merge lands (defined now, applied in a follow-up). */
+  PendingMerge: "grove.dev/pending-merge",
+} as const;
+export type KindFinalizer = (typeof KindFinalizer)[keyof typeof KindFinalizer];
+
+/**
+ * Propagation finalizers placed on the OWNER at delete time to encode the
+ * cascade policy (mirrors k8s `foregroundDeletion`/`orphan`). Background uses
+ * no propagation finalizer. Reconstructable from store state after a restart.
+ */
+export const PropagationFinalizer = {
+  Foreground: "grove.dev/foreground-deletion",
+  Orphan: "grove.dev/orphan",
+} as const;
+export type PropagationFinalizer =
+  (typeof PropagationFinalizer)[keyof typeof PropagationFinalizer];
+
+export type CascadePolicy = "Foreground" | "Background" | "Orphan";
 
 export interface DeletionAuditEvent {
   readonly at: string;

--- a/src/core/owner-graph.test.ts
+++ b/src/core/owner-graph.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { PropagationFinalizer } from "./lifecycle-metadata.js";
-import {
-  type GcNode,
-  planDanglingChild,
-  planOwnerDeletion,
-  policyOf,
-} from "./owner-graph.js";
+import { KindFinalizer, PropagationFinalizer } from "./lifecycle-metadata.js";
+import { type GcNode, planDanglingChild, planOwnerDeletion, policyOf } from "./owner-graph.js";
 
 function node(over: Partial<GcNode> & Pick<GcNode, "kind" | "id" | "uid">): GcNode {
   return {
@@ -30,10 +25,19 @@ describe("policyOf", () => {
   test("Foreground / Orphan / Background derived from owner finalizers", () => {
     expect(policyOf(node({ kind: "taskGroup", id: "tg", uid: "u" }))).toBe("Background");
     expect(
-      policyOf(node({ kind: "taskGroup", id: "tg", uid: "u", finalizers: [PropagationFinalizer.Foreground] })),
+      policyOf(
+        node({
+          kind: "taskGroup",
+          id: "tg",
+          uid: "u",
+          finalizers: [PropagationFinalizer.Foreground],
+        }),
+      ),
     ).toBe("Foreground");
     expect(
-      policyOf(node({ kind: "taskGroup", id: "tg", uid: "u", finalizers: [PropagationFinalizer.Orphan] })),
+      policyOf(
+        node({ kind: "taskGroup", id: "tg", uid: "u", finalizers: [PropagationFinalizer.Orphan] }),
+      ),
     ).toBe("Orphan");
   });
 });
@@ -183,5 +187,124 @@ describe("idempotency", () => {
     // After reap the node would be gone; re-running planDanglingChild on a
     // hypothetical leftover with empty finalizers is a single reap, not a loop.
     expect(planOwnerDeletion(reaped, [])).toEqual(first);
+  });
+});
+
+describe("planOwnerDeletion — multi-step convergence (pure snapshot simulation)", () => {
+  test("Foreground arc: mark child → terminating → remove-finalizer → reap", () => {
+    const owner = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      finalizers: [PropagationFinalizer.Foreground],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    // Pass 1: child unmarked → mark it.
+    expect(planOwnerDeletion(owner, [child("a", "u-tg")])).toEqual([
+      { type: "mark-deletion", ref: { kind: "agentTask", id: "a" } },
+    ]);
+    // Pass 2: child marked but still present → stay terminating.
+    const marked = child("a", "u-tg", { deletionTimestamp: "2026-06-08T00:00:01.000Z" });
+    expect(planOwnerDeletion(owner, [marked])).toEqual([]);
+    // Pass 3: child gone → remove foreground finalizer.
+    expect(planOwnerDeletion(owner, [])).toEqual([
+      {
+        type: "remove-finalizer",
+        ref: { kind: "taskGroup", id: "tg" },
+        finalizer: PropagationFinalizer.Foreground,
+      },
+    ]);
+    // Pass 4: finalizer cleared → reap.
+    const cleared = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      finalizers: [],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    expect(planOwnerDeletion(cleared, [])).toEqual([
+      { type: "reap", ref: { kind: "taskGroup", id: "tg" } },
+    ]);
+  });
+
+  test("Orphan arc: orphan child → remove-finalizer → reap", () => {
+    const owner = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      finalizers: [PropagationFinalizer.Orphan],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    // Pass 1: controlled child → orphan it.
+    expect(planOwnerDeletion(owner, [child("a", "u-tg")])).toEqual([
+      { type: "orphan", ref: { kind: "agentTask", id: "a" }, ownerUid: "u-tg" },
+    ]);
+    // Pass 2: child's controller ownerRef stripped → no longer controlled → remove orphan finalizer.
+    const detached = node({ kind: "agentTask", id: "a", uid: "uid-a", ownerRefs: [] });
+    expect(planOwnerDeletion(owner, [detached])).toEqual([
+      {
+        type: "remove-finalizer",
+        ref: { kind: "taskGroup", id: "tg" },
+        finalizer: PropagationFinalizer.Orphan,
+      },
+    ]);
+    // Pass 3: finalizer cleared → reap (orphaned child preserved, not reaped).
+    const cleared = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      finalizers: [],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    expect(planOwnerDeletion(cleared, [detached])).toEqual([
+      { type: "reap", ref: { kind: "taskGroup", id: "tg" } },
+    ]);
+  });
+});
+
+describe("kind finalizer gates reap under Foreground", () => {
+  test("owner with [Foreground, pending-review] and no children removes Foreground first, never reaps while pending-review remains", () => {
+    const owner = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      finalizers: [PropagationFinalizer.Foreground, KindFinalizer.PendingReview],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    // Foreground finalizer is removed first (NOT reap).
+    expect(planOwnerDeletion(owner, [])).toEqual([
+      {
+        type: "remove-finalizer",
+        ref: { kind: "taskGroup", id: "tg" },
+        finalizer: PropagationFinalizer.Foreground,
+      },
+    ]);
+    // After Foreground is stripped, the kind finalizer still blocks reap.
+    const afterStrip = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      finalizers: [KindFinalizer.PendingReview],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    expect(planOwnerDeletion(afterStrip, [])).toEqual([]);
+  });
+});
+
+describe("Orphan idempotency before write lands", () => {
+  test("re-running on the same controlled snapshot re-emits orphan (loop must no-op safely)", () => {
+    const owner = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      finalizers: [PropagationFinalizer.Orphan],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    const first = planOwnerDeletion(owner, [child("a", "u-tg")]);
+    const second = planOwnerDeletion(owner, [child("a", "u-tg")]);
+    expect(second).toEqual(first);
+    expect(first).toEqual([
+      { type: "orphan", ref: { kind: "agentTask", id: "a" }, ownerUid: "u-tg" },
+    ]);
   });
 });

--- a/src/core/owner-graph.test.ts
+++ b/src/core/owner-graph.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import { PropagationFinalizer } from "./lifecycle-metadata.js";
+import {
+  type GcNode,
+  planDanglingChild,
+  planOwnerDeletion,
+  policyOf,
+} from "./owner-graph.js";
+
+function node(over: Partial<GcNode> & Pick<GcNode, "kind" | "id" | "uid">): GcNode {
+  return {
+    resourceVersion: "1",
+    ownerRefs: [],
+    finalizers: [],
+    ...over,
+  };
+}
+
+function child(id: string, ownerUid: string, over: Partial<GcNode> = {}): GcNode {
+  return node({
+    kind: "agentTask",
+    id,
+    uid: `uid-${id}`,
+    ownerRefs: [{ kind: "taskGroup", id: "tg", uid: ownerUid, controller: true }],
+    ...over,
+  });
+}
+
+describe("policyOf", () => {
+  test("Foreground / Orphan / Background derived from owner finalizers", () => {
+    expect(policyOf(node({ kind: "taskGroup", id: "tg", uid: "u" }))).toBe("Background");
+    expect(
+      policyOf(node({ kind: "taskGroup", id: "tg", uid: "u", finalizers: [PropagationFinalizer.Foreground] })),
+    ).toBe("Foreground");
+    expect(
+      policyOf(node({ kind: "taskGroup", id: "tg", uid: "u", finalizers: [PropagationFinalizer.Orphan] })),
+    ).toBe("Orphan");
+  });
+});
+
+describe("planOwnerDeletion — no deletionTimestamp", () => {
+  test("not being deleted → no actions", () => {
+    const owner = node({ kind: "taskGroup", id: "tg", uid: "u-tg" });
+    expect(planOwnerDeletion(owner, [child("a", "u-tg")])).toEqual([]);
+  });
+});
+
+describe("planOwnerDeletion — Foreground", () => {
+  const owner = node({
+    kind: "taskGroup",
+    id: "tg",
+    uid: "u-tg",
+    finalizers: [PropagationFinalizer.Foreground],
+    deletionTimestamp: "2026-06-08T00:00:00.000Z",
+  });
+
+  test("marks unmarked controlled children", () => {
+    const actions = planOwnerDeletion(owner, [child("a", "u-tg"), child("b", "u-tg")]);
+    expect(actions).toEqual([
+      { type: "mark-deletion", ref: { kind: "agentTask", id: "a" } },
+      { type: "mark-deletion", ref: { kind: "agentTask", id: "b" } },
+    ]);
+  });
+
+  test("children marked but still present → still terminating (no actions)", () => {
+    const marked = child("a", "u-tg", { deletionTimestamp: "2026-06-08T00:00:01.000Z" });
+    expect(planOwnerDeletion(owner, [marked])).toEqual([]);
+  });
+
+  test("children gone → remove foreground finalizer", () => {
+    expect(planOwnerDeletion(owner, [])).toEqual([
+      {
+        type: "remove-finalizer",
+        ref: { kind: "taskGroup", id: "tg" },
+        finalizer: PropagationFinalizer.Foreground,
+      },
+    ]);
+  });
+
+  test("finalizer removed + children gone → reap", () => {
+    const reapable = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      finalizers: [],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    expect(planOwnerDeletion(reapable, [])).toEqual([
+      { type: "reap", ref: { kind: "taskGroup", id: "tg" } },
+    ]);
+  });
+});
+
+describe("planOwnerDeletion — Orphan", () => {
+  const owner = node({
+    kind: "taskGroup",
+    id: "tg",
+    uid: "u-tg",
+    finalizers: [PropagationFinalizer.Orphan],
+    deletionTimestamp: "2026-06-08T00:00:00.000Z",
+  });
+
+  test("strips the controller ownerRef from children", () => {
+    expect(planOwnerDeletion(owner, [child("a", "u-tg")])).toEqual([
+      { type: "orphan", ref: { kind: "agentTask", id: "a" }, ownerUid: "u-tg" },
+    ]);
+  });
+
+  test("children detached → remove orphan finalizer, then reap on next pass", () => {
+    expect(planOwnerDeletion(owner, [])).toEqual([
+      {
+        type: "remove-finalizer",
+        ref: { kind: "taskGroup", id: "tg" },
+        finalizer: PropagationFinalizer.Orphan,
+      },
+    ]);
+  });
+});
+
+describe("planOwnerDeletion — Background", () => {
+  test("marks children AND reaps owner immediately", () => {
+    const owner = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    expect(planOwnerDeletion(owner, [child("a", "u-tg")])).toEqual([
+      { type: "mark-deletion", ref: { kind: "agentTask", id: "a" } },
+      { type: "reap", ref: { kind: "taskGroup", id: "tg" } },
+    ]);
+  });
+});
+
+describe("reap gating by finalizer", () => {
+  test("deletionTimestamp set but a kind finalizer present → no reap", () => {
+    const owner = node({
+      kind: "agentTask",
+      id: "at",
+      uid: "u",
+      finalizers: ["grove.dev/pending-review"],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    expect(planOwnerDeletion(owner, [])).toEqual([]);
+  });
+});
+
+describe("planDanglingChild", () => {
+  test("owner gone, child unmarked → mark for deletion", () => {
+    expect(planDanglingChild(child("a", "u-tg"), false)).toEqual([
+      { type: "mark-deletion", ref: { kind: "agentTask", id: "a" } },
+    ]);
+  });
+
+  test("owner gone, child marked, finalizers empty → reap", () => {
+    const marked = child("a", "u-tg", { deletionTimestamp: "2026-06-08T00:00:01.000Z" });
+    expect(planDanglingChild(marked, false)).toEqual([
+      { type: "reap", ref: { kind: "agentTask", id: "a" } },
+    ]);
+  });
+
+  test("owner still exists → no actions", () => {
+    expect(planDanglingChild(child("a", "u-tg"), true)).toEqual([]);
+  });
+
+  test("no controller ownerRef → not a dangling candidate", () => {
+    const orphaned = node({ kind: "agentTask", id: "a", uid: "u-a" });
+    expect(planDanglingChild(orphaned, false)).toEqual([]);
+  });
+});
+
+describe("idempotency", () => {
+  test("converged Foreground owner (children gone, finalizer cleared) yields reap then nothing", () => {
+    const reaped = node({
+      kind: "taskGroup",
+      id: "tg",
+      uid: "u-tg",
+      finalizers: [],
+      deletionTimestamp: "2026-06-08T00:00:00.000Z",
+    });
+    const first = planOwnerDeletion(reaped, []);
+    expect(first).toEqual([{ type: "reap", ref: { kind: "taskGroup", id: "tg" } }]);
+    // After reap the node would be gone; re-running planDanglingChild on a
+    // hypothetical leftover with empty finalizers is a single reap, not a loop.
+    expect(planOwnerDeletion(reaped, [])).toEqual(first);
+  });
+});

--- a/src/core/owner-graph.ts
+++ b/src/core/owner-graph.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure cascade/reap decision core for the garbage collector (Epic D #306).
+ *
+ * No I/O, no async, no clock — every function is a pure projection over an
+ * entity snapshot, so cascade logic is unit-testable in isolation. The
+ * GarbageCollector loop (garbage-collector.ts) supplies the snapshots and
+ * executes the returned actions against a store.
+ */
+
+import {
+  type CascadePolicy,
+  type OwnerKind,
+  type OwnerRef,
+  PropagationFinalizer,
+} from "./lifecycle-metadata.js";
+
+/** Identity of a GC-managed node: (kind, id). */
+export interface GcRef {
+  readonly kind: OwnerKind;
+  readonly id: string;
+}
+
+/** Minimal lifecycle projection of any GC-managed entity. */
+export interface GcNode {
+  readonly kind: OwnerKind;
+  readonly id: string;
+  readonly uid: string;
+  /** Resource version for CAS writes (string, store-defined). */
+  readonly resourceVersion: string;
+  readonly ownerRefs: readonly OwnerRef[];
+  readonly finalizers: readonly string[];
+  readonly deletionTimestamp?: string | undefined;
+}
+
+/** One reconcile-step action. The loop stamps timestamps and threads CAS. */
+export type GcAction =
+  | { readonly type: "mark-deletion"; readonly ref: GcRef }
+  | { readonly type: "orphan"; readonly ref: GcRef; readonly ownerUid: string }
+  | { readonly type: "remove-finalizer"; readonly ref: GcRef; readonly finalizer: string }
+  | { readonly type: "reap"; readonly ref: GcRef };
+
+export function refOf(node: GcNode): GcRef {
+  return { kind: node.kind, id: node.id };
+}
+
+/** Derive cascade policy from the propagation finalizer the owner carries. */
+export function policyOf(owner: GcNode): CascadePolicy {
+  if (owner.finalizers.includes(PropagationFinalizer.Foreground)) return "Foreground";
+  if (owner.finalizers.includes(PropagationFinalizer.Orphan)) return "Orphan";
+  return "Background";
+}
+
+/** Does `child` carry a controller ownerRef pointing at `ownerUid`? */
+function controlledBy(child: GcNode, ownerUid: string): boolean {
+  return child.ownerRefs.some((ref) => ref.uid === ownerUid && ref.controller === true);
+}
+
+/** Reap only when deletion is requested AND every finalizer is cleared. */
+function reapIfReady(node: GcNode): readonly GcAction[] {
+  if (node.deletionTimestamp === undefined) return [];
+  return node.finalizers.length === 0 ? [{ type: "reap", ref: refOf(node) }] : [];
+}
+
+/**
+ * One idempotent reconcile step for a node that has a deletionTimestamp.
+ * Cascades to its controlled children per policy, then reaps itself when ready.
+ * Returns `[]` when the node is not being deleted or the world is converged.
+ */
+export function planOwnerDeletion(
+  owner: GcNode,
+  children: readonly GcNode[],
+): readonly GcAction[] {
+  if (owner.deletionTimestamp === undefined) return [];
+  const controlled = children.filter((child) => controlledBy(child, owner.uid));
+  const policy = policyOf(owner);
+
+  if (policy === "Orphan") {
+    if (controlled.length > 0) {
+      return controlled.map((child) => ({
+        type: "orphan" as const,
+        ref: refOf(child),
+        ownerUid: owner.uid,
+      }));
+    }
+    if (owner.finalizers.includes(PropagationFinalizer.Orphan)) {
+      return [
+        { type: "remove-finalizer", ref: refOf(owner), finalizer: PropagationFinalizer.Orphan },
+      ];
+    }
+    return reapIfReady(owner);
+  }
+
+  if (policy === "Foreground") {
+    const blocking = controlled.filter((child) => child.deletionTimestamp === undefined);
+    if (blocking.length > 0) {
+      return blocking.map((child) => ({ type: "mark-deletion" as const, ref: refOf(child) }));
+    }
+    // Children are marked but still present — stay Terminating until they're gone.
+    if (controlled.length > 0) return [];
+    if (owner.finalizers.includes(PropagationFinalizer.Foreground)) {
+      return [
+        {
+          type: "remove-finalizer",
+          ref: refOf(owner),
+          finalizer: PropagationFinalizer.Foreground,
+        },
+      ];
+    }
+    return reapIfReady(owner);
+  }
+
+  // Background: mark children for async GC, reap owner immediately.
+  const actions: GcAction[] = controlled
+    .filter((child) => child.deletionTimestamp === undefined)
+    .map((child) => ({ type: "mark-deletion" as const, ref: refOf(child) }));
+  actions.push(...reapIfReady(owner));
+  return actions;
+}
+
+/**
+ * GC backstop: a child whose controller owner UID no longer resolves.
+ * `ownerExists` is true only when the controller owner is present AND its UID
+ * still matches (a recreated owner with a new UID counts as gone).
+ */
+export function planDanglingChild(
+  child: GcNode,
+  ownerExists: boolean,
+): readonly GcAction[] {
+  const hasController = child.ownerRefs.some((ref) => ref.controller === true);
+  if (!hasController || ownerExists) return [];
+  if (child.deletionTimestamp === undefined) {
+    return [{ type: "mark-deletion", ref: refOf(child) }];
+  }
+  return reapIfReady(child);
+}

--- a/src/core/owner-graph.ts
+++ b/src/core/owner-graph.ts
@@ -35,10 +35,12 @@ export interface GcNode {
 /** One reconcile-step action. The loop stamps timestamps and threads CAS. */
 export type GcAction =
   | { readonly type: "mark-deletion"; readonly ref: GcRef }
+  // idempotent: loop must tolerate the ownerRef already being absent (no-op, not an error)
   | { readonly type: "orphan"; readonly ref: GcRef; readonly ownerUid: string }
   | { readonly type: "remove-finalizer"; readonly ref: GcRef; readonly finalizer: string }
   | { readonly type: "reap"; readonly ref: GcRef };
 
+/** Identity (kind+id) of a node, for building GcAction targets. */
 export function refOf(node: GcNode): GcRef {
   return { kind: node.kind, id: node.id };
 }
@@ -66,10 +68,7 @@ function reapIfReady(node: GcNode): readonly GcAction[] {
  * Cascades to its controlled children per policy, then reaps itself when ready.
  * Returns `[]` when the node is not being deleted or the world is converged.
  */
-export function planOwnerDeletion(
-  owner: GcNode,
-  children: readonly GcNode[],
-): readonly GcAction[] {
+export function planOwnerDeletion(owner: GcNode, children: readonly GcNode[]): readonly GcAction[] {
   if (owner.deletionTimestamp === undefined) return [];
   const controlled = children.filter((child) => controlledBy(child, owner.uid));
   const policy = policyOf(owner);
@@ -96,6 +95,9 @@ export function planOwnerDeletion(
       return blocking.map((child) => ({ type: "mark-deletion" as const, ref: refOf(child) }));
     }
     // Children are marked but still present — stay Terminating until they're gone.
+    // Children with their own kind finalizers (e.g. pending-review) stay in `controlled`
+    // until reaped, so the owner will not get `remove-finalizer` until every controlled
+    // child is gone from the store.
     if (controlled.length > 0) return [];
     if (owner.finalizers.includes(PropagationFinalizer.Foreground)) {
       return [
@@ -121,11 +123,10 @@ export function planOwnerDeletion(
  * GC backstop: a child whose controller owner UID no longer resolves.
  * `ownerExists` is true only when the controller owner is present AND its UID
  * still matches (a recreated owner with a new UID counts as gone).
+ * `ownerExists` must be resolved against the CONTROLLER owner ref (the one
+ * with `controller: true`), not just any ownerRef on the child.
  */
-export function planDanglingChild(
-  child: GcNode,
-  ownerExists: boolean,
-): readonly GcAction[] {
+export function planDanglingChild(child: GcNode, ownerExists: boolean): readonly GcAction[] {
   const hasController = child.ownerRefs.some((ref) => ref.controller === true);
   if (!hasController || ownerExists) return [];
   if (child.deletionTimestamp === undefined) {

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -490,9 +490,11 @@ export interface AgentTaskStore {
   listAgentTaskEntities(query?: AgentTaskQuery): Promise<readonly AgentTaskEntity[]>;
 
   /**
-   * Set `deletionTimestamp` (and optionally seed propagation/kind finalizers)
-   * on the spec row. Idempotent: a second call with deletion already set is a
-   * no-op write that still bumps RV. CAS-aware via `opts.ifMatch` (spec RV).
+   * Set `deletionTimestamp` on the spec row to begin termination. Idempotent:
+   * when deletion is already set this is a TRUE no-op — no resource_version bump
+   * and no write event — so the GC's `withIfMatch` loop doesn't churn on
+   * repeated calls. Does NOT seed finalizers (callers set those at create time).
+   * CAS-aware via `opts.ifMatch` (compared against the spec resource_version).
    */
   setAgentTaskDeletion(
     taskId: string,

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -489,5 +489,37 @@ export interface AgentTaskStore {
   /** Return AgentTasks wrapped in the Entity envelope. */
   listAgentTaskEntities(query?: AgentTaskQuery): Promise<readonly AgentTaskEntity[]>;
 
+  /**
+   * Set `deletionTimestamp` (and optionally seed propagation/kind finalizers)
+   * on the spec row. Idempotent: a second call with deletion already set is a
+   * no-op write that still bumps RV. CAS-aware via `opts.ifMatch` (spec RV).
+   */
+  setAgentTaskDeletion(
+    taskId: string,
+    deletionTimestamp: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>>;
+
+  /** Remove a single finalizer from the spec row. CAS-aware (spec RV). */
+  removeAgentTaskFinalizer(
+    taskId: string,
+    finalizer: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>>;
+
+  /** Remove every ownerRef whose uid === ownerUid from the spec row (orphan). */
+  removeAgentTaskOwnerRef(
+    taskId: string,
+    ownerUid: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>>;
+
+  /**
+   * Hard-delete the spec row (status drops via the FK ON DELETE CASCADE).
+   * MUST throw if the row still has finalizers. CAS-aware (spec RV). Returns
+   * the pre-delete view on success.
+   */
+  reapAgentTask(taskId: string, opts?: CasOpts): Promise<CasMutationResult<AgentTaskView>>;
+
   close(): void;
 }

--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -1286,4 +1286,48 @@ describe("SqliteAgentTaskStore lifecycle mutators (#306)", () => {
       stores.close();
     }
   });
+
+  test("spec mutators honor ifMatch CAS — stale RV is rejected", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      const created = expectOk(
+        await stores.agentTaskStore.putAgentTaskSpec(
+          spec("t4", { ownerRef: { kind: "taskGroup", id: "tg", uid: "u-tg", controller: true } }),
+        ),
+      );
+      const staleRv = String(created.spec.resourceVersion ?? created.spec.generation);
+      // A real change bumps the spec resource_version.
+      expectOk(await stores.agentTaskStore.removeAgentTaskOwnerRef("t4", "u-tg"));
+      // The stale ifMatch must now be rejected.
+      const result = await stores.agentTaskStore.setAgentTaskDeletion(
+        "t4",
+        "2026-06-08T01:00:00.000Z",
+        { ifMatch: staleRv },
+      );
+      expect(result.kind).toBe("rv-mismatch");
+    } finally {
+      stores.close();
+    }
+  });
+
+  test("removeAgentTaskOwnerRef is a true no-op on re-call (no RV churn, ownerRef stays absent)", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      expectOk(
+        await stores.agentTaskStore.putAgentTaskSpec(
+          spec("t5", { ownerRef: { kind: "taskGroup", id: "tg", uid: "u-tg", controller: true } }),
+        ),
+      );
+      const stripped = expectOk(await stores.agentTaskStore.removeAgentTaskOwnerRef("t5", "u-tg"));
+      expect(stripped.spec.ownerRef).toBeUndefined();
+      const rvAfterStrip = stripped.spec.resourceVersion;
+      // Idempotent re-call: no matching owner → no-op. RV unchanged; ownerRef stays
+      // ABSENT (must not be corrupted into a null literal in owner_ref_json).
+      const again = expectOk(await stores.agentTaskStore.removeAgentTaskOwnerRef("t5", "u-tg"));
+      expect(again.spec.ownerRef).toBeUndefined();
+      expect(again.spec.resourceVersion).toBe(rvAfterStrip);
+    } finally {
+      stores.close();
+    }
+  });
 });

--- a/src/local/sqlite-store.test.ts
+++ b/src/local/sqlite-store.test.ts
@@ -13,9 +13,11 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { AgentTaskSpecRecord } from "../core/agent-task.js";
 import { expectOk } from "../core/cas.js";
 import { runClaimStoreTests } from "../core/claim-store.conformance.js";
 import type { OwnerRef } from "../core/lifecycle-metadata.js";
+import { KindFinalizer } from "../core/lifecycle-metadata.js";
 import type { Claim } from "../core/models.js";
 import { ClaimStatus, ContributionKind, RelationType } from "../core/models.js";
 import { runContributionStoreTests } from "../core/store.conformance.js";
@@ -1216,5 +1218,72 @@ describe("SqliteClaimStore onClaimWrite hook", () => {
     expect(events.length).toBe(2);
     expect(events[0]?.op).toBe("ADDED");
     expect(events[1]?.op).toBe("MODIFIED");
+  });
+});
+
+describe("SqliteAgentTaskStore lifecycle mutators (#306)", () => {
+  function spec(id: string, over: Partial<AgentTaskSpecRecord> = {}): AgentTaskSpecRecord {
+    return {
+      id,
+      worktree: "/wt",
+      runtime: "claude",
+      role: "coder",
+      prompt: "go",
+      dependsOn: [],
+      generation: 1,
+      createdAt: "2026-06-08T00:00:00.000Z",
+      ...over,
+    };
+  }
+
+  test("setAgentTaskDeletion stamps the spec row", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      expectOk(await stores.agentTaskStore.putAgentTaskSpec(spec("t1")));
+      const r = expectOk(
+        await stores.agentTaskStore.setAgentTaskDeletion("t1", "2026-06-08T01:00:00.000Z"),
+      );
+      expect(r.spec.deletionTimestamp).toBe("2026-06-08T01:00:00.000Z");
+    } finally {
+      stores.close();
+    }
+  });
+
+  test("reapAgentTask refuses while finalizers remain, succeeds once cleared", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      expectOk(
+        await stores.agentTaskStore.putAgentTaskSpec(
+          spec("t2", { finalizers: [KindFinalizer.PendingReview] }),
+        ),
+      );
+      expectOk(await stores.agentTaskStore.setAgentTaskDeletion("t2", "2026-06-08T01:00:00.000Z"));
+
+      await expect(stores.agentTaskStore.reapAgentTask("t2")).rejects.toThrow(/finalizer/i);
+
+      expectOk(
+        await stores.agentTaskStore.removeAgentTaskFinalizer("t2", KindFinalizer.PendingReview),
+      );
+      expectOk(await stores.agentTaskStore.reapAgentTask("t2"));
+
+      expect(await stores.agentTaskStore.getAgentTask("t2")).toBeUndefined();
+    } finally {
+      stores.close();
+    }
+  });
+
+  test("removeAgentTaskOwnerRef strips matching refs (orphan)", async () => {
+    const stores = createSqliteStores(":memory:");
+    try {
+      expectOk(
+        await stores.agentTaskStore.putAgentTaskSpec(
+          spec("t3", { ownerRef: { kind: "taskGroup", id: "tg", uid: "u-tg", controller: true } }),
+        ),
+      );
+      const r = expectOk(await stores.agentTaskStore.removeAgentTaskOwnerRef("t3", "u-tg"));
+      expect(r.spec.ownerRef).toBeUndefined();
+    } finally {
+      stores.close();
+    }
   });
 });

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -2234,6 +2234,128 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
     return { kind: "ok", view };
   };
 
+  setAgentTaskDeletion = async (
+    taskId: string,
+    deletionTimestamp: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>> =>
+    this.mutateSpec(taskId, opts, (existing) => {
+      const next = existing.deletionTimestamp ?? deletionTimestamp;
+      this.db
+        .prepare(
+          `UPDATE agent_task_spec
+             SET deletion_timestamp = ?, generation = generation + 1, resource_version = resource_version + 1
+           WHERE id = ?`,
+        )
+        .run(next, taskId);
+    });
+
+  removeAgentTaskFinalizer = async (
+    taskId: string,
+    finalizer: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>> =>
+    this.mutateSpec(taskId, opts, (existing) => {
+      const remaining = (existing.finalizers ?? []).filter((f) => f !== finalizer);
+      this.db
+        .prepare(
+          `UPDATE agent_task_spec
+             SET finalizers_json = ?, generation = generation + 1, resource_version = resource_version + 1
+           WHERE id = ?`,
+        )
+        .run(JSON.stringify(remaining), taskId);
+    });
+
+  removeAgentTaskOwnerRef = async (
+    taskId: string,
+    ownerUid: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>> =>
+    this.mutateSpec(taskId, opts, (existing) => {
+      const cleared = existing.ownerRef !== undefined && existing.ownerRef.uid === ownerUid;
+      this.db
+        .prepare(
+          `UPDATE agent_task_spec
+             SET owner_ref_json = ?, generation = generation + 1, resource_version = resource_version + 1
+           WHERE id = ?`,
+        )
+        .run(cleared ? null : JSON.stringify(existing.ownerRef ?? null), taskId);
+    });
+
+  reapAgentTask = async (
+    taskId: string,
+    opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>> => {
+    let mismatch: CasMutationResult<AgentTaskView> | null = null;
+    let deleted: AgentTaskView | null = null;
+    const tx = this.db.transaction(() => {
+      const existing = this.readAgentTask(taskId);
+      if (existing === null) {
+        throw new NotFoundError({
+          resource: "AgentTask",
+          identifier: taskId,
+          message: `AgentTask '${taskId}' not found`,
+        });
+      }
+      const cas = checkIfMatch(
+        existing.spec.resourceVersion,
+        opts?.ifMatch,
+        existing.spec.generation,
+      );
+      if (cas !== null) {
+        mismatch = cas;
+        return;
+      }
+      if ((existing.spec.finalizers ?? []).length > 0) {
+        throw new Error(
+          `reapAgentTask refused: '${taskId}' still has finalizers [${(existing.spec.finalizers ?? []).join(", ")}]`,
+        );
+      }
+      deleted = existing;
+      // agent_task_status drops via FK ON DELETE CASCADE.
+      this.db.prepare("DELETE FROM agent_task_spec WHERE id = ?").run(taskId);
+    });
+    tx.immediate();
+    if (mismatch !== null) return mismatch;
+    if (deleted === null) throw new Error(`reapAgentTask('${taskId}') produced no view`);
+    return { kind: "ok", view: deleted };
+  };
+
+  /** Shared CAS wrapper for spec-row lifecycle edits. */
+  private mutateSpec(
+    taskId: string,
+    opts: CasOpts | undefined,
+    apply: (existing: AgentTaskSpecRecord) => void,
+  ): CasMutationResult<AgentTaskView> {
+    let mismatch: CasMutationResult<AgentTaskView> | null = null;
+    const tx = this.db.transaction(() => {
+      const existing = this.readAgentTask(taskId);
+      if (existing === null) {
+        throw new NotFoundError({
+          resource: "AgentTask",
+          identifier: taskId,
+          message: `AgentTask '${taskId}' not found`,
+        });
+      }
+      const cas = checkIfMatch(
+        existing.spec.resourceVersion,
+        opts?.ifMatch,
+        existing.spec.generation,
+      );
+      if (cas !== null) {
+        mismatch = cas;
+        return;
+      }
+      apply(existing.spec);
+    });
+    tx.immediate();
+    if (mismatch !== null) return mismatch;
+    const view = this.readAgentTask(taskId);
+    if (view === null) throw new Error(`Failed to read back agent task '${taskId}'`);
+    this.emitAgentTaskWrite("MODIFIED", view);
+    return { kind: "ok", view };
+  }
+
   async listAgentTaskEntities(query?: AgentTaskQuery): Promise<readonly AgentTaskEntity[]> {
     const namespace = readStoreNamespace(this.db);
     const views = await this.listAgentTasks(query);

--- a/src/local/sqlite-store.ts
+++ b/src/local/sqlite-store.ts
@@ -70,7 +70,12 @@ import { computeContributionContentHash } from "../core/content-dedup.js";
 import type { ClaimEntity, ContributionEntity } from "../core/entity.js";
 import { claimViewToEntity, contributionToEntity } from "../core/entity.js";
 import { ClaimConflictError, NotFoundError, StateConflictError } from "../core/errors.js";
-import type { Finalizer, OwnerRef } from "../core/lifecycle-metadata.js";
+import type {
+  Finalizer,
+  KindFinalizer,
+  OwnerRef,
+  PropagationFinalizer,
+} from "../core/lifecycle-metadata.js";
 import { toUtcIso } from "../core/time.js";
 
 export const CURRENT_SCHEMA_VERSION = 16;
@@ -1371,7 +1376,11 @@ function rowToAgentTaskSpec(row: AgentTaskSpecRow): AgentTaskSpecRecord {
     ...(row.owner_ref_json === null
       ? {}
       : { ownerRef: JSON.parse(row.owner_ref_json) as OwnerRef }),
-    finalizers: JSON.parse(row.finalizers_json) as readonly Finalizer[],
+    finalizers: JSON.parse(row.finalizers_json) as readonly (
+      | Finalizer
+      | KindFinalizer
+      | PropagationFinalizer
+    )[],
     ...(row.deletion_timestamp === null ? {} : { deletionTimestamp: row.deletion_timestamp }),
     createdAt: row.created_at,
     resourceVersion: row.resource_version,
@@ -2240,14 +2249,15 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
     opts?: CasOpts,
   ): Promise<CasMutationResult<AgentTaskView>> =>
     this.mutateSpec(taskId, opts, (existing) => {
-      const next = existing.deletionTimestamp ?? deletionTimestamp;
+      if (existing.deletionTimestamp !== undefined) return false; // already terminating — no-op
       this.db
         .prepare(
           `UPDATE agent_task_spec
              SET deletion_timestamp = ?, generation = generation + 1, resource_version = resource_version + 1
            WHERE id = ?`,
         )
-        .run(next, taskId);
+        .run(deletionTimestamp, taskId);
+      return true;
     });
 
   removeAgentTaskFinalizer = async (
@@ -2256,7 +2266,10 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
     opts?: CasOpts,
   ): Promise<CasMutationResult<AgentTaskView>> =>
     this.mutateSpec(taskId, opts, (existing) => {
-      const remaining = (existing.finalizers ?? []).filter((f) => f !== finalizer);
+      const current = existing.finalizers ?? [];
+      if (!current.includes(finalizer as Finalizer | KindFinalizer | PropagationFinalizer))
+        return false; // not present — no-op
+      const remaining = current.filter((f) => f !== finalizer);
       this.db
         .prepare(
           `UPDATE agent_task_spec
@@ -2264,6 +2277,7 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
            WHERE id = ?`,
         )
         .run(JSON.stringify(remaining), taskId);
+      return true;
     });
 
   removeAgentTaskOwnerRef = async (
@@ -2272,14 +2286,15 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
     opts?: CasOpts,
   ): Promise<CasMutationResult<AgentTaskView>> =>
     this.mutateSpec(taskId, opts, (existing) => {
-      const cleared = existing.ownerRef !== undefined && existing.ownerRef.uid === ownerUid;
+      if (existing.ownerRef === undefined || existing.ownerRef.uid !== ownerUid) return false; // no matching owner — no-op
       this.db
         .prepare(
           `UPDATE agent_task_spec
-             SET owner_ref_json = ?, generation = generation + 1, resource_version = resource_version + 1
+             SET owner_ref_json = NULL, generation = generation + 1, resource_version = resource_version + 1
            WHERE id = ?`,
         )
-        .run(cleared ? null : JSON.stringify(existing.ownerRef ?? null), taskId);
+        .run(taskId);
+      return true;
     });
 
   reapAgentTask = async (
@@ -2321,13 +2336,21 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
     return { kind: "ok", view: deleted };
   };
 
-  /** Shared CAS wrapper for spec-row lifecycle edits. */
+  /**
+   * Shared CAS wrapper for spec-row lifecycle edits. `apply` runs the `UPDATE`
+   * (which bumps generation + resource_version) only when it changes the row,
+   * and returns whether it did. A `false` return is a true no-op: no RV bump,
+   * no MODIFIED event — so idempotent re-calls (e.g. the GC re-emitting an
+   * orphan/finalizer action) don't churn the `withIfMatch` retry loop or
+   * corrupt the row.
+   */
   private mutateSpec(
     taskId: string,
     opts: CasOpts | undefined,
-    apply: (existing: AgentTaskSpecRecord) => void,
+    apply: (existing: AgentTaskSpecRecord) => boolean,
   ): CasMutationResult<AgentTaskView> {
     let mismatch: CasMutationResult<AgentTaskView> | null = null;
+    let changed = false;
     const tx = this.db.transaction(() => {
       const existing = this.readAgentTask(taskId);
       if (existing === null) {
@@ -2346,13 +2369,13 @@ export class SqliteAgentTaskStore implements AgentTaskStore {
         mismatch = cas;
         return;
       }
-      apply(existing.spec);
+      changed = apply(existing.spec);
     });
     tx.immediate();
     if (mismatch !== null) return mismatch;
     const view = this.readAgentTask(taskId);
     if (view === null) throw new Error(`Failed to read back agent task '${taskId}'`);
-    this.emitAgentTaskWrite("MODIFIED", view);
+    if (changed) this.emitAgentTaskWrite("MODIFIED", view);
     return { kind: "ok", view };
   }
 

--- a/src/server/garbage-collector-wiring.test.ts
+++ b/src/server/garbage-collector-wiring.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { GarbageCollector } from "../core/garbage-collector.js";
+import { InMemoryGcStore } from "../core/in-memory-gc-store.js";
+import {
+  createGarbageCollectorWiring,
+  garbageCollectorEnabled,
+} from "./garbage-collector-wiring.js";
+
+describe("garbage-collector-wiring", () => {
+  test("enabled by default, disabled by GROVE_GC=0", () => {
+    expect(garbageCollectorEnabled({})).toBe(true);
+    expect(garbageCollectorEnabled({ GROVE_GC: "0" })).toBe(false);
+    expect(garbageCollectorEnabled({ GROVE_GC: "1" })).toBe(true);
+  });
+
+  test("constructs a GarbageCollector over the supplied store", () => {
+    const wiring = createGarbageCollectorWiring({ store: new InMemoryGcStore(), workerCount: 2 });
+    expect(wiring.collector).toBeInstanceOf(GarbageCollector);
+  });
+});

--- a/src/server/garbage-collector-wiring.test.ts
+++ b/src/server/garbage-collector-wiring.test.ts
@@ -17,4 +17,15 @@ describe("garbage-collector-wiring", () => {
     const wiring = createGarbageCollectorWiring({ store: new InMemoryGcStore(), workerCount: 2 });
     expect(wiring.collector).toBeInstanceOf(GarbageCollector);
   });
+
+  test("accepts and forwards onAction to the GarbageCollector without throwing", () => {
+    const onAction = () => {
+      /* spy placeholder */
+    };
+    const wiring = createGarbageCollectorWiring({
+      store: new InMemoryGcStore(),
+      onAction,
+    });
+    expect(wiring.collector).toBeInstanceOf(GarbageCollector);
+  });
 });

--- a/src/server/garbage-collector-wiring.ts
+++ b/src/server/garbage-collector-wiring.ts
@@ -1,0 +1,30 @@
+import { GarbageCollector, type GcStore } from "../core/garbage-collector.js";
+
+export function garbageCollectorEnabled(
+  env: Readonly<Record<string, string | undefined>>,
+): boolean {
+  return env.GROVE_GC !== "0";
+}
+
+export interface GarbageCollectorWiringOptions {
+  readonly store: GcStore;
+  readonly workerCount?: number | undefined;
+  readonly resyncIntervalMs?: number | undefined;
+  readonly onError?: ((error: unknown, key: string) => void) | undefined;
+}
+
+export interface GarbageCollectorWiring {
+  readonly collector: GarbageCollector;
+}
+
+export function createGarbageCollectorWiring(
+  options: GarbageCollectorWiringOptions,
+): GarbageCollectorWiring {
+  const collector = new GarbageCollector({
+    store: options.store,
+    workerCount: options.workerCount,
+    resyncIntervalMs: options.resyncIntervalMs,
+    onError: options.onError,
+  });
+  return { collector };
+}

--- a/src/server/garbage-collector-wiring.ts
+++ b/src/server/garbage-collector-wiring.ts
@@ -1,4 +1,5 @@
 import { GarbageCollector, type GcStore } from "../core/garbage-collector.js";
+import type { GcAction } from "../core/owner-graph.js";
 
 export function garbageCollectorEnabled(
   env: Readonly<Record<string, string | undefined>>,
@@ -11,6 +12,7 @@ export interface GarbageCollectorWiringOptions {
   readonly workerCount?: number | undefined;
   readonly resyncIntervalMs?: number | undefined;
   readonly onError?: ((error: unknown, key: string) => void) | undefined;
+  readonly onAction?: ((action: GcAction) => void) | undefined;
 }
 
 export interface GarbageCollectorWiring {
@@ -25,6 +27,7 @@ export function createGarbageCollectorWiring(
     workerCount: options.workerCount,
     resyncIntervalMs: options.resyncIntervalMs,
     onError: options.onError,
+    onAction: options.onAction,
   });
   return { collector };
 }

--- a/src/server/routes/agent-tasks.test.ts
+++ b/src/server/routes/agent-tasks.test.ts
@@ -129,6 +129,34 @@ class TestAgentTaskStore implements AgentTaskStore {
     return views.map((v) => agentTaskViewToEntity(v));
   }
 
+  async setAgentTaskDeletion(
+    _taskId: string,
+    _deletionTimestamp: string,
+    _opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>> {
+    throw new Error("not implemented in test store");
+  }
+
+  async removeAgentTaskFinalizer(
+    _taskId: string,
+    _finalizer: string,
+    _opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>> {
+    throw new Error("not implemented in test store");
+  }
+
+  async removeAgentTaskOwnerRef(
+    _taskId: string,
+    _ownerUid: string,
+    _opts?: CasOpts,
+  ): Promise<CasMutationResult<AgentTaskView>> {
+    throw new Error("not implemented in test store");
+  }
+
+  async reapAgentTask(_taskId: string, _opts?: CasOpts): Promise<CasMutationResult<AgentTaskView>> {
+    throw new Error("not implemented in test store");
+  }
+
   close(): void {
     /* test store */
   }

--- a/src/server/task-controller-wiring.test.ts
+++ b/src/server/task-controller-wiring.test.ts
@@ -117,16 +117,16 @@ function fakeTaskStore() {
         return [] as never;
       },
       async setAgentTaskDeletion() {
-        return undefined as never;
+        throw new Error("not implemented in fakeTaskStore");
       },
       async removeAgentTaskFinalizer() {
-        return undefined as never;
+        throw new Error("not implemented in fakeTaskStore");
       },
       async removeAgentTaskOwnerRef() {
-        return undefined as never;
+        throw new Error("not implemented in fakeTaskStore");
       },
       async reapAgentTask() {
-        return undefined as never;
+        throw new Error("not implemented in fakeTaskStore");
       },
       close() {
         // no-op stub

--- a/src/server/task-controller-wiring.test.ts
+++ b/src/server/task-controller-wiring.test.ts
@@ -116,6 +116,18 @@ function fakeTaskStore() {
       async listAgentTaskEntities() {
         return [] as never;
       },
+      async setAgentTaskDeletion() {
+        return undefined as never;
+      },
+      async removeAgentTaskFinalizer() {
+        return undefined as never;
+      },
+      async removeAgentTaskOwnerRef() {
+        return undefined as never;
+      },
+      async reapAgentTask() {
+        return undefined as never;
+      },
       close() {
         // no-op stub
       },


### PR DESCRIPTION
## Summary

Kubernetes-style garbage collector for Grove's entity hierarchy (Epic D / #285, D5). Closes #306.

- **OwnerRef** gains a `controller?: boolean` flag + `taskGroup`/`agentTask` kinds; new `grove.dev/*` finalizer constants (`KindFinalizer.PendingReview`/`PendingMerge`, `PropagationFinalizer.Foreground`/`Orphan`) and a `CascadePolicy` type.
- **`owner-graph.ts`** — pure, I/O-free cascade/reap decision core (`policyOf`, `planOwnerDeletion`, `planDanglingChild`). Idempotent: returns `[]` at convergence.
- **`garbage-collector.ts`** — `GarbageCollector` reconcile loop (same skeleton as `task-controller`/`claim-controller`) over a segregated `GcStore` interface; CAS via `withIfMatch`, cross-level re-drive so multi-level cascades converge without waiting for resync.
- **Real persistence** — `SqliteAgentTaskStore` gains `setAgentTaskDeletion` / `removeAgentTaskFinalizer` / `removeAgentTaskOwnerRef` / `reapAgentTask` (finalizer-guarded hard delete; status row drops via the existing FK cascade). No schema migration (columns already existed).
- **`AgentTaskGcStore` + `CompositeGcStore`** bridge the loop to real AgentTask rows and span an (in-memory) TaskGroup owner + real AgentTask children.
- Wiring seam `garbage-collector-wiring.ts` (gated by `GROVE_GC`); **live `serve.ts` activation deliberately deferred** with TaskGroup persistence.

Cascade policy is encoded as a propagation finalizer on the owner at delete time (mirrors k8s `foregroundDeletion`/`orphan`), so policy survives restarts.

## Acceptance criteria (#306)

| Criterion | Status |
| --- | --- |
| Delete TaskGroup → children cascade | ✅ Foreground + Background, in-memory **and over real SQLite** |
| Finalizer blocks deletion until removed | ✅ generic gate proven via AgentTask `pending-review` (in-memory + real SQLite). MergeTask/`pending-merge` **deferred** (mechanism ready) |
| Orphan mode preserves children | ✅ child kept, controller ownerRef stripped, not marked deleted |

## Deferred follow-ups (documented in spec/plan/code, not dropped)

- `MergeTask` entity + `grove.dev/pending-merge` (one constant + one assignment away).
- `TaskGroup` persistence (SQLite/Nexus) + live server-side GC activation.
- `Terminating` condition emission (needs status writes).
- Full dangling-child sweep (`listAll`) — `resync()` only enumerates pending-deletion owners + their children; documented inline.

## Notable review fixes (adversarial review during development)

- Fixed a **cross-level cascade convergence stall** (owner waited a full resync per level) + added real-worker-loop tests that fail-before/pass-after.
- Fixed an **`owner_ref_json` `"null"`-string corruption + RV churn** in the no-op write path.

## Test plan

- [x] `bunx tsc --noEmit` clean (the `erasableSyntaxOnly`/`isolatedDeclarations` gate).
- [x] Pre-push gate (typecheck + full build) green.
- [x] New GC suites stable across repeated isolated runs: `owner-graph`, `garbage-collector` (incl. real-worker-loop convergence), `in-memory-gc-store`, `agent-task-gc-store` (real SQLite Foreground/Background cascade + `pending-review` reap-block), `sqlite-store` lifecycle mutators (CAS + no-op + FK-cascade), `garbage-collector-wiring`.
- [x] Whole-implementation review: READY TO MERGE (reap-safety + RV contract hold globally; no CAS livelock).

_Note: the full `bun test` suite is green on this code when not resource-contended; an over-parallel coverage run produced timeouts in unrelated subprocess-heavy CLI-init/Nexus tests + one pre-existing Docker-probe test (`resolveBackend`), none in the changed code — verified by isolated re-runs._